### PR TITLE
Show impact of a possible ResolutionStrategy implementation

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveRedundantDependencyVersions.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveRedundantDependencyVersions.java
@@ -341,7 +341,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                                     try {
                                         List<ResolvedDependency> resolved = mpd.download(toSearch, null, null, repositories)
                                                 .resolve(emptyList(), mpd, repositories, ctx)
-                                                .resolveDependencies(Scope.Runtime, mpd, ctx);
+                                                .resolveDependencies(Scope.Runtime, mpd, ResolutionStrategy.NEWEST_WINS, ctx);
                                         for (ResolvedDependency r : resolved) {
                                             if (Objects.equals(searchGav.getGroupId(), r.getGroupId()) && Objects.equals(searchGav.getArtifactId(), r.getArtifactId())) {
                                                 return searchGav.getVersion() == null || matchesComparator(r.getVersion(), searchGav.getVersion());

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -998,7 +998,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
             MavenPomDownloader mpd = new MavenPomDownloader(ctx);
             Pom pom = mpd.download(gav, null, null, gp.getMavenRepositories());
             ResolvedPom resolvedPom = pom.resolve(emptyList(), mpd, gp.getMavenRepositories(), ctx);
-            List<ResolvedDependency> transitiveDependencies = resolvedPom.resolveDependencies(Scope.Runtime, mpd, ctx);
+            List<ResolvedDependency> transitiveDependencies = resolvedPom.resolveDependencies(Scope.Runtime, mpd, ResolutionStrategy.NEWEST_WINS, ctx);
             org.openrewrite.maven.tree.Dependency newRequested = org.openrewrite.maven.tree.Dependency.builder()
                     .gav(gav)
                     .build();
@@ -1170,7 +1170,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                     }
 
                     List<ResolvedDependency> transitiveDependencies = filterTransitiveDependencies(
-                            resolvedPom.resolveDependencies(Scope.Runtime, mpd, ctx),
+                            resolvedPom.resolveDependencies(Scope.Runtime, mpd, ResolutionStrategy.NEWEST_WINS, ctx),
                             existingTransitiveGAs,
                             newTransitiveGAs
                     );

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/AddDependencyVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/AddDependencyVisitor.java
@@ -241,7 +241,7 @@ public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
                 Pom pom = mpd.download(gav, null, null, gp.getMavenRepositories());
                 ResolvedPom resolvedPom = pom.resolve(emptyList(), mpd, gp.getMavenRepositories(), ctx);
                 resolvedGav = resolvedPom.getGav();
-                transitiveDependencies = resolvedPom.resolveDependencies(Scope.Runtime, mpd, ctx);
+                transitiveDependencies = resolvedPom.resolveDependencies(Scope.Runtime, mpd, ResolutionStrategy.NEWEST_WINS, ctx);
             }
             Map<String, GradleDependencyConfiguration> nameToConfiguration = gp.getNameToConfiguration();
             Map<String, GradleDependencyConfiguration> newNameToConfiguration = new HashMap<>(nameToConfiguration.size());

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
@@ -21,10 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.maven.internal.MavenPomDownloader;
 import org.openrewrite.maven.internal.RawPom;
-import org.openrewrite.maven.tree.MavenResolutionResult;
-import org.openrewrite.maven.tree.Parent;
-import org.openrewrite.maven.tree.Pom;
-import org.openrewrite.maven.tree.ResolvedPom;
+import org.openrewrite.maven.tree.*;
 import org.openrewrite.tree.ParseError;
 import org.openrewrite.xml.XmlParser;
 import org.openrewrite.xml.tree.Xml;
@@ -118,7 +115,7 @@ public class MavenParser implements Parser {
                         effectivelyActiveProfiles,
                         properties);
                 if (!skipDependencyResolution) {
-                    model = model.resolveDependencies(downloader, ctx);
+                    model = model.resolveDependencies(downloader, ResolutionStrategy.NEAREST_WINS, ctx);
                 }
                 parsed.add(docToPom.getKey().withMarkers(docToPom.getKey().getMarkers().compute(model, (old, n) -> n)));
             } catch (MavenDownloadingExceptions e) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
@@ -181,7 +181,7 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
                             return module;
                         }
                     }))
-                    .resolveDependencies(downloader, ctx);
+                    .resolveDependencies(downloader, ResolutionStrategy.NEAREST_WINS, ctx);
             if (exceptions.get() != null) {
                 throw exceptions.get();
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/NearestWins.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/NearestWins.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.internal;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.maven.MavenDownloadingException;
+import org.openrewrite.maven.internal.grammar.VersionRangeLexer;
+import org.openrewrite.maven.internal.grammar.VersionRangeParser;
+import org.openrewrite.maven.internal.grammar.VersionRangeParserBaseVisitor;
+import org.openrewrite.maven.tree.Version;
+
+import java.util.Iterator;
+
+import static java.util.stream.Collectors.toList;
+
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class NearestWins extends VersionRequirement {
+
+    @Nullable
+    private final NearestWins nearer;
+
+    private final VersionSpec versionSpec;
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        if (nearer != null) {
+            builder.append(nearer).append(", ");
+        }
+        builder.append(versionSpec);
+        return builder.toString();
+    }
+
+    public NearestWins addRequirement(String requested) {
+        if (versionSpec instanceof DirectRequirement) {
+            return this;
+        }
+
+        VersionSpec newRequirement = buildVersionSpec(requested, false);
+
+        NearestWins next = this;
+        while (next != null) {
+            if (next.versionSpec.equals(newRequirement)) {
+                return this;
+            }
+            next = next.nearer;
+        }
+
+        return new NearestWins(this, newRequirement);
+    }
+
+    static VersionSpec buildVersionSpec(String requested, boolean direct) {
+        if ("LATEST".equals(requested)) {
+            return DynamicVersion.LATEST;
+        } else if ("RELEASE".equals(requested)) {
+            return DynamicVersion.RELEASE;
+        } else if (requested.contains("[") || requested.contains("(")) {
+            // for things like the profile activation block of where the range is unclosed but maven still handles it, e.g.
+            // https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.12.0-rc2/jackson-databind-2.12.0-rc2.pom
+            if (!(requested.contains("]") || requested.contains(")"))) {
+                requested += "]";
+            }
+
+            VersionRangeParser parser = new VersionRangeParser(new CommonTokenStream(new VersionRangeLexer(
+                    CharStreams.fromString(requested))));
+
+            parser.removeErrorListeners();
+            parser.addErrorListener(new PrintingErrorListener());
+
+            return new VersionRangeParserBaseVisitor<VersionSpec>() {
+                @Override
+                public VersionSpec visitVersionRequirement(VersionRangeParser.VersionRequirementContext ctx) {
+                    return new RangeSet(ctx.range().stream()
+                            .map(range -> {
+                                Version lower, upper;
+                                if (range.bounds().boundedLower() != null) {
+                                    Iterator<TerminalNode> versionIter = range.bounds().boundedLower().Version().iterator();
+                                    lower = versionIter.hasNext() ? toVersion(versionIter.next()) : null;
+                                    upper = versionIter.hasNext() ? toVersion(versionIter.next()) : null;
+                                } else if (range.bounds().unboundedLower() != null) {
+                                    TerminalNode upperVersionNode = range.bounds().unboundedLower().Version();
+                                    lower = null;
+                                    upper = upperVersionNode != null ? toVersion(upperVersionNode) : null;
+                                } else {
+                                    lower = toVersion(range.bounds().exactly().Version());
+                                    upper = toVersion(range.bounds().exactly().Version());
+                                }
+                                return new Range(
+                                        range.CLOSED_RANGE_OPEN() != null, lower,
+                                        range.CLOSED_RANGE_CLOSE() != null, upper
+                                );
+                            })
+                            .collect(toList())
+                    );
+                }
+
+                private Version toVersion(TerminalNode version) {
+                    return new Version(version.getText());
+                }
+            }.visit(parser.versionRequirement());
+        }
+        return direct ?
+                new DirectRequirement(requested) :
+                new SoftRequirement(requested);
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = true)
+    private static class DirectRequirement extends SoftRequirement {
+        private DirectRequirement(String version) {
+            super(version);
+        }
+
+        @Override
+        public String toString() {
+            return "Version='" + version + "'";
+        }
+    }
+
+    protected @Nullable String cacheResolved(DownloadOperation<Iterable<String>> availableVersions) throws MavenDownloadingException {
+        String nearestSoftRequirement = null;
+        NearestWins next = this;
+        NearestWins nearestHardRequirement = null;
+
+        while (next != null) {
+            VersionSpec spec = next.versionSpec;
+            if (spec instanceof DirectRequirement) {
+                // dependencies defined in the project POM always win
+                return ((DirectRequirement) spec).getVersion();
+            } else if (spec instanceof SoftRequirement) {
+                nearestSoftRequirement = ((SoftRequirement) spec).version;
+            } else {
+                nearestHardRequirement = next;
+            }
+            next = next.nearer;
+        }
+
+        if (nearestHardRequirement == null) {
+            return nearestSoftRequirement;
+        }
+        VersionSpec hardRequirement = nearestHardRequirement.versionSpec;
+        Version latest = null;
+        for (String availableVersion : availableVersions.call()) {
+            Version version = new Version(availableVersion);
+
+            if ((hardRequirement instanceof DynamicVersion || hardRequirement instanceof RangeSet) && hardRequirement.matches(version)) {
+                if (latest == null || version.compareTo(latest) > 0) {
+                    latest = version;
+                }
+            }
+        }
+
+        if (latest == null) {
+            // No version matches the hard requirement.
+            return null;
+        }
+
+        return latest.toString();
+    }
+
+    private static class PrintingErrorListener extends BaseErrorListener {
+        @Override
+        public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
+                                int line, int charPositionInLine, String msg, RecognitionException e) {
+            System.out.printf("Syntax error at line %d:%d %s%n", line, charPositionInLine, msg);
+        }
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/NewestWins.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/NewestWins.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.internal;
+
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.maven.MavenDownloadingException;
+import org.openrewrite.maven.internal.grammar.VersionRangeLexer;
+import org.openrewrite.maven.internal.grammar.VersionRangeParser;
+import org.openrewrite.maven.internal.grammar.VersionRangeParserBaseVisitor;
+import org.openrewrite.maven.tree.Version;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+
+public class NewestWins extends VersionRequirement {
+
+    private final Set<VersionSpec> requestedVersions = new HashSet<>();
+
+    NewestWins(VersionSpec requestedVersions) {
+        this.requestedVersions.add(requestedVersions);
+    }
+
+    @Override
+    public String toString() {
+        return requestedVersions.stream().map(Object::toString).collect(Collectors.joining(", "));
+    }
+
+    public NewestWins addRequirement(String requested) {
+        VersionSpec requestedSpec = buildVersionSpec(requested);
+        if (requestedVersions.add(requestedSpec)) {
+            super.selected = null;
+        }
+        return this;
+    }
+
+    static VersionSpec buildVersionSpec(String requested) {
+        if ("LATEST".equals(requested)) {
+            return DynamicVersion.LATEST;
+        } else if ("RELEASE".equals(requested)) {
+            return DynamicVersion.RELEASE;
+        } else if (requested.contains("[") || requested.contains("(")) {
+            // for things like the profile activation block of where the range is unclosed but maven still handles it, e.g.
+            // https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.12.0-rc2/jackson-databind-2.12.0-rc2.pom
+            if (!(requested.contains("]") || requested.contains(")"))) {
+                requested += "]";
+            }
+
+            VersionRangeParser parser = new VersionRangeParser(new CommonTokenStream(new VersionRangeLexer(
+                    CharStreams.fromString(requested))));
+
+            parser.removeErrorListeners();
+            parser.addErrorListener(new PrintingErrorListener());
+
+            return new VersionRangeParserBaseVisitor<VersionSpec>() {
+                @Override
+                public VersionSpec visitVersionRequirement(VersionRangeParser.VersionRequirementContext ctx) {
+                    return new RangeSet(ctx.range().stream()
+                            .map(range -> {
+                                Version lower, upper;
+                                if (range.bounds().boundedLower() != null) {
+                                    Iterator<TerminalNode> versionIter = range.bounds().boundedLower().Version().iterator();
+                                    lower = versionIter.hasNext() ? toVersion(versionIter.next()) : null;
+                                    upper = versionIter.hasNext() ? toVersion(versionIter.next()) : null;
+                                } else if (range.bounds().unboundedLower() != null) {
+                                    TerminalNode upperVersionNode = range.bounds().unboundedLower().Version();
+                                    lower = null;
+                                    upper = upperVersionNode != null ? toVersion(upperVersionNode) : null;
+                                } else {
+                                    lower = toVersion(range.bounds().exactly().Version());
+                                    upper = toVersion(range.bounds().exactly().Version());
+                                }
+                                return new Range(
+                                        range.CLOSED_RANGE_OPEN() != null, lower,
+                                        range.CLOSED_RANGE_CLOSE() != null, upper
+                                );
+                            })
+                            .collect(toList())
+                    );
+                }
+
+                private Version toVersion(TerminalNode version) {
+                    return new Version(version.getText());
+                }
+            }.visit(parser.versionRequirement());
+        }
+        return new SoftRequirement(requested);
+    }
+
+    protected @Nullable String cacheResolved(DownloadOperation<Iterable<String>> availableVersions) throws MavenDownloadingException {
+        Version latestVersion = null;
+        for (String availableVersion : availableVersions.call()) {
+            Version version = new Version(availableVersion);
+            if (requestedVersions.stream().anyMatch(spec -> spec.matches(version))) {
+                if (latestVersion == null || version.compareTo(latestVersion) > 0) {
+                    latestVersion = version;
+                }
+            }
+        }
+        return latestVersion != null ? latestVersion.toString() : null;
+    }
+
+    private static class PrintingErrorListener extends BaseErrorListener {
+        @Override
+        public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
+                                int line, int charPositionInLine, String msg, RecognitionException e) {
+            System.out.printf("Syntax error at line %d:%d %s%n", line, charPositionInLine, msg);
+        }
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/VersionRequirement.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/VersionRequirement.java
@@ -16,143 +16,58 @@
 package org.openrewrite.maven.internal;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import lombok.Value;
-import org.antlr.v4.runtime.*;
-import org.antlr.v4.runtime.tree.TerminalNode;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.maven.MavenDownloadingException;
-import org.openrewrite.maven.internal.grammar.VersionRangeLexer;
-import org.openrewrite.maven.internal.grammar.VersionRangeParser;
-import org.openrewrite.maven.internal.grammar.VersionRangeParserBaseVisitor;
-import org.openrewrite.maven.tree.GroupArtifact;
-import org.openrewrite.maven.tree.MavenMetadata;
-import org.openrewrite.maven.tree.MavenRepository;
-import org.openrewrite.maven.tree.Version;
+import org.openrewrite.maven.tree.*;
 
-import java.util.Iterator;
 import java.util.List;
 
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
-@RequiredArgsConstructor
-public class VersionRequirement {
+public abstract class VersionRequirement {
 
     @Nullable
-    private final VersionRequirement nearer;
+    protected volatile transient String selected;
 
-    private final VersionSpec versionSpec;
-
-    @Nullable
-    private volatile transient String selected;
-
-    @Override
-    public String toString() {
-        StringBuilder builder = new StringBuilder();
-        if (nearer != null) {
-            builder.append(nearer).append(", ");
+    public static VersionRequirement fromVersion(String requested, ResolutionStrategy resolutionStrategy, int depth) {
+        if (resolutionStrategy == ResolutionStrategy.NEAREST_WINS) {
+            return new NearestWins(null, NearestWins.buildVersionSpec(requested, depth == 0));
         }
-        builder.append(versionSpec);
-        return builder.toString();
+        return new NewestWins(NewestWins.buildVersionSpec(requested));
     }
 
-    public static VersionRequirement fromVersion(String requested, int depth) {
-        return new VersionRequirement(null, VersionSpec.build(requested, depth == 0));
+    public abstract VersionRequirement addRequirement(String requested);
+
+    public @Nullable String resolve(GroupArtifact groupArtifact, MavenPomDownloader downloader, List<MavenRepository> repositories) throws MavenDownloadingException {
+        return resolve(() -> {
+            MavenMetadata metadata = downloader.downloadMetadata(groupArtifact, null, repositories);
+            return metadata.getVersioning().getVersions();
+        });
     }
 
-    public VersionRequirement addRequirement(String requested) {
-        if (versionSpec instanceof DirectRequirement) {
-            return this;
+    public @Nullable String resolve(DownloadOperation<Iterable<String>> availableVersions) throws MavenDownloadingException {
+        if (selected == null) {
+            //TODO Is it bad that LATEST and RELEASE are also cached -> if a new version is released, it won't be picked up in the current cached state. Existing behavior to cache them though.
+            selected = cacheResolved(availableVersions);
         }
-
-        VersionSpec newRequirement = VersionSpec.build(requested, false);
-
-        VersionRequirement next = this;
-        while (next != null) {
-            if (next.versionSpec.equals(newRequirement)) {
-                return this;
-            }
-            next = next.nearer;
-        }
-
-        return new VersionRequirement(this, newRequirement);
+        return selected;
     }
+
+    protected abstract @Nullable String cacheResolved(DownloadOperation<Iterable<String>> availableVersions) throws MavenDownloadingException;
 
     interface VersionSpec {
-        static VersionSpec build(String requested, boolean direct) {
-            if ("LATEST".equals(requested)) {
-                return DynamicVersion.LATEST;
-            } else if ("RELEASE".equals(requested)) {
-                return DynamicVersion.RELEASE;
-            } else if (requested.contains("[") || requested.contains("(")) {
-                // for things like the profile activation block of where the range is unclosed but maven still handles it, e.g.
-                // https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.12.0-rc2/jackson-databind-2.12.0-rc2.pom
-                if (!(requested.contains("]") || requested.contains(")"))) {
-                    requested += "]";
-                }
 
-                VersionRangeParser parser = new VersionRangeParser(new CommonTokenStream(new VersionRangeLexer(
-                        CharStreams.fromString(requested))));
-
-                parser.removeErrorListeners();
-                parser.addErrorListener(new PrintingErrorListener());
-
-                return new VersionRangeParserBaseVisitor<VersionSpec>() {
-                    @Override
-                    public VersionSpec visitVersionRequirement(VersionRangeParser.VersionRequirementContext ctx) {
-                        return new RangeSet(ctx.range().stream()
-                                .map(range -> {
-                                    Version lower, upper;
-                                    if (range.bounds().boundedLower() != null) {
-                                        Iterator<TerminalNode> versionIter = range.bounds().boundedLower().Version().iterator();
-                                        lower = versionIter.hasNext() ? toVersion(versionIter.next()) : null;
-                                        upper = versionIter.hasNext() ? toVersion(versionIter.next()) : null;
-                                    } else if (range.bounds().unboundedLower() != null) {
-                                        TerminalNode upperVersionNode = range.bounds().unboundedLower().Version();
-                                        lower = null;
-                                        upper = upperVersionNode != null ? toVersion(upperVersionNode) : null;
-                                    } else {
-                                        lower = toVersion(range.bounds().exactly().Version());
-                                        upper = toVersion(range.bounds().exactly().Version());
-                                    }
-                                    return new Range(
-                                            range.CLOSED_RANGE_OPEN() != null, lower,
-                                            range.CLOSED_RANGE_CLOSE() != null, upper
-                                    );
-                                })
-                                .collect(toList())
-                        );
-                    }
-
-                    private Version toVersion(TerminalNode version) {
-                        return new Version(version.getText());
-                    }
-                }.visit(parser.versionRequirement());
-            }
-            return direct ?
-                    new DirectRequirement(requested) :
-                    new SoftRequirement(requested);
-        }
-    }
-
-    @Value
-    @EqualsAndHashCode(callSuper = true)
-    private static class DirectRequirement extends SoftRequirement {
-        private DirectRequirement(String version) {
-            super(version);
-        }
-
-        @Override
-        public String toString() {
-            return "Version='" + version + "'";
-        }
+        boolean matches(Version version);
     }
 
     @Data
-    private static class SoftRequirement implements VersionSpec {
+    protected static class SoftRequirement implements VersionSpec {
         final String version;
+
+        public boolean matches(Version version) {
+            return this.version.equals(version.toString());
+        }
 
         @Override
         public String toString() {
@@ -160,7 +75,7 @@ public class VersionRequirement {
         }
     }
 
-    private enum DynamicVersion implements VersionSpec {
+    protected enum DynamicVersion implements VersionSpec {
         LATEST,
         RELEASE;
 
@@ -176,7 +91,7 @@ public class VersionRequirement {
     }
 
     @Value
-    private static class RangeSet implements VersionSpec {
+    protected static class RangeSet implements VersionSpec {
         List<Range> ranges;
 
         public boolean matches(Version version) {
@@ -209,7 +124,7 @@ public class VersionRequirement {
     }
 
     @Value
-    private static class Range {
+    protected static class Range {
         boolean lowerClosed;
 
         @Nullable
@@ -222,73 +137,7 @@ public class VersionRequirement {
 
         @Override
         public String toString() {
-            return (lowerClosed ? "[" : "(") + lower + "," + upper +
-                    (upperClosed ? ']' : ')');
-        }
-    }
-
-    public @Nullable String resolve(DownloadOperation<Iterable<String>> availableVersions) throws MavenDownloadingException {
-        if (selected == null) {
-            selected = cacheResolved(availableVersions);
-        }
-        return selected;
-    }
-
-    private @Nullable String cacheResolved(DownloadOperation<Iterable<String>> availableVersions) throws MavenDownloadingException {
-        String nearestSoftRequirement = null;
-        VersionRequirement next = this;
-        VersionRequirement nearestHardRequirement = null;
-
-        while (next != null) {
-            VersionSpec spec = next.versionSpec;
-            if (spec instanceof DirectRequirement) {
-                // dependencies defined in the project POM always win
-                return ((DirectRequirement) spec).getVersion();
-            } else if (spec instanceof SoftRequirement) {
-                nearestSoftRequirement = ((SoftRequirement) spec).version;
-            } else {
-                nearestHardRequirement = next;
-            }
-            next = next.nearer;
-        }
-
-        if (nearestHardRequirement == null) {
-            return nearestSoftRequirement;
-        }
-        VersionSpec hardRequirement = nearestHardRequirement.versionSpec;
-        Version latest = null;
-        for (String availableVersion : availableVersions.call()) {
-            Version version = new Version(availableVersion);
-
-            if ((hardRequirement instanceof DynamicVersion && ((DynamicVersion) hardRequirement).matches(version)) ||
-                (hardRequirement instanceof RangeSet && ((RangeSet) hardRequirement).matches(version))) {
-
-                if (latest == null || version.compareTo(latest) > 0) {
-                    latest = version;
-                }
-            }
-        }
-
-        if (latest == null) {
-            // No version matches the hard requirement.
-            return null;
-        }
-
-        return latest.toString();
-    }
-
-    public @Nullable String resolve(GroupArtifact groupArtifact, MavenPomDownloader downloader, List<MavenRepository> repositories) throws MavenDownloadingException {
-        return resolve(() -> {
-            MavenMetadata metadata = downloader.downloadMetadata(groupArtifact, null, repositories);
-            return metadata.getVersioning().getVersions();
-        });
-    }
-
-    private static class PrintingErrorListener extends BaseErrorListener {
-        @Override
-        public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
-                                int line, int charPositionInLine, String msg, RecognitionException e) {
-            System.out.printf("Syntax error at line %d:%d %s%n", line, charPositionInLine, msg);
+            return (lowerClosed ? "[" : "(") + lower + "," + upper + (upperClosed ? ']' : ')');
         }
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
@@ -180,13 +180,17 @@ public class MavenResolutionResult implements Marker {
     private static final Scope[] RESOLVE_SCOPES = new Scope[]{Scope.Compile, Scope.Runtime, Scope.Test, Scope.Provided};
 
     public MavenResolutionResult resolveDependencies(MavenPomDownloader downloader, ExecutionContext ctx) throws MavenDownloadingExceptions {
+        return resolveDependencies(downloader, ResolutionStrategy.NEAREST_WINS, ctx);
+    }
+
+    public MavenResolutionResult resolveDependencies(MavenPomDownloader downloader, ResolutionStrategy resolutionStrategy, ExecutionContext ctx) throws MavenDownloadingExceptions {
         Map<Scope, List<ResolvedDependency>> dependencies = new HashMap<>();
         MavenDownloadingExceptions exceptions = null;
 
         Map<GroupArtifact, Set<GroupArtifactVersion>> exceptionsInLowerScopes = new HashMap<>();
         for (Scope scope : RESOLVE_SCOPES) {
             try {
-                dependencies.put(scope, pom.resolveDependencies(scope, downloader, ctx));
+                dependencies.put(scope, pom.resolveDependencies(scope, downloader, resolutionStrategy, ctx));
             } catch (MavenDownloadingExceptions e) {
                 for (MavenDownloadingException exception : e.getExceptions()) {
                     if (exceptionsInLowerScopes.computeIfAbsent(new GroupArtifact(

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ProfileActivation.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ProfileActivation.java
@@ -67,7 +67,7 @@ public class ProfileActivation {
         }
 
         try {
-            return version.equals(VersionRequirement.fromVersion(jdk, 0).resolve(() -> singletonList(version)));
+            return version.equals(VersionRequirement.fromVersion(jdk, ResolutionStrategy.NEAREST_WINS, 0).resolve(() -> singletonList(version)));
         } catch (MavenDownloadingException e) {
             // unreachable
             return false;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolutionStrategy.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolutionStrategy.java
@@ -1,0 +1,6 @@
+package org.openrewrite.maven.tree;
+
+public enum ResolutionStrategy {
+    NEAREST_WINS, //Maven style, where the nearest dependency in the tree is used
+    NEWEST_WINS   //Gradle style, where the latest version is used
+}

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -1359,7 +1359,7 @@ class MavenPomDownloaderTest implements RewriteTest {
                   </project>
         """).toList().getFirst();
         MavenResolutionResult resolutionResult = doc.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
-        resolutionResult = resolutionResult.resolveDependencies(new MavenPomDownloader(emptyMap(), new InMemoryExecutionContext(), null, null), new InMemoryExecutionContext());
+        resolutionResult = resolutionResult.resolveDependencies(new MavenPomDownloader(emptyMap(), new InMemoryExecutionContext(), null, null), ResolutionStrategy.NEAREST_WINS, new InMemoryExecutionContext());
         List<ResolvedDependency> deps = resolutionResult.getDependencies().get(Scope.Compile);
         assertThat(deps).hasSize(35);
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/tree/MavenResolutionResultTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/tree/MavenResolutionResultTest.java
@@ -1,0 +1,387 @@
+package org.openrewrite.maven.tree;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.maven.MavenExecutionContextView;
+import org.openrewrite.maven.MavenSettings;
+import org.openrewrite.maven.internal.MavenPomDownloader;
+import org.openrewrite.maven.internal.RawPom;
+
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.Tree.randomId;
+
+class MavenResolutionResultTest {
+    @Nested
+    class ResolveDependencies {
+
+        @Nested
+        // This is the strategy that Maven normally uses
+        class NearestWins {
+
+            @CsvSource({"2.15.0,2.13.0", "2.13.0,2.15.0", "2.13.0,2.13.0"})
+            @ParameterizedTest
+            void latestMentionedWinsResolution(String firstVersion, String secondVersion) {
+                MavenResolutionResult result = resolvePom("""
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                  
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>%s</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>%s</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """.formatted(firstVersion, secondVersion), ResolutionStrategy.NEAREST_WINS);
+
+                assertThat(result.findDependencies("com.fasterxml.jackson.core", "jackson-core", Scope.Compile))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly(secondVersion);
+            }
+
+            @CsvSource(value = {"[2.13.0,2.15.1);[2.10.0,2.13.0];2.13.0", "(2.10.0,2.13.0];[1.0.0,2.15.1);2.15.0", "[2.13.0];[2.13.0];2.13.0"}, delimiter = ';')
+            @ParameterizedTest
+            void canHandleRanges(String firstVersion, String secondVersion, String expected) {
+                MavenResolutionResult result = resolvePom("""
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                  
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>%s</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>%s</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """.formatted(firstVersion, secondVersion), ResolutionStrategy.NEAREST_WINS);
+
+                assertThat(result.findDependencies("com.fasterxml.jackson.core", "jackson-core", Scope.Compile))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly(expected);
+            }
+
+            @CsvSource({"2.15.0,2.13.0", "2.13.0,2.15.0", "2.13.0,2.13.0"})
+            @ParameterizedTest
+            void canHandlePropertyVersions(String firstVersion, String secondVersion) {
+                MavenResolutionResult result = resolvePom("""
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <properties>
+                      <jackson.version.first>%s</jackson.version.first>
+                      <jackson.version.second>%s</jackson.version.second>
+                    </properties>
+                  
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>${jackson.version.first}</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>${jackson.version.second}</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """.formatted(firstVersion, secondVersion), ResolutionStrategy.NEAREST_WINS);
+
+                assertThat(result.findDependencies("com.fasterxml.jackson.core", "jackson-core", Scope.Compile))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly(secondVersion);
+            }
+
+            @Test
+            void depth0First() {
+                MavenResolutionResult result = resolvePom("""
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                  
+                    <dependencies>
+                      <dependency>
+                        <!-- Transitively brings 2.12.2 -->
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java</artifactId>
+                        <version>7.0.0</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>2.12.0</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, ResolutionStrategy.NEAREST_WINS);
+
+                assertThat(result.findDependencies("com.fasterxml.jackson.core", "jackson-core", Scope.Compile))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly("2.12.0");
+            }
+
+            @Test
+            void shallowestFirst() {
+                MavenResolutionResult result = resolvePom("""
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                  
+                    <dependencies>
+                      <dependency>
+                        <!-- Transitively brings 2.12.2 at depth 1 -->
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java</artifactId>
+                        <version>7.0.0</version>
+                      </dependency>
+                      <dependency>
+                        <!-- Transitively brings 2.17.3 at depth 3 -->
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                        <version>3.3.9</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, ResolutionStrategy.NEAREST_WINS);
+
+                assertThat(result.findDependencies("com.fasterxml.jackson.core", "jackson-annotations", Scope.Compile))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly("2.12.2");
+            }
+        }
+
+        @Nested
+        // This is the strategy that Gradle normally uses, but we're using maven poms to have reusability in the tests as they internally map to the same Dependency classes
+        class NewestWins {
+
+            @CsvSource({"2.15.0,2.13.0", "2.13.0,2.15.0", "2.15.0,2.15.0"})
+            @ParameterizedTest
+            void newestWinsResolution(String firstVersion, String secondVersion) {
+                MavenResolutionResult result = resolvePom("""
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                  
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>%s</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>%s</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """.formatted(firstVersion, secondVersion), ResolutionStrategy.NEWEST_WINS);
+
+                assertThat(result.findDependencies("com.fasterxml.jackson.core", "jackson-core", Scope.Compile))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly("2.15.0");
+            }
+
+            @CsvSource(value = {"[2.13.0,2.15.1);[2.10.0,2.13.0];2.15.0", "(2.10.0,2.13.0];[1.0.0,2.15.1);2.15.0", "[2.13.0];[2.13.0];2.13.0"}, delimiter = ';')
+            @ParameterizedTest
+            void canHandleRanges(String firstVersion, String secondVersion, String expected) {
+                MavenResolutionResult result = resolvePom("""
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                  
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>%s</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>%s</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """.formatted(firstVersion, secondVersion), ResolutionStrategy.NEWEST_WINS);
+
+                assertThat(result.findDependencies("com.fasterxml.jackson.core", "jackson-core", Scope.Compile))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly(expected);
+            }
+
+            @CsvSource({"2.15.0,2.13.0", "2.13.0,2.15.0", "2.15.0,2.15.0"})
+            @ParameterizedTest
+            void canHandlePropertyVersions(String firstVersion, String secondVersion) {
+                MavenResolutionResult result = resolvePom("""
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <properties>
+                      <jackson.version.first>%s</jackson.version.first>
+                      <jackson.version.second>%s</jackson.version.second>
+                    </properties>
+                  
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>${jackson.version.first}</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>${jackson.version.second}</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """.formatted(firstVersion, secondVersion), ResolutionStrategy.NEWEST_WINS);
+
+                assertThat(result.findDependencies("com.fasterxml.jackson.core", "jackson-core", Scope.Compile))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly("2.15.0");
+            }
+
+            @Test
+            void transitiveOverDirect() {
+                MavenResolutionResult result = resolvePom("""
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                  
+                    <dependencies>
+                      <dependency>
+                        <!-- Transitively brings 2.12.2 -->
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java</artifactId>
+                        <version>7.0.0</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                        <version>2.12.0</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, ResolutionStrategy.NEWEST_WINS);
+
+                assertThat(result.findDependencies("com.fasterxml.jackson.core", "jackson-core", Scope.Compile))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly("2.12.2");
+            }
+
+            @Test
+            void newestVersionWins() {
+                MavenResolutionResult result = resolvePom("""
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                  
+                    <dependencies>
+                      <dependency>
+                        <!-- Transitively brings 2.12.2 at depth 1 -->
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java</artifactId>
+                        <version>7.0.0</version>
+                      </dependency>
+                      <dependency>
+                        <!-- Transitively brings 2.17.3 at depth 3 -->
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                        <version>3.3.9</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, ResolutionStrategy.NEWEST_WINS);
+
+                assertThat(result.findDependencies("com.fasterxml.jackson.core", "jackson-annotations", Scope.Compile))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly("2.17.3");
+            }
+        }
+
+        private MavenResolutionResult resolvePom(@Language("xml") String pomContent, ResolutionStrategy resolutionStrategy, String... activeProfiles) {
+            return resolvePom(pomContent, resolutionStrategy, emptyMap(), activeProfiles);
+        }
+
+        private MavenResolutionResult resolvePom(@Language("xml") String pomContent, ResolutionStrategy resolutionStrategy, Map<String, String> properties, String... activeProfiles) {
+            try {
+                ExecutionContext ctx = new InMemoryExecutionContext();
+                Pom pom = RawPom.parse(new ByteArrayInputStream(pomContent.getBytes()), null).toPom(null, null);
+
+                if (pom.getProperties().isEmpty()) {
+                    pom = pom.withProperties(new LinkedHashMap<>());
+                }
+                pom.getProperties().putAll(properties);
+
+                MavenPomDownloader downloader = new MavenPomDownloader(singletonMap(null, pom), ctx);
+
+                MavenExecutionContextView mavenCtx = MavenExecutionContextView.view(ctx);
+                MavenSettings sanitizedSettings = mavenCtx.getSettings() == null ? null : mavenCtx.getSettings().withServers(null);
+                List<String> effectivelyActiveProfiles = Arrays.stream(activeProfiles).toList();
+
+                ResolvedPom resolvedPom = pom.resolve(effectivelyActiveProfiles, downloader, ctx);
+                return new MavenResolutionResult(randomId(), null, resolvedPom, emptyList(), null, emptyMap(), sanitizedSettings, effectivelyActiveProfiles, properties)
+                  .resolveDependencies(downloader, resolutionStrategy, ctx);
+            } catch (Throwable e) {
+                throw new RuntimeException("Failed to resolve POM", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What's changed?
After the previous PR we've mentioned implementation of something like a `ResolutionStrategy` would come in handy for later purposes. This PR adds the ResolutionStrategies `Newest_Wins` and `Nearest_Wins`.

## Anyone you would like to review specifically?
@sambsnyd 

## Any additional context
If we want to support Gradle specific behavior further, we should still have to add support for a `VersionSpec` that is able to work with `+`.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
