### PR TITLE
UpgradeParentVersion, ChangeParentPom to provide except to RemoveRedundantDependencyVersions

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.maven;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
@@ -104,6 +105,39 @@ public class ChangeParentPom extends Recipe {
             required = false)
     @Nullable
     Boolean allowVersionDowngrades;
+
+    @Option(displayName = "Except",
+            description = "Accepts a list of GAVs that will be passed to RemoveRedundantDependencyVersions.",
+            example = "com.jcraft:jsch",
+            required = false)
+    @Nullable
+    List<String> except;
+
+    @JsonCreator
+    public ChangeParentPom(String oldGroupId, @Nullable String newGroupId, String oldArtifactId,
+                           @Nullable String newArtifactId, String newVersion,
+                           @Nullable String oldRelativePath, @Nullable String newRelativePath,
+                           @Nullable String versionPattern, @Nullable Boolean allowVersionDowngrades) {
+        this(oldGroupId, newGroupId, oldArtifactId, newArtifactId, newVersion,
+                oldRelativePath, newRelativePath, versionPattern, allowVersionDowngrades, null);
+    }
+
+    public ChangeParentPom(String oldGroupId, @Nullable String newGroupId, String oldArtifactId,
+                           @Nullable String newArtifactId, String newVersion,
+                           @Nullable String oldRelativePath, @Nullable String newRelativePath,
+                           @Nullable String versionPattern, @Nullable Boolean allowVersionDowngrades,
+                           @Nullable List<String> except) {
+        this.oldGroupId = oldGroupId;
+        this.newGroupId = newGroupId;
+        this.oldArtifactId = oldArtifactId;
+        this.newArtifactId = newArtifactId;
+        this.newVersion = newVersion;
+        this.oldRelativePath = oldRelativePath;
+        this.newRelativePath = newRelativePath;
+        this.versionPattern = versionPattern;
+        this.allowVersionDowngrades = allowVersionDowngrades;
+        this.except = except;
+    }
 
     @Override
     public String getDisplayName() {
@@ -241,7 +275,7 @@ public class ChangeParentPom extends Recipe {
                                     doAfterVisit(visitor);
                                 }
                                 maybeUpdateModel();
-                                doAfterVisit(new RemoveRedundantDependencyVersions(null, null, GTE, null).getVisitor());
+                                doAfterVisit(new RemoveRedundantDependencyVersions(null, null, GTE, except).getVisitor());
                             }
                         } catch (MavenDownloadingException e) {
                             for (Map.Entry<MavenRepository, String> repositoryResponse : e.getRepositoryResponses().entrySet()) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
@@ -15,12 +15,15 @@
  */
 package org.openrewrite.maven;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.semver.Semver;
+
+import java.util.List;
 
 @Getter
 @Value
@@ -56,6 +59,13 @@ public class UpgradeParentVersion extends Recipe {
     @Nullable
     Boolean onlyExternal;
 
+    @Option(displayName = "Except",
+            description = "Accepts a list of GAVs that is passed to RemoveRedundantDependencyVersions recipe via ChangeParentPom.",
+            example = "com.jcraft:jsch",
+            required = false)
+    @Nullable
+    List<String> except;
+
     @Override
     public String getDisplayName() {
         return "Upgrade Maven parent project version";
@@ -70,6 +80,23 @@ public class UpgradeParentVersion extends Recipe {
     public String getDescription() {
         return "Set the parent pom version number according to a [version selector](https://docs.openrewrite.org/reference/dependency-version-selectors) " +
                "or to a specific version number.";
+    }
+
+    @JsonCreator
+    public UpgradeParentVersion(String groupId, String artifactId, String newVersion,
+                                   @Nullable String versionPattern, @Nullable Boolean onlyExternal) {
+        this(groupId, artifactId, newVersion, versionPattern, onlyExternal, null);
+    }
+
+    public UpgradeParentVersion(String groupId, String artifactId, String newVersion,
+                                   @Nullable String versionPattern, @Nullable Boolean onlyExternal,
+                                   @Nullable List<String> except) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.newVersion = newVersion;
+        this.versionPattern = versionPattern;
+        this.onlyExternal = onlyExternal;
+        this.except = except;
     }
 
     @Override
@@ -89,6 +116,6 @@ public class UpgradeParentVersion extends Recipe {
 
     private ChangeParentPom changeParentPom() {
         return new ChangeParentPom(groupId, null, artifactId, null, newVersion, Boolean.TRUE.equals(onlyExternal) ? "" : null, null,
-                versionPattern, false);
+                versionPattern, false, except);
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -25,6 +25,8 @@ import org.openrewrite.Issue;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.List;
+
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -1783,4 +1783,77 @@ class ChangeParentPomTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void changeParentWithExceptDependencies() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeParentPom(
+            "org.springframework.boot",
+            "org.springframework.boot",
+            "spring-boot-starter-parent",
+            "spring-boot-starter-parent",
+            "2.7.18",
+            null,
+            null,
+            null,
+            false,
+            List.of("com.fasterxml.jackson.core:jackson-annotations")
+          )),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>2.7.17</version>
+                </parent>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1.0.0</version>
+                <dependencies>
+                  <!-- This dependency is in except list and should keep its version -->
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                    <version>2.13.5</version>
+                  </dependency>
+                  <!-- This dependency is not in except list and should have version removed -->
+                  <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                    <version>5.3.23</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>2.7.18</version>
+                </parent>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1.0.0</version>
+                <dependencies>
+                  <!-- This dependency is in except list and should keep its version -->
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                    <version>2.13.5</version>
+                  </dependency>
+                  <!-- This dependency is not in except list and should have version removed -->
+                  <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
@@ -297,4 +297,79 @@ class UpgradeParentVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/5796")
+    @Test
+    void upgradeVersionWithDependencyExclusion() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeParentVersion(
+            "org.springframework.boot",
+            "spring-boot-starter-parent",
+            "1.5.22.RELEASE",
+            null,
+            null,
+            List.of("org.projectlombok:lombok")
+          )),
+          pomXml(
+            """
+              <project>
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>1.5.12.RELEASE</version>
+                  <relativePath/> <!-- lookup parent from repository -->
+                </parent>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                    <version>2.7.8</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                    <version>1.16.18</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                    <version>1.3.03</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>1.5.22.RELEASE</version>
+                  <relativePath/> <!-- lookup parent from repository -->
+                </parent>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                  </dependency>
+                  <dependency>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                    <version>1.16.18</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
The UpgradeParentVersion recipe accepts the except parameter and passes it to ChangeParentPom
The ChangeParentPom recipe passes the except parameter to RemoveRedundantDependencyVersions
Enabling provision to pass exclusion list of dependencies list to RemoveRedundantDependencyVersions while calling UpgradeParentVersion.

## What's your motivation?
This change is done to address the enhance request described in [#5796](https://github.com/openrewrite/rewrite/issues/5796)

## Anything in particular you'd like reviewers to focus on?
There is requirement to upgrade the parent version in our project and also we should not remove duplicate dependencies for some set of the dependencies. Hence this change is required to handle that situation.

### Checklist
I've added unit tests to cover the cases of passing the except parameter in UpgradeParentVersionTest and ChangeParentPomTest