### PR TITLE
Call `UnnecessaryParenthesesVisitor` on parent after `RemoveObjectsIsNull`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveObjectsIsNullTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveObjectsIsNullTest.java
@@ -230,4 +230,29 @@ class RemoveObjectsIsNullTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4031")
+    @Test
+    void unwrapReturnedBinary() {
+        rewriteRun(
+          java(
+            """            
+            import java.util.Objects;
+
+            class Foo {
+              boolean foo(Object o) {
+                return Objects.isNull(o);
+              }
+            }
+            """,
+            """            
+            class Foo {
+              boolean foo(Object o) {
+                return o == null;
+              }
+            }
+            """
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Dependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Dependency.java
@@ -23,7 +23,8 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Collections.*;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 
 @Value
 @Builder


### PR DESCRIPTION
- Fixes https://github.com/openrewrite/rewrite/issues/4031