### PR TITLE
Allow ChangeDependencyGroupIdAndArtifactId to update in a chainable way keeping the ScanningRecipe in place

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -1801,4 +1801,68 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void canChangeSameDependencyMultipleTimesInASingleRecipeRun() {
+        rewriteRun(spec -> spec.recipeFromYaml("""
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: test.recipe
+              displayName: Test Recipe
+              description: Test Recipe.
+              recipeList:
+                - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+                    oldGroupId: org.bouncycastle
+                    oldArtifactId: bcprov-jdk15on
+                    newArtifactId: bcprov-jdk15to18
+                    newVersion: latest.release
+                - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+                    oldGroupId: org.bouncycastle
+                    oldArtifactId: bcprov-jdk15to18
+                    newArtifactId: bcprov-jdk18on
+                    newVersion: latest.release
+              """,
+            "test.recipe"
+          ),
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.bouncycastle</groupId>
+                      <artifactId>bcprov-jdk15on</artifactId>
+                      <version>1.70</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """,
+              """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.bouncycastle</groupId>
+                      <artifactId>bcprov-jdk18on</artifactId>
+                      <version>1.81</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Fix cross-recipe state tracking for sequential dependency transformations

### Summary
This PR enhances the `ChangeDependencyGroupIdAndArtifactId` recipe to correctly handle sequential transformations of the same dependency within a single recipe run. The fix uses the `ExecutionContext` to pass state between different recipe scanning phases, enabling later recipe executions to detect when a dependency will already have been modified by an earlier recipe in the chain by the time this visitor receives it.

### Problem
When multiple `ChangeDependencyGroupIdAndArtifactId` recipes are chained together in a single recipe run (e.g., transforming A→B then B→C), the second recipe would fail to find and transform the dependency because it was still looking for the original coordinates rather than the updated ones from the first transformation.

### Solution
The implementation now leverages the `ExecutionContext` to store transformation state between recipe scanning phases:

1. **Scanning Phase**: During the initial scanning phase, each recipe records which dependencies it will transform in the `ExecutionContext`
2. **State Tracking**: This context is passed between different recipe runs, allowing subsequent recipes to check if a dependency tag will be modified by an earlier recipe

### Changes
#### ChangeDependencyGroupIdAndArtifactId.java
- Added `ExecutionContext` state management to track transformations across recipe executions
- Implemented logic to detect and handle dependencies that have been modified by earlier recipes in the chain
- Ensures proper coordination between scanning and visitation phases
- Cleaned up the Accumulator a bit to use the same object.

#### ChangeDependencyGroupIdAndArtifactIdTest.java  
- Added comprehensive test `canChangeSameDependencyMultipleTimesInASingleRecipeRun()` that validates a sequential transformation of bouncycastle dependencies: `bcprov-jdk15on` → `bcprov-jdk15to18` → `bcprov-jdk18on`

### Technical Details
The `ExecutionContext` serves as a communication channel between recipe phases, storing metadata about planned transformations. This allows the recipe framework to maintain awareness of in-flight changes, ensuring that subsequent recipes in a chain operate on the most current state rather than the original document state. Note that this is not the change that I originally intended / am very happy with, but other attempts to use cursor messages etc have all proved not to be working. 

### Testing
- New test validates complex transformation chains work correctly
- Ensures recipes can handle both single transformations and sequential multi-step transformations
- All existing tests continue to pass, confirming backward compatibility