### PR TITLE
Exclude ibm `icu4j` from antlr

### DIFF
--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -37,7 +37,9 @@ dependencies {
     api("io.micrometer:micrometer-core:1.9.+")
     api("org.jetbrains:annotations:latest.release")
 
-    antlrGeneration("org.antlr:antlr4:4.13.2")
+    antlrGeneration("org.antlr:antlr4:4.13.2") {
+        exclude(group = "com.ibm.icu", module = "icu4j")
+    }
     implementation("org.antlr:antlr4-runtime:4.13.2")
     // Pinned to 9.+ because 10.x does not support Java 8: https://checkstyle.sourceforge.io/#JRE_and_JDK
     checkstyle("com.puppycrawl.tools:checkstyle:9.+") {

--- a/rewrite-protobuf/build.gradle.kts
+++ b/rewrite-protobuf/build.gradle.kts
@@ -25,7 +25,9 @@ dependencies {
 
     compileOnly(project(":rewrite-test"))
 
-    antlrGeneration("org.antlr:antlr4:4.13.2")
+    antlrGeneration("org.antlr:antlr4:4.13.2"){
+        exclude(group = "com.ibm.icu", module = "icu4j")
+    }
     implementation("org.antlr:antlr4-runtime:4.13.2")
     implementation("io.micrometer:micrometer-core:1.9.+")
 

--- a/rewrite-toml/build.gradle.kts
+++ b/rewrite-toml/build.gradle.kts
@@ -23,7 +23,9 @@ dependencies {
     implementation("org.antlr:antlr4-runtime:4.13.2")
     implementation("io.micrometer:micrometer-core:1.9.+")
 
-    antlrGeneration("org.antlr:antlr4:4.13.2")
+    antlrGeneration("org.antlr:antlr4:4.13.2"){
+        exclude(group = "com.ibm.icu", module = "icu4j")
+    }
 
     compileOnly(project(":rewrite-test"))
 

--- a/rewrite-xml/build.gradle.kts
+++ b/rewrite-xml/build.gradle.kts
@@ -25,7 +25,9 @@ dependencies {
 
     compileOnly(project(":rewrite-test"))
 
-    antlrGeneration("org.antlr:antlr4:4.13.2")
+    antlrGeneration("org.antlr:antlr4:4.13.2"){
+        exclude(group = "com.ibm.icu", module = "icu4j")
+    }
     implementation("org.antlr:antlr4-runtime:4.13.2")
     implementation("io.micrometer:micrometer-core:1.9.+")
     implementation("org.apache.commons:commons-text:1.11.+")


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Exclude ibm icu4j dependency, as it looks like we're not using the unicode support it brings to antlr

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Vulnerability reporting brought it to attention

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
We could also override the version, but it seems all versions currently available are vulnerable

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
