### PR TITLE
Support dependency Map notation for version reference in Settings

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -200,6 +200,8 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                             } else if (arg.getValue() instanceof J.Identifier) {
                                 J.Identifier value = (J.Identifier) arg.getValue();
                                 valueValue = value.getSimpleName();
+                            } else if (arg.getValue() instanceof J.FieldAccess) {
+                                valueValue = arg.getValue().printTrimmed(getCursor());
                             } else if (arg.getValue() instanceof G.GString) {
                                 G.GString value = (G.GString) arg.getValue();
                                 List<J> strings = value.getStrings();
@@ -207,6 +209,8 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                     G.GString.Value versionGStringValue = (G.GString.Value) strings.get(0);
                                     if (versionGStringValue.getTree() instanceof J.Identifier) {
                                         valueValue = ((J.Identifier) versionGStringValue.getTree()).getSimpleName();
+                                    } else if (versionGStringValue.getTree() instanceof J.FieldAccess) {
+                                        valueValue = versionGStringValue.getTree().printTrimmed(getCursor());
                                     }
                                 }
                             }
@@ -454,11 +458,13 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         artifactValue = ((J.Assignment) depArgs.get(1)).getAssignment();
                         versionExp = ((J.Assignment) depArgs.get(2)).getAssignment();
                     }
-                    if (groupValue instanceof J.Literal && artifactValue instanceof J.Literal && versionExp instanceof J.Identifier) {
+                    if (groupValue instanceof J.Literal && artifactValue instanceof J.Literal && (versionExp instanceof J.Identifier || versionExp instanceof J.FieldAccess)) {
                         J.Literal groupLiteral = (J.Literal) groupValue;
                         J.Literal artifactLiteral = (J.Literal) artifactValue;
                         if (groupLiteral.getValue() instanceof String && artifactLiteral.getValue() instanceof String && shouldResolveVersion((String) groupLiteral.getValue(), (String) artifactLiteral.getValue())) {
-                            String versionVariableName = ((J.Identifier) versionExp).getSimpleName();
+                            String versionVariableName = versionExp instanceof J.Identifier ?
+                                    ((J.Identifier) versionExp).getSimpleName() :
+                                    (versionExp).printTrimmed(getCursor());
                             acc.variableNames.computeIfAbsent(versionVariableName, it -> new HashMap<>())
                                     .computeIfAbsent(new GroupArtifact((String) groupLiteral.getValue(), (String) artifactLiteral.getValue()), it -> new HashSet<>())
                                     .add(method.getSimpleName());
@@ -624,6 +630,10 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                             return a;
                         }
                         Map<GroupArtifact, Set<String>> groupArtifactSetMap = acc.versionPropNameToGA.get("gradle." + a.getVariable());
+                        // Guard to ensure that an unsupported notation doesn't throw an exception
+                        if (groupArtifactSetMap == null) {
+                            return a;
+                        }
                         GroupArtifact ga = groupArtifactSetMap.entrySet().stream().findFirst().map(Map.Entry::getKey).orElse(null);
                         if (ga == null) {
                             return a;

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -1953,8 +1953,14 @@ class UpgradeDependencyVersionTest implements RewriteTest {
         );
     }
 
-    @Test
-    void upgradeVersionInSettingsGradleExt() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "\"com.fasterxml.jackson.core:jackson-databind:${gradle.jackson}\"",
+      "group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: gradle.jackson",
+      "group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: \"$gradle.jackson\"",
+      "group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: \"${gradle.jackson}\""
+    })
+    void upgradeVersionInSettingsGradleExt(String dependencyNotation) {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyVersion("com.fasterxml.jackson.core", "jackson-databind", "2.15.0", null)),
           settingsGradle(
@@ -1980,9 +1986,9 @@ class UpgradeDependencyVersionTest implements RewriteTest {
               }
 
               dependencies {
-                  implementation "com.fasterxml.jackson.core:jackson-databind:${gradle.jackson}"
+                  implementation %s
               }
-              """
+              """.formatted(dependencyNotation)
           )
         );
     }


### PR DESCRIPTION
## What's changed?

The UpgradeDependencyVersion recipe needs to support the Map notation in different variations when referencing a version from the Settings file.

- `group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: gradle.jackson`
- `group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "$gradle.jackson"`
- `group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${gradle.jackson}"`

## What's your motivation?

The Map notation with an extra property reference from the Settings file throws the following exceptions.

```
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Map.entrySet()" because "groupArtifactSetMap" is null
	at org.openrewrite.gradle.UpgradeDependencyVersion$UpdateGradle$1.visitAssignment(UpgradeDependencyVersion.java:627)
	at org.openrewrite.gradle.UpgradeDependencyVersion$UpdateGradle$1.visitAssignment(UpgradeDependencyVersion.java:619)
	at org.openrewrite.java.tree.J$Assignment.acceptJava(J.java:509)
	at org.openrewrite.java.tree.J.accept(J.java:60)
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:245)
```

and 

```
Caused by: org.openrewrite.internal.RecipeRunException: java.lang.NullPointerException: Cannot invoke "java.util.Map.entrySet()" because "groupArtifactSetMap" is null
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:281)
	at org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:311)
	at org.openrewrite.java.JavaVisitor.visitReturn(JavaVisitor.java:1046)
	at org.openrewrite.java.JavaIsoVisitor.visitReturn(JavaIsoVisitor.java:300)
	at org.openrewrite.java.JavaIsoVisitor.visitReturn(JavaIsoVisitor.java:30)
	at org.openrewrite.java.tree.J$Return.acceptJava(J.java:5345)
	at org.openrewrite.java.tree.J.accept(J.java:60)
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:245)
```

The following PR didn't fully address the issue yet:

- https://github.com/openrewrite/rewrite/pull/5808 