### PR TITLE
Fix ClassCastException for `valueMatches` in AddOrUpdateAnnotationAttribute

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
@@ -340,7 +340,6 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
             return oldAttributeValue.equals(((J.Literal) expression).getValue());
         } else if (expression instanceof J.FieldAccess) {
             J.FieldAccess fa = (J.FieldAccess) expression;
-            // An enum in an inner class
             if (!(fa.getTarget() instanceof J.Identifier)) {
                 return oldAttributeValue.equals(fa.toString());
             }


### PR DESCRIPTION
## What's changed?
Improved check to be sure no ClassCastException can occur.

## What's your motivation?
If an Unknown typed JavaType is used as constant, a

```
Caused by: java.lang.ClassCastException: class org.openrewrite.java.tree.J$FieldAccess cannot be cast to class org.openrewrite.java.tree.J$Identifier (org.openrewrite.java.tree.J$FieldAccess and org.openrewrite.java.tree.J$Identifier are in unnamed module of loader 'app')
```

is thrown.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
