### PR TITLE
 Fix template generation to preserve statements when adding before/after coordinates

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/template/GroovyBlockStatementTemplateGenerator.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/template/GroovyBlockStatementTemplateGenerator.java
@@ -18,10 +18,7 @@ package org.openrewrite.groovy.internal.template;
 import org.openrewrite.Cursor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.java.internal.template.BlockStatementTemplateGenerator;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.*;
 
 import java.util.Collection;
 import java.util.Set;
@@ -32,17 +29,19 @@ public class GroovyBlockStatementTemplateGenerator extends BlockStatementTemplat
     }
 
     @Override
-    protected void contextFreeTemplate(Cursor cursor, J j, Collection<JavaType.GenericTypeVariable> typeVariables, StringBuilder before, StringBuilder after) {
+    protected void contextFreeTemplate(Cursor cursor, J j, Collection<JavaType.GenericTypeVariable> typeVariables, StringBuilder before, StringBuilder after, JavaCoordinates.Mode mode) {
         if (j instanceof J.MethodInvocation) {
             before.insert(0, "class Template {\n");
             JavaType.Method methodType = ((J.MethodInvocation) j).getMethodType();
-            if (methodType == null || methodType.getReturnType() != JavaType.Primitive.Void) {
+            if (mode == JavaCoordinates.Mode.REPLACEMENT && (methodType == null || methodType.getReturnType() != JavaType.Primitive.Void)) {
                 before.append("Object o = ");
             }
             after.append(";\n}");
         } else if (j instanceof Expression && !(j instanceof J.Assignment)) {
             before.insert(0, "class Template {\n");
-            before.append("Object o = ");
+            if(mode == JavaCoordinates.Mode.REPLACEMENT) {
+                before.append("Object o = ");
+            }
             after.append(";\n}");
         } else if (j instanceof J.ClassDeclaration || j instanceof G.ClassDeclaration) {
             throw new IllegalArgumentException(

--- a/rewrite-java/src/test/java/org/openrewrite/java/AddFirstStatementTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/AddFirstStatementTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.AdHocRecipe;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class AddFirstStatementTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new AdHocRecipe("Test", "Test", false, () -> new JavaIsoVisitor<>(){
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                J.MethodDeclaration md = super.visitMethodDeclaration(method, ctx);
+                if(md.getBody() != null && md.getBody().getStatements().size() == 1) {
+                    md = JavaTemplate.builder("String newLine = \"test\";")
+                      .javaParser(JavaParser.fromJavaVersion())
+                      .build()
+                      .apply(getCursor(), md.getBody().getCoordinates().firstStatement());
+                }
+                return md;
+            }
+        }, null, null));
+    }
+
+    // Without the change this test succeeds
+    @Test
+    void firstStatementIsMethodInvocationWithAssignment() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              public class Subject {
+                  @Override
+                  public void doSomething(Data o) {
+                      int r = o.get();
+                  }
+
+                  private static interface Data  {
+                      int get();
+                  }
+              }
+              """,
+            """
+              public class Subject {
+                  @Override
+                  public void doSomething(Data o) {
+                      String newLine = "test";
+                      int r = o.get();
+                  }
+              
+                  private static interface Data  {
+                      int get();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    // Without the change this test fails
+    // The reason is that the new statement is an assignment:
+    // String newLine = "test";
+    // The javacoordinates are at md.getBody().getCoordinates().firstStatement():
+    // o.get();
+    // The template does not know what you want to do at this point. You might want to replace the method invocation with a constant "123" which would result in invalid code.
+    // The template will automatically prefix the statement with "Object o = " to make sure the code compiles.
+    // This is correct when replacing the statement, the end result would be:
+    // Object o = "123";
+    // In this case we are not replacing the statement, but prepending it. Because the block generator had no information about the mode, it would still apply the prefix:
+    // Object o = String newLine = "test";
+    // The fix to add the mode makes sure that when not replacing, the provided template should be valid in itself, so no modification is required.
+    @Test
+    void firstStatementIsMethodInvocationWithReturnTypeWithoutAssignment() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              public class Subject {
+                  @Override
+                  public void doSomething(Data o) {
+                      o.get();
+                  }
+
+                  private static interface Data  {
+                      int get();
+                  }
+              }
+              """,
+            """
+              public class Subject {
+                  @Override
+                  public void doSomething(Data o) {
+                      String newLine = "test";
+                      o.get();
+                  }
+              
+                  private static interface Data  {
+                      int get();
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinBlockStatementTemplateGenerator.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinBlockStatementTemplateGenerator.java
@@ -17,10 +17,7 @@ package org.openrewrite.kotlin.internal.template;
 
 import org.openrewrite.Cursor;
 import org.openrewrite.java.internal.template.BlockStatementTemplateGenerator;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.*;
 import org.openrewrite.kotlin.tree.K;
 
 import java.util.Collection;
@@ -32,17 +29,19 @@ public class KotlinBlockStatementTemplateGenerator extends BlockStatementTemplat
     }
 
     @Override
-    protected void contextFreeTemplate(Cursor cursor, J j, Collection<JavaType.GenericTypeVariable> typeVariables, StringBuilder before, StringBuilder after) {
+    protected void contextFreeTemplate(Cursor cursor, J j, Collection<JavaType.GenericTypeVariable> typeVariables, StringBuilder before, StringBuilder after, JavaCoordinates.Mode mode) {
         if (j instanceof J.MethodInvocation) {
             before.insert(0, "class Template {\n");
             JavaType.Method methodType = ((J.MethodInvocation) j).getMethodType();
-            if (methodType == null || methodType.getReturnType() != JavaType.Primitive.Void) {
+            if (mode == JavaCoordinates.Mode.REPLACEMENT && (methodType == null || methodType.getReturnType() != JavaType.Primitive.Void)) {
                 before.append("var o : Any = ");
             }
             after.append(";\n}");
         } else if (j instanceof Expression && !(j instanceof J.Assignment)) {
             before.insert(0, "class Template {\n");
-            before.append("var o : Any = ");
+            if(mode == JavaCoordinates.Mode.REPLACEMENT) {
+                before.append("var o : Any = ");
+            }
             after.append(";\n}");
         } else if (j instanceof J.ClassDeclaration || j instanceof K.ClassDeclaration) {
             throw new IllegalArgumentException(


### PR DESCRIPTION
## What's changed?
This PR fixes an issue where the template generator incorrectly modified statements when using JavaCoordinates to add statements before or after existing code, rather than replacing them.

## What's your motivation?
When using JavaTemplate to add a statement before an existing method invocation (e.g., using `firstStatement()` coordinates), the template generator would incorrectly prefix the new statement with variable declarations like `Object o =`. This happened because the generator didn't distinguish between REPLACEMENT mode (where such prefixes ensure valid compilation) and addition modes (BEFORE/AFTER) where the statement should remain unmodified.

For example, when adding `String newLine = "test";` before `o.get();`, the generator would produce the invalid statement: `Object o = String newLine = "test";`

Solution

- Added the JavaCoordinates.Mode parameter to the contextFreeTemplate method signature
- Modified template generation logic to only add variable declaration prefixes when in REPLACEMENT mode
- Applied the fix consistently across Java, Groovy, and Kotlin template generators

