### PR TITLE
Prevent version downgrade in Settings file referenced by buildscript

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -2034,7 +2034,7 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @Test
-    void doesNotDowngradeVersionInSettingsGradleExt() {
+    void doesNotDowngradeRegularDependencyVersionInSettingsGradleExt() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyVersion("com.fasterxml.jackson.core", "jackson-databind", "2.13.2", null)),
           settingsGradle(
@@ -2056,6 +2056,32 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     
               dependencies {
                   implementation "com.fasterxml.jackson.core:jackson-databind:${gradle.jackson}"
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotDowngradeBuildscriptDependencyVersionInSettingsGradleExt() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("com.fasterxml.jackson.core", "jackson-databind", "2.13.2", null)),
+          settingsGradle(
+            """
+              gradle.ext {
+                  jackson = '2.13.3'
+              }
+              """
+          ),
+          buildGradle(
+            """
+              buildscript {
+                  repositories {
+                      mavenCentral()
+                  }
+                  dependencies {
+                      classpath "com.fasterxml.jackson.core:jackson-databind:${gradle.jackson}"
+                  }
               }
               """
           )


### PR DESCRIPTION
## What's changed?

Prevents the downgrade of a dependency version defined in Settings file by the org.openrewrite.gradle.UpgradeDependencyVersion recipe if referenced from `buildscript` via extra property.

## What's your motivation?

Given the following build script:

```
buildscript {
    repositories {
        mavenCentral()
    }
    dependencies {
        classpath "com.fasterxml.jackson.core:jackson-databind:${gradle.jackson}"
    }
}
```

and the settings file with the following contents:

```
gradle.ext {
    jackson = '2.13.3'
}
```

A run of the org.openrewrite.gradle.UpgradeDependencyVersion with a lower version

```
$ mod run . --recipe org.openrewrite.gradle.UpgradeDependencyVersion --recipe-option "groupId=com.fasterxml.jackson.core" --recipe-option "artifactId=jackson-databind" --recipe-option "newVersion=2.13.2"
```

should not downgrade the version. The recipe should only perform a version upgrade.

```
diff --git a/settings.gradle b/settings.gradle
index 36269c7..56944a6 100644
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@ org.openrewrite.java.dependencies.UpgradeDependencyVersion
 gradle.ext {
-  jackson = '2.13.3'
+  jackson = '2.13.2'
 }
\ No newline at end of file
```