### PR TITLE
Allow `AddOrUpdateAnnotationAttribute` to be chained after `ChangeType` and other recipes that produce shallow types

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -2324,6 +2324,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/pull/5918")
     @Test
     void attributeWithShallowType() {
         rewriteRun(
@@ -2340,15 +2341,15 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           java(
             """
               package org.example;
-              public @interface Foo {
-                  boolean required();
+              public @interface Bar {
               }
               """
           ),
           java(
             """
               package org.example;
-              public @interface Bar {
+              public @interface Foo {
+                  boolean required();
               }
               """
           ),

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
@@ -98,8 +98,8 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
             @Override
             public J.Annotation visitAnnotation(J.Annotation original, ExecutionContext ctx) {
                 J.Annotation a = super.visitAnnotation(original, ctx);
-                if (!TypeUtils.isOfClassType(a.getType(), annotationType)
-                        || !(a.getType() instanceof JavaType.ShallowClass || findMethod(a, attributeName()).isPresent())) {
+                if (!TypeUtils.isOfClassType(a.getType(), annotationType) ||
+                        !(a.getType() instanceof JavaType.ShallowClass || findMethod(a, attributeName()).isPresent())) {
                     return a;
                 }
 


### PR DESCRIPTION
If annotation type is `ShallowClass` without methods a product of a type change from a previous recipe than `AddOrUpdateAnnotationAttribute` recipe doesn't add/change the attribute