### PR TITLE
Upgrade annotation processor versions in Maven when using UpgradeDependencyVersion

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -2103,4 +2103,27 @@ class UpgradeDependencyVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void upgradeAnnotationProcessors() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.mapstruct", "mapstruct*", "1.6.x", null)),
+          //language=groovy
+          buildGradle(
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+              dependencies {
+                  implementation 'org.mapstruct:mapstruct:1.4.1.Final'
+                  annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.1.Final'
+              }
+              """,
+            spec -> spec.after(actual ->
+              assertThat(actual)
+                .doesNotContain("1.4.1.Final")
+                .containsPattern("1.6.\\d+(.\\d+)?")
+                .actual())
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -45,6 +45,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     static final XPathMatcher PROFILE_MANAGED_DEPENDENCY_MATCHER = new XPathMatcher("/project/profiles/profile/dependencyManagement/dependencies/dependency");
     static final XPathMatcher PROPERTY_MATCHER = new XPathMatcher("/project/properties/*");
     static final XPathMatcher PLUGIN_MATCHER = new XPathMatcher("//plugins/plugin");
+    static final XPathMatcher ANNOTATION_PROCESSORS_PATH_MATCHER = new XPathMatcher("//annotationProcessorPaths/path");
     static final XPathMatcher MANAGED_PLUGIN_MATCHER = new XPathMatcher("//pluginManagement/plugins/plugin");
     static final XPathMatcher PARENT_MATCHER = new XPathMatcher("/project/parent");
     static final XPathMatcher PROJECT_MATCHER = new XPathMatcher("/project");
@@ -277,7 +278,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
         return isTag("project") && PROJECT_MATCHER.matches(getCursor());
     }
 
-    private boolean isTag(String name) {
+    protected boolean isTag(String name) {
         // `XPathMatcher` is still a bit expensive
         return getCursor().getValue() instanceof Xml.Tag && name.equals(getCursor().<Xml.Tag>getValue().getName());
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -225,8 +225,8 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                 maybeUpdateModel();
                             }
                         }
-                    } else if (isPluginDependencyTag(groupId, artifactId)) {
-                        t = upgradePluginDependency(ctx, t);
+                    } else if (isPluginDependencyTag(groupId, artifactId) || isAnnotationProcessorPathTag(groupId, artifactId)) {
+                        t = upgradeTag(ctx, t);
                     }
                 } catch (MavenDownloadingException e) {
                     return e.warn(t);
@@ -329,7 +329,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 return null;
             }
 
-            private Xml.Tag upgradePluginDependency(ExecutionContext ctx, Xml.Tag t) throws MavenDownloadingException {
+            private Xml.Tag upgradeTag(ExecutionContext ctx, Xml.Tag t) throws MavenDownloadingException {
                 String groupId = t.getChildValue("groupId").orElse(null);
                 String artifactId = t.getChildValue("artifactId").orElse(null);
                 String version = t.getChildValue("version").orElse(null);
@@ -372,6 +372,15 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                     throws MavenDownloadingException {
                 return MavenDependency.findNewerVersion(groupId, artifactId, version, getResolutionResult(), metadataFailures,
                         versionComparator, ctx);
+            }
+
+            public boolean isAnnotationProcessorPathTag(String groupId, String artifactId) {
+                if (!isTag("path") || !ANNOTATION_PROCESSORS_PATH_MATCHER.matches(getCursor())) {
+                    return false;
+                }
+                Xml.Tag tag = getCursor().getValue();
+                return matchesGlob(tag.getChildValue("groupId").orElse(null), groupId) &&
+                        matchesGlob(tag.getChildValue("artifactId").orElse(null), artifactId);
             }
         };
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -631,6 +631,94 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @Test
+    void upgradeAnnotationProcessors() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.mapstruct", "mapstruct*", "1.6.x", null, null, null)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.mapstruct</groupId>
+                        <artifactId>mapstruct</artifactId>
+                        <version>1.4.1.Final</version>
+                    </dependency>
+                </dependencies>
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <version>3.8.1</version>
+                      <configuration>
+                        <annotationProcessorPaths>
+                          <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.4.1.Final</version>
+                          </path>
+                        </annotationProcessorPaths>
+                      </configuration>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """,
+            spec -> spec.after(actual ->
+              assertThat(actual)
+                .doesNotContain("1.4.1.Final")
+                .containsPattern("<version>1.6.\\d+(.\\d+)?</version>")
+                .actual())
+          )
+        );
+    }
+
+    @Test
+    void upgradeAnnotationProcessorsVersionProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.mapstruct", "mapstruct*", "1.6.x", null, null, null)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <properties>
+                    <org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
+                </properties>
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <version>3.8.1</version>
+                      <configuration>
+                        <annotationProcessorPaths>
+                          <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${org.mapstruct.version}</version>
+                          </path>
+                        </annotationProcessorPaths>
+                      </configuration>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """,
+            spec -> spec.after(actual ->
+              assertThat(actual)
+                .doesNotContain("1.4.1.Final")
+                .containsPattern("<org.mapstruct.version>1.6.\\d+(.\\d+)?</org.mapstruct.version>")
+                .actual())
+          )
+        );
+    }
+
+    @Test
     void upgradePluginDependenciesOnProperty() {
         rewriteRun(
           // Using latest.patch to validate the version property resolution, since it's needed for matching the valid patch.


### PR DESCRIPTION
## Summary

This PR extends Maven's `UpgradeDependencyVersion` recipe to automatically upgrade annotation processor versions in Maven's `<annotationProcessorPaths>` configuration, bringing Maven's behavior in line with how Gradle already handles annotation processor upgrades.

## Problem

Previously, when using `UpgradeDependencyVersion` to upgrade dependencies like MapStruct, the recipe would upgrade:
- Regular dependencies in `<dependencies>`
- Plugin dependencies in `<plugin><dependencies>`
- Gradle annotation processors

However, it would **not** upgrade Maven annotation processors defined in:
```xml
<annotationProcessorPaths>
  <path>
    <groupId>org.mapstruct</groupId>
    <artifactId>mapstruct-processor</artifactId>
    <version>1.4.1.Final</version>
  </path>
</annotationProcessorPaths>
```

This inconsistency meant that users had to manually update annotation processor versions in Maven projects, even when using automated dependency upgrade recipes.

## Solution

This change treats Maven's `<annotationProcessorPaths><path>` elements similarly to plugin dependencies, ensuring they are upgraded alongside regular dependencies. The implementation:

1. Adds detection for annotation processor path tags using a new `ANNOTATION_PROCESSORS_PATH_MATCHER`
2. Reuses the existing upgrade logic (renamed from `upgradePluginDependency` to `upgradeTag`) for both plugin dependencies and annotation processor paths
3. Properly handles version properties used in annotation processor declarations

## Testing

Added comprehensive tests demonstrating:
- Direct version upgrades in annotation processor paths
- Version property resolution for annotation processors
- Verification that Gradle variant of the recipe at the moment does the same thing.

## Impact

This ensures consistent dependency management across build systems, eliminating the need for manual intervention when upgrading libraries that include annotation processors (like MapStruct, Lombok, etc.).

## References

- Related discussion: https://github.com/openrewrite/rewrite-migrate-java/pull/818#issuecomment-3196376207