### PR TITLE
Write Gradle Wrapper scripts with UTF-8 encoding

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -39,6 +39,7 @@ import org.openrewrite.semver.VersionComparator;
 import org.openrewrite.text.PlainText;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.*;
 
@@ -330,6 +331,7 @@ public class UpdateGradleWrapper extends ScanningRecipe<UpdateGradleWrapper.Grad
                     .text(gradlewText)
                     .sourcePath(WRAPPER_SCRIPT_LOCATION)
                     .fileAttributes(wrapperScriptAttributes)
+                    .charsetName(StandardCharsets.UTF_8.name())
                     .build();
             gradleWrapperFiles.add(gradlew);
         }
@@ -340,6 +342,7 @@ public class UpdateGradleWrapper extends ScanningRecipe<UpdateGradleWrapper.Grad
                     .text(gradlewBatText)
                     .sourcePath(WRAPPER_BATCH_LOCATION)
                     .fileAttributes(wrapperScriptAttributes)
+                    .charsetName(StandardCharsets.UTF_8.name())
                     .build();
             gradleWrapperFiles.add(gradlewBat);
         }
@@ -389,7 +392,7 @@ public class UpdateGradleWrapper extends ScanningRecipe<UpdateGradleWrapper.Grad
                     String gradlewText = unixScript(gradleWrapper, ctx);
                     PlainText gradlew = (PlainText) setExecutable(sourceFile);
                     if (!gradlewText.equals(gradlew.getText())) {
-                        gradlew = gradlew.withText(gradlewText);
+                        gradlew = (PlainText) gradlew.withText(gradlewText).withCharset(StandardCharsets.UTF_8);
                     }
                     return gradlew;
                 }
@@ -397,7 +400,7 @@ public class UpdateGradleWrapper extends ScanningRecipe<UpdateGradleWrapper.Grad
                     String gradlewBatText = batchScript(gradleWrapper, ctx);
                     PlainText gradlewBat = (PlainText) setExecutable(sourceFile);
                     if (!gradlewBatText.equals(gradlewBat.getText())) {
-                        gradlewBat = gradlewBat.withText(gradlewBatText);
+                        gradlewBat = (PlainText) gradlewBat.withText(gradlewBatText).withCharset(StandardCharsets.UTF_8);
                     }
                     return gradlewBat;
                 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -79,6 +79,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
                 var gradleSh = result(run, PlainText.class, "gradlew");
                 assertThat(gradleSh.getSourcePath()).isEqualTo(WRAPPER_SCRIPT_LOCATION);
                 assertThat(gradleSh.getText()).isEqualTo(GRADLEW_TEXT);
+                assertThat(gradleSh.getCharset().name()).isEqualTo("UTF-8");
                 //noinspection DataFlowIssue
                 assertThat(gradleSh.getFileAttributes()).isNotNull();
                 assertThat(gradleSh.getFileAttributes().isReadable()).isTrue();
@@ -87,6 +88,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
                 var gradleBat = result(run, PlainText.class, "gradlew.bat");
                 assertThat(gradleBat.getSourcePath()).isEqualTo(WRAPPER_BATCH_LOCATION);
                 assertThat(gradleBat.getText()).isEqualTo(GRADLEW_BAT_TEXT);
+                assertThat(gradleBat.getCharset().name()).isEqualTo("UTF-8");
 
                 var gradleWrapperJar = result(run, RemoteArchive.class, "gradle-wrapper.jar");
                 assertThat(gradleWrapperJar.getSourcePath()).isEqualTo(WRAPPER_JAR_LOCATION);
@@ -131,6 +133,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
               var gradleSh = result(run, PlainText.class, "gradlew");
               assertThat(gradleSh.getSourcePath()).isEqualTo(WRAPPER_SCRIPT_LOCATION);
               assertThat(gradleSh.getText()).isEqualTo(GRADLEW_TEXT);
+              assertThat(gradleSh.getCharset().name()).isEqualTo("UTF-8");
               //noinspection DataFlowIssue
               assertThat(gradleSh.getFileAttributes()).isNotNull();
               assertThat(gradleSh.getFileAttributes().isReadable()).isTrue();
@@ -139,6 +142,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
               var gradleBat = result(run, PlainText.class, "gradlew.bat");
               assertThat(gradleBat.getSourcePath()).isEqualTo(WRAPPER_BATCH_LOCATION);
               assertThat(gradleBat.getText()).isEqualTo(GRADLEW_BAT_TEXT);
+              assertThat(gradleBat.getCharset().name()).isEqualTo("UTF-8");
 
               var gradleWrapperProperties = result(run, Properties.File.class, "gradle-wrapper.properties");
               assertThat(gradleWrapperProperties.getSourcePath()).isEqualTo(WRAPPER_PROPERTIES_LOCATION);


### PR DESCRIPTION
## What's changed?

Set the encoding when writing the Gradle Wrapper scripts to UTF-8.

## What's your motivation?

Allow for properly encoding special characters used in the scripts.

## Anyone you would like to review specifically?

@shanman190 