### PR TITLE
Simplify `Environment#scanJar()`

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/config/ClasspathScanningLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/ClasspathScanningLoaderTest.java
@@ -36,6 +36,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ClasspathScanningLoaderTest {
@@ -61,7 +62,7 @@ class ClasspathScanningLoaderTest {
         );
 
         Environment fullEnv = Environment.builder()
-          .scanJar(concreteJar, emptyList(), fullClassLoader)
+          .scanJar(concreteJar, singletonList(coreJar), fullClassLoader)
           .build();
 
         assertThat(fullEnv.listRecipes()).hasSize(1);

--- a/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -150,7 +149,7 @@ public class RecipeSpec {
 
     private static Recipe recipeFromInputStream(InputStream yaml, String... activeRecipes) {
         return Environment.builder()
-                .load(new YamlResourceLoader(yaml, URI.create("rewrite.yml"), new Properties(), null, emptyList(),
+                .load(new YamlResourceLoader(yaml, URI.create("rewrite.yml"), new Properties(), null, null,
                         mapper -> mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)))
                 .build()
                 .activateRecipes(activeRecipes);


### PR DESCRIPTION
The logic of `Environment#scanJar()` was quite convoluted with a lot of delegate resource loaders. This is now drastically simplified.