### PR TITLE
Make sure `Attributed#getAttributes()` does not return `null`

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleDependencyConfiguration.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleDependencyConfiguration.java
@@ -141,6 +141,7 @@ public class GradleDependencyConfiguration implements Serializable, Attributed {
     @Nullable // TO-BE-REMOVED(2025-12-31) This annotation and the explicit getter below can be removed in the future
     Map<String, String> attributes;
 
+    @Override
     public Map<String, String> getAttributes() {
         return attributes != null ? attributes : emptyMap();
     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleDependencyConfiguration.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleDependencyConfiguration.java
@@ -138,7 +138,7 @@ public class GradleDependencyConfiguration implements Serializable, Attributed {
     @NonFinal
     List<GradleDependencyConstraint> constraints;
 
-    @Nullable
+    @Nullable // TO-BE-REMOVED(2025-12-31) This annotation and the explicit getter below can be removed in the future
     Map<String, String> attributes;
 
     public Map<String, String> getAttributes() {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleDependencyConfiguration.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleDependencyConfiguration.java
@@ -138,7 +138,12 @@ public class GradleDependencyConfiguration implements Serializable, Attributed {
     @NonFinal
     List<GradleDependencyConstraint> constraints;
 
+    @Nullable
     Map<String, String> attributes;
+
+    public Map<String, String> getAttributes() {
+        return attributes != null ? attributes : emptyMap();
+    }
 
     /**
      * When the current list of directResolved dependencies may have been invalidated by a mutation this stores the

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Dependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Dependency.java
@@ -54,6 +54,7 @@ public class Dependency implements Serializable, Attributed {
     @Nullable // TO-BE-REMOVED(2025-12-31) This annotation and the explicit getter below can be removed in the future
     Map<String, String> attributes = emptyMap();
 
+    @Override
     public Map<String, String> getAttributes() {
         return attributes != null ? attributes : emptyMap();
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Dependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Dependency.java
@@ -51,7 +51,7 @@ public class Dependency implements Serializable, Attributed {
     String optional;
 
     @Builder.Default
-    @Nullable
+    @Nullable // TO-BE-REMOVED(2025-12-31) This annotation and the explicit getter below can be removed in the future
     Map<String, String> attributes = emptyMap();
 
     public Map<String, String> getAttributes() {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Dependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Dependency.java
@@ -51,7 +51,12 @@ public class Dependency implements Serializable, Attributed {
     String optional;
 
     @Builder.Default
+    @Nullable
     Map<String, String> attributes = emptyMap();
+
+    public Map<String, String> getAttributes() {
+        return attributes != null ? attributes : emptyMap();
+    }
 
     public @Nullable String getGroupId() {
         return gav.getGroupId();


### PR DESCRIPTION
This is required for existing models, which haven't been updated yet since this feature was added.

```
java.lang.NullPointerException: Cannot invoke "java.util.Map.get(Object)" because the return value of "org.openrewrite.maven.attributes.Attributed.getAttributes()" is null
  org.openrewrite.maven.attributes.Attributed.findAttribute(Attributed.java:40)
  org.openrewrite.gradle.marker.GradleDependencyConfiguration$LazyResolutionContext.resolve(GradleDependencyConfiguration.java:185)
  org.openrewrite.gradle.marker.GradleDependencyConfiguration.getDirectResolved(GradleDependencyConfiguration.java:103)
  org.openrewrite.gradle.marker.GradleDependencyConfiguration.getResolved(GradleDependencyConfiguration.java:112)
  org.openrewrite.gradle.trait.GradleDependency$Matcher.test(GradleDependency.java:154)
  org.openrewrite.gradle.trait.GradleDependency$Matcher.test(GradleDependency.java:54)
  org.openrewrite.trait.SimpleTraitMatcher.get(SimpleTraitMatcher.java:33)
  org.openrewrite.gradle.ChangeDependency$1.visitMethodInvocation(ChangeDependency.java:216)
  org.openrewrite.gradle.ChangeDependency$1.visitMethodInvocation(ChangeDependency.java:174)
  org.openrewrite.java.tree.J$MethodInvocation.acceptJava(J.java:4290)
  org.openrewrite.java.tree.J.accept(J.java:60)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:245)
  org.openrewrite.gradle.ChangeDependency$1.visit(ChangeDependency.java:205)
  org.openrewrite.gradle.ChangeDependency$1.visit(ChangeDependency.java:174)
  org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:311)
  org.openrewrite.java.JavaVisitor.visitRightPadded(JavaVisitor.java:1310)
  ...
```