### PR TITLE
Extending `AddCommentToMethodInvocations` to handle constructors as well

### DIFF
--- a/rewrite-java/src/test/java/org/openrewrite/java/AddCommentToMethodInvocationsTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/AddCommentToMethodInvocationsTest.java
@@ -33,6 +33,7 @@ class AddCommentToMethodInvocationsTest implements RewriteTest {
           """
             package foo;
             public class Foo {
+                public Foo(String a) {}
                 public void bar(String arg) {}
                 public boolean gar() {
                     return true;
@@ -217,6 +218,34 @@ class AddCommentToMethodInvocationsTest implements RewriteTest {
                   void method(Foo foo) {
                       /* this is a * terrible idea */
                       foo.bar("a");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void handleNewClass() {
+        rewriteRun(
+          spec -> spec.recipe(new AddCommentToMethodInvocations("commenting on a new class", "foo.Foo <constructor>(..)")),
+          //language=java
+          java(
+            """
+              import foo.Foo;
+              
+              class Other {
+                  void method() {
+                      Foo foo = new Foo("hi");
+                  }
+              }
+              """,
+            """
+              import foo.Foo;
+              
+              class Other {
+                  void method() {
+                      Foo foo = /* commenting on a new class */ new Foo("hi");
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
When provided with a method pattern like `com.example.Something <constructor>(..)` it will now also match those

## What's your motivation?
Need this for another PR related to usages of a class that does not have a migration path

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
