### PR TITLE
Set group and description for rewrite-gradle-tooling-model

### DIFF
--- a/rewrite-gradle-tooling-model/model/build.gradle.kts
+++ b/rewrite-gradle-tooling-model/model/build.gradle.kts
@@ -3,6 +3,9 @@ plugins {
     id("org.openrewrite.build.java8-text-blocks")
 }
 
+group = "org.openrewrite.gradle.tooling"
+description = "A model for extracting semantic information out of Gradle build files necessary for refactoring them."
+
 val pluginLocalTestClasspath = configurations.create("pluginLocalTestClasspath")
 
 dependencies {


### PR DESCRIPTION
Atm, publishing of the last release (the first one with this module) is happening to the `org.openrewrite` group. 
This clashes with the existing group and might make users unaware of new available versions. 

We still have a big version jump from 3.x to 8.x, but that's not really something we can fix right now, i guess.

You can see that the original code also had this property applied by applying it on all subprojects: https://github.com/openrewrite/rewrite-gradle-tooling-model/blob/main/build.gradle.kts#L5

During move, it was only set on the plugin section, not the model.