### PR TITLE
Fix concurrent modification exception on sorting

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -38,6 +38,7 @@ import org.openrewrite.maven.tree.ManagedDependency.Imported;
 import org.openrewrite.maven.tree.Plugin.Execution;
 
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
@@ -83,7 +84,7 @@ public class ResolvedPom {
         this.requested = requested;
         this.activeProfiles = activeProfiles;
         this.properties = properties;
-        this.dependencyManagement = dependencyManagement;
+        this.dependencyManagement = new CopyOnWriteArrayList<>(dependencyManagement);
         this.dependencyManagementSorted = dependencyManagementSorted;
         if (initialRepositories != null) {
             this.initialRepositories = initialRepositories;
@@ -489,7 +490,7 @@ public class ResolvedPom {
 
             resolveParentDependenciesRecursively(pomAncestry, managedDependencyMap);
             if (!managedDependencyMap.isEmpty()) {
-                dependencyManagement = new ArrayList<>(managedDependencyMap.values());
+                dependencyManagement = new CopyOnWriteArrayList<>(managedDependencyMap.values());
                 dependencyManagementSorted = false;
             }
         }


### PR DESCRIPTION
```
Caused by: java.lang.IllegalStateException: Unable to get values of org.jspecify:jspecify:1.0.0
	at org.openrewrite.maven.tree.ResolvedPom.getValues(ResolvedPom.java:1227)
	at org.openrewrite.maven.tree.ResolvedPom.resolveDependencies(ResolvedPom.java:1011)
	at org.openrewrite.maven.tree.ResolvedPom.resolveDependencies(ResolvedPom.java:984)
	at org.openrewrite.maven.tree.MavenResolutionResult.resolveDependencies(MavenResolutionResult.java:189)
	... 18 common frames omitted
Caused by: java.util.ConcurrentModificationException: null
	at java.base/java.util.ArrayList.sort(ArrayList.java:1723)
	at org.openrewrite.maven.tree.ResolvedPom.getDependencyManagement(ResolvedPom.java:145)
	at org.openrewrite.maven.tree.ResolvedPom.getManagedDependency(ResolvedPom.java:379)
	at org.openrewrite.maven.tree.ResolvedPom.getManagedExclusions(ResolvedPom.java:369)
	at org.openrewrite.maven.tree.ResolvedPom.getValues(ResolvedPom.java:1204)
	... 21 common frames omitted
```