### PR TITLE
Making the `exclusions` and `applyTo` options for `CoalesceProperties` actually optional when invoking from declarative recipe.

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalesceProperties.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalesceProperties.java
@@ -34,13 +34,15 @@ public class CoalesceProperties extends Recipe {
 
     @Option(displayName = "Exclusions",
             description = "An optional list of [JsonPath](https://docs.openrewrite.org/reference/jsonpath-and-jsonpathmatcher-reference) expressions to specify keys that should not be unfolded.",
-            example = "$..[org.springframework.security]")
+            example = "$..[org.springframework.security]",
+            required = false)
     List<String> exclusions;
 
     @Option(displayName = "Apply to",
             description = "An optional list of [JsonPath](https://docs.openrewrite.org/reference/jsonpath-and-jsonpathmatcher-reference) expressions that specify which keys the recipe should target only. " +
                     "Only the properties matching these expressions will be unfolded.",
-            example = "$..[org.springframework.security]")
+            example = "$..[org.springframework.security]",
+            required = false)
     List<String> applyTo;
 
     public CoalesceProperties() {

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CoalescePropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CoalescePropertiesTest.java
@@ -288,9 +288,100 @@ class CoalescePropertiesTest implements RewriteTest {
     }
 
     @Test
+    void usingYamlTest() {
+        rewriteRun(
+          spec -> spec.recipeFromYaml(
+            //language=yaml
+            """
+              type: specs.openrewrite.org/v1beta/recipe
+              name: com.testing.TestRecipe
+              displayName: Test Recipe
+              description: "Test recipe."
+              recipeList:
+                - org.openrewrite.yaml.CoalesceProperties
+              
+              """,
+            "com.testing.TestRecipe"
+          ),
+          //language=yaml
+          yaml(
+            """
+              dynatrace:
+                info:
+                  nom_application: financement-default
+                  nom_org: financement-defaut-org
+                  equipes_support:
+                    escouade:
+                      destinataire_courriel:
+                        a:
+                          - courriel: CSMF-financement-defaut@desjardins.com
+                  tags:
+                    - surveillance
+                    - maintenance
+              """,
+            """
+              dynatrace.info:
+                nom_application: financement-default
+                nom_org: financement-defaut-org
+                equipes_support.escouade.destinataire_courriel.a:
+                  - courriel: CSMF-financement-defaut@desjardins.com
+                tags:
+                  - surveillance
+                  - maintenance
+              """
+          )
+        );
+    }
+
+    @Test
     void exclusion() {
         rewriteRun(
           spec -> spec.recipe(new CoalesceProperties(List.of("$..logging", "$..some"), null)),
+          yaml(
+            """
+              a:
+                first:
+                  logging:
+                    level:
+                      com.company.extern.service: DEBUG
+                      com.another.package: INFO
+              some:
+                things:
+                  else: value
+              """,
+            """
+              a.first:
+                logging:
+                  level:
+                    com.company.extern.service: DEBUG
+                    com.another.package: INFO
+              some:
+                things:
+                  else: value
+              """
+          )
+        );
+    }
+
+    @Test
+    void exclusionUsingYaml() {
+        rewriteRun(
+          spec -> spec.recipeFromYaml(
+            //language=yaml
+            """
+              type: specs.openrewrite.org/v1beta/recipe
+              name: com.testing.TestRecipe
+              displayName: Test Recipe
+              description: "Test recipe."
+              recipeList:
+                - org.openrewrite.yaml.CoalesceProperties:
+                    exclusions:
+                      - $..logging
+                      - $..some
+              """,
+            "com.testing.TestRecipe"
+          ),
+          //language=yaml
           yaml(
             """
               a:
@@ -346,9 +437,97 @@ class CoalescePropertiesTest implements RewriteTest {
     }
 
     @Test
+    void applyToUsingYaml() {
+        rewriteRun(
+          spec -> spec.recipeFromYaml(
+            //language=yaml
+            """
+              type: specs.openrewrite.org/v1beta/recipe
+              name: com.testing.TestRecipe
+              displayName: Test Recipe
+              description: "Test recipe."
+              recipeList:
+                - org.openrewrite.yaml.CoalesceProperties:
+                    applyTo: ["$..logging", "$..some"]
+              """,
+            "com.testing.TestRecipe"
+          ),
+          //language=yaml
+          yaml(
+            """
+              a:
+                first:
+                  logging:
+                    level:
+                      com.company.extern.service: DEBUG
+                      com.another.package: INFO
+              some:
+                things:
+                  else: value
+              """,
+            """
+              a:
+                first:
+                  logging.level:
+                    com.company.extern.service: DEBUG
+                    com.another.package: INFO
+              some.things.else: value
+              """
+          )
+        );
+    }
+
+    @Test
     void applyToWithExclusion() {
         rewriteRun(
           spec -> spec.recipe(new CoalesceProperties(List.of("$..endpoint"), List.of("$.management2"))),
+          yaml(
+            """
+              management:
+                  metrics:
+                      enable.process.files: true
+                  endpoint:
+                      health.show-components: always
+              management2:
+                  metrics:
+                      enable.process.files: true
+                  endpoint:
+                      health.show-components: always
+              """,
+            """
+              management:
+                  metrics:
+                      enable.process.files: true
+                  endpoint:
+                      health.show-components: always
+              management2:
+                  metrics.enable.process.files: true
+                  endpoint:
+                      health.show-components: always
+              """
+          )
+        );
+    }
+
+    @Test
+    void applyToWithExclusionUsingYaml() {
+        rewriteRun(
+          spec -> spec
+            .recipeFromYaml(
+              //language=yaml
+              """
+                type: specs.openrewrite.org/v1beta/recipe
+                name: com.testing.TestRecipe
+                displayName: Test Recipe
+                description: "Test recipe."
+                recipeList:
+                  - org.openrewrite.yaml.CoalesceProperties:
+                      exclusions: $..endpoint
+                      applyTo: $.management2
+                """,
+              "com.testing.TestRecipe"
+            ),
+          //language=yaml
           yaml(
             """
               management:


### PR DESCRIPTION
## What's changed?
Made the options for `CoalesceProperties` have `required = false`, as there are already constructors provided that work around an absence of parameters being passed in, and the original intent was that they would be optional.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
