### PR TITLE
Only attempt to query Artifactory if wildcard notation was requested

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
@@ -114,7 +114,8 @@ public class GradleWrapper {
             );
         }
 
-        if (currentDistributionUrl.contains("/artifactory")) {
+        // Only list all versions via Artifactory if a wildcard notation was requested or null, e.g. 8.x
+        if (currentDistributionUrl.contains("/artifactory") && !(versionComparator instanceof ExactVersion)) {
             String artifactoryUrl = currentDistributionUrl.substring(0, currentDistributionUrl.lastIndexOf("/"));
             List<GradleVersion> allVersions = listAllPrivateArtifactoryVersions(artifactoryUrl, ctx);
             return allVersions.stream()


### PR DESCRIPTION
## What's changed?
If an exact version is requested, then bypass querying Artifactory.

## What's your motivation?
End user issue encountered with a `RewriteTest` unit test and not being able to query Artifactory.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
@Jenson3210 

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
