### PR TITLE
Compare `JavaType.Method.name` before `declaringType` in `equals(Object)`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -1565,8 +1565,8 @@ public interface JavaType {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Method method = (Method) o;
-            return Objects.equals(declaringType, method.declaringType) &&
-                   name.equals(method.name) &&
+            return Objects.equals(name, method.name) &&
+                   Objects.equals(declaringType, method.declaringType) &&
                    Objects.equals(returnType, method.returnType) &&
                    Arrays.equals(parameterTypes, method.parameterTypes);
         }

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -68,7 +68,7 @@ recipeList:
   - org.openrewrite.java.recipes.UseTreeRandomId
   - org.openrewrite.java.recipes.migrate.RemoveTraitsUsageRecipes
   - org.openrewrite.staticanalysis.NeedBraces
-  - org.openrewrite.staticanalysis.RemoveSystemOutPrintln
+#  - org.openrewrite.staticanalysis.RemoveSystemOutPrintln
 #  - org.openrewrite.java.RemoveAnnotation:
 #      annotationPattern: '@org.openrewrite.NlsRewrite.DisplayName'
 #  - org.openrewrite.java.RemoveAnnotation:


### PR DESCRIPTION
As discovered on
- https://github.com/openrewrite/rewrite-static-analysis/pull/727#discussion_r2309690738

Before we had
https://github.com/openrewrite/rewrite/blob/8ce5308a9557dd6ca91253a5c8fb7e6c34a0ef5a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java#L1563-L1572

Which then led to calling equals on the `declaringType` first, which for `FullyQualified.Class` looks like:
https://github.com/openrewrite/rewrite/blob/8ce5308a9557dd6ca91253a5c8fb7e6c34a0ef5a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java#L576-L583

Whereas the `name` is just a String that we can more cheaply compare and reject, making it unnecessary to do name comparisons first in
https://github.com/openrewrite/rewrite-static-analysis/blob/232339c63ac81a5e47275a093beb845154b6f745/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethods.java#L96-L98