### PR TITLE
fix(yaml): handle anchored map within sequence

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -53,7 +53,7 @@ import static org.openrewrite.Tree.randomId;
 public class YamlParser implements org.openrewrite.Parser {
     private static final Pattern VARIABLE_PATTERN = Pattern.compile(":\\s+(@[^\n\r@]+@)");
     // Only match single-line Helm templates that don't span multiple lines
-    private static final Pattern HELM_TEMPLATE_PATTERN = Pattern.compile("\\{\\{[^{}\\n\\r]*\\}\\}");
+    private static final Pattern HELM_TEMPLATE_PATTERN = Pattern.compile("\\{\\{[^{}\\n\\r]*}}");
 
     @Override
     public Stream<SourceFile> parse(@Language("yml") String... sources) {
@@ -184,12 +184,11 @@ public class YamlParser implements org.openrewrite.Parser {
 
                         MappingStartEvent mappingStartEvent = (MappingStartEvent) event;
                         Yaml.Anchor anchor = null;
-                        int mappingEndIndex = event.getEndMark().getIndex();
                         if (mappingStartEvent.getAnchor() != null) {
-                            anchor = buildYamlAnchor(reader, lastEnd, fmt, mappingStartEvent.getAnchor(), mappingEndIndex, false);
+                            anchor = buildYamlAnchor(reader, lastEnd, fmt, mappingStartEvent.getAnchor(), event.getEndMark().getIndex(), false);
                             anchors.put(mappingStartEvent.getAnchor(), anchor);
 
-                            // dashPrefixIndex could be 0 (if anchoring a sequence item) or greater than 0 (if anchoring a the entire list)
+                            // dashPrefixIndex could be 0 (if anchoring a sequence item) or greater than 0 (if anchoring entire list)
                             int dashPrefixIndex = commentAwareIndexOf('-', fmt);
                             lastEnd = lastEnd + mappingStartEvent.getAnchor().length() + fmt.length() + 1;
 
@@ -488,10 +487,12 @@ public class YamlParser implements org.openrewrite.Parser {
             postFix.append(c);
         }
 
-        int prefixStart = commentAwareIndexOf(':', eventPrefix);
         String prefix = "";
         if (!isForScalar) {
-            prefixStart = prefixStart == -1 ? commentAwareIndexOf('-', eventPrefix) : prefixStart;
+            int prefixStart = commentAwareIndexOf(':', eventPrefix);
+            if (prefixStart == -1) {
+                prefixStart = commentAwareIndexOf('-', eventPrefix);
+            }
             prefix = (prefixStart > -1 && eventPrefix.length() > prefixStart + 1) ? eventPrefix.substring(prefixStart + 1) : "";
         }
         return new Yaml.Anchor(randomId(), prefix, postFix.toString(), Markers.EMPTY, anchorKey);

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/MappingTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/MappingTest.java
@@ -248,9 +248,9 @@ class MappingTest implements RewriteTest {
         rewriteRun(
           yaml(
             """
-                    -data: &first
-                      test: 0
-              """
+            -data: &first
+              test: 0
+            """
           )
         );
     }
@@ -452,7 +452,7 @@ class MappingTest implements RewriteTest {
     void mappingSequenceWithAnchor() {
         rewriteRun(
           yaml(
-            """
+              """
               defaults:
                 - &first
                   A: 1

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/MappingTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/MappingTest.java
@@ -229,6 +229,46 @@ class MappingTest implements RewriteTest {
         );
     }
 
+    @Test
+    void keysWithDashes() {
+        rewriteRun(
+          yaml(
+            """
+            foo-bar: 1
+            foo-bar-baz: 2
+            foo-: 3
+            -foo: 4
+            """
+          )
+        );
+    }
+
+    @Test
+    void keysWithDashesAnchored() {
+        rewriteRun(
+          yaml(
+            """
+                    -data: &first
+                      test: 0
+              """
+          )
+        );
+    }
+
+    @Test
+    void keysWithDashesInsideSequence() {
+        rewriteRun(
+          yaml(
+            """
+            - foo-bar: 1
+            - bar-baz-qux: 2
+            - nested:
+                deep-key-name: 3
+            """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/3632")
     @Test
     void multilineScalar() {
@@ -403,6 +443,27 @@ class MappingTest implements RewriteTest {
                 << : *defaults
                 A: 23
                 C: 99
+              """
+          )
+        );
+    }
+
+    @Test
+    void mappingSequenceWithAnchor() {
+        rewriteRun(
+          yaml(
+            """
+              defaults:
+                - &first
+                  A: 1
+                  B: 2
+              mapping:
+                - &first
+                  A: 1
+                  B: 2
+                - <<: *first
+                  A: 23
+                  C: 99
               """
           )
         );

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/SequenceTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/SequenceTest.java
@@ -120,6 +120,23 @@ class SequenceTest implements RewriteTest {
     }
 
     @Test
+    void sequenceWithAnchors() {
+        rewriteRun(
+          yaml(
+            """
+            - &first
+              A: 1
+              B: 2
+            - <<: *first
+              A: 23
+              C: 99
+              D: 123
+            """
+          )
+        );
+    }
+
+    @Test
     void inlineSequenceWithWhitespaceBeforeCommas() {
         rewriteRun(
           yaml(


### PR DESCRIPTION
## What's changed?
rewrite-yaml's parsing of anchored maps within a sequence, as described by my issue 
- #5924

## What's your motivation?
The parsing of valid yaml containing an anchored map within a sequence would result in the `-` being dropped in the output - which is invalid yaml in some cases.

## Anything in particular you'd like reviewers to focus on?
I was unsure why `fmt` was being reevaluated within the anchoring block, as the motivation was not commented and was the source of this bug. I've removed the fmt and resolved the handling of the `-` and anchor prefix.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
n/a

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
