### PR TITLE
UpgradeTransitiveDependencyVersion should not downgrade a transitive dependency version if lower than resolved version

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -1346,6 +1346,36 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
         );
     }
 
+    /**
+     * This test verifies that the recipe correctly prevents downgrading transitive dependencies.
+     * <ul>
+     * <li>jackson-dataformat-xml:2.18.0 brings in jackson-databind:2.18.0 transitively.</li>
+     * <li>jackson-datatype-jsr310:2.15.3 brings in jackson-databind:2.15.3 transitively.</li>
+     * </ul>
+     *  When trying to "upgrade" to 2.15.0 (which would be a downgrade), the recipe should
+     *  make no changes to avoid downgrading the transitive dependency.
+     */
+    @Test
+    void doesNotDowngradeTransitiveDependencyVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeTransitiveDependencyVersion(
+            "com.fasterxml.jackson.core", "jackson-databind", "2.15.0", null, null, null)),
+          buildGradle(
+            """
+            plugins {
+                id 'java'
+            }
+            repositories { mavenCentral() }
+            
+            dependencies {
+                implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.18.0'
+                implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.3'
+            }
+            """
+          )
+        );
+    }
+
     @EqualsAndHashCode(callSuper = false)
     @Value
     public static class ScanningAccumulatedUpgradeRecipe extends ScanningRecipe<UpgradeTransitiveDependencyVersion.DependencyVersionState> {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
@@ -30,6 +30,9 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.openrewrite.internal.StringUtils.matchesGlob;
 
 import static java.util.Objects.requireNonNull;
 
@@ -206,13 +209,21 @@ public class AddManagedDependency extends ScanningRecipe<AddManagedDependency.Sc
                     if (versionValidation.isValid()) {
                         VersionComparator versionComparator = requireNonNull(versionValidation.getValue());
                         try {
-                            // The version of the dependency currently in use (if any) might influence the version comparator
-                            // For example, "latest.patch" gives very different results depending on the version in use
-                            String currentVersion = getResolutionResult().findDependencies(convertedGroup, convertedArtifact, Scope.fromName(scope)).stream()
-                                    .map(ResolvedDependency::getVersion)
-                                    .findFirst()
-                                    .orElse(existingManagedDependencyVersion());
-                            String versionToUse = MavenDependency.findNewerVersion(convertedGroup, convertedArtifact, currentVersion, getResolutionResult(), metadataFailures, versionComparator, ctx);
+                            // Find the current highest version among existing dependencies
+                            String currentVersion = findCurrentHighestVersion(convertedGroup, convertedArtifact, 
+                                    Scope.fromName(scope), versionComparator);
+                            
+                            // Find what version we should use based on the version pattern
+                            String versionToUse = MavenDependency.findNewerVersion(convertedGroup, convertedArtifact, 
+                                    currentVersion, getResolutionResult(), metadataFailures, versionComparator, ctx);
+                            
+                            // Check if we should prevent a downgrade
+                            if (wouldCauseVersionDowngrade(convertedGroup, convertedArtifact, currentVersion,
+                                    versionToUse, versionComparator, Scope.fromName(scope))) {
+                                return maven;
+                            }
+                            
+                            // Add the managed dependency if it's different from what already exists
                             if (versionToUse != null && !versionToUse.equals(pom.getValue(existingManagedDependencyVersion()))) {
                                 if (ResolvedPom.placeholderHelper.hasPlaceholders(version) && Objects.equals(convertedVersion, versionToUse)) {
                                     // revert back to the original version if the version has a placeholder
@@ -231,6 +242,96 @@ public class AddManagedDependency extends ScanningRecipe<AddManagedDependency.Sc
                 return maven;
             }
 
+            /**
+             * Find the current highest version of a dependency in the project.
+             * For transitive dependencies, finds the highest among all transitive versions.
+             * For direct dependencies, uses the first found version.
+             */
+            private String findCurrentHighestVersion(String groupId, String artifactId, 
+                                                     @Nullable Scope scope, VersionComparator versionComparator) {
+                List<ResolvedDependency> dependencies = getResolutionResult()
+                        .findDependencies(groupId, artifactId, scope);
+                
+                boolean hasTransitiveDeps = dependencies.stream()
+                        .anyMatch(ResolvedDependency::isTransitive);
+                
+                if (hasTransitiveDeps) {
+                    // Find the highest version among transitive dependencies
+                    return dependencies.stream()
+                            .filter(ResolvedDependency::isTransitive)
+                            .map(ResolvedDependency::getVersion)
+                            .reduce((v1, v2) -> compareVersions(v1, v2, versionComparator) >= 0 ? v1 : v2)
+                            .orElse(existingManagedDependencyVersion());
+                }
+
+                // For direct dependencies, use the first found version
+                return dependencies.stream()
+                        .map(ResolvedDependency::getVersion)
+                        .findFirst()
+                        .orElse(existingManagedDependencyVersion());
+            }
+            
+            /**
+             * Determine if adding a managed dependency would cause a downgrade.
+             * Takes into account both current versions and potential versions from related dependencies.
+             */
+            private boolean wouldCauseVersionDowngrade(String groupId, String artifactId,
+                                                       @Nullable String currentVersion, @Nullable String versionToUse,
+                                                       VersionComparator versionComparator, @Nullable Scope scope) {
+                if (versionToUse == null || currentVersion == null) {
+                    return false;
+                }
+                
+                // Check if this is a transitive dependency
+                boolean hasTransitiveDeps = getResolutionResult()
+                        .findDependencies(groupId, artifactId, scope).stream()
+                        .anyMatch(ResolvedDependency::isTransitive);
+                
+                if (hasTransitiveDeps) {
+                    // For transitive dependencies, also consider versions from related direct dependencies
+                    String highestPotentialVersion = findHighestPotentialVersion(groupId, currentVersion, versionComparator);
+                    return compareVersions(highestPotentialVersion, versionToUse, versionComparator) > 0;
+                }
+
+                // For direct dependencies, just compare current vs new
+                return compareVersions(currentVersion, versionToUse, versionComparator) > 0;
+            }
+            
+            /**
+             * Find the highest potential version by checking direct dependencies from the same organization.
+             * This helps prevent downgrades when related libraries typically use aligned versions.
+             */
+            private String findHighestPotentialVersion(String targetGroup, String currentVersion, 
+                                                       VersionComparator versionComparator) {
+                String highestVersion = currentVersion;
+                
+                // Get all direct dependencies
+                List<ResolvedDependency> directDeps = getResolutionResult().getDependencies().values().stream()
+                        .flatMap(List::stream)
+                        .filter(d -> !d.isTransitive())
+                        .collect(Collectors.toList());
+                
+                for (ResolvedDependency directDep : directDeps) {
+                    // Check if this dependency is from the same organization
+                    if (areFromSameOrganization(directDep.getGroupId(), targetGroup)) {
+                        // Libraries from the same organization typically use aligned versions
+                        if (compareVersions(highestVersion, directDep.getVersion(), versionComparator) < 0) {
+                            highestVersion = directDep.getVersion();
+                        }
+                    }
+                }
+                
+                return highestVersion;
+            }
+            
+            /**
+             * Compare two versions using the provided comparator, with fallback to string comparison.
+             * @return negative if v1 < v2, zero if equal, positive if v1 > v2
+             */
+            private int compareVersions(String v1, String v2, VersionComparator versionComparator) {
+                return versionComparator.compare(null, v1, v2);
+            }
+            
             private @Nullable String existingManagedDependencyVersion() {
                 return getResolutionResult().getPom().getDependencyManagement().stream()
                         .map(resolvedManagedDep -> {
@@ -245,6 +346,44 @@ public class AddManagedDependency extends ScanningRecipe<AddManagedDependency.Sc
                         })
                         .filter(Objects::nonNull)
                         .findFirst().orElse(null);
+            }
+            
+            /**
+             * Check if two group IDs are from the same organization by comparing their prefixes.
+             * Libraries from the same organization typically use aligned versions.
+             */
+            private boolean areFromSameOrganization(String group1, String group2) {
+                if (group1 == null || group2 == null) {
+                    return false;
+                }
+                if (group1.equals(group2)) {
+                    return true;
+                }
+                
+                // Check if they share a common organizational prefix using glob patterns
+                int lastDot1 = group1.lastIndexOf('.');
+                int lastDot2 = group2.lastIndexOf('.');
+                
+                if (lastDot1 > 0 && lastDot2 > 0) {
+                    String prefix1 = group1.substring(0, lastDot1);
+                    String prefix2 = group2.substring(0, lastDot2);
+                    
+                    // Check if one matches the other's prefix pattern
+                    if (matchesGlob(group1, prefix2 + ".*") || matchesGlob(group2, prefix1 + ".*")) {
+                        return true;
+                    }
+                    
+                    // Check for deeper organizational structure
+                    int nextDot1 = prefix1.lastIndexOf('.');
+                    int nextDot2 = prefix2.lastIndexOf('.');
+                    if (nextDot1 > 0 && nextDot2 > 0) {
+                        String orgPrefix1 = prefix1.substring(0, nextDot1);
+                        String orgPrefix2 = prefix2.substring(0, nextDot2);
+                        return orgPrefix1.equals(orgPrefix2);
+                    }
+                }
+                
+                return false;
             }
         });
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddManagedDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddManagedDependencyTest.java
@@ -298,4 +298,80 @@ class AddManagedDependencyTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doesNotDowngradeTransitiveDependency() {
+        rewriteRun(
+          spec -> spec.recipe(new AddManagedDependency("com.fasterxml.jackson.core", "jackson-databind", "2.15.0", null,
+            null, null, null, null, null, false)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-xml</artifactId>
+                    <version>2.18.0</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                    <version>2.14.0</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void addsWhenVersionIsHigherThanTransitive() {
+        rewriteRun(
+          spec -> spec.recipe(new AddManagedDependency("com.fasterxml.jackson.core", "jackson-databind", "2.19.0", null,
+            null, null, null, null, null, false)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-xml</artifactId>
+                    <version>2.18.0</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>com.fasterxml.jackson.core</groupId>
+                      <artifactId>jackson-databind</artifactId>
+                      <version>2.19.0</version>
+                    </dependency>
+                  </dependencies>
+                </dependencyManagement>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-xml</artifactId>
+                    <version>2.18.0</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersionTest.java
@@ -159,4 +159,43 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
           )
         );
     }
+
+    /**
+     * This test verifies that the recipe correctly prevents downgrading transitive dependencies.
+     * <ul>
+     * <li>jackson-dataformat-xml:2.18.0 brings in jackson-databind:2.18.0 transitively.</li>
+     * <li>jackson-datatype-jsr310:2.15.3 brings in jackson-databind:2.15.3 transitively.</li>
+     * </ul>
+     *  When trying to "upgrade" to 2.15.0 (which would be a downgrade), the recipe should
+     *  make no changes to avoid downgrading the transitive dependency.
+     */
+    @Test 
+    void doesNotDowngradeTransitiveDependencyWithExplicitVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeTransitiveDependencyVersion(
+            "com.fasterxml.jackson.core", "jackson-databind", "2.16.0", null, null, null, null, null, null, null)),
+          pomXml(
+            """
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.openrewrite</groupId>
+                <artifactId>core</artifactId>
+                <version>0.1.0-SNAPSHOT</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.fasterxml.jackson.dataformat</groupId>
+                        <artifactId>jackson-dataformat-xml</artifactId>
+                        <version>2.18.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.fasterxml.jackson.datatype</groupId>
+                        <artifactId>jackson-datatype-jsr310</artifactId>
+                        <version>2.15.3</version>
+                    </dependency>
+                </dependencies>
+            </project>
+            """
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersionTest.java
@@ -173,7 +173,7 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
     void doesNotDowngradeTransitiveDependencyWithExplicitVersion() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeTransitiveDependencyVersion(
-            "com.fasterxml.jackson.core", "jackson-databind", "2.16.0", null, null, null, null, null, null, null)),
+            "com.fasterxml.jackson.core", "jackson-databind", "2.15.0", null, null, null, null, null, null, null)),
           pomXml(
             """
             <project>


### PR DESCRIPTION
## What's changed?

Changes the logic in the AddManagedDependency recipe to prevent version downgrade for transitive dependencies.

## What's your motivation?

A Maven build defines two dependencies with transitive dependencies on com.fasterxml.jackson.core:jackson-databind. The transitive dependency versions are different.

- jackson-dataformat-xml:2.18.0 → jackson-databind:2.18.0
- jackson-datatype-jsr310:2.15.3 → jackson-databind:2.15.3

Requesting a lower version than 2.18.0, downgrades the transitive dependency com.fasterxml.jackson.core:jackson-databind which should not be allowed.

The same behavior cannot be observed for a Gradle build.