### PR TITLE
Use flyweights for classes representing GAV coordinates.

### DIFF
--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
@@ -135,36 +135,24 @@ public final class GradleProjectBuilder {
         }
     }
 
-    private static final Map<GroupArtifact, GroupArtifact> groupArtifactCache = new ConcurrentHashMap<>();
-
     private static GroupArtifact groupArtifact(org.openrewrite.maven.tree.Dependency dep) {
-        //noinspection ConstantConditions
-        return groupArtifactCache.computeIfAbsent(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()), it -> it);
+        return GroupArtifact.of(dep.getGroupId(), dep.getArtifactId());
     }
 
     private static GroupArtifact groupArtifact(ResolvedDependency dep) {
-        return groupArtifactCache.computeIfAbsent(new GroupArtifact(dep.getModuleGroup(), dep.getModuleName()), it -> it);
+        return GroupArtifact.of(dep.getModuleGroup(), dep.getModuleName());
     }
 
-    private static final Map<GroupArtifactVersion, GroupArtifactVersion> groupArtifactVersionCache = new ConcurrentHashMap<>();
-
     private static GroupArtifactVersion groupArtifactVersion(ResolvedDependency dep) {
-        return groupArtifactVersionCache.computeIfAbsent(
-                new GroupArtifactVersion(dep.getModuleGroup(), dep.getModuleName(), unspecifiedToNull(dep.getModuleVersion())),
-                it -> it);
+        return GroupArtifactVersion.of(dep.getModuleGroup(), dep.getModuleName(), unspecifiedToNull(dep.getModuleVersion()));
     }
 
     private static GroupArtifactVersion groupArtifactVersion(Dependency dep) {
-        return groupArtifactVersionCache.computeIfAbsent(
-                new GroupArtifactVersion(dep.getGroup(), dep.getName(), unspecifiedToNull(dep.getVersion())), it -> it);
+        return GroupArtifactVersion.of(dep.getGroup(), dep.getName(), unspecifiedToNull(dep.getVersion()));
     }
 
-    private static final Map<ResolvedGroupArtifactVersion, ResolvedGroupArtifactVersion> resolvedGroupArtifactVersionCache = new ConcurrentHashMap<>();
-
     private static ResolvedGroupArtifactVersion resolvedGroupArtifactVersion(ResolvedDependency dep) {
-        return resolvedGroupArtifactVersionCache.computeIfAbsent(new ResolvedGroupArtifactVersion(
-                        null, dep.getModuleGroup(), dep.getModuleName(), dep.getModuleVersion(), null),
-                it -> it);
+        return ResolvedGroupArtifactVersion.of(null, dep.getModuleGroup(), dep.getModuleName(), dep.getModuleVersion(), null);
     }
 
     /**
@@ -434,8 +422,5 @@ public final class GradleProjectBuilder {
     @SuppressWarnings("unused")
     public static void clearCaches() {
         requestedCache.clear();
-        groupArtifactCache.clear();
-        groupArtifactVersionCache.clear();
-        resolvedGroupArtifactVersionCache.clear();
     }
 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
@@ -216,8 +216,8 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
 
                         GradleConfigurationFilter gradleConfigurationFilter = new GradleConfigurationFilter(gp, resolvedConfigurations);
                         gradleConfigurationFilter.removeTransitiveConfigurations();
-                        gradleConfigurationFilter.removeConfigurationsContainingDependency(new GroupArtifact(groupId, artifactId));
-                        gradleConfigurationFilter.removeConfigurationsContainingTransitiveDependency(new GroupArtifact(groupId, artifactId));
+                        gradleConfigurationFilter.removeConfigurationsContainingDependency(GroupArtifact.of(groupId, artifactId));
+                        gradleConfigurationFilter.removeConfigurationsContainingTransitiveDependency(GroupArtifact.of(groupId, artifactId));
                         resolvedConfigurations = gradleConfigurationFilter.getFilteredConfigurations();
 
                         if (resolvedConfigurations.isEmpty()) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java
@@ -91,7 +91,7 @@ public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
                 } else {
                     try {
                         resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                                .select(new GroupArtifact(groupId, artifactId), configuration, version, versionPattern, ctx);
+                                .select(GroupArtifact.of(groupId, artifactId), configuration, version, versionPattern, ctx);
                     } catch (MavenDownloadingException e) {
                         return (J) e.warn(tree);
                     }
@@ -106,7 +106,7 @@ public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
                 sourceFile = org.openrewrite.gradle.internal.AddDependencyVisitor.addDependency(
                         sourceFile,
                         gradleProject.getConfiguration(configuration),
-                        new GroupArtifactVersion(groupId, artifactId, versionWithPattern),
+                        GroupArtifactVersion.of(groupId, artifactId, versionWithPattern),
                         classifier,
                         ctx
                 );

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddPlatformDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddPlatformDependency.java
@@ -171,7 +171,7 @@ public class AddPlatformDependency extends ScanningRecipe<AddPlatformDependency.
 
                         GradleConfigurationFilter gradleConfigurationFilter = new GradleConfigurationFilter(gp, resolvedConfigurations);
                         gradleConfigurationFilter.removeTransitiveConfigurations();
-                        gradleConfigurationFilter.removeConfigurationsContainingDependency(new GroupArtifact(groupId, artifactId));
+                        gradleConfigurationFilter.removeConfigurationsContainingDependency(GroupArtifact.of(groupId, artifactId));
                         resolvedConfigurations = gradleConfigurationFilter.getFilteredConfigurations();
 
                         if (resolvedConfigurations.isEmpty()) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -247,7 +247,7 @@ public class ChangeDependency extends Recipe {
                                 String resolvedVersion;
                                 try {
                                     resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                                            .select(new GroupArtifact(updated.getGroupId(), updated.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
+                                            .select(GroupArtifact.of(updated.getGroupId(), updated.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
                                 } catch (MavenDownloadingException e) {
                                     return e.warn(m);
                                 }
@@ -281,7 +281,7 @@ public class ChangeDependency extends Recipe {
                                 String resolvedVersion;
                                 try {
                                     resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                                            .select(new GroupArtifact(updated.getGroupId(), updated.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
+                                            .select(GroupArtifact.of(updated.getGroupId(), updated.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
                                 } catch (MavenDownloadingException e) {
                                     return e.warn(m);
                                 }
@@ -354,7 +354,7 @@ public class ChangeDependency extends Recipe {
                         String resolvedVersion;
                         try {
                             resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                                    .select(new GroupArtifact(updatedGroupId, updatedArtifactId), m.getSimpleName(), newVersion, versionPattern, ctx);
+                                    .select(GroupArtifact.of(updatedGroupId, updatedArtifactId), m.getSimpleName(), newVersion, versionPattern, ctx);
                         } catch (MavenDownloadingException e) {
                             return e.warn(m);
                         }
@@ -437,7 +437,7 @@ public class ChangeDependency extends Recipe {
                         String resolvedVersion;
                         try {
                             resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                                    .select(new GroupArtifact(updatedGroupId, updatedArtifactId), m.getSimpleName(), newVersion, versionPattern, ctx);
+                                    .select(GroupArtifact.of(updatedGroupId, updatedArtifactId), m.getSimpleName(), newVersion, versionPattern, ctx);
                         } catch (MavenDownloadingException e) {
                             return e.warn(m);
                         }
@@ -525,7 +525,7 @@ public class ChangeDependency extends Recipe {
                         String resolvedVersion;
                         try {
                             resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                                    .select(new GroupArtifact(updatedGroupId, updatedArtifactId), m.getSimpleName(), newVersion, versionPattern, ctx);
+                                    .select(GroupArtifact.of(updatedGroupId, updatedArtifactId), m.getSimpleName(), newVersion, versionPattern, ctx);
                         } catch (MavenDownloadingException e) {
                             return e.warn(m);
                         }
@@ -574,7 +574,7 @@ public class ChangeDependency extends Recipe {
                                 String resolvedVersion;
                                 try {
                                     resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                                            .select(new GroupArtifact(updated.getGroupId(), updated.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
+                                            .select(GroupArtifact.of(updated.getGroupId(), updated.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
                                 } catch (MavenDownloadingException e) {
                                     return e.warn(m);
                                 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyVersionSelector.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyVersionSelector.java
@@ -79,7 +79,7 @@ public class DependencyVersionSelector {
             }
         }
         return select(
-                new GroupArtifactVersion(ga.getGroupId(), ga.getArtifactId(), currentVersion),
+                GroupArtifactVersion.of(ga.getGroupId(), ga.getArtifactId(), currentVersion),
                 configuration,
                 // we don't want to select the latest patch in the 0.x line...
                 "latest.patch".equalsIgnoreCase(version) && "0".equals(currentVersion) ? "latest.release" : version,
@@ -106,7 +106,7 @@ public class DependencyVersionSelector {
                          @Nullable String version,
                          @Nullable String versionPattern,
                          ExecutionContext ctx) throws MavenDownloadingException {
-        return select(new GroupArtifactVersion(gav.getGroupId(), gav.getArtifactId(), gav.getVersion()),
+        return select(GroupArtifactVersion.of(gav.getGroupId(), gav.getArtifactId(), gav.getVersion()),
                 configuration, version, versionPattern, ctx);
     }
 
@@ -202,7 +202,7 @@ public class DependencyVersionSelector {
 
     private MavenMetadata downloadMetadata(String groupId, String artifactId, List<MavenRepository> repositories, ExecutionContext ctx) throws MavenDownloadingException {
         return new MavenPomDownloader(ctx).downloadMetadata(
-                new GroupArtifact(groupId, artifactId), null, repositories);
+                GroupArtifact.of(groupId, artifactId), null, repositories);
     }
 
     private List<MavenRepository> determineRepos(@Nullable String configuration) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveRedundantDependencyVersions.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveRedundantDependencyVersions.java
@@ -151,7 +151,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                                         J.Literal l = (J.Literal) m.getArguments().get(0);
                                         if (l.getType() == JavaType.Primitive.String) {
                                             Dependency dependency = DependencyStringNotationConverter.parse((String) l.getValue());
-                                            gav = new GroupArtifactVersion(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion());
+                                            gav = GroupArtifactVersion.of(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion());
                                         }
                                     } else if (m.getArguments().get(0) instanceof G.MapEntry) {
                                         String groupId = null;
@@ -176,7 +176,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                                         }
 
                                         if (groupId != null && artifactId != null && version != null) {
-                                            gav = new GroupArtifactVersion(groupId, artifactId, version);
+                                            gav = GroupArtifactVersion.of(groupId, artifactId, version);
                                         }
                                     }
                                     if (gav != null) {
@@ -227,7 +227,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                                             requested.stream()
                                                     .sorted(VERSION_COMPARATOR.reversed())
                                                     .skip(1)
-                                                    .forEach(redundant -> toBeRemoved.add(requestedToDeclaration.get(new GroupArtifactVersion(ga.getGroupId(), ga.getArtifactId(), redundant))));
+                                                    .forEach(redundant -> toBeRemoved.add(requestedToDeclaration.get(GroupArtifactVersion.of(ga.getGroupId(), ga.getArtifactId(), redundant))));
                                         }
 
                                         // With the list of redundant declarations in-hand, remove them from the dependencies block

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -234,7 +234,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         }
 
                         String versionVariableName = declaredVersion;
-                        GroupArtifact ga = new GroupArtifact(declaredGroupId, declaredArtifactId);
+                        GroupArtifact ga = GroupArtifact.of(declaredGroupId, declaredArtifactId);
                         if (gradleProject != null) {
                             acc.getConfigurationPerGAPerModule().computeIfAbsent(getGradleProjectKey(gradleProject), k -> new HashMap<>())
                                     .computeIfAbsent(ga, k -> new HashSet<>())
@@ -245,7 +245,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         }
                         try {
                             String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                                    .select(new GroupArtifact(declaredGroupId, declaredArtifactId), m.getSimpleName(), newVersion, versionPattern, ctx);
+                                    .select(GroupArtifact.of(declaredGroupId, declaredArtifactId), m.getSimpleName(), newVersion, versionPattern, ctx);
                             acc.versionPropNameToGA
                                     .computeIfAbsent(versionVariableName, k -> new HashMap<>())
                                     .computeIfAbsent(ga, k -> new HashSet<>())
@@ -306,7 +306,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         }
 
                         String versionVariableName = declaredVersion;
-                        GroupArtifact ga = new GroupArtifact(declaredGroupId, declaredArtifactId);
+                        GroupArtifact ga = GroupArtifact.of(declaredGroupId, declaredArtifactId);
                         if (gradleProject != null) {
                             acc.getConfigurationPerGAPerModule().computeIfAbsent(getGradleProjectKey(gradleProject), k -> new HashMap<>())
                                     .computeIfAbsent(ga, k -> new HashSet<>())
@@ -317,7 +317,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         }
                         try {
                             String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                                    .select(new GroupArtifact(declaredGroupId, declaredArtifactId), m.getSimpleName(), newVersion, versionPattern, ctx);
+                                    .select(GroupArtifact.of(declaredGroupId, declaredArtifactId), m.getSimpleName(), newVersion, versionPattern, ctx);
                             acc.versionPropNameToGA
                                     .computeIfAbsent(versionVariableName, k -> new HashMap<>())
                                     .computeIfAbsent(ga, k -> new HashSet<>())
@@ -379,7 +379,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                             if (dep == null || versionVariableName == null) {
                                 continue;
                             }
-                            GroupArtifact ga = new GroupArtifact(dep.getGroupId(), dep.getArtifactId());
+                            GroupArtifact ga = GroupArtifact.of(dep.getGroupId(), dep.getArtifactId());
                             if (gradleProject != null) {
                                 acc.getConfigurationPerGAPerModule().computeIfAbsent(getGradleProjectKey(gradleProject), k -> new HashMap<>())
                                         .computeIfAbsent(ga, k -> new HashSet<>())
@@ -390,7 +390,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                             }
                             try {
                                 String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                                        .select(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
+                                        .select(GroupArtifact.of(dep.getGroupId(), dep.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
                                 acc.versionPropNameToGA
                                         .computeIfAbsent(versionVariableName, k -> new HashMap<>())
                                         .computeIfAbsent(ga, k -> new HashSet<>())
@@ -439,7 +439,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         Dependency dep = DependencyStringNotationConverter.parse((String) groupArtifact.getValue());
                         if (dep != null && shouldResolveVersion(dep.getGroupId(), dep.getArtifactId())) {
                             acc.variableNames.computeIfAbsent(((J.Identifier) versionVariable).getSimpleName(), it -> new HashMap<>())
-                                    .computeIfAbsent(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()), it -> new HashSet<>())
+                                    .computeIfAbsent(GroupArtifact.of(dep.getGroupId(), dep.getArtifactId()), it -> new HashSet<>())
                                     .add(method.getSimpleName());
                         }
                     }
@@ -465,7 +465,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                     ((J.Identifier) versionExp).getSimpleName() :
                                     (versionExp).printTrimmed(getCursor());
                             acc.variableNames.computeIfAbsent(versionVariableName, it -> new HashMap<>())
-                                    .computeIfAbsent(new GroupArtifact((String) groupLiteral.getValue(), (String) artifactLiteral.getValue()), it -> new HashSet<>())
+                                    .computeIfAbsent(GroupArtifact.of((String) groupLiteral.getValue(), (String) artifactLiteral.getValue()), it -> new HashSet<>())
                                     .add(method.getSimpleName());
                         }
                     }
@@ -510,7 +510,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                     }
 
                                     String selectedVersion = versionSelector.select(groupArtifact, null, newVersion, versionPattern, ctx);
-                                    GroupArtifactVersion gav = new GroupArtifactVersion(groupArtifact.getGroupId(), groupArtifact.getArtifactId(), selectedVersion);
+                                    GroupArtifactVersion gav = GroupArtifactVersion.of(groupArtifact.getGroupId(), groupArtifact.getArtifactId(), selectedVersion);
                                     upgrades.add(gav);
 
                                 }
@@ -518,7 +518,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                             } else {
                                 for (Map.Entry<GroupArtifact, @Nullable Object> newVersion : acc.gaToNewVersion.entrySet()) {
                                     if (newVersion.getValue() instanceof String) {
-                                        GroupArtifactVersion gav = new GroupArtifactVersion(newVersion.getKey().getGroupId(), newVersion.getKey().getArtifactId(), (String) newVersion.getValue());
+                                        GroupArtifactVersion gav = GroupArtifactVersion.of(newVersion.getKey().getGroupId(), newVersion.getKey().getArtifactId(), (String) newVersion.getValue());
                                         upgrades.add(gav);
                                     }
                                 }
@@ -705,7 +705,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                     }
                     Dependency dep = DependencyStringNotationConverter.parse((String) groupArtifact.getValue());
                     if (dep != null && dependencyMatcher.matches(dep.getGroupId(), dep.getArtifactId())) {
-                        Object scanResult = acc.gaToNewVersion.get(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()));
+                        Object scanResult = acc.gaToNewVersion.get(GroupArtifact.of(dep.getGroupId(), dep.getArtifactId()));
                         if (scanResult instanceof Exception) {
                             getCursor().putMessage(UPDATE_VERSION_ERROR_KEY, scanResult);
                             return arg;
@@ -727,7 +727,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                     }
                     Dependency dep = DependencyStringNotationConverter.parse((String) groupArtifact.getValue());
                     if (dep != null && dependencyMatcher.matches(dep.getGroupId(), dep.getArtifactId())) {
-                        Object scanResult = acc.gaToNewVersion.get(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()));
+                        Object scanResult = acc.gaToNewVersion.get(GroupArtifact.of(dep.getGroupId(), dep.getArtifactId()));
                         if (scanResult instanceof Exception) {
                             getCursor().putMessage(UPDATE_VERSION_ERROR_KEY, scanResult);
                             return arg;
@@ -750,7 +750,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                     if (dep != null && dependencyMatcher.matches(dep.getGroupId(), dep.getArtifactId()) &&
                         dep.getVersion() != null &&
                         !dep.getVersion().startsWith("$")) {
-                        Object scanResult = acc.gaToNewVersion.get(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()));
+                        Object scanResult = acc.gaToNewVersion.get(GroupArtifact.of(dep.getGroupId(), dep.getArtifactId()));
                         if (scanResult instanceof Exception) {
                             getCursor().putMessage(UPDATE_VERSION_ERROR_KEY, scanResult);
                             return arg;
@@ -795,7 +795,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                     if (groupLiteral.getValue() == null || artifactLiteral.getValue() == null || !dependencyMatcher.matches((String) groupLiteral.getValue(), (String) artifactLiteral.getValue())) {
                         return m;
                     }
-                    Object scanResult = acc.gaToNewVersion.get(new GroupArtifact((String) groupLiteral.getValue(), (String) artifactLiteral.getValue()));
+                    Object scanResult = acc.gaToNewVersion.get(GroupArtifact.of((String) groupLiteral.getValue(), (String) artifactLiteral.getValue()));
                     if (scanResult instanceof Exception) {
                         return Markup.warn(m, (Exception) scanResult);
                     }
@@ -809,7 +809,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         }
                         String selectedVersion;
                         try {
-                            GroupArtifactVersion gav = new GroupArtifactVersion((String) groupLiteral.getValue(), (String) artifactLiteral.getValue(), version);
+                            GroupArtifactVersion gav = GroupArtifactVersion.of((String) groupLiteral.getValue(), (String) artifactLiteral.getValue(), version);
                             selectedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
                                     .select(gav, m.getSimpleName(), newVersion, versionPattern, ctx);
                         } catch (MavenDownloadingException e) {
@@ -862,7 +862,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                     if (groupLiteral.getValue() == null || artifactLiteral.getValue() == null || !dependencyMatcher.matches((String) groupLiteral.getValue(), (String) artifactLiteral.getValue())) {
                         return m;
                     }
-                    Object scanResult = acc.gaToNewVersion.get(new GroupArtifact((String) groupLiteral.getValue(), (String) artifactLiteral.getValue()));
+                    Object scanResult = acc.gaToNewVersion.get(GroupArtifact.of((String) groupLiteral.getValue(), (String) artifactLiteral.getValue()));
                     if (scanResult instanceof Exception) {
                         return Markup.warn(m, (Exception) scanResult);
                     }
@@ -876,7 +876,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         }
                         String selectedVersion;
                         try {
-                            GroupArtifactVersion gav = new GroupArtifactVersion((String) groupLiteral.getValue(), (String) artifactLiteral.getValue(), version);
+                            GroupArtifactVersion gav = GroupArtifactVersion.of((String) groupLiteral.getValue(), (String) artifactLiteral.getValue(), version);
                             selectedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
                                     .select(gav, m.getSimpleName(), newVersion, versionPattern, ctx);
                         } catch (MavenDownloadingException e) {
@@ -924,7 +924,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
 
         private void replaceVariableValue(String versionVariableName, J.MethodInvocation m, String groupId, String artifactId) {
             acc.variableNames.computeIfAbsent(versionVariableName, it -> new HashMap<>())
-                    .computeIfAbsent(new GroupArtifact(groupId, artifactId), it -> new HashSet<>())
+                    .computeIfAbsent(GroupArtifact.of(groupId, artifactId), it -> new HashSet<>())
                     .add(m.getSimpleName());
         }
     }
@@ -992,7 +992,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
         private J.@Nullable Literal getNewVersion(J.Literal literal, Map.Entry<GroupArtifact, Set<String>> gaWithConfigurations, ExecutionContext ctx) throws MavenDownloadingException {
             GroupArtifact ga = gaWithConfigurations.getKey();
             DependencyVersionSelector dependencyVersionSelector = new DependencyVersionSelector(metadataFailures, gradleProject, null);
-            GroupArtifactVersion gav = new GroupArtifactVersion(ga.getGroupId(), ga.getArtifactId(), (String) literal.getValue());
+            GroupArtifactVersion gav = GroupArtifactVersion.of(ga.getGroupId(), ga.getArtifactId(), (String) literal.getValue());
 
             String selectedVersion;
             try {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -193,7 +193,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                         }
                         Map<GradleDependencyConfiguration, String> configs = update.getValue();
                         for (Map.Entry<GradleDependencyConfiguration, String> config : configs.entrySet()) {
-                            dependenciesToUpdate.put(new GroupArtifact(update.getKey().getGroupId(), update.getKey().getArtifactId()), config.getValue());
+                            dependenciesToUpdate.put(GroupArtifact.of(update.getKey().getGroupId(), update.getKey().getArtifactId()), config.getValue());
                         }
                     }
                 }
@@ -252,7 +252,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                                     }
 
                                     acc.updatesPerProject.get(getGradleProjectKey(gradleProject)).merge(
-                                            new GroupArtifact(resolved.getGroupId(), resolved.getArtifactId()),
+                                            GroupArtifact.of(resolved.getGroupId(), resolved.getArtifactId()),
                                             singletonMap(constraintConfig, selected),
                                             (existing, update) -> {
                                                 Map<GradleDependencyConfiguration, String> all = new LinkedHashMap<>(existing);
@@ -351,7 +351,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                     if (declaredGroupId == null || declaredArtifactId == null || declaredVersion == null) {
                         return m;
                     }
-                    acc.versionPropNameToGA.put(declaredVersion, new GroupArtifact(declaredGroupId, declaredArtifactId));
+                    acc.versionPropNameToGA.put(declaredVersion, GroupArtifact.of(declaredGroupId, declaredArtifactId));
                 } else {
                     for (Expression depArg : m.getArguments()) {
                         if (depArg instanceof G.GString) {
@@ -360,7 +360,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                                 org.openrewrite.gradle.internal.Dependency dep = DependencyStringNotationConverter.parse((String) ((J.Literal) strings.get(0)).getValue());
                                 if (dep != null) {
                                     G.GString.Value versionValue = (G.GString.Value) strings.get(1);
-                                    acc.versionPropNameToGA.put(versionValue.getTree().toString(), new GroupArtifact(dep.getGroupId(), dep.getArtifactId()));
+                                    acc.versionPropNameToGA.put(versionValue.getTree().toString(), GroupArtifact.of(dep.getGroupId(), dep.getArtifactId()));
                                 }
                             }
                         } else if (depArg instanceof K.StringTemplate) {
@@ -369,7 +369,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                                 org.openrewrite.gradle.internal.Dependency dep = DependencyStringNotationConverter.parse((String) ((J.Literal) strings.get(0)).getValue());
                                 if (dep != null) {
                                     K.StringTemplate.Expression versionValue = (K.StringTemplate.Expression) strings.get(1);
-                                    acc.versionPropNameToGA.put(versionValue.getTree().toString(), new GroupArtifact(dep.getGroupId(), dep.getArtifactId()));
+                                    acc.versionPropNameToGA.put(versionValue.getTree().toString(), GroupArtifact.of(dep.getGroupId(), dep.getArtifactId()));
                                 }
                             }
                         }
@@ -479,7 +479,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                         String configName = configToVersion.getKey().getName();
                         String newVersion = configToVersion.getValue();
                         configsToUpdate.computeIfAbsent(configName, it -> new HashSet<>())
-                                .add(new GroupArtifactVersion(groupId, artifactId, newVersion));
+                                .add(GroupArtifactVersion.of(groupId, artifactId, newVersion));
                     }
                 }
                 return gp.addOrUpdateConstraints(configsToUpdate, ctx);
@@ -528,7 +528,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                         }
                         Map<GradleDependencyConfiguration, String> configs = update.getValue();
                         for (Map.Entry<GradleDependencyConfiguration, String> config : configs.entrySet()) {
-                            cu = (JavaSourceFile) new AddConstraint(cu instanceof K.CompilationUnit, config.getKey().getName(), new GroupArtifactVersion(update.getKey().getGroupId(),
+                            cu = (JavaSourceFile) new AddConstraint(cu instanceof K.CompilationUnit, config.getKey().getName(), GroupArtifactVersion.of(update.getKey().getGroupId(),
                                     update.getKey().getArtifactId(), config.getValue()), gradleProject, because).visitNonNull(cu, ctx);
                         }
                     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/Dependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/Dependency.java
@@ -40,7 +40,7 @@ public class Dependency {
     String ext;
 
     public GroupArtifactVersion getGav() {
-        return new GroupArtifactVersion(groupId, artifactId, version);
+        return GroupArtifactVersion.of(groupId, artifactId, version);
     }
 
     public String toStringNotation() {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleDependencyConfiguration.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleDependencyConfiguration.java
@@ -416,9 +416,9 @@ public class GradleDependencyConfiguration implements Serializable, Attributed {
         if (others == null || others.isEmpty()) {
             return new ArrayList<>(preferred);
         }
-        Map<GroupArtifact, GradleDependencyConstraint> results = preferred.stream().collect(toMap(it -> new GroupArtifact(it.getGroupId(), it.getArtifactId()), it -> it, GradleDependencyConfiguration::newer));
+        Map<GroupArtifact, GradleDependencyConstraint> results = preferred.stream().collect(toMap(it -> GroupArtifact.of(it.getGroupId(), it.getArtifactId()), it -> it, GradleDependencyConfiguration::newer));
         for (GradleDependencyConstraint lowerPrecedenceConstraint : others) {
-            results.putIfAbsent(new GroupArtifact(lowerPrecedenceConstraint.getGroupId(), lowerPrecedenceConstraint.getArtifactId()), lowerPrecedenceConstraint);
+            results.putIfAbsent(GroupArtifact.of(lowerPrecedenceConstraint.getGroupId(), lowerPrecedenceConstraint.getArtifactId()), lowerPrecedenceConstraint);
         }
         return new ArrayList<>(results.values());
     }
@@ -449,7 +449,7 @@ public class GradleDependencyConfiguration implements Serializable, Attributed {
                 if (Objects.equals(d.getGroupId(), gav.getGroupId()) &&
                     Objects.equals(d.getArtifactId(), gav.getArtifactId()) &&
                     !Objects.equals(d.getVersion(), Semver.max(d.getVersion(), gav.getVersion()))) {
-                    return d.withGav(new GroupArtifactVersion(gav.getGroupId(), gav.getArtifactId(), gav.getVersion()));
+                    return d.withGav(GroupArtifactVersion.of(gav.getGroupId(), gav.getArtifactId(), gav.getVersion()));
                 }
             }
             return d;
@@ -614,7 +614,7 @@ public class GradleDependencyConfiguration implements Serializable, Attributed {
                 continue;
             }
             managed.add(new ManagedDependency.Defined(
-                    new GroupArtifactVersion(constraint.getGroupId(), constraint.getArtifactId(), version),
+                    GroupArtifactVersion.of(constraint.getGroupId(), constraint.getArtifactId(), version),
                     null,
                     null,
                     null,

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
@@ -200,10 +200,10 @@ public class AddDevelocityGradlePlugin extends Recipe {
 
             private @Nullable String findNewerVersion(DependencyVersionSelector versionSelector, ExecutionContext ctx) throws MavenDownloadingException {
                 String newVersion = versionSelector
-                        .select(new GroupArtifact("com.gradle.develocity", "com.gradle.develocity.gradle.plugin"), "classpath", version, null, ctx);
+                        .select(GroupArtifact.of("com.gradle.develocity", "com.gradle.develocity.gradle.plugin"), "classpath", version, null, ctx);
                 if (newVersion == null) {
                     newVersion = versionSelector
-                            .select(new GroupArtifact("com.gradle.enterprise", "com.gradle.enterprise.gradle.plugin"), "classpath", version, null, ctx);
+                            .select(GroupArtifact.of("com.gradle.enterprise", "com.gradle.enterprise.gradle.plugin"), "classpath", version, null, ctx);
                 }
                 return newVersion;
             }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
@@ -114,7 +114,7 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
             }
 
             try {
-                version = new DependencyVersionSelector(null, maybeGp.orElse(null), maybeGs.orElse(null)).select(new GroupArtifact(pluginId, pluginId + ".gradle.plugin"), "classpath", newVersion, versionPattern, ctx);
+                version = new DependencyVersionSelector(null, maybeGp.orElse(null), maybeGs.orElse(null)).select(GroupArtifact.of(pluginId, pluginId + ".gradle.plugin"), "classpath", newVersion, versionPattern, ctx);
             } catch (MavenDownloadingException e) {
                 return e.warn(cu);
             }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/ChangePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/ChangePlugin.java
@@ -183,7 +183,7 @@ public class ChangePlugin extends Recipe {
                         if (!StringUtils.isBlank(newVersion)) {
                             try {
                                 String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, gradleSettings)
-                                        .select(new GroupArtifact(newPluginId, newPluginId + ".gradle.plugin"), "classpath", newVersion, null, ctx);
+                                        .select(GroupArtifact.of(newPluginId, newPluginId + ".gradle.plugin"), "classpath", newVersion, null, ctx);
                                 if (resolvedVersion == null) {
                                     return m;
                                 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/ChangePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/ChangePluginVersion.java
@@ -149,7 +149,7 @@ public class ChangePluginVersion extends Recipe {
 
                 try {
                     String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, gradleSettings)
-                            .select(new GroupArtifactVersion(pluginId, pluginId + ".gradle.plugin", currentVersion), "classpath", selectedNewVersion, versionPattern, ctx);
+                            .select(GroupArtifactVersion.of(pluginId, pluginId + ".gradle.plugin", currentVersion), "classpath", selectedNewVersion, versionPattern, ctx);
                     if (resolvedVersion == null) {
                         return m;
                     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
@@ -85,7 +85,7 @@ public class MigrateGradleEnterpriseToDevelocity extends Recipe {
 
                         try {
                             String newVersion = new DependencyVersionSelector(metadataFailures, null, maybeGs.get())
-                                    .select(new GroupArtifact("com.gradle.develocity", "com.gradle.develocity.gradle.plugin"), "classpath", version, null, ctx);
+                                    .select(GroupArtifact.of("com.gradle.develocity", "com.gradle.develocity.gradle.plugin"), "classpath", version, null, ctx);
                             if (newVersion == null) {
                                 // The develocity plugin was first published as of 3.17
                                 return cu;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
@@ -169,7 +169,7 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                     String currentVersion = literalValue(versionArgs.get(0));
                     if (currentVersion != null) {
                         String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, gradleSettings)
-                                .select(new GroupArtifactVersion(pluginId, pluginId + ".gradle.plugin", currentVersion), "classpath", newVersion, versionPattern, ctx);
+                                .select(GroupArtifactVersion.of(pluginId, pluginId + ".gradle.plugin", currentVersion), "classpath", newVersion, versionPattern, ctx);
                         acc.pluginIdToNewVersion.put(pluginId, resolvedVersion);
                     } else if (versionArgs.get(0) instanceof G.GString) {
                         G.GString gString = (G.GString) versionArgs.get(0);
@@ -180,7 +180,7 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                         G.GString.Value gStringValue = (G.GString.Value) gString.getStrings().get(0);
                         String versionVariableName = gStringValue.getTree().toString();
                         String resolvedPluginVersion = new DependencyVersionSelector(metadataFailures, gradleProject, gradleSettings)
-                                .select(new GroupArtifact(pluginId, pluginId + ".gradle.plugin"), "classpath", newVersion, versionPattern, ctx);
+                                .select(GroupArtifact.of(pluginId, pluginId + ".gradle.plugin"), "classpath", newVersion, versionPattern, ctx);
 
                         acc.versionPropNameToPluginId.put(versionVariableName, pluginId);
                         assert resolvedPluginVersion != null;
@@ -189,7 +189,7 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                         J.Identifier identifier = (J.Identifier) versionArgs.get(0);
                         String versionVariableName = identifier.getSimpleName();
                         String resolvedPluginVersion = new DependencyVersionSelector(metadataFailures, gradleProject, gradleSettings)
-                                .select(new GroupArtifact(pluginId, pluginId + ".gradle.plugin"), "classpath", newVersion, versionPattern, ctx);
+                                .select(GroupArtifact.of(pluginId, pluginId + ".gradle.plugin"), "classpath", newVersion, versionPattern, ctx);
 
                         acc.versionPropNameToPluginId.put(versionVariableName, pluginId);
                         assert resolvedPluginVersion != null;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
@@ -132,9 +132,6 @@ public class DependencyInsight extends Recipe {
                         continue;
                     }
                     for (ResolvedDependency resolvedDependency : c.getDirectResolved()) {
-                        if (!resolvedDependency.isDirect()) { // for some reason the direct resolved ones are also containing depth ones.
-                            continue;
-                        }
                         List<ResolvedDependency> nestedMatchingDependencies = resolvedDependency.findDependencies(groupIdPattern, artifactIdPattern);
                         for (ResolvedDependency dep : nestedMatchingDependencies) {
                             if (version != null) {
@@ -147,8 +144,9 @@ public class DependencyInsight extends Recipe {
                                     }
                                 }
                             }
-                            GroupArtifactVersion requestedGav = new GroupArtifactVersion(resolvedDependency.getGroupId(), resolvedDependency.getArtifactId(), resolvedDependency.getVersion());
-                            GroupArtifactVersion targetGav = new GroupArtifactVersion(dep.getGroupId(), dep.getArtifactId(), dep.getVersion());
+
+                            GroupArtifactVersion requestedGav = resolvedDependency.getGav().asGroupArtifactVersion();
+                            GroupArtifactVersion targetGav = dep.getGav().asGroupArtifactVersion();
                             configurationToDirectDependency.computeIfAbsent(c.getName(), EMPTY).add(requestedGav);
                             directDependencyToTargetDependency.computeIfAbsent(requestedGav, EMPTY).add(targetGav);
                             dependenciesInUse.insertRow(ctx, new DependenciesInUse.Row(

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleDependency.java
@@ -171,13 +171,13 @@ public class GradleDependency implements Trait<J.MethodInvocation> {
                     // Couldn't find the actual resolved dependency, return a virtualized one instead
                     ResolvedDependency resolvedDependency = ResolvedDependency.builder()
                             .depth(-1)
-                            .gav(new ResolvedGroupArtifactVersion(null, dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion() != null ? dependency.getVersion() : "", null))
+                            .gav(ResolvedGroupArtifactVersion.of(null, dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion() != null ? dependency.getVersion() : "", null))
                             .classifier(dependency.getClassifier())
                             .type(dependency.getExt())
                             .requested(Dependency.builder()
                                     .scope(methodInvocation.getSimpleName())
                                     .type(dependency.getExt())
-                                    .gav(new GroupArtifactVersion(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion()))
+                                    .gav(GroupArtifactVersion.of(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion()))
                                     .classifier(dependency.getClassifier())
                                     .build())
                             .build();

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/JvmTestSuite.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/JvmTestSuite.java
@@ -104,7 +104,7 @@ public class JvmTestSuite implements Trait<Statement> {
                         return AddDependencyVisitor.addDependency(
                                 (JavaSourceFile) j,
                                 gradleProject.getConfiguration(targetConfiguration),
-                                new GroupArtifactVersion(groupId, artifactId, resolvedVersion),
+                                GroupArtifactVersion.of(groupId, artifactId, resolvedVersion),
                                 classifier,
                                 ctx
                         );
@@ -136,7 +136,7 @@ public class JvmTestSuite implements Trait<Statement> {
             return version;
         }
         return new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                .select(new GroupArtifact(groupId, artifactId), configuration, version, versionPattern, ctx);
+                .select(GroupArtifact.of(groupId, artifactId), configuration, version, versionPattern, ctx);
     }
 
     public boolean isAcceptable(String configuration) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/SpringDependencyManagementPluginEntry.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/SpringDependencyManagementPluginEntry.java
@@ -209,7 +209,7 @@ public class SpringDependencyManagementPluginEntry implements Trait<J.MethodInvo
                     String notation = (String) ((J.Literal) argument).getValue();
                     int versionIdx = notation == null ? -1 : notation.lastIndexOf(':');
                     if (versionIdx != -1) {
-                        dependencies.add(new GroupArtifactVersion(notation.substring(0, versionIdx), entry, notation.substring(versionIdx + 1)));
+                        dependencies.add(GroupArtifactVersion.of(notation.substring(0, versionIdx), entry, notation.substring(versionIdx + 1)));
                     }
                     return;
                 } else if (argument instanceof G.MapLiteral) {
@@ -296,7 +296,7 @@ public class SpringDependencyManagementPluginEntry implements Trait<J.MethodInvo
             if (dependencyManagement.getArtifacts().stream().allMatch(artifact ->
                     depMatcher.matches(dependencyManagement.getGroup(), artifact))) {
                 for (String managedArtifact : dependencyManagement.getArtifacts()) {
-                    GroupArtifactVersion original = new GroupArtifactVersion(dependencyManagement.getGroup(), managedArtifact, dependencyManagement.getVersion());
+                    GroupArtifactVersion original = GroupArtifactVersion.of(dependencyManagement.getGroup(), managedArtifact, dependencyManagement.getVersion());
                     GroupArtifactVersion updated = original;
                     if (!StringUtils.isBlank(newGroup) && !newGroup.equals(updated.getGroupId())) {
                         updated = updated.withGroupId(newGroup);
@@ -308,7 +308,7 @@ public class SpringDependencyManagementPluginEntry implements Trait<J.MethodInvo
                         String resolvedVersion;
                         try {
                             resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                                    .select(new GroupArtifact(updated.getGroupId(), updated.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
+                                    .select(GroupArtifact.of(updated.getGroupId(), updated.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
                         } catch (MavenDownloadingException e) {
                             return e.warn(m);
                         }
@@ -434,7 +434,7 @@ public class SpringDependencyManagementPluginEntry implements Trait<J.MethodInvo
                             String resolvedVersion;
                             try {
                                 resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                                        .select(new GroupArtifact(updated.getGroupId(), updated.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
+                                        .select(GroupArtifact.of(updated.getGroupId(), updated.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
                             } catch (MavenDownloadingException e) {
                                 return e.warn(m);
                             }
@@ -549,13 +549,13 @@ public class SpringDependencyManagementPluginEntry implements Trait<J.MethodInvo
             String updatedVersion = version == null ? null : version.getValue();
             if (!StringUtils.isBlank(newVersion)) {
                 String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                        .select(new GroupArtifact(updatedGroupId, updatedArtifactId), configuration, newVersion, versionPattern, ctx);
+                        .select(GroupArtifact.of(updatedGroupId, updatedArtifactId), configuration, newVersion, versionPattern, ctx);
                 if (resolvedVersion != null && !resolvedVersion.equals(updatedVersion)) {
                     updatedVersion = resolvedVersion;
                 }
             }
 
-            return new GroupArtifactVersion(updatedGroupId, updatedArtifactId, updatedVersion);
+            return GroupArtifactVersion.of(updatedGroupId, updatedArtifactId, updatedVersion);
         }
     }
 
@@ -653,7 +653,7 @@ public class SpringDependencyManagementPluginEntry implements Trait<J.MethodInvo
             GavMapEntry<? extends Expression> version = entries.get(VERSION);
 
             if (group != null && (artifact != null || !StringUtils.isBlank(artifactName))) {
-                return new GroupArtifactVersion(
+                return GroupArtifactVersion.of(
                         group.getValue(),
                         !StringUtils.isBlank(artifactName) ? artifactName : requireNonNull(artifact).getValue(),
                         version == null ? null : version.getValue()

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
@@ -56,7 +56,7 @@ class GradleProjectTest implements RewriteTest {
     void noopUpgrade() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyInMarker(
-            new GroupArtifactVersion("org.openrewrite", "rewrite-java", "8.56.0"),
+            GroupArtifactVersion.of("org.openrewrite", "rewrite-java", "8.56.0"),
             "implementation",
             (original, updated) -> assertThat(updated).isSameAs(original)
           )),
@@ -80,7 +80,7 @@ class GradleProjectTest implements RewriteTest {
     void multiProject() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyInMarker(
-            new GroupArtifactVersion("org.openrewrite", "rewrite-java", "8.57.0"),
+            GroupArtifactVersion.of("org.openrewrite", "rewrite-java", "8.57.0"),
             "implementation",
             (original, updated) -> {
                 // mostly interested that a ProjectDependency does not cause an exception
@@ -134,7 +134,7 @@ class GradleProjectTest implements RewriteTest {
     void plusVersion() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyInMarker(
-            new GroupArtifactVersion("org.openrewrite", "rewrite-java", "8.57.0"),
+            GroupArtifactVersion.of("org.openrewrite", "rewrite-java", "8.57.0"),
             "implementation",
             (original, updated) -> {
                 GradleDependencyConfiguration implementation = updated.getConfiguration("implementation");
@@ -176,7 +176,7 @@ class GradleProjectTest implements RewriteTest {
     void simpleUpgrade() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyInMarker(
-            new GroupArtifactVersion("org.openrewrite", "rewrite-java", "8.57.0"),
+            GroupArtifactVersion.of("org.openrewrite", "rewrite-java", "8.57.0"),
             "implementation",
             (original, updated) -> {
                 GradleDependencyConfiguration implementation = updated.getConfiguration("implementation");
@@ -219,7 +219,7 @@ class GradleProjectTest implements RewriteTest {
     void bomUpgrade() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyInMarker(
-            new GroupArtifactVersion("org.openrewrite", "rewrite-bom", "8.57.0"),
+            GroupArtifactVersion.of("org.openrewrite", "rewrite-bom", "8.57.0"),
             "implementation",
             (original, updated) -> {
                 GradleDependencyConfiguration implementation = updated.getConfiguration("implementation");
@@ -263,7 +263,7 @@ class GradleProjectTest implements RewriteTest {
     void removesDefunctTransitives() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyInMarker(
-            new GroupArtifactVersion("io.vertx", "vertx-core", "5.0.1"),
+            GroupArtifactVersion.of("io.vertx", "vertx-core", "5.0.1"),
             "implementation",
             (original, updated) -> {
                 assertThat(updated).isNotSameAs(original);
@@ -314,7 +314,7 @@ class GradleProjectTest implements RewriteTest {
     void removeDependency() {
         rewriteRun(
           spec -> spec.recipe(new RemoveDependency(
-            List.of(new GroupArtifact("org.openrewrite", "rewrite-core")),
+            List.of(GroupArtifact.of("org.openrewrite", "rewrite-core")),
             (original, updated) -> {
                 assertThat(updated).isNotSameAs(original);
 
@@ -349,7 +349,7 @@ class GradleProjectTest implements RewriteTest {
     void changeConstraint() {
         rewriteRun(
           spec -> spec.recipe(new ChangeConstraint(
-            Map.of("implementation", List.of(new GroupArtifactVersion("com.fasterxml.jackson.core", "jackson-databind", "2.19.2"))),
+            Map.of("implementation", List.of(GroupArtifactVersion.of("com.fasterxml.jackson.core", "jackson-databind", "2.19.2"))),
             (original, updated) -> {
                 GradleDependencyConfiguration implementation = updated.getConfiguration("implementation");
                 assertThat(implementation).isNotNull();

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDevelocityMavenExtension.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDevelocityMavenExtension.java
@@ -425,7 +425,7 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
         MavenExecutionContextView mctx = MavenExecutionContextView.view(ctx);
         MavenPomDownloader pomDownloader = new MavenPomDownloader(emptyMap(), ctx, mctx.getSettings(), mctx.getActiveProfiles());
         VersionComparator versionComparator = new LatestRelease(null);
-        GroupArtifact develocityExtension = new GroupArtifact("com.gradle", DEVELOCITY_MAVEN_EXTENSION_ARTIFACT_ID);
+        GroupArtifact develocityExtension = GroupArtifact.of("com.gradle", DEVELOCITY_MAVEN_EXTENSION_ARTIFACT_ID);
         try {
             MavenMetadata extensionMetadata = pomDownloader.downloadMetadata(develocityExtension, null, singletonList(MavenRepository.MAVEN_CENTRAL));
             return extensionMetadata.getVersioning()

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -198,7 +198,7 @@ public class ChangeParentPom extends Recipe {
 
                             // Retain managed versions from the old parent that are not managed in the new parent
                             MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, mrr.getMavenSettings(), mrr.getActiveProfiles());
-                            ResolvedPom newParent = mpd.download(new GroupArtifactVersion(targetGroupId, targetArtifactId, targetVersion.get()), null, resolvedPom, resolvedPom.getRepositories())
+                            ResolvedPom newParent = mpd.download(GroupArtifactVersion.of(targetGroupId, targetArtifactId, targetVersion.get()), null, resolvedPom, resolvedPom.getRepositories())
                                     .resolve(emptyList(), mpd, ctx);
                             List<ResolvedManagedDependency> dependenciesWithoutExplicitVersions = getDependenciesUnmanagedByNewParent(mrr, newParent);
                             for (ResolvedManagedDependency dep : dependenciesWithoutExplicitVersions) {
@@ -347,7 +347,7 @@ public class ChangeParentPom extends Recipe {
                             String artifactId = resolvedPom.getValue(it.getArtifactId());
                             return dep.getGroupId().equals(groupId) && dep.getArtifactId().equals(artifactId);
                         }))
-                .map(dep -> new GroupArtifactVersion(dep.getGroupId(), dep.getArtifactId(), null))
+                .map(dep -> GroupArtifactVersion.of(dep.getGroupId(), dep.getArtifactId(), null))
                 .collect(toCollection(LinkedHashSet::new));
 
         if (requestedWithoutExplicitVersion.isEmpty()) {
@@ -371,11 +371,11 @@ public class ChangeParentPom extends Recipe {
 
         // Remove from the list any that would still be managed under the new parent
         Set<GroupArtifact> newParentManagedGa = newParent.getDependencyManagement().stream()
-                .map(dep -> new GroupArtifact(dep.getGav().getGroupId(), dep.getGav().getArtifactId()))
+                .map(dep -> GroupArtifact.of(dep.getGav().getGroupId(), dep.getGav().getArtifactId()))
                 .collect(toSet());
 
         return depsWithoutExplicitVersion.stream()
-                .filter(it -> !newParentManagedGa.contains(new GroupArtifact(it.getGav().getGroupId(), it.getGav().getArtifactId())))
+                .filter(it -> !newParentManagedGa.contains(GroupArtifact.of(it.getGav().getGroupId(), it.getGav().getArtifactId())))
                 .collect(toList());
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/IncrementProjectVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/IncrementProjectVersion.java
@@ -113,7 +113,7 @@ public class IncrementProjectVersion extends ScanningRecipe<Map<GroupArtifact, S
                 if (newVersion.equals(oldVersion)) {
                     return t;
                 }
-                acc.put(new GroupArtifact(
+                acc.put(GroupArtifact.of(
                                 t.getChildValue("groupId").orElse(null), t.getChildValue("artifactId").orElse(null)),
                         newVersion);
                 return t;
@@ -169,7 +169,7 @@ public class IncrementProjectVersion extends ScanningRecipe<Map<GroupArtifact, S
                     t.getMarkers().findFirst(AlreadyIncremented.class).isPresent()) {
                     return t;
                 }
-                String newVersion = acc.get(new GroupArtifact(
+                String newVersion = acc.get(GroupArtifact.of(
                         t.getChildValue("groupId").orElse(null),
                         t.getChildValue("artifactId").orElse(null)));
                 String oldVersion = t.getChildValue("version").orElse(null);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ManageDependencies.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ManageDependencies.java
@@ -99,7 +99,7 @@ public class ManageDependencies extends ScanningRecipe<Map<GroupArtifactVersion,
                 Xml.Document doc = super.visitDocument(document, ctx);
                 Collection<ResolvedDependency> manageableDependencies = findDependencies(groupPattern, artifactPattern != null ? artifactPattern : "*");
                 ResolvedGroupArtifactVersion root = findRootPom(getResolutionResult()).getPom().getGav();
-                rootGavToDependencies.computeIfAbsent(new GroupArtifactVersion(root.getGroupId(), root.getArtifactId(), root.getVersion()), v -> new ArrayList<>()).addAll(manageableDependencies);
+                rootGavToDependencies.computeIfAbsent(GroupArtifactVersion.of(root.getGroupId(), root.getArtifactId(), root.getVersion()), v -> new ArrayList<>()).addAll(manageableDependencies);
                 return doc;
             }
         });
@@ -115,7 +115,7 @@ public class ManageDependencies extends ScanningRecipe<Map<GroupArtifactVersion,
                 Collection<ResolvedDependency> manageableDependencies;
                 if (Boolean.TRUE.equals(addToRootPom)) {
                     ResolvedPom pom = getResolutionResult().getPom();
-                    GroupArtifactVersion gav = new GroupArtifactVersion(pom.getGav().getGroupId(), pom.getGav().getArtifactId(), pom.getGav().getVersion());
+                    GroupArtifactVersion gav = GroupArtifactVersion.of(pom.getGav().getGroupId(), pom.getGav().getArtifactId(), pom.getGav().getVersion());
                     manageableDependencies = rootGavToDependencies.get(gav);
                 } else {
                     manageableDependencies = findDependencies(groupPattern, artifactPattern != null ? artifactPattern : "*");
@@ -128,7 +128,7 @@ public class ManageDependencies extends ScanningRecipe<Map<GroupArtifactVersion,
                         String alreadyManagedVersion = getResolutionResult().getPom().getManagedVersion(rmd.getGroupId(), rmd.getArtifactId(), rmd.getType(),
                                 rmd.getClassifier());
                         if (rmd.getDepth() <= 1 && alreadyManagedVersion == null) {
-                            maxVersionByGroupArtifact.compute(new GroupArtifact(rmd.getGroupId(), rmd.getArtifactId()),
+                            maxVersionByGroupArtifact.compute(GroupArtifact.of(rmd.getGroupId(), rmd.getArtifactId()),
                                     (ga, existing) -> existing == null || existing.getVersion().compareTo(rmd.getVersion()) < 0 ?
                                             rmd : existing);
                         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenDownloadingExceptions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenDownloadingExceptions.java
@@ -61,7 +61,7 @@ public class MavenDownloadingExceptions extends Exception {
     public Xml.Document warn(Xml.Document document) {
         Map<GroupArtifact, List<MavenDownloadingException>> byGav = new HashMap<>();
         for (MavenDownloadingException exception : exceptions) {
-            byGav.computeIfAbsent(new GroupArtifact(exception.getRoot().getGroupId(),
+            byGav.computeIfAbsent(GroupArtifact.of(exception.getRoot().getGroupId(),
                     exception.getRoot().getArtifactId()), ga -> new ArrayList<>()).add(exception);
         }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -426,7 +426,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
                 .map(MavenSettings.ActiveProfiles::getActiveProfiles)
                 .orElse(null);
         return new MavenPomDownloader(getResolutionResult().getProjectPoms(), ctx, maybeSettings.orElse(null), activeProfiles)
-                .downloadMetadata(new GroupArtifact(groupId, artifactId), containingPom, getResolutionResult().getPom().getRepositories());
+                .downloadMetadata(GroupArtifact.of(groupId, artifactId), containingPom, getResolutionResult().getPom().getRepositories());
     }
 
     public MavenMetadata downloadPluginMetadata(String groupId, String artifactId, ExecutionContext ctx) throws MavenDownloadingException {
@@ -440,7 +440,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
                 .map(MavenSettings.ActiveProfiles::getActiveProfiles)
                 .orElse(null);
         return new MavenPomDownloader(getResolutionResult().getProjectPoms(), ctx, maybeSettings.orElse(null), activeProfiles)
-                .downloadMetadata(new GroupArtifact(groupId, artifactId), containingPom, getResolutionResult().getPom().getPluginRepositories());
+                .downloadMetadata(GroupArtifact.of(groupId, artifactId), containingPom, getResolutionResult().getPom().getPluginRepositories());
     }
 
     /**

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveExclusion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveExclusion.java
@@ -119,7 +119,7 @@ public class RemoveExclusion extends Recipe {
             }
 
             private GroupArtifact groupArtifact(Xml.Tag tag) {
-                return new GroupArtifact(
+                return GroupArtifact.of(
                         tag.getChildValue("groupId").orElseThrow(IllegalArgumentException::new),
                         tag.getChildValue("artifactId").orElseThrow(IllegalArgumentException::new)
                 );

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
@@ -60,7 +60,7 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
 
         Optional<Xml.Tag> parent = document.getRoot().getChild("parent");
         if (parent.isPresent()) {
-            Parent updatedParent = new Parent(new GroupArtifactVersion(
+            Parent updatedParent = new Parent(GroupArtifactVersion.of(
                     parent.get().getChildValue("groupId").orElse(null),
                     parent.get().getChildValue("artifactId").orElseThrow(() -> new IllegalStateException("GAV must have artifactId")),
                     parent.get().getChildValue("version").orElse(null)
@@ -76,7 +76,7 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
             List<Dependency> requestedDependencies = new ArrayList<>(eachDependency.size());
             for (Xml.Tag dependency : eachDependency) {
                 requestedDependencies.add(Dependency.builder()
-                        .gav(new GroupArtifactVersion(
+                        .gav(GroupArtifactVersion.of(
                                 dependency.getChildValue("groupId").orElse(null),
                                 dependency.getChildValue("artifactId").orElseThrow(() -> new IllegalStateException("Dependency must have artifactId")),
                                 dependency.getChildValue("version").orElse(null)
@@ -102,7 +102,7 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
                 List<ManagedDependency> requestedManagedDependencies = new ArrayList<>(eachDependency.size());
                 for (Xml.Tag dependency : eachDependency) {
                     String scope = dependency.getChildValue("scope").orElse(null);
-                    GroupArtifactVersion gav = new GroupArtifactVersion(
+                    GroupArtifactVersion gav = GroupArtifactVersion.of(
                             dependency.getChildValue("groupId").orElse(null),
                             dependency.getChildValue("artifactId").orElseThrow(() -> new IllegalStateException("Dependency must have artifactId")),
                             dependency.getChildValue("version").orElse(null)
@@ -154,7 +154,7 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
                     List<Xml.Tag> eachExclusion = exclusions.getChildren("exclusion");
                     List<GroupArtifact> requestedExclusions = new ArrayList<>(eachExclusion.size());
                     for (Xml.Tag exclusion : eachExclusion) {
-                        requestedExclusions.add(new GroupArtifact(
+                        requestedExclusions.add(GroupArtifact.of(
                                 exclusion.getChildValue("groupId").orElse(null),
                                 exclusion.getChildValue("artifactId").orElse(null)
                         ));

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -133,7 +133,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
                 ResolvedPom pom = getResolutionResult().getPom();
-                accumulator.projectArtifacts.add(new GroupArtifact(pom.getGroupId(), pom.getArtifactId()));
+                accumulator.projectArtifacts.add(GroupArtifact.of(pom.getGroupId(), pom.getArtifactId()));
                 return super.visitDocument(document, ctx);
             }
 
@@ -306,7 +306,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                     String artifactId = managedDependency.getArtifactId();
                     String version = managedDependency.getVersion();
                     if (version != null &&
-                        !accumulator.projectArtifacts.contains(new GroupArtifact(groupId, artifactId)) &&
+                        !accumulator.projectArtifacts.contains(GroupArtifact.of(groupId, artifactId)) &&
                         matchesGlob(groupId, UpgradeDependencyVersion.this.groupId) &&
                         matchesGlob(artifactId, UpgradeDependencyVersion.this.artifactId)) {
                         return upgradeVersion(ctx, t, managedDependency.getRequested().getVersion(), groupId, artifactId, version);
@@ -316,7 +316,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         if (dm.getBomGav() != null) {
                             String group = getResolutionResult().getPom().getValue(tag.getChildValue("groupId").orElse(getResolutionResult().getPom().getGroupId()));
                             String artifactId = getResolutionResult().getPom().getValue(tag.getChildValue("artifactId").orElse(""));
-                            if (!accumulator.projectArtifacts.contains(new GroupArtifact(group, artifactId))) {
+                            if (!accumulator.projectArtifacts.contains(GroupArtifact.of(group, artifactId))) {
                                 ResolvedGroupArtifactVersion bom = dm.getBomGav();
                                 if (Objects.equals(group, bom.getGroupId()) &&
                                     Objects.equals(artifactId, bom.getArtifactId())) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/cache/RocksdbMavenPomCache.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/cache/RocksdbMavenPomCache.java
@@ -148,7 +148,7 @@ public class RocksdbMavenPomCache implements MavenPomCache {
             return deserializePom(cache.get(serialize(gav.toString().getBytes(StandardCharsets.UTF_8))));
         } catch (RocksDBException e) {
             throw new MavenDownloadingException("Failed to deserialize POM from RocksDB cache", e,
-                    new GroupArtifactVersion(gav.getGroupId(), gav.getArtifactId(), gav.getVersion()));
+                    GroupArtifactVersion.of(gav.getGroupId(), gav.getArtifactId(), gav.getVersion()));
         }
     }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -175,7 +175,7 @@ public class MavenPomDownloader {
         for (Pom projectPom : projectPoms.values()) {
             List<Pom> ancestryWithinProject = getAncestryWithinProject(projectPom, projectPoms);
             Map<String, String> mergedProperties = mergeProperties(ancestryWithinProject);
-            GroupArtifactVersion gav = new GroupArtifactVersion(
+            GroupArtifactVersion gav = GroupArtifactVersion.of(
                     projectPom.getGroupId(),
                     projectPom.getArtifactId(),
                     ResolvedPom.placeholderHelper.replacePlaceholders(projectPom.getVersion(), mergedProperties::get)
@@ -223,7 +223,7 @@ public class MavenPomDownloader {
     }
 
     public MavenMetadata downloadMetadata(GroupArtifact groupArtifact, @Nullable ResolvedPom containingPom, List<MavenRepository> repositories) throws MavenDownloadingException {
-        return downloadMetadata(new GroupArtifactVersion(groupArtifact.getGroupId(), groupArtifact.getArtifactId(), null),
+        return downloadMetadata(GroupArtifactVersion.of(groupArtifact.getGroupId(), groupArtifact.getArtifactId(), null),
                 containingPom,
                 repositories);
     }
@@ -553,7 +553,7 @@ public class MavenPomDownloader {
                 continue;
             }
 
-            ResolvedGroupArtifactVersion resolvedGav = new ResolvedGroupArtifactVersion(
+            ResolvedGroupArtifactVersion resolvedGav = ResolvedGroupArtifactVersion.of(
                     repo.getUri(), gav.getGroupId(), gav.getArtifactId(), gav.getVersion(), versionMaybeDatedSnapshot);
             Optional<Pom> result = mavenCache.getPom(resolvedGav);
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawGradleModule.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawGradleModule.java
@@ -100,7 +100,7 @@ public class RawGradleModule {
         DependencyAttributes attributes;
 
         GroupArtifactVersion asGav() {
-            return new GroupArtifactVersion(group, module, version == null ? null : version.getRequires());
+            return GroupArtifactVersion.of(group, module, version == null ? null : version.getRequires());
         }
     }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
@@ -423,7 +423,7 @@ public class RawPom {
 
 
     public Pom toPom(@Nullable Path inputPath, @Nullable MavenRepository repo) {
-        org.openrewrite.maven.tree.Parent parent = getParent() == null ? null : new org.openrewrite.maven.tree.Parent(new GroupArtifactVersion(
+        org.openrewrite.maven.tree.Parent parent = getParent() == null ? null : new org.openrewrite.maven.tree.Parent(GroupArtifactVersion.of(
                 getParent().getGroupId(), getParent().getArtifactId(),
                 getParent().getVersion()), getParent().getRelativePath());
 
@@ -431,7 +431,7 @@ public class RawPom {
                 .sourcePath(inputPath)
                 .repository(repo)
                 .parent(parent)
-                .gav(new ResolvedGroupArtifactVersion(
+                .gav(ResolvedGroupArtifactVersion.of(
                         repo == null ? null : repo.getUri(),
                         Objects.requireNonNull(getGroupId()),
                         artifactId,
@@ -543,7 +543,7 @@ public class RawPom {
             if (unmappedDependencies != null) {
                 dependencyManagementDependencies = new ArrayList<>(unmappedDependencies.size());
                 for (Dependency d : unmappedDependencies) {
-                    GroupArtifactVersion dGav = new GroupArtifactVersion(d.getGroupId(), d.getArtifactId(), d.getVersion());
+                    GroupArtifactVersion dGav = GroupArtifactVersion.of(d.getGroupId(), d.getArtifactId(), d.getVersion());
                     if ("import".equals(d.getScope())) {
                         dependencyManagementDependencies.add(new ManagedDependency.Imported(dGav));
                     } else {
@@ -562,7 +562,7 @@ public class RawPom {
             if (unmappedDependencies != null) {
                 dependencies = new ArrayList<>(unmappedDependencies.size());
                 for (Dependency d : unmappedDependencies) {
-                    GroupArtifactVersion dGav = new GroupArtifactVersion(d.getGroupId(), d.getArtifactId(), d.getVersion());
+                    GroupArtifactVersion dGav = GroupArtifactVersion.of(d.getGroupId(), d.getArtifactId(), d.getVersion());
                     dependencies.add(
                             org.openrewrite.maven.tree.Dependency.builder()
                                     .gav(dGav)
@@ -583,7 +583,7 @@ public class RawPom {
         if (rawDependencies != null) {
             dependencies = new ArrayList<>(rawDependencies.size());
             for (Dependency d : rawDependencies) {
-                GroupArtifactVersion dGav = new GroupArtifactVersion(d.getGroupId(), d.getArtifactId(), d.getVersion());
+                GroupArtifactVersion dGav = GroupArtifactVersion.of(d.getGroupId(), d.getArtifactId(), d.getVersion());
                 dependencies.add(org.openrewrite.maven.tree.Dependency.builder()
                         .gav(dGav)
                         .classifier(d.getClassifier())

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/trait/MavenDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/trait/MavenDependency.java
@@ -80,7 +80,7 @@ public class MavenDependency implements Trait<Xml.Tag> {
                                 .map(MavenSettings::getActiveProfiles)
                                 .map(MavenSettings.ActiveProfiles::getActiveProfiles)
                                 .orElse(null)
-                ).downloadMetadata(new GroupArtifact(groupId, artifactId), null, mrr.getPom().getRepositories()));
+                ).downloadMetadata(GroupArtifact.of(groupId, artifactId), null, mrr.getPom().getRepositories()));
             } catch (NumberFormatException e) {
                 // this can happen when we encounter exotic, non-semver version numbers
                 return null;
@@ -103,7 +103,7 @@ public class MavenDependency implements Trait<Xml.Tag> {
                         // fact that it's not in the metadata. Usually it won't be, only in situations like the
                         // MapR repository mentioned in the comment above will it be.
                         Pom pom = new MavenPomDownloader(emptyMap(), ctx,
-                                mrr.getMavenSettings(), mrr.getActiveProfiles()).download(new GroupArtifactVersion(groupId, artifactId, ((ExactVersion) versionComparator).getVersion()),
+                                mrr.getMavenSettings(), mrr.getActiveProfiles()).download(GroupArtifactVersion.of(groupId, artifactId, ((ExactVersion) versionComparator).getVersion()),
                                 null, null, mrr.getPom().getRepositories());
                         if (pom.getGav().getVersion().equals(exactVersion)) {
                             return exactVersion;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/GroupArtifact.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/GroupArtifact.java
@@ -16,14 +16,89 @@
 
 package org.openrewrite.maven.tree;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.errorprone.annotations.InlineMe;
 import lombok.Value;
-import lombok.With;
+import lombok.experimental.NonFinal;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
+import java.lang.ref.WeakReference;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
 
 @Value
-@With
 public class GroupArtifact implements Serializable {
+    private static final LinkedHashMap<String, WeakReference<GroupArtifact>> CACHE = new LinkedHashMap<String, WeakReference<GroupArtifact>>() {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry eldest) {
+            return size() > 10_000;
+        }
+    };
+
     String groupId;
     String artifactId;
+
+    @NonFinal
+    transient int hash;
+
+    /**
+     * Static factory method of() should be used instead. This is temporarily still public for minimally-disruptive deprecation.
+     */
+    @Deprecated
+    @InlineMe(replacement = "GroupArtifact.of(groupId, artifactId)", imports = "org.openrewrite.maven.tree.GroupArtifact")
+    public GroupArtifact(String groupId, String artifactId) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+    }
+
+    @JsonCreator
+    public static GroupArtifact of(
+            @Nullable String groupId,
+            String artifactId) {
+        String finalGroup = groupId == null ? "" : groupId;
+        String key = finalGroup + ":" + artifactId;
+
+        synchronized (CACHE) {
+            WeakReference<GroupArtifact> ref = CACHE.get(key);
+            GroupArtifact instance = ref != null ? ref.get() : null;
+
+            if (instance == null) {
+                instance = new GroupArtifact(finalGroup, artifactId);
+                CACHE.put(key, new WeakReference<>(instance));
+            }
+
+            return instance;
+        }
+    }
+
+    public GroupArtifact withGroupId(String groupId) {
+        return groupId.equals(this.groupId) ? this : of(groupId, artifactId);
+    }
+
+    public GroupArtifact withArtifactId(String artifactId) {
+        return artifactId.equals(this.artifactId) ? this : of(groupId, artifactId);
+    }
+
+    @Override
+    public int hashCode() {
+        int h = hash;
+        if (h == 0) {
+            h = Objects.hash(artifactId, groupId);
+        }
+        return h;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GroupArtifact that = (GroupArtifact) o;
+        return Objects.equals(groupId, that.groupId) && Objects.equals(artifactId, that.artifactId);
+    }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
@@ -189,7 +189,7 @@ public class MavenResolutionResult implements Marker {
                 dependencies.put(scope, pom.resolveDependencies(scope, downloader, ctx));
             } catch (MavenDownloadingExceptions e) {
                 for (MavenDownloadingException exception : e.getExceptions()) {
-                    if (exceptionsInLowerScopes.computeIfAbsent(new GroupArtifact(
+                    if (exceptionsInLowerScopes.computeIfAbsent(GroupArtifact.of(
                             exception.getRoot().getGroupId() == null ? "" : exception.getRoot().getGroupId(),
                             exception.getRoot().getArtifactId()), ga -> new HashSet<>()).add(exception.getFailedOn())) {
                         exceptions = MavenDownloadingExceptions.append(exceptions, exception);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedGroupArtifactVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedGroupArtifactVersion.java
@@ -16,16 +16,26 @@
 
 package org.openrewrite.maven.tree;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.errorprone.annotations.InlineMe;
 import lombok.Value;
-import lombok.With;
 import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
+import java.lang.ref.WeakReference;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 
 @Value
-@With
 public class ResolvedGroupArtifactVersion implements Serializable {
+    private static final LinkedHashMap<String, WeakReference<ResolvedGroupArtifactVersion>> CACHE = new LinkedHashMap<String, WeakReference<ResolvedGroupArtifactVersion>>() {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry eldest) {
+            return size() > 10_000;
+        }
+    };
+
     @Nullable
     String repository;
 
@@ -40,23 +50,76 @@ public class ResolvedGroupArtifactVersion implements Serializable {
     @Nullable
     String datedSnapshotVersion;
 
+    @InlineMe(
+            replacement = "ResolvedGroupArtifactVersion.of(repository, groupId, artifactId, version, datedSnapshotVersion)",
+            imports = "org.openrewrite.maven.tree.ResolvedGroupArtifactVersion")
+    public ResolvedGroupArtifactVersion(@Nullable String repository, String groupId, String artifactId, String version, @Nullable String datedSnapshotVersion) {
+        this.repository = repository;
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+        this.datedSnapshotVersion = datedSnapshotVersion;
+    }
+
+    @JsonCreator
+    public static ResolvedGroupArtifactVersion of(
+            @Nullable String repository,
+            String groupId,
+            String artifactId,
+            String version,
+            @Nullable String datedSnapshotVersion) {
+        String key = (repository == null ? "" : repository) + "::" + groupId + ":" + artifactId + ":" + version + ":" + (datedSnapshotVersion == null ? "" : datedSnapshotVersion);
+
+        synchronized (CACHE) {
+            WeakReference<ResolvedGroupArtifactVersion> ref = CACHE.get(key);
+            ResolvedGroupArtifactVersion instance = ref != null ? ref.get() : null;
+
+            if (instance == null) {
+                instance = new ResolvedGroupArtifactVersion(repository, groupId, artifactId, version, datedSnapshotVersion);
+                CACHE.put(key, new WeakReference<>(instance));
+            }
+
+            return instance;
+        }
+    }
+
     @Override
     public String toString() {
         return groupId + ":" + artifactId + ":" + (datedSnapshotVersion == null ? version : datedSnapshotVersion);
     }
 
     public GroupArtifact asGroupArtifact() {
-        return new GroupArtifact(groupId, artifactId);
+        return GroupArtifact.of(groupId, artifactId);
     }
 
     public GroupArtifactVersion asGroupArtifactVersion() {
-        return new GroupArtifactVersion(groupId, artifactId, version);
+        return GroupArtifactVersion.of(groupId, artifactId, version);
+    }
+
+    public ResolvedGroupArtifactVersion withRepository(@Nullable String repository) {
+        return Objects.equals(repository, this.repository) ? this : of(repository, groupId, artifactId, version, datedSnapshotVersion);
+    }
+
+    public ResolvedGroupArtifactVersion withGroupId(String groupId) {
+        return groupId.equals(this.groupId) ? this : of(repository, groupId, artifactId, version, datedSnapshotVersion);
+    }
+
+    public ResolvedGroupArtifactVersion withArtifactId(String artifactId) {
+        return artifactId.equals(this.artifactId) ? this : of(repository, groupId, artifactId, version, datedSnapshotVersion);
+    }
+
+    public ResolvedGroupArtifactVersion withVersion(String version) {
+        return version.equals(this.version) ? this : of(repository, groupId, artifactId, version, datedSnapshotVersion);
+    }
+
+    public ResolvedGroupArtifactVersion withDatedSnapshotVersion(@Nullable String datedSnapshotVersion) {
+        return Objects.equals(datedSnapshotVersion, this.datedSnapshotVersion) ? this : of(repository, groupId, artifactId, version, datedSnapshotVersion);
     }
 
     public ResolvedGroupArtifactVersion withGroupArtifact(GroupArtifact ga) {
         if (Objects.equals(ga.getGroupId(), groupId) && Objects.equals(ga.getArtifactId(), artifactId)) {
             return this;
         }
-        return new ResolvedGroupArtifactVersion(repository, ga.getGroupId(), ga.getArtifactId(), version, datedSnapshotVersion);
+        return ResolvedGroupArtifactVersion.of(repository, ga.getGroupId(), ga.getArtifactId(), version, datedSnapshotVersion);
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -1029,7 +1029,7 @@ public class ResolvedPom {
                         continue;
                     }
 
-                    GroupArtifact ga = new GroupArtifact(d.getGroupId() == null ? "" : d.getGroupId(), d.getArtifactId());
+                    GroupArtifact ga = GroupArtifact.of(d.getGroupId(), d.getArtifactId());
                     VersionRequirement existingRequirement = requirements.get(ga);
                     if (existingRequirement == null) {
                         VersionRequirement newRequirement = VersionRequirement.fromVersion(d.getVersion(), depth);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenWrapper.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenWrapper.java
@@ -116,7 +116,7 @@ public class MavenWrapper {
 
         List<MavenRepository> repositories = singletonList(repository);
         try {
-            GroupArtifact wrapperDistributionGroupArtifact = new GroupArtifact("org.apache.maven.wrapper", "maven-wrapper-distribution");
+            GroupArtifact wrapperDistributionGroupArtifact = GroupArtifact.of("org.apache.maven.wrapper", "maven-wrapper-distribution");
             MavenMetadata wrapperMetadata = pomDownloader.downloadMetadata(wrapperDistributionGroupArtifact, null, repositories);
             String resolvedWrapperVersion = wrapperMetadata.getVersioning()
                     .getVersions()
@@ -124,10 +124,10 @@ public class MavenWrapper {
                     .filter(v -> wrapperVersionComparator.isValid(null, v))
                     .max((v1, v2) -> wrapperVersionComparator.compare(null, v1, v2))
                     .orElseThrow(() -> new IllegalStateException("Expected to find at least one Maven wrapper version to select from."));
-            String resolvedWrapperUri = getDownloadUriFor(repository, new GroupArtifact("org.apache.maven.wrapper", "maven-wrapper"), resolvedWrapperVersion, null, "jar");
+            String resolvedWrapperUri = getDownloadUriFor(repository, GroupArtifact.of("org.apache.maven.wrapper", "maven-wrapper"), resolvedWrapperVersion, null, "jar");
             String resolvedWrapperDistributionUri = getDownloadUriFor(repository, wrapperDistributionGroupArtifact, resolvedWrapperVersion, wrapperDistributionType.classifier, "zip");
 
-            GroupArtifact distributionGroupArtifact = new GroupArtifact("org.apache.maven", "apache-maven");
+            GroupArtifact distributionGroupArtifact = GroupArtifact.of("org.apache.maven", "apache-maven");
             MavenMetadata distributionMetadata = pomDownloader.downloadMetadata(distributionGroupArtifact, null, repositories);
             String resolvedDistributionVersion = distributionMetadata.getVersioning()
                     .getVersions()

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/PrintMavenAsDot.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/PrintMavenAsDot.java
@@ -62,7 +62,7 @@ public class PrintMavenAsDot extends Recipe {
 
                 // for convenience, we construct a ResolvedDependency out of the POM's GAV.
                 ResolvedGroupArtifactVersion root =
-                        new ResolvedGroupArtifactVersion(
+                        ResolvedGroupArtifactVersion.of(
                                 null,
                                 mrr.getPom().getGroupId(),
                                 mrr.getPom().getArtifactId(),

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -3957,11 +3957,11 @@ class MavenParserTest implements RewriteTest {
                     .map(ResolvedGroupArtifactVersion::asGroupArtifactVersion)
                     .as("At one point this test failed with no version number found for jakarta.xml.bind-api because ResolvedPom was not considering classifiers as significant for dependency management")
                     .containsExactlyInAnyOrder(
-                      new GroupArtifactVersion("org.glassfish.jaxb", "jaxb-runtime", "2.3.9"),
-                      new GroupArtifactVersion("jakarta.xml.bind", "jakarta.xml.bind-api", "2.3.3"),
-                      new GroupArtifactVersion("org.glassfish.jaxb", "txw2", "2.3.9"),
-                      new GroupArtifactVersion("com.sun.istack", "istack-commons-runtime", "3.0.12"),
-                      new GroupArtifactVersion("com.sun.activation", "jakarta.activation", "1.2.2")
+                      GroupArtifactVersion.of("org.glassfish.jaxb", "jaxb-runtime", "2.3.9"),
+                      GroupArtifactVersion.of("jakarta.xml.bind", "jakarta.xml.bind-api", "2.3.3"),
+                      GroupArtifactVersion.of("org.glassfish.jaxb", "txw2", "2.3.9"),
+                      GroupArtifactVersion.of("com.sun.istack", "istack-commons-runtime", "3.0.12"),
+                      GroupArtifactVersion.of("com.sun.activation", "jakarta.activation", "1.2.2")
                     );
               }
             )

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/cache/LocalMavenArtifactCacheTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/cache/LocalMavenArtifactCacheTest.java
@@ -59,7 +59,7 @@ class LocalMavenArtifactCacheTest {
 
     private static ResolvedDependency findDependency() {
         ExecutionContext ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
-        ResolvedGroupArtifactVersion recipeGav = new ResolvedGroupArtifactVersion(
+        ResolvedGroupArtifactVersion recipeGav = ResolvedGroupArtifactVersion.of(
           "https://repo1.maven.org/maven2",
           "org.openrewrite.recipe",
           "rewrite-testing-frameworks",

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -160,7 +160,7 @@ class MavenPomDownloaderTest implements RewriteTest {
             var centralOverride = new MavenRepository("repo", "https://google.com/definitelydoesnotexist/", null, null, true, null, null, null, null);
             var downloader = new MavenPomDownloader(emptyMap(), ctx);
             try {
-                downloader.download(new GroupArtifactVersion("org.openrewrite", "nonexistent", "7.0.0"), null, null, List.of(centralOverride));
+                downloader.download(GroupArtifactVersion.of("org.openrewrite", "nonexistent", "7.0.0"), null, null, List.of(centralOverride));
                 Assertions.fail();
             } catch (MavenDownloadingException ignore) {
             }
@@ -191,7 +191,7 @@ class MavenPomDownloaderTest implements RewriteTest {
 
             try {
                 new MavenPomDownloader(ctx)
-                  .download(new GroupArtifactVersion("org.openrewrite", "rewrite-core", "7.0.0"), null, null, singletonList(nonexistentRepo));
+                  .download(GroupArtifactVersion.of("org.openrewrite", "rewrite-core", "7.0.0"), null, null, singletonList(nonexistentRepo));
             } catch (Exception e) {
                 // not expected to succeed
             }
@@ -219,7 +219,7 @@ class MavenPomDownloaderTest implements RewriteTest {
             });
 
             new MavenPomDownloader(ctx)
-              .download(new GroupArtifactVersion("org.openrewrite", "rewrite-core", "7.0.0"), null, null, List.of(MAVEN_CENTRAL, nonExistentRepo));
+              .download(GroupArtifactVersion.of("org.openrewrite", "rewrite-core", "7.0.0"), null, null, List.of(MAVEN_CENTRAL, nonExistentRepo));
             assertThat(attemptedUris).isEmpty();
         }
 
@@ -240,7 +240,7 @@ class MavenPomDownloaderTest implements RewriteTest {
 
             try {
                 new MavenPomDownloader(ctx)
-                  .download(new GroupArtifactVersion("org.openrewrite", "rewrite-core", "7.0.0"), null, null, singletonList(nonexistentRepo));
+                  .download(GroupArtifactVersion.of("org.openrewrite", "rewrite-core", "7.0.0"), null, null, singletonList(nonexistentRepo));
             } catch (Exception e) {
                 // not expected to succeed
             }
@@ -272,7 +272,7 @@ class MavenPomDownloaderTest implements RewriteTest {
               .sourcePath(pomPath)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-              .gav(new ResolvedGroupArtifactVersion(
+              .gav(ResolvedGroupArtifactVersion.of(
                 "${REPO_URL}", "org.openrewrite", "rewrite-core", "7.0.0", null))
               .build();
             ResolvedPom resolvedPom = ResolvedPom.builder()
@@ -572,7 +572,7 @@ class MavenPomDownloaderTest implements RewriteTest {
                   .uri("http://%s:%d/maven/".formatted(snapshotServer.getHostName(), snapshotServer.getPort()))
                   .build();
 
-                var gav = new GroupArtifactVersion("com.some", "an-artifact", "10.5.0-SNAPSHOT");
+                var gav = GroupArtifactVersion.of("com.some", "an-artifact", "10.5.0-SNAPSHOT");
                 var mavenPomDownloader = new MavenPomDownloader(emptyMap(), ctx);
 
                 var pomPath = Path.of("pom.xml");
@@ -580,7 +580,7 @@ class MavenPomDownloaderTest implements RewriteTest {
                   .sourcePath(pomPath)
                   .repository(snapshotRepo)
                   .properties(singletonMap("REPO_URL", snapshotRepo.getUri()))
-                  .gav(new ResolvedGroupArtifactVersion(
+                  .gav(ResolvedGroupArtifactVersion.of(
                     "${REPO_URL}", gav.getGroupId(), gav.getArtifactId(), gav.getVersion(), null))
                   .build();
                 var resolvedPom = ResolvedPom.builder()
@@ -612,7 +612,7 @@ class MavenPomDownloaderTest implements RewriteTest {
               .deriveMetadataIfMissing(true)
               .build();
             MavenMetadata metaData = new MavenPomDownloader(emptyMap(), ctx)
-              .downloadMetadata(new GroupArtifact("fred", "fred"), null, List.of(repository));
+              .downloadMetadata(GroupArtifact.of("fred", "fred"), null, List.of(repository));
             assertThat(metaData.getVersioning().getVersions()).hasSize(3).containsAll(List.of("1.0.0", "1.1.0", "2.0.0"));
         }
 
@@ -710,7 +710,7 @@ class MavenPomDownloaderTest implements RewriteTest {
             // Does not return invalid dependency.
             assertThrows(MavenDownloadingException.class, () ->
               new MavenPomDownloader(emptyMap(), ctx)
-                .download(new GroupArtifactVersion("com.bad", "bad-artifact", "1"), null, null, List.of(mavenLocal)));
+                .download(GroupArtifactVersion.of("com.bad", "bad-artifact", "1"), null, null, List.of(mavenLocal)));
         }
 
         @Test
@@ -743,7 +743,7 @@ class MavenPomDownloaderTest implements RewriteTest {
             // Does not return invalid dependency.
             assertThrows(MavenDownloadingException.class, () ->
               new MavenPomDownloader(emptyMap(), ctx)
-                .download(new GroupArtifactVersion("com.bad", "bad-artifact", "1"), null, null, List.of(mavenLocal)));
+                .download(GroupArtifactVersion.of("com.bad", "bad-artifact", "1"), null, null, List.of(mavenLocal)));
         }
 
         @Test
@@ -757,7 +757,7 @@ class MavenPomDownloaderTest implements RewriteTest {
 
             // Do not return invalid dependency
             assertThrows(MavenDownloadingException.class, () -> new MavenPomDownloader(emptyMap(), ctx)
-              .download(new GroupArtifactVersion("com.bad", "bad-artifact", "1"), null, null, List.of(mavenLocal)));
+              .download(GroupArtifactVersion.of("com.bad", "bad-artifact", "1"), null, null, List.of(mavenLocal)));
         }
 
         @Test
@@ -776,7 +776,7 @@ class MavenPomDownloaderTest implements RewriteTest {
 
             // Do not throw exception since we have a jar
             var result = new MavenPomDownloader(emptyMap(), ctx)
-              .download(new GroupArtifactVersion("com.some", "some-artifact", "1"), null, null, List.of(mavenLocal));
+              .download(GroupArtifactVersion.of("com.some", "some-artifact", "1"), null, null, List.of(mavenLocal));
             assertThat(result.getGav().getGroupId()).isEqualTo("com.some");
             assertThat(result.getGav().getArtifactId()).isEqualTo("some-artifact");
             assertThat(result.getGav().getVersion()).isEqualTo("1");
@@ -798,7 +798,7 @@ class MavenPomDownloaderTest implements RewriteTest {
         @Test
         void connectTimeout() {
             var downloader = new MavenPomDownloader(ctx);
-            var gav = new GroupArtifactVersion("org.openrewrite", "rewrite-core", "7.0.0");
+            var gav = GroupArtifactVersion.of("org.openrewrite", "rewrite-core", "7.0.0");
             var repos = singletonList(MavenRepository.builder()
               .id("non-routable").uri("http://10.0.0.0/maven").knownToExist(true).build());
 
@@ -826,20 +826,20 @@ class MavenPomDownloaderTest implements RewriteTest {
                 </project>
                 """.getBytes());
             Files.write(jar, "I'm a jar".getBytes()); // empty jars get ignored
-            return new GroupArtifactVersion("org.openrewrite", "rewrite", "1.0.0");
+            return GroupArtifactVersion.of("org.openrewrite", "rewrite", "1.0.0");
         }
 
         @Test
         void shouldNotThrowExceptionForModulesInModulesWithRightProperty() {
-            var gav = new GroupArtifactVersion("test", "test2", "${test}");
+            var gav = GroupArtifactVersion.of("test", "test2", "${test}");
 
             Path testTest2PomXml = Path.of("test/test2/pom.xml");
             Pom pom = Pom.builder()
               .sourcePath(testTest2PomXml)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-              .parent(new Parent(new GroupArtifactVersion("test", "test", "${test}"), "../pom.xml"))
-              .gav(new ResolvedGroupArtifactVersion(
+              .parent(new Parent(GroupArtifactVersion.of("test", "test", "${test}"), "../pom.xml"))
+              .gav(ResolvedGroupArtifactVersion.of(
                 "${REPO_URL}", "test", "test2", "7.0.0", null))
               .build();
 
@@ -854,8 +854,8 @@ class MavenPomDownloaderTest implements RewriteTest {
               .sourcePath(testPomXml)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-              .parent(new Parent(new GroupArtifactVersion("test", "root-test", "${test}"), "../pom.xml"))
-              .gav(new ResolvedGroupArtifactVersion(
+              .parent(new Parent(GroupArtifactVersion.of("test", "root-test", "${test}"), "../pom.xml"))
+              .gav(ResolvedGroupArtifactVersion.of(
                 "${REPO_URL}", "test", "test", "7.0.0", null))
               .build();
 
@@ -866,7 +866,7 @@ class MavenPomDownloaderTest implements RewriteTest {
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("test", "7.0.0"))
               .parent(null)
-              .gav(new ResolvedGroupArtifactVersion(
+              .gav(ResolvedGroupArtifactVersion.of(
                 "${REPO_URL}", "test", "root-test", "7.0.0", null))
               .build();
 
@@ -885,15 +885,15 @@ class MavenPomDownloaderTest implements RewriteTest {
 
         @Test
         void shouldThrowExceptionForModulesInModulesWithNoRightProperty() {
-            var gav = new GroupArtifactVersion("test", "test2", "${test}");
+            var gav = GroupArtifactVersion.of("test", "test2", "${test}");
 
             Path testTest2PomXml = Path.of("test/test2/pom.xml");
             Pom pom = Pom.builder()
               .sourcePath(testTest2PomXml)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-              .parent(new Parent(new GroupArtifactVersion("test", "test", "${test}"), "../pom.xml"))
-              .gav(new ResolvedGroupArtifactVersion(
+              .parent(new Parent(GroupArtifactVersion.of("test", "test", "${test}"), "../pom.xml"))
+              .gav(ResolvedGroupArtifactVersion.of(
                 "${REPO_URL}", "test", "test2", "7.0.0", null))
               .build();
 
@@ -908,8 +908,8 @@ class MavenPomDownloaderTest implements RewriteTest {
               .sourcePath(testPomXml)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-              .parent(new Parent(new GroupArtifactVersion("test", "root-test", "${test}"), "../pom.xml"))
-              .gav(new ResolvedGroupArtifactVersion(
+              .parent(new Parent(GroupArtifactVersion.of("test", "root-test", "${test}"), "../pom.xml"))
+              .gav(ResolvedGroupArtifactVersion.of(
                 "${REPO_URL}", "test", "test", "7.0.0", null))
               .build();
 
@@ -920,7 +920,7 @@ class MavenPomDownloaderTest implements RewriteTest {
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("tt", "7.0.0"))
               .parent(null)
-              .gav(new ResolvedGroupArtifactVersion(
+              .gav(ResolvedGroupArtifactVersion.of(
                 "${REPO_URL}", "test", "root-test", "7.0.0", null))
               .build();
 
@@ -939,15 +939,15 @@ class MavenPomDownloaderTest implements RewriteTest {
 
         @Test
         void canResolveDifferentVersionOfProjectPom() {
-            var gav = new GroupArtifactVersion("org.springframework.boot", "spring-boot-starter-parent", "3.0.0");
+            var gav = GroupArtifactVersion.of("org.springframework.boot", "spring-boot-starter-parent", "3.0.0");
 
             Path pomPath = Path.of("pom.xml");
             Pom pom = Pom.builder()
               .sourcePath(pomPath)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-              .parent(new Parent(new GroupArtifactVersion("org.springframework.boot", "spring-boot-dependencies", "2.7.0"), null))
-              .gav(new ResolvedGroupArtifactVersion(
+              .parent(new Parent(GroupArtifactVersion.of("org.springframework.boot", "spring-boot-dependencies", "2.7.0"), null))
+              .gav(ResolvedGroupArtifactVersion.of(
                 "${REPO_URL}", "org.springframework.boot", "spring-boot-starter-parent", "2.7.0", null))
               .build();
 
@@ -1056,7 +1056,7 @@ class MavenPomDownloaderTest implements RewriteTest {
         @Test
         void invalidArtifact() {
             var downloader = new MavenPomDownloader(emptyMap(), ctx);
-            var gav = new GroupArtifactVersion("fred", "fred", "1.0.0");
+            var gav = GroupArtifactVersion.of("fred", "fred", "1.0.0");
             mockServer(500,
               repo1 -> mockServer(400, repo2 -> {
                   var repositories = List.of(
@@ -1082,7 +1082,7 @@ class MavenPomDownloaderTest implements RewriteTest {
         @Test
         void useSnapshotTimestampVersion() {
             var downloader = new MavenPomDownloader(emptyMap(), ctx);
-            var gav = new GroupArtifactVersion("fred", "fred", "2020.0.2-20210127.131051-2");
+            var gav = GroupArtifactVersion.of("fred", "fred", "2020.0.2-20210127.131051-2");
             try (MockWebServer mockRepo = getMockServer()) {
                 mockRepo.setDispatcher(new Dispatcher() {
                     @Override
@@ -1118,7 +1118,7 @@ class MavenPomDownloaderTest implements RewriteTest {
         @Test
         void usesAnonymousRequestIfRepositoryRejectsCredentials() {
             var downloader = new MavenPomDownloader(emptyMap(), ctx);
-            var gav = new GroupArtifactVersion("fred", "fred", "1.0.0");
+            var gav = GroupArtifactVersion.of("fred", "fred", "1.0.0");
             try (MockWebServer mockRepo = getMockServer()) {
                 mockRepo.setDispatcher(new Dispatcher() {
                     @Override
@@ -1153,7 +1153,7 @@ class MavenPomDownloaderTest implements RewriteTest {
         @Test
         void usesAuthenticationIfRepositoryHasCredentials() {
             var downloader = new MavenPomDownloader(emptyMap(), ctx);
-            var gav = new GroupArtifactVersion("fred", "fred", "1.0.0");
+            var gav = GroupArtifactVersion.of("fred", "fred", "1.0.0");
             try (MockWebServer mockRepo = getMockServer()) {
                 mockRepo.setDispatcher(new Dispatcher() {
                     @Override
@@ -1197,7 +1197,7 @@ class MavenPomDownloaderTest implements RewriteTest {
         @Test
         void doesNotUseAuthenticationIfCredentialsCannotBeResolved() {
             var downloader = new MavenPomDownloader(emptyMap(), ctx);
-            var gav = new GroupArtifactVersion("fred", "fred", "1.0.0");
+            var gav = GroupArtifactVersion.of("fred", "fred", "1.0.0");
             try (MockWebServer mockRepo = getMockServer()) {
                 mockRepo.setDispatcher(new Dispatcher() {
                     @Override
@@ -1254,7 +1254,7 @@ class MavenPomDownloaderTest implements RewriteTest {
                   .build());
 
                 var downloader = new MavenPomDownloader(emptyMap(), ctx);
-                var gav = new GroupArtifactVersion("fred", "fred", "1");
+                var gav = GroupArtifactVersion.of("fred", "fred", "1");
                 assertThrows(MavenDownloadingException.class, () -> downloader.download(gav, null, null, repositories));
             }
         }
@@ -1282,7 +1282,7 @@ class MavenPomDownloaderTest implements RewriteTest {
                   .password("pass")
                   .build());
 
-                var gav = new GroupArtifactVersion("fred", "fred", "1");
+                var gav = GroupArtifactVersion.of("fred", "fred", "1");
                 var downloader = new MavenPomDownloader(emptyMap(), ctx);
                 Pom downloaded = downloader.download(gav, null, null, repositories);
                 assertThat(downloaded.getGav().getGroupId()).isEqualTo("fred");
@@ -1327,7 +1327,7 @@ class MavenPomDownloaderTest implements RewriteTest {
                   .password("pass")
                   .build());
 
-                var gav = new GroupArtifactVersion("fred", "fred", "1");
+                var gav = GroupArtifactVersion.of("fred", "fred", "1");
                 var downloader = new MavenPomDownloader(emptyMap(), ctx);
                 assertThatThrownBy(() -> downloader.download(gav, null, null, repositories))
                   .isInstanceOf(MavenDownloadingException.class)

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/MavenArtifactDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/MavenArtifactDownloaderTest.java
@@ -42,7 +42,7 @@ class MavenArtifactDownloaderTest {
         MavenArtifactCache artifactCache = new LocalMavenArtifactCache(tempDir);
         MavenArtifactDownloader downloader = new MavenArtifactDownloader(
           artifactCache, null, t -> ctx.getOnError().accept(t));
-        ResolvedGroupArtifactVersion recipeGav = new ResolvedGroupArtifactVersion(
+        ResolvedGroupArtifactVersion recipeGav = ResolvedGroupArtifactVersion.of(
           "https://repo1.maven.org/maven2",
           "org.openrewrite.recipe",
           "rewrite-testing-frameworks",


### PR DESCRIPTION
We have seen high GC overhead / memory pressure related to these objects. They are created and discarded frequently both during parsing and recipe execution. 
