### PR TITLE
Support adding search markers in Rewrite RPC remote peers

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/Markers.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/Markers.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BinaryOperator;
 
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.openrewrite.Tree.randomId;
 
@@ -110,6 +111,7 @@ public class Markers implements RpcCodec<Markers> {
     }
 
     public Markers removeByType(Class<? extends Marker> type) {
+        //noinspection DataFlowIssue
         return withMarkers(ListUtils.map(this.markers, m -> type.equals(m.getClass()) ? null : m));
     }
 
@@ -146,7 +148,7 @@ public class Markers implements RpcCodec<Markers> {
     /**
      * Add a new marker or update some existing marker.
      *
-     * @param m   A marker, which may or may not already exist already.
+     * @param m   A marker, which may or may not already exist.
      * @param <M> The marker type.
      * @return If a marker already exists that matches by object equality, an unchanged markers reference
      * is returned. Otherwise, the supplied marker is added.
@@ -178,6 +180,6 @@ public class Markers implements RpcCodec<Markers> {
     @Override
     public Markers rpcReceive(Markers before, RpcReceiveQueue q) {
         return withId(q.receiveAndGet(getId(), UUID::fromString))
-                .withMarkers(q.receiveList(getMarkers(), null));
+                .withMarkers(requireNonNull(q.receiveList(getMarkers(), null)));
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -324,10 +324,9 @@ public class RewriteRpc {
     public <T> T getObject(String id) {
         // Check if we have a cached version of this object
         Object localObject = localObjects.get(id);
-        String lastKnownId = localObject != null ? id : null;
 
         RpcReceiveQueue q = new RpcReceiveQueue(remoteRefs, () -> send("GetObject",
-                new GetObject(id, lastKnownId), GetObjectResponse.class));
+                new GetObject(id), GetObjectResponse.class));
         Object remoteObject = q.receive(localObject, null);
         if (q.take().getState() != END_OF_OBJECT) {
             throw new IllegalStateException("Expected END_OF_OBJECT");

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -70,6 +70,11 @@ public class RewriteRpcProcess extends Thread {
         return environment;
     }
 
+    public RewriteRpcProcess trace() {
+        this.trace = true;
+        return this;
+    }
+
     @Override
     public void run() {
         try {

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -62,14 +62,6 @@ public class RpcSendQueue {
         batch.clear();
     }
 
-    public <T> void sendMarkers(T parent, Function<T, Markers> markersFn) {
-        getAndSend(parent, t2 -> asRef(markersFn.apply(t2)), markersRef -> {
-            Markers markers = Reference.getValue(markersRef);
-            getAndSend(requireNonNull(markers), Markers::getId);
-            getAndSendList(markers, Markers::getMarkers, Marker::getId, null);
-        });
-    }
-
     public <T, U> void getAndSend(T parent, Function<T, @Nullable U> value) {
         getAndSend(parent, value, null);
     }

--- a/rewrite-core/src/main/java/org/openrewrite/text/PlainText.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/PlainText.java
@@ -163,7 +163,7 @@ public class PlainText implements SourceFileWithReferences, Tree, RpcCodec<Plain
     @Override
     public void rpcSend(PlainText after, RpcSendQueue q) {
         q.getAndSend(after, Tree::getId);
-        q.sendMarkers(after, Tree::getMarkers);
+        q.getAndSend(after, Tree::getMarkers);
         q.getAndSend(after, (PlainText d) -> d.getSourcePath().toString());
         q.getAndSend(after, (PlainText d) -> d.getCharset().name());
         q.getAndSend(after, PlainText::isCharsetBomMarked);
@@ -172,7 +172,7 @@ public class PlainText implements SourceFileWithReferences, Tree, RpcCodec<Plain
         q.getAndSend(after, PlainText::getText);
         q.getAndSendList(after, PlainText::getSnippets, Tree::getId, snippet -> {
             q.getAndSend(snippet, Tree::getId);
-            q.sendMarkers(snippet, Tree::getMarkers);
+            q.getAndSend(snippet, Tree::getMarkers);
             q.getAndSend(snippet, Snippet::getText);
         });
     }
@@ -180,7 +180,7 @@ public class PlainText implements SourceFileWithReferences, Tree, RpcCodec<Plain
     @Override
     public PlainText rpcReceive(PlainText t, RpcReceiveQueue q) {
         return t.withId(q.receiveAndGet(t.getId(), UUID::fromString))
-                .withMarkers(q.receiveMarkers(t.getMarkers()))
+                .withMarkers(q.receive(t.getMarkers()))
                 .withSourcePath(q.<Path, String>receiveAndGet(t.getSourcePath(), Paths::get))
                 .withCharsetName(q.receiveAndGet(t.getCharsetName(), String::toString))
                 .withCharsetBomMarked(q.receive(t.isCharsetBomMarked()))
@@ -189,7 +189,7 @@ public class PlainText implements SourceFileWithReferences, Tree, RpcCodec<Plain
                 .withText(q.receive(t.getText()))
                 .withSnippets(q.receiveList(t.getSnippets(), s -> s
                         .withId(q.receiveAndGet(s.getId(), UUID::fromString))
-                        .withMarkers(q.receiveMarkers(s.getMarkers()))
+                        .withMarkers(q.receive(s.getMarkers()))
                         .withText(q.receive(s.getText()))));
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/tree/ParseError.java
+++ b/rewrite-core/src/main/java/org/openrewrite/tree/ParseError.java
@@ -125,7 +125,7 @@ public class ParseError implements SourceFile, RpcCodec<ParseError> {
     @Override
     public void rpcSend(ParseError after, RpcSendQueue q) {
         q.getAndSend(after, Tree::getId);
-        q.sendMarkers(after, Tree::getMarkers);
+        q.getAndSend(after, Tree::getMarkers);
         q.getAndSend(after, (ParseError d) -> d.getSourcePath().toString());
         q.getAndSend(after, (ParseError d) -> d.getCharset().name());
         q.getAndSend(after, ParseError::isCharsetBomMarked);
@@ -137,7 +137,7 @@ public class ParseError implements SourceFile, RpcCodec<ParseError> {
     @Override
     public ParseError rpcReceive(ParseError t, RpcReceiveQueue q) {
         return t.withId(q.receiveAndGet(t.getId(), UUID::fromString))
-                .withMarkers(q.receiveMarkers(t.getMarkers()))
+                .withMarkers(q.receive(t.getMarkers()))
                 .withSourcePath(q.<Path, String>receiveAndGet(t.getSourcePath(), Paths::get))
                 .withCharset(q.<Charset, String>receiveAndGet(t.getCharset(), Charset::forName))
                 .withCharsetBomMarked(q.receive(t.isCharsetBomMarked()))

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaReceiver.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaReceiver.java
@@ -35,9 +35,10 @@ public class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
 
     @Override
     public J preVisit(J j, RpcReceiveQueue q) {
-        return ((J) j.withId(q.receiveAndGet(j.getId(), UUID::fromString)))
-                .withPrefix(q.receive(j.getPrefix(), space -> visitSpace(space, q)))
-                .withMarkers(q.receiveMarkers(j.getMarkers()));
+        J j2 = j.withId(q.receiveAndGet(j.getId(), UUID::fromString));
+        j2 = j2.withPrefix(q.receive(j.getPrefix(), space -> visitSpace(space, q)));
+        j2 = j2.withMarkers(q.receive(j.getMarkers()));
+        return j2;
     }
 
     @Override
@@ -608,7 +609,7 @@ public class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
                         return ((TextComment) c).withMultiline(q.receive(c.isMultiline()))
                                 .withText(q.receive(((TextComment) c).getText()))
                                 .withSuffix(q.receive(c.getSuffix()))
-                                .withMarkers(q.receiveMarkers(c.getMarkers()));
+                                .withMarkers(q.receive(c.getMarkers()));
                     }
                     return c;
                 }))
@@ -620,7 +621,7 @@ public class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
                 .withBefore(q.receive(container.getBefore(), space -> visitSpace(space, q)))
                 .getPadding().withElements(q.receiveList(container.getPadding().getElements(),
                         e -> visitRightPadded(e, q)))
-                .withMarkers(q.receiveMarkers(container.getMarkers()));
+                .withMarkers(q.receive(container.getMarkers()));
     }
 
     public <T> JLeftPadded<T> visitLeftPadded(JLeftPadded<T> left, RpcReceiveQueue q) {
@@ -636,14 +637,14 @@ public class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
                     }
                     return t;
                 }))
-                .withMarkers(q.receiveMarkers(left.getMarkers()));
+                .withMarkers(q.receive(left.getMarkers()));
     }
 
     public <T> JLeftPadded<T> visitLeftPadded(JLeftPadded<T> left, RpcReceiveQueue q, Function<Object, T> elementMapping) {
         return left
                 .withBefore(q.receive(left.getBefore(), s -> visitSpace(s, q)))
                 .withElement(requireNonNull(q.receiveAndGet(left.getElement(), elementMapping)))
-                .withMarkers(q.receiveMarkers(left.getMarkers()));
+                .withMarkers(q.receive(left.getMarkers()));
     }
 
     public <T> JRightPadded<T> visitRightPadded(JRightPadded<T> right, RpcReceiveQueue q) {
@@ -659,7 +660,7 @@ public class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
                     return t;
                 }))
                 .withAfter(q.receive(right.getAfter(), s -> visitSpace(s, q)))
-                .withMarkers(q.receiveMarkers(right.getMarkers()));
+                .withMarkers(q.receive(right.getMarkers()));
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaSender.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaSender.java
@@ -32,7 +32,7 @@ public class JavaSender extends JavaVisitor<RpcSendQueue> {
     public J preVisit(J j, RpcSendQueue q) {
         q.getAndSend(j, Tree::getId);
         q.getAndSend(j, J::getPrefix, space -> visitSpace(getValueNonNull(space), q));
-        q.sendMarkers(j, Tree::getMarkers);
+        q.getAndSend(j, Tree::getMarkers);
         return j;
     }
 
@@ -596,7 +596,7 @@ public class JavaSender extends JavaVisitor<RpcSendQueue> {
         } else {
             q.getAndSend(left, JLeftPadded::getElement);
         }
-        q.sendMarkers(left, JLeftPadded::getMarkers);
+        q.getAndSend(left, JLeftPadded::getMarkers);
     }
 
     public <T> void visitRightPadded(JRightPadded<T> right, RpcSendQueue q) {
@@ -609,13 +609,13 @@ public class JavaSender extends JavaVisitor<RpcSendQueue> {
             q.getAndSend(right, JRightPadded::getElement);
         }
         q.getAndSend(right, JRightPadded::getAfter, space -> visitSpace(getValueNonNull(space), q));
-        q.sendMarkers(right, JRightPadded::getMarkers);
+        q.getAndSend(right, JRightPadded::getMarkers);
     }
 
     public <J2 extends J> void visitContainer(JContainer<J2> container, RpcSendQueue q) {
         q.getAndSend(container, JContainer::getBefore, space -> visitSpace(getValueNonNull(space), q));
         q.getAndSendList(container, c -> c.getPadding().getElements(), e -> e.getElement().getId(), e -> visitRightPadded(e, q));
-        q.sendMarkers(container, JContainer::getMarkers);
+        q.getAndSend(container, JContainer::getMarkers);
     }
 
     public void visitSpace(Space space, RpcSendQueue q) {
@@ -637,7 +637,7 @@ public class JavaSender extends JavaVisitor<RpcSendQueue> {
                         throw new IllegalArgumentException("Unexpected comment type " + c.getClass().getName());
                     }
                     q.getAndSend(c, Comment::getSuffix);
-                    q.sendMarkers(c, Comment::getMarkers);
+                    q.getAndSend(c, Comment::getMarkers);
                 });
         q.getAndSend(space, Space::getWhitespace);
     }

--- a/rewrite-javascript/rewrite/fixtures/change-text.ts
+++ b/rewrite-javascript/rewrite/fixtures/change-text.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {ReplacedText} from "./replaced-text";
+import {ExecutionContext, Option, Recipe, Transient, TreeVisitor} from "@openrewrite/rewrite";
+import {PlainText, PlainTextVisitor} from "@openrewrite/rewrite/text";
+
+export class ChangeText extends Recipe {
+    name = "org.openrewrite.example.text.change-text"
+    displayName = "Change text";
+    description = "Change the text of a file.";
+
+    @Option({
+        displayName: "Text",
+        description: "Text to change to"
+    })
+    text!: string;
+
+    constructor(options: { text: string }) {
+        super(options);
+    }
+
+    @Transient
+    replacedText = ReplacedText.dataTable;
+
+    instanceName(): string {
+        return `Change text to '${this.text}'`;
+    }
+
+    get editor(): TreeVisitor<any, ExecutionContext> {
+        const toText = this.text;
+        const replacedText = this.replacedText;
+        return new class extends PlainTextVisitor<ExecutionContext> {
+            visitText(text: PlainText, ctx: ExecutionContext): Promise<PlainText> {
+                return this.produceTree(text, ctx, draft => {
+                    if (draft.text != toText) {
+                        replacedText.insertRow(ctx, new ReplacedText(text.sourcePath, draft.text));
+                    }
+                    draft.text = toText;
+                })
+            }
+        }
+    }
+}

--- a/rewrite-javascript/rewrite/fixtures/change-version.ts
+++ b/rewrite-javascript/rewrite/fixtures/change-version.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {ExecutionContext, Option, Recipe} from "@openrewrite/rewrite";
+import {Json, JsonVisitor} from "@openrewrite/rewrite/json";
+
+export class ChangeVersion extends Recipe {
+    name = "org.openrewrite.example.npm.change-version";
+    displayName = "Change version in `package.json`";
+    description = "Change the version in both `package.json` and `package-lock.json`.";
+
+    @Option({
+        displayName: "Version",
+        description: "The version to change to."
+    })
+    version!: string
+
+    constructor(options: { version: string }) {
+        super(options);
+    }
+
+    get editor(): JsonVisitor<ExecutionContext> {
+        const v = this.version;
+        return new class extends JsonVisitor<ExecutionContext> {
+            protected async visitDocument(document: Json.Document, p: ExecutionContext): Promise<Json | undefined> {
+                // Only visit package.json and package-lock.json files
+                if (!(document.sourcePath.endsWith("package.json") || document.sourcePath.endsWith("package-lock.json"))) {
+                    return document;
+                }
+                return super.visitDocument(document, p);
+            }
+
+            protected async visitMember(member: Json.Member, p: ExecutionContext): Promise<Json | undefined> {
+                return this.produceJson<Json.Member>(await super.visitMember(member, p), p, draft => {
+                    let key = member.key.element;
+                    if (key.kind === Json.Kind.Literal && key.value === "version") {
+                        if (draft.value.kind === Json.Kind.Literal) {
+                            draft.value.value = v;
+                            draft.value.source = `"${v}"`;
+                        }
+                    }
+                });
+            }
+        };
+    }
+}

--- a/rewrite-javascript/rewrite/fixtures/create-text.ts
+++ b/rewrite-javascript/rewrite/fixtures/create-text.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {ExecutionContext, Option, ScanningRecipe, SourceFile} from "@openrewrite/rewrite";
+import {PlainTextParser} from "@openrewrite/rewrite/text";
+
+export class CreateText extends ScanningRecipe<{ exists: boolean }> {
+    name = "org.openrewrite.example.text.create-text";
+    displayName = "Create text file";
+    description = "Create a new text file.";
+
+    @Option({
+        displayName: "Text",
+        description: "Text to change to"
+    })
+    text!: string
+
+    @Option({
+        displayName: "Source path",
+        description: "The source path of the file to create."
+    })
+    sourcePath!: string
+
+    constructor(options: { text: string, sourcePath: string }) {
+        super(options);
+    }
+
+    initialValue(_ctx: ExecutionContext): { exists: boolean; } {
+        return {exists: false};
+    }
+
+    async generate(acc: { exists: boolean }, _ctx: ExecutionContext): Promise<SourceFile[]> {
+        if (acc.exists) {
+            return [];
+        }
+
+        const results: SourceFile[] = [];
+        for await (const file of new PlainTextParser().parse({text: this.text, sourcePath: this.sourcePath})) {
+            results.push(file);
+        }
+        return results;
+    }
+}

--- a/rewrite-javascript/rewrite/fixtures/recipe-with-recipe-list.ts
+++ b/rewrite-javascript/rewrite/fixtures/recipe-with-recipe-list.ts
@@ -13,19 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {RecipeRegistry} from "@openrewrite/rewrite";
-import {FindIdentifier} from "./search-recipe";
-import {CreateText} from "./create-text";
 import {ChangeText} from "./change-text";
-import {ChangeVersion} from "./change-version";
-import {RecipeWithRecipeList} from "./recipe-with-recipe-list";
-import {ReplaceId} from "./replace-id";
+import {Recipe} from "@openrewrite/rewrite";
 
-export function activate(registry: RecipeRegistry) {
-    registry.register(ChangeText);
-    registry.register(CreateText);
-    registry.register(ChangeVersion);
-    registry.register(RecipeWithRecipeList);
-    registry.register(ReplaceId);
-    registry.register(FindIdentifier);
+export class RecipeWithRecipeList extends Recipe {
+    name = "org.openrewrite.example.text.with-recipe-list"
+    displayName = "A recipe that has a recipe list";
+    description = "To verify that it is possible for a recipe list to be called over RPC.";
+
+    async recipeList() {
+        return [new ChangeText({text: "hello"})];
+    }
 }

--- a/rewrite-javascript/rewrite/fixtures/replace-id.ts
+++ b/rewrite-javascript/rewrite/fixtures/replace-id.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {createDraft, finishDraft} from "immer";
+import {ExecutionContext, Markers, randomId, Recipe, TreeVisitor} from "@openrewrite/rewrite";
+import {JavaScriptVisitor} from "@openrewrite/rewrite/javascript";
+import {J} from "@openrewrite/rewrite/java";
+
+export class ReplaceId extends Recipe {
+    name = "org.openrewrite.example.javascript.replace-id"
+    displayName = "Replace IDs";
+    description = "Replaces the ID of every `Tree` and `Marker` object in a JavaScript source.";
+
+    get editor(): TreeVisitor<any, ExecutionContext> {
+        return new class extends JavaScriptVisitor<ExecutionContext> {
+            protected async preVisit(tree: J, _p: ExecutionContext): Promise<J | undefined> {
+                let draft = createDraft(tree);
+                draft.id = randomId();
+                return finishDraft(draft);
+            }
+
+            protected async visitMarkers(markers: Markers, p: ExecutionContext): Promise<Markers> {
+                let draft = createDraft(markers);
+                draft.id = randomId();
+                return super.visitMarkers(finishDraft(draft), p);
+            }
+        }
+    }
+}

--- a/rewrite-javascript/rewrite/fixtures/replaced-text.ts
+++ b/rewrite-javascript/rewrite/fixtures/replaced-text.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Column, DataTable} from "@openrewrite/rewrite";
+
+export class ReplacedText {
+    @Column({
+        displayName: "Source Path",
+        description: "The path of the file that was changed."
+    })
+    readonly sourcePath: string
+
+    @Column({
+        displayName: "Text",
+        description: "The text that was replaced."
+    })
+    readonly text: string
+
+    constructor(sourcePath: string, text: string) {
+        this.sourcePath = sourcePath;
+        this.text = text;
+    }
+
+    static dataTable = new DataTable<ReplacedText>(
+        "org.openrewrite.text.replaced-text",
+        "Replaced text",
+        "Text that was replaced.",
+        ReplacedText
+    );
+}

--- a/rewrite-javascript/rewrite/fixtures/search-recipe.ts
+++ b/rewrite-javascript/rewrite/fixtures/search-recipe.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {ExecutionContext, foundSearchResult, Option, Recipe, TreeVisitor} from "@openrewrite/rewrite";
+import {JavaScriptVisitor} from "@openrewrite/rewrite/javascript";
+import {J} from "@openrewrite/rewrite/java";
+
+export class FindIdentifier extends Recipe {
+    name = "org.openrewrite.example.javascript.find-identifier"
+    displayName = "Find identifier";
+    description = "Find matching identifiers in JavaScript code.";
+
+    @Option({
+        displayName: "Identifier",
+        description: "The identifier to find."
+    })
+    identifier!: string;
+
+    constructor(options: { identifier: string }) {
+        super(options);
+    }
+
+    get editor(): TreeVisitor<any, ExecutionContext> {
+        const identifier = this.identifier;
+        return new class extends JavaScriptVisitor<ExecutionContext> {
+            protected async visitIdentifier(ident: J.Identifier, ctx: ExecutionContext): Promise<J | undefined> {
+                if (ident.simpleName === identifier) {
+                    return foundSearchResult(ident)
+                }
+                return super.visitIdentifier(ident, ctx);
+            }
+        };
+    }
+}

--- a/rewrite-javascript/rewrite/src/javascript/print.ts
+++ b/rewrite-javascript/rewrite/src/javascript/print.ts
@@ -1773,7 +1773,7 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
 
     private async afterSyntaxMarkers(markers: Markers, p: PrintOutputCapture) {
         for (const marker of markers.markers) {
-            p.out.concat(p.markerPrinter.afterSyntax(marker, new Cursor(marker, this.cursor), this.JAVA_SCRIPT_MARKER_WRAPPER));
+            p.append(p.markerPrinter.afterSyntax(marker, new Cursor(marker, this.cursor), this.JAVA_SCRIPT_MARKER_WRAPPER));
         }
     }
 
@@ -1783,18 +1783,14 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
 
     private async beforeSyntaxExt(prefix: J.Space, markers: Markers, p: PrintOutputCapture) {
         for (const marker of markers.markers) {
-            p.out.concat(
-                p.markerPrinter.beforePrefix(marker, new Cursor(marker, this.cursor), this.JAVA_SCRIPT_MARKER_WRAPPER)
-            );
+            p.append(p.markerPrinter.beforePrefix(marker, new Cursor(marker, this.cursor), this.JAVA_SCRIPT_MARKER_WRAPPER));
         }
 
         await this.visitSpace(prefix, p);
         await this.visitMarkers(markers, p);
 
         for (const marker of markers.markers) {
-            p.out.concat(
-                p.markerPrinter.beforeSyntax(marker, new Cursor(marker, this.cursor), this.JAVA_SCRIPT_MARKER_WRAPPER)
-            );
+            p.append(p.markerPrinter.beforeSyntax(marker, new Cursor(marker, this.cursor), this.JAVA_SCRIPT_MARKER_WRAPPER));
         }
     }
 

--- a/rewrite-javascript/rewrite/src/javascript/rpc.ts
+++ b/rewrite-javascript/rewrite/src/javascript/rpc.ts
@@ -41,7 +41,7 @@ class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
     override async preVisit(j: JS, q: RpcSendQueue): Promise<J | undefined> {
         await q.getAndSend(j, j2 => j2.id);
         await q.getAndSend(j, j2 => j2.prefix, space => this.visitSpace(space, q));
-        await q.sendMarkers(j, j2 => j2.markers);
+        await q.getAndSend(j, j2 => j2.markers);
         return j;
     }
 
@@ -566,7 +566,7 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
 
         draft.id = await q.receive(j.id);
         draft.prefix = await q.receive(j.prefix, space => this.visitSpace(space, q));
-        draft.markers = await q.receiveMarkers(j.markers);
+        draft.markers = await q.receive(j.markers);
 
         return finishDraft(draft);
     }

--- a/rewrite-javascript/rewrite/src/json/rpc.ts
+++ b/rewrite-javascript/rewrite/src/json/rpc.ts
@@ -26,7 +26,7 @@ class JsonSender extends JsonVisitor<RpcSendQueue> {
         await q.getAndSend(j, j2 => j2.id);
         await q.getAndSend(j, j2 => asRef(j2.prefix),
             async space => await this.visitSpace(space, q));
-        await q.sendMarkers(j, j2 => j2.markers);
+        await q.getAndSend(j, j2 => j2.markers);
         return j;
     }
 
@@ -81,7 +81,7 @@ class JsonSender extends JsonVisitor<RpcSendQueue> {
             await q.getAndSend(c, c2 => c2.multiline);
             await q.getAndSend(c, c2 => c2.text);
             await q.getAndSend(c, c2 => c2.suffix);
-            await q.sendMarkers(c, c2 => c2.markers);
+            await q.getAndSend(c, c2 => c2.markers);
         });
         await q.getAndSend(space, s => s.whitespace);
         return space;
@@ -90,7 +90,7 @@ class JsonSender extends JsonVisitor<RpcSendQueue> {
     protected async visitRightPadded<T extends Json>(right: Json.RightPadded<T>, q: RpcSendQueue): Promise<Json.RightPadded<T> | undefined> {
         await q.getAndSend(right, r => r.element, j => this.visit(j, q));
         await q.getAndSend(right, r => asRef(r.after), async space => await this.visitSpace(space, q));
-        await q.sendMarkers(right, r => r.markers);
+        await q.getAndSend(right, r => r.markers);
         return right;
     }
 }
@@ -102,7 +102,7 @@ class JsonReceiver extends JsonVisitor<RpcReceiveQueue> {
         const draft = createDraft(j)
         draft.id = await q.receive(j.id);
         draft.prefix = await q.receive(j.prefix, async space => await this.visitSpace(space, q));
-        draft.markers = await q.receiveMarkers(j.markers);
+        draft.markers = await q.receive(j.markers);
         return finishDraft(draft);
     }
 
@@ -165,7 +165,7 @@ class JsonReceiver extends JsonVisitor<RpcReceiveQueue> {
                     draft.multiline = await q.receive(c.multiline);
                     draft.text = await q.receive(c.text);
                     draft.suffix = await q.receive(c.suffix);
-                    draft.markers = await q.receiveMarkers(c.markers);
+                    draft.markers = await q.receive(c.markers);
                 })
             });
             draft.whitespace = await q.receive(space.whitespace);

--- a/rewrite-javascript/rewrite/src/parse-error.ts
+++ b/rewrite-javascript/rewrite/src/parse-error.ts
@@ -69,7 +69,7 @@ RpcCodecs.registerCodec(ParseErrorKind, {
     async rpcReceive(before: ParseError, q: RpcReceiveQueue): Promise<ParseError> {
         const draft: Draft<ParseError> = createDraft(before);
         draft.id = await q.receive(before.id);
-        draft.markers = await q.receiveMarkers(before.markers);
+        draft.markers = await q.receive(before.markers);
         draft.sourcePath = await q.receive(before.sourcePath);
         draft.charsetName = await q.receive(before.charsetName);
         draft.charsetBomMarked = await q.receive(before.charsetBomMarked);
@@ -81,7 +81,7 @@ RpcCodecs.registerCodec(ParseErrorKind, {
 
     async rpcSend(after: ParseError, q: RpcSendQueue): Promise<void> {
         await q.getAndSend(after, p => p.id);
-        await q.sendMarkers(after, p => p.markers);
+        await q.getAndSend(after, p => p.markers);
         await q.getAndSend(after, p => p.sourcePath);
         await q.getAndSend(after, p => p.charsetName);
         await q.getAndSend(after, p => p.charsetBomMarked);

--- a/rewrite-javascript/rewrite/src/print.ts
+++ b/rewrite-javascript/rewrite/src/print.ts
@@ -46,6 +46,7 @@ export namespace MarkerPrinter {
             return "";
         },
     }
+
     export const SEARCH_MARKERS_ONLY: MarkerPrinter = {
         beforeSyntax(marker: Marker, _cursor: Cursor, commentWrapper: CommentWrapper): string {
             if (marker.kind == MarkersKind.SearchResult) {
@@ -61,6 +62,7 @@ export namespace MarkerPrinter {
             return "";
         },
     }
+
     export const FENCED: MarkerPrinter = {
         beforeSyntax(marker: Marker, _cursor: Cursor, _commentWrapper: CommentWrapper): string {
             if (marker.kind == MarkersKind.SearchResult || marker.kind.startsWith("org.openrewrite.marker.Markup$")) {
@@ -78,6 +80,7 @@ export namespace MarkerPrinter {
             return "";
         },
     }
+
     export const SANITIZED: MarkerPrinter = {
         beforeSyntax(): string {
             return "";

--- a/rewrite-javascript/rewrite/src/reference.ts
+++ b/rewrite-javascript/rewrite/src/reference.ts
@@ -33,15 +33,18 @@ export function asRef<T extends {} | undefined>(obj: T): T extends undefined ? u
     try {
         // Spread would create a new object. This can be used multiple times on the
         // same object without changing the reference.
-        Object.assign(obj, {[REFERENCE_KEY]: true});
+        (obj as any)[REFERENCE_KEY] = true;
         return obj as any;
-    } catch (Error) {
-        return obj as any;
+    } catch {
+        // The object is frozen/sealed/non-extensible. Clone to a new object.
+        const cloned = {...obj as any};
+        cloned[REFERENCE_KEY] = true;
+        return cloned;
     }
 }
 
-export function isRef(obj?: any): obj is Reference {
-    return obj !== undefined && obj !== null && obj[REFERENCE_KEY] === true;
+export function isRef(obj: any): obj is Reference {
+    return obj !== undefined && obj[REFERENCE_KEY] === true;
 }
 
 export class ReferenceMap {

--- a/rewrite-javascript/rewrite/src/rpc/queue.ts
+++ b/rewrite-javascript/rewrite/src/rpc/queue.ts
@@ -16,7 +16,7 @@
 import {emptyMarkers, Marker, Markers, MarkersKind} from "../markers";
 import {saveTrace, trace} from "./trace";
 import {createDraft, finishDraft} from "immer";
-import {asRef, isRef, Reference, ReferenceMap} from "./reference";
+import {asRef, isRef, Reference, ReferenceMap} from "../reference";
 import {Writable} from "node:stream";
 
 /**
@@ -90,12 +90,7 @@ export class RpcSendQueue {
     }
 
     async generate(after: any, before: any): Promise<RpcObjectData[]> {
-        if (after.kind === MarkersKind.Markers) {
-            // FIXME check if we can solve this via RpcCodec
-            await this.sendMarkers(undefined!, _ => after);
-        } else {
-            await this.send(after, before);
-        }
+        await this.send(after, before);
 
         const result = this.q;
         result.push({state: RpcObjectState.END_OF_OBJECT});

--- a/rewrite-javascript/rewrite/src/rpc/request/get-object.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/get-object.ts
@@ -15,7 +15,7 @@
  */
 import * as rpc from "vscode-jsonrpc/node";
 import {RpcObjectData, RpcObjectState, RpcSendQueue} from "../queue";
-import {ReferenceMap} from "../reference";
+import {ReferenceMap} from "../../reference";
 
 export class GetObject {
     constructor(private readonly id: string, private readonly lastKnownId?: string) {

--- a/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
+++ b/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
@@ -34,7 +34,7 @@ import {RpcRecipe} from "./recipe";
 import {ExecutionContext} from "../execution";
 import {InstallRecipes, InstallRecipesResponse} from "./request/install-recipes";
 import {ParserInput} from "../parser";
-import {ReferenceMap} from "./reference";
+import {ReferenceMap} from "../reference";
 import {Writable} from "node:stream";
 
 export class RewriteRpc {

--- a/rewrite-javascript/rewrite/src/test/rewrite-test.ts
+++ b/rewrite-javascript/rewrite/src/test/rewrite-test.ts
@@ -249,4 +249,3 @@ export class AdHocRecipe extends Recipe {
 export function fromVisitor(visitor: TreeVisitor<any, any>): Recipe {
     return new AdHocRecipe(visitor);
 }
-

--- a/rewrite-javascript/rewrite/src/text/rpc.ts
+++ b/rewrite-javascript/rewrite/src/text/rpc.ts
@@ -21,7 +21,7 @@ import {TreeKind} from "../tree";
 async function receiveSnippet(before: PlainText.Snippet, q: RpcReceiveQueue): Promise<PlainText.Snippet | undefined> {
     const draft: Draft<PlainText.Snippet> = createDraft(before);
     draft.id = await q.receive(before.id);
-    draft.markers = await q.receiveMarkers(before.markers);
+    draft.markers = await q.receive(before.markers);
     draft.text = await q.receive(before.text);
     return finishDraft(draft);
 }
@@ -30,7 +30,7 @@ const textCodec: RpcCodec<PlainText> = {
     async rpcReceive(before: PlainText, q: RpcReceiveQueue): Promise<PlainText> {
         const draft: Draft<PlainText> = createDraft(before);
         draft.id = await q.receive(before.id);
-        draft.markers = await q.receiveMarkers(before.markers);
+        draft.markers = await q.receive(before.markers);
         draft.sourcePath = await q.receive(before.sourcePath);
         draft.charsetName = await q.receive(before.charsetName);
         draft.charsetBomMarked = await q.receive(before.charsetBomMarked);
@@ -43,7 +43,7 @@ const textCodec: RpcCodec<PlainText> = {
 
     async rpcSend(after: PlainText, q: RpcSendQueue): Promise<void> {
         await q.getAndSend(after, p => p.id);
-        await q.sendMarkers(after, p => p.markers);
+        await q.getAndSend(after, p => p.markers);
         await q.getAndSend(after, p => p.sourcePath);
         await q.getAndSend(after, p => p.charsetName);
         await q.getAndSend(after, p => p.charsetBomMarked);
@@ -52,7 +52,7 @@ const textCodec: RpcCodec<PlainText> = {
         await q.getAndSend(after, p => p.text);
         await q.getAndSendList(after, a => a.snippets, s => s.id, async (snippet) => {
             await q.getAndSend(snippet, p => p.id);
-            await q.sendMarkers(snippet, p => p.markers);
+            await q.getAndSend(snippet, p => p.markers);
             await q.getAndSend(snippet, p => p.text);
         });
     }

--- a/rewrite-javascript/rewrite/test/data-table.test.ts
+++ b/rewrite-javascript/rewrite/test/data-table.test.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ReplacedText} from "../fixtures/example-recipe";
+
+import {ReplacedText} from "../fixtures/replaced-text";
 
 describe("data tables", () => {
 

--- a/rewrite-javascript/rewrite/test/recipe.test.ts
+++ b/rewrite-javascript/rewrite/test/recipe.test.ts
@@ -15,7 +15,8 @@
  */
 import {RecipeRegistry} from "@openrewrite/rewrite";
 import {describe} from "@jest/globals";
-import {ChangeText, activate} from "../fixtures/example-recipe";
+import {activate} from "../fixtures/example-recipe";
+import {ChangeText} from "../fixtures/change-text";
 
 describe("recipes", () => {
 

--- a/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
@@ -1,3 +1,5 @@
+// noinspection JSUnusedLocalSymbols
+
 /*
  * Copyright 2025 the original author or authors.
  * <p>
@@ -115,6 +117,17 @@ describe("Rewrite RPC", () => {
                 ),
                 path: "hello.txt"
             }
+        );
+    });
+
+    test("runSearchRecipe", async () => {
+        spec.recipe = await client.prepareRecipe("org.openrewrite.example.javascript.find-identifier", {identifier: "hello"});
+        await spec.rewriteRun(
+            //language=javascript
+            javascript(
+                "const hello = 'world'",
+                "const /*~~>*/hello = 'world'"
+            )
         );
     });
 

--- a/rewrite-javascript/rewrite/test/test/rewrite-test.test.ts
+++ b/rewrite-javascript/rewrite/test/test/rewrite-test.test.ts
@@ -1,8 +1,8 @@
 import {describe} from "@jest/globals";
 import {RecipeSpec} from "@openrewrite/rewrite/test";
 import {text} from "@openrewrite/rewrite/text";
-import {ChangeText} from "../../fixtures/example-recipe";
 import {json} from "@openrewrite/rewrite/json";
+import {ChangeText} from "../../fixtures/change-text";
 
 describe("rewrite test", () => {
     const spec = new RecipeSpec();

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
@@ -40,6 +40,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.javascript.Assertions.javascript;
 import static org.openrewrite.json.Assertions.json;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 import static org.openrewrite.test.SourceSpecs.text;
@@ -96,6 +97,23 @@ class JavaScriptRewriteRpcTest implements RewriteTest {
               }
               """,
             spec -> spec.path("package.json")
+          )
+        );
+    }
+
+    @SuppressWarnings("JSUnusedLocalSymbols")
+    @DocumentExample
+    @Test
+    void runSearchRecipe() {
+        installRecipes();
+        rewriteRun(
+          spec -> spec
+            .recipe(client.prepareRecipe("org.openrewrite.example.javascript.find-identifier",
+              Map.of("identifier", "hello")))
+            .expectedCyclesThatMakeChanges(1),
+          javascript(
+            "const hello = 'world'",
+            "const /*~~>*/hello = 'world'"
           )
         );
     }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
@@ -52,7 +52,7 @@ public class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
     public J preVisit(J j, RpcReceiveQueue q) {
         return ((J) j.withId(q.receiveAndGet(j.getId(), UUID::fromString)))
                 .withPrefix(q.receive(j.getPrefix(), space -> visitSpace(space, q)))
-                .withMarkers(q.receiveMarkers(j.getMarkers()));
+                .withMarkers(q.receive(j.getMarkers()));
     }
 
     @Override

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
@@ -47,7 +47,7 @@ public class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
     public J preVisit(J j, RpcSendQueue q) {
         q.getAndSend(j, Tree::getId);
         q.getAndSend(j, J::getPrefix, space -> visitSpace(space, q));
-        q.sendMarkers(j, Tree::getMarkers);
+        q.getAndSend(j, Tree::getMarkers);
 
         return j;
     }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -170,6 +170,7 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
                     "rewrite-rpc",
                     log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
                     verboseLogging ? "--verbose" : null,
+                    "--trace-get-object-output",
                     recipeInstallDir == null ? null : "--recipe-install-dir=" + recipeInstallDir.toAbsolutePath().normalize().toString()
             ).filter(Objects::nonNull).toArray(String[]::new);
 

--- a/rewrite-json/src/main/java/org/openrewrite/json/internal/rpc/JsonReceiver.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/internal/rpc/JsonReceiver.java
@@ -37,7 +37,7 @@ public class JsonReceiver extends JsonVisitor<RpcReceiveQueue> {
     public Json preVisit(@NonNull Json j, RpcReceiveQueue q) {
         j = j.withId(q.receiveAndGet(j.getId(), UUID::fromString));
         j = j.withPrefix(q.receive(j.getPrefix(), space -> visitSpace(space, q)));
-        return j.withMarkers(q.receiveMarkers(j.getMarkers()));
+        return j.withMarkers(q.receive(j.getMarkers()));
     }
 
     @Override
@@ -94,7 +94,7 @@ public class JsonReceiver extends JsonVisitor<RpcReceiveQueue> {
                         .withMultiline(q.receive(c.isMultiline()))
                         .withText(q.receive(c.getText()))
                         .withSuffix(q.receive(c.getSuffix()))
-                        .withMarkers(q.receiveMarkers(c.getMarkers()))))
+                        .withMarkers(q.receive(c.getMarkers()))))
                 .withWhitespace(q.receive(space.getWhitespace()));
     }
 
@@ -105,6 +105,6 @@ public class JsonReceiver extends JsonVisitor<RpcReceiveQueue> {
         //noinspection unchecked
         return right.withElement(q.receive(right.getElement(), j -> (T) visitNonNull(j, q)))
                 .withAfter(q.receive(right.getAfter(), space -> visitSpace(space, q)))
-                .withMarkers(q.receiveMarkers(right.getMarkers()));
+                .withMarkers(q.receive(right.getMarkers()));
     }
 }

--- a/rewrite-json/src/main/java/org/openrewrite/json/internal/rpc/JsonSender.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/internal/rpc/JsonSender.java
@@ -34,7 +34,7 @@ public class JsonSender extends JsonVisitor<RpcSendQueue> {
         q.getAndSend(j, Tree::getId);
         q.getAndSend(j, j2 -> asRef(j2.getPrefix()), space ->
                 visitSpace(Reference.getValueNonNull(space), q));
-        q.sendMarkers(j, Tree::getMarkers);
+        q.getAndSend(j, Tree::getMarkers);
         return j;
     }
 
@@ -98,7 +98,7 @@ public class JsonSender extends JsonVisitor<RpcSendQueue> {
             q.getAndSend(c, Comment::isMultiline);
             q.getAndSend(c, Comment::getText);
             q.getAndSend(c, Comment::getSuffix);
-            q.sendMarkers(c, Comment::getMarkers);
+            q.getAndSend(c, Comment::getMarkers);
         });
         q.getAndSend(space, Space::getWhitespace);
         return space;
@@ -110,7 +110,7 @@ public class JsonSender extends JsonVisitor<RpcSendQueue> {
         q.getAndSend(right, JsonRightPadded::getElement, j -> visit(j, q));
         q.getAndSend(right, j -> asRef(j.getAfter()),
                 space -> visitSpace(Reference.getValueNonNull(space), q));
-        q.sendMarkers(right, JsonRightPadded::getMarkers);
+        q.getAndSend(right, JsonRightPadded::getMarkers);
         return right;
     }
 }


### PR DESCRIPTION
## What's changed?

Working towards a fully functional JavaScript recipe development experience, and we have a need to support adding search result markers.
