### PR TITLE
`RewriteTest` should load recipes through `RecipeLoader`, not `RecipeIntrospectionUtils`

### DIFF
--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.test;
 
-import lombok.RequiredArgsConstructor;
-import lombok.experimental.Delegate;
 import org.assertj.core.api.SoftAssertions;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
@@ -707,24 +705,5 @@ class RewriteTestUtils {
             }
         }
         return false;
-    }
-}
-
-@RequiredArgsConstructor
-class DelegateSourceFileForDiff implements SourceFile {
-    @Delegate(excludes = PrintAll.class)
-    private final SourceFile delegate;
-
-    private final String expected;
-
-    @Override
-    public <P> String printAll(PrintOutputCapture<P> out) {
-        out.append(expected);
-        return out.getOut();
-    }
-
-    @SuppressWarnings("unused") // Lombok delegate exclude
-    interface PrintAll {
-        <P> String printAll(PrintOutputCapture<P> out);
     }
 }

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -173,7 +173,8 @@ public interface RewriteTest extends SourceSpecs {
                     .as("Recipe must be serializable/deserializable")
                     .isEqualTo(recipe);
             assertThatCode(() -> {
-                Recipe r = RecipeIntrospectionUtils.constructRecipe(recipe.getClass());
+                Recipe r = new RecipeLoader(recipe.getClass().getClassLoader())
+                        .load(recipe.getClass(), null);
                 // getRecipeList should not fail with default parameters from RecipeIntrospectionUtils.
                 r.getRecipeList();
                 // We add recipes to HashSet in some places, we need to validate that hashCode and equals does not fail.


### PR DESCRIPTION
As reported via Slack this helps recipes written in Kotlin; follows on from:
- https://github.com/openrewrite/rewrite/pull/5595