### PR TITLE
Introduce support for pattern matching within the `Semver` type classes

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/CaretRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/CaretRange.java
@@ -80,14 +80,14 @@ public class CaretRange extends LatestRelease {
             lower = major + "." + minor + "." + patch + "." + micro;
         }
 
-        if (!"0".equals(major) || minor == null) {
+        if (minor == null) {
             upper = Integer.toString(parseInt(major) + 1);
-        } else if (!"0".equals(minor) || patch == null) {
-            upper = major + "." + (parseInt(minor) + 1);
-        } else if (!"0".equals(patch) && micro == null) {
-            upper = major + "." + minor + "." + patch;
+        } else if (patch == null) {
+            upper = (parseInt(major) + 1) + ".0";
+        } else if (micro == null) {
+            upper = (parseInt(major) + 1) + ".0.0";
         } else {
-            upper = major + "." + minor + "." + patch + "." + micro;
+            upper = (parseInt(major) + 1) + ".0.0.0";
         }
 
         return Validated.valid("caretRange", new CaretRange(lower, upper, metadataPattern));

--- a/rewrite-core/src/main/java/org/openrewrite/semver/CaretRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/CaretRange.java
@@ -85,11 +85,23 @@ public class CaretRange extends LatestRelease {
         if (minor == null) {
             upper = Integer.toString(parseInt(major) + 1);
         } else if (patch == null) {
-            upper = (parseInt(major) + 1) + ".0";
+            if ("0".equals(major)) {
+                upper = "0." + (parseInt(minor) + 1);
+            } else {
+                upper = (parseInt(major) + 1) + ".0";
+            }
         } else if (micro == null) {
-            upper = (parseInt(major) + 1) + ".0.0";
+            if ("0".equals(major)) {
+                upper = "0." + (parseInt(minor) + 1) + ".0";
+            } else {
+                upper = (parseInt(major) + 1) + ".0.0";
+            }
         } else {
-            upper = (parseInt(major) + 1) + ".0.0.0";
+            if ("0".equals(major)) {
+                upper = "0." + (parseInt(minor) + 1) + ".0.0";
+            } else {
+                upper = (parseInt(major) + 1) + ".0.0.0";
+            }
         }
 
         return Validated.valid("caretRange", new CaretRange(lower, upper, metadataPattern));

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -91,9 +91,9 @@ public class LatestRelease implements VersionComparator {
             return 1;
         } else if ("LATEST".equalsIgnoreCase(v2) || "latest.integration".equalsIgnoreCase(v2) || "latest.snapshot".equalsIgnoreCase(v2)) {
             return -1;
-        } else if ("RELEASE".equalsIgnoreCase(v1) || "latest.release".equalsIgnoreCase(v1)) {
+        } else if ("RELEASE".equalsIgnoreCase(v1) || "latest.release".equalsIgnoreCase(v1) || "latest.major".equalsIgnoreCase(v1)) {
             return 1;
-        } else if ("RELEASE".equalsIgnoreCase(v2) || "latest.release".equalsIgnoreCase(v2)) {
+        } else if ("RELEASE".equalsIgnoreCase(v2) || "latest.release".equalsIgnoreCase(v2) || "latest.major".equalsIgnoreCase(v2)) {
             return -1;
         } else if ("latest.minor".equalsIgnoreCase(v1)) {
             return 1;

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -87,13 +87,21 @@ public class LatestRelease implements VersionComparator {
     public int compare(@Nullable String currentVersion, String v1, String v2) {
         if (v1.equalsIgnoreCase(v2)) {
             return 0;
-        } else if ("LATEST".equalsIgnoreCase(v1) || "latest.integration".equalsIgnoreCase(v1)) {
+        } else if ("LATEST".equalsIgnoreCase(v1) || "latest.integration".equalsIgnoreCase(v1) || "latest.snapshot".equalsIgnoreCase(v1)) {
             return 1;
-        } else if ("LATEST".equalsIgnoreCase(v2) || "latest.integration".equalsIgnoreCase(v2)) {
+        } else if ("LATEST".equalsIgnoreCase(v2) || "latest.integration".equalsIgnoreCase(v2) || "latest.snapshot".equalsIgnoreCase(v2)) {
             return -1;
         } else if ("RELEASE".equalsIgnoreCase(v1) || "latest.release".equalsIgnoreCase(v1)) {
             return 1;
         } else if ("RELEASE".equalsIgnoreCase(v2) || "latest.release".equalsIgnoreCase(v2)) {
+            return -1;
+        } else if ("latest.minor".equalsIgnoreCase(v1)) {
+            return 1;
+        } else if ("latest.minor".equalsIgnoreCase(v2)) {
+            return -1;
+        } else if ("latest.patch".equalsIgnoreCase(v1)) {
+            return 1;
+        } else if ("latest.patch".equalsIgnoreCase(v2)) {
             return -1;
         }
 

--- a/rewrite-core/src/main/java/org/openrewrite/semver/SetRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/SetRange.java
@@ -21,6 +21,8 @@ import org.openrewrite.Validated;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.Objects.requireNonNull;
+
 public class SetRange extends LatestRelease {
     private static final Pattern SET_RANGE_PATTERN = Pattern.compile("([\\[(])(\\d+(\\.\\d+)?(\\.\\d+)?(\\.\\d+)?)?\\s*,\\s*(\\d+(\\.\\d+)?(\\.\\d+)?(\\.\\d+)?)?([\\])])");
 
@@ -53,5 +55,74 @@ public class SetRange extends LatestRelease {
             return Validated.invalid("setRange", pattern, "not a set range");
         }
         return Validated.valid("setRange", new SetRange(matcher.group(2), "[".equals(matcher.group(1)), matcher.group(6), "]".equals(matcher.group(10)), metadataPattern));
+    }
+
+    @Override
+    public int compare(@Nullable String currentVersion, String v1, String v2) {
+        boolean v1Matches = SET_RANGE_PATTERN.matcher(v1).matches();
+        boolean v2Matches = SET_RANGE_PATTERN.matcher(v2).matches();
+        if (v1Matches && v2Matches) {
+            SetRange setRangeV1 = requireNonNull(build(v1, null).getValue());
+            SetRange setRangeV2 = requireNonNull(build(v2, null).getValue());
+            int compare = super.compare(currentVersion, setRangeV1.upper, setRangeV2.upper);
+            if (compare != 0) {
+                return compare;
+            }
+
+            if (setRangeV1.upperClosed && !setRangeV2.upperClosed) {
+                return 1;
+            } else if (!setRangeV1.upperClosed && setRangeV2.upperClosed) {
+                return -1;
+            }
+
+            compare = super.compare(currentVersion, setRangeV1.lower, setRangeV2.lower);
+            if (compare != 0) {
+                return compare;
+            }
+
+            if (setRangeV1.lowerClosed && !setRangeV2.lowerClosed) {
+                return -1;
+            } else if (!setRangeV1.lowerClosed && setRangeV2.lowerClosed) {
+                return 1;
+            }
+
+            return 0;
+        } else if (v1Matches) {
+            SetRange setRangeV1 = requireNonNull(build(v1, null).getValue());
+            int compare = super.compare(currentVersion, setRangeV1.upper, v2);
+            if (setRangeV1.upperClosed && compare < 0) {
+                return compare;
+            } else if (!setRangeV1.upperClosed && compare == 0) {
+                return -1;
+            }
+
+            compare = super.compare(currentVersion, setRangeV1.lower, v2);
+            if (setRangeV1.lowerClosed && compare > 0) {
+                return compare;
+            } else if (!setRangeV1.lowerClosed && compare == 0) {
+                return 1;
+            }
+
+            return 0;
+        } else if (v2Matches) {
+            SetRange setRangeV2 = requireNonNull(build(v2, null).getValue());
+            int compare = super.compare(currentVersion, v1, setRangeV2.upper);
+            if (setRangeV2.upperClosed && compare > 0) {
+                return compare;
+            } else if (!setRangeV2.upperClosed && compare == 0) {
+                return 1;
+            }
+
+            compare = super.compare(currentVersion, v1, setRangeV2.lower);
+            if (setRangeV2.lowerClosed && compare < 0) {
+                return compare;
+            } else if (!setRangeV2.lowerClosed && compare == 0) {
+                return -1;
+            }
+
+            return 0;
+        }
+
+        return super.compare(currentVersion, v1, v2);
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/semver/TildeRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/TildeRange.java
@@ -22,6 +22,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.lang.Integer.parseInt;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Allows patch-level changes if a minor version is specified on the comparator. Allows minor-level changes if not.
@@ -80,5 +81,43 @@ public class TildeRange extends LatestRelease {
         }
 
         return Validated.valid("tildeRange", new TildeRange(lower, upper, metadataPattern, requireRelease));
+    }
+
+    @Override
+    public int compare(@Nullable String currentVersion, String v1, String v2) {
+        if (v1.startsWith("~") && v2.startsWith("~")) {
+            TildeRange tildeRangeV1 = requireNonNull(build(v1, null).getValue());
+            TildeRange tildeRangeV2 = requireNonNull(build(v2, null).getValue());
+            int compare = super.compare(currentVersion, tildeRangeV1.upperExclusive, tildeRangeV2.upperExclusive);
+            if (compare != 0) {
+                return compare;
+            }
+
+            return super.compare(currentVersion, tildeRangeV1.lower, tildeRangeV2.lower);
+        } else if (v1.startsWith("~")) {
+            TildeRange tildeRangeV1 = requireNonNull(build(v1, null).getValue());
+            int compare = super.compare(currentVersion, tildeRangeV1.upperExclusive, v2);
+            if (compare < 0) {
+                return compare;
+            } else if (compare == 0) {
+                return -1;
+            }
+
+            compare = super.compare(currentVersion, tildeRangeV1.lower, v2);
+            return Math.max(compare, 0);
+        } else if (v2.startsWith("~")) {
+            TildeRange tildeRangeV2 = requireNonNull(build(v2, null).getValue());
+            int compare = super.compare(currentVersion, v1, tildeRangeV2.upperExclusive);
+            if (compare > 0) {
+                return compare;
+            } else if (compare == 0) {
+                return 1;
+            }
+
+            compare = super.compare(currentVersion, v1, tildeRangeV2.lower);
+            return Math.min(compare, 0);
+        }
+
+        return super.compare(currentVersion, v1, v2);
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
@@ -21,12 +21,14 @@ import org.openrewrite.Validated;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Any of X, x, or * may be used to "stand in" for one of the numeric values in the [major, minor, patch] tuple.
  * <a href="https://github.com/npm/node-semver#x-ranges-12x-1x-12-">X-Ranges</a>.
  */
 public class XRange extends LatestRelease {
-    private static final Pattern X_RANGE_PATTERN = Pattern.compile("([*xX]|\\d+)(?:\\.([*xX]|\\d+)(?:\\.([*xX]|\\d+))?(?:\\.([*xX]|\\d+))?)?");
+    private static final Pattern X_RANGE_PATTERN = Pattern.compile("[*xX]|\\d+\\.([*xX]|\\d+\\.([*xX]|\\d+\\.([*xX]|\\d+\\.[*xX])))");
 
     private final String major;
     private final String minor;
@@ -76,27 +78,121 @@ public class XRange extends LatestRelease {
 
     public static Validated<XRange> build(String pattern, @Nullable String metadataPattern) {
         Matcher matcher = X_RANGE_PATTERN.matcher(pattern);
-        if (!matcher.matches() || !(pattern.contains("x") || pattern.contains("X") || pattern.contains("*"))) {
+        if (!matcher.matches()) {
             return Validated.invalid("xRange", pattern, "not an x-range");
         }
 
-        String major = normalizeWildcard(matcher.group(1));
-        String minor = normalizeWildcard(matcher.group(2) == null ? "0" : matcher.group(2));
-        String patch = normalizeWildcard(matcher.group(3) == null ? "0" : matcher.group(3));
-        String micro = normalizeWildcard(matcher.group(4) == null ? "0" : matcher.group(4));
-
-        if ("*".equals(major) && (matcher.group(2) != null || matcher.group(3) != null || matcher.group(4) != null)) {
-            return Validated.invalid("xRange", pattern, "not an x-range: nothing can follow a wildcard");
-        } else if ("*".equals(minor) && (matcher.group(3) != null || matcher.group(4) != null)) {
-            return Validated.invalid("xRange", pattern, "not an x-range: nothing can follow a wildcard");
-        } else if ("*".equals(patch) && matcher.group(4) != null) {
-            return Validated.invalid("xRange", pattern, "not an x-range: nothing can follow a wildcard");
-        }
+        String[] parts = pattern.split("\\.");
+        String major = normalizeWildcard(parts[0]);
+        String minor = normalizeWildcard(parts.length < 2 ? "*" : parts[1]);
+        String patch = normalizeWildcard(parts.length < 3 ? "*" : parts[2]);
+        String micro = normalizeWildcard(parts.length < 4 ? "*" : parts[3]);
 
         return Validated.valid("xRange", new XRange(major, minor, patch, micro, metadataPattern));
     }
 
     private static String normalizeWildcard(String part) {
         return "*".equals(part) || "x".equals(part) || "X".equals(part) ? "*" : part;
+    }
+
+    @Override
+    public int compare(@Nullable String currentVersion, String v1, String v2) {
+        boolean v1Matches = X_RANGE_PATTERN.matcher(v1).matches();
+        boolean v2Matches = X_RANGE_PATTERN.matcher(v2).matches();
+        if (v1Matches && v2Matches) {
+            XRange xrangeV1 = requireNonNull(build(v1, null).getValue());
+            XRange xrangeV2 = requireNonNull(build(v2, null).getValue());
+
+            if ("*".equals(xrangeV1.major) && "*".equals(xrangeV2.major)) {
+                return 0;
+            } else if ("*".equals(xrangeV1.major)) {
+                return 1;
+            } else if ("*".equals(xrangeV2.major)) {
+                return -1;
+            }
+
+            int compare = xrangeV1.major.compareTo(xrangeV2.major);
+            if (compare != 0) {
+                return compare;
+            }
+
+            if ("*".equals(xrangeV1.minor) && "*".equals(xrangeV2.minor)) {
+                return 0;
+            } else if ("*".equals(xrangeV1.minor)) {
+                return 1;
+            } else if ("*".equals(xrangeV2.minor)) {
+                return -1;
+            }
+
+            compare =  xrangeV1.minor.compareTo(xrangeV2.minor);
+            if (compare != 0) {
+                return compare;
+            }
+
+            if ("*".equals(xrangeV1.patch) && "*".equals(xrangeV2.patch)) {
+                return 0;
+            } else if ("*".equals(xrangeV1.patch)) {
+                return 1;
+            } else if ("*".equals(xrangeV2.patch)) {
+                return -1;
+            }
+
+            // Micro is guaranteed to be the same, so we can stop here
+            return xrangeV1.patch.compareTo(xrangeV2.patch);
+        } else if (v1Matches) {
+            XRange xrangeV1 = requireNonNull(build(v1, null).getValue());
+            if ("*".equals(xrangeV1.major)) {
+                return 0;
+            }
+
+            Matcher gav = VersionComparator.RELEASE_PATTERN.matcher(normalizeVersion(v2));
+            gav.matches();
+
+            if (!xrangeV1.major.equals(gav.group(1))) {
+                return xrangeV1.major.compareTo(gav.group(1));
+            }
+
+            if ("*".equals(xrangeV1.minor)) {
+                return 0;
+            } else if (gav.group(2) == null || !xrangeV1.minor.equals(gav.group(2))) {
+                return xrangeV1.minor.compareTo(gav.group(2));
+            }
+
+            if ("*".equals(xrangeV1.patch)) {
+                return 0;
+            } else if (gav.group(3) == null || !xrangeV1.patch.equals(gav.group(3))) {
+                return xrangeV1.patch.compareTo(gav.group(3));
+            }
+
+            return 0;
+        } else if (v2Matches) {
+            XRange xrangeV2 = requireNonNull(build(v2, null).getValue());
+            if ("*".equals(xrangeV2.major)) {
+                return 0;
+            }
+
+            Matcher gav = VersionComparator.RELEASE_PATTERN.matcher(normalizeVersion(v1));
+            gav.matches();
+
+            if (!gav.group(1).equals(xrangeV2.major)) {
+                return gav.group(1).compareTo(xrangeV2.major);
+            }
+
+            if ("*".equals(xrangeV2.minor)) {
+                return 0;
+            } else if (gav.group(2) == null || !gav.group(2).equals(xrangeV2.minor)) {
+                return gav.group(2).compareTo(xrangeV2.minor);
+            }
+
+            if ("*".equals(xrangeV2.patch)) {
+                return 0;
+            } else if (gav.group(3) == null || !gav.group(3).equals(xrangeV2.patch)) {
+                return gav.group(3).compareTo(xrangeV2.patch);
+            }
+
+            return 0;
+        }
+
+        return super.compare(currentVersion, v1, v2);
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/semver/CaretRangeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/CaretRangeTest.java
@@ -95,7 +95,7 @@ class CaretRangeTest {
     }
 
     /**
-     * ^0.0.x := >=0.0.0 <1.0.0
+     * ^0.0.x := >=0.0.0 <0.1.0
      */
     @Test
     void desugarPatchWildcard() {
@@ -104,8 +104,7 @@ class CaretRangeTest {
         assertThat(caretRange).isNotNull();
         assertThat(caretRange.isValid("1.0", "0.0.0")).isTrue();
         assertThat(caretRange.isValid("1.0", "0.0.1")).isTrue();
-        assertThat(caretRange.isValid("1.0", "0.1.0")).isTrue();
-        assertThat(caretRange.isValid("1.0", "1.0.0")).isFalse();
+        assertThat(caretRange.isValid("1.0", "0.1.0")).isFalse();
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/semver/CaretRangeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/CaretRangeTest.java
@@ -68,7 +68,7 @@ class CaretRangeTest {
     }
 
     /**
-     * ^0.2.3 := >=0.2.3 <0.3.0
+     * ^0.2.3 := >=0.2.3 <1.0.0
      */
     @Test
     void updatePatch() {
@@ -77,18 +77,8 @@ class CaretRangeTest {
         assertThat(caretRange).isNotNull();
         assertThat(caretRange.isValid("1.0", "0.2.3")).isTrue();
         assertThat(caretRange.isValid("1.0", "0.2.4")).isTrue();
-        assertThat(caretRange.isValid("1.0", "0.3.0")).isFalse();
-    }
-
-    @Test
-    void updateNothing() {
-        CaretRange caretRange = CaretRange
-            .build("^0.0.3", null)
-            .getValue();
-
-        assertThat(caretRange).isNotNull();
-        assertThat(caretRange.isValid("1.0", "0.0.3")).isFalse();
-        assertThat(caretRange.isValid("1.0", "0.0.4")).isFalse();
+        assertThat(caretRange.isValid("1.0", "0.9.0")).isTrue();
+        assertThat(caretRange.isValid("1.0", "1.0.0")).isFalse();
     }
 
     /**
@@ -106,7 +96,7 @@ class CaretRangeTest {
     }
 
     /**
-     * ^0.0.x := >=0.0.0 <0.1.0
+     * ^0.0.x := >=0.0.0 <1.0.0
      */
     @Test
     void desugarPatchWildcard() {
@@ -115,6 +105,7 @@ class CaretRangeTest {
         assertThat(caretRange).isNotNull();
         assertThat(caretRange.isValid("1.0", "0.0.0")).isTrue();
         assertThat(caretRange.isValid("1.0", "0.0.1")).isTrue();
-        assertThat(caretRange.isValid("1.0", "0.1.0")).isFalse();
+        assertThat(caretRange.isValid("1.0", "0.1.0")).isTrue();
+        assertThat(caretRange.isValid("1.0", "1.0.0")).isFalse();
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/semver/CaretRangeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/CaretRangeTest.java
@@ -68,7 +68,7 @@ class CaretRangeTest {
     }
 
     /**
-     * ^0.2.3 := >=0.2.3 <1.0.0
+     * ^0.2.3 := >=0.2.3 <0.3.0
      */
     @Test
     void updatePatch() {
@@ -77,8 +77,7 @@ class CaretRangeTest {
         assertThat(caretRange).isNotNull();
         assertThat(caretRange.isValid("1.0", "0.2.3")).isTrue();
         assertThat(caretRange.isValid("1.0", "0.2.4")).isTrue();
-        assertThat(caretRange.isValid("1.0", "0.9.0")).isTrue();
-        assertThat(caretRange.isValid("1.0", "1.0.0")).isFalse();
+        assertThat(caretRange.isValid("1.0", "0.3.0")).isFalse();
     }
 
     /**

--- a/rewrite-core/src/test/java/org/openrewrite/semver/CaretRangeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/CaretRangeTest.java
@@ -108,4 +108,21 @@ class CaretRangeTest {
         assertThat(caretRange.isValid("1.0", "0.1.0")).isTrue();
         assertThat(caretRange.isValid("1.0", "1.0.0")).isFalse();
     }
+
+    @Test
+    void compare() {
+        CaretRange caretRange = CaretRange.build("^1.0", null).getValue();
+
+        assertThat(caretRange).isNotNull();
+        assertThat(caretRange.compare(null, "0.9", "^1.0")).isNegative();
+        assertThat(caretRange.compare(null, "^1.0", "0.9")).isPositive();
+        assertThat(caretRange.compare(null, "1.0", "^1.0")).isZero();
+        assertThat(caretRange.compare(null, "^1.0", "1.0")).isZero();
+        assertThat(caretRange.compare(null, "1.999", "^1.0")).isZero();
+        assertThat(caretRange.compare(null, "^1.0", "1.999")).isZero();
+        assertThat(caretRange.compare(null, "^1.0", "^1.0")).isZero();
+        assertThat(caretRange.compare(null, "^1.0.1", "^1.0")).isPositive();
+        assertThat(caretRange.compare(null, "2.0", "^1.0")).isPositive();
+        assertThat(caretRange.compare(null, "^1.0", "2.0")).isNegative();
+    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/semver/HyphenRangeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/HyphenRangeTest.java
@@ -80,4 +80,26 @@ class HyphenRangeTest {
         assertThat(hyphenRange.isValid("1.0", "2.0.1")).isFalse();
         assertThat(hyphenRange.isValid("1.0", "2.0.0.1")).isFalse();
     }
+
+    @Test
+    void compare() {
+        HyphenRange hyphenRange = HyphenRange.build("1.2 - 2", null).getValue();
+
+        assertThat(hyphenRange).isNotNull();
+        assertThat(hyphenRange.compare(null, "0.9", "1 - 2")).isNegative();
+        assertThat(hyphenRange.compare(null, "1 - 2", "0.9")).isPositive();
+        assertThat(hyphenRange.compare(null, "1.0", "1 - 2")).isZero();
+        assertThat(hyphenRange.compare(null, "1 - 2", "1.0")).isZero();
+        assertThat(hyphenRange.compare(null, "2.0", "1 - 2")).isZero();
+        assertThat(hyphenRange.compare(null, "1 - 2", "2.0")).isZero();
+        assertThat(hyphenRange.compare(null, "1.999", "1 - 2")).isZero();
+        assertThat(hyphenRange.compare(null, "1 - 2", "1.999")).isZero();
+        assertThat(hyphenRange.compare(null, "1 - 2", "1 - 2")).isZero();
+        assertThat(hyphenRange.compare(null, "1.0.1 - 2", "1 - 2")).isPositive();
+        assertThat(hyphenRange.compare(null, "0.9 - 2", "1 - 2")).isNegative();
+        assertThat(hyphenRange.compare(null, "1 - 2.0.1", "1 - 2")).isPositive();
+        assertThat(hyphenRange.compare(null, "1 - 1.9", "1 - 2")).isNegative();
+        assertThat(hyphenRange.compare(null, "2.1", "1 - 2")).isPositive();
+        assertThat(hyphenRange.compare(null, "1 - 2", "2.1")).isNegative();
+    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/semver/LatestIntegrationTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/LatestIntegrationTest.java
@@ -17,6 +17,8 @@ package org.openrewrite.semver;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LatestIntegrationTest {
@@ -44,5 +46,36 @@ public class LatestIntegrationTest {
 
         assertThat(latestIntegration.compare(null, "1.0", "1.1.a")).isLessThan(0);
         assertThat(latestIntegration.compare(null, "1.0", "1.1.1.1.a")).isLessThan(0);
+    }
+
+    @Test
+    void compare() {
+        assertThat(latestIntegration.compare(null, "1.0", "latest.integration")).isNegative();
+        assertThat(latestIntegration.compare(null, "latest.integration", "1.0")).isPositive();
+        assertThat(latestIntegration.compare(null, "1.0", "latest.snapshot")).isNegative();
+        assertThat(latestIntegration.compare(null, "latest.snapshot", "1.0")).isPositive();
+    }
+
+    @Test
+    void upgrade() {
+        assertThat(latestIntegration.upgrade("2.10.0", List.of("2.9.0"))).isNotPresent();
+
+        assertThat(latestIntegration.upgrade("2.10.0", List.of("2.10.1-SNAPSHOT"))).isPresent()
+          .get().isEqualTo("2.10.1-SNAPSHOT");
+
+        assertThat(latestIntegration.upgrade("2.10.0", List.of("2.10.1"))).isPresent()
+          .get().isEqualTo("2.10.1");
+
+        assertThat(latestIntegration.upgrade("2.10.0", List.of("2.11.0-SNAPSHOT"))).isPresent()
+          .get().isEqualTo("2.11.0-SNAPSHOT");
+
+        assertThat(latestIntegration.upgrade("2.10.0", List.of("2.11.0"))).isPresent()
+          .get().isEqualTo("2.11.0");
+
+        assertThat(latestIntegration.upgrade("2.10.0", List.of("3.0.0-SNAPSHOT"))).isPresent()
+          .get().isEqualTo("3.0.0-SNAPSHOT");
+
+        assertThat(latestIntegration.upgrade("2.10.0", List.of("3.0.0"))).isPresent()
+          .get().isEqualTo("3.0.0");
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/semver/LatestMinorTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/LatestMinorTest.java
@@ -17,6 +17,8 @@ package org.openrewrite.semver;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LatestMinorTest {
@@ -39,5 +41,30 @@ public class LatestMinorTest {
     @Test
     void noSnapshots() {
         assertThat(latestMinor.isValid("1.0.0", "1.1.0-SNAPSHOT")).isFalse();
+    }
+
+    @Test
+    void compare() {
+        assertThat(latestMinor.compare(null, "1.0", "latest.minor")).isNegative();
+        assertThat(latestMinor.compare(null, "latest.minor", "1.0")).isPositive();
+    }
+
+    @Test
+    void upgrade() {
+        assertThat(latestMinor.upgrade("2.10.0", List.of("2.9.0"))).isNotPresent();
+
+        assertThat(latestMinor.upgrade("2.10.0", List.of("2.10.1-SNAPSHOT"))).isNotPresent();
+
+        assertThat(latestMinor.upgrade("2.10.0", List.of("2.10.1"))).isPresent()
+          .get().isEqualTo("2.10.1");
+
+        assertThat(latestMinor.upgrade("2.10.0", List.of("2.11.0-SNAPSHOT"))).isNotPresent();
+
+        assertThat(latestMinor.upgrade("2.10.0", List.of("2.11.0"))).isPresent()
+          .get().isEqualTo("2.11.0");
+
+        assertThat(latestMinor.upgrade("2.10.0", List.of("3.0.0-SNAPSHOT"))).isNotPresent();
+
+        assertThat(latestMinor.upgrade("2.10.0", List.of("3.0.0"))).isNotPresent();
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
@@ -74,6 +74,8 @@ class LatestPatchTest {
     void compare() {
         assertThat(latestPatch.compare("1.0", "1.0.1", "1.0.2")).isLessThan(0);
         assertThat(latestPatch.compare("1.0", "1.0.0.1", "1.0.1")).isLessThan(0);
+        assertThat(latestPatch.compare(null, "1.0", "latest.patch")).isNegative();
+        assertThat(latestPatch.compare(null, "latest.patch", "1.0")).isPositive();
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/semver/SetRangeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/SetRangeTest.java
@@ -98,4 +98,30 @@ class SetRangeTest {
         assertThat(setRange.isValid(null, "2.0")).isTrue();
         assertThat(setRange.isValid(null, "9999.0")).isTrue();
     }
+
+    @Test
+    void compare() {
+        SetRange setRange = SetRange.build("[1,2)", null).getValue();
+
+        assertThat(setRange).isNotNull();
+        assertThat(setRange.compare(null, "0.9", "[1,2)")).isNegative();
+        assertThat(setRange.compare(null, "[1,2)", "0.9")).isPositive();
+        assertThat(setRange.compare(null, "1.0", "[1,2)")).isZero();
+        assertThat(setRange.compare(null, "[1,2)", "1.0")).isZero();
+        assertThat(setRange.compare(null, "1.0", "(1,2)")).isNegative();
+        assertThat(setRange.compare(null, "(1,2)", "1.0")).isPositive();
+        assertThat(setRange.compare(null, "2.1", "(1,2]")).isPositive();
+        assertThat(setRange.compare(null, "(1,2]", "2.1")).isNegative();
+        assertThat(setRange.compare(null, "2.0", "(1,2]")).isZero();
+        assertThat(setRange.compare(null, "(1,2]", "2.0")).isZero();
+        assertThat(setRange.compare(null, "2.0", "(1,2)")).isPositive();
+        assertThat(setRange.compare(null, "(1,2)", "2.0")).isNegative();
+        assertThat(setRange.compare(null, "[1,2)", "[1,2)")).isZero();
+        assertThat(setRange.compare(null, "[1.0.1,2)", "[1,2)")).isPositive();
+        assertThat(setRange.compare(null, "[0.9,2)", "[1,2)")).isNegative();
+        assertThat(setRange.compare(null, "[1,2.0.1)", "[1,2)")).isPositive();
+        assertThat(setRange.compare(null, "[1,1.9)", "[1,2)")).isNegative();
+        assertThat(setRange.compare(null, "[1,2]", "[1,2)")).isPositive();
+        assertThat(setRange.compare(null, "(1,2)", "[1,2)")).isPositive();
+    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/semver/TildeRangeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/TildeRangeTest.java
@@ -94,4 +94,21 @@ class TildeRangeTest {
         assertThat(tildeRange.isValid("1.0", "1.9.9")).isTrue();
         assertThat(tildeRange.isValid("1.0", "2.0.0")).isFalse();
     }
+
+    @Test
+    void compare() {
+        TildeRange tildeRange = TildeRange.build("~1.0", null).getValue();
+
+        assertThat(tildeRange).isNotNull();
+        assertThat(tildeRange.compare(null, "0.9", "~1.0")).isNegative();
+        assertThat(tildeRange.compare(null, "~1.0", "0.9")).isPositive();
+        assertThat(tildeRange.compare(null, "1.0", "~1.0")).isZero();
+        assertThat(tildeRange.compare(null, "~1.0", "1.0")).isZero();
+        assertThat(tildeRange.compare(null, "1.1", "~1.0")).isPositive();
+        assertThat(tildeRange.compare(null, "~1.0", "1.1")).isNegative();
+        assertThat(tildeRange.compare(null, "~1.0", "~1.0")).isZero();
+        assertThat(tildeRange.compare(null, "~1.0.1", "~1.0")).isPositive();
+        assertThat(tildeRange.compare(null, "1.9", "~1")).isZero();
+        assertThat(tildeRange.compare(null, "~1", "1.9")).isZero();
+    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/semver/XRangeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/XRangeTest.java
@@ -77,7 +77,7 @@ class XRangeTest {
     }
 
     /**
-     * 1.2.X := >=1.2.0 <1.3.1
+     * 1.2.X := >=1.2.0 <1.3.0
      */
     @Test
     void matchingMajorAndMinorVersions() {
@@ -129,5 +129,21 @@ class XRangeTest {
         assertThat(xRange.isValid(null, "3.6.1-SNAPSHOT")).isFalse();
         assertThat(xRange.isValid(null, "3.6.0")).isTrue();
         assertThat(xRange.upgrade("3.4.0", List.of("3.6.0", "3.6.1-SNAPSHOT")).orElse(null)).isEqualTo("3.6.0");
+    }
+
+    @Test
+    void compare() {
+        XRange xrange = XRange.build("1.0.x", null).getValue();
+
+        assertThat(xrange).isNotNull();
+        assertThat(xrange.compare(null, "0.9", "1.0.x")).isNegative();
+        assertThat(xrange.compare(null, "1.0.x", "0.9")).isPositive();
+        assertThat(xrange.compare(null, "1.0", "1.0.x")).isZero();
+        assertThat(xrange.compare(null, "1.0.x", "1.0")).isZero();
+        assertThat(xrange.compare(null, "1.1", "1.0.x")).isPositive();
+        assertThat(xrange.compare(null, "1.0.x", "1.1")).isNegative();
+        assertThat(xrange.compare(null, "1.0.x", "1.0.x")).isZero();
+        assertThat(xrange.compare(null, "1.x", "1.0.x")).isPositive();
+        assertThat(xrange.compare(null, "1.0.x", "1.x")).isNegative();
     }
 }


### PR DESCRIPTION
## What's changed?
- `CaretRange` incorrect upper bound
- Add support for comparison of a `CaretRange` boundary when within an existing `CaretRange`
- Add support for comparison of a `HyphenRange` boundary when within an existing `HyphenRange`
- Add support for comparison of a `SetRange` boundary when within an existing `SetRange`
- Add support for comparison of a `TildeRange` boundary when within an existing `TildeRange`
- Add support for comparison of an `XRange` boundary when within an existing `XRange`

## What's your motivation?
I'm reanalyzing the `SemVer` semantics because I have a use case within `UpdateGradleWrapper` in which I want to take the user supplied pattern and use that as a comparison against the current Gradle version discovered from the `BuildTool` marker. By enabling patterns to be compared within the same class, this will allow me to effectively define a precondition such that running `UpdateGradleWrapper(version=7.x)` will be skipped when the current version is 8.2, as an example.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
None

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
