### PR TITLE
Use `LinkedHashMap` for `org.openrewrite.dataTables` message values for consistent ordering of entries

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/DataTable.java
+++ b/rewrite-core/src/main/java/org/openrewrite/DataTable.java
@@ -23,8 +23,9 @@ import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @param <Row> The model type for a single row of this data table.
@@ -53,7 +54,6 @@ public class DataTable<Row> {
         this.description = description;
 
         // Only null when transferring DataTables over RPC.
-        //noinspection ConstantValue
         if (recipe != null) {
             recipe.addDataTable(this);
         }
@@ -73,7 +73,7 @@ public class DataTable<Row> {
         if (!allowWritingInThisCycle(ctx)) {
             return;
         }
-        ctx.computeMessage(ExecutionContext.DATA_TABLES, row, ConcurrentHashMap::new, (extract, allDataTables) -> {
+        ctx.computeMessage(ExecutionContext.DATA_TABLES, row, () -> Collections.synchronizedMap(new LinkedHashMap<>()), (extract, allDataTables) -> {
             //noinspection unchecked
             List<Row> dataTablesOfType = (List<Row>) allDataTables.computeIfAbsent(this, c -> new ArrayList<>());
             dataTablesOfType.add(row);

--- a/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
+++ b/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
@@ -24,11 +24,12 @@ import org.openrewrite.*;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
@@ -115,7 +116,7 @@ public class RecipeRunStats extends DataTable<RecipeRunStats.Row> {
 
     private void addRowToDataTable(ExecutionContext ctx, Row row) {
         //noinspection DuplicatedCode
-        ctx.computeMessage(ExecutionContext.DATA_TABLES, row, ConcurrentHashMap::new, (extract, allDataTables) -> {
+        ctx.computeMessage(ExecutionContext.DATA_TABLES, row, () -> Collections.synchronizedMap(new LinkedHashMap<>()), (extract, allDataTables) -> {
             //noinspection unchecked
             List<Row> dataTablesOfType = (List<Row>) allDataTables.computeIfAbsent(this, c -> new ArrayList<>());
             dataTablesOfType.add(row);


### PR DESCRIPTION
## What's changed?
Replaced the value type of `org.openrewrite.dataTables` messages from a `ConcurrentHashMap` to a `synchronized` `LinkedHashMap` in order to preserve ordering of inserted data tables.

## What's your motivation?
This change as well as https://github.com/moderneinc/rewrite-devcenter/pull/31 addresses an issue in `rewrite-devcenter` which produced incorrect results when more than one `UpgradesAndMigrations` card was used in a DevCenter recipe.

## Anything in particular you'd like reviewers to focus on?
Compatibility issues relating to the changes of the `org.openrewrite.dataTables` value type.

## Anyone you would like to review specifically?
@Jenson3210 @sjungling @pstreef 

## Have you considered any alternatives or workarounds?
No

## Any additional context
No

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
