### PR TITLE
Fix against a deadlock when concurrently creating OperatingSystemProvenance markers

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/OperatingSystemProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/OperatingSystemProvenance.java
@@ -32,7 +32,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyList;
@@ -42,12 +44,28 @@ import static java.util.Collections.emptyList;
  */
 @SuppressWarnings("StaticInitializerReferencesSubClass")
 public abstract class OperatingSystemProvenance implements Marker {
-    public static final Windows WINDOWS = new Windows();
-    public static final MacOs MAC_OS = new MacOs();
-    public static final Solaris SOLARIS = new Solaris();
-    public static final Linux LINUX = new Linux();
-    public static final FreeBSD FREE_BSD = new FreeBSD();
-    public static final Unix UNIX = new Unix();
+    private static final Map<String, OperatingSystemProvenance> OS_INSTANCES = new ConcurrentHashMap<>();
+
+    private static OperatingSystemProvenance getOsInstance(String key) {
+        return OS_INSTANCES.computeIfAbsent(key, k -> {
+            switch (k) {
+                case "WINDOWS":
+                    return new Windows();
+                case "MAC_OS":
+                    return new MacOs();
+                case "SOLARIS":
+                    return new Solaris();
+                case "LINUX":
+                    return new Linux();
+                case "FREE_BSD":
+                    return new FreeBSD();
+                case "UNIX":
+                    return new Unix();
+                default:
+                    throw new IllegalArgumentException("Unknown OS type: " + k);
+            }
+        });
+    }
 
     private static OperatingSystemProvenance currentOs;
     private final String toStringValue;
@@ -155,18 +173,18 @@ public abstract class OperatingSystemProvenance implements Marker {
     public static OperatingSystemProvenance forName(String os) {
         String osName = os.toLowerCase();
         if (osName.contains("windows")) {
-            return WINDOWS;
+            return getOsInstance("WINDOWS");
         } else if (osName.contains("mac os x") || osName.contains("darwin") || osName.contains("osx")) {
-            return MAC_OS;
+            return getOsInstance("MAC_OS");
         } else if (osName.contains("sunos") || osName.contains("solaris")) {
-            return SOLARIS;
+            return getOsInstance("SOLARIS");
         } else if (osName.contains("linux")) {
-            return LINUX;
+            return getOsInstance("LINUX");
         } else if (osName.contains("freebsd")) {
-            return FREE_BSD;
+            return getOsInstance("FREE_BSD");
         } else {
             // Not strictly true
-            return UNIX;
+            return getOsInstance("UNIX");
         }
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/marker/OperatingSystemProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/OperatingSystemProvenance.java
@@ -47,6 +47,8 @@ public abstract class OperatingSystemProvenance implements Marker {
     private static final Map<String, OperatingSystemProvenance> OS_INSTANCES = new ConcurrentHashMap<>();
 
     private static OperatingSystemProvenance getOsInstance(String key) {
+        // This is to work around JLS/JVM bug which allows for deadlocks in class initializations
+        // see https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4891511
         return OS_INSTANCES.computeIfAbsent(key, k -> {
             switch (k) {
                 case "WINDOWS":

--- a/rewrite-core/src/test/java/org/openrewrite/marker/OperatingSystemProvenanceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marker/OperatingSystemProvenanceTest.java
@@ -17,9 +17,67 @@ package org.openrewrite.marker;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class OperatingSystemProvenanceTest {
+
+    @Test
+    void noDeadlockBetweenLinuxAndMacOs() throws InterruptedException {
+        // This test must be first to ensure classes are not already initialized
+        int threadCount = 20;
+        CountDownLatch startLatch = new CountDownLatch( 1);
+        CountDownLatch completeLatch = new CountDownLatch(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger exceptionCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadNum = i;
+            executor.submit(() -> {
+                try {
+                    // Wait for all threads to be ready
+                    startLatch.await();
+                    
+                    // Use reflection to load Linux and MacOs classes directly
+                    if (threadNum % 2 == 0) {
+                        // Load Linux class via reflection
+                        Class<?> linuxClass = Class.forName("org.openrewrite.marker.OperatingSystemProvenance$Linux");
+                        assertThat(linuxClass).isNotNull();
+                        assertThat(linuxClass.getSimpleName()).isEqualTo("Linux");
+                    } else {
+                        // Load MacOs class via reflection
+                        Class<?> macOsClass = Class.forName("org.openrewrite.marker.OperatingSystemProvenance$MacOs");
+                        assertThat(macOsClass).isNotNull();
+                        assertThat(macOsClass.getSimpleName()).isEqualTo("MacOs");
+                    }
+                    
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    exceptionCount.incrementAndGet();
+                } finally {
+                    completeLatch.countDown();
+                }
+            });
+        }
+
+        // Start all threads simultaneously
+        startLatch.countDown();
+        
+        // Wait for all threads to complete
+        boolean completed = completeLatch.await(1, TimeUnit.SECONDS);
+        executor.shutdown();
+        
+        assertThat(completed).as("All threads should complete within timeout").isTrue();
+        assertThat(successCount.get()).as("All threads should succeed").isEqualTo(threadCount);
+        assertThat(exceptionCount.get()).as("No threads should throw exceptions").isEqualTo(0);
+    }
 
     @Test
     void hostname() {

--- a/rewrite-core/src/test/java/org/openrewrite/marker/OperatingSystemProvenanceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marker/OperatingSystemProvenanceTest.java
@@ -30,53 +30,39 @@ class OperatingSystemProvenanceTest {
     @Test
     void noDeadlockBetweenLinuxAndMacOs() throws InterruptedException {
         // This test must be first to ensure classes are not already initialized
-        int threadCount = 20;
-        CountDownLatch startLatch = new CountDownLatch( 1);
+
+        // given
+        int threadCount = 10;
+        CountDownLatch startLatch = new CountDownLatch(1);
         CountDownLatch completeLatch = new CountDownLatch(threadCount);
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        AtomicInteger successCount = new AtomicInteger(0);
-        AtomicInteger exceptionCount = new AtomicInteger(0);
 
         for (int i = 0; i < threadCount; i++) {
             final int threadNum = i;
             executor.submit(() -> {
                 try {
-                    // Wait for all threads to be ready
                     startLatch.await();
                     
-                    // Use reflection to load Linux and MacOs classes directly
                     if (threadNum % 2 == 0) {
-                        // Load Linux class via reflection
-                        Class<?> linuxClass = Class.forName("org.openrewrite.marker.OperatingSystemProvenance$Linux");
-                        assertThat(linuxClass).isNotNull();
-                        assertThat(linuxClass.getSimpleName()).isEqualTo("Linux");
+                        Class.forName("org.openrewrite.marker.OperatingSystemProvenance$Linux");
                     } else {
-                        // Load MacOs class via reflection
-                        Class<?> macOsClass = Class.forName("org.openrewrite.marker.OperatingSystemProvenance$MacOs");
-                        assertThat(macOsClass).isNotNull();
-                        assertThat(macOsClass.getSimpleName()).isEqualTo("MacOs");
+                        Class.forName("org.openrewrite.marker.OperatingSystemProvenance$MacOs");
                     }
-                    
-                    successCount.incrementAndGet();
                 } catch (Exception e) {
                     e.printStackTrace();
-                    exceptionCount.incrementAndGet();
                 } finally {
                     completeLatch.countDown();
                 }
             });
         }
 
-        // Start all threads simultaneously
+        // when
         startLatch.countDown();
         
-        // Wait for all threads to complete
+        // test
         boolean completed = completeLatch.await(1, TimeUnit.SECONDS);
         executor.shutdown();
-        
-        assertThat(completed).as("All threads should complete within timeout").isTrue();
-        assertThat(successCount.get()).as("All threads should succeed").isEqualTo(threadCount);
-        assertThat(exceptionCount.get()).as("No threads should throw exceptions").isEqualTo(0);
+        assertThat(completed).as("All threads should complete within 1 second (no deadlock)").isTrue();
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

Removing the constants for particular OSes in `OperatingSystemProvenance`, replacing it with lazy-loaded private map.

## What's your motivation?

- Fix a concurrency bug in `OperatingSystemProvenance` and its inner classes
- ... which led to Moderne CLI dead-lock when deserializing LSTs coming from various sources (i.e. some built on Linux in Moderne SaaS, some built locally on my Mac laptop)

## Considerations

- Although we are adding lazy-init logic for these subclass instances (e.g. Linux). We don't care that much if they are not singletons - i.e. something (e.g. Jackson deserialization of LSTs) creates multiple instances of Linux.
- What we are optimizing here is not to have a deadlock during class init.