### PR TITLE
Only trigger Artifactory private listing when using HTTP(S) and the path beginning with Artifactory

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
@@ -114,7 +114,8 @@ public class GradleWrapper {
             );
         }
 
-        if (currentDistributionUrl.contains("/artifactory")) {
+        URI currentDistributionUri = URI.create(currentDistributionUrl);
+        if (currentDistributionUri.getScheme().startsWith("http") && currentDistributionUri.getPath().startsWith("/artifactory")) {
             String artifactoryUrl = currentDistributionUrl.substring(0, currentDistributionUrl.lastIndexOf("/"));
             List<GradleVersion> allVersions = listAllPrivateArtifactoryVersions(artifactoryUrl, ctx);
             return allVersions.stream()


### PR DESCRIPTION
## What's changed?
Ensure usage of `currentDistributionUrl` with respect to dynamically listing versions from a private Artifactory is limited to HTTP(S) and a path beginning with `/artifactory`. This ensures that we can reach the Artifactory REST API for listing versions without being inadvertently redirected to the HTML directory listing that Artifactory also supports.

## What's your motivation?
Fixes #5994.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
We could add logic to parse the HTML as was suggested via #5995, but this runs the risk of being pretty fragile.

## Any additional context
N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
