### PR TITLE
First Maven dependency declaration wins for equal distance

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddManagedDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddManagedDependencyTest.java
@@ -397,7 +397,7 @@ class AddManagedDependencyTest implements RewriteTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"2.14.0", "2.15.3"})
+    @ValueSource(strings = {"2.14.0", "2.15.3", "2.18.0"})
     void doesNotDowngradeVersionIfTransitiveDependencyAppearsInTreeWithDifferentVersions(String requestedVersion) {
         rewriteRun(
           spec -> spec.recipe(new AddManagedDependency("com.fasterxml.jackson.core", "jackson-databind", requestedVersion, null,

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -29,7 +29,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.*;
 import org.openrewrite.maven.http.OkHttpSender;
@@ -45,6 +47,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.groupingBy;
 import static org.assertj.core.api.Assertions.*;
@@ -4094,6 +4097,67 @@ class MavenParserTest implements RewriteTest {
                   .containsExactly(secondVersion);
             })
           )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("jacksonDependencies")
+    void firstDeclarationWinsForEqualDistanceOfTransitiveDependencies(String dependencies, String resolvedTransitiveVersion) {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  %s
+                </dependencies>
+              </project>
+              """.formatted(dependencies),
+            spec -> spec.afterRecipe(pom -> {
+                MavenResolutionResult resolution = pom.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+                assertThat(resolution.findDependencies("com.fasterxml.jackson.core", "jackson-databind", Scope.Compile))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly(resolvedTransitiveVersion);
+            })
+          )
+        );
+    }
+
+    private static Stream<Arguments> jacksonDependencies() {
+        return Stream.of(
+          Arguments.of(
+            """
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>2.18.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>2.15.3</version>
+            </dependency>
+            """,
+            "2.18.0"),
+          Arguments.of(
+            """
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>2.15.3</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>2.18.0</version>
+            </dependency>
+            """,
+            "2.15.3")
         );
     }
 


### PR DESCRIPTION
## What's changed?

If two dependency versions are at the same depth in the dependency tree (in this case `com.fasterxml.jackson.core:jackson-databind`), Maven resolves the version from the dependency that was declared first in the POM file. This can be reproduced by the following examples run with Maven 3.6.3.

Given the following set of dependency declarations:

```
<dependencies>
    <dependency>
        <groupId>com.fasterxml.jackson.dataformat</groupId>
        <artifactId>jackson-dataformat-xml</artifactId>
        <version>2.18.0</version>
    </dependency>
    <dependency>
        <groupId>com.fasterxml.jackson.datatype</groupId>
        <artifactId>jackson-datatype-jsr310</artifactId>
        <version>2.15.3</version>
    </dependency>
</dependencies>
```

Maven resolves to:

```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ my-app ---
[INFO] com.mycompany.app:my-app:jar:1
[INFO] +- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:jar:2.18.0:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.0:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.0:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.0:compile
[INFO] |  +- org.codehaus.woodstox:stax2-api:jar:4.2.2:compile
[INFO] |  \- com.fasterxml.woodstox:woodstox-core:jar:7.0.0:compile
[INFO] \- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.15.3:compile
```

And for the changed order of the same dependencies:

```
<dependencies>
    <dependency>
        <groupId>com.fasterxml.jackson.datatype</groupId>
        <artifactId>jackson-datatype-jsr310</artifactId>
        <version>2.15.3</version>
    </dependency>
    <dependency>
        <groupId>com.fasterxml.jackson.dataformat</groupId>
        <artifactId>jackson-dataformat-xml</artifactId>
        <version>2.18.0</version>
    </dependency>
</dependencies>
```

Maven resolves to:

```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ my-app ---
[INFO] com.mycompany.app:my-app:jar:1
[INFO] +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.15.3:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.15.3:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.15.3:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-databind:jar:2.15.3:compile
[INFO] \- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:jar:2.18.0:compile
[INFO]    +- org.codehaus.woodstox:stax2-api:jar:4.2.2:compile
[INFO]    \- com.fasterxml.woodstox:woodstox-core:jar:7.0.0:compile
```

This change improves on the Maven resolution result to make it behave more like Maven itself.

## What's your motivation?

Our Maven resolution result does not resolve the correct version if two transitive dependencies are at the same depth with different versions.

For example, the following test case would resolve 2.15.3 instead of 2.18.0 assuming "last declared" should always win.

```
@Test
void firstDeclarationWinsForEqualDistanceOfTransitiveDependencies() {
    rewriteRun(
      pomXml(
        //language=xml
        """
          <project>
            <groupId>com.mycompany.app</groupId>
            <artifactId>my-app</artifactId>
            <version>1</version>
            <dependencies>
              <dependency>
                <groupId>com.fasterxml.jackson.dataformat</groupId>
                <artifactId>jackson-dataformat-xml</artifactId>
                <version>2.18.0</version>
              </dependency>
              <dependency>
                <groupId>com.fasterxml.jackson.datatype</groupId>
                <artifactId>jackson-datatype-jsr310</artifactId>
                <version>2.15.3</version>
              </dependency>
            </dependencies>
          </project>
          """,
        spec -> spec.afterRecipe(pom -> {
            MavenResolutionResult resolution = pom.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
            assertThat(resolution.findDependencies("com.fasterxml.jackson.core", "jackson-databind", Scope.Compile))
              .hasSize(1)
              .extracting(ResolvedDependency::getGav)
              .extracting(ResolvedGroupArtifactVersion::getVersion)
              .containsExactly("2.18.0");
        })
      )
    );
}
```