### PR TITLE
Changing `ChangeManagedDependencyGroupIdAndArtifactId` so that if you've provided a `newVersion`, it doesn't find a `version` tag on the existing managed dependency, and the parent pom is not in the project, then it will add the `version` tag for that managed dependency

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactIdTest.java
@@ -368,9 +368,6 @@ class ChangeManagedDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                   <artifactId>jackson-bom</artifactId>
                   <version>2.20.0</version>
                 </parent>
-                <modules>
-                  <module>child-project</module>
-                </modules>
                 <dependencyManagement>
                   <dependencies>
                     <dependency>


### PR DESCRIPTION
## What's changed?
- Originally, if you were calling `ChangeManagedDependencyGroupIdAndArtifactId` and providing a `newVersion`, if it didn't find an existing `version` tag, it wouldn't actually apply the `newVersion`, meaning it might not have a version provided at all in cases that you're changing `groupId` or `artifactId`, leading to dependency resolution failure.
- Now if it hits this case, it will check if the parent of this POM is in the project, and if it is not, then it will actually add the `version` tag for the managed dependency with the `newVersion`

## What's your motivation?
- It's a bit of a unique case, but potentially one you might see when using BOM parents for example. I want them not to break.

## Any additional context
- May possibly need to still check if the resolved POM would have had a version available for the new `groupId` / `artifactId`

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
