### PR TITLE
Add precondition support to Rewrite JavaScript.

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Preconditions.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Preconditions.java
@@ -160,7 +160,7 @@ public class Preconditions {
 
         @Override
         public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
-            // if tree isn't an instanceof SourceFile, then a precondition visitor may
+            // if tree isn't an instanceof of SourceFile, then a precondition visitor may
             // not be able to do its work because it may assume we are starting from the root level
             return !(tree instanceof SourceFile) || check.visit(tree, ctx) != tree ?
                     v.visit(tree, ctx) :
@@ -169,7 +169,7 @@ public class Preconditions {
 
         @Override
         public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx, Cursor parent) {
-            // if tree isn't an instanceof SourceFile, then a precondition visitor may
+            // if tree isn't an instanceof of SourceFile, then a precondition visitor may
             // not be able to do its work because it may assume we are starting from the root level
             return !(tree instanceof SourceFile) || check.visit(tree, ctx, parent) != tree ?
                     v.visit(tree, ctx, parent) :

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -142,29 +142,18 @@ public class RewriteRpc {
         return visit(sourceFile, visitorName, p, null);
     }
 
-    public <P> @Nullable Tree visit(Tree tree, String visitorName, P p, @Nullable Cursor cursor) {
-        VisitResponse response = scan(tree, visitorName, p, cursor);
-        return response.isModified() ?
-                getObject(tree.getId().toString()) :
-                tree;
-    }
-
-    public <P> VisitResponse scan(SourceFile sourceFile, String visitorName, P p) {
-        return scan(sourceFile, visitorName, p, null);
-    }
-
-    public <P> VisitResponse scan(Tree sourceFile, String visitorName, P p,
-                                  @Nullable Cursor cursor) {
-        // Set the local state of this tree, so that when the remote
-        // asks for it, we know what to send.
+    public <P> @Nullable Tree visit(Tree sourceFile, String visitorName, P p, @Nullable Cursor cursor) {
+        // Set the local state of this tree, so that when the remote asks for it, we know what to send.
         localObjects.put(sourceFile.getId().toString(), sourceFile);
 
         String pId = maybeUnwrapExecutionContext(p);
-
         List<String> cursorIds = getCursorIds(cursor);
 
-        return send("Visit", new Visit(visitorName, null, sourceFile.getId().toString(), pId, cursorIds),
-                VisitResponse.class);
+        VisitResponse response = send("Visit", new Visit(visitorName, null,
+                sourceFile.getId().toString(), pId, cursorIds), VisitResponse.class);
+        return response.isModified() ?
+                getObject(sourceFile.getId().toString()) :
+                sourceFile;
     }
 
     public Collection<? extends SourceFile> generate(String remoteRecipeId, ExecutionContext ctx) {

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcRecipe.java
@@ -16,6 +16,7 @@
 package org.openrewrite.rpc;
 
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.config.OptionDescriptor;

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcVisitor.java
@@ -1,0 +1,27 @@
+package org.openrewrite.rpc;
+
+import lombok.RequiredArgsConstructor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+
+@RequiredArgsConstructor
+class RpcVisitor extends TreeVisitor<Tree, ExecutionContext> {
+    private final RewriteRpc rpc;
+    private final String visitorName;
+
+    @Override
+    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+        // TODO at the point where we add a second RPC language like Python, we should
+        //  narrow this check to the set of source files that the remote peer supports
+        return sourceFile instanceof RpcCodec;
+    }
+
+    @Override
+    public Tree preVisit(Tree tree, ExecutionContext ctx) {
+        stopAfterPreVisit();
+        rpc.scan((SourceFile) tree, visitorName, ctx);
+        return tree;
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcVisitor.java
@@ -14,9 +14,7 @@ class RpcVisitor extends TreeVisitor<Tree, ExecutionContext> {
 
     @Override
     public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-        // TODO at the point where we add a second RPC language like Python, we should
-        //  narrow this check to the set of source files that the remote peer supports
-        return sourceFile instanceof RpcCodec;
+        return rpc.getLanguages().contains(sourceFile.getClass().getName());
     }
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcVisitor.java
@@ -1,6 +1,7 @@
 package org.openrewrite.rpc;
 
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
@@ -19,9 +20,8 @@ class RpcVisitor extends TreeVisitor<Tree, ExecutionContext> {
     }
 
     @Override
-    public Tree preVisit(Tree tree, ExecutionContext ctx) {
+    public @Nullable Tree preVisit(Tree tree, ExecutionContext ctx) {
         stopAfterPreVisit();
-        rpc.scan((SourceFile) tree, visitorName, ctx);
-        return tree;
+        return rpc.visit((SourceFile) tree, visitorName, ctx);
     }
 }

--- a/rewrite-javascript/rewrite/fixtures/change-text.ts
+++ b/rewrite-javascript/rewrite/fixtures/change-text.ts
@@ -39,7 +39,7 @@ export class ChangeText extends Recipe {
         return `Change text to '${this.text}'`;
     }
 
-    get editor(): TreeVisitor<any, ExecutionContext> {
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
         const toText = this.text;
         const replacedText = this.replacedText;
         return new class extends PlainTextVisitor<ExecutionContext> {

--- a/rewrite-javascript/rewrite/fixtures/change-version.ts
+++ b/rewrite-javascript/rewrite/fixtures/change-version.ts
@@ -31,7 +31,7 @@ export class ChangeVersion extends Recipe {
         super(options);
     }
 
-    get editor(): JsonVisitor<ExecutionContext> {
+    async editor(): Promise<JsonVisitor<ExecutionContext>> {
         const v = this.version;
         return new class extends JsonVisitor<ExecutionContext> {
             protected async visitDocument(document: Json.Document, p: ExecutionContext): Promise<Json | undefined> {

--- a/rewrite-javascript/rewrite/fixtures/example-recipe.ts
+++ b/rewrite-javascript/rewrite/fixtures/example-recipe.ts
@@ -20,6 +20,7 @@ import {ChangeText} from "./change-text";
 import {ChangeVersion} from "./change-version";
 import {RecipeWithRecipeList} from "./recipe-with-recipe-list";
 import {ReplaceId} from "./replace-id";
+import {FindIdentifierWithRemotePathPrecondition} from "./remote-path-precondition";
 
 export function activate(registry: RecipeRegistry) {
     registry.register(ChangeText);
@@ -28,4 +29,5 @@ export function activate(registry: RecipeRegistry) {
     registry.register(RecipeWithRecipeList);
     registry.register(ReplaceId);
     registry.register(FindIdentifier);
+    registry.register(FindIdentifierWithRemotePathPrecondition);
 }

--- a/rewrite-javascript/rewrite/fixtures/modify-all-trees.ts
+++ b/rewrite-javascript/rewrite/fixtures/modify-all-trees.ts
@@ -38,7 +38,7 @@ class ModifyAllTrees extends Recipe {
     description: string = "Add a `Marker` to all trees so that we can test " +
         "that each element is sent back to a remote RPC process.";
 
-    get editor(): TreeVisitor<any, ExecutionContext> {
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
         return new class extends TreeVisitor<Tree, ExecutionContext> {
             protected async preVisit(tree: Tree, p: ExecutionContext): Promise<Tree> {
                 return this.produceTree(tree, p, draft => {

--- a/rewrite-javascript/rewrite/fixtures/path-precondition.ts
+++ b/rewrite-javascript/rewrite/fixtures/path-precondition.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    check,
+    ExecutionContext,
+    foundSearchResult,
+    isSourceFile,
+    Option,
+    Recipe,
+    TreeVisitor
+} from "@openrewrite/rewrite";
+import {FindIdentifier} from "./search-recipe";
+
+/**
+ * A visitor that adds a search result if the source file has a specific path
+ */
+export class PathPreconditionVisitor extends TreeVisitor<any, ExecutionContext> {
+    constructor(private readonly requiredPath: string) {
+        super();
+    }
+
+    async visit<R extends any>(tree: any, _: ExecutionContext): Promise<R | undefined> {
+        if (isSourceFile(tree) && tree.sourcePath === this.requiredPath) {
+            // Add a search result to indicate the precondition passed
+            return foundSearchResult(tree) as R;
+        }
+        // Return unchanged to indicate the precondition failed
+        return tree as R;
+    }
+}
+
+/**
+ * A recipe that finds identifiers in files matching a specific path
+ */
+export class FindIdentifierWithPathPrecondition extends Recipe {
+    name = "org.openrewrite.example.javascript.find-identifier-with-path"
+    displayName = "Find identifier with path precondition";
+    description = "Find identifiers in files with a specific path.";
+
+    @Option({
+        displayName: "Required Path",
+        description: "The source path that must match."
+    })
+    requiredPath!: string;
+
+    @Option({
+        displayName: "Identifier",
+        description: "The identifier to find."
+    })
+    identifier!: string;
+
+    constructor(options: { requiredPath: string, identifier: string }) {
+        super(options);
+    }
+
+    get editor(): TreeVisitor<any, ExecutionContext> {
+        const precondition = new PathPreconditionVisitor(this.requiredPath);
+        const findIdentifier = new FindIdentifier({identifier: this.identifier});
+
+        // Use the check function to apply the precondition
+        return check(precondition, findIdentifier.editor);
+    }
+}
+
+/**
+ * A recipe that conditionally finds identifiers based on a boolean flag
+ */
+export class ConditionalFindIdentifier extends Recipe {
+    name = "org.openrewrite.example.javascript.conditional-find-identifier"
+    displayName = "Conditionally find identifier";
+    description = "Find identifiers based on a boolean condition.";
+
+    @Option({
+        displayName: "Should Search",
+        description: "Whether to search for identifiers or not."
+    })
+    shouldSearch!: boolean;
+
+    @Option({
+        displayName: "Identifier",
+        description: "The identifier to find."
+    })
+    identifier!: string;
+
+    constructor(options: { shouldSearch: boolean, identifier: string }) {
+        super(options);
+    }
+
+    get editor(): TreeVisitor<any, ExecutionContext> {
+        const findIdentifier = new FindIdentifier({identifier: this.identifier});
+
+        // Use the check function with a boolean condition
+        return check(this.shouldSearch, findIdentifier.editor);
+    }
+}

--- a/rewrite-javascript/rewrite/fixtures/path-precondition.ts
+++ b/rewrite-javascript/rewrite/fixtures/path-precondition.ts
@@ -66,12 +66,12 @@ export class FindIdentifierWithPathPrecondition extends Recipe {
         super(options);
     }
 
-    get editor(): TreeVisitor<any, ExecutionContext> {
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
         const precondition = new PathPreconditionVisitor(this.requiredPath);
         const findIdentifier = new FindIdentifier({identifier: this.identifier});
 
         // Use the check function to apply the precondition
-        return check(precondition, findIdentifier.editor);
+        return await check(precondition, findIdentifier.editor());
     }
 }
 
@@ -99,10 +99,10 @@ export class ConditionalFindIdentifier extends Recipe {
         super(options);
     }
 
-    get editor(): TreeVisitor<any, ExecutionContext> {
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
         const findIdentifier = new FindIdentifier({identifier: this.identifier});
 
         // Use the check function with a boolean condition
-        return check(this.shouldSearch, findIdentifier.editor);
+        return check(this.shouldSearch, findIdentifier.editor());
     }
 }

--- a/rewrite-javascript/rewrite/fixtures/remote-path-precondition.ts
+++ b/rewrite-javascript/rewrite/fixtures/remote-path-precondition.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {check, ExecutionContext, Option, Recipe, TreeVisitor} from "@openrewrite/rewrite";
+import {RewriteRpc} from "@openrewrite/rewrite/rpc";
+import {FindIdentifier} from "./search-recipe";
+
+/**
+ * A recipe that finds identifiers in files matching a specific path
+ */
+export class FindIdentifierWithRemotePathPrecondition extends Recipe {
+    name = "org.openrewrite.example.javascript.remote-find-identifier-with-path"
+    displayName = "Find identifier with remotely defined path precondition";
+    description = "Find identifiers in files with a specific path.";
+
+    @Option({
+        displayName: "Required Path",
+        description: "The source path that must match."
+    })
+    requiredPath!: string;
+
+    @Option({
+        displayName: "Identifier",
+        description: "The identifier to find."
+    })
+    identifier!: string;
+
+    constructor(options: { requiredPath: string, identifier: string }) {
+        super(options);
+    }
+
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
+        const findIdentifier = new FindIdentifier({identifier: this.identifier});
+
+        // Use the check function to apply the precondition
+        return check(
+            RewriteRpc.get().prepareRecipe("org.openrewrite.FindSourceFiles", {filePattern: this.requiredPath}),
+            findIdentifier.editor()
+        );
+    }
+}

--- a/rewrite-javascript/rewrite/fixtures/replace-id.ts
+++ b/rewrite-javascript/rewrite/fixtures/replace-id.ts
@@ -23,7 +23,7 @@ export class ReplaceId extends Recipe {
     displayName = "Replace IDs";
     description = "Replaces the ID of every `Tree` and `Marker` object in a JavaScript source.";
 
-    get editor(): TreeVisitor<any, ExecutionContext> {
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
         return new class extends JavaScriptVisitor<ExecutionContext> {
             protected async preVisit(tree: J, _p: ExecutionContext): Promise<J | undefined> {
                 let draft = createDraft(tree);

--- a/rewrite-javascript/rewrite/fixtures/search-recipe.ts
+++ b/rewrite-javascript/rewrite/fixtures/search-recipe.ts
@@ -32,7 +32,7 @@ export class FindIdentifier extends Recipe {
         super(options);
     }
 
-    get editor(): TreeVisitor<any, ExecutionContext> {
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
         const identifier = this.identifier;
         return new class extends JavaScriptVisitor<ExecutionContext> {
             protected async visitIdentifier(ident: J.Identifier, ctx: ExecutionContext): Promise<J | undefined> {

--- a/rewrite-javascript/rewrite/src/index.ts
+++ b/rewrite-javascript/rewrite/src/index.ts
@@ -27,6 +27,7 @@ export * from "./tree";
 export * from "./visitor";
 export * from "./parser";
 export * from "./parse-error";
+export * from "./preconditions";
 export * from "./uuid";
 export * from "./util";
 export * from "./recipe";

--- a/rewrite-javascript/rewrite/src/java/visitor.ts
+++ b/rewrite-javascript/rewrite/src/java/visitor.ts
@@ -34,7 +34,7 @@ import {JavaType} from "./type";
 export class JavaVisitor<P> extends TreeVisitor<J, P> {
     // protected javadocVisitor: any | null = null;
 
-    isAcceptable(sourceFile: SourceFile): boolean {
+    async isAcceptable(sourceFile: SourceFile): Promise<boolean> {
         return isJava(sourceFile);
     }
 

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -23,7 +23,7 @@ import ComputedPropertyName = JS.ComputedPropertyName;
 
 export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
-    override isAcceptable(sourceFile: SourceFile): boolean {
+    override async isAcceptable(sourceFile: SourceFile): Promise<boolean> {
         return isJavaScript(sourceFile);
     }
 

--- a/rewrite-javascript/rewrite/src/json/visitor.ts
+++ b/rewrite-javascript/rewrite/src/json/visitor.ts
@@ -18,7 +18,7 @@ import {isJson, Json} from "./tree";
 import {createDraft, Draft, finishDraft} from "immer";
 
 export class JsonVisitor<P> extends TreeVisitor<Json, P> {
-    isAcceptable(sourceFile: SourceFile): boolean {
+    async isAcceptable(sourceFile: SourceFile): Promise<boolean> {
         return isJson(sourceFile);
     }
 

--- a/rewrite-javascript/rewrite/src/parse-error.ts
+++ b/rewrite-javascript/rewrite/src/parse-error.ts
@@ -32,7 +32,7 @@ export function isParseError(tree: any): tree is ParseError {
 }
 
 export class ParseErrorVisitor<P> extends TreeVisitor<Tree, P> {
-    public isAcceptable(sourceFile: SourceFile, p: P): boolean {
+    async isAcceptable(sourceFile: SourceFile, p: P): Promise<boolean> {
         return isParseError(sourceFile);
     }
 

--- a/rewrite-javascript/rewrite/src/preconditions.ts
+++ b/rewrite-javascript/rewrite/src/preconditions.ts
@@ -34,8 +34,9 @@ class Check<T extends Tree, P> extends TreeVisitor<T, P> {
         super();
     }
 
-    isAcceptable(sourceFile: SourceFile, p: P): boolean {
-        return this.check.isAcceptable(sourceFile, p) && this.v.isAcceptable(sourceFile, p);
+    async isAcceptable(sourceFile: SourceFile, p: P): Promise<boolean> {
+        return await this.check.isAcceptable(sourceFile, p) &&
+            await this.v.isAcceptable(sourceFile, p);
     }
 
     async visit<R extends T>(tree: Tree, p: P, parent?: Cursor): Promise<R | undefined> {

--- a/rewrite-javascript/rewrite/src/preconditions.ts
+++ b/rewrite-javascript/rewrite/src/preconditions.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {noopVisitor, TreeVisitor} from './visitor';
+import {Cursor, isSourceFile, SourceFile, Tree} from './tree';
+
+export function check<T extends Tree, P>(
+    checkCondition: TreeVisitor<T, P> | boolean,
+    v: TreeVisitor<T, P>
+): TreeVisitor<T, P> {
+    if (typeof checkCondition === 'boolean') {
+        return checkCondition ? v : noopVisitor<T, P>();
+    }
+    return new Check(checkCondition, v);
+}
+
+class Check<T extends Tree, P> extends TreeVisitor<T, P> {
+    constructor(
+        private readonly check: TreeVisitor<T, P>,
+        private readonly v: TreeVisitor<T, P>
+    ) {
+        super();
+    }
+
+    isAcceptable(sourceFile: SourceFile, p: P): boolean {
+        return this.check.isAcceptable(sourceFile, p) && this.v.isAcceptable(sourceFile, p);
+    }
+
+    async visit<R extends T>(tree: Tree, p: P, parent?: Cursor): Promise<R | undefined> {
+        // if tree isn't an instanceof of SourceFile, then a precondition visitor may
+        // not be able to do its work because it may assume we are starting from the root level
+        if (!isSourceFile(tree)) {
+            return parent !== undefined
+                ? this.v.visit<R>(tree, p, parent)
+                : this.v.visit<R>(tree, p);
+        }
+
+        const checkResult = parent !== undefined
+            ? await this.check.visit(tree, p, parent)
+            : await this.check.visit(tree, p);
+
+        // If check visitor modified the tree (returned something different), run the main visitor
+        if (checkResult !== (tree as unknown as T)) {
+            return parent !== undefined
+                ? this.v.visit<R>(tree, p, parent)
+                : this.v.visit<R>(tree, p);
+        }
+
+        return tree as unknown as R;
+    }
+}

--- a/rewrite-javascript/rewrite/src/recipe.ts
+++ b/rewrite-javascript/rewrite/src/recipe.ts
@@ -166,7 +166,7 @@ export abstract class ScanningRecipe<P> extends Recipe {
         return new class extends TreeVisitor<any, ExecutionContext> {
             private delegate?: TreeVisitor<any, ExecutionContext>
 
-            isAcceptable(sourceFile: SourceFile, ctx: ExecutionContext): boolean {
+            async isAcceptable(sourceFile: SourceFile, ctx: ExecutionContext): Promise<boolean> {
                 return this.delegateForCtx(ctx).isAcceptable(sourceFile, ctx);
             }
 

--- a/rewrite-javascript/rewrite/src/recipe.ts
+++ b/rewrite-javascript/rewrite/src/recipe.ts
@@ -109,10 +109,10 @@ export abstract class Recipe {
     /**
      * Returns the visitor that performs the transformation. This method is called by the
      * recipe framework during execution and must be overridden by concrete recipe implementations.
-     * 
+     *
      * @returns A visitor that performs the recipe's transformation
      */
-    get editor(): TreeVisitor<any, ExecutionContext> {
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
         return noopVisitor()
     }
 
@@ -159,7 +159,7 @@ export abstract class ScanningRecipe<P> extends Recipe {
 
     abstract initialValue(ctx: ExecutionContext): P
 
-    get editor(): TreeVisitor<any, ExecutionContext> {
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
         const editorWithContext = (cursor: Cursor, ctx: ExecutionContext) =>
             this.editorWithData(this.accumulator(cursor, ctx));
 
@@ -167,23 +167,23 @@ export abstract class ScanningRecipe<P> extends Recipe {
             private delegate?: TreeVisitor<any, ExecutionContext>
 
             async isAcceptable(sourceFile: SourceFile, ctx: ExecutionContext): Promise<boolean> {
-                return this.delegateForCtx(ctx).isAcceptable(sourceFile, ctx);
+                return (await this.delegateForCtx(ctx)).isAcceptable(sourceFile, ctx);
             }
 
             async visit<R extends Tree>(tree: Tree, ctx: ExecutionContext, parent?: Cursor): Promise<R | undefined> {
-                return this.delegateForCtx(ctx).visit(tree, ctx, parent);
+                return (await this.delegateForCtx(ctx)).visit(tree, ctx, parent);
             }
 
-            private delegateForCtx(ctx: ExecutionContext) {
+            private async delegateForCtx(ctx: ExecutionContext) {
                 if (!this.delegate) {
-                    this.delegate = editorWithContext(this.cursor, ctx);
+                    this.delegate = await editorWithContext(this.cursor, ctx);
                 }
                 return this.delegate;
             }
         }
     }
 
-    editorWithData(acc: P): TreeVisitor<any, ExecutionContext> {
+    async editorWithData(acc: P): Promise<TreeVisitor<any, ExecutionContext>> {
         return noopVisitor();
     }
 
@@ -191,7 +191,7 @@ export abstract class ScanningRecipe<P> extends Recipe {
         return [];
     }
 
-    scanner(acc: P): TreeVisitor<any, ExecutionContext> {
+    async scanner(acc: P): Promise<TreeVisitor<any, ExecutionContext>> {
         return noopVisitor();
     }
 }

--- a/rewrite-javascript/rewrite/src/recipe/order-imports.ts
+++ b/rewrite-javascript/rewrite/src/recipe/order-imports.ts
@@ -28,7 +28,7 @@ export class OrderImports extends Recipe {
     description = "Sort top-level imports alphabetically within groups: no qualifier, asterisk, multiple, single.";
 
 
-    get editor(): TreeVisitor<any, ExecutionContext> {
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
         return new class extends JavaScriptVisitor<ExecutionContext> {
 
             protected async visitJsCompilationUnit(cu: JS.CompilationUnit, p: ExecutionContext): Promise<J | undefined> {

--- a/rewrite-javascript/rewrite/src/rpc/recipe.ts
+++ b/rewrite-javascript/rewrite/src/rpc/recipe.ts
@@ -46,11 +46,11 @@ export class RpcRecipe extends ScanningRecipe<number> {
         return 0
     }
 
-    editorWithData(_acc: number): TreeVisitor<any, ExecutionContext> {
+    async editorWithData(_acc: number): Promise<TreeVisitor<any, ExecutionContext>> {
         return this.editVisitor ? new RpcVisitor(this.rpc, this.editVisitor) : noopVisitor();
     }
 
-    scanner(_acc: number): TreeVisitor<any, ExecutionContext> {
+    async scanner(_acc: number): Promise<TreeVisitor<any, ExecutionContext>> {
         return this.scanVisitor ? new RpcVisitor(this.rpc, this.scanVisitor) : noopVisitor();
     }
 

--- a/rewrite-javascript/rewrite/src/rpc/recipe.ts
+++ b/rewrite-javascript/rewrite/src/rpc/recipe.ts
@@ -90,10 +90,8 @@ export class RpcVisitor extends TreeVisitor<Tree, ExecutionContext> {
         super();
     }
 
-    isAcceptable(sourceFile: SourceFile, ctx: ExecutionContext): boolean {
-        // TODO: at the point where we add a second RPC language like Python, we should
-        //  narrow this check to the set of source files that the remote peer supports
-        return true;
+    async isAcceptable(sourceFile: SourceFile, _: ExecutionContext): Promise<boolean> {
+        return (await this.rpc.languages()).includes(sourceFile.kind);
     }
 
     protected async preVisit(tree: Tree, ctx: ExecutionContext): Promise<Tree | undefined> {

--- a/rewrite-javascript/rewrite/src/rpc/request/get-languages.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/get-languages.ts
@@ -1,0 +1,16 @@
+import * as rpc from "vscode-jsonrpc/node";
+
+export class GetLanguages {
+    static handle(connection: rpc.MessageConnection): void {
+        connection.onRequest(new rpc.RequestType0<string[], Error>("GetLanguages"), async () => {
+            // Include all languages you want this server to support receiving from a remote peer
+            const languages: string[] = [
+                "org.openrewrite.text.PlainText",
+                "org.openrewrite.json.tree.Json$Document",
+                "org.openrewrite.java.tree.J$CompilationUnit",
+                "org.openrewrite.javascript.tree.JS$CompilationUnit",
+            ];
+            return languages;
+        });
+    }
+}

--- a/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
+++ b/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
@@ -162,21 +162,14 @@ export class RewriteRpc {
     }
 
     async visit(tree: Tree, visitorName: string, p: any, cursor?: Cursor): Promise<Tree> {
-        let response = await this.scan(tree, visitorName, p, cursor);
-        if (response.modified) {
-            return this.getObject(tree.id.toString());
-        }
-        return tree;
-    }
-
-    scan(tree: Tree, visitorName: string, p: any, cursor?: Cursor): Promise<VisitResponse> {
         this.localObjects.set(tree.id.toString(), tree);
         const pId = this.localObject(p);
         const cursorIds = this.getCursorIds(cursor);
-        return this.connection.sendRequest(
+        const response = await this.connection.sendRequest(
             new rpc.RequestType<Visit, VisitResponse, Error>("Visit"),
             new Visit(visitorName, undefined, tree.id.toString(), pId, cursorIds)
         );
+        return response.modified ? this.getObject(tree.id.toString()) : tree;
     }
 
     async generate(remoteRecipeId: string, ctx: ExecutionContext): Promise<SourceFile[]> {

--- a/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
+++ b/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
@@ -39,6 +39,8 @@ import {Writable} from "node:stream";
 import {GetLanguages} from "./request/get-languages";
 
 export class RewriteRpc {
+    private static _global?: RewriteRpc;
+
     private readonly snowflake = SnowflakeId();
 
     readonly localObjects: Map<string, ((input: string) => any) | any> = new Map();
@@ -84,6 +86,17 @@ export class RewriteRpc {
         InstallRecipes.handle(this.connection, options.recipeInstallDir ?? ".rewrite", registry, options.logger);
 
         this.connection.listen();
+    }
+
+    static set(value: RewriteRpc) {
+        this._global = value;
+    }
+
+    static get(): RewriteRpc {
+        if (!this._global) {
+            throw new Error("RewriteRpc not initialized");
+        }
+        return this._global;
     }
 
     end(): RewriteRpc {

--- a/rewrite-javascript/rewrite/src/rpc/server.ts
+++ b/rewrite-javascript/rewrite/src/rpc/server.ts
@@ -121,13 +121,13 @@ async function main() {
         logger.info(`connection disposed`);
     });
 
-    new RewriteRpc(connection, {
+    RewriteRpc.set(new RewriteRpc(connection, {
         batchSize: options.batchSize,
         logger: logger,
         traceGetObjectInput: options.traceGetObjectInput ? log : undefined,
         traceGetObjectOutput: options.traceGetObjectOutput,
         recipeInstallDir: recipeInstallDir
-    });
+    }));
 
     // log uncaught exceptions
     process.on('uncaughtException', (error) => {

--- a/rewrite-javascript/rewrite/src/run.ts
+++ b/rewrite-javascript/rewrite/src/run.ts
@@ -66,7 +66,7 @@ export async function scheduleRun(recipe: Recipe, before: SourceFile[], ctx: Exe
         for (const b of before) {
             await recurseRecipeList(recipe, b, async (recipe, b2) => {
                 if (recipe instanceof ScanningRecipe) {
-                    return recipe.scanner(recipe.accumulator(cursor, ctx)).visit(b2, ctx, cursor)
+                    return (await recipe.scanner(recipe.accumulator(cursor, ctx))).visit(b2, ctx, cursor)
                 }
             });
         }
@@ -82,14 +82,14 @@ export async function scheduleRun(recipe: Recipe, before: SourceFile[], ctx: Exe
     const changeset: Result[] = [];
 
     for (const b of before) {
-        const editedB = await recurseRecipeList(recipe, b, (recipe, b2) => recipe.editor.visit(b2, ctx));
+        const editedB = await recurseRecipeList(recipe, b, async (recipe, b2) => (await recipe.editor()).visit(b2, ctx));
         if (editedB !== b) {
             changeset.push(new Result(b, editedB));
         }
     }
 
     for (const g of generated) {
-        const editedG = await recurseRecipeList(recipe, g, (recipe, g2) => recipe.editor.visit(g2, ctx));
+        const editedG = await recurseRecipeList(recipe, g, async (recipe, g2) => (await recipe.editor()).visit(g2, ctx));
         if (editedG) {
             changeset.push(new Result(undefined, editedG));
         }

--- a/rewrite-javascript/rewrite/src/test/rewrite-test.ts
+++ b/rewrite-javascript/rewrite/src/test/rewrite-test.ts
@@ -208,7 +208,7 @@ class NoopRecipe extends Recipe {
     displayName = "Do nothing";
     description = "Default no-op test, does nothing.";
 
-    get editor(): TreeVisitor<any, ExecutionContext> {
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
         return noopVisitor();
     }
 }
@@ -241,7 +241,7 @@ export class AdHocRecipe extends Recipe {
         super();
     }
 
-    get editor(): TreeVisitor<any, any> {
+    async editor(): Promise<TreeVisitor<any, any>> {
         return this.visitor;
     }
 }

--- a/rewrite-javascript/rewrite/src/text/visitor.ts
+++ b/rewrite-javascript/rewrite/src/text/visitor.ts
@@ -19,7 +19,7 @@ import {mapAsync} from "../util";
 import {isPlainText, PlainText} from "./tree";
 
 export class PlainTextVisitor<P> extends TreeVisitor<Tree, P> {
-    isAcceptable(sourceFile: SourceFile): boolean {
+    async isAcceptable(sourceFile: SourceFile): Promise<boolean> {
         return isPlainText(sourceFile);
     }
 

--- a/rewrite-javascript/rewrite/src/visitor.ts
+++ b/rewrite-javascript/rewrite/src/visitor.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {emptyMarkers, findMarker, Marker, Markers} from "./markers";
+import {emptyMarkers, Marker, Markers} from "./markers";
 import {Cursor, isSourceFile, rootCursor, SourceFile, Tree} from "./tree";
 import {createDraft, Draft, finishDraft, Objectish} from "immer";
 import {mapAsync} from "./util";

--- a/rewrite-javascript/rewrite/src/visitor.ts
+++ b/rewrite-javascript/rewrite/src/visitor.ts
@@ -61,7 +61,7 @@ export abstract class TreeVisitor<T extends Tree, P> {
 
         let t: T | undefined
         const isAcceptable = (!(isSourceFile(tree)) ||
-            this.isAcceptable(tree, p));
+            await this.isAcceptable(tree, p));
 
         try {
             if (isAcceptable) {
@@ -108,7 +108,7 @@ export abstract class TreeVisitor<T extends Tree, P> {
         this.cursor.messages.set(stopAfterPreVisit, true);
     }
 
-    isAcceptable(sourceFile: SourceFile, p: P): boolean {
+    async isAcceptable(sourceFile: SourceFile, p: P): Promise<boolean> {
         return true;
     }
 

--- a/rewrite-javascript/rewrite/test/preconditions.test.ts
+++ b/rewrite-javascript/rewrite/test/preconditions.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {RecipeSpec} from "../src/test";
+import {javascript} from "../src/javascript";
+import {FindIdentifierWithPathPrecondition, ConditionalFindIdentifier} from "../fixtures/path-precondition";
+
+describe('Preconditions', () => {
+    test('visitor precondition - should only mark identifiers in matching path', async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new FindIdentifierWithPathPrecondition({
+            requiredPath: 'test.js',
+            identifier: 'foo'
+        });
+
+        await spec.rewriteRun(
+            {
+                ...javascript('const foo = 1;', 'const /*~~>*/foo = 1;'),
+                path: 'test.js'
+            },
+            {
+                ...javascript('const foo = 2;'),
+                path: 'other.js'
+            }
+        );
+    });
+
+    test('boolean precondition - should mark when true', async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new ConditionalFindIdentifier({
+            shouldSearch: true,
+            identifier: 'bar'
+        });
+
+        await spec.rewriteRun(
+            javascript('const bar = 1;', 'const /*~~>*/bar = 1;')
+        );
+    });
+
+    test('boolean precondition - should not mark when false', async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new ConditionalFindIdentifier({
+            shouldSearch: false,
+            identifier: 'bar'
+        });
+
+        await spec.rewriteRun(
+            javascript('const bar = 1;')
+        );
+    });
+});

--- a/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
@@ -120,6 +120,10 @@ describe("Rewrite RPC", () => {
         );
     });
 
+    test("languages", async () => {
+        expect(await client.languages()).toContainEqual(JS.Kind.CompilationUnit);
+    });
+
     test("runSearchRecipe", async () => {
         spec.recipe = await client.prepareRecipe("org.openrewrite.example.javascript.find-identifier", {identifier: "hello"});
         await spec.rewriteRun(

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
@@ -117,6 +117,22 @@ class JavaScriptRewriteRpcTest implements RewriteTest {
     }
 
     @Test
+    void runSearchRecipeWithJavaRecipeActingAsPrecondition() {
+        installRecipes();
+        rewriteRun(
+          spec -> spec
+            .recipe(client.prepareRecipe("org.openrewrite.example.javascript.remote-find-identifier-with-path",
+              Map.of("identifier", "hello", "requiredPath", "hello.js")))
+            .expectedCyclesThatMakeChanges(1),
+          javascript(
+            "const hello = 'world'",
+            "const /*~~>*/hello = 'world'",
+            spec -> spec.path("hello.js")
+          )
+        );
+    }
+
+    @Test
     void printJava() {
         assertThat(client.installRecipes(new File("rewrite/dist-fixtures/modify-all-trees.js")))
           .isEqualTo(1);


### PR DESCRIPTION
## What's changed?

* Introduce a new `check` syntax for adding preconditions to JavaScript recipes.
* Any Java recipe can serve as a precondition to a JavaScript recipe (!!).
* Added `GetLanguages` Rewrite RPC command so each peer can specify its supported languages and strengthened the check in `RpcVisitor#isAcceptable` to the languages supported by the remote peer (not just check to see if the source file implements `RpcCodec`).

This support also answers a long held question about Rewrite RPC: how would we use visitors defined in Java in JavaScript if those visitors have arbitrary constructor arguments? The answer is still we don't directly, but what's clear is any such visitor that is wrapped in a `Recipe` can expose inputs and the `Recipe` machinery expresses already that inputs must be deserializable, their format, etc.