### PR TITLE
Groovy - `getDelimiter` handling ~/ regex in enums

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2911,7 +2911,7 @@ public class GroovyParserVisitor {
 
     private boolean validateIsDelimiter(@Nullable ASTNode node, int c) {
         if (node == null) {
-            return false;
+            return true;
         }
         FindBinaryOperationVisitor visitor = new FindBinaryOperationVisitor(source.substring(c, c + 1), c, sourceLineNumberOffsets);
         node.visit(visitor);

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/EnumTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/EnumTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.groovy.tree;
 
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.ExpectedToFail;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.groovy.Assertions.groovy;
@@ -228,6 +229,25 @@ class EnumTest implements RewriteTest {
                   A(X x) {}
               }
               """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/6003")
+    @Test
+    void regexpPatternInEnum() {
+        rewriteRun(
+          groovy(
+            """
+            enum E {
+                OPTION1(~/alef/)
+                final Pattern pattern
+
+                E(Pattern pattern) {
+                    this.pattern = pattern
+                }
+            }
+            """
           )
         );
     }


### PR DESCRIPTION
## What's changed?

Fix in the Groovy parser logic to handle
```
            enum E {
                OPTION1(~/alef/)
            }
```

## What's your motivation?

- Fixes #6003.
