### PR TITLE
5958: RemoveTrailingWhitespace from plain text files

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/text/RemoveTrailingWhitespace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/RemoveTrailingWhitespace.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.text;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+public class RemoveTrailingWhitespace extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Remove trailing whitespace";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove any extra trailing whitespace from the end of each line.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new RemoveTrailingWhitespaceVisitor<>();
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/text/RemoveTrailingWhitespaceVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/RemoveTrailingWhitespaceVisitor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.text;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.Tree;
+
+public class RemoveTrailingWhitespaceVisitor<P> extends PlainTextVisitor<P> {
+    @Nullable
+    private final Tree stopAfter;
+
+    @JsonCreator
+    public RemoveTrailingWhitespaceVisitor(@Nullable Tree stopAfter) {
+        this.stopAfter = stopAfter;
+    }
+
+    public RemoveTrailingWhitespaceVisitor() {
+        this(null);
+    }
+
+    @Override
+    public @Nullable Tree visit(@Nullable Tree tree, P p, Cursor parent) {
+        return super.visit(tree, p, parent);
+    }
+
+}

--- a/rewrite-core/src/test/java/org/openrewrite/text/RemoveTrailingWhitespaceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/text/RemoveTrailingWhitespaceTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.text;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpec;
+
+import static org.openrewrite.test.SourceSpecs.text;
+
+class RemoveTrailingWhitespaceTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveTrailingWhitespace());
+    }
+
+    @DocumentExample
+    @SuppressWarnings("TrailingWhitespacesInTextBlock")
+    @Test
+    void removeTrailingFirst() {
+        rewriteRun(
+          text(
+            """
+               Lorem ipsum dolor sit amet, consectetur adipiscing elit,\s\s 
+               sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              """,
+            """
+               Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+               sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              """,
+            SourceSpec::noTrim
+          )
+        );
+    }
+
+    @SuppressWarnings("TrailingWhitespacesInTextBlock")
+    @Test
+    void removeTrailingLast() {
+        rewriteRun(
+          text(
+            """
+               Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+               sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\s\s
+              """,
+            """
+               Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+               sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              """,
+            SourceSpec::noTrim
+          )
+        );
+    }
+
+    @SuppressWarnings("TrailingWhitespacesInTextBlock")
+    @Test
+    void removeTrailingAll() {
+        rewriteRun(
+          text(
+            """
+               Lorem ipsum dolor sit amet, consectetur adipiscing elit,\s\s 
+               sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\s\s
+              """,
+            """
+               Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+               sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              """,
+            SourceSpec::noTrim
+          )
+        );
+    }
+
+    @SuppressWarnings("TrailingWhitespacesInTextBlock")
+    @Test
+    void removeTrailingBetween() {
+        rewriteRun(
+          text(
+            """
+               \s\s
+               Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+               \s\s 
+               sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+               \s\s
+              """,
+            """
+               
+               Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+               
+               sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+               
+              """,
+            SourceSpec::noTrim
+          )
+        );
+    }
+
+
+    @SuppressWarnings("TrailingWhitespacesInTextBlock")
+    @Test
+    void removeTrailingConsecutive() {
+        rewriteRun(
+          text(
+            """
+               Lorem ipsum dolor sit amet, consectetur adipiscing elit,\s\s
+               \s\s 
+               sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              """,
+            """
+               Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+               
+               sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              """,
+            SourceSpec::noTrim
+          )
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Recipe to remove trailing whitespace from plain-text files

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Resolves #5958 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
Patterned after other RemoveTrailingWhitespace recipes

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
