### PR TITLE
Groovy - handling closures `{}` in enums

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2904,6 +2904,8 @@ public class GroovyParserVisitor {
             return isPatternOperator ? PATTERN_SINGLE_QUOTE_STRING : SINGLE_QUOTE_STRING;
         } else if (source.startsWith("[", c)) {
             return ARRAY;
+        } else if (source.startsWith("{", c)) {
+            return CLOSURE;
         }
 
         return null;

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/Delimiter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/Delimiter.java
@@ -34,7 +34,8 @@ public enum Delimiter {
     PATTERN_DOLLAR_SLASHY_STRING("~$/", "$/"),
     SINGLE_LINE_COMMENT("//", "\n"),
     MULTILINE_COMMENT("/*", "*/"),
-    ARRAY("[", "]");
+    ARRAY("[", "]"),
+    CLOSURE("{", "}");
 
     public final String open;
     public final String close;

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/EnumTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/EnumTest.java
@@ -251,4 +251,30 @@ class EnumTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void closureInEnum() {
+        rewriteRun(
+          groovy(
+            """
+            import java.util.function.Function
+            enum TagNameSerializer {
+                DEFAULT('default',
+                    { String s ->
+                        return "not " + s;
+                    }
+                )
+
+                private final String type
+                private final Function<String, String> fun
+
+                private TagNameSerializer(String type, Function<String, String> fun) {
+                    this.type = type
+                    this.fun = fun
+                }
+            }
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

- Similar to #6009.
Fixing the handling of closures as arguments to enums in Groovy.

## What's your motivation?

A bug resulting in an infinite loop in parsing such Groovy files.

## OSS repro

- https://github.com/allegro/axion-release-plugin/blob/5b331e64544a84fe4d81f2625ce31b0d2a8abb53/src/main/groovy/pl/allegro/tech/build/axion/release/domain/TagNameSerializer.groovy#L9
