### PR TITLE
Retrieve available Gradle versions only when requested would result in a possible update

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -205,10 +205,15 @@ public class UpdateGradleWrapper extends ScanningRecipe<UpdateGradleWrapper.Grad
                         String currentDistributionUrl = entry.getValue().getText();
                         acc.currentDistributionUrl = currentDistributionUrl;
 
+                        String newVersion = isBlank(version) ? "latest.release" : version;
+                        VersionComparator versionComparator = requireNonNull(Semver.validate(newVersion, null).getValue());
+                        if (versionComparator.compare(null, acc.currentMarker.getVersion(), newVersion) > 0) {
+                            return entry;
+                        }
+
                         GradleWrapper gradleWrapper = getGradleWrapper(currentDistributionUrl, ctx);
                         String gradleWrapperVersion = gradleWrapper.getVersion();
 
-                        VersionComparator versionComparator = requireNonNull(Semver.validate(isBlank(version) ? "latest.release" : version, null).getValue());
                         int compare = versionComparator.compare(null, acc.currentMarker.getVersion(), gradleWrapperVersion);
                         // maybe we want to update the distribution type or url
                         if (compare < 0) {


### PR DESCRIPTION
## What's your motivation?
In the current state, the recipe was always attempting to list the available versions, then compare these resolved versions against the current version to decide if there was any work to be done. However, as of the advent of dynamic SemVer resolution against private Artifactory distribution sources, these sources may not contain the requested Gradle distributions for a myriad of reasons -- because they were pruned as unused, were never brought in due to manual processes, etc -- so as a result the recipe would error out because it was unable to find _any_ versions that matched the requested pattern. 

## What's changed?
By using recent changes in the `org.openrewrite.semver` package, we can now compare the requested SemVer version pattern against the current `BuildTool` version. By doing so, this enables us to short circuit the recipe's activity. This is especially important with our chained migration recipes and past migrations that are no longer relevant for the current project. 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
