### PR TITLE
Groovy - special handling of double-quote values in enum arguments

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -470,6 +470,9 @@ public class GroovyParserVisitor {
                         if ("\"".equals(delimiter.close)) {
                             // This is to prevent sourceBefore interpreting // in strings as comments
                             cursor = source.indexOf("\"", cursor) + 1;
+                            while (source.charAt(cursor - 2) == '\\') {
+                                cursor = source.indexOf("\"", cursor) + 1;
+                            }
                         } else {
                             sourceBefore(delimiter.close);
                         }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -467,7 +467,7 @@ public class GroovyParserVisitor {
                     Delimiter delimiter = getDelimiter(null, cursor);
                     if (delimiter != null) {
                         cursor += delimiter.open.length();
-                        if (delimiter.close == "\"") {
+                        if ("\"".equals(delimiter.close)) {
                             // This is to prevent sourceBefore interpreting // in strings as comments
                             cursor = source.indexOf("\"", cursor) + 1;
                         } else {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -467,7 +467,12 @@ public class GroovyParserVisitor {
                     Delimiter delimiter = getDelimiter(null, cursor);
                     if (delimiter != null) {
                         cursor += delimiter.open.length();
-                        sourceBefore(delimiter.close);
+                        if (delimiter.close == "\"") {
+                            // This is to prevent sourceBefore interpreting // in strings as comments
+                            cursor = source.indexOf("\"", cursor) + 1;
+                        } else {
+                            sourceBefore(delimiter.close);
+                        }
                     } else {
                         name();
                     }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/EnumTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/EnumTest.java
@@ -278,6 +278,7 @@ class EnumTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/6015")
     @Test
     void uris() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/EnumTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/EnumTest.java
@@ -277,4 +277,21 @@ class EnumTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void uris() {
+        rewriteRun(
+          groovy(
+            """
+            enum E {
+              LOCAL("http://localhost:8080/api/v1/clusters")
+
+              E(String uri) {
+              }
+            }
+            """
+          )
+        );
+    }
+
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/EnumTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/EnumTest.java
@@ -285,7 +285,8 @@ class EnumTest implements RewriteTest {
           groovy(
             """
             enum E {
-              LOCAL("http://localhost:8080/api/v1/clusters")
+              LOCAL("http://localhost:8080/api/v1/clusters"),
+              LOCAL_WITH_ESCAPED_QUOTE("http://localhost:8080\\"/invalid/url/I/know")
 
               E(String uri) {
               }


### PR DESCRIPTION
## What's changed?

In Groovy handling double-quoted arguments (i.e. Strings) in enum arguments in a different way than the other arguments. Here we shouldn't use the `sourceBefore()` hack which is designed to handle whitespace. Manual `cursor` advancement instead.

## What's your motivation?

- fixes #6015
