### PR TITLE
Add charset to `FindSourceFiles` data table

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/FindSourceFiles.java
+++ b/rewrite-core/src/main/java/org/openrewrite/FindSourceFiles.java
@@ -63,7 +63,7 @@ public class FindSourceFiles extends Recipe {
                     Path sourcePath = sourceFile.getSourcePath();
                     if (matches(sourcePath)) {
                         results.insertRow(ctx, new SourcesFiles.Row(sourcePath.toString(),
-                                tree.getClass().getSimpleName()));
+                                tree.getClass().getSimpleName(), sourceFile.getCharset() == null ? null : sourceFile.getCharset().toString()));
                         return SearchResult.found(sourceFile);
                     }
                 }

--- a/rewrite-core/src/main/java/org/openrewrite/table/SourcesFiles.java
+++ b/rewrite-core/src/main/java/org/openrewrite/table/SourcesFiles.java
@@ -36,5 +36,9 @@ public class SourcesFiles extends DataTable<SourcesFiles.Row> {
         @Column(displayName = "LST type",
                 description = "The LST model type that the file is parsed as.")
         String type;
+
+        @Column(displayName = "Character encoding",
+                description = "The detected character encoding of the file")
+        String encoding;
     }
 }


### PR DESCRIPTION
## What's changed?
Added encoding column to `SourceFiles` data table as part of `FindSourceFiles` recipe.

## What's your motivation?
Character encoding tends to come up from time to time as an issue encountered with a source file contained within an LST. By including it in the data table, we can now observe the detected encoding across numerous repositories. This can also be informative for an organization when considering a migration from Java versions prior to Java 18 with respect to the new default character set is now universally UTF-8.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
