### PR TITLE
Yaml newline after end of document

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
@@ -19,6 +19,7 @@ import org.openrewrite.Cursor;
 import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.yaml.YamlVisitor;
+import org.openrewrite.yaml.marker.TrailingContent;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.function.UnaryOperator;
@@ -51,6 +52,8 @@ public class YamlPrinter<P> extends YamlVisitor<PrintOutputCapture<P>> {
         if (end.isExplicit()) {
             p.append("...");
         }
+        end.getMarkers().findFirst(TrailingContent.class).ifPresent(t -> p.append(t.getContent()));
+        afterSyntax(end, p);
         return end;
     }
 

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/marker/TrailingContent.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/marker/TrailingContent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.yaml.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * A marker to store trailing content after an explicit document end marker ("...").
+ * This is used to preserve newlines or other whitespace that follows the "..." marker.
+ */
+@Value
+@With
+public class TrailingContent implements Marker {
+    UUID id;
+    String content;
+}

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.Issue;
 import org.openrewrite.SourceFile;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpec;
 import org.openrewrite.tree.ParseError;
 import org.openrewrite.yaml.tree.Yaml;
 
@@ -461,6 +462,31 @@ class YamlParserTest implements RewriteTest {
               - item2
               other_anchor: *anchor
               """
+          )
+        );
+    }
+
+    @Test
+    void yamlWithExplicitDocumentEndMarker() {
+        rewriteRun(
+          yaml(
+            """
+              key: value
+              ...
+              """
+          )
+        );
+    }
+
+    @Test
+    void yamlWithExplicitDocumentEndMarkerAndNewline() {
+        rewriteRun(
+          yaml(
+            """
+              key: value
+              ...
+              """,
+            SourceSpec::noTrim
           )
         );
     }


### PR DESCRIPTION
## What's changed?
Add a trailing content marker for content after document end `...` (https://yaml.org/spec/1.2.2/#22-structures).

## What's your motivation?
This wasn't captured, and thus led to failure to faithfully reproduce the file, which lead to parse failures and missed changes.

## Anything in particular you'd like reviewers to focus on?
I'm not a huge fan of the new marker added. Open to alternatives.

## Have you considered any alternatives or workarounds?
We could model the whitespace as prefix on the next element, or failing that, as suffix on the `Yaml.Documents`. Neither seemed too appealing for what is a rare edge case that one is unlikely to target with recipes.

https://github.com/openrewrite/rewrite/blob/9d7fe7709a41e66816033b29786deab0173b3091/rewrite-yaml/src/main/java/org/openrewrite/yaml/tree/Yaml.java#L179-L206