### PR TITLE
Fixed a bug where root entries with newlines in front would have the entire entry be indented after unfolding.

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/UnfoldProperties.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/UnfoldProperties.java
@@ -105,6 +105,8 @@ public class UnfoldProperties extends Recipe {
                                 int identLevel = Math.abs(getIndentLevel(entry) - getIndentLevel(newEntry));
                                 if (!hasLineBreak(entry.getPrefix()) && hasLineBreak(newEntry.getPrefix())) {
                                     newEntry = newEntry.withPrefix(substringOfAfterFirstLineBreak(entry.getPrefix()));
+                                } else if (identLevel == 0 && hasLineBreak(newEntry.getPrefix())) {
+                                    identLevel = 2; // autFormat indents the entire block by 2 spaces though it is a root level entry -> shift by 2 later
                                 }
                                 doAfterVisit(new ShiftFormatLeftVisitor<>(newEntry, identLevel));
                             }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
@@ -137,6 +137,33 @@ class UnfoldPropertiesTest implements RewriteTest {
     }
 
     @Test
+    void unfoldFromRootWithNewLine() {
+        rewriteRun(
+          yaml(
+            """
+              logging.level.com.example: DEBUG
+              
+              management.test:
+                a.b:
+                  value: c
+              """,
+            """
+              logging:
+                level:
+                  com:
+                    example: DEBUG
+              
+              management:
+                test:
+                  a:
+                    b:
+                      value: c
+              """
+          )
+        );
+    }
+
+    @Test
     void exclusions() {
         rewriteRun(
           spec -> spec.recipe(new UnfoldProperties(List.of(
@@ -350,7 +377,7 @@ class UnfoldPropertiesTest implements RewriteTest {
 
     @ExpectedToFail("Comments are not supported yet")
     @Test
-    void mergeDuplicatedSectionsWitComments() {
+    void mergeDuplicatedSectionsWithComments() {
         rewriteRun(
           yaml(
             """


### PR DESCRIPTION
Fixed the following bug.

When unfolding yaml: 
```yaml
logging.level.com.example: DEBUG
              
management.test:
  a.b:
    value: c
```

expected
```yaml
logging:
  level:
    com:
      example: DEBUG

management:
  test:
    a:
      b:
        value: c
```

actual
```yaml
logging:
  level:
    com:
      example: DEBUG

  management:
    test:
      a:
        b:
          value: c
```