### PR TITLE
Remove unnecessary location of recipe in error message preventing StackOverflow

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -151,8 +151,7 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
             // Cycle detected - throw exception to fail fast
             String cycle = String.join(" -> ", initializingRecipes) + " -> " + recipeName;
             throw new RecipeIntrospectionException(
-                    "Recipe '" + recipeIdentifier + "' creates a cycle: " + cycle +
-                    " (in " + source + ")");
+                    "Recipe '" + recipeIdentifier + "' creates a cycle: " + cycle);
         } else {
             initializingRecipes.add(recipeName);
             declarativeRecipe.initialize(declarativeRecipe.uninitializedRecipes, declarativeRecipe.recipeList, availableRecipes, initializingRecipes);


### PR DESCRIPTION


<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Remove unnecessary jar location from the error message that appears when a StackOverflow would have been prevented by cycle detection (see https://github.com/openrewrite/rewrite/pull/6024 for more details)

## What's your motivation?
This jar location is unnecessary information; in all cases where the jar is being loaded, the user already knows which jar it is.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
