### PR TITLE
UpgradeDependencyVersion needs to support common Groovy property access notations

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -31,6 +31,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
@@ -119,6 +120,8 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
     }
 
     private static final String UPDATE_VERSION_ERROR_KEY = "UPDATE_VERSION_ERROR_KEY";
+    private static final MethodMatcher PROPERTY_METHOD = new MethodMatcher("* property(String)");
+    private static final MethodMatcher FIND_PROPERTY_METHOD = new MethodMatcher("* findProperty(String)");
 
     @Value
     public static class DependencyVersionState {
@@ -434,8 +437,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
              * or {@code findProperty('guavaVersion')}.
              */
             private @Nullable String extractPropertyNameFromMethodInvocation(J.MethodInvocation mi) {
-                String methodName = mi.getSimpleName();
-                if ("property".equals(methodName) || "findProperty".equals(methodName)) {
+                if (PROPERTY_METHOD.matches(mi, true) || FIND_PROPERTY_METHOD.matches(mi, true)) {
                     if (!mi.getArguments().isEmpty() && mi.getArguments().get(0) instanceof J.Literal) {
                         J.Literal literal = (J.Literal) mi.getArguments().get(0);
                         if (literal.getValue() instanceof String) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -201,6 +201,11 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                 valueValue = value.getSimpleName();
                             } else if (arg.getValue() instanceof J.FieldAccess) {
                                 valueValue = arg.getValue().printTrimmed(getCursor());
+                            } else if (arg.getValue() instanceof J.MethodInvocation) {
+                                J.MethodInvocation methodInvocation = (J.MethodInvocation) arg.getValue();
+                                valueValue = extractPropertyNameFromMethodInvocation(methodInvocation);
+                            } else if (arg.getValue() instanceof G.Binary) {
+                                valueValue = extractPropertyNameFromGBinary((G.Binary) arg.getValue());
                             } else if (arg.getValue() instanceof G.GString) {
                                 G.GString value = (G.GString) arg.getValue();
                                 List<J> strings = value.getStrings();
@@ -210,6 +215,10 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                         valueValue = ((J.Identifier) versionGStringValue.getTree()).getSimpleName();
                                     } else if (versionGStringValue.getTree() instanceof J.FieldAccess) {
                                         valueValue = versionGStringValue.getTree().printTrimmed(getCursor());
+                                    } else if (versionGStringValue.getTree() instanceof J.MethodInvocation) {
+                                        valueValue = extractPropertyNameFromMethodInvocation((J.MethodInvocation) versionGStringValue.getTree());
+                                    } else if (versionGStringValue.getTree() instanceof G.Binary) {
+                                        valueValue = extractPropertyNameFromGBinary((G.Binary) versionGStringValue.getTree());
                                     }
                                 }
                             }
@@ -358,6 +367,10 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                     versionVariableName = f.toString();
                                 } else if (versionValue.getTree() instanceof J.Identifier) {
                                     versionVariableName = ((J.Identifier) versionValue.getTree()).getSimpleName();
+                                } else if (versionValue.getTree() instanceof J.MethodInvocation) {
+                                    versionVariableName = extractPropertyNameFromMethodInvocation((J.MethodInvocation) versionValue.getTree());
+                                } else if (versionValue.getTree() instanceof G.Binary) {
+                                    versionVariableName = extractPropertyNameFromGBinary((G.Binary) versionValue.getTree());
                                 }
                             } else if (depArg instanceof K.StringTemplate) {
                                 K.StringTemplate template = (K.StringTemplate) depArg;
@@ -414,6 +427,37 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 //noinspection ConstantValue
                 return (groupId == null || artifactId == null) ||
                        new DependencyMatcher(groupId, artifactId, null).matches(declaredGroupId, declaredArtifactId);
+            }
+
+            /**
+             * Extract property name from method invocation patterns like {@code property('guavaVersion')}
+             * or {@code findProperty('guavaVersion')}.
+             */
+            private @Nullable String extractPropertyNameFromMethodInvocation(J.MethodInvocation mi) {
+                String methodName = mi.getSimpleName();
+                if ("property".equals(methodName) || "findProperty".equals(methodName)) {
+                    if (!mi.getArguments().isEmpty() && mi.getArguments().get(0) instanceof J.Literal) {
+                        J.Literal literal = (J.Literal) mi.getArguments().get(0);
+                        if (literal.getValue() instanceof String) {
+                            return (String) literal.getValue();
+                        }
+                    }
+                }
+                return null;
+            }
+
+            /**
+             * Handle Groovy binary access like {@code project.properties['guavaVersion']}
+             * where the binary operator is {@code Access} (bracket notation).
+             */
+            private @Nullable String extractPropertyNameFromGBinary(G.Binary binary) {
+                if (binary.getOperator() == G.Binary.Type.Access && binary.getRight() instanceof J.Literal) {
+                    J.Literal right = (J.Literal) binary.getRight();
+                    if (right.getValue() instanceof String) {
+                        return (String) right.getValue();
+                    }
+                }
+                return null;
             }
 
             private void gatherVariables(J.MethodInvocation method) {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.gradle;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.*;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -826,10 +826,15 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"$guavaVersion", "${guavaVersion}",
-      "${property('guavaVersion')}", "${project.property('guavaVersion')}",
-      "${findProperty('guavaVersion')}", "${project.findProperty('guavaVersion')}",
-      "${project.properties['guavaVersion']}"})
+    @ValueSource(strings = {
+      "$guavaVersion",
+      "${guavaVersion}",
+      "${property('guavaVersion')}",
+      "${project.property('guavaVersion')}",
+      "${findProperty('guavaVersion')}",
+      "${project.findProperty('guavaVersion')}",
+      "${project.properties['guavaVersion']}"
+    })
     void versionInPropertiesFile(String propertyNotation) {
         rewriteRun(
           properties(
@@ -1137,10 +1142,19 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"guavaVersion", "\"$guavaVersion\"", "\"${guavaVersion}\"",
-      "property('guavaVersion')", "\"${property('guavaVersion')}\"", "\"${project.property('guavaVersion')}\"",
-      "findProperty('guavaVersion')", "\"${findProperty('guavaVersion')}\"", "\"${project.findProperty('guavaVersion')}\"",
-      "project.properties['guavaVersion']", "\"${project.properties['guavaVersion']}\""})
+    @ValueSource(strings = {
+      "guavaVersion",
+      "\"$guavaVersion\"",
+      "\"${guavaVersion}\"",
+      "property('guavaVersion')",
+      "\"${property('guavaVersion')}\"",
+      "\"${project.property('guavaVersion')}\"",
+      "findProperty('guavaVersion')",
+      "\"${findProperty('guavaVersion')}\"",
+      "\"${project.findProperty('guavaVersion')}\"",
+      "project.properties['guavaVersion']",
+      "\"${project.properties['guavaVersion']}\""
+    })
     void mapNotationVariableInPropertiesFile(String propertyNotation) {
         rewriteRun(
           properties(

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.gradle;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.*;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
@@ -824,8 +825,12 @@ class UpgradeDependencyVersionTest implements RewriteTest {
         );
     }
 
-    @Test
-    void versionInPropertiesFile() {
+    @ParameterizedTest
+    @ValueSource(strings = {"$guavaVersion", "${guavaVersion}",
+      "${property('guavaVersion')}", "${project.property('guavaVersion')}",
+      "${findProperty('guavaVersion')}", "${project.findProperty('guavaVersion')}",
+      "${project.properties['guavaVersion']}"})
+    void versionInPropertiesFile(String propertyNotation) {
         rewriteRun(
           properties(
             """
@@ -847,9 +852,9 @@ class UpgradeDependencyVersionTest implements RewriteTest {
               }
 
               dependencies {
-                implementation ("com.google.guava:guava:$guavaVersion")
+                implementation ("com.google.guava:guava:%s")
               }
-              """
+              """.formatted(propertyNotation)
           )
         );
     }
@@ -1131,8 +1136,12 @@ class UpgradeDependencyVersionTest implements RewriteTest {
         );
     }
 
-    @Test
-    void mapNotationVariableInPropertiesFile() {
+    @ParameterizedTest
+    @ValueSource(strings = {"guavaVersion", "\"$guavaVersion\"", "\"${guavaVersion}\"",
+      "property('guavaVersion')", "\"${property('guavaVersion')}\"", "\"${project.property('guavaVersion')}\"",
+      "findProperty('guavaVersion')", "\"${findProperty('guavaVersion')}\"", "\"${project.findProperty('guavaVersion')}\"",
+      "project.properties['guavaVersion']", "\"${project.properties['guavaVersion']}\""})
+    void mapNotationVariableInPropertiesFile(String propertyNotation) {
         rewriteRun(
           properties(
             """
@@ -1154,9 +1163,9 @@ class UpgradeDependencyVersionTest implements RewriteTest {
               }
 
               dependencies {
-                implementation group: "com.google.guava", name: "guava", version: guavaVersion
+                implementation group: "com.google.guava", name: "guava", version: %s
               }
-              """
+              """.formatted(propertyNotation)
           )
         );
     }


### PR DESCRIPTION
## What's changed?

Adds support for parsing the property name when using the following APIs:

- [Project#property(String)](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#property(java.lang.String))
- [Project#findProperty(String)](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#findProperty(java.lang.String))
- [Project#getProperties()](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#getProperties())

Using the `project` reference is implied in the Groovy DSL so we need to support the use with and without it. We also needed to make sure that GString interpolation works (while poor practices if just wrapped into double quotes without adding anything to the String).

## What's your motivation?

A property defined in `gradle.properties` can be accessed in a variety of ways in the Gradle Groovy DSL. This change supports all common notations.
