### PR TITLE
Groovy: Guard against NPE when coming across a multi variable assignment

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2338,7 +2338,7 @@ public class GroovyParserVisitor {
             queue.add(new G.Unary(randomId(), fmt, Markers.EMPTY, JLeftPadded.build(G.Unary.Type.Spread), visit(spreadExpression.getExpression()), null));
         }
 
-        public TypeTree visitVariableExpressionType(VariableExpression expression) {
+        public TypeTree visitVariableExpressionType(@Nullable VariableExpression expression) {
             if (expression == null) {
                 return null;
             }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2339,6 +2339,9 @@ public class GroovyParserVisitor {
         }
 
         public TypeTree visitVariableExpressionType(VariableExpression expression) {
+            if (expression == null) {
+                return null;
+            }
             if (!expression.isDynamicTyped() && expression.getOriginType().isArray()) {
                 return visitTypeTree(expression.getOriginType());
             }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added a guard for now -> a solution for proper parsing is being worked on 
- https://github.com/openrewrite/rewrite/pull/5293

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Instead of throwing a `GroovyParsingException` the code will now properly flow into this handling https://github.com/openrewrite/rewrite/blob/765ad965581a5868e341d13096092a3e17e8dbe3/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java#L1649-L1652 which gives a informational message on what's going on

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
I did verify with a test but that test remains failing so there's no sense in adding it
```
Caused by: org.openrewrite.groovy.GroovyParsingException: Failed to parse file.groovy at cursor position 17. The surrounding characters in the original source are:
tag = '0.0.0'
def~cursor~> (major, minor, patch) = tag.tokenize('.')
	at org.openrewrite.groovy.GroovyParserVisitor.visit(GroovyParserVisitor.java:209)
	at org.openrewrite.groovy.GroovyParser.lambda$parseInputs$3(GroovyParser.java:149)
	... 15 more
Caused by: java.lang.UnsupportedOperationException: Parsing multiple assignment (e.g.: def (a, b) = [1, 2]) is not implemented
```

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
