### PR TITLE
feat:  Recursively excludedRecipeList #1714

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -283,6 +283,10 @@ public class YamlResourceLoader implements ResourceLoader {
         if (recipeList == null) {
             throw new RecipeException("Invalid Recipe [" + name + "] recipeList is null");
         }
+        final List<String> excludedRecipeList = (List<String>) yaml.get("excludedRecipeList");
+        if (excludedRecipeList != null) {
+            recipe.setExcludedRecipeList(excludedRecipeList);
+        }
         for (int i = 0; i < recipeList.size(); i++) {
             loadRecipe(
                     name,


### PR DESCRIPTION
ie: using UpgradeSpringBoot_3_5 recipe but exclude all  httpclient5 recipes :
```
recipeList:
  - org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_5
excludedRecipeList:
  - org.openrewrite.apache.httpclient5.*
```

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
