### PR TITLE
JavaScript printing of templated expressions

### DIFF
--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/FindMethodsTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/FindMethodsTest.java
@@ -39,10 +39,10 @@ class FindMethodsTest implements RewriteTest {
     @BeforeEach
     void before() {
         JavaScriptRewriteRpc.setFactory(JavaScriptRewriteRpc.builder()
-            .recipeInstallDir(tempDir)
-            .log(tempDir.resolve("rpc.log"))
-            .verboseLogging()
-//          .inspectBrk()
+          .recipeInstallDir(tempDir)
+          .log(tempDir.resolve("rpc.log"))
+          .verboseLogging()
+          .inspectBrk()
         );
     }
 
@@ -97,6 +97,17 @@ class FindMethodsTest implements RewriteTest {
           typescript(
             "'hello world'.split(' ')",
             "/*~~>*/'hello world'.split(' ')"
+          )
+        );
+    }
+
+    @Test
+    void splitWithTemplateString() {
+        rewriteRun(
+          spec -> spec.recipe(new FindMethods("*..* split(..)", false)),
+          javascript(
+            "'hello'.split(`; ${cookieName}=`)",
+            "/*~~>*/'hello'.split(`; ${cookieName}=`)"
           )
         );
     }


### PR DESCRIPTION
## What's changed?
An RPC asymmetry that causes printing of subtrees to sometimes fail.