### PR TITLE
fix: ChangePackage from packageName is part of the submodule dir name issue

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -259,10 +259,13 @@ public class ChangePackage extends Recipe {
                     String path = ((SourceFile) sf).getSourcePath().toString().replace('\\', '/');
                     String changingFrom = getCursor().getMessage(RENAME_FROM_KEY);
                     assert changingFrom != null;
-                    sf = ((SourceFile) sf).withSourcePath(Paths.get(path.replaceFirst(
-                            changingFrom.replace('.', '/'),
-                            changingTo.replace('.', '/')
-                    )));
+                    final int dirIdx = path.indexOf('/');
+                    final String newPath = path.substring(0, dirIdx) + path.substring(dirIdx)
+                            .replaceFirst(
+                                changingFrom.replace('.', '/'),
+                                changingTo.replace('.', '/')
+                            );
+                    sf = ((SourceFile) sf).withSourcePath(Paths.get(newPath));
 
                     for (J.Import anImport : sf.getImports()) {
                         if (anImport.getPackageName().equals(changingTo) && !anImport.isStatic()) {


### PR DESCRIPTION
ie:
```
submodule name: p1-core and ChangePackage from: p1.sub1-> to: p2.sub1

before this pr result ->  p2-core/src/java/sub1/xx
after  this pr result   -> p1-core/src/java/p2/sub1/xx
```

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
