### PR TITLE
`JavaParser` should first check type tables

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -22,7 +22,6 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ToBeRemoved;
 import org.openrewrite.java.internal.JavaTypeCache;
-import org.openrewrite.java.internal.parser.JavaParserClasspathLoader;
 import org.openrewrite.java.internal.parser.RewriteClasspathJarClasspathLoader;
 import org.openrewrite.java.internal.parser.TypeTable;
 import org.openrewrite.java.marker.JavaSourceSet;
@@ -131,27 +130,35 @@ public interface JavaParser extends Parser {
         List<Path> artifacts = new ArrayList<>(artifactNamesWithVersions.length);
         Set<String> missingArtifactNames = new LinkedHashSet<>(Arrays.asList(artifactNamesWithVersions));
 
-        try (RewriteClasspathJarClasspathLoader rewriteClasspathJarClasspathLoader = new RewriteClasspathJarClasspathLoader(ctx)) {
-            List<JavaParserClasspathLoader> loaders = new ArrayList<>(2);
-            loaders.add(rewriteClasspathJarClasspathLoader);
-            // TODO support annotations in type tables (e.g. required by meta annotations support)
-            Optional.ofNullable(TypeTable.fromClasspath(ctx, missingArtifactNames)).ifPresent(loaders::add);
+        TypeTable typeTable = TypeTable.fromClasspath(ctx, missingArtifactNames);
+        if (typeTable != null) {
+            for (Iterator<String> it = missingArtifactNames.iterator(); it.hasNext(); ) {
+                String missingArtifactName = it.next();
+                Path located = typeTable.load(missingArtifactName);
+                if (located != null) {
+                    artifacts.add(located);
+                    it.remove();
+                }
+            }
+        }
 
-            for (JavaParserClasspathLoader loader : loaders) {
+        if (!missingArtifactNames.isEmpty()) {
+            try (RewriteClasspathJarClasspathLoader classpathLoader = new RewriteClasspathJarClasspathLoader(ctx)) {
                 for (String missingArtifactName : new ArrayList<>(missingArtifactNames)) {
-                    Path located = loader.load(missingArtifactName);
+                    Path located = classpathLoader.load(missingArtifactName);
                     if (located != null) {
                         artifacts.add(located);
                         missingArtifactNames.remove(missingArtifactName);
                     }
                 }
             }
-
-            if (!missingArtifactNames.isEmpty()) {
-                String missing = missingArtifactNames.stream().sorted().collect(joining("', '", "'", "'"));
-                throw new IllegalArgumentException(String.format("Unable to find classpath resource dependencies beginning with: %s", missing));
-            }
         }
+
+        if (!missingArtifactNames.isEmpty()) {
+            String missing = missingArtifactNames.stream().sorted().collect(joining("', '", "'", "'"));
+            throw new IllegalArgumentException(String.format("Unable to find classpath resource dependencies beginning with: %s", missing));
+        }
+
         return artifacts;
     }
 


### PR DESCRIPTION
Changes `JavaParser#classpathFromResources()` so that it first checks for classpath entries in any type tables it finds on the classpath, before it checks for jars in `/META-INF/rewrite/classpath`.
