### PR TITLE
Remove 99-percentile columns from `RecipeRunStats` data table

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
+++ b/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
@@ -144,7 +144,7 @@ public class RecipeRunStats extends DataTable<RecipeRunStats.Row> {
 
     private static class PhaseTimer {
         private static final long ONE_MICROSECOND = 1_000;
-        private static final long TWENTY_MINUTES = Duration.ofMinutes(20).toNanos();
+        private static final long TEN_MINUTES = Duration.ofMinutes(10).toNanos();
 
         final Histogram histogram;
 
@@ -156,7 +156,7 @@ public class RecipeRunStats extends DataTable<RecipeRunStats.Row> {
         private long maxNs = 0;
 
         PhaseTimer() {
-            histogram = new Histogram(ONE_MICROSECOND, TWENTY_MINUTES, 1);
+            histogram = new Histogram(ONE_MICROSECOND, TEN_MINUTES, 1);
             histogram.setAutoResize(true);
         }
 

--- a/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
+++ b/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
@@ -53,11 +53,11 @@ public class RecipeRunStats extends DataTable<RecipeRunStats.Row> {
     }
 
     public void recordScan(Recipe recipe, Callable<SourceFile> scan) throws Exception {
-        recipeTimers.computeIfAbsent(recipe.getName(), k -> new RecipeTimers()).scan.recordTimed(scan);
+        recipeTimers.computeIfAbsent(recipe.getName(), k -> new RecipeTimers()).recordScan(scan);
     }
 
     public @Nullable SourceFile recordEdit(Recipe recipe, Callable<SourceFile> edit) throws Exception {
-        return recipeTimers.computeIfAbsent(recipe.getName(), k -> new RecipeTimers()).edit.recordTimed(edit);
+        return recipeTimers.computeIfAbsent(recipe.getName(), k -> new RecipeTimers()).recordEdit(edit);
     }
 
     public void flush(ExecutionContext ctx) {
@@ -132,6 +132,14 @@ public class RecipeRunStats extends DataTable<RecipeRunStats.Row> {
     private static class RecipeTimers {
         final PhaseTimer scan = new PhaseTimer();
         final PhaseTimer edit = new PhaseTimer();
+
+        void recordScan(Callable<SourceFile> scanCallable) throws Exception {
+            scan.recordTimed(scanCallable);
+        }
+
+        @Nullable SourceFile recordEdit(Callable<SourceFile> editCallable) throws Exception {
+            return edit.recordTimed(editCallable);
+        }
     }
 
     private static class PhaseTimer {

--- a/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
+++ b/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
@@ -125,7 +125,8 @@ public class RecipeRunStats extends DataTable<RecipeRunStats.Row> {
             scan.recordTimed(scanCallable);
         }
 
-        @Nullable SourceFile recordEdit(Callable<SourceFile> editCallable) throws Exception {
+        @Nullable
+        SourceFile recordEdit(Callable<SourceFile> editCallable) throws Exception {
             return edit.recordTimed(editCallable);
         }
     }


### PR DESCRIPTION
The only operational use of P99 is in A/B testing and we haven’t ever operated something like that for multiple versions of recipes.