### PR TITLE
Fix HCL parser idempotency issue with empty arrays containing newlines

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
@@ -650,10 +650,16 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
             Space tuplePrefix = sourceBefore("[");
             List<HclRightPadded<Expression>> mappedValues = new ArrayList<>();
             List<HCLParser.ExpressionContext> values = ctx.expression();
-            for (int i = 0; i < values.size(); i++) {
-                HCLParser.ExpressionContext value = values.get(i);
-                mappedValues.add(HclRightPadded.build((Expression) visit(value))
-                        .withAfter(i == values.size() - 1 ? sourceBefore("]") : sourceBefore(",")));
+            if (values.isEmpty()) {
+                // For empty arrays, preserve the whitespace before the closing bracket using Hcl.Empty
+                mappedValues.add(
+                        HclRightPadded.build(new Hcl.Empty(randomId(), sourceBefore("]"), Markers.EMPTY)));
+            } else {
+                for (int i = 0; i < values.size(); i++) {
+                    HCLParser.ExpressionContext value = values.get(i);
+                    mappedValues.add(HclRightPadded.build((Expression) visit(value))
+                            .withAfter(i == values.size() - 1 ? sourceBefore("]") : sourceBefore(",")));
+                }
             }
 
             return new Hcl.Tuple(randomId(), Space.format(prefix), Markers.EMPTY, HclContainer

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCollectionValueTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCollectionValueTest.java
@@ -68,4 +68,16 @@ class HclCollectionValueTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void emptyArrayWithNewLine() {
+        rewriteRun(
+          hcl(
+            """
+              default = [
+              ]
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes #6074 
- Preserves whitespace in empty HCL arrays that contain newlines between brackets

## Changes
- Modified `visitTuple` method in `HclParserVisitor` to handle empty arrays similarly to how empty objects are handled
- When an array is empty, uses `Hcl.Empty` to preserve whitespace before the closing bracket
- Added test case to verify empty arrays with newlines maintain their formatting

## Test plan
✅ Added test case `emptyArrayWithNewLine` that verifies arrays like:
```hcl
default = [
]
```
maintain their formatting instead of being collapsed to `default = []`

✅ All existing HCL tests pass
✅ Follows the same pattern used for empty objects in the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)