### PR TITLE
Get GAV coordinates for type table entries

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/marker/JavaSourceSetTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/marker/JavaSourceSetTest.java
@@ -73,6 +73,12 @@ class JavaSourceSetTest {
     }
 
     @Test
+    void gavCoordinateFromTypeTable() {
+        assertThat(gavFromPath(Paths.get("/home/tim/.rewrite/classpath/.tt/org/junit/jupiter/junit-jupiter-api/6.0.0-RC3")))
+          .isEqualTo("org.junit.jupiter:junit-jupiter-api:6.0.0-RC3");
+    }
+
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/pull/4401")
     void tolerateWeirdClassNames(){
         assertThat(JavaSourceSet.isDeclarable("fj.data.$")).isFalse();

--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
@@ -222,6 +222,7 @@ public class JavaSourceSet implements SourceSet {
         List<String> pathParts = Arrays.asList(pathStr.split("/"));
         // Example maven path: ~/.m2/repository/org/openrewrite/rewrite-core/8.32.0/rewrite-core-8.32.0.jar
         // Example gradle path: ~/.gradle/caches/modules-2/files-2.1/org.openrewrite/rewrite-core/8.32.0/64ddcc371f1bf29593b4b27e907757d5554d1a83/rewrite-core-8.32.0.jar
+        // Example typetable path: ~/.rewrite/classpath/.tt/org/junit/jupiter/junit-jupiter-api/6.0.0-RC3
 
         // Either of these directories may be relocated, so a fixed index is unreliable
         String groupId = null;
@@ -232,6 +233,13 @@ public class JavaSourceSet implements SourceSet {
                 groupId = pathParts.get(pathParts.size() - 5);
                 artifactId = pathParts.get(pathParts.size() - 4);
                 version = pathParts.get(pathParts.size() - 3);
+            } else if (pathParts.contains(".tt")) {
+                int ttIndex = pathParts.indexOf(".tt");
+                if (pathParts.size() - ttIndex > 3) {
+                    groupId = String.join(".", pathParts.subList(ttIndex + 1, pathParts.size() - 2));
+                    artifactId = pathParts.get(pathParts.size() - 2);
+                    version = pathParts.get(pathParts.size() - 1);
+                }
             } else if (pathParts.size() >= 4) {
                 version = pathParts.get(pathParts.size() - 2);
                 artifactId = pathParts.get(pathParts.size() - 3);
@@ -320,6 +328,6 @@ public class JavaSourceSet implements SourceSet {
 
     static boolean isDeclarable(String className) {
         int dotIndex = Math.max(className.lastIndexOf("."), className.lastIndexOf('$'));
-        return dotIndex != -1 && dotIndex < className.length() -1 && Character.isJavaIdentifierStart(className.charAt(dotIndex + 1));
+        return dotIndex != -1 && dotIndex < className.length() - 1 && Character.isJavaIdentifierStart(className.charAt(dotIndex + 1));
     }
 }


### PR DESCRIPTION
We didn't yet support type tables for JavaSourceSet, meaning I could not do the following:
```java
    SourceSpecs junit6Source =
      java(
        """
          import org.junit.jupiter.api.Test;
          class TestWith5 {
            @Test
            void test() {
            }
          }
          """,
        """
          import org.junit.jupiter.api.Test;
          class TestWith5 {
            /*~~>*/@Test
            void test() {
            }
          }
          """,
        spec -> spec.markers(
          JavaSourceSet.build("test", JavaParser.dependenciesFromResources(new InMemoryExecutionContext(), "junit-jupiter-api"))));
```

Where the dependency is provided by 
```gradle
recipeDependencies {
    testParserClasspath("org.junit.jupiter:junit-jupiter-api:6.0.0-RC3")
}
```

- For https://github.com/moderneinc/rewrite-devcenter/pull/33