### PR TITLE
Adapt preconditions types

### DIFF
--- a/rewrite-javascript/rewrite/package-lock.json
+++ b/rewrite-javascript/rewrite/package-lock.json
@@ -15,6 +15,7 @@
         "dedent": "^1.5.3",
         "diff": "^7.0.0",
         "immer": "^10.1.1",
+        "picomatch": "^4.0.3",
         "tmp-promise": "^3.0.3",
         "typescript": "^5.8.3",
         "vscode-jsonrpc": "^8.2.1"
@@ -25,6 +26,7 @@
       "devDependencies": {
         "@types/diff": "^5.2.2",
         "@types/jest": "^29.5.13",
+        "@types/picomatch": "^4.0.2",
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0",
         "ts-jest": "^29.2.5",
@@ -1097,6 +1099,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -1201,6 +1210,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/arg": {
@@ -2851,6 +2873,19 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-util/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/jest-validate": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
@@ -3112,6 +3147,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -3344,13 +3392,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"

--- a/rewrite-javascript/rewrite/package.json
+++ b/rewrite-javascript/rewrite/package.json
@@ -35,6 +35,7 @@
     "dedent": "^1.5.3",
     "diff": "^7.0.0",
     "immer": "^10.1.1",
+    "picomatch": "^4.0.3",
     "tmp-promise": "^3.0.3",
     "typescript": "^5.8.3",
     "vscode-jsonrpc": "^8.2.1"
@@ -42,6 +43,7 @@
   "devDependencies": {
     "@types/diff": "^5.2.2",
     "@types/jest": "^29.5.13",
+    "@types/picomatch": "^4.0.2",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
     "ts-jest": "^29.2.5",

--- a/rewrite-javascript/rewrite/src/java/tree.ts
+++ b/rewrite-javascript/rewrite/src/java/tree.ts
@@ -24,7 +24,23 @@ export interface J extends Tree {
     readonly prefix: J.Space;
 }
 
+export namespace J {
+    export function isMethodCall(e?: Expression): e is MethodCall {
+        return e?.kind === J.Kind.NewClass ||
+            e?.kind === J.Kind.MethodInvocation ||
+            e?.kind === J.Kind.MemberReference;
+    }
+
+    export function hasType<T extends J>(tree: T): tree is T & { type: Type } {
+        return tree && 'type' in tree && tree.type != null;
+    }
+}
+
 export interface Expression extends J {
+}
+
+export interface MethodCall extends Expression {
+    readonly methodType?: Type.Method;
 }
 
 export interface TypedTree extends J {
@@ -458,13 +474,12 @@ export namespace J {
         readonly codePoint: string;
     }
 
-    export interface MemberReference extends J, Expression {
+    export interface MemberReference extends J, MethodCall {
         readonly kind: typeof Kind.MemberReference;
         readonly containing: RightPadded<Expression>;
         readonly typeParameters?: Container<Expression>;
         readonly reference: LeftPadded<Identifier>;
         readonly type?: Type;
-        readonly methodType?: Type.Method;
         readonly variableType?: Type.Variable;
     }
 
@@ -483,13 +498,12 @@ export namespace J {
         readonly methodType?: Type.Method;
     }
 
-    export interface MethodInvocation extends J, TypedTree, Expression {
+    export interface MethodInvocation extends J, TypedTree, MethodCall {
         readonly kind: typeof Kind.MethodInvocation;
         readonly select?: RightPadded<Expression>;
         readonly typeParameters?: Container<Expression>;
         readonly name: Identifier;
         readonly arguments: Container<Expression>;
-        readonly methodType?: Type.Method;
     }
 
     export interface Modifier extends J {
@@ -536,7 +550,7 @@ export namespace J {
         readonly type?: Type;
     }
 
-    export interface NewClass extends J, TypedTree, Expression {
+    export interface NewClass extends J, TypedTree, MethodCall {
         readonly kind: typeof Kind.NewClass;
         readonly enclosing?: RightPadded<Expression>;
         readonly new: Space;
@@ -812,12 +826,6 @@ export interface TextComment extends Comment {
 
 export interface DocComment extends Comment {
     // TODO implement me!
-}
-
-const javaKindValues = new Set(Object.values(J.Kind));
-
-export function isJava(tree: any): tree is J {
-    return javaKindValues.has(tree["kind"]);
 }
 
 export function isLiteral(tree: any): tree is J.Literal {

--- a/rewrite-javascript/rewrite/src/java/type.ts
+++ b/rewrite-javascript/rewrite/src/java/type.ts
@@ -249,6 +249,16 @@ export namespace Type {
         return type?.kind === Type.Kind.Parameterized;
     }
 
+    export function isFullyQualified(type?: Type): type is Type.FullyQualified {
+        return type != null && (
+            type.kind === Type.Kind.Class ||
+            type.kind === Type.Kind.Annotation ||
+            type.kind === Type.Kind.Parameterized ||
+            type.kind === Type.Kind.Array ||
+            type.kind === Type.Kind.ShallowClass
+        );
+    }
+
     export interface FullyQualified extends Type {
     }
 

--- a/rewrite-javascript/rewrite/src/java/visitor.ts
+++ b/rewrite-javascript/rewrite/src/java/visitor.ts
@@ -16,16 +16,32 @@
 import {Cursor, isTree, SourceFile} from "../tree";
 import {mapAsync} from "../util";
 import {produceAsync, TreeVisitor, ValidImmerRecipeReturnType} from "../visitor";
-import {
-    Expression,
-    isJava,
-    isSpace,
-    J,
-    NameTree,
-    Statement, TypedTree, TypeTree
-} from "./tree";
+import {Expression, isSpace, J, NameTree, Statement, TypedTree, TypeTree} from "./tree";
 import {createDraft, Draft, finishDraft} from "immer";
 import {Type} from "./type";
+
+const javaKindValues = new Set(Object.values(J.Kind));
+
+const extendedJavaKinds = new Map<string, <P>(visitor: JavaVisitor<P>) => JavaVisitor<P>>();
+
+/**
+ * Register additional kind values for interfaces that extend J.
+ * This allows isJava to recognize implementations of those interfaces.
+ * @param kinds - Array of kind values to register
+ * @param adapter - Adapter function to transform a JavaVisitor to, for example, a JavaScriptVisitor
+ */
+export function registerJavaExtensionKinds(
+    kinds: readonly string[],
+    adapter: <P>(visitor: JavaVisitor<P>) => JavaVisitor<P>
+): void {
+    for (const kind of kinds) {
+        extendedJavaKinds.set(kind, adapter);
+    }
+}
+
+export function isJava(tree: any): tree is J {
+    return javaKindValues.has(tree["kind"]) || extendedJavaKinds.has(tree["kind"]);
+}
 
 export class JavaVisitor<P> extends TreeVisitor<J, P> {
     // protected javadocVisitor: any | null = null;
@@ -1200,6 +1216,10 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
             case J.Kind.Yield:
                 return this.visitYield(t as J.Yield, p);
             default:
+                const adapter = extendedJavaKinds.get(t.kind)
+                if (adapter) {
+                    return adapter(this).visit(t, p);
+                }
                 return Promise.resolve(t);
         }
     }

--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -1898,7 +1898,7 @@ export class JavaScriptParserVisitor {
                 function: select,
                 typeParameters: typeArguments,
                 arguments: this.mapCommaSeparatedList(node.getChildren(this.sourceFile).slice(-3)),
-                functionType: this.mapMethodType(node)
+                methodType: this.mapMethodType(node)
             }
         }
     }

--- a/rewrite-javascript/rewrite/src/javascript/preconditions.ts
+++ b/rewrite-javascript/rewrite/src/javascript/preconditions.ts
@@ -15,15 +15,26 @@
  */
 import {RewriteRpc} from "../rpc";
 import {Recipe} from "../recipe";
+import {UsesMethod, UsesType} from "./search";
+import {ExecutionContext} from "../execution";
+import {TreeVisitor} from "../visitor";
+import {IsSourceFile} from "../search";
 
-export async function hasSourcePath(filePattern: string): Promise<Recipe> {
-    return RewriteRpc.get().prepareRecipe("org.openrewrite.FindSourceFiles", {filePattern})
+export async function hasSourcePath(filePattern: string): Promise<TreeVisitor<any, ExecutionContext>> {
+    return await (await RewriteRpc.get()?.prepareRecipe("org.openrewrite.FindSourceFiles", {
+        filePattern
+    }))?.editor() || new IsSourceFile(filePattern);
 }
 
-export async function usesMethod(methodMatcher: string, matchOverrides: boolean = false): Promise<Recipe> {
-    return RewriteRpc.get().prepareRecipe("org.openrewrite.java.search.UsesMethod", {methodMatcher, matchOverrides})
+export async function usesMethod(methodMatcher: string, matchOverrides: boolean = false): Promise<TreeVisitor<any, ExecutionContext>> {
+    return await (await RewriteRpc.get()?.prepareRecipe("org.openrewrite.java.search.UsesMethod", {
+        methodMatcher,
+        matchOverrides
+    }))?.editor() || new UsesMethod(methodMatcher)
 }
 
-export async function usesType(fullyQualifiedType: string): Promise<Recipe> {
-    return RewriteRpc.get().prepareRecipe("org.openrewrite.java.search.UsesType", {fullyQualifiedType})
+export async function usesType(fullyQualifiedType: string): Promise<TreeVisitor<any, ExecutionContext>> {
+    return await (await RewriteRpc.get()?.prepareRecipe("org.openrewrite.java.search.UsesType", {
+        fullyQualifiedType
+    }))?.editor() || new UsesType(fullyQualifiedType);
 }

--- a/rewrite-javascript/rewrite/src/javascript/rpc.ts
+++ b/rewrite-javascript/rewrite/src/javascript/rpc.ts
@@ -105,7 +105,7 @@ class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
         await q.getAndSend(functionCall, m => m.function, f => this.visitRightPadded(f, q));
         await q.getAndSend(functionCall, m => m.typeParameters, params => this.visitContainer(params, q));
         await q.getAndSend(functionCall, m => m.arguments, args => this.visitContainer(args, q));
-        await q.getAndSend(functionCall, m => asRef(m.functionType), type => this.visitType(type, q));
+        await q.getAndSend(functionCall, m => asRef(m.methodType), type => this.visitType(type, q));
         return functionCall;
     }
 
@@ -643,7 +643,7 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
         draft.function = await q.receive(functionCall.function, select => this.visitRightPadded(select, q));
         draft.typeParameters = await q.receive(functionCall.typeParameters, typeParams => this.visitContainer(typeParams, q));
         draft.arguments = await q.receive(functionCall.arguments, args => this.visitContainer(args, q));
-        draft.functionType = await q.receive(functionCall.functionType, type => this.visitType(type, q) as unknown as Type.Method);
+        draft.methodType = await q.receive(functionCall.methodType, type => this.visitType(type, q) as unknown as Type.Method);
 
         return finishDraft(draft);
     }

--- a/rewrite-javascript/rewrite/src/javascript/search/index.ts
+++ b/rewrite-javascript/rewrite/src/javascript/search/index.ts
@@ -1,0 +1,2 @@
+export * from './uses-method';
+export * from './uses-type';

--- a/rewrite-javascript/rewrite/src/javascript/search/uses-method.ts
+++ b/rewrite-javascript/rewrite/src/javascript/search/uses-method.ts
@@ -1,0 +1,21 @@
+import {Expression, J, JavaVisitor} from "../../java";
+import {ExecutionContext} from "../../execution";
+import {MethodMatcher} from "../method-matcher";
+import {JS} from "../tree";
+import {foundSearchResult} from "../../markers";
+
+export class UsesMethod extends JavaVisitor<ExecutionContext> {
+    private readonly matcher;
+
+    constructor(pattern: string) {
+        super();
+        this.matcher = new MethodMatcher(pattern);
+    }
+
+    protected async visitExpression(expression: Expression, p: ExecutionContext): Promise<J | undefined> {
+        if (JS.isMethodCall(expression) && this.matcher.matches(expression.methodType)) {
+            return foundSearchResult(expression);
+        }
+        return super.visitExpression(expression, p);
+    }
+}

--- a/rewrite-javascript/rewrite/src/javascript/search/uses-type.ts
+++ b/rewrite-javascript/rewrite/src/javascript/search/uses-type.ts
@@ -1,0 +1,27 @@
+import {J, JavaVisitor, Type} from "../../java";
+import {ExecutionContext} from "../../execution";
+import * as picomatch from "picomatch";
+import {foundSearchResult} from "../../markers";
+
+export class UsesType extends JavaVisitor<ExecutionContext> {
+    private readonly matcher: picomatch.Matcher;
+
+    constructor(typePattern: string) {
+        super();
+        // Create a picomatch matcher for the pattern
+        this.matcher = picomatch.default ? picomatch.default(typePattern) : (picomatch as any)(typePattern);
+    }
+
+    protected async preVisit(tree: J, _: ExecutionContext): Promise<J | undefined> {
+        if (J.hasType(tree)) {
+            const type = tree.type;
+            if (Type.isFullyQualified(type)) {
+                const fullyQualifiedName = Type.FullyQualified.getFullyQualifiedName(type);
+                if (this.matcher(fullyQualifiedName)) {
+                    return foundSearchResult(tree);
+                }
+            }
+        }
+        return tree;
+    }
+}

--- a/rewrite-javascript/rewrite/src/javascript/tree.ts
+++ b/rewrite-javascript/rewrite/src/javascript/tree.ts
@@ -17,7 +17,20 @@
  */
 
 import {SourceFile} from "../tree";
-import {Expression, J, NameTree, Statement, Type, TypedTree, TypeTree, VariableDeclarator,} from "../java";
+import {
+    Expression,
+    J,
+    JavaVisitor,
+    MethodCall,
+    NameTree,
+    Statement,
+    Type,
+    TypedTree,
+    TypeTree,
+    VariableDeclarator,
+    registerJavaExtensionKinds
+} from "../java";
+import {JavaScriptVisitor} from "./visitor";
 
 export interface JS extends J {
 }
@@ -93,6 +106,10 @@ export namespace JS {
         Void: "org.openrewrite.javascript.tree.JS$Void",
         WithStatement: "org.openrewrite.javascript.tree.JS$WithStatement",
     } as const;
+
+    export function isMethodCall(e?: Expression): e is MethodCall {
+        return J.isMethodCall(e) || e?.kind === JS.Kind.FunctionCall;
+    }
 
     /**
      * Represents the root of a JavaScript AST (compilation unit).
@@ -650,12 +667,11 @@ export namespace JS {
      * @example data["key"](5, 0, 4)
      * @example (() => { return 3 + 5 })()
      */
-    export interface FunctionCall extends JS, Expression {
+    export interface FunctionCall extends JS, MethodCall {
         readonly kind: typeof Kind.FunctionCall;
         readonly function?: J.RightPadded<Expression>;
         readonly typeParameters?: J.Container<Expression>;
         readonly arguments: J.Container<Expression>;
-        readonly functionType?: Type.Method;
     }
 
     /**
@@ -900,6 +916,34 @@ export namespace JSX {
 }
 
 const KindValues = new Set(Object.values(JS.Kind));
+
+function javascriptVisitorAdapter<P>(visitor: JavaVisitor<P>): JavaVisitor<P> {
+    const adaptedVisitor = new JavaScriptVisitor<P>();
+
+    // Walk up the prototype chain of the visitor to get all overridden methods
+    let proto = Object.getPrototypeOf(visitor);
+    while (proto && proto !== JavaVisitor.prototype) {
+        Object.getOwnPropertyNames(proto).forEach(name => {
+            const descriptor = Object.getOwnPropertyDescriptor(proto, name);
+            if (descriptor && typeof descriptor.value === 'function' && name !== 'constructor') {
+                // Copy the method, binding it to jsVisitor
+                (adaptedVisitor as any)[name] = descriptor.value.bind(adaptedVisitor);
+            }
+        });
+        proto = Object.getPrototypeOf(proto);
+    }
+
+    // Also copy any instance properties
+    Object.keys(visitor).forEach(key => {
+        if (!(key in adaptedVisitor)) {
+            (adaptedVisitor as any)[key] = (visitor as any)[key];
+        }
+    });
+
+    return adaptedVisitor;
+}
+
+registerJavaExtensionKinds(Object.values(JS.Kind), javascriptVisitorAdapter);
 
 export function isJavaScript(tree: any): tree is JS {
     return KindValues.has(tree["kind"]);

--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -587,6 +587,15 @@ export class JavaScriptTypeMapping {
             if (builtInTypes.has(cleanedName)) {
                 return `lib.${cleanedName}`;
             }
+
+            // Handle constructor types for built-in objects
+            // e.g., PromiseConstructor -> lib.Promise
+            if (cleanedName.endsWith('Constructor')) {
+                const baseName = cleanedName.substring(0, cleanedName.length - 'Constructor'.length);
+                if (builtInTypes.has(baseName)) {
+                    return `lib.${baseName}`;
+                }
+            }
         }
 
         return cleanedName;

--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -22,13 +22,6 @@ class NonDraftableType {
     [immerable] = false;
 }
 
-const builtInTypes = new Set([
-    'Array', 'Object', 'Function', 'String', 'Number', 'Boolean',
-    'Date', 'RegExp', 'Error', 'Promise', 'Map', 'Set', 'WeakMap',
-    'WeakSet', 'Symbol', 'BigInt', 'HTMLElement', 'Document',
-    'Window', 'Console', 'JSON', 'Math', 'Reflect', 'Proxy'
-]);
-
 export class JavaScriptTypeMapping {
     private readonly typeCache: Map<string | number, Type> = new Map();
     private readonly regExpSymbol: ts.Symbol | undefined;
@@ -121,7 +114,7 @@ export class JavaScriptTypeMapping {
 
     primitiveType(node: ts.Node): Type.Primitive {
         const type = this.type(node);
-        if (Type.isClass(type) && type.fullyQualifiedName === 'lib.RegExp') {
+        if (Type.isClass(type) && type.fullyQualifiedName === 'RegExp') {
             return Type.Primitive.String;
         }
         return Type.isPrimitive(type) ? type : Type.Primitive.None;
@@ -302,12 +295,12 @@ export class JavaScriptTypeMapping {
                         if ((mappedType as any).keyword === 'String') {
                             declaringType = {
                                 kind: Type.Kind.Class,
-                                fullyQualifiedName: 'lib.String'
+                                fullyQualifiedName: 'String'
                             } as Type.FullyQualified;
                         } else if ((mappedType as any).keyword === 'Number') {
                             declaringType = {
                                 kind: Type.Kind.Class,
-                                fullyQualifiedName: 'lib.Number'
+                                fullyQualifiedName: 'Number'
                             } as Type.FullyQualified;
                         } else {
                             // Fallback for other types
@@ -321,17 +314,17 @@ export class JavaScriptTypeMapping {
 
                 // For string methods like 'hello'.split(), ensure we have a proper declaring type for primitives
                 if (!isImport && declaringType === Type.unknownType) {
-                    // If the expression type is a primitive string, use lib.String as declaring type
+                    // If the expression type is a primitive string, use String as declaring type
                     const typeString = this.checker.typeToString(exprType);
                     if (typeString === 'string' || exprType.flags & ts.TypeFlags.String || exprType.flags & ts.TypeFlags.StringLiteral) {
                         declaringType = {
                             kind: Type.Kind.Class,
-                            fullyQualifiedName: 'lib.String'
+                            fullyQualifiedName: 'string'
                         } as Type.FullyQualified;
                     } else if (typeString === 'number' || exprType.flags & ts.TypeFlags.Number || exprType.flags & ts.TypeFlags.NumberLiteral) {
                         declaringType = {
                             kind: Type.Kind.Class,
-                            fullyQualifiedName: 'lib.Number'
+                            fullyQualifiedName: 'number'
                         } as Type.FullyQualified;
                     } else {
                         // Fallback for other primitive types or unknown
@@ -582,23 +575,9 @@ export class JavaScriptTypeMapping {
             }
         }
 
-        // If it's just a simple name without dots, check if it's a built-in type
-        if (!cleanedName.includes('.')) {
-            if (builtInTypes.has(cleanedName)) {
-                return `lib.${cleanedName}`;
-            }
-
-            // Handle constructor types for built-in objects
-            // e.g., PromiseConstructor -> lib.Promise
-            if (cleanedName.endsWith('Constructor')) {
-                const baseName = cleanedName.substring(0, cleanedName.length - 'Constructor'.length);
-                if (builtInTypes.has(baseName)) {
-                    return `lib.${baseName}`;
-                }
-            }
-        }
-
-        return cleanedName;
+        return cleanedName.endsWith('Constructor') ?
+            cleanedName.substring(0, cleanedName.length - 'Constructor'.length) :
+            cleanedName;
     }
 
 

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -254,7 +254,7 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
             draft.function = await this.visitOptionalRightPadded(functionCall.function, p);
             draft.typeParameters = await this.visitOptionalContainer(functionCall.typeParameters, p);
             draft.arguments = await this.visitContainer(functionCall.arguments, p);
-            draft.functionType = await this.visitType(functionCall.functionType, p) as Type.Method | undefined;
+            draft.methodType = await this.visitType(functionCall.methodType, p) as Type.Method | undefined;
         });
     }
 

--- a/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
+++ b/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
@@ -92,10 +92,7 @@ export class RewriteRpc {
         this._global = value;
     }
 
-    static get(): RewriteRpc {
-        if (!this._global) {
-            throw new Error("RewriteRpc not initialized");
-        }
+    static get(): RewriteRpc | undefined {
         return this._global;
     }
 

--- a/rewrite-javascript/rewrite/src/search/index.ts
+++ b/rewrite-javascript/rewrite/src/search/index.ts
@@ -1,0 +1,1 @@
+export * from './is-source-file'

--- a/rewrite-javascript/rewrite/src/search/is-source-file.ts
+++ b/rewrite-javascript/rewrite/src/search/is-source-file.ts
@@ -1,0 +1,26 @@
+import {TreeVisitor} from "../visitor";
+import {ExecutionContext} from "../execution";
+import {isSourceFile} from "../tree";
+import {foundSearchResult} from "../markers";
+import * as picomatch from "picomatch";
+
+export class IsSourceFile extends TreeVisitor<any, ExecutionContext> {
+    private readonly matcher: picomatch.Matcher;
+
+    constructor(filePattern: string) {
+        super();
+        // Create a picomatch matcher for the pattern
+        this.matcher = picomatch.default ? picomatch.default(filePattern) : (picomatch as any)(filePattern);
+    }
+
+    protected async preVisit(tree: any, _: ExecutionContext): Promise<any> {
+        this.stopAfterPreVisit();
+        if (isSourceFile(tree) && tree.sourcePath) {
+            const path = tree.sourcePath.replace(/\\/g, '/'); // Normalize to Unix separators
+            if (this.matcher(path)) {
+                return foundSearchResult(tree);
+            }
+        }
+        return tree;
+    }
+}

--- a/rewrite-javascript/rewrite/test/javascript/method-matcher.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/method-matcher.test.ts
@@ -32,31 +32,6 @@ describe('MethodMatcher', () => {
         return new MethodMatcherRecipe();
     }
 
-    describe('Pattern: lib.* *(..)', () => {
-        test('should match any type in lib package, any method, any args', async () => {
-            const spec = new RecipeSpec();
-            spec.recipe = markMatchedMethods('lib.* *(..)');
-
-            //language=typescript
-            await spec.rewriteRun(
-                typescript(
-                    `
-                        const arr = [];
-                        arr.map(x => x);
-                        arr.filter(x => x);
-                    `,
-                    //@formatter:off
-                `
-                    const arr = [];
-                    /*~~>*/arr.map(x => x);
-                    /*~~>*/arr.filter(x => x);
-                `
-                //@formatter:on
-                )
-            );
-        });
-    });
-
     describe('Pattern: *.Array *(..)', () => {
         test('should match any method of Array regardless of package', async () => {
             const spec = new RecipeSpec();
@@ -237,7 +212,7 @@ describe('MethodMatcher', () => {
     describe('Pattern: console *(..)', () => {
         test('should match any console method', async () => {
             const spec = new RecipeSpec();
-            spec.recipe = markMatchedMethods('lib.Console *(..)');
+            spec.recipe = markMatchedMethods('Console *(..)');
 
             //language=typescript
             await spec.rewriteRun(
@@ -264,7 +239,7 @@ describe('MethodMatcher', () => {
     describe('Pattern: Math max(number, number)', () => {
         test('should match Math.max with two number arguments', async () => {
             const spec = new RecipeSpec();
-            spec.recipe = markMatchedMethods('lib.Math max(lib.Array)');
+            spec.recipe = markMatchedMethods('Math max(Array)');
 
             //language=typescript
             await spec.rewriteRun(
@@ -289,7 +264,7 @@ describe('MethodMatcher', () => {
     describe('Pattern with empty arguments', () => {
         test('should match methods with no arguments', async () => {
             const spec = new RecipeSpec();
-            spec.recipe = markMatchedMethods('DateConstructor now()');
+            spec.recipe = markMatchedMethods('Date now()');
 
             //language=typescript
             await spec.rewriteRun(

--- a/rewrite-javascript/rewrite/test/javascript/search/uses-method.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/search/uses-method.test.ts
@@ -1,0 +1,80 @@
+// noinspection JSUnusedLocalSymbols
+
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {describe, test} from "@jest/globals";
+import {fromVisitor, RecipeSpec} from "../../../src/test";
+import {typescript} from "../../../src/javascript";
+import {UsesMethod} from "../../../src/javascript/search";
+
+describe('UsesMethod visitor', () => {
+    test('should find exact method match', async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new UsesMethod("lib.Array push(..)"));
+
+        //language=typescript
+        await spec.rewriteRun(
+            typescript(
+                `
+                    const arr = [1, 2];
+                    arr.push(3);
+                `,
+                //@formatter:off
+                `
+                    const arr = [1, 2];
+                    /*~~>*/arr.push(3);
+                `
+                //@formatter:on
+            )
+        );
+    });
+
+    test('should match with wildcard package pattern', async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new UsesMethod("*.Array map(..)"));
+
+        //language=typescript
+        await spec.rewriteRun(
+            typescript(
+                `[1, 2].map(x => x * 2);`,
+                //@formatter:off
+                `/*~~>*/[1, 2].map(x => x * 2);`
+                //@formatter:on
+            )
+        );
+    });
+
+    test('should match methods with any arguments', async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new UsesMethod("lib.Array push(..)"));
+
+        //language=typescript
+        await spec.rewriteRun(
+            typescript(
+                `
+                    const arr = [1, 2];
+                    arr.push(3);
+                `,
+                //@formatter:off
+                `
+                    const arr = [1, 2];
+                    /*~~>*/arr.push(3);
+                `
+                //@formatter:on
+            )
+        );
+    });
+});

--- a/rewrite-javascript/rewrite/test/javascript/search/uses-method.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/search/uses-method.test.ts
@@ -23,7 +23,7 @@ import {UsesMethod} from "../../../src/javascript/search";
 describe('UsesMethod visitor', () => {
     test('should find exact method match', async () => {
         const spec = new RecipeSpec();
-        spec.recipe = fromVisitor(new UsesMethod("lib.Array push(..)"));
+        spec.recipe = fromVisitor(new UsesMethod("Array push(..)"));
 
         //language=typescript
         await spec.rewriteRun(
@@ -59,7 +59,7 @@ describe('UsesMethod visitor', () => {
 
     test('should match methods with any arguments', async () => {
         const spec = new RecipeSpec();
-        spec.recipe = fromVisitor(new UsesMethod("lib.Array push(..)"));
+        spec.recipe = fromVisitor(new UsesMethod("Array push(..)"));
 
         //language=typescript
         await spec.rewriteRun(

--- a/rewrite-javascript/rewrite/test/javascript/search/uses-type.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/search/uses-type.test.ts
@@ -23,7 +23,7 @@ import {UsesType} from "../../../src/javascript/search";
 describe('UsesType visitor', () => {
     test('should find exact type match', async () => {
         const spec = new RecipeSpec();
-        spec.recipe = fromVisitor(new UsesType("lib.Array"));
+        spec.recipe = fromVisitor(new UsesType("Array"));
 
         //language=typescript
         await spec.rewriteRun(
@@ -36,7 +36,7 @@ describe('UsesType visitor', () => {
 
     test('should match with glob pattern', async () => {
         const spec = new RecipeSpec();
-        spec.recipe = fromVisitor(new UsesType("*.Promise"));
+        spec.recipe = fromVisitor(new UsesType("*romise"));
 
         //language=typescript
         await spec.rewriteRun(

--- a/rewrite-javascript/rewrite/test/javascript/search/uses-type.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/search/uses-type.test.ts
@@ -1,0 +1,49 @@
+// noinspection JSUnusedLocalSymbols
+
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {describe, test} from "@jest/globals";
+import {fromVisitor, RecipeSpec} from "../../../src/test";
+import {typescript} from "../../../src/javascript";
+import {UsesType} from "../../../src/javascript/search";
+
+describe('UsesType visitor', () => {
+    test('should find exact type match', async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new UsesType("lib.Array"));
+
+        //language=typescript
+        await spec.rewriteRun(
+            typescript(
+                `const arr = [1, 2]`,
+                `const /*~~>*/arr = /*~~>*/[1, 2]`
+            )
+        );
+    });
+
+    test('should match with glob pattern', async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new UsesType("*.Promise"));
+
+        //language=typescript
+        await spec.rewriteRun(
+            typescript(
+                `const p = Promise.resolve("data")`,
+                `const /*~~>*/p = /*~~>*/Promise.resolve("data")`
+            )
+        );
+    });
+});

--- a/rewrite-javascript/rewrite/test/javascript/type-mapping.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/type-mapping.test.ts
@@ -391,6 +391,22 @@ describe('JavaScript type mapping', () => {
             }, {unsafeCleanup: true});
         });
 
+        test('Promise not PromiseConstructor', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = markTypes((_, type) => {
+                return Type.isClass(type) ? type.fullyQualifiedName : null;
+            });
+            await spec.rewriteRun(
+                //language=typescript
+                typescript(
+                    `Promise.resolve("data")`,
+                    //@formatter:off
+                    `/*~~(lib.Promise)~~>*/Promise.resolve("data")`
+                    //@formatter:on
+                )
+            )
+        })
+
         test('deprecated node methods with ES6 imports', async () => {
             const spec = new RecipeSpec();
             spec.recipe = markTypes((_, type) => {

--- a/rewrite-javascript/rewrite/test/javascript/type-mapping.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/type-mapping.test.ts
@@ -294,7 +294,7 @@ describe('JavaScript type mapping', () => {
                         element = div;
                     `,
                     `
-                        let element: /*~~(lib.HTMLElement (235 members))~~>*/HTMLElement;
+                        let element: /*~~(HTMLElement (235 members))~~>*/HTMLElement;
                         const div = document.createElement('div');
                         element = div;
                     `
@@ -401,7 +401,7 @@ describe('JavaScript type mapping', () => {
                 typescript(
                     `Promise.resolve("data")`,
                     //@formatter:off
-                    `/*~~(lib.Promise)~~>*/Promise.resolve("data")`
+                    `/*~~(Promise)~~>*/Promise.resolve("data")`
                     //@formatter:on
                 )
             )
@@ -421,11 +421,13 @@ describe('JavaScript type mapping', () => {
                         typescript(
                             `
                                 import * as util from 'util';
+
                                 util.isArray([])
                             `,
                             //@formatter:off
                             `
                                 import * as util from 'util';
+
                                 /*~~(util)~~>*/util.isArray([])
                             `
                             //@formatter:on
@@ -566,12 +568,10 @@ describe('JavaScript type mapping', () => {
         test('should map array types as class types', async () => {
             const spec = new RecipeSpec();
             spec.recipe = markTypes((node, type) => {
-                // Mark array literals - arrays are now treated as class types
                 if (node?.kind === J.Kind.NewArray) {
                     if (Type.isClass(type)) {
-                        // Arrays should now be mapped as lib.Array class type
-                        if (type.fullyQualifiedName === 'lib.Array') {
-                            return 'lib.Array';
+                        if (type.fullyQualifiedName === 'Array') {
+                            return 'Array';
                         }
                     }
                     return null;
@@ -587,8 +587,8 @@ describe('JavaScript type mapping', () => {
                         let strings: Array<string> = ["a", "b"];
                     `,
                     `
-                        let numbers: number[] = /*~~(lib.Array)~~>*/[1, 2, 3];
-                        let strings: Array<string> = /*~~(lib.Array)~~>*/["a", "b"];
+                        let numbers: number[] = /*~~(Array)~~>*/[1, 2, 3];
+                        let strings: Array<string> = /*~~(Array)~~>*/["a", "b"];
                     `
                 )
             );
@@ -639,9 +639,9 @@ describe('JavaScript type mapping', () => {
                 // Mark array literals assigned to readonly arrays - arrays are now class types
                 if (node?.kind === J.Kind.NewArray) {
                     if (Type.isClass(type)) {
-                        // Both readonly and regular arrays should be mapped as lib.Array
-                        if (type.fullyQualifiedName === 'lib.Array') {
-                            return 'lib.Array';
+                        // Both readonly and regular arrays should be mapped as Array
+                        if (type.fullyQualifiedName === 'Array') {
+                            return 'Array';
                         }
                     }
                     return null;
@@ -658,9 +658,9 @@ describe('JavaScript type mapping', () => {
                         const frozenArray = Object.freeze([1, 2, 3]);
                     `,
                     `
-                        const readonlyNumbers: readonly number[] = /*~~(lib.Array)~~>*/[1, 2, 3];
-                        const readonlyStrings: ReadonlyArray<string> = /*~~(lib.Array)~~>*/["a", "b"];
-                        const frozenArray = Object.freeze(/*~~(lib.Array)~~>*/[1, 2, 3]);
+                        const readonlyNumbers: readonly number[] = /*~~(Array)~~>*/[1, 2, 3];
+                        const readonlyStrings: ReadonlyArray<string> = /*~~(Array)~~>*/["a", "b"];
+                        const frozenArray = Object.freeze(/*~~(Array)~~>*/[1, 2, 3]);
                     `
                 )
             );

--- a/rewrite-javascript/rewrite/test/search/is-source-file.test.ts
+++ b/rewrite-javascript/rewrite/test/search/is-source-file.test.ts
@@ -1,0 +1,50 @@
+// noinspection JSUnusedLocalSymbols
+
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {describe, test} from "@jest/globals";
+import {fromVisitor, RecipeSpec} from "../../src/test";
+import {typescript} from "../../src/javascript";
+import {IsSourceFile} from "../../src/search";
+
+describe('IsSourceFile visitor', () => {
+    test('should match files based on glob pattern', async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new IsSourceFile("src/**/*.tsx"));
+
+        await spec.rewriteRun(
+            // Should match - file matches the pattern
+            {
+                //language=typescript
+                ...typescript(
+                    `const a = 1`,
+                    //@formatter:off
+                    `/*~~>*/const a = 1`
+                    //@formatter:on
+                ),
+                path: "src/components/deep/Component.tsx",
+            },
+            // Should not match - different extension
+            {
+                //language=typescript
+                ...typescript(
+                    `const a = 1`
+                ),
+                path: "src/utils/helper.ts"
+            }
+        );
+    });
+});


### PR DESCRIPTION
## What's changed?

* `JavaVisitor` -> `JavaScriptVisitor` adaptability in typescript recipes
* Remove `lib.` prefix from core types because it's counterintuitive
* Add common precondition alternatives when Java RPC isn't controlling recipe execution
