### PR TITLE
Fix missing rows when multiple recipes write to the same data table in the same recipe run.

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/RecipeRun.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeRun.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import static java.util.Collections.emptyList;
 import static org.openrewrite.internal.RecipeIntrospectionUtils.dataTableDescriptorFromDataTable;
 
 @Value
@@ -51,16 +50,18 @@ public class RecipeRun {
         return null;
     }
 
-    public <E> @Nullable List<E> getDataTableRows(String name) {
+    public <E> List<E> getDataTableRows(String name) {
+        List<E> results = new ArrayList<>();
         for (Map.Entry<DataTable<?>, List<?>> dataTableAndRows : dataTables.entrySet()) {
             if (dataTableAndRows.getKey().getName().equals(name)) {
                 //noinspection unchecked
-                return (List<E>) dataTableAndRows.getValue();
+                results.addAll ((List<E>) dataTableAndRows.getValue());
             }
         }
-        return emptyList();
+        return results;
     }
 
+    @SuppressWarnings("unused")
     public void exportDatatablesToCsv(Path filePath, ExecutionContext ctx) {
         try {
             Files.createDirectories(filePath);

--- a/rewrite-core/src/test/java/org/openrewrite/DataTableTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/DataTableTest.java
@@ -16,10 +16,14 @@
 package org.openrewrite;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import lombok.Value;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.test.RewriteTest.toRecipe;
@@ -59,9 +63,38 @@ class DataTableTest implements RewriteTest {
     void descriptor() {
         Recipe recipe = toRecipe();
         new WordTable(recipe);
-
         assertThat(recipe.getDataTableDescriptors()).hasSize(4);
         assertThat(recipe.getDataTableDescriptors().getFirst().getColumns()).hasSize(2);
+    }
+
+    @Test
+    void multipleRecipesWriteToSameDataTable() {
+        rewriteRun(
+          spec -> spec
+            .recipe(new CompositeRecipe(List.of(
+              toRecipe(r -> new PlainTextVisitor<>() {
+                  final WordTable wordTable = new WordTable(r);
+
+                  @Override
+                  public PlainText visitText(PlainText text, ExecutionContext ctx) {
+                      wordTable.insertRow(ctx, new WordTable.Row(0, "first"));
+                      return text;
+                  }
+              }),
+              toRecipe(r -> new PlainTextVisitor<>() {
+                  final WordTable wordTable = new WordTable(r);
+
+                  @Override
+                  public PlainText visitText(PlainText text, ExecutionContext ctx) {
+                      wordTable.insertRow(ctx, new WordTable.Row(1, "second"));
+                      return text;
+                  }
+              })
+            )))
+            .dataTable(WordTable.Row.class, rows -> assertThat(rows.stream().map(WordTable.Row::getText))
+              .containsExactlyInAnyOrder("first", "second")),
+          text("test")
+        );
     }
 
     @JsonIgnoreType
@@ -70,28 +103,13 @@ class DataTableTest implements RewriteTest {
             super(recipe, "Words", "Each word in the text.");
         }
 
+        @Value
         static class Row {
             @Column(displayName = "Position", description = "The index position of the word in the text.")
-            private int position;
+            int position;
 
             @Column(displayName = "Text", description = "The text of the word.")
-            private String text;
-
-            public Row() {
-            }
-
-            public Row(int position, String text) {
-                this.position = position;
-                this.text = text;
-            }
-
-            public int getPosition() {
-                return position;
-            }
-
-            public String getText() {
-                return text;
-            }
+            String text;
         }
     }
 }

--- a/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
@@ -211,8 +211,7 @@ public class RecipeSpec {
         return afterRecipe(run -> {
             for (Map.Entry<DataTable<?>, List<?>> dataTableListEntry : run.getDataTables().entrySet()) {
                 if (dataTableListEntry.getKey().getType().equals(rowType)) {
-                    //noinspection unchecked
-                    List<E> rows = (List<E>) dataTableListEntry.getValue();
+                    List<E> rows = run.getDataTableRows(dataTableListEntry.getKey().getName());
                     assertThat(rows).isNotNull();
                     assertThat(rows).isNotEmpty();
                     extract.accept(rows);
@@ -226,6 +225,7 @@ public class RecipeSpec {
                         .map(it -> it.getType().getName().replace("$", "."))
                         .collect(joining(","));
             }
+            //noinspection ResultOfMethodCallIgnored
             fail(message);
         });
     }


### PR DESCRIPTION
Previously if multiple different instances of the same data table were created in a recipe run we'd return the results from only one of them. And it would be chosen, effectively, at random based on the iteration order of an unordered collection.