### PR TITLE
JavaScript `RemoveImport` visitor

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/index.ts
+++ b/rewrite-javascript/rewrite/src/javascript/index.ts
@@ -23,5 +23,7 @@ export * from "./preconditions";
 export * from "./templating";
 export * from "./method-matcher";
 
+export * from "./remove-import";
+
 import "./print";
 import "./rpc";

--- a/rewrite-javascript/rewrite/src/javascript/remove-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/remove-import.ts
@@ -1,0 +1,765 @@
+import {JavaScriptVisitor} from "./visitor";
+import {J} from "../java";
+import {JS} from "./tree";
+import {mapAsync} from "../util";
+
+// Type alias for RightPadded elements to simplify type signatures
+type RightPaddedElement<T extends J> = {
+    element?: T;
+    after?: J.Space;
+    markers?: any;
+    kind?: any;  // Add kind to match the RightPadded type structure
+}
+
+export class RemoveImport<P> extends JavaScriptVisitor<P> {
+    /**
+     * @param target Either the module name (e.g., 'fs') to remove specific members from,
+     *               or the name of the import to remove entirely
+     * @param member Optionally, the specific member to remove from the import.
+     *               If not specified, removes the import matching `target`
+     */
+    constructor(private readonly target: string,
+                private readonly member?: string) {
+        super();
+    }
+
+    /**
+     * Generic helper to filter elements from a RightPadded array while preserving formatting.
+     * When removing elements, the prefix from the first removed element is applied to the
+     * first remaining element to maintain proper spacing.
+     */
+    private async filterElementsWithPrefixPreservation<T extends J>(
+        elements: RightPaddedElement<T>[],
+        shouldKeep: (elem: T) => boolean,
+        updatePrefix: (elem: T, prefix: J.Space) => Promise<T>,
+        _p: P
+    ): Promise<{ filtered: RightPaddedElement<T>[], allRemoved: boolean }> {
+        const filtered: RightPaddedElement<T>[] = [];
+        let removedPrefix: J.Space | undefined;
+
+        for (const elem of elements) {
+            if (elem.element && shouldKeep(elem.element)) {
+                // If we removed the previous element and this is the first kept element,
+                // apply the removed element's prefix to maintain formatting
+                if (removedPrefix && filtered.length === 0) {
+                    const updatedElement = await updatePrefix(elem.element, removedPrefix);
+                    filtered.push({...elem, element: updatedElement});
+                    removedPrefix = undefined;
+                } else {
+                    filtered.push(elem);
+                }
+            } else if (elem.element) {
+                // Store the prefix of the first removed element
+                if (filtered.length === 0 && !removedPrefix) {
+                    removedPrefix = elem.element.prefix;
+                }
+            } else {
+                // Keep non-element entries (shouldn't happen but be safe)
+                filtered.push(elem);
+            }
+        }
+
+        return {
+            filtered,
+            allRemoved: filtered.length === 0
+        };
+    }
+
+    /**
+     * Helper to update an import clause by removing specific bindings
+     */
+    private async updateImportClause(
+        jsImport: JS.Import,
+        importClause: JS.ImportClause,
+        updateFn: (draft: any) => void,
+        p: P
+    ): Promise<JS.Import> {
+        return this.produceJavaScript<JS.Import>(jsImport, p, async draft => {
+            if (draft.importClause) {
+                draft.importClause = await this.produceJavaScript<JS.ImportClause>(
+                    importClause, p, async (clauseDraft: any) => updateFn(clauseDraft)
+                );
+            }
+        });
+    }
+
+    override async visitJsCompilationUnit(compilationUnit: JS.CompilationUnit, p: P): Promise<J | undefined> {
+        // First, collect all used identifiers in the file
+        const usedIdentifiers = new Set<string>();
+        const usedTypes = new Set<string>();
+
+        // Traverse the AST to collect used identifiers
+        await this.collectUsedIdentifiers(compilationUnit, usedIdentifiers, usedTypes);
+
+
+
+        // Now process imports with knowledge of what's used
+        return this.produceJavaScript<JS.CompilationUnit>(compilationUnit, p, async draft => {
+            let nextStatementPrefix: J.Space | undefined;
+
+            draft.statements = await mapAsync(compilationUnit.statements, async (stmt, index) => {
+                const statement = stmt.element;
+
+                // Handle ES6 imports
+                if (statement?.kind === JS.Kind.Import) {
+                    const jsImport = statement as JS.Import;
+                    const result = await this.processImport(jsImport, usedIdentifiers, usedTypes, p);
+                    if (result === undefined) {
+                        // Store the prefix for the next statement to avoid leaving blank lines
+                        if (index < compilationUnit.statements.length - 1) {
+                            const nextStmt = compilationUnit.statements[index + 1];
+                            if (nextStmt?.element) {
+                                nextStatementPrefix = jsImport.prefix;
+                            }
+                        }
+                        // Remove the entire import
+                        return undefined;
+                    }
+                    return {...stmt, element: result};
+                }
+
+                // Handle CommonJS require statements
+                // Note: const fs = require() comes as J.VariableDeclarations, not ScopedVariableDeclarations
+                if (statement?.kind === J.Kind.VariableDeclarations) {
+                    const varDecl = statement as J.VariableDeclarations;
+                    const result = await this.processRequireFromVarDecls(varDecl, usedIdentifiers, p);
+                    if (result === undefined) {
+                        // Store the prefix for the next statement to avoid leaving blank lines
+                        if (index < compilationUnit.statements.length - 1) {
+                            const nextStmt = compilationUnit.statements[index + 1];
+                            if (nextStmt?.element) {
+                                nextStatementPrefix = varDecl.prefix;
+                            }
+                        }
+                        // Remove the entire require statement
+                        return undefined;
+                    }
+                    return {...stmt, element: result};
+                }
+
+                // Apply stored prefix if this statement follows a removed import
+                if (nextStatementPrefix && statement) {
+                    const updatedStatement = await this.visit(statement, p) as J;
+                    if (updatedStatement) {
+                        (updatedStatement as any).prefix = nextStatementPrefix;
+                        nextStatementPrefix = undefined;
+                        return {...stmt, element: updatedStatement};
+                    }
+                }
+
+                return stmt;
+            });
+
+            // Filter out undefined (removed) statements
+            draft.statements = draft.statements.filter(s => s !== undefined);
+            draft.eof = await this.visitSpace(compilationUnit.eof, p);
+        });
+    }
+
+    private async processImport(
+        jsImport: JS.Import,
+        usedIdentifiers: Set<string>,
+        usedTypes: Set<string>,
+        p: P
+    ): Promise<JS.Import | undefined> {
+        // Check if this import is from the target module
+        if (!this.isTargetModule(jsImport)) {
+            return jsImport;
+        }
+
+        const importClause = jsImport.importClause;
+        if (!importClause) {
+            // Side-effect import like: import 'module'
+            if (this.member === '*') {
+                return undefined; // Remove the entire import
+            }
+            return jsImport;
+        }
+
+        // Process default import
+        if (importClause.name) {
+            const defaultName = importClause.name.element;
+            if (defaultName && defaultName.kind === J.Kind.Identifier) {
+                const identifier = defaultName as J.Identifier;
+                const name = identifier.simpleName;
+
+                if (this.shouldRemoveImport(name, usedIdentifiers, usedTypes)) {
+                    // If there are no named imports, remove the entire import
+                    if (!importClause.namedBindings) {
+                        return undefined;
+                    }
+                    // Otherwise, just remove the default import
+                    return this.updateImportClause(jsImport, importClause, draft => {
+                        draft.name = undefined;
+                    }, p);
+                }
+            }
+        }
+
+        // Process named imports
+        if (importClause.namedBindings) {
+            const namedBindings = importClause.namedBindings;
+
+            // Handle namespace import: import * as X from 'module'
+            if (namedBindings.kind === J.Kind.Identifier) {
+                const identifier = namedBindings as J.Identifier;
+                const name = identifier.simpleName;
+
+                if (this.shouldRemoveImport(name, usedIdentifiers, usedTypes)) {
+                    // If there's no default import, remove the entire import
+                    if (!importClause.name) {
+                        return undefined;
+                    }
+                    // Otherwise, just remove the namespace import
+                    return this.updateImportClause(jsImport, importClause, draft => {
+                        draft.namedBindings = undefined;
+                    }, p);
+                }
+            } else if (namedBindings.kind === JS.Kind.Alias) {
+                // Handle import * as X from 'module' - represented as Alias with propertyName = "*"
+                const alias = namedBindings as JS.Alias;
+                const aliasName = (alias.alias as J.Identifier).simpleName;
+
+                if (this.shouldRemoveImport(aliasName, usedIdentifiers, usedTypes)) {
+                    // If there's no default import, remove the entire import
+                    if (!importClause.name) {
+                        return undefined;
+                    }
+                    // Otherwise, just remove the namespace import
+                    return this.updateImportClause(jsImport, importClause, draft => {
+                        draft.namedBindings = undefined;
+                    }, p);
+                }
+            }
+
+            // Handle named imports: import { a, b } from 'module'
+            if (namedBindings.kind === JS.Kind.NamedImports) {
+                const namedImports = namedBindings as JS.NamedImports;
+                const updatedImports = await this.processNamedImports(namedImports, usedIdentifiers, usedTypes, p);
+
+                if (updatedImports === undefined) {
+                    // All named imports were removed
+                    if (!importClause.name) {
+                        // No default import either, remove the entire import
+                        return undefined;
+                    }
+                    // Keep the import with just the default import
+                    return this.updateImportClause(jsImport, importClause, draft => {
+                        draft.namedBindings = undefined;
+                    }, p);
+                } else if (updatedImports !== namedImports) {
+                    // Some named imports were removed
+                    return this.updateImportClause(jsImport, importClause, draft => {
+                        draft.namedBindings = updatedImports;
+                    }, p);
+                }
+            }
+        }
+
+        return jsImport;
+    }
+
+    private async processNamedImports(
+        namedImports: JS.NamedImports,
+        usedIdentifiers: Set<string>,
+        usedTypes: Set<string>,
+        p: P
+    ): Promise<JS.NamedImports | undefined> {
+        const { filtered, allRemoved } = await this.filterElementsWithPrefixPreservation(
+            namedImports.elements.elements,
+            (elem: J) => {
+                if (elem.kind === JS.Kind.ImportSpecifier) {
+                    const importName = this.getImportName(elem as JS.ImportSpecifier);
+                    return !this.shouldRemoveImport(importName, usedIdentifiers, usedTypes);
+                }
+                return true; // Keep non-ImportSpecifier elements
+            },
+            async (elem: J, prefix: J.Space) => {
+                if (elem.kind === JS.Kind.ImportSpecifier) {
+                    return this.produceJavaScript<JS.ImportSpecifier>(
+                        elem as JS.ImportSpecifier, p, async draft => {
+                            draft.prefix = prefix;
+                        }
+                    );
+                }
+                return elem;
+            },
+            p
+        );
+
+        if (allRemoved) {
+            return undefined;
+        }
+
+        if (filtered.length === namedImports.elements.elements.length) {
+            return namedImports; // No changes
+        }
+
+        // Create updated named imports with filtered elements
+        return this.produceJavaScript<JS.NamedImports>(namedImports, p, async draft => {
+            draft.elements = {
+                ...namedImports.elements,
+                elements: filtered as any
+            };
+        });
+    }
+
+    private async processRequireFromVarDecls(
+        varDecls: J.VariableDeclarations,
+        usedIdentifiers: Set<string>,
+        p: P
+    ): Promise<J.VariableDeclarations | undefined> {
+        // Check if this is a require() call
+        if (varDecls.variables.length !== 1) {
+            return varDecls;
+        }
+
+        const namedVar = varDecls.variables[0].element;
+        if (!namedVar) {
+            return varDecls;
+        }
+
+        const initializer = namedVar.initializer?.element;
+        if (!initializer || initializer.kind !== J.Kind.MethodInvocation) {
+            return varDecls;
+        }
+
+        const methodInv = initializer as J.MethodInvocation;
+        if (methodInv.name?.kind !== J.Kind.Identifier || (methodInv.name as J.Identifier).simpleName !== 'require') {
+            return varDecls;
+        }
+
+        // This is a require() statement
+        const pattern = namedVar.name;
+        if (!pattern) {
+            return varDecls;
+        }
+
+        // Handle: const fs = require('fs')
+        if (pattern.kind === J.Kind.Identifier) {
+            const varName = (pattern as J.Identifier).simpleName;
+            if (this.shouldRemoveImport(varName, usedIdentifiers, new Set())) {
+                return undefined; // Remove the entire require statement
+            }
+        }
+
+        // Handle: const { readFile } = require('fs')
+        if (pattern.kind === JS.Kind.ObjectBindingPattern && this.member !== undefined) {
+            const objectPattern = pattern as JS.ObjectBindingPattern;
+            const updatedPattern = await this.processObjectBindingPattern(objectPattern, usedIdentifiers, p);
+
+            if (updatedPattern === undefined) {
+                return undefined; // Remove entire require
+            } else if (updatedPattern !== objectPattern) {
+                // Update with filtered bindings
+                return this.produceJava<J.VariableDeclarations>(varDecls, p, async draft => {
+                    const updatedNamedVar = await this.produceJava<J.VariableDeclarations.NamedVariable>(
+                        namedVar, p, async namedDraft => {
+                            namedDraft.name = updatedPattern;
+                        }
+                    );
+                    draft.variables = [{...varDecls.variables[0], element: updatedNamedVar}];
+                });
+            }
+        }
+
+        return varDecls;
+    }
+
+private async processObjectBindingPattern(
+        pattern: JS.ObjectBindingPattern,
+        usedIdentifiers: Set<string>,
+        p: P
+    ): Promise<JS.ObjectBindingPattern | undefined> {
+        const { filtered, allRemoved } = await this.filterElementsWithPrefixPreservation(
+            pattern.bindings.elements,
+            (elem: J) => {
+                if (elem.kind === JS.Kind.BindingElement) {
+                    const name = this.getBindingElementName(elem as JS.BindingElement);
+                    return !this.shouldRemoveImport(name, usedIdentifiers, new Set());
+                } else if (elem.kind === J.Kind.Identifier) {
+                    const name = (elem as J.Identifier).simpleName;
+                    return !this.shouldRemoveImport(name, usedIdentifiers, new Set());
+                }
+                return true; // Keep other element types
+            },
+            async (elem: J, prefix: J.Space) => {
+                if (elem.kind === J.Kind.Identifier) {
+                    return this.produceJava<J.Identifier>(
+                        elem as J.Identifier, p, async draft => {
+                            draft.prefix = prefix;
+                        }
+                    );
+                } else if (elem.kind === JS.Kind.BindingElement) {
+                    return this.produceJavaScript<JS.BindingElement>(
+                        elem as JS.BindingElement, p, async draft => {
+                            draft.prefix = prefix;
+                        }
+                    );
+                }
+                return elem;
+            },
+            p
+        );
+
+        if (allRemoved) {
+            return undefined;
+        }
+
+        if (filtered.length === pattern.bindings.elements.length) {
+            return pattern;
+        }
+
+        return this.produceJavaScript<JS.ObjectBindingPattern>(pattern, p, async draft => {
+            draft.bindings = {
+                ...pattern.bindings,
+                elements: filtered as any
+            };
+        });
+    }
+
+    private getImportName(specifier: JS.ImportSpecifier): string {
+        const spec = specifier.specifier;
+        if (spec?.kind === JS.Kind.Alias) {
+            // Handle aliased import: import { foo as bar }
+            const alias = spec as JS.Alias;
+            const propertyName = alias.propertyName.element;
+            if (propertyName?.kind === J.Kind.Identifier) {
+                return (propertyName as J.Identifier).simpleName;
+            }
+        } else if (spec?.kind === J.Kind.Identifier) {
+            // Handle regular import: import { foo }
+            return (spec as J.Identifier).simpleName;
+        }
+        return '';
+    }
+
+    private getBindingElementName(bindingElement: JS.BindingElement): string {
+        const name = bindingElement.name;
+        if (name?.kind === J.Kind.Identifier) {
+            return (name as J.Identifier).simpleName;
+        }
+        return '';
+    }
+
+    private shouldRemoveImport(
+        name: string,
+        usedIdentifiers: Set<string>,
+        usedTypes: Set<string>
+    ): boolean {
+        // If member is specified, we're removing a specific member from a module
+        if (this.member !== undefined) {
+            // Only remove if this is the specific member we're looking for
+            if (this.member !== name) {
+                return false;
+            }
+        } else {
+            // If no member specified, we're removing based on the import name itself
+            if (this.target !== name) {
+                return false;
+            }
+        }
+
+        // Check if it's used
+        return !(usedIdentifiers.has(name) || usedTypes.has(name));
+    }
+
+    private isTargetModule(jsImport: JS.Import): boolean {
+        // If member is specified, we're looking for imports from a specific module
+        if (this.member !== undefined) {
+            const moduleSpecifier = jsImport.moduleSpecifier?.element;
+            if (!moduleSpecifier || moduleSpecifier.kind !== J.Kind.Literal) {
+                return false;
+            }
+
+            const literal = moduleSpecifier as J.Literal;
+            const moduleName = literal.value?.toString().replace(/['"`]/g, '');
+
+            // Match the module name
+            return moduleName === this.target;
+        }
+
+        // If no member specified, we process all imports to check their names
+        return true;
+    }
+
+    /**
+     * Helper to traverse parameters from various node types
+     */
+    private async traverseParameters(
+        params: any,
+        usedIdentifiers: Set<string>,
+        usedTypes: Set<string>
+    ): Promise<void> {
+        if (!params || typeof params !== 'object') return;
+
+        if (Array.isArray(params)) {
+            for (const p of params) {
+                await this.collectUsedIdentifiers(p, usedIdentifiers, usedTypes);
+            }
+        } else if (params.elements) {
+            for (const p of params.elements) {
+                if (p.element) {
+                    await this.collectUsedIdentifiers(p.element, usedIdentifiers, usedTypes);
+                }
+            }
+        } else if (params.parameters) {
+            for (const p of params.parameters) {
+                const elem = p.element || p;
+                await this.collectUsedIdentifiers(elem, usedIdentifiers, usedTypes);
+            }
+        }
+    }
+
+    /**
+     * Helper to traverse statements from various node types
+     */
+    private async traverseStatements(
+        statements: any,
+        usedIdentifiers: Set<string>,
+        usedTypes: Set<string>
+    ): Promise<void> {
+        if (!statements) return;
+
+        if (Array.isArray(statements)) {
+            for (const stmt of statements) {
+                const element = stmt.element || stmt;
+                if (element) {
+                    await this.collectUsedIdentifiers(element, usedIdentifiers, usedTypes);
+                }
+            }
+        }
+    }
+
+    /**
+     * Helper to check for type expressions and collect type usage
+     */
+    private async checkTypeExpression(
+        node: any,
+        usedTypes: Set<string>
+    ): Promise<void> {
+        if (node.typeExpression) {
+            await this.collectTypeUsage(node.typeExpression, usedTypes);
+        }
+    }
+
+    private async collectUsedIdentifiers(
+        node: J,
+        usedIdentifiers: Set<string>,
+        usedTypes: Set<string>
+    ): Promise<void> {
+        // This is a simplified version - in a real implementation,
+        // we'd need to traverse the entire AST and collect all identifier usages
+        // For now, we'll implement a basic traversal
+
+        if (node.kind === J.Kind.Identifier) {
+            const identifier = node as J.Identifier;
+            usedIdentifiers.add(identifier.simpleName);
+        } else if (node.kind === J.Kind.MethodInvocation) {
+            const methodInv = node as J.MethodInvocation;
+
+            // Check if this is a member access pattern like fs.readFileSync
+            if (methodInv.select?.element?.kind === J.Kind.FieldAccess) {
+                const fieldAccess = methodInv.select.element as J.FieldAccess;
+                if (fieldAccess.target?.kind === J.Kind.Identifier) {
+                    usedIdentifiers.add((fieldAccess.target as J.Identifier).simpleName);
+                }
+            } else if (methodInv.select?.element?.kind === J.Kind.Identifier) {
+                // Direct identifier like fs in fs.method() - though this is rare
+                usedIdentifiers.add((methodInv.select.element as J.Identifier).simpleName);
+            }
+
+            // Collect method name
+            if (methodInv.name && methodInv.name.kind === J.Kind.Identifier) {
+                usedIdentifiers.add((methodInv.name as J.Identifier).simpleName);
+            }
+            // Recursively check arguments
+            if (methodInv.arguments) {
+                for (const arg of methodInv.arguments.elements) {
+                    if (arg.element) {
+                        await this.collectUsedIdentifiers(arg.element, usedIdentifiers, usedTypes);
+                    }
+                }
+            }
+            // Check select (object being called on)
+            if (methodInv.select?.element) {
+                await this.collectUsedIdentifiers(methodInv.select.element, usedIdentifiers, usedTypes);
+            }
+        } else if (node.kind === J.Kind.MemberReference) {
+            const memberRef = node as J.MemberReference;
+            if (memberRef.containing && memberRef.containing.element?.kind === J.Kind.Identifier) {
+                usedIdentifiers.add((memberRef.containing.element as J.Identifier).simpleName);
+            }
+        } else if (node.kind === J.Kind.FieldAccess) {
+            // Handle field access like fs.readFileSync
+            const fieldAccess = node as J.FieldAccess;
+            if (fieldAccess.target?.kind === J.Kind.Identifier) {
+                usedIdentifiers.add((fieldAccess.target as J.Identifier).simpleName);
+            }
+            // Recursively check the target
+            if (fieldAccess.target) {
+                await this.collectUsedIdentifiers(fieldAccess.target, usedIdentifiers, usedTypes);
+            }
+        } else if (node.kind === JS.Kind.CompilationUnit) {
+            const cu = node as JS.CompilationUnit;
+            for (const stmt of cu.statements) {
+                if (stmt.element && stmt.element.kind !== JS.Kind.Import) {
+                    // Skip require() statements at the top level
+                    if (stmt.element.kind === J.Kind.VariableDeclarations) {
+                        const varDecls = stmt.element as J.VariableDeclarations;
+                        // Check if this is a require() statement
+                        let isRequire = false;
+                        for (const v of varDecls.variables) {
+                            const namedVar = v.element;
+                            if (namedVar?.initializer?.element?.kind === J.Kind.MethodInvocation) {
+                                const methodInv = namedVar.initializer.element as J.MethodInvocation;
+                                if (methodInv.name?.kind === J.Kind.Identifier &&
+                                    (methodInv.name as J.Identifier).simpleName === 'require') {
+                                    isRequire = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (!isRequire) {
+                            // Not a require statement, process normally
+                            await this.collectUsedIdentifiers(stmt.element, usedIdentifiers, usedTypes);
+                        }
+                    } else if (stmt.element.kind !== JS.Kind.ScopedVariableDeclarations) {
+                        // Process other non-import, non-require statements normally
+                        await this.collectUsedIdentifiers(stmt.element, usedIdentifiers, usedTypes);
+                    }
+                }
+            }
+        } else if (node.kind === J.Kind.Return) {
+            // Handle return statements
+            const returnStmt = node as J.Return;
+            if (returnStmt.expression) {
+                await this.collectUsedIdentifiers(returnStmt.expression, usedIdentifiers, usedTypes);
+            }
+        } else if (node.kind === J.Kind.Block) {
+            const block = node as J.Block;
+            for (const stmt of block.statements) {
+                if (stmt.element) {
+                    await this.collectUsedIdentifiers(stmt.element, usedIdentifiers, usedTypes);
+                }
+            }
+        } else if (node.kind === J.Kind.MethodDeclaration) {
+            const method = node as J.MethodDeclaration;
+            // Check parameters for type usage
+            if (method.parameters) {
+                for (const param of method.parameters.elements) {
+                    // Parameters can be various types, handle them recursively
+                    if (param.element) {
+                        await this.collectUsedIdentifiers(param.element, usedIdentifiers, usedTypes);
+                    }
+                }
+            }
+            // Check body
+            if (method.body) {
+                await this.collectUsedIdentifiers(method.body, usedIdentifiers, usedTypes);
+            }
+        } else if ((node as any).typeExpression) {
+            // Handle nodes with type expressions (parameters, variables, etc.)
+            await this.checkTypeExpression(node, usedTypes);
+            // Continue traversing other parts
+            if ((node as any).name) {
+                await this.collectUsedIdentifiers((node as any).name, usedIdentifiers, usedTypes);
+            }
+            if ((node as any).initializer) {
+                await this.collectUsedIdentifiers((node as any).initializer, usedIdentifiers, usedTypes);
+            }
+        } else if (node.kind === JS.Kind.ArrowFunction || node.kind === J.Kind.Lambda) {
+            // Handle arrow functions and lambdas
+            const func = node as any;
+            if (func.parameters) {
+                await this.collectUsedIdentifiers(func.parameters, usedIdentifiers, usedTypes);
+            }
+            if (func.lambda) {
+                await this.collectUsedIdentifiers(func.lambda, usedIdentifiers, usedTypes);
+            }
+            if (func.body) {
+                await this.collectUsedIdentifiers(func.body, usedIdentifiers, usedTypes);
+            }
+        } else if (node.kind === J.Kind.Lambda) {
+            const lambda = node as J.Lambda;
+            if (lambda.parameters?.parameters) {
+                for (const param of lambda.parameters.parameters) {
+                    if (param.element) {
+                        await this.collectUsedIdentifiers(param.element, usedIdentifiers, usedTypes);
+                    }
+                }
+            }
+            if (lambda.body) {
+                await this.collectUsedIdentifiers(lambda.body, usedIdentifiers, usedTypes);
+            }
+        } else if (node.kind === J.Kind.VariableDeclarations) {
+            const varDecls = node as J.VariableDeclarations;
+            // Check the type expression on the VariableDeclarations itself
+            await this.checkTypeExpression(varDecls, usedTypes);
+            for (const v of varDecls.variables) {
+                const namedVar = v.element;
+                if (namedVar) {
+                    // Check type annotation on the variable
+                    await this.checkTypeExpression(namedVar, usedTypes);
+                    // Check the variable name
+                    if (namedVar.name) {
+                        await this.collectUsedIdentifiers(namedVar.name, usedIdentifiers, usedTypes);
+                    }
+                    // Check the initializer
+                    if (namedVar.initializer && namedVar.initializer.element) {
+                        await this.collectUsedIdentifiers(namedVar.initializer.element, usedIdentifiers, usedTypes);
+                    }
+                }
+            }
+        } else if ((node as any).statements) {
+            // Generic handler for nodes with statements
+            await this.traverseStatements((node as any).statements, usedIdentifiers, usedTypes);
+        } else if ((node as any).body) {
+            // Generic handler for nodes with body
+            await this.collectUsedIdentifiers((node as any).body, usedIdentifiers, usedTypes);
+        } else if ((node as any).parameters) {
+            // Handle anything with parameters (functions, methods, etc.)
+            await this.traverseParameters((node as any).parameters, usedIdentifiers, usedTypes);
+            // Continue with the body if it exists
+            if ((node as any).body) {
+                await this.collectUsedIdentifiers((node as any).body, usedIdentifiers, usedTypes);
+            }
+        }
+    }
+
+    private async collectTypeUsage(typeExpr: J, usedTypes: Set<string>): Promise<void> {
+        if (typeExpr.kind === J.Kind.Identifier) {
+            usedTypes.add((typeExpr as J.Identifier).simpleName);
+        } else if (typeExpr.kind === J.Kind.ParameterizedType) {
+            const paramType = typeExpr as J.ParameterizedType;
+            // In TypeScript AST, ParameterizedType might have a different structure
+            // We'll need to handle the type parameters appropriately
+            if (paramType.typeParameters) {
+                for (const typeParam of paramType.typeParameters.elements) {
+                    if (typeParam.element) {
+                        await this.collectTypeUsage(typeParam.element, usedTypes);
+                    }
+                }
+            }
+        } else if (typeExpr.kind === JS.Kind.TypeTreeExpression) {
+            // Handle TypeTreeExpression which wraps type identifiers
+            const typeTree = typeExpr as JS.TypeTreeExpression;
+            if (typeTree.expression) {
+                await this.collectTypeUsage(typeTree.expression, usedTypes);
+            }
+        } else if (typeExpr.kind === JS.Kind.TypeInfo) {
+            // Handle TypeInfo which contains type identifiers
+            const typeInfo = typeExpr as JS.TypeInfo;
+            if (typeInfo.typeIdentifier) {
+                await this.collectTypeUsage(typeInfo.typeIdentifier, usedTypes);
+            }
+        } else if ((typeExpr as any).expression) {
+            // Generic handler for nodes with expression property
+            await this.collectTypeUsage((typeExpr as any).expression, usedTypes);
+        } else if ((typeExpr as any).typeIdentifier) {
+            // Generic handler for nodes with typeIdentifier property
+            await this.collectTypeUsage((typeExpr as any).typeIdentifier, usedTypes);
+        }
+        // Add more type expression handlers as needed
+    }
+}

--- a/rewrite-javascript/rewrite/src/javascript/remove-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/remove-import.ts
@@ -18,8 +18,8 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
      * @param member Optionally, the specific member to remove from the import.
      *               If not specified, removes the import matching `target`
      */
-    constructor(private readonly target: string,
-                private readonly member?: string) {
+    constructor(readonly target: string,
+                readonly member?: string) {
         super();
     }
 

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -22,24 +22,8 @@ import {Expression, J, Type, JavaVisitor, NameTree, Statement, TypedTree} from "
 import {createDraft, Draft, finishDraft} from "immer";
 import {isJavaScript, JS, JSX} from "./tree";
 import ComputedPropertyName = JS.ComputedPropertyName;
-import {RemoveImport} from "./remove-import";
 
 export class JavaScriptVisitor<P> extends JavaVisitor<P> {
-
-    /**
-     * @param target Either the module name (e.g., 'fs') to remove specific members from,
-     *               or the name of the import to remove entirely
-     * @param member Optionally, the specific member to remove from the import.
-     *               If not specified, removes the import matching `target`
-     */
-    protected maybeRemoveImport(target: string, member?: string) {
-        for (const v of this.afterVisit || []) {
-            if (v instanceof RemoveImport && v.target === target && v.member === member) {
-                return;
-            }
-        }
-        this.afterVisit.push(new RemoveImport(target, member));
-    }
 
     override async isAcceptable(sourceFile: SourceFile): Promise<boolean> {
         return isJavaScript(sourceFile);

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -22,8 +22,24 @@ import {Expression, J, Type, JavaVisitor, NameTree, Statement, TypedTree} from "
 import {createDraft, Draft, finishDraft} from "immer";
 import {isJavaScript, JS, JSX} from "./tree";
 import ComputedPropertyName = JS.ComputedPropertyName;
+import {RemoveImport} from "./remove-import";
 
 export class JavaScriptVisitor<P> extends JavaVisitor<P> {
+
+    /**
+     * @param target Either the module name (e.g., 'fs') to remove specific members from,
+     *               or the name of the import to remove entirely
+     * @param member Optionally, the specific member to remove from the import.
+     *               If not specified, removes the import matching `target`
+     */
+    protected maybeRemoveImport(target: string, member?: string) {
+        for (const v of this.afterVisit || []) {
+            if (v instanceof RemoveImport && v.target === target && v.member === member) {
+                return;
+            }
+        }
+        this.afterVisit.push(new RemoveImport(target, member));
+    }
 
     override async isAcceptable(sourceFile: SourceFile): Promise<boolean> {
         return isJavaScript(sourceFile);
@@ -72,10 +88,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitAlias(alias: JS.Alias, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(alias, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.Alias) {
-               return expression;
-           }
-           alias = expression as JS.Alias;
+        if (!expression?.kind || expression.kind !== JS.Kind.Alias) {
+            return expression;
+        }
+        alias = expression as JS.Alias;
 
         return this.produceJavaScript<JS.Alias>(alias, p, async draft => {
             draft.propertyName = await this.visitRightPadded(alias.propertyName, p);
@@ -85,10 +101,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitArrowFunction(arrowFunction: JS.ArrowFunction, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(arrowFunction, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.ArrowFunction) {
-               return expression;
-           }
-           arrowFunction = expression as JS.ArrowFunction;
+        if (!expression?.kind || expression.kind !== JS.Kind.ArrowFunction) {
+            return expression;
+        }
+        arrowFunction = expression as JS.ArrowFunction;
 
         const statement = await this.visitStatement(arrowFunction, p);
         if (!statement?.kind || statement.kind !== JS.Kind.ArrowFunction) {
@@ -115,10 +131,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitAwait(await_: JS.Await, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(await_, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.Await) {
-               return expression;
-           }
-           await_ = expression as JS.Await;
+        if (!expression?.kind || expression.kind !== JS.Kind.Await) {
+            return expression;
+        }
+        await_ = expression as JS.Await;
 
         return this.produceJavaScript<JS.Await>(await_, p, async draft => {
             draft.expression = await this.visitDefined<Expression>(await_.expression, p);
@@ -175,10 +191,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitConditionalType(conditionalType: JS.ConditionalType, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(conditionalType, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.ConditionalType) {
-               return expression;
-           }
-           conditionalType = expression as JS.ConditionalType;
+        if (!expression?.kind || expression.kind !== JS.Kind.ConditionalType) {
+            return expression;
+        }
+        conditionalType = expression as JS.ConditionalType;
 
         return this.produceJavaScript<JS.ConditionalType>(conditionalType, p, async draft => {
             draft.checkType = await this.visitDefined<Expression>(conditionalType.checkType, p);
@@ -189,10 +205,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitDelete(delete_: JS.Delete, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(delete_, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.Delete) {
-               return expression;
-           }
-           delete_ = expression as JS.Delete;
+        if (!expression?.kind || expression.kind !== JS.Kind.Delete) {
+            return expression;
+        }
+        delete_ = expression as JS.Delete;
 
         const statement = await this.visitStatement(delete_, p);
         if (!statement?.kind || statement.kind !== JS.Kind.Delete) {
@@ -207,10 +223,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitExpressionStatement(expressionStatement: JS.ExpressionStatement, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(expressionStatement, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.ExpressionStatement) {
-               return expression;
-           }
-           expressionStatement = expression as JS.ExpressionStatement;
+        if (!expression?.kind || expression.kind !== JS.Kind.ExpressionStatement) {
+            return expression;
+        }
+        expressionStatement = expression as JS.ExpressionStatement;
 
         const statement = await this.visitStatement(expressionStatement, p);
         if (!statement?.kind || statement.kind !== JS.Kind.ExpressionStatement) {
@@ -225,10 +241,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitExpressionWithTypeArguments(expressionWithTypeArguments: JS.ExpressionWithTypeArguments, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(expressionWithTypeArguments, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.ExpressionWithTypeArguments) {
-               return expression;
-           }
-           expressionWithTypeArguments = expression as JS.ExpressionWithTypeArguments;
+        if (!expression?.kind || expression.kind !== JS.Kind.ExpressionWithTypeArguments) {
+            return expression;
+        }
+        expressionWithTypeArguments = expression as JS.ExpressionWithTypeArguments;
 
         return this.produceJavaScript<JS.ExpressionWithTypeArguments>(expressionWithTypeArguments, p, async draft => {
             draft.clazz = await this.visitDefined<J>(expressionWithTypeArguments.clazz, p);
@@ -260,10 +276,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitFunctionType(functionType: JS.FunctionType, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(functionType, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.FunctionType) {
-               return expression;
-           }
-           functionType = expression as JS.FunctionType;
+        if (!expression?.kind || expression.kind !== JS.Kind.FunctionType) {
+            return expression;
+        }
+        functionType = expression as JS.FunctionType;
 
         return this.produceJavaScript<JS.FunctionType>(functionType, p, async draft => {
             draft.constructorType = await this.visitLeftPadded(functionType.constructorType, p);
@@ -275,10 +291,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitInferType(inferType: JS.InferType, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(inferType, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.InferType) {
-               return expression;
-           }
-           inferType = expression as JS.InferType;
+        if (!expression?.kind || expression.kind !== JS.Kind.InferType) {
+            return expression;
+        }
+        inferType = expression as JS.InferType;
 
         return this.produceJavaScript<JS.InferType>(inferType, p, async draft => {
             draft.typeParameter = await this.visitLeftPadded(inferType.typeParameter, p);
@@ -288,10 +304,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitImportType(importType: JS.ImportType, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(importType, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.ImportType) {
-               return expression;
-           }
-           importType = expression as JS.ImportType;
+        if (!expression?.kind || expression.kind !== JS.Kind.ImportType) {
+            return expression;
+        }
+        importType = expression as JS.ImportType;
 
         return this.produceJavaScript<JS.ImportType>(importType, p, async draft => {
             draft.hasTypeof = await this.visitRightPadded(importType.hasTypeof, p);
@@ -327,10 +343,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitNamedImports(namedImports: JS.NamedImports, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(namedImports, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.NamedImports) {
-               return expression;
-           }
-           namedImports = expression as JS.NamedImports;
+        if (!expression?.kind || expression.kind !== JS.Kind.NamedImports) {
+            return expression;
+        }
+        namedImports = expression as JS.NamedImports;
 
         return this.produceJavaScript<JS.NamedImports>(namedImports, p, async draft => {
             draft.elements = await this.visitContainer(namedImports.elements, p);
@@ -340,10 +356,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitImportSpecifier(importSpecifier: JS.ImportSpecifier, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(importSpecifier, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.ImportSpecifier) {
-               return expression;
-           }
-           importSpecifier = expression as JS.ImportSpecifier;
+        if (!expression?.kind || expression.kind !== JS.Kind.ImportSpecifier) {
+            return expression;
+        }
+        importSpecifier = expression as JS.ImportSpecifier;
 
         return this.produceJavaScript<JS.ImportSpecifier>(importSpecifier, p, async draft => {
             draft.importType = await this.visitLeftPadded(importSpecifier.importType, p);
@@ -390,10 +406,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitLiteralType(literalType: JS.LiteralType, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(literalType, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.LiteralType) {
-               return expression;
-           }
-           literalType = expression as JS.LiteralType;
+        if (!expression?.kind || expression.kind !== JS.Kind.LiteralType) {
+            return expression;
+        }
+        literalType = expression as JS.LiteralType;
 
         return this.produceJavaScript<JS.LiteralType>(literalType, p, async draft => {
             draft.literal = await this.visitDefined<Expression>(literalType.literal, p);
@@ -403,10 +419,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitMappedType(mappedType: JS.MappedType, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(mappedType, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.MappedType) {
-               return expression;
-           }
-           mappedType = expression as JS.MappedType;
+        if (!expression?.kind || expression.kind !== JS.Kind.MappedType) {
+            return expression;
+        }
+        mappedType = expression as JS.MappedType;
 
         return this.produceJavaScript<JS.MappedType>(mappedType, p, async draft => {
             draft.prefixToken = mappedType.prefixToken && await this.visitLeftPadded(mappedType.prefixToken, p);
@@ -435,10 +451,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitObjectBindingPattern(objectBindingPattern: JS.ObjectBindingPattern, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(objectBindingPattern, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.ObjectBindingPattern) {
-               return expression;
-           }
-           objectBindingPattern = expression as JS.ObjectBindingPattern;
+        if (!expression?.kind || expression.kind !== JS.Kind.ObjectBindingPattern) {
+            return expression;
+        }
+        objectBindingPattern = expression as JS.ObjectBindingPattern;
 
         return this.produceJavaScript<JS.ObjectBindingPattern>(objectBindingPattern, p, async draft => {
             draft.leadingAnnotations = await mapAsync(objectBindingPattern.leadingAnnotations, item => this.visitDefined<J.Annotation>(item, p));
@@ -464,10 +480,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitSatisfiesExpression(satisfiesExpression: JS.SatisfiesExpression, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(satisfiesExpression, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.SatisfiesExpression) {
-               return expression;
-           }
-           satisfiesExpression = expression as JS.SatisfiesExpression;
+        if (!expression?.kind || expression.kind !== JS.Kind.SatisfiesExpression) {
+            return expression;
+        }
+        satisfiesExpression = expression as JS.SatisfiesExpression;
 
         return this.produceJavaScript<JS.SatisfiesExpression>(satisfiesExpression, p, async draft => {
             draft.expression = await this.visitDefined<J>(satisfiesExpression.expression, p);
@@ -491,10 +507,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitStatementExpression(statementExpression: JS.StatementExpression, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(statementExpression, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.StatementExpression) {
-               return expression;
-           }
-           statementExpression = expression as JS.StatementExpression;
+        if (!expression?.kind || expression.kind !== JS.Kind.StatementExpression) {
+            return expression;
+        }
+        statementExpression = expression as JS.StatementExpression;
 
         const statement = await this.visitStatement(statementExpression, p);
         if (!statement?.kind || statement.kind !== JS.Kind.StatementExpression) {
@@ -509,10 +525,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitTaggedTemplateExpression(taggedTemplateExpression: JS.TaggedTemplateExpression, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(taggedTemplateExpression, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.TaggedTemplateExpression) {
-               return expression;
-           }
-           taggedTemplateExpression = expression as JS.TaggedTemplateExpression;
+        if (!expression?.kind || expression.kind !== JS.Kind.TaggedTemplateExpression) {
+            return expression;
+        }
+        taggedTemplateExpression = expression as JS.TaggedTemplateExpression;
 
         const statement = await this.visitStatement(taggedTemplateExpression, p);
         if (!statement?.kind || statement.kind !== JS.Kind.TaggedTemplateExpression) {
@@ -530,10 +546,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitTemplateExpression(templateExpression: JS.TemplateExpression, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(templateExpression, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.TemplateExpression) {
-               return expression;
-           }
-           templateExpression = expression as JS.TemplateExpression;
+        if (!expression?.kind || expression.kind !== JS.Kind.TemplateExpression) {
+            return expression;
+        }
+        templateExpression = expression as JS.TemplateExpression;
 
         const statement = await this.visitStatement(templateExpression, p);
         if (!statement?.kind || statement.kind !== JS.Kind.TemplateExpression) {
@@ -557,10 +573,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitTuple(tuple: JS.Tuple, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(tuple, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.Tuple) {
-               return expression;
-           }
-           tuple = expression as JS.Tuple;
+        if (!expression?.kind || expression.kind !== JS.Kind.Tuple) {
+            return expression;
+        }
+        tuple = expression as JS.Tuple;
 
         return this.produceJavaScript<JS.Tuple>(tuple, p, async draft => {
             draft.elements = await this.visitContainer(tuple.elements, p);
@@ -586,10 +602,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitTypeOf(typeOf: JS.TypeOf, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(typeOf, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.TypeOf) {
-               return expression;
-           }
-           typeOf = expression as JS.TypeOf;
+        if (!expression?.kind || expression.kind !== JS.Kind.TypeOf) {
+            return expression;
+        }
+        typeOf = expression as JS.TypeOf;
 
         return this.produceJavaScript<JS.TypeOf>(typeOf, p, async draft => {
             draft.expression = await this.visitDefined<Expression>(typeOf.expression, p);
@@ -599,10 +615,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitTypeTreeExpression(typeTreeExpression: JS.TypeTreeExpression, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(typeTreeExpression, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.TypeTreeExpression) {
-               return expression;
-           }
-           typeTreeExpression = expression as JS.TypeTreeExpression;
+        if (!expression?.kind || expression.kind !== JS.Kind.TypeTreeExpression) {
+            return expression;
+        }
+        typeTreeExpression = expression as JS.TypeTreeExpression;
 
         return this.produceJavaScript<JS.TypeTreeExpression>(typeTreeExpression, p, async draft => {
             draft.expression = await this.visitDefined<Expression>(typeTreeExpression.expression, p);
@@ -620,10 +636,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitIndexedAccessType(indexedAccessType: JS.IndexedAccessType, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(indexedAccessType, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.IndexedAccessType) {
-               return expression;
-           }
-           indexedAccessType = expression as JS.IndexedAccessType;
+        if (!expression?.kind || expression.kind !== JS.Kind.IndexedAccessType) {
+            return expression;
+        }
+        indexedAccessType = expression as JS.IndexedAccessType;
 
         return this.produceJavaScript<JS.IndexedAccessType>(indexedAccessType, p, async draft => {
             draft.objectType = await this.visitDefined<TypedTree>(indexedAccessType.objectType, p);
@@ -641,10 +657,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitTypeQuery(typeQuery: JS.TypeQuery, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(typeQuery, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.TypeQuery) {
-               return expression;
-           }
-           typeQuery = expression as JS.TypeQuery;
+        if (!expression?.kind || expression.kind !== JS.Kind.TypeQuery) {
+            return expression;
+        }
+        typeQuery = expression as JS.TypeQuery;
 
         return this.produceJavaScript<JS.TypeQuery>(typeQuery, p, async draft => {
             draft.typeExpression = await this.visitDefined<TypedTree>(typeQuery.typeExpression, p);
@@ -655,10 +671,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitTypeInfo(typeInfo: JS.TypeInfo, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(typeInfo, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.TypeInfo) {
-               return expression;
-           }
-           typeInfo = expression as JS.TypeInfo;
+        if (!expression?.kind || expression.kind !== JS.Kind.TypeInfo) {
+            return expression;
+        }
+        typeInfo = expression as JS.TypeInfo;
 
         return this.produceJavaScript<JS.TypeInfo>(typeInfo, p, async draft => {
             draft.typeIdentifier = await this.visitDefined<TypedTree>(typeInfo.typeIdentifier, p);
@@ -667,10 +683,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitComputedPropertyName(computedPropertyName: JS.ComputedPropertyName, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(computedPropertyName, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.ComputedPropertyName) {
-               return expression;
-           }
-           computedPropertyName = expression as JS.ComputedPropertyName;
+        if (!expression?.kind || expression.kind !== JS.Kind.ComputedPropertyName) {
+            return expression;
+        }
+        computedPropertyName = expression as JS.ComputedPropertyName;
 
         return this.produceJavaScript<JS.ComputedPropertyName>(computedPropertyName, p, async draft => {
             draft.expression = await this.visitRightPadded(computedPropertyName.expression, p);
@@ -679,10 +695,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitTypeOperator(typeOperator: JS.TypeOperator, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(typeOperator, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.TypeOperator) {
-               return expression;
-           }
-           typeOperator = expression as JS.TypeOperator;
+        if (!expression?.kind || expression.kind !== JS.Kind.TypeOperator) {
+            return expression;
+        }
+        typeOperator = expression as JS.TypeOperator;
 
         return this.produceJavaScript<JS.TypeOperator>(typeOperator, p, async draft => {
             draft.expression = await this.visitLeftPadded(typeOperator.expression, p);
@@ -691,10 +707,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitTypePredicate(typePredicate: JS.TypePredicate, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(typePredicate, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.TypePredicate) {
-               return expression;
-           }
-           typePredicate = expression as JS.TypePredicate;
+        if (!expression?.kind || expression.kind !== JS.Kind.TypePredicate) {
+            return expression;
+        }
+        typePredicate = expression as JS.TypePredicate;
 
         return this.produceJavaScript<JS.TypePredicate>(typePredicate, p, async draft => {
             draft.asserts = await this.visitLeftPadded(typePredicate.asserts, p);
@@ -706,10 +722,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitUnion(union: JS.Union, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(union, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.Union) {
-               return expression;
-           }
-           union = expression as JS.Union;
+        if (!expression?.kind || expression.kind !== JS.Kind.Union) {
+            return expression;
+        }
+        union = expression as JS.Union;
 
         return this.produceJavaScript<JS.Union>(union, p, async draft => {
             draft.types = await mapAsync(union.types, item => this.visitRightPadded(item, p));
@@ -719,10 +735,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitIntersection(intersection: JS.Intersection, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(intersection, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.Intersection) {
-               return expression;
-           }
-           intersection = expression as JS.Intersection;
+        if (!expression?.kind || expression.kind !== JS.Kind.Intersection) {
+            return expression;
+        }
+        intersection = expression as JS.Intersection;
 
         return this.produceJavaScript<JS.Intersection>(intersection, p, async draft => {
             draft.types = await mapAsync(intersection.types, item => this.visitRightPadded(item, p));
@@ -732,10 +748,10 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitVoid(void_: JS.Void, p: P): Promise<J | undefined> {
         const expression = await this.visitExpression(void_, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.Void) {
-               return expression;
-           }
-           void_ = expression as JS.Void;
+        if (!expression?.kind || expression.kind !== JS.Kind.Void) {
+            return expression;
+        }
+        void_ = expression as JS.Void;
 
         return this.produceJavaScript<JS.Void>(void_, p, async draft => {
             draft.expression = await this.visitDefined<Expression>(void_.expression, p);

--- a/rewrite-javascript/rewrite/src/visitor.ts
+++ b/rewrite-javascript/rewrite/src/visitor.ts
@@ -40,7 +40,7 @@ const stopAfterPreVisit = Symbol("STOP_AFTER_PRE_VISIT")
 export abstract class TreeVisitor<T extends Tree, P> {
     protected cursor: Cursor = rootCursor();
     private visitCount: number = 0;
-    protected afterVisit: TreeVisitor<any, P>[] = [];
+    public afterVisit: TreeVisitor<any, P>[] = [];
 
     async visitDefined<R extends T>(tree: Tree, p: P, parent?: Cursor): Promise<R> {
         return (await this.visit<R>(tree, p, parent))!;

--- a/rewrite-javascript/rewrite/src/visitor.ts
+++ b/rewrite-javascript/rewrite/src/visitor.ts
@@ -40,7 +40,7 @@ const stopAfterPreVisit = Symbol("STOP_AFTER_PRE_VISIT")
 export abstract class TreeVisitor<T extends Tree, P> {
     protected cursor: Cursor = rootCursor();
     private visitCount: number = 0;
-    private afterVisit?: TreeVisitor<any, P>[];
+    protected afterVisit: TreeVisitor<any, P>[] = [];
 
     async visitDefined<R extends T>(tree: Tree, p: P, parent?: Cursor): Promise<R> {
         return (await this.visit<R>(tree, p, parent))!;
@@ -80,14 +80,14 @@ export abstract class TreeVisitor<T extends Tree, P> {
 
             if (topLevel) {
                 if (this.afterVisit) {
-                    for (const v of this.afterVisit) {
+                    while (this.afterVisit.length > 0) {
+                        const v = this.afterVisit.shift()!;
                         v.cursor = this.cursor;
                         if (t !== undefined) {
                             t = await v.visit(t, p);
                         }
                     }
                 }
-                this.afterVisit = undefined;
                 this.visitCount = 0;
             }
         } catch (e) {

--- a/rewrite-javascript/rewrite/test/javascript/remove-import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/remove-import.test.ts
@@ -1,0 +1,300 @@
+// noinspection JSUnusedLocalSymbols,TypeScriptCheckImport,TypeScriptUnresolvedReference,ES6UnusedImports
+
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {describe, test} from "@jest/globals";
+import {fromVisitor, RecipeSpec} from "../../src/test";
+import {typescript} from "../../src/javascript";
+import {RemoveImport} from "../../src/javascript/remove-import";
+
+describe('RemoveImport visitor', () => {
+    describe('named imports', () => {
+        test('should remove specific named import', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs", "readFile"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import {readFile, writeFile} from 'fs';
+
+                        function example() {
+                            writeFile('test.txt', 'content', () => {
+                            });
+                        }
+                    `,
+                    `
+                        import {writeFile} from 'fs';
+
+                        function example() {
+                            writeFile('test.txt', 'content', () => {
+                            });
+                        }
+                    `
+                )
+            );
+        });
+
+        test('should remove entire import when only one named import', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs", "readFile"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import {readFile} from 'fs';
+
+                        function example() {
+                            console.log('test');
+                        }
+                    `,
+                    `
+                        function example() {
+                            console.log('test');
+                        }
+                    `
+                )
+            );
+        });
+
+        test('should not remove import if it is used', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs", "readFile"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import {readFile} from 'fs';
+
+                        function example() {
+                            readFile('test.txt', (err, data) => {
+                            });
+                        }
+                    `
+                )
+            );
+        });
+    });
+
+    describe('default imports', () => {
+        test('should remove default import', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import fs from 'fs';
+
+                        function example() {
+                            console.log('test');
+                        }
+                    `,
+                    `
+                        function example() {
+                            console.log('test');
+                        }
+                    `
+                )
+            );
+        });
+
+        test('should not remove default import if used', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import fs from 'fs';
+
+                        function example() {
+                            fs.readFileSync('test.txt');
+                        }
+                    `
+                )
+            );
+        });
+    });
+
+    describe('namespace imports', () => {
+        test('should remove namespace import', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import * as fs from 'fs';
+
+                        function example() {
+                            console.log('test');
+                        }
+                    `,
+                    `
+                        function example() {
+                            console.log('test');
+                        }
+                    `
+                )
+            );
+        });
+
+        test('should not remove namespace import if used', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import * as fs from 'fs';
+
+                        function example() {
+                            return fs.readFileSync('test.txt');
+                        }
+                    `
+                )
+            );
+        });
+    });
+
+    describe('type imports', () => {
+        test('should remove type import', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs", "Stats"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import type {Stats} from 'fs';
+
+                        function example() {
+                            return null;
+                        }
+                    `,
+                    `
+                        function example() {
+                            return null;
+                        }
+                    `
+                )
+            );
+        });
+
+        test('should remove specific type from type import', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs", "Stats"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import type {Stats, Dirent} from 'fs';
+
+                        function example(d: Dirent) {
+                            return d.name;
+                        }
+                    `,
+                    `
+                        import type {Dirent} from 'fs';
+
+                        function example(d: Dirent) {
+                            return d.name;
+                        }
+                    `
+                )
+            );
+        });
+
+        test('should not remove type import if used', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs", "Stats"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import type {Stats} from 'fs';
+
+                        function example(stats: Stats) {
+                            return stats.size;
+                        }
+                    `
+                )
+            );
+        });
+    });
+
+    describe('CommonJS requires', () => {
+        test('should remove require statement', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        const fs = require('fs');
+
+                        function example() {
+                            return null;
+                        }
+                    `,
+                    `
+                        function example() {
+                            return null;
+                        }
+                    `
+                )
+            );
+        });
+
+        test('should remove destructured require', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs", "readFile"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        const {readFile, writeFile} = require('fs');
+
+                        function example() {
+                            writeFile('test.txt', 'content', () => {
+                            });
+                        }
+                    `,
+                    `
+                        const {writeFile} = require('fs');
+
+                        function example() {
+                            writeFile('test.txt', 'content', () => {
+                            });
+                        }
+                    `
+                )
+            );
+        });
+    });
+});


### PR DESCRIPTION
## What's changed?

JavaScript has unique import structures, so support a general purpose `RemoveImport` visitor usable in many recipes.