### PR TITLE
Use Maven repository credentials in `GradleProjectBuilder`

### DIFF
--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
@@ -94,8 +94,10 @@ public final class GradleProjectBuilder {
                             .uri(repo.getUrl().toString())
                             .releases(true)
                             .snapshots(true);
-                    Optional.ofNullable(repo.getCredentials().getUsername()).ifPresent(builder::username);
-                    Optional.ofNullable(repo.getCredentials().getPassword()).ifPresent(builder::password);
+                    if (GradleVersion.current().compareTo(GradleVersion.version("6.6")) >= 0) {
+                        Optional.ofNullable(repo.getCredentials().getUsername()).ifPresent(builder::username);
+                        Optional.ofNullable(repo.getCredentials().getPassword()).ifPresent(builder::password);
+                    }
                     return builder.build();
                 })
                 .collect(toList());

--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
@@ -90,6 +90,8 @@ public final class GradleProjectBuilder {
                 .map(repo -> MavenRepository.builder()
                         .id(repo.getName())
                         .uri(repo.getUrl().toString())
+                        .username(repo.getCredentials().getUsername())
+                        .password(repo.getCredentials().getPassword())
                         .releases(true)
                         .snapshots(true)
                         .build())

--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
@@ -88,19 +88,16 @@ public final class GradleProjectBuilder {
         return repositories.stream()
                 .filter(MavenArtifactRepository.class::isInstance)
                 .map(MavenArtifactRepository.class::cast)
-                .map(repo -> {
-                    MavenRepository.Builder builder = MavenRepository.builder()
-                            .id(repo.getName())
-                            .uri(repo.getUrl().toString())
-                            .releases(true)
-                            .snapshots(true);
-                    mapAuthentication(repo, builder);
-                    return builder.build();
-                })
+                .map(repo -> withAuthentication(repo, MavenRepository.builder()
+                        .id(repo.getName())
+                        .uri(repo.getUrl().toString())
+                        .releases(true)
+                        .snapshots(true))
+                        .build())
                 .collect(toList());
     }
 
-    private static void mapAuthentication(MavenArtifactRepository repo, MavenRepository.Builder builder) {
+    private static MavenRepository.Builder withAuthentication(MavenArtifactRepository repo, MavenRepository.Builder builder) {
         try {
             PasswordCredentials passwordCredentials = repo.getCredentials(PasswordCredentials.class);
             Optional.ofNullable(passwordCredentials.getUsername()).ifPresent(builder::username);
@@ -108,6 +105,7 @@ public final class GradleProjectBuilder {
         } catch (IllegalArgumentException e) {
             // We're not using password credentials
         }
+        return builder;
     }
 
     public static List<GradlePluginDescriptor> pluginDescriptors(@Nullable PluginManager pluginManager) {

--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
@@ -19,6 +19,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.*;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.artifacts.repositories.PasswordCredentials;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.initialization.Settings;
@@ -87,14 +88,16 @@ public final class GradleProjectBuilder {
         return repositories.stream()
                 .filter(MavenArtifactRepository.class::isInstance)
                 .map(MavenArtifactRepository.class::cast)
-                .map(repo -> MavenRepository.builder()
-                        .id(repo.getName())
-                        .uri(repo.getUrl().toString())
-                        .username(repo.getCredentials().getUsername())
-                        .password(repo.getCredentials().getPassword())
-                        .releases(true)
-                        .snapshots(true)
-                        .build())
+                .map(repo -> {
+                    MavenRepository.Builder builder = MavenRepository.builder()
+                            .id(repo.getName())
+                            .uri(repo.getUrl().toString())
+                            .releases(true)
+                            .snapshots(true);
+                    Optional.ofNullable(repo.getCredentials().getUsername()).ifPresent(builder::username);
+                    Optional.ofNullable(repo.getCredentials().getPassword()).ifPresent(builder::password);
+                    return builder.build();
+                })
                 .collect(toList());
     }
 

--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
@@ -94,13 +94,20 @@ public final class GradleProjectBuilder {
                             .uri(repo.getUrl().toString())
                             .releases(true)
                             .snapshots(true);
-                    if (GradleVersion.current().compareTo(GradleVersion.version("6.6")) >= 0) {
-                        Optional.ofNullable(repo.getCredentials().getUsername()).ifPresent(builder::username);
-                        Optional.ofNullable(repo.getCredentials().getPassword()).ifPresent(builder::password);
-                    }
+                    mapAuthentication(repo, builder);
                     return builder.build();
                 })
                 .collect(toList());
+    }
+
+    private static void mapAuthentication(MavenArtifactRepository repo, MavenRepository.Builder builder) {
+        try {
+            PasswordCredentials passwordCredentials = repo.getCredentials(PasswordCredentials.class);
+            Optional.ofNullable(passwordCredentials.getUsername()).ifPresent(builder::username);
+            Optional.ofNullable(passwordCredentials.getPassword()).ifPresent(builder::password);
+        } catch (IllegalArgumentException e) {
+            // We're not using password credentials
+        }
     }
 
     public static List<GradlePluginDescriptor> pluginDescriptors(@Nullable PluginManager pluginManager) {

--- a/rewrite-gradle-tooling-model/plugin/src/main/java/org/openrewrite/gradle/toolingapi/ToolingApiOpenRewriteModelPlugin.java
+++ b/rewrite-gradle-tooling-model/plugin/src/main/java/org/openrewrite/gradle/toolingapi/ToolingApiOpenRewriteModelPlugin.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.gradle.toolingapi;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -26,6 +27,7 @@ import org.openrewrite.RecipeSerializer;
 import org.openrewrite.gradle.marker.GradleProjectBuilder;
 import org.openrewrite.gradle.marker.GradleSettings;
 import org.openrewrite.gradle.marker.GradleSettingsBuilder;
+import org.openrewrite.maven.tree.MavenRepository;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -44,7 +46,7 @@ public class ToolingApiOpenRewriteModelPlugin implements Plugin<Project> {
         registry.register(new OpenRewriteModelBuilder());
     }
 
-    private static final ObjectMapper mapper = new RecipeSerializer().getMapper();
+    private static final ObjectMapper mapper = new RecipeSerializer().getMapper().copy().addMixIn(MavenRepository.class, MavenRepositoryMixin.class);
 
     private static class OpenRewriteModelBuilder implements ToolingModelBuilder {
         @Override
@@ -70,5 +72,13 @@ public class ToolingApiOpenRewriteModelPlugin implements Plugin<Project> {
                 throw new RuntimeException("Failed to serialize Gradle model to JSON", e);
             }
         }
+    }
+
+    interface MavenRepositoryMixin {
+        @JsonProperty(access = JsonProperty.Access.READ_WRITE)
+        String getUsername();
+
+        @JsonProperty(access = JsonProperty.Access.READ_WRITE)
+        String getPassword();
     }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
@@ -82,7 +82,16 @@ class GradleProjectTest implements RewriteTest {
           spec -> spec.recipe(new UpgradeDependencyInMarker(
             new GroupArtifactVersion("org.openrewrite", "rewrite-java", "8.56.0"),
             "implementation",
-            (original, updated) -> assertThat(updated).isSameAs(original)
+            (original, updated) -> assertThat(updated)
+              .isSameAs(original)
+              .extracting(GradleProject::getMavenRepositories)
+              .satisfies(list -> assertThat(list)
+                .singleElement()
+                .satisfies(repo -> {
+                      assertThat(repo.getUri()).isEqualTo("https://example.com/maven2");
+                      assertThat(repo.getUsername()).isEqualTo("dummyuser");
+                      assertThat(repo.getPassword()).isEqualTo("dummypass");
+                }))
           )),
           buildGradle(
             """

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
@@ -235,13 +235,6 @@ class GradleProjectTest implements RewriteTest {
                     assertThat(repo.getPassword()).isNull();
                 }))
           )),
-          properties(
-            """
-            mySecureRepositoryUsername=dummyuser
-            mySecureRepositoryPassword=dummypass
-            """,
-            spec -> spec.path("gradle.properties")
-          ),
           buildGradle(
             """
               plugins {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
@@ -77,6 +77,39 @@ class GradleProjectTest implements RewriteTest {
     }
 
     @Test
+    void repositoryWithBasicCredentials() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyInMarker(
+            new GroupArtifactVersion("org.openrewrite", "rewrite-java", "8.56.0"),
+            "implementation",
+            (original, updated) -> assertThat(updated).isSameAs(original)
+          )),
+          buildGradle(
+            """
+              plugins {
+                  id("java")
+              }
+              repositories {
+                  maven {
+                      url = "https://example.com/maven2"
+                      credentials {
+                        user = "dummyuser"
+                        password = "dummypass"
+                      }
+                      authentication {
+                        basic(BasicAuthentication)
+                      }
+                  }
+              }
+              dependencies {
+                  implementation("org.openrewrite:rewrite-java:8.56.0")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void multiProject() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyInMarker(

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
@@ -36,7 +36,6 @@ import org.openrewrite.test.SourceSpec;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -87,13 +86,12 @@ class GradleProjectTest implements RewriteTest {
             "implementation",
             (original, updated) -> assertThat(updated)
               .isSameAs(original)
-              .extracting(GradleProject::getMavenRepositories)
-              .satisfies(list -> assertThat(list)
+              .satisfies(gp -> assertThat(gp.getMavenRepositories())
                 .singleElement()
                 .satisfies(repo -> {
-                      assertThat(repo.getUri()).isEqualTo("https://example.com/maven2");
-                      assertThat(repo.getUsername()).isEqualTo("dummyuser");
-                      assertThat(repo.getPassword()).isEqualTo("dummypass");
+                    assertThat(repo.getUri()).isEqualTo("https://example.com/maven2");
+                    assertThat(repo.getUsername()).isEqualTo("dummyuser");
+                    assertThat(repo.getPassword()).isEqualTo("dummypass");
                 }))
           )),
           properties(
@@ -133,8 +131,7 @@ class GradleProjectTest implements RewriteTest {
             "implementation",
             (original, updated) -> assertThat(updated)
               .isSameAs(original)
-              .extracting(GradleProject::getMavenRepositories)
-              .satisfies(list -> assertThat(list)
+              .satisfies(gp -> assertThat(gp.getMavenRepositories())
                 .singleElement()
                 .satisfies(repo -> {
                     assertThat(repo.getUri()).isEqualTo("https://example.com/maven2");
@@ -182,8 +179,7 @@ class GradleProjectTest implements RewriteTest {
             "implementation",
             (original, updated) -> assertThat(updated)
               .isSameAs(original)
-              .extracting(GradleProject::getMavenRepositories)
-              .satisfies(list -> assertThat(list)
+              .satisfies(gp -> assertThat(gp.getMavenRepositories())
                 .singleElement()
                 .satisfies(repo -> {
                     assertThat(repo.getUri()).isEqualTo("https://example.com/maven2");
@@ -193,9 +189,9 @@ class GradleProjectTest implements RewriteTest {
           )),
           properties(
             """
-            mySecureRepositoryUsername=dummyuser
-            mySecureRepositoryPassword=dummypass
-            """,
+              mySecureRepositoryUsername=dummyuser
+              mySecureRepositoryPassword=dummypass
+              """,
             spec -> spec.path("gradle.properties")
           ),
           buildGradle(
@@ -226,8 +222,7 @@ class GradleProjectTest implements RewriteTest {
             "implementation",
             (original, updated) -> assertThat(updated)
               .isSameAs(original)
-              .extracting(GradleProject::getMavenRepositories)
-              .satisfies(list -> assertThat(list)
+              .satisfies(gp -> assertThat(gp.getMavenRepositories())
                 .singleElement()
                 .satisfies(repo -> {
                     assertThat(repo.getUri()).isEqualTo("https://example.com/maven2");
@@ -551,7 +546,7 @@ class GradleProjectTest implements RewriteTest {
 
                 GradleDependencyConstraint jacksonConstraint = constraints.stream()
                   .filter(c -> "com.fasterxml.jackson.core".equals(c.getGroupId()) &&
-                               "jackson-databind".equals(c.getArtifactId()))
+                    "jackson-databind".equals(c.getArtifactId()))
                   .findFirst()
                   .orElse(null);
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
@@ -93,7 +93,7 @@ class GradleProjectTest implements RewriteTest {
                   maven {
                       url = "https://example.com/maven2"
                       credentials {
-                        user = "dummyuser"
+                        username = "dummyuser"
                         password = "dummypass"
                       }
                       authentication {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

This PR changes the logic in GradleProjectBuilder mapRepositories

We are now mapping the Maven Repository "username" and "password" if they exist.

## What's your motivation?

- Closes https://github.com/openrewrite/rewrite/issues/6044


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
