### PR TITLE
ChangeValue for Json should use JsonParser to interpret the target value argument

### DIFF
--- a/rewrite-json/src/test/java/org/openrewrite/json/ChangeValueTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/ChangeValueTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.json;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RewriteTest;
@@ -86,21 +87,6 @@ class ChangeValueTest implements RewriteTest {
     }
 
     @Test
-    void changeToString() {
-        rewriteRun(
-          spec -> spec.recipe(new ChangeValue("$.apiVersion", "\"v2\"")),
-          json(
-            """
-              { "apiVersion": "v1" }
-              """,
-            """
-              { "apiVersion": "v2" }
-              """
-          )
-        );
-    }
-
-    @Test
     void changeToNumber() {
         rewriteRun(
           spec -> spec.recipe(new ChangeValue("$.apiVersion", "\"123\"")),
@@ -161,15 +147,30 @@ class ChangeValueTest implements RewriteTest {
     }
 
     @Test
-    void changeToObject() {
+    void changeToStringWithDoubleQuotes() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeValue("$.apiVersion", "\"{\"a\":\"b\"}\"")),
+          spec -> spec.recipe(new ChangeValue("$.apiVersion", "\"v2\"")),
           json(
             """
               { "apiVersion": "v1" }
               """,
             """
-              { "apiVersion": {"a":"b"} }
+              { "apiVersion": "v2" }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeToStringWithDoubleQuotesAroundSingleQuotes() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue("$.apiVersion", "\"'v2'\"")),
+          json(
+            """
+              { "apiVersion": "v1" }
+              """,
+            """
+              { "apiVersion": 'v2' }
               """
           )
         );
@@ -179,6 +180,21 @@ class ChangeValueTest implements RewriteTest {
     void changeToStringSingleQuotes() {
         rewriteRun(
           spec -> spec.recipe(new ChangeValue("$.apiVersion", "'v2'")),
+          json(
+            """
+              { "apiVersion": "v1" }
+              """,
+            """
+              { "apiVersion": 'v2' }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeToStringSingleQuotesAroundDoubleQuotes() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue("$.apiVersion", "'\"v2\"'")),
           json(
             """
               { "apiVersion": "v1" }
@@ -200,6 +216,22 @@ class ChangeValueTest implements RewriteTest {
               """,
             """
               { "apiVersion": "v2" }
+              """
+          )
+        );
+    }
+
+    @Disabled("Changing to object is not yet supported")
+    @Test
+    void changeToObject() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue("$.apiVersion", "\"{\"a\":\"b\"}\"")),
+          json(
+            """
+              { "apiVersion": "v1" }
+              """,
+            """
+              { "apiVersion": {"a":"b"} }
               """
           )
         );

--- a/rewrite-json/src/test/java/org/openrewrite/json/ChangeValueTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/ChangeValueTest.java
@@ -31,7 +31,7 @@ class ChangeValueTest implements RewriteTest {
             "\"monitoring\""
           )),
           json(
-                """
+            """
               {
                 "apiVersion": "v1",
                 "metadata": {
@@ -61,7 +61,7 @@ class ChangeValueTest implements RewriteTest {
             "\"Deployment\""
           )),
           json(
-                """
+            """
               {
                 "subjects": [
                   {
@@ -80,6 +80,126 @@ class ChangeValueTest implements RewriteTest {
                   }
                 ]
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeToString() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue("$.apiVersion", "\"v2\"")),
+          json(
+            """
+              { "apiVersion": "v1" }
+              """,
+            """
+              { "apiVersion": "v2" }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeToNumber() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue("$.apiVersion", "\"123\"")),
+          json(
+            """
+              { "apiVersion": "v1" }
+              """,
+            """
+              { "apiVersion": 123 }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeToNumberWithoutQuotes() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue("$.apiVersion", "123")),
+          json(
+            """
+              { "apiVersion": "v1" }
+              """,
+            """
+              { "apiVersion": 123 }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeToBoolean() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue("$.apiVersion", "\"true\"")),
+          json(
+            """
+              { "apiVersion": "v1" }
+              """,
+            """
+              { "apiVersion": true }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeToBooleanWithoutQuotes() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue("$.apiVersion", "true")),
+          json(
+            """
+              { "apiVersion": "v1" }
+              """,
+            """
+              { "apiVersion": true }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeToObject() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue("$.apiVersion", "\"{\"a\":\"b\"}\"")),
+          json(
+            """
+              { "apiVersion": "v1" }
+              """,
+            """
+              { "apiVersion": {"a":"b"} }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeToStringSingleQuotes() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue("$.apiVersion", "'v2'")),
+          json(
+            """
+              { "apiVersion": "v1" }
+              """,
+            """
+              { "apiVersion": "v2" }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeToStringWithoutQuotes() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue("$.apiVersion", "v2")),
+          json(
+            """
+              { "apiVersion": "v1" }
+              """,
+            """
+              { "apiVersion": "v2" }
               """
           )
         );


### PR DESCRIPTION
We saw folks needing to escape arguments awkwardly, especially when the target value contains quotes. By handing off to the parser we hope to see this resolved.