### PR TITLE
Use internal method to get credentials to avoid accidentally setting an invalid state

### DIFF
--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
@@ -116,15 +116,18 @@ public final class GradleProjectBuilder {
 
     @SuppressWarnings("unchecked")
     private static @Nullable Credentials getCredentials(AuthenticationSupportedInternal authenticatedRepo) {
-        Object configuredCredentials = authenticatedRepo.getConfiguredCredentials();
-        if (configuredCredentials instanceof Property) {
-            // Gradle 6.6+ returns a Property<Credentials> instance
-            return ((Property<Credentials>) configuredCredentials).getOrNull();
-        }
-        if (configuredCredentials instanceof Credentials) {
-            // Gradle < 6.6 returns a Credentials instance
-            return (Credentials) configuredCredentials;
-        }
+        try {
+            Method getConfiguredCredentialsMethod = AuthenticationSupportedInternal.class.getDeclaredMethod("getConfiguredCredentials");
+            Object configuredCredentials = getConfiguredCredentialsMethod.invoke(authenticatedRepo);
+            if (configuredCredentials instanceof Property) {
+                // Gradle 6.6+ returns a Property<Credentials> instance
+                return ((Property<Credentials>) configuredCredentials).getOrNull();
+            }
+            if (configuredCredentials instanceof Credentials) {
+                // Gradle < 6.6 returns a Credentials instance
+                return (Credentials) configuredCredentials;
+            }
+        } catch (Exception ignored) {}
         return null;
     }
 


### PR DESCRIPTION
## What's changed?
Use internal `getConfiguredCredentials()` to avoid eager initialization of an empty credentials object in Gradle.

## What's your motivation?
Internal to `getCredentials()` and `getCredentials(Class<?>)`, it would create an instance of `PasswordCredentials` with null values. As a result of `mavenLocal()` being a `MavenArtifactRepository` and deeply internal checks, credentials existing for a repository with type `file` is invalid and we were incidentally triggering credentials to be populated thus causing errors later on that were not observed at first.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
- Related to https://github.com/openrewrite/rewrite/pull/6096

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
