### PR TITLE
Drop sparsely used commons-lang3

### DIFF
--- a/rewrite-core/build.gradle.kts
+++ b/rewrite-core/build.gradle.kts
@@ -18,7 +18,8 @@ dependencies {
     // Caffeine 2.x works with Java 8, Caffeine 3.x is Java 11 only.
     implementation("com.github.ben-manes.caffeine:caffeine:2.+")
 
-    implementation("org.apache.commons:commons-lang3:latest.release")
+    // For Levenshtein distance of mismatched recipes
+    implementation("org.apache.commons:commons-text:latest.release")
 
     implementation("io.micrometer:micrometer-core:1.9.+")
     implementation("io.github.classgraph:classgraph:latest.release")

--- a/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
@@ -29,10 +29,10 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.*;
 
+import static java.lang.String.join;
 import static java.util.Collections.*;
 import static java.util.Comparator.comparingInt;
 import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang3.StringUtils.join;
 import static org.openrewrite.ExcludeFileFromGitignore.Repository;
 import static org.openrewrite.PathUtils.separatorsToUnix;
 import static org.openrewrite.jgit.ignore.IgnoreNode.MatchResult.*;
@@ -94,7 +94,7 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
                     String separator = text.getText().contains("\r\n") ? "\r\n" : "\n";
                     List<String> newRules = ignoreNode.getRules().stream().map(IgnoreRule::getText).collect(toList());
                     String[] currentContent = text.getText().split(separator);
-                    text = text.withText(join(sortRules(currentContent, newRules), separator));
+                    text = text.withText(join(separator, sortRules(currentContent, newRules)));
                 }
                 return text;
             }

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -16,10 +16,10 @@
 package org.openrewrite;
 
 import lombok.Value;
-import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.jgit.transport.URIish;
+import org.openrewrite.jgit.util.StringUtils;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -15,7 +15,7 @@
  */
 package org.openrewrite.config;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Recipe;
 import org.openrewrite.RecipeException;
@@ -159,7 +159,7 @@ public class Environment {
             @SuppressWarnings("deprecation")
             List<String> suggestions = recipesNotFound.stream()
                     .map(r -> recipesByName.keySet().stream()
-                            .min(comparingInt(a -> StringUtils.getLevenshteinDistance(a, r)))
+                            .min(comparingInt(a -> LevenshteinDistance.getDefaultInstance().apply(a, r)))
                             .orElse(r))
                     .collect(toList());
             String message = String.format("Recipe(s) not found: %s\nDid you mean: %s",

--- a/rewrite-core/src/main/java/org/openrewrite/text/Find.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/Find.java
@@ -17,7 +17,6 @@ package org.openrewrite.text;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.apache.commons.lang3.BooleanUtils;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.binary.Binary;
@@ -156,7 +155,7 @@ public class Find extends Recipe {
                     int matchStart = matcher.start();
                     snippets.add(snippet(rawText.substring(previousEnd, matchStart)));
                     String text = rawText.substring(matchStart, matcher.end());
-                    snippets.add(SearchResult.found(snippet(text), BooleanUtils.isTrue(description) ? text : null));
+                    snippets.add(SearchResult.found(snippet(text), Boolean.TRUE.equals(description) ? text : null));
                     previousEnd = matcher.end();
 
                     // For the first match, search backwards

--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -48,7 +48,6 @@ dependencies {
     compileOnly(project(":rewrite-test"))
     compileOnly("org.junit.jupiter:junit-jupiter-api")
     compileOnly("org.assertj:assertj-core:latest.release")
-    implementation("org.apache.commons:commons-lang3:latest.release")
     implementation("org.apache.commons:commons-text:latest.release")
     implementation("io.github.classgraph:classgraph:latest.release")
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddLiteralMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddLiteralMethodArgument.java
@@ -17,10 +17,10 @@ package org.openrewrite.java;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
@@ -44,7 +44,7 @@ public class AddLiteralMethodArgument extends Recipe {
      * See {@link  MethodMatcher} for details on the expression's syntax.
      */
     @Option(displayName = "Method pattern",
-            description = MethodMatcher.METHOD_PATTERN_DESCRIPTION,
+            description = MethodMatcher.METHOD_PATTERN_INVOCATIONS_DESCRIPTION,
             example = "com.yourorg.A foo(int, int)")
     String methodPattern;
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeStaticFieldToMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeStaticFieldToMethod.java
@@ -17,9 +17,7 @@ package org.openrewrite.java;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.apache.commons.lang3.StringUtils;
 import org.intellij.lang.annotations.Language;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.search.UsesField;
@@ -115,12 +113,10 @@ public class ChangeStaticFieldToMethod extends Recipe {
                 return makeNewMethod(newClass).apply(getCursor(), coordinates);
             }
 
-            @NonNull
             private JavaTemplate makeNewMethod(String newClass) {
-
-                String packageName = StringUtils.substringBeforeLast(newClass, ".");
-                String simpleClassName = StringUtils.substringAfterLast(newClass, ".");
-
+                int lastIndexOfDot = newClass.lastIndexOf('.');
+                String packageName = newClass.substring(0, lastIndexOfDot);
+                String simpleClassName = newClass.substring(lastIndexOfDot + 1);
                 String methodInvocationTemplate = simpleClassName + (newTarget != null ? "." + newTarget + "." : ".") + newMethodName + "()";
 
                 @Language("java") String methodStub;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRepository.java
@@ -17,12 +17,12 @@ package org.openrewrite.maven;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
@@ -76,9 +76,7 @@ public class RemoveRepository extends Recipe {
     }
 
     private boolean isSameUrlAndID(Xml.Tag repo) {
-        boolean sameURL = StringUtils.isBlank(this.url) || StringUtils.equals(this.url, repo.getChildValue("url").orElse(null));
-        boolean sameID = StringUtils.isBlank(this.id) || StringUtils.equals(this.id, repo.getChildValue("id").orElse(null));
-
-        return sameURL && sameID;
+        return (StringUtils.isBlank(this.url) || this.url.equals(repo.getChildValue("url").orElse(null))) &&
+                (StringUtils.isBlank(this.id) || this.id.equals(repo.getChildValue("id").orElse(null)));
     }
 }


### PR DESCRIPTION
Turns out we were mostly using it for the wrong reasons; other existing classes work just as well, or the more targeted commons-text. That last one we also only have for a single use case, but it's a nice bit to keep. If we want to further reduce the dependencies then we can inline that one algorithm.

Prompted by seeing a warning about: https://nvd.nist.gov/vuln/detail/CVE-2025-48924
Note that the fix has already been out in [3.18.0 since Jul 09, 2025](https://mvnrepository.com/artifact/org.apache.commons/commons-lang3/3.18.0), so we're not vulnerable.
Just thought it better to remove the dependency when it's not needed at all.