### PR TITLE
Add Kotlin settings file support to AddSettingsPluginRepository

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
@@ -152,16 +152,16 @@ public class AddPluginVisitor extends JavaIsoVisitor<ExecutionContext> {
     public @Nullable J preVisit(@NonNull J tree, ExecutionContext ctx) {
         if (tree instanceof JavaSourceFile) {
             if (tree instanceof G.CompilationUnit) {
-                return visitCompilationUnit((G.CompilationUnit) tree, ctx);
+                return addPluginToGroovyCompilationUnit((G.CompilationUnit) tree, ctx);
             }
             if (tree instanceof K.CompilationUnit) {
-                return visitCompilationUnit((K.CompilationUnit) tree, ctx);
+                return addPluginToKotlinCompilationUnit((K.CompilationUnit) tree, ctx);
             }
         }
         return super.preVisit(tree, ctx);
     }
 
-    private G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
+    private G.CompilationUnit addPluginToGroovyCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
         if (!FindPlugins.find(cu, pluginId).isEmpty() && (acceptTransitive == null || acceptTransitive)) {
             return cu;
         }
@@ -291,7 +291,7 @@ public class AddPluginVisitor extends JavaIsoVisitor<ExecutionContext> {
         }
     }
 
-    private K.CompilationUnit visitCompilationUnit(K.CompilationUnit cu, ExecutionContext ctx) {
+    private K.CompilationUnit addPluginToKotlinCompilationUnit(K.CompilationUnit cu, ExecutionContext ctx) {
         MethodMatcher pluginsMatcher = new MethodMatcher("*..* plugins(..)");
         MethodMatcher pluginIdMatcher = new MethodMatcher("*..* id(..)");
         AtomicBoolean hasPlugin = new JavaIsoVisitor<AtomicBoolean>() {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
@@ -17,20 +17,23 @@ package org.openrewrite.gradle.plugins;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Parser;
+import org.openrewrite.Tree;
 import org.openrewrite.gradle.DependencyVersionSelector;
 import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.gradle.marker.GradleSettings;
 import org.openrewrite.gradle.search.FindPlugins;
-import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.FindMethods;
 import org.openrewrite.java.tree.*;
+import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.tree.GroupArtifact;
 import org.openrewrite.tree.ParseError;
@@ -41,12 +44,13 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
+public class AddPluginVisitor extends JavaIsoVisitor<ExecutionContext> {
     String pluginId;
 
     @Nullable
@@ -61,20 +65,44 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
     @Nullable
     Boolean acceptTransitive;
 
-    private static @Nullable Comment getLicenseHeader(G.CompilationUnit cu) {
-        if (!cu.getStatements().isEmpty()) {
-            Statement firstStatement = cu.getStatements().get(0);
-            if (!firstStatement.getComments().isEmpty()) {
-                Comment firstComment = firstStatement.getComments().get(0);
+    private static @Nullable Comment getLicenseHeader(Tree tree) {
+        if (tree instanceof G.CompilationUnit) {
+            G.CompilationUnit cu = (G.CompilationUnit) tree;
+            if (!cu.getStatements().isEmpty()) {
+                Statement firstStatement = cu.getStatements().get(0);
+                if (!firstStatement.getComments().isEmpty()) {
+                    Comment firstComment = firstStatement.getComments().get(0);
+                    if (isLicenseHeader(firstComment)) {
+                        return firstComment;
+                    }
+                }
+            } else if (cu.getEof() != null && !cu.getEof().getComments().isEmpty()) {
+                Comment firstComment = cu.getEof().getComments().get(0);
                 if (isLicenseHeader(firstComment)) {
-                    return firstComment;
+                    // Adding suffix so when we later use it, formats well.
+                    return firstComment.withSuffix("\n\n");
                 }
             }
-        } else if (cu.getEof() != null && !cu.getEof().getComments().isEmpty()) {
-            Comment firstComment = cu.getEof().getComments().get(0);
-            if (isLicenseHeader(firstComment)) {
-                // Adding suffix so when we later use it, formats well.
-                return firstComment.withSuffix("\n\n");
+        }
+        if (tree instanceof K.CompilationUnit) {
+            K.CompilationUnit cu = (K.CompilationUnit) tree;
+            if (!cu.getStatements().isEmpty()) {
+                Statement firstStatement = cu.getStatements().get(0);
+                if (firstStatement instanceof J.Block && !((J.Block) firstStatement).getStatements().isEmpty()) {
+                    firstStatement = ((J.Block) firstStatement).getStatements().get(0);
+                }
+                if (!firstStatement.getComments().isEmpty()) {
+                    Comment firstComment = firstStatement.getComments().get(0);
+                    if (isLicenseHeader(firstComment)) {
+                        return firstComment;
+                    }
+                }
+            } else if (cu.getEof() != null && !cu.getEof().getComments().isEmpty()) {
+                Comment firstComment = cu.getEof().getComments().get(0);
+                if (isLicenseHeader(firstComment)) {
+                    // Adding suffix so when we later use it, formats well.
+                    return firstComment.withSuffix("\n\n");
+                }
             }
         }
         return null;
@@ -85,19 +113,55 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
                ((TextComment) comment).getText().contains("License");
     }
 
-    private static G.CompilationUnit removeLicenseHeader(G.CompilationUnit cu) {
-        if (!cu.getStatements().isEmpty()) {
-            return cu.withStatements(ListUtils.mapFirst(cu.getStatements(),
-                    s -> s.withComments(s.getComments().subList(1, s.getComments().size()))
-            ));
-        } else {
-            List<Comment> eofComments = cu.getEof().getComments();
-            return cu.withEof(cu.getEof().withComments(eofComments.subList(1, eofComments.size())));
+    private static Tree removeLicenseHeader(Tree tree) {
+        if (tree instanceof G.CompilationUnit) {
+            G.CompilationUnit cu = (G.CompilationUnit) tree;
+            if (!cu.getStatements().isEmpty()) {
+                return cu.withStatements(ListUtils.mapFirst(cu.getStatements(),
+                        s -> s.withComments(s.getComments().subList(1, s.getComments().size()))
+                ));
+            } else {
+                List<Comment> eofComments = cu.getEof().getComments();
+                return cu.withEof(cu.getEof().withComments(eofComments.subList(1, eofComments.size())));
+            }
         }
+        if (tree instanceof K.CompilationUnit) {
+            K.CompilationUnit cu = (K.CompilationUnit) tree;
+            if (!cu.getStatements().isEmpty()) {
+                if (cu.getStatements().get(0) instanceof J.Block && !((J.Block) cu.getStatements().get(0)).getStatements().isEmpty()) {
+                    return cu.withStatements(ListUtils.mapFirst(cu.getStatements(), b ->
+                            ((J.Block) b).withStatements(ListUtils.mapFirst(((J.Block) b).getStatements(), s -> {
+                                if (!s.getComments().isEmpty()) {
+                                    if (isLicenseHeader(s.getComments().get(0))) {
+                                        return s.withComments(s.getComments().subList(1, s.getComments().size()));
+                                    }
+                                }
+                                return s;
+                            }))
+                    ));
+                }
+            } else {
+                List<Comment> eofComments = cu.getEof().getComments();
+                return cu.withEof(cu.getEof().withComments(eofComments.subList(1, eofComments.size())));
+            }
+        }
+        return tree;
     }
 
     @Override
-    public G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
+    public @Nullable J preVisit(@NonNull J tree, ExecutionContext ctx) {
+        if (tree instanceof JavaSourceFile) {
+            if (tree instanceof G.CompilationUnit) {
+                return visitCompilationUnit((G.CompilationUnit) tree, ctx);
+            }
+            if (tree instanceof K.CompilationUnit) {
+                return visitCompilationUnit((K.CompilationUnit) tree, ctx);
+            }
+        }
+        return super.preVisit(tree, ctx);
+    }
+
+    private G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
         if (!FindPlugins.find(cu, pluginId).isEmpty() && (acceptTransitive == null || acceptTransitive)) {
             return cu;
         }
@@ -123,7 +187,7 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
         AtomicInteger singleQuote = new AtomicInteger();
         AtomicInteger doubleQuote = new AtomicInteger();
         AtomicBoolean pluginAlreadyApplied = new AtomicBoolean();
-        new GroovyIsoVisitor<Integer>() {
+        new JavaIsoVisitor<Integer>() {
             final MethodMatcher pluginIdMatcher = new MethodMatcher("PluginSpec id(..)");
 
             @Override
@@ -145,7 +209,7 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
                 }
                 return m;
             }
-        }.visitCompilationUnit(cu, 0);
+        }.visit(cu, 0);
 
         if (pluginAlreadyApplied.get()) {
             return cu;
@@ -185,7 +249,7 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
                 if (insertAtIdx == 0) {
                     Comment licenseHeader = getLicenseHeader(cu);
                     if (licenseHeader != null) {
-                        cu = removeLicenseHeader(cu);
+                        cu = (G.CompilationUnit) removeLicenseHeader(cu);
                         statement = statement.withComments(singletonList(licenseHeader));
                     }
                     Space leadingSpace = Space.firstPrefix(cu.getStatements());
@@ -223,6 +287,143 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
                     }
                 }
                 return stat;
+            }));
+        }
+    }
+
+    private K.CompilationUnit visitCompilationUnit(K.CompilationUnit cu, ExecutionContext ctx) {
+        MethodMatcher pluginsMatcher = new MethodMatcher("*..* plugins(..)");
+        MethodMatcher pluginIdMatcher = new MethodMatcher("*..* id(..)");
+        AtomicBoolean hasPlugin = new JavaIsoVisitor<AtomicBoolean>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean found) {
+                J.MethodInvocation m = super.visitMethodInvocation(method, found);
+                if (pluginIdMatcher.matches(m, true)) {
+                    if (m.getArguments().get(0) instanceof J.Literal) {
+                        J.Literal l = (J.Literal) m.getArguments().get(0);
+                        if (pluginId.equals(l.getValue())) {
+                            found.set(true);
+                            return m;
+                        }
+                    }
+                }
+                return m;
+            }
+        }.reduce(cu, new AtomicBoolean());
+        if (hasPlugin.get()) {
+            return cu;
+        }
+
+        String version;
+        if (newVersion == null) {
+            // We have been requested to add a versionless plugin
+            version = null;
+        } else {
+            Optional<GradleProject> maybeGp = cu.getMarkers().findFirst(GradleProject.class);
+            Optional<GradleSettings> maybeGs = cu.getMarkers().findFirst(GradleSettings.class);
+            if (!maybeGp.isPresent() && !maybeGs.isPresent()) {
+                return cu;
+            }
+
+            try {
+                version = new DependencyVersionSelector(null, maybeGp.orElse(null), maybeGs.orElse(null)).select(new GroupArtifact(pluginId, pluginId + ".gradle.plugin"), "classpath", newVersion, versionPattern, ctx);
+            } catch (MavenDownloadingException e) {
+                return e.warn(cu);
+            }
+        }
+
+        String source = "plugins {\n" +
+                "    id(\"" + pluginId + "\")" + (version != null ? " version \"" + version + "\"" : "") + (version != null && Boolean.FALSE.equals(apply) ? " apply " + apply : "") + "\n" +
+                "}";
+        Statement statement = GradleParser.builder().build()
+                .parseInputs(singletonList(Parser.Input.fromString(Paths.get("build.gradle.kts"), source)), null, ctx)
+                .findFirst()
+                .map(parsed -> {
+                    if (parsed instanceof ParseError) {
+                        throw ((ParseError) parsed).toException();
+                    }
+                    return ((K.CompilationUnit) parsed);
+                })
+                .map(parsed -> parsed.getStatements().get(0))
+                .map(block -> ((J.Block)block).getStatements().get(0))
+                .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"));
+
+        AtomicBoolean hasPluginsBlock = new JavaIsoVisitor<AtomicBoolean>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean found) {
+                J.MethodInvocation m = super.visitMethodInvocation(method, found);
+                if (pluginsMatcher.matches(m, true)) {
+                    found.set(true);
+                }
+                return m;
+            }
+        }.reduce(cu, new AtomicBoolean());
+        if (!hasPluginsBlock.get()) {
+            J.Block block = (J.Block) cu.getStatements().get(0);
+            if (cu.getSourcePath().endsWith(Paths.get("settings.gradle")) &&
+                    !block.getStatements().isEmpty() &&
+                    block.getStatements().get(0) instanceof J.MethodInvocation &&
+                    "pluginManagement".equals(((J.MethodInvocation) block.getStatements().get(0)).getSimpleName())) {
+                block = block.withStatements(ListUtils.insert(block.getStatements(), autoFormat(statement.withPrefix(Space.format("\n\n")), ctx, getCursor()), 1));
+            } else {
+                int insertAtIdx = 0;
+                for (int i = 0; i < cu.getStatements().size(); i++) {
+                    Statement existingStatement = cu.getStatements().get(i);
+                    if (existingStatement instanceof J.MethodInvocation && "buildscript".equals(((J.MethodInvocation) existingStatement).getSimpleName())) {
+                        insertAtIdx = i + 1;
+                        break;
+                    }
+                }
+                if (insertAtIdx == 0) {
+                    Comment licenseHeader = getLicenseHeader(cu);
+                    if (licenseHeader != null) {
+                        cu = (K.CompilationUnit) removeLicenseHeader(cu);
+                        block = (J.Block) cu.getStatements().get(0);
+                        statement = statement.withComments(singletonList(licenseHeader));
+                    }
+                    Space leadingSpace = Space.firstPrefix(block.getStatements());
+                    block = block.withStatements(ListUtils.insert(
+                            Space.formatFirstPrefix(block.getStatements(), leadingSpace.withWhitespace("\n\n" + leadingSpace.getWhitespace())),
+                            statement,
+                            insertAtIdx));
+                } else {
+                    block = block.withStatements(ListUtils.insert(block.getStatements(), statement.withPrefix(Space.format("\n\n")), insertAtIdx));
+                }
+            }
+            J.Block newStatement = block;
+            return cu.withStatements(ListUtils.mapFirst(cu.getStatements(), __ -> newStatement));
+        } else {
+            J.MethodInvocation pluginDef = (J.MethodInvocation)(((J.Block) ((J.Lambda) ((J.MethodInvocation) statement).getArguments().get(0)).getBody()).getStatements().get(0));
+            return cu.withStatements(ListUtils.mapFirst(cu.getStatements(), b -> {
+                if (b instanceof J.Block) {
+                    J.Block block = (J.Block) b;
+                    return block.withStatements(ListUtils.map(block.getStatements(), stat -> {
+                        if (stat instanceof J.MethodInvocation) {
+                            J.MethodInvocation m = (J.MethodInvocation) stat;
+                            if (pluginsMatcher.matches(m, true)) {
+                                return m.withArguments(ListUtils.map(m.getArguments(), a -> {
+                                    if (a instanceof J.Lambda) {
+                                        J.Lambda l = (J.Lambda) a;
+                                        J.Block body = (J.Block) l.getBody();
+                                        List<Statement> pluginStatements = body.getStatements();
+                                        if (!pluginStatements.isEmpty() && pluginStatements.get(pluginStatements.size() - 1) instanceof J.Return) {
+                                            Statement last = pluginStatements.remove(pluginStatements.size() - 1);
+                                            Expression lastExpr = requireNonNull(((J.Return) last).getExpression());
+                                            pluginStatements.add(lastExpr.withPrefix(last.getPrefix()));
+                                        } else if (pluginStatements.isEmpty()) {
+                                            body = body.withPrefix(Space.EMPTY).withEnd(Space.build("\n", emptyList()));
+                                        }
+                                        pluginStatements.add(pluginDef);
+                                        return l.withBody(body.withStatements(pluginStatements));
+                                    }
+                                    return a;
+                                }));
+                            }
+                        }
+                        return stat;
+                    }));
+                }
+                return b;
             }));
         }
     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepository.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepository.java
@@ -22,17 +22,23 @@ import org.openrewrite.*;
 import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.gradle.IsSettingsGradle;
 import org.openrewrite.gradle.search.FindRepository;
-import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.groovy.format.AutoFormat;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.kotlin.tree.K;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -65,85 +71,148 @@ public class AddSettingsPluginRepository extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new IsSettingsGradle<>(), new GroovyIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(new IsSettingsGradle<>(), new JavaIsoVisitor<ExecutionContext>() {
             @Override
-            public G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
-                if (cu == new FindRepository(type, url, FindRepository.Purpose.Plugin).getVisitor().visit(cu, ctx)) {
-                    G.CompilationUnit g = super.visitCompilationUnit(cu, ctx);
-
-                    J.MethodInvocation pluginManagement = generatePluginManagementBlock(ctx);
-
-                    List<Statement> statements = new ArrayList<>(g.getStatements());
-                    if (statements.isEmpty()) {
-                        statements.add(pluginManagement);
-                    } else {
-                        Statement statement = statements.get(0);
-                        if (statement instanceof J.MethodInvocation &&
-                            "pluginManagement".equals(((J.MethodInvocation) statement).getSimpleName())) {
-                            J.MethodInvocation m = (J.MethodInvocation) statement;
-                            m = m.withArguments(ListUtils.mapFirst(m.getArguments(), arg -> {
-                                if (arg instanceof J.Lambda && ((J.Lambda) arg).getBody() instanceof J.Block) {
-                                    J.Lambda lambda = (J.Lambda) arg;
-                                    J.Block block = (J.Block) lambda.getBody();
-                                    return lambda.withBody(block.withStatements(ListUtils.map(block.getStatements(), statement2 -> {
-                                        if ((statement2 instanceof J.MethodInvocation && "repositories".equals(((J.MethodInvocation) statement2).getSimpleName())) ||
-                                            (statement2 instanceof J.Return && ((J.Return) statement2).getExpression() instanceof J.MethodInvocation && "repositories".equals(((J.MethodInvocation) ((J.Return) statement2).getExpression()).getSimpleName()))) {
-                                            J.MethodInvocation m2 = (J.MethodInvocation) (statement2 instanceof J.Return ? ((J.Return) statement2).getExpression() : statement2);
-                                            return m2.withArguments(ListUtils.mapFirst(m2.getArguments(), arg2 -> {
-                                                if (arg2 instanceof J.Lambda && ((J.Lambda) arg2).getBody() instanceof J.Block) {
-                                                    J.Lambda lambda2 = (J.Lambda) arg2;
-                                                    J.Block block2 = (J.Block) lambda2.getBody();
-                                                    return lambda2.withBody(block2.withStatements(ListUtils.concat(block2.getStatements(), extractRepository(pluginManagement))));
-                                                }
-                                                return arg2;
-                                            }));
-                                        }
-                                        return statement2;
-                                    })));
-                                }
-                                return arg;
-                            }));
-                            statements.set(0, m);
-                        } else {
-                            statements.add(0, pluginManagement);
-                            statements.set(1, statements.get(1).withPrefix(Space.format("\n\n")));
+            public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree instanceof JavaSourceFile) {
+                    if (tree == new FindRepository(type, url, FindRepository.Purpose.Plugin).getVisitor().visit(tree, ctx)) {
+                        if (tree instanceof G.CompilationUnit) {
+                            return visitCompilationUnit((G.CompilationUnit) tree, ctx);
+                        }
+                        if (tree instanceof K.CompilationUnit) {
+                            return visitCompilationUnit((K.CompilationUnit) tree, ctx);
                         }
                     }
-
-                    return autoFormat(g.withStatements(statements), ctx);
                 }
-
-                return cu;
+                return super.visit(tree, ctx);
             }
 
-            private J.MethodInvocation generatePluginManagementBlock(ExecutionContext ctx) {
+            public G.CompilationUnit visitCompilationUnit(G.CompilationUnit g, ExecutionContext ctx) {
+                J.MethodInvocation pluginManagement = (J.MethodInvocation) generatePluginManagementBlock(G.CompilationUnit.class, cu -> cu.getStatements().get(0), ctx);
+
+                List<Statement> statements = new ArrayList<>(g.getStatements());
+                if (statements.isEmpty()) {
+                    statements.add(pluginManagement);
+                } else {
+                    addPluginManagementRepos(statements, pluginManagement);
+                }
+
+                return (G.CompilationUnit) new AutoFormat().getVisitor().visitNonNull(g.withStatements(statements), ctx);
+            }
+
+            public K.CompilationUnit visitCompilationUnit(K.CompilationUnit k, ExecutionContext ctx) {
+                J.Block pluginManagement = (J.Block) generatePluginManagementBlock(K.CompilationUnit.class, cu -> cu.getStatements().get(0), ctx);
+
+                List<Statement> statements = new ArrayList<>(k.getStatements());
+
+                if (statements.isEmpty()) {
+                    statements.addAll(pluginManagement.getStatements());
+                } else {
+                    Statement blockStatement = statements.get(0);
+                    if (blockStatement instanceof J.Block) {
+                        J.Block b = (J.Block) blockStatement;
+                        List<Statement> blockStatements = new ArrayList<>(b.getStatements());
+                        if (blockStatements.isEmpty()) {
+                            statements.addAll(pluginManagement.getStatements());
+                        } else {
+                            statements.set(0, b.withStatements(addPluginManagementRepos(blockStatements, pluginManagement)));
+                        }
+                    }
+                }
+
+                return (K.CompilationUnit) new AutoFormat().getVisitor().visitNonNull(k.withStatements(statements), ctx);
+            }
+
+            private List<Statement> addPluginManagementRepos(List<Statement> statements, J pluginManagement) {
+                Statement statement = statements.get(0);
+                if (statement instanceof J.MethodInvocation &&
+                        "pluginManagement".equals(((J.MethodInvocation) statement).getSimpleName())) {
+                    J.MethodInvocation m = (J.MethodInvocation) statement;
+                    m = m.withArguments(ListUtils.mapFirst(m.getArguments(), arg -> {
+                        if (arg instanceof J.Lambda && ((J.Lambda) arg).getBody() instanceof J.Block) {
+                            J.Lambda lambda = (J.Lambda) arg;
+                            J.Block block = (J.Block) lambda.getBody();
+                            return lambda.withBody(block.withStatements(ListUtils.map(block.getStatements(), statement2 -> {
+                                if ((statement2 instanceof J.MethodInvocation && "repositories".equals(((J.MethodInvocation) statement2).getSimpleName())) ||
+                                        (statement2 instanceof J.Return && ((J.Return) statement2).getExpression() instanceof J.MethodInvocation && "repositories".equals(((J.MethodInvocation) ((J.Return) statement2).getExpression()).getSimpleName()))) {
+                                    J.MethodInvocation m2 = (J.MethodInvocation) (statement2 instanceof J.Return ? ((J.Return) statement2).getExpression() : statement2);
+                                    m2 = m2.withArguments(ListUtils.mapFirst(m2.getArguments(), arg2 -> {
+                                        if (arg2 instanceof J.Lambda && ((J.Lambda) arg2).getBody() instanceof J.Block) {
+                                            J.Lambda lambda2 = (J.Lambda) arg2;
+                                            J.Block block2 = (J.Block) lambda2.getBody();
+                                            Statement lastStatement = block2.getStatements().get(block2.getStatements().size() - 1);
+                                            return lambda2.withBody(block2.withStatements(ListUtils.concat(ListUtils.mapLast(block2.getStatements(), s -> s instanceof J.Return ? ((J.Return) s).getExpression().withPrefix(lastStatement.getPrefix()) : s), (Statement) (lastStatement instanceof J.Return ? ((J.Return) lastStatement).withExpression(extractRepository(pluginManagement).withPrefix(Space.EMPTY)) : extractRepository(pluginManagement).withPrefix(lastStatement.getPrefix())).withComments(emptyList()))));
+                                        }
+                                        return arg2;
+                                    }));
+                                    if (statement2 instanceof J.Return) {
+                                        return ((J.Return) statement2).withExpression(m2);
+                                    }
+                                    return m2;
+                                }
+                                return statement2;
+                            })));
+                        }
+                        return arg;
+                    }));
+                    statements.set(0, m);
+                } else {
+                    statements.add(0, pluginManagement instanceof J.Block ? (J.Block) pluginManagement : (J.MethodInvocation) pluginManagement);
+                    statements.set(1, statements.get(1).withPrefix(Space.format("\n\n")));
+                }
+                return statements;
+            }
+
+            private <T extends JavaSourceFile> J generatePluginManagementBlock(Class<T> compilationUnitClass, Function<T, J> methodExtractor, ExecutionContext ctx) {
                 String code;
                 if (url == null) {
-                    code = "pluginManagement {" +
-                           "    repositories {" +
-                           "        " + type + "()" +
-                           "    }" +
-                           "}";
+                    code = "pluginManagement {\n" +
+                            "    repositories {\n" +
+                            "        " + type + "()\n" +
+                            "    }\n" +
+                            "}";
+                } else if (G.class.isAssignableFrom(compilationUnitClass)) {
+                    code = "pluginManagement {\n" +
+                            "    repositories {\n" +
+                            "        " + type + " {\n" +
+                            "            url = \"" + url + "\"\n" +
+                            "        }\n" +
+                            "    }\n" +
+                            "}";
                 } else {
-                    code = "pluginManagement {" +
-                           "    repositories {" +
-                           "        " + type + " {" +
-                           "            url = \"" + url + "\"" +
-                           "        }" +
-                           "    }" +
-                           "}";
+                    code = "pluginManagement {\n" +
+                            "    repositories {\n" +
+                            "        " + type + " {\n" +
+                            "            url = uri(\"" + url + "\")\n" +
+                            "        }\n" +
+                            "    }\n" +
+                            "}";
                 }
 
-                return (J.MethodInvocation) GradleParser.builder().build().parseInputs(singletonList(Parser.Input.fromString(Paths.get("settings.gradle"), code)), null, ctx)
-                        .map(G.CompilationUnit.class::cast)
-                        .collect(toList()).get(0).getStatements().get(0);
+                Path path = Paths.get("settings" + (G.class.isAssignableFrom(compilationUnitClass) ? ".gradle" : ".gradle.kts"));
+                return methodExtractor.apply(
+                        GradleParser.builder().build().parseInputs(singletonList(Parser.Input.fromString(path, code)), null, ctx)
+                                .map(compilationUnitClass::cast)
+                                .collect(toList()).get(0)
+                );
             }
 
-            private J.MethodInvocation extractRepository(J.MethodInvocation pluginManagement) {
-                J.MethodInvocation repositories = (J.MethodInvocation) ((J.Return) ((J.Block) ((J.Lambda) pluginManagement
-                        .getArguments().get(0)).getBody()).getStatements().get(0)).getExpression();
-                return (J.MethodInvocation) requireNonNull(((J.Return) ((J.Block) ((J.Lambda) requireNonNull(repositories)
-                        .getArguments().get(0)).getBody()).getStatements().get(0)).getExpression());
+            private J.MethodInvocation extractRepository(J j) {
+                J.MethodInvocation pluginManagement;
+                if (j instanceof J.MethodInvocation) {
+                    pluginManagement = (J.MethodInvocation) j;
+                } else {
+                    pluginManagement = (J.MethodInvocation) ((J.Block) j).getStatements().get(0);
+                }
+                J mi = ((J.Block) ((J.Lambda) pluginManagement.getArguments().get(0)).getBody()).getStatements().get(0);
+                if (mi instanceof J.Return) {
+                    mi = ((J.Return) mi).getExpression().withPrefix(mi.getPrefix());
+                }
+                mi = ((J.Block)((J.Lambda) requireNonNull((J.MethodInvocation) mi).getArguments().get(0)).getBody()).getStatements().get(0);
+                if (mi instanceof J.Return) {
+                    mi = ((J.Return) mi).getExpression().withPrefix(mi.getPrefix());
+                }
+                return (J.MethodInvocation) mi;
             }
         });
     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindRepository.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindRepository.java
@@ -88,7 +88,7 @@ public class FindRepository extends Recipe {
     }
 
     private class RepositoryVisitor extends JavaIsoVisitor<ExecutionContext> {
-        private final MethodMatcher repositoryMatcher = new MethodMatcher("org.gradle.api.artifacts.dsl.RepositoryHandler " + type + "(..)", true);
+        private final MethodMatcher repositoryMatcher = new MethodMatcher("org.gradle.api.artifacts.dsl.RepositoryHandler " + (type != null ? type : "*") + "(..)", true);
 
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindRepository.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindRepository.java
@@ -21,13 +21,14 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.gradle.IsBuildGradle;
 import org.openrewrite.gradle.IsSettingsGradle;
-import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.GroovyPrinter;
 import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.marker.SearchResult;
 
 @Value
@@ -68,13 +69,13 @@ public class FindRepository extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         MethodMatcher pluginManagementMatcher = new MethodMatcher("RewriteSettings pluginManagement(..)");
         MethodMatcher buildscriptMatcher = new MethodMatcher("RewriteGradleProject buildscript(..)");
-        return Preconditions.check(Preconditions.or(new IsBuildGradle<>(), new IsSettingsGradle<>()), new GroovyIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(Preconditions.or(new IsBuildGradle<>(), new IsSettingsGradle<>()), new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 if (purpose == null) {
                     return new RepositoryVisitor().visitMethodInvocation(method, ctx);
                 } else {
-                    boolean isPluginBlock = pluginManagementMatcher.matches(method) || buildscriptMatcher.matches(method);
+                    boolean isPluginBlock = pluginManagementMatcher.matches(method, true) || buildscriptMatcher.matches(method, true);
                     if ((purpose == Purpose.Project && !isPluginBlock) ||
                         (purpose == Purpose.Plugin && isPluginBlock)) {
                         return new RepositoryVisitor().visitMethodInvocation(method, ctx);
@@ -86,14 +87,14 @@ public class FindRepository extends Recipe {
         });
     }
 
-    private class RepositoryVisitor extends GroovyIsoVisitor<ExecutionContext> {
-        private final MethodMatcher repositoryMatcher = new MethodMatcher("org.gradle.api.artifacts.dsl.RepositoryHandler *(..)", true);
+    private class RepositoryVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private final MethodMatcher repositoryMatcher = new MethodMatcher("org.gradle.api.artifacts.dsl.RepositoryHandler " + type + "(..)", true);
 
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
 
-            if (!repositoryMatcher.matches(m)) {
+            if (!repositoryMatcher.matches(m, true)) {
                 return m;
             }
 
@@ -130,12 +131,17 @@ public class FindRepository extends Recipe {
                             url.equals(((J.Literal) assignment.getAssignment()).getValue())) {
                             return true;
                         } else if (assignment.getAssignment() instanceof J.MethodInvocation &&
-                                   "uri".equals(((J.MethodInvocation) assignment.getAssignment()).getSimpleName()) &&
-                                   ((J.MethodInvocation) assignment.getAssignment()).getArguments().get(0) instanceof J.Literal &&
+                                   "uri".equals(((J.MethodInvocation) assignment.getAssignment()).getSimpleName())) {
+                            if (((J.MethodInvocation) assignment.getAssignment()).getArguments().get(0) instanceof J.Literal &&
                                    url.equals(((J.Literal) ((J.MethodInvocation) assignment.getAssignment()).getArguments().get(0)).getValue())) {
-                            return true;
+                                return true;
+                            } else if (((J.MethodInvocation) assignment.getAssignment()).getArguments().get(0) instanceof K.StringTemplate) {
+                                String valueSource = TemplateAsString.getValueSource(((J.MethodInvocation) assignment.getAssignment()).getArguments().get(0));
+                                String testSource = ((K.StringTemplate) ((J.MethodInvocation) assignment.getAssignment()).getArguments().get(0)).getDelimiter() + url + ((K.StringTemplate) ((J.MethodInvocation) assignment.getAssignment()).getArguments().get(0)).getDelimiter();
+                                return testSource.equals(valueSource);
+                            }
                         } else if (assignment.getAssignment() instanceof G.GString) {
-                            String valueSource = assignment.getAssignment().withPrefix(Space.EMPTY).printTrimmed(new GroovyPrinter<>());
+                            String valueSource = TemplateAsString.getValueSource(assignment.getAssignment());
                             String testSource = ((G.GString) assignment.getAssignment()).getDelimiter() + url + ((G.GString) assignment.getAssignment()).getDelimiter();
                             return testSource.equals(valueSource);
                         }
@@ -162,6 +168,59 @@ public class FindRepository extends Recipe {
             }
 
             return false;
+        }
+    }
+
+    private static class TemplateAsString extends JavaIsoVisitor<StringBuilder> {
+
+        private static String getValueSource(J tree) {
+            return new TemplateAsString().reduce((Tree) tree.withPrefix(Space.EMPTY), new StringBuilder()).toString();
+        }
+
+        @Override
+        public @Nullable J visit(@Nullable Tree tree, StringBuilder builder) {
+            if (tree instanceof K.StringTemplate) {
+                builder.append(((K.StringTemplate) tree).getDelimiter());
+                super.visit(tree, builder);
+                builder.append(((K.StringTemplate) tree).getDelimiter());
+            } else if (tree instanceof K.StringTemplate.Expression) {
+                builder.append("$");
+                if (((K.StringTemplate.Expression) tree).isEnclosedInBraces()) {
+                    builder.append("{");
+                }
+                super.visit(tree, builder);
+                if (((K.StringTemplate.Expression) tree).isEnclosedInBraces()) {
+                    builder.append("}");
+                }
+            } else if (tree instanceof G.GString) {
+                builder.append(((G.GString) tree).getDelimiter());
+                super.visit(tree, builder);
+                builder.append(((G.GString) tree).getDelimiter());
+            } else if (tree instanceof G.GString.Value) {
+                builder.append("$");
+                if (((G.GString.Value) tree).isEnclosedInBraces()) {
+                    builder.append("{");
+                }
+                super.visit(tree, builder);
+                if (((G.GString.Value) tree).isEnclosedInBraces()) {
+                    builder.append("}");
+                }
+            } else {
+                super.visit(tree, builder);
+            }
+            return (J) tree;
+        }
+
+        @Override
+        public J.Literal visitLiteral(J.Literal literal, StringBuilder builder) {
+            builder.append(literal.getValue());
+            return super.visitLiteral(literal, builder);
+        }
+
+        @Override
+        public J.Identifier visitIdentifier(J.Identifier identifier, StringBuilder builder) {
+            builder.append(identifier.getSimpleName());
+            return super.visitIdentifier(identifier, builder);
         }
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepositoryTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepositoryTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.settingsGradle;
+import static org.openrewrite.gradle.Assertions.settingsGradleKts;
 
 class AddSettingsPluginRepositoryTest implements RewriteTest {
     @DocumentExample
@@ -160,6 +161,150 @@ class AddSettingsPluginRepositoryTest implements RewriteTest {
               pluginManagement {
                   repositories {
                       maven { url "${NEXUS_URL}/snapshots" }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptySettingsFileKts() {
+        rewriteRun(
+          spec -> spec.recipe(new AddSettingsPluginRepository("maven", "https://repo.example.com/snapshots")),
+          settingsGradleKts(
+            "",
+            """
+              pluginManagement {
+                  repositories {
+                      maven {
+                          url = uri("https://repo.example.com/snapshots")
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noPluginManagementBlockKts() {
+        rewriteRun(
+          spec -> spec.recipe(new AddSettingsPluginRepository("maven", "https://repo.example.com/snapshots")),
+          settingsGradleKts(
+            """
+              rootProject.name = "demo"
+              """,
+            """
+              pluginManagement {
+                  repositories {
+                      maven {
+                          url = uri("https://repo.example.com/snapshots")
+                      }
+                  }
+              }
+
+              rootProject.name = "demo"
+              """
+          )
+        );
+    }
+
+    @Test
+    void existingPluginManagementBlockKts() {
+        rewriteRun(
+          spec -> spec.recipe(new AddSettingsPluginRepository("maven", "https://repo.example.com/snapshots")),
+          settingsGradleKts(
+            """
+              pluginManagement {
+                  repositories {
+                      mavenLocal()
+                  }
+              }
+              """,
+            """
+              pluginManagement {
+                  repositories {
+                      mavenLocal()
+                      maven {
+                          url = uri("https://repo.example.com/snapshots")
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void skipWhenExistsKts() {
+        rewriteRun(
+          spec -> spec.recipe(new AddSettingsPluginRepository("maven", "https://repo.example.com/snapshots")),
+          settingsGradleKts(
+            """
+              pluginManagement {
+                  repositories {
+                      maven { url = uri("https://repo.example.com/snapshots") }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addMavenLocalKts() {
+        rewriteRun(
+          spec -> spec.recipe(new AddSettingsPluginRepository("mavenLocal", null)),
+          settingsGradleKts(
+            """
+              pluginManagement {
+                  repositories {
+                      maven {
+                          url = uri("https://repo.example.com/snapshots")
+                      }
+                  }
+              }
+              """,
+            """
+              pluginManagement {
+                  repositories {
+                      maven {
+                          url = uri("https://repo.example.com/snapshots")
+                      }
+                      mavenLocal()
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void existingRepositoryUsingMethodKts() {
+        rewriteRun(
+          spec -> spec.recipe(new AddSettingsPluginRepository("maven", "https://repo.example.com/snapshots")),
+          settingsGradleKts(
+            """
+              pluginManagement {
+                  repositories {
+                      maven { url = uri("https://repo.example.com/snapshots") }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void existingRepositoryUsingMethodAndGroovyStringKts() {
+        rewriteRun(
+          spec -> spec.recipe(new AddSettingsPluginRepository("maven", "${NEXUS_URL}/snapshots")),
+          settingsGradleKts(
+            """
+              pluginManagement {
+                  repositories {
+                      maven { url = uri("${NEXUS_URL}/snapshots") }
                   }
               }
               """

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindRepositoryTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindRepositoryTest.java
@@ -19,8 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.settingsGradle;
+import static org.openrewrite.gradle.Assertions.*;
 
 class FindRepositoryTest implements RewriteTest {
     @DocumentExample
@@ -195,6 +194,126 @@ class FindRepositoryTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(new FindRepository("mavenCentral", null, null)),
           buildGradle(
+            """
+              repositories {
+                mavenCentral()
+              }
+              """,
+            """
+              repositories {
+                /*~~>*/mavenCentral()
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void repositoryByUrlAndPurposeProjectKts() {
+        rewriteRun(
+          spec -> spec.recipe(new FindRepository(null, "https://central.sonatype.com/repository/maven-snapshots", FindRepository.Purpose.Project)),
+          buildGradleKts(
+            """
+              buildscript {
+                repositories {
+                  maven { url = "https://central.sonatype.com/repository/maven-snapshots" }
+                }
+              }
+
+              repositories {
+                maven { url = "https://central.sonatype.com/repository/maven-snapshots" }
+              }
+              """,
+            """
+              buildscript {
+                repositories {
+                  maven { url = "https://central.sonatype.com/repository/maven-snapshots" }
+                }
+              }
+
+              repositories {
+                /*~~>*/maven { url = "https://central.sonatype.com/repository/maven-snapshots" }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void repositoryByUrlAndPurposePluginKts() {
+        rewriteRun(
+          spec -> spec.recipe(new FindRepository(null, "https://central.sonatype.com/repository/maven-snapshots", FindRepository.Purpose.Plugin)),
+          buildGradleKts(
+            """
+              buildscript {
+                repositories {
+                  maven { url = "https://central.sonatype.com/repository/maven-snapshots" }
+                }
+              }
+
+              repositories {
+                maven { url = "https://central.sonatype.com/repository/maven-snapshots" }
+              }
+              """,
+            """
+              buildscript {
+                repositories {
+                  /*~~>*/maven { url = "https://central.sonatype.com/repository/maven-snapshots" }
+                }
+              }
+
+              repositories {
+                maven { url = "https://central.sonatype.com/repository/maven-snapshots" }
+              }
+              """
+          ),
+          settingsGradleKts(
+            """
+              pluginManagement {
+                repositories {
+                  maven { url = "https://central.sonatype.com/repository/maven-snapshots" }
+                }
+              }
+              """,
+            """
+              pluginManagement {
+                repositories {
+                  /*~~>*/maven { url = "https://central.sonatype.com/repository/maven-snapshots" }
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void groovyStringRepositoryKts() {
+        rewriteRun(
+          spec -> spec.recipe(new FindRepository(null, "${NEXUS_URL}/content/repositories/snapshots", null)),
+          settingsGradleKts(
+            """
+              pluginManagement {
+                repositories {
+                  maven { url = uri("${NEXUS_URL}/content/repositories/snapshots") }
+                }
+              }
+              """,
+            """
+              pluginManagement {
+                repositories {
+                  /*~~>*/maven { url = uri("${NEXUS_URL}/content/repositories/snapshots") }
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void repositoryByTypeKts() {
+        rewriteRun(
+          spec -> spec.recipe(new FindRepository("mavenCentral", null, null)),
+          buildGradleKts(
             """
               repositories {
                 mavenCentral()


### PR DESCRIPTION
## Summary

Extends the `AddSettingsPluginRepository` recipe to support Kotlin DSL settings files (`settings.gradle.kts`) in addition to the existing Groovy settings file (`settings.gradle`) support.

## Changes

### Core Recipe Updates
- **Refactored visitor hierarchy**: Changed from `GroovyIsoVisitor` to `JavaIsoVisitor` to handle both Groovy and Kotlin ASTs
- **Added K.CompilationUnit support**: Implemented separate visitor methods for both `G.CompilationUnit` (Groovy) and `K.CompilationUnit` (Kotlin)
- **Improved code generation**: Updated template code generation to produce syntax appropriate for each language (e.g., `url = "..."` for Groovy vs `url = uri("...")` for Kotlin)

### Repository Search Improvements
- **Enhanced FindRepository**: Updated to work with both Groovy and Kotlin file types
- **Kotlin string template handling**: Added `TemplateAsString` helper class to properly match URLs in Kotlin string templates (`K.StringTemplate`) alongside existing Groovy GString support (removing the `print` need)