### PR TITLE
Attempt to fix type information when unfolding wildcard imports

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
@@ -185,6 +185,9 @@ public class RemoveImport<P> extends JavaIsoVisitor<P> {
         for (String other : otherImportsUsed) {
             J.Import unfolded = starImport.withQualid(starImport.getQualid().withName(starImport
                     .getQualid().getName().withSimpleName(other))).withId(randomId());
+            if (unfolded.getQualid().getType() instanceof JavaType.Unknown) {
+                unfolded = unfolded.withQualid(unfolded.getQualid().withType(JavaType.buildType(unfolded.getQualid().toString())));
+            }
             unfoldedImports.add(i++ == 0 ? unfolded : unfolded.withPrefix(Space.format("\n")));
         }
         return unfoldedImports;


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Wildcard imports receive type Unknown however after we unfold them they should be specific imports that have type information

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
When a `org.junit.*` import is unfolded during the junit 4 to 5 migration and attempt is made to move some imports to their respective JUnit 5 variant ambiguity occurs because the type information is invalid

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
