### PR TITLE
Guard against MavenResolutionResult.parentPomIsProjectPom() considering anything within .m2 to be part of the current repository.

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/Assertions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/Assertions.java
@@ -20,15 +20,23 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.ParseExceptionResult;
 import org.openrewrite.SourceFile;
+import org.openrewrite.maven.internal.RawPom;
 import org.openrewrite.maven.tree.MavenResolutionResult;
+import org.openrewrite.maven.tree.Pom;
 import org.openrewrite.test.SourceSpec;
 import org.openrewrite.test.SourceSpecs;
 import org.openrewrite.test.TypeValidation;
 import org.openrewrite.xml.tree.Xml;
 import org.opentest4j.AssertionFailedError;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.function.Consumer;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.openrewrite.maven.tree.MavenRepository.MAVEN_LOCAL_DEFAULT;
 
@@ -86,5 +94,127 @@ public class Assertions {
                     .orElseThrow(() -> new AssertionFailedError("No MavenResolutionResult found on " + sourceFile.getSourcePath()));
         }
         return sourceFile;
+    }
+
+    /**
+     * Publishes test POMs to the local Maven repository for use as parents or dependencies in tests,
+     * executes the provided test code, then cleans up the published POMs.
+     * This ensures the POMs are resolved as external dependencies rather than being parsed as part of the project.
+     * WARNING: To avoid overwriting real POMs in your local repository, only use this method with
+     * invented/test GAV coordinates. Avoid real coordinates like org.springframework.boot:spring-boot-starter-parent.
+     *
+     * @param pomXmls The POM XML content strings, each containing groupId, artifactId, and version elements
+     * @param testCode The test code to execute after publishing the POMs
+     * @throws IllegalArgumentException if any POM XML doesn't contain required GAV coordinates or uses a well-known groupId
+     */
+    @SuppressWarnings("ConstantValue")
+    public static void withLocalRepository(@Language("xml") String[] pomXmls, Runnable testCode) {
+        if (pomXmls.length == 0) {
+            throw new IllegalArgumentException("At least one POM must be provided");
+        }
+
+        // List of well-known groupIds that should not be overwritten
+        java.util.Set<String> protectedGroupIds = new java.util.HashSet<>(java.util.Arrays.asList(
+                "org.springframework",
+                "org.springframework.boot",
+                "org.apache",
+                "org.apache.maven",
+                "org.junit",
+                "com.google",
+                "com.fasterxml",
+                "jakarta",
+                "javax",
+                "io.quarkus",
+                "org.eclipse",
+                "org.jetbrains"
+        ));
+
+        java.util.List<Path> publishedFiles = new java.util.ArrayList<>();
+        try {
+            Path localRepo = Paths.get(System.getProperty("user.home"), ".m2", "repository");
+
+            // Publish all POMs
+            for (String pomXml : pomXmls) {
+                RawPom rawPom = RawPom.parse(
+                        new ByteArrayInputStream(pomXml.getBytes(UTF_8)),
+                        null
+                );
+                Pom pom = rawPom.toPom(Paths.get("pom.xml"), null);
+
+                String groupId = pom.getGroupId();
+                String artifactId = pom.getArtifactId();
+                String version = pom.getVersion();
+
+                if (groupId == null || groupId.trim().isEmpty()) {
+                    throw new IllegalArgumentException("POM XML must contain a groupId");
+                }
+                if (artifactId == null || artifactId.trim().isEmpty()) {
+                    throw new IllegalArgumentException("POM XML must contain an artifactId");
+                }
+                if (version == null || version.trim().isEmpty()) {
+                    throw new IllegalArgumentException("POM XML must contain a version");
+                }
+
+                // Check if the groupId is protected
+                for (String protectedPrefix : protectedGroupIds) {
+                    if (groupId.startsWith(protectedPrefix)) {
+                        throw new IllegalArgumentException(
+                                "Cannot use withLocalRepository with well-known groupId: " + groupId +
+                                ". Please use test-specific coordinates like 'com.example.test' to avoid overwriting real POMs.");
+                    }
+                }
+
+                String[] groupParts = groupId.split("\\.");
+                Path pomDir = localRepo;
+                for (String part : groupParts) {
+                    pomDir = pomDir.resolve(part);
+                }
+                pomDir = pomDir.resolve(artifactId).resolve(version);
+
+                Files.createDirectories(pomDir);
+
+                Path pomFile = pomDir.resolve(artifactId + "-" + version + ".pom");
+                Files.write(pomFile, pomXml.getBytes(UTF_8));
+                publishedFiles.add(pomFile);
+            }
+
+            testCode.run();
+
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to publish POM to local repository", e);
+        } finally {
+            for (Path file : publishedFiles) {
+                try {
+                    Files.deleteIfExists(file);
+                    Path parent = file.getParent();
+                    while (parent != null && !parent.equals(Paths.get(System.getProperty("user.home"), ".m2", "repository"))) {
+                        try {
+                            Files.deleteIfExists(parent);
+                            parent = parent.getParent();
+                        } catch (IOException ignored) {
+                            break;
+                        }
+                    }
+                } catch (IOException e) {
+                    System.err.println("Warning: Failed to clean up test POM: " + file + " - " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Convenience overload that accepts a single POM.
+     * @see #withLocalRepository(String[], Runnable)
+     */
+    public static void withLocalRepository(@Language("xml") String pomXml, Runnable testCode) {
+        withLocalRepository(new String[]{pomXml}, testCode);
+    }
+
+    /**
+     * Convenience overload that accepts two POMs.
+     * @see #withLocalRepository(String[], Runnable)
+     */
+    public static void withLocalRepository(@Language("xml") String pomXml1, @Language("xml") String pomXml2, Runnable testCode) {
+        withLocalRepository(new String[]{pomXml1, pomXml2}, testCode);
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersion.java
@@ -17,18 +17,16 @@ package org.openrewrite.maven;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
+import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.maven.tree.Plugin;
+import org.openrewrite.maven.tree.ResolvedPom;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 @Value
@@ -87,19 +85,22 @@ public class UpdateMavenProjectPropertyJavaVersion extends Recipe {
                 // Update properties already defined in the current pom
                 Xml.Document d = super.visitDocument(document, ctx);
 
-                // Return early if the parent appears to be within the current repository, as properties defined there will be updated
-                if (getResolutionResult().getParent() != null && getResolutionResult().parentPomIsProjectPom()) {
+                // Return early if the parent is within the current repository, as properties defined there will be updated
+                if (getResolutionResult().parentPomIsProjectPom()) {
                     // Unless the plugin config in the parent defines source/target/release with a property
-                    for (Plugin plugin : getResolutionResult().getParent().getPom().getPlugins()) {
+                    for (Plugin plugin : Optional.ofNullable(getResolutionResult().getParent())
+                            .map(MavenResolutionResult::getPom)
+                            .map(ResolvedPom::getPlugins)
+                            .orElse(emptyList())) {
                         if ("org.apache.maven.plugins".equals(plugin.getGroupId()) && "maven-compiler-plugin".equals(plugin.getArtifactId()) && plugin.getConfiguration() != null) {
                             for (String property : JAVA_VERSION_PROPERTIES) {
                                 if (getResolutionResult().getPom().getRequested().getProperties().get(property) != null) {
                                     try {
                                         float parsed = Float.parseFloat(getResolutionResult().getPom().getProperties().get(property));
                                         if (parsed < version &&
-                                            ((plugin.getConfiguration().get("source") != null && plugin.getConfiguration().get("source").textValue().contains(property)) ||
-                                            (plugin.getConfiguration().get("target") != null && plugin.getConfiguration().get("target").textValue().contains(property)) ||
-                                            (plugin.getConfiguration().get("release") != null && plugin.getConfiguration().get("release").textValue().contains(property)))) {
+                                                ((plugin.getConfiguration().get("source") != null && plugin.getConfiguration().get("source").textValue().contains(property)) ||
+                                                (plugin.getConfiguration().get("target") != null && plugin.getConfiguration().get("target").textValue().contains(property)) ||
+                                                (plugin.getConfiguration().get("release") != null && plugin.getConfiguration().get("release").textValue().contains(property)))) {
                                             d = (Xml.Document) new AddPropertyVisitor(property, String.valueOf(version), null)
                                                     .visitNonNull(d, ctx);
                                             maybeUpdateModel();

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
@@ -230,10 +230,19 @@ public class MavenResolutionResult implements Marker {
     }
 
     private Map<Path, Pom> getProjectPomsRecursive(Map<Path, Pom> projectPoms) {
+        // Strange edge case: Some projects specify a <relativePath> to their parent in the maven local directory
+        // e.g.: ../../../.m2/repository/
+        // This is bizarre and generally pointless, but not technically disallowed by Maven
         if (parent != null && !projectPoms.containsKey(parent.getPom().getRequested().getSourcePath())) {
-            parent.getProjectPomsRecursive(projectPoms);
+            Path parentPath = parent.getPom().getRequested().getSourcePath();
+            if (parentPath != null && !parentPath.toString().contains(".m2")) {
+                parent.getProjectPomsRecursive(projectPoms);
+            }
         }
-        projectPoms.put(requireNonNull(pom.getRequested().getSourcePath()), pom.getRequested());
+        Path currentPath = requireNonNull(pom.getRequested().getSourcePath());
+        if (!currentPath.toString().contains(".m2")) {
+            projectPoms.put(currentPath, pom.getRequested());
+        }
         for (MavenResolutionResult module : modules) {
             if (!projectPoms.containsKey(module.getPom().getRequested().getSourcePath())) {
                 module.getProjectPomsRecursive(projectPoms);


### PR DESCRIPTION

Apparently some strange poms will provide a relativePath to their parent in the maven local directory. No idea why someone would do that when that's already where maven will look even if you don't tell it to.

Also added a test utility to write test poms to maven local., since there's no easy way to tell the test framework not to treat a pom like it's in the same repository as other code under test.

- Fix issue #6113
