### PR TITLE
Fix NPE and NoSuchMethodError

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/format/WrapMethodChains.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/WrapMethodChains.java
@@ -41,34 +41,38 @@ public class WrapMethodChains<P> extends JavaIsoVisitor<P> {
     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, P ctx) {
         J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
 
-        // This is nullable for backwards compatibility
-        if (style.getChainedMethodCalls() != null && style.getChainedMethodCalls().getWrap() == LineWrapSetting.WrapAlways) {
-            List<MethodMatcher> matchers = style.getChainedMethodCalls().getBuilderMethods().stream()
-                    .map(name -> String.format("*..* %s(..)", name))
-                    .map(MethodMatcher::new)
-                    .collect(toList());
-            J.MethodInvocation chainStarter = findChainStarterInChain(m, matchers);
-            // If there is no chain starter in the chain, or the current method is the actual chain starter call (current chain starter call does not need newline)
-            if (chainStarter == null || chainStarter == m) {
-                return m;
-            }
+        try {
+            // TODO: This is nullable for backwards compatibility of lst styles. Remove this null-check in a future release.
+            if (style.getChainedMethodCalls() != null && style.getChainedMethodCalls().getWrap() == LineWrapSetting.WrapAlways) {
+                List<MethodMatcher> matchers = style.getChainedMethodCalls().getBuilderMethods().stream()
+                        .map(name -> String.format("*..* %s(..)", name))
+                        .map(MethodMatcher::new)
+                        .collect(toList());
+                J.MethodInvocation chainStarter = findChainStarterInChain(m, matchers);
+                // If there is no chain starter in the chain, or the current method is the actual chain starter call (current chain starter call does not need newline)
+                if (chainStarter == null || chainStarter == m) {
+                    return m;
+                }
 
-            Space after = m.getPadding().getSelect().getAfter();
-            //Already on a new line
-            if (after.getLastWhitespace().contains("\n")) {
-                return m;
-            }
+                Space after = m.getPadding().getSelect().getAfter();
+                //Already on a new line
+                if (after.getLastWhitespace().contains("\n")) {
+                    return m;
+                }
 
-            //Only update the whitespace, preserving comments
-            if (after.getComments().isEmpty()) {
-                after = after.withWhitespace("\n");
-            } else {
-                after = after.withComments(ListUtils.mapLast(after.getComments(), comment -> comment.withSuffix("\n")));
+                //Only update the whitespace, preserving comments
+                if (after.getComments().isEmpty()) {
+                    after = after.withWhitespace("\n");
+                } else {
+                    after = after.withComments(ListUtils.mapLast(after.getComments(), comment -> comment.withSuffix("\n")));
+                }
+                if (after != m.getPadding().getSelect().getAfter()) {
+                    m = m.getPadding().withSelect(m.getPadding().getSelect().withAfter(after))
+                            .withArguments(ListUtils.map(m.getArguments(), arg -> arg.withPrefix(Space.EMPTY)));
+                }
             }
-            if (after != m.getPadding().getSelect().getAfter()) {
-                m = m.getPadding().withSelect(m.getPadding().getSelect().withAfter(after))
-                        .withArguments(ListUtils.map(m.getArguments(), arg -> arg.withPrefix(Space.EMPTY)));
-            }
+        } catch (NoSuchMethodError ignore) {
+            // TODO: This can happen in older versions of the runtime (parent-first loaded). Remove this try/catch in a future release.
         }
 
         return m;


### PR DESCRIPTION
Older lsts might have style attached without this newly introduced style.
Older runtime versions might have have not have the getter on the style in their runtime. (parent-first loading)


This version ran fine against lsts using an older runtime that threw NoSuchMethod and on newer runtime.