### PR TITLE
Make sure core modules are preloaded

### DIFF
--- a/rewrite-javascript/rewrite/src/rpc/request/install-recipes.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/install-recipes.ts
@@ -118,7 +118,11 @@ export class InstallRecipes {
 
                     let recipeModule;
                     try {
-                        setupSharedDependencies(resolvedPath);
+                        // Pre-load core modules that are used by recipes but loaded lazily
+                        // This ensures they're in require.cache before setupSharedDependencies runs
+                        preloadCoreModules(logger);
+
+                        setupSharedDependencies(resolvedPath, logger);
                         recipeModule = require(resolvedPath);
                     } catch (e: any) {
                         throw new Error(`Failed to load recipe module from ${resolvedPath}: ${e.stack}`);
@@ -143,37 +147,136 @@ export class InstallRecipes {
 }
 
 /**
+ * Pre-loads core modules that are typically loaded lazily by recipes.
+ * This ensures they're in require.cache before setupSharedDependencies runs,
+ * so they can be properly mapped to avoid instanceof failures.
+ */
+function preloadCoreModules(logger?: rpc.Logger) {
+    const modulesToPreload = [
+        '../..',
+        '../../java',
+        '../../javascript',
+        '../../json',
+        '../../rpc',
+        '../../search',
+        '../../text',
+    ];
+
+    modulesToPreload.forEach(modulePath => {
+        try {
+            require(modulePath);
+            if (logger) {
+                logger.info(`[preloadCoreModules] Loaded ${modulePath}`);
+            }
+        } catch (e) {
+            if (logger) {
+                logger.warn(`[preloadCoreModules] Failed to load ${modulePath}: ${e}`);
+            }
+        }
+    });
+}
+
+/**
  * Ensures dynamically loaded modules share the same class instances as the host
  * by mapping require.cache entries. This prevents instanceof failures when the
  * same package is installed in multiple node_modules directories.
  */
-function setupSharedDependencies(targetModulePath: string) {
+function setupSharedDependencies(targetModulePath: string, logger?: rpc.Logger) {
     const sharedDeps = ['@openrewrite/rewrite', 'vscode-jsonrpc'];
     const targetDir = path.dirname(targetModulePath);
 
     sharedDeps.forEach(depName => {
-        const depPattern = path.sep + 'node_modules' + path.sep + depName.replace('/', path.sep);
+        try {
+            // Step 1: Find where this package is currently loaded from (host)
+            const hostPackageEntry = require.resolve(depName);
 
-        for (const cachedPath of Object.keys(require.cache)) {
-            if (!cachedPath.includes(depPattern)) continue;
+            // Step 2: Find the package root by looking for package.json
+            let hostPackageRoot = path.dirname(hostPackageEntry);
+            while (hostPackageRoot !== path.dirname(hostPackageRoot)) {
+                const packageJsonPath = path.join(hostPackageRoot, 'package.json');
+                if (fs.existsSync(packageJsonPath)) {
+                    try {
+                        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+                        if (pkg.name === depName) {
+                            break; // Found the package root
+                        }
+                    } catch (e) {
+                        // Not a valid package.json, continue
+                    }
+                }
+                hostPackageRoot = path.dirname(hostPackageRoot);
+            }
 
-            try {
-                // Extract subpath: /path/node_modules/@pkg/dist/tree.js -> dist/tree.js
-                const pkgIndex = cachedPath.indexOf(depPattern);
-                let subpath = cachedPath.substring(pkgIndex + depPattern.length)
-                    .replace(/^[/\\]/, '')           // Remove leading slash
-                    .replace(/\.(js|ts)$/, '')        // Remove extension
-                    .replace(/^dist[/\\]/, '')        // Remove dist/ prefix if present
-                    .replace(/[/\\]index$/, '');      // Remove /index suffix
+            if (logger) {
+                logger.info(`[setupSharedDependencies] Host package root for ${depName}: ${hostPackageRoot}`);
+            }
 
-                // Build require path: @pkg or @pkg/subpath
-                const requirePath = subpath ? `${depName}/${subpath}` : depName;
+            // Step 3: Find where the target's node_modules has this package
+            // We explicitly look in node_modules to avoid finding npm-linked global packages
+            let targetPackageRoot: string | undefined;
 
-                // Resolve from target's perspective and map cache
-                const targetDepPath = require.resolve(requirePath, {paths: [targetDir]});
-                require.cache[targetDepPath] = require.cache[cachedPath];
-            } catch (e) {
-                // Target can't resolve this path, skip
+            // Walk up from targetDir looking for node_modules containing this package
+            let searchDir = targetDir;
+            while (searchDir !== path.dirname(searchDir)) {
+                const nodeModulesPath = path.join(searchDir, 'node_modules', ...depName.split('/'));
+                if (fs.existsSync(nodeModulesPath)) {
+                    const packageJsonPath = path.join(nodeModulesPath, 'package.json');
+                    if (fs.existsSync(packageJsonPath)) {
+                        try {
+                            const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+                            if (pkg.name === depName) {
+                                targetPackageRoot = nodeModulesPath;
+                                break;
+                            }
+                        } catch (e) {
+                            // Not a valid package.json, continue
+                        }
+                    }
+                }
+                searchDir = path.dirname(searchDir);
+            }
+
+            if (!targetPackageRoot) {
+                if (logger) {
+                    logger.warn(`[setupSharedDependencies] Could not find ${depName} in target's node_modules`);
+                }
+                return; // Can't map this package
+            }
+
+            if (logger) {
+                logger.info(`[setupSharedDependencies] Target package root for ${depName}: ${targetPackageRoot}`);
+            }
+
+            // If they're the same, no mapping needed
+            if (hostPackageRoot === targetPackageRoot) {
+                if (logger) {
+                    logger.info(`[setupSharedDependencies] Same package root, no mapping needed for ${depName}`);
+                }
+                return;
+            }
+
+            // Step 4: Map all cached modules from host package to target package
+            const hostPrefix = hostPackageRoot + path.sep;
+
+            let mappedCount = 0;
+            for (const cachedPath of Object.keys(require.cache)) {
+                if (cachedPath.startsWith(hostPrefix)) {
+                    // This module belongs to the host package
+                    const relativePath = cachedPath.substring(hostPrefix.length);
+                    const targetPath = path.join(targetPackageRoot, relativePath);
+
+                    // Map the target path to use the host's cached module
+                    require.cache[targetPath] = require.cache[cachedPath];
+                    mappedCount++;
+                }
+            }
+
+            if (logger) {
+                logger.info(`[setupSharedDependencies] Mapped ${mappedCount} modules for ${depName}`);
+            }
+        } catch (e) {
+            if (logger) {
+                logger.error(`[setupSharedDependencies] Failed to setup ${depName}: ${e}`);
             }
         }
     });


### PR DESCRIPTION
So that core modules get correctly mapped when an installed recipe depends upon them, we need to first preload them during recipe installation.

Also, make sure that module mapping works correctly, regardless of whether the server was started using a globally installed `rewrite-rpc` script, a specific package version using `--package`, or the file system path to the compiled `server.js` script.
