### PR TITLE
Add Named Capture Support to JavaScript Templating API

### DIFF
--- a/rewrite-javascript/rewrite/test/javascript/templating/replace.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/replace.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {fromVisitor, RecipeSpec} from "../../../src/test";
-import {JavaScriptVisitor, template, typescript} from "../../../src/javascript";
+import {capture, JavaScriptVisitor, template, typescript} from "../../../src/javascript";
 import {Expression, J} from "../../../src/java";
 import {produce} from "immer";
 import {produceAsync} from "../../../src";
@@ -95,6 +95,85 @@ describe('template2 replace', () => {
         return spec.rewriteRun(
             //language=typescript
             typescript('(1 + 2) == 3', '3 == 3'),
+        );
+    });
+
+    test('late binding with capture', () => {
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitLiteral(literal: J.Literal, p: any): Promise<J | undefined> {
+                if (literal.valueSource === '1') {
+                    // Create a replacement value
+                    const replacement = produce(literal, draft => {
+                        draft.value = 42;
+                        draft.valueSource = '42';
+                    });
+
+                    // Use capture for late binding - myValue capture is looked up in the values map
+                    const myValue = capture();
+                    return template`${myValue}`.apply(this.cursor, literal, new Map([[myValue.name, replacement]]));
+                }
+                return literal;
+            }
+        });
+        return spec.rewriteRun(
+            //language=typescript
+            typescript('const a = 1', 'const a = 42'),
+        );
+    });
+
+    test('literal string insertion', () => {
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitLiteral(literal: J.Literal, p: any): Promise<J | undefined> {
+                if (literal.valueSource === '1') {
+                    // Strings are inserted literally into the template
+                    return template`${'myValue'}`.apply(this.cursor, literal);
+                }
+                return literal;
+            }
+        });
+        return spec.rewriteRun(
+            //language=typescript
+            typescript('const a = 1', 'const a = myValue'),
+        );
+    });
+
+    test('capture mixed with literal strings', () => {
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitLiteral(literal: J.Literal, p: any): Promise<J | undefined> {
+                if (literal.valueSource === '1') {
+                    // Create a replacement value
+                    const replacement = produce(literal, draft => {
+                        draft.value = 10;
+                        draft.valueSource = '10';
+                    });
+
+                    // Mix capture (late binding) with literal string insertion
+                    const x = capture();
+                    return template`${x} + ${'y'}`.apply(this.cursor, literal, new Map([[x.name, replacement]]));
+                }
+                return literal;
+            }
+        });
+        return spec.rewriteRun(
+            //language=typescript
+            typescript('const a = 1', 'const a = 10 + y'),
+        );
+    });
+
+    test('literal string for identifier', () => {
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitLiteral(literal: J.Literal, p: any): Promise<J | undefined> {
+                if (literal.valueSource === '1') {
+                    // Simulate the instanceof example - type is just a string
+                    const type = 'Date';
+                    return template`${literal} instanceof ${type}`.apply(this.cursor, literal);
+                }
+                return literal;
+            }
+        });
+        return spec.rewriteRun(
+            //language=typescript
+            typescript('const a = 1', 'const a = 1 instanceof Date'),
         );
     });
 });

--- a/rewrite-javascript/rewrite/test/javascript/templating/unnamed-capture.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/unnamed-capture.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {fromVisitor, RecipeSpec} from "../../../src/test";
-import {JavaScriptVisitor, pattern, rewrite, template, typescript} from "../../../src/javascript";
+import {capture, JavaScriptVisitor, pattern, rewrite, template, typescript} from "../../../src/javascript";
 import {Expression, J} from "../../../src/java";
 
 describe('unnamed capture', () => {
@@ -25,11 +25,14 @@ describe('unnamed capture', () => {
         spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
 
             protected override async visitExpression(expr: Expression, p: any): Promise<J | undefined> {
-                //language=typescript
-                let m = await pattern`${"left"} + ${"right"}`.match(expr) ||
-                    await pattern`${"left"} * ${"right"}`.match(expr);
+                const left = capture();
+                const right = capture();
 
-                return m && await template`${"right"} + ${"left"}`.apply(this.cursor, expr, m) || expr;
+                //language=typescript
+                let m = await pattern`${left} + ${right}`.match(expr) ||
+                    await pattern`${left} * ${right}`.match(expr);
+
+                return m && await template`${right} + ${left}`.apply(this.cursor, expr, m) || expr;
             }
         });
 
@@ -47,14 +50,17 @@ describe('unnamed capture', () => {
 
         spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
             override async visitTernary(ternary: J.Ternary, p: any): Promise<J | undefined> {
+                const obj = capture();
+                const property = capture();
+                const defaultValue = capture();
 
                 //language=typescript
                 return await rewrite(() => ({
                     before: [
-                        pattern`${"obj"} === null || ${"obj"} === undefined ? ${"defaultValue"} : ${"obj"}.${"property"}`,
-                        pattern`${"obj"} === undefined || ${"obj"} === null ? ${"defaultValue"} : ${"obj"}.${"property"}`
+                        pattern`${obj} === null || ${obj} === undefined ? ${defaultValue} : ${obj}.${property}`,
+                        pattern`${obj} === undefined || ${obj} === null ? ${defaultValue} : ${obj}.${property}`
                     ],
-                    after: template`${"obj"}?.${"property"} ?? ${"defaultValue"}`
+                    after: template`${obj}?.${property} ?? ${defaultValue}`
                 }))
                     .tryOn(this.cursor, ternary) || super.visitTernary(ternary, p);
             }


### PR DESCRIPTION
This PR adds support for named captures in the JavaScript templating API, allowing for more concise pattern matching and template generation.

Added optional `name` parameter to the `capture()` function, enabling inline named captures for cleaner rewrite rules.

### Key Changes

#### Named Captures Support

The `capture()` function now accepts an optional name parameter:

```typescript
// Inline named captures (new!)
pattern`${capture('left')} + ${capture('right')}`
template`${capture('right')} + ${capture('left')}`

// Unnamed captures (existing)
const left = capture();
const right = capture();
pattern`${left} + ${right}`
template`${right} + ${left}`
```

### Trade-offs

Slightly more verbose for rewrite rules:

```typescript
rewrite(() => ({
    before: pattern`${capture('left')} + ${capture('right')}`,
    after: template`${capture('right')} + ${capture('left')}`
}))
```

But enables direct literal string insertion:

```typescript
const type = 'Date';
template`${arg} instanceof ${type}`  // Generates: arg instanceof Date
```

This is valuable for common use cases where you want to insert variable code fragments.

### API Behavior

Template parameter types:
- `capture()` objects → Late binding via the values map (for pattern matching)
- Tree nodes → Direct AST substitution
- Strings/numbers/booleans → Inserted literally as code

The explicit `capture()` requirement makes the API more extensible for future enhancements while keeping common literal insertion cases simple.
