### PR TITLE
`HasMethod` and `HasType`, and use of them in JavaScript preconditions

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/HasMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/HasMethod.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.MethodMatcher;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class HasMethod extends Recipe {
+    /**
+     * A method pattern that is used to find matching method invocations.
+     * See {@link MethodMatcher} for details on the expression's syntax.
+     */
+    @Option(displayName = "Method pattern",
+            description = MethodMatcher.METHOD_PATTERN_INVOCATIONS_DESCRIPTION,
+            example = "java.util.List add(..)")
+    String methodPattern;
+
+    @Option(displayName = "Match on overrides",
+            description = "When enabled, find methods that are overrides of the method pattern.",
+            required = false)
+    @Nullable
+    Boolean matchOverrides;
+
+    @Override
+    public String getDisplayName() {
+        return "Find files that have at least one use of a method";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Marks files that have at least one occurrence of a method matching a pattern.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new UsesMethod<>(methodPattern, matchOverrides);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/HasType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/HasType.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class HasType extends Recipe {
+    @Option(displayName = "Fully-qualified type name",
+            description = "A fully-qualified type name, that is used to find matching type references. " +
+                          "Supports glob expressions. `java..*` finds every type from every subpackage of the `java` package.",
+            example = "java.util.List")
+    String fullyQualifiedTypeName;
+
+    @Option(displayName = "Check for assignability",
+            description = "When enabled, find type references that are assignable to the provided type.",
+            required = false)
+    @Nullable
+    Boolean checkAssignability;
+
+    @Override
+    public String getDisplayName() {
+        return "Find files that have at least one use of a type";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Marks files that have at least one occurrence of a type, even if the " +
+               "name of that type doesn't appear in the source code.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new UsesType<>(fullyQualifiedTypeName, checkAssignability);
+    }
+}

--- a/rewrite-javascript/rewrite/src/javascript/preconditions.ts
+++ b/rewrite-javascript/rewrite/src/javascript/preconditions.ts
@@ -27,14 +27,14 @@ export function hasSourcePath(filePattern: string): Promise<RpcRecipe> | TreeVis
 }
 
 export function usesMethod(methodPattern: string, matchOverrides: boolean = false): Promise<RpcRecipe> | TreeVisitor<any, ExecutionContext> {
-    return RewriteRpc.get() ? RewriteRpc.get()!.prepareRecipe("org.openrewrite.java.search.FindMethods", {
+    return RewriteRpc.get() ? RewriteRpc.get()!.prepareRecipe("org.openrewrite.java.search.HasMethod", {
         methodPattern,
         matchOverrides
     }) : new UsesMethod(methodPattern);
 }
 
 export function usesType(fullyQualifiedType: string): Promise<RpcRecipe> | TreeVisitor<any, ExecutionContext> {
-    return RewriteRpc.get() ? RewriteRpc.get()!.prepareRecipe("org.openrewrite.java.search.FindTypes", {
+    return RewriteRpc.get() ? RewriteRpc.get()!.prepareRecipe("org.openrewrite.java.search.HasType", {
         fullyQualifiedType,
         checkAssignability: false
     }) : new UsesType(fullyQualifiedType);


### PR DESCRIPTION
## What's changed?

Added a couple new recipes that are designed for use in preconditions in JavaScript recipes.

## What's your motivation?
`FindMethods` and `FindTypes` produce data tables that require printing the found code, which in some respects negates the performance benefit of evaluating the precondition on the Java side in the first place.
