### PR TITLE
RPC: Treat changed object type as ADD

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcReceiveQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcReceiveQueue.java
@@ -131,11 +131,11 @@ public class RpcReceiveQueue {
 
                 // TODO handle enums here
 
-                RpcCodec<T> rpcCodec;
+                RpcCodec<T> codec;
                 if (onChange != null) {
                     after = onChange.apply(before);
-                } else if (before != null && (rpcCodec = RpcCodec.forInstance(before, sourceFileType)) != null) {
-                    after = rpcCodec.rpcReceive(before, this);
+                } else if (before != null && (codec = RpcCodec.forInstance(before, sourceFileType)) != null) {
+                    after = codec.rpcReceive(before, this);
                 } else if (message.getValueType() == null) {
                     after = message.getValue();
                 } else {

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RpcReceiveQueueTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RpcReceiveQueueTest.java
@@ -17,6 +17,8 @@ package org.openrewrite.rpc;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Checksum;
+import org.openrewrite.FileAttributes;
 import org.openrewrite.Tree;
 import org.openrewrite.text.PlainText;
 
@@ -86,6 +88,22 @@ public class RpcReceiveQueueTest {
 
         assertThat(after).isEqualTo(newId);
         assertThat(after.getId()).isEqualTo(newId.getId());
+    }
+
+    @Test
+    void changePropertyType() {
+        // Test changing a property from FileAttributes to Checksum
+        // This simulates a recipe that changes the type of an object assigned to a property
+        FileAttributes beforeAttr = new FileAttributes(null, null, null, true, true, false, 100);
+        Checksum afterChecksum = new Checksum("SHA-256", new byte[]{1, 2, 3});
+
+        sq.send(afterChecksum, beforeAttr, null);
+        assertThat(batches).isNotEmpty();
+
+        Object received = rq.receive(beforeAttr);
+
+        assertThat(received).isInstanceOf(Checksum.class);
+        assertThat(((Checksum) received).getAlgorithm()).isEqualTo("SHA-256");
     }
 
     private List<RpcObjectData> encode(List<RpcObjectData> batch) {

--- a/rewrite-javascript/rewrite/test/rpc/queue.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/queue.test.ts
@@ -1,5 +1,5 @@
 import {Json} from "../../src/json";
-import {asRef} from "../../src/rpc";
+import {asRef, ReferenceMap, RpcReceiveQueue, RpcSendQueue} from "../../src/rpc";
 
 describe("RPC queues", () => {
 
@@ -16,4 +16,38 @@ describe("RPC queues", () => {
         refs.set(ref1, 1);
         expect(refs.has(ref2)).toBeTruthy();
     })
+
+    test("changePropertyType", async () => {
+        // Test changing a property from one type to another type
+        // This simulates a recipe that changes the type of an object assigned to a property
+
+        // Create a wrapper object with a property that changes type
+        interface Wrapper {
+            id: string;
+            value: any; // This property will change from Literal to Identifier
+        }
+
+        const beforeWrapper: Wrapper = {
+            id: "test",
+            value: {kind: Json.Kind.Literal, value: "old-value"}
+        };
+
+        const afterWrapper: Wrapper = {
+            id: "test",
+            value: {kind: Json.Kind.Identifier, name: "new-name"}
+        };
+
+        const sq = new RpcSendQueue(new ReferenceMap(), Json.Kind.Document, false);
+        const batch = await sq.generate(afterWrapper, beforeWrapper);
+        expect(batch.length).toBeGreaterThan(0);
+
+        const rq = new RpcReceiveQueue(new Map(), undefined, async () => batch, undefined, false);
+        const received = await rq.receive(beforeWrapper) as Wrapper;
+
+        // Verify the wrapper's id stayed the same
+        expect(received.id).toBe("test");
+        // Verify the property changed from Literal to Identifier
+        expect(received.value.kind).toBe(Json.Kind.Identifier);
+        expect(received.value.kind).not.toBe(beforeWrapper.value.kind);
+    });
 });


### PR DESCRIPTION
When diffing the object graphs and serializing this to a stream of `RpcObjectData` objects, the case of an object with a changed type wasn't handled. So if, for example, a `Json.Literal` is replaced by a `Json.Identifier`, this needs special handling, as otherwise the diff will fail on the receiver side.

The solution is to send an `ADD` event rather than a `CHANGE` event.
