### PR TITLE
Prevent leaking of the rewrite-js RPC process

### DIFF
--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -49,11 +49,13 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
      */
     private final String command;
     private final Map<String, String> commandEnv;
+    private final RewriteRpcProcess process;
 
-    JavaScriptRewriteRpc(JsonRpc jsonRpc, Environment marketplace, String command, Map<String, String> commandEnv) {
-        super(jsonRpc, marketplace);
+    JavaScriptRewriteRpc(RewriteRpcProcess process, Environment marketplace, String command, Map<String, String> commandEnv) {
+        super(process.getRpcClient(), marketplace);
         this.command = command;
         this.commandEnv = commandEnv;
+        this.process = process;
     }
 
     public static @Nullable JavaScriptRewriteRpc get() {
@@ -66,6 +68,12 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
 
     public static void setFactory(Builder builder) {
         MANAGER.setFactory(builder);
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        process.shutdown();
     }
 
     public static void shutdownCurrent() {
@@ -283,7 +291,7 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
             process.start();
 
             try {
-                return (JavaScriptRewriteRpc) new JavaScriptRewriteRpc(process.getRpcClient(), marketplace,
+                return (JavaScriptRewriteRpc) new JavaScriptRewriteRpc(process, marketplace,
                         String.join(" ", cmdArr), process.environment())
                         .livenessCheck(process::getLivenessCheck)
                         .timeout(timeout)


### PR DESCRIPTION
## What's changed?
Prevent leaking of the rewrite-js RPC process

## What's your motivation?
The more rewrite-js RPC tasks that are needed during a process will result in many processes sticking around that aren't necessary.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
Anybody

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
