### PR TITLE
JavaScript: Allow incomplete `\x` hex escape sequences

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
@@ -112,10 +112,10 @@ public class RemoveImport<P> extends JavaIsoVisitor<P> {
             JavaSourceFile c = cu;
 
             boolean keepImport = !force && (typeUsed || !otherTypesInPackageUsed.isEmpty() && type.endsWith(".*"));
-            AtomicReference<Space> spaceForNextImport = new AtomicReference<>();
+            AtomicReference<@Nullable Space> spaceForNextImport = new AtomicReference<>();
             c = c.withImports(ListUtils.flatMap(c.getImports(), import_ -> {
-                if (spaceForNextImport.get() != null) {
-                    Space removedPrefix = spaceForNextImport.get();
+                Space removedPrefix = spaceForNextImport.get();
+                if (removedPrefix != null) {
                     Space currentPrefix = import_.getPrefix();
                     if (removedPrefix.getLastWhitespace().isEmpty() ||
                         (countTrailingLinebreaks(removedPrefix) > countTrailingLinebreaks(currentPrefix))) {

--- a/rewrite-javascript/rewrite/src/index.ts
+++ b/rewrite-javascript/rewrite/src/index.ts
@@ -36,9 +36,10 @@ export * from "./run";
 // register all recipes in this package
 export async function activate(registry: RecipeRegistry): Promise<void> {
     const {OrderImports} = await import("./recipe/index.js");
-    const {ModernizeOctalLiterals} = await import("./javascript/migrate/es6/index.js");
+    const {ModernizeOctalLiterals, RemoveDuplicateObjectKeys} = await import("./javascript/migrate/es6/index.js");
     registry.register(OrderImports);
     registry.register(ModernizeOctalLiterals);
+    registry.register(RemoveDuplicateObjectKeys);
 }
 
 RpcCodecs.registerCodec(MarkersKind.ParseExceptionResult, {

--- a/rewrite-javascript/rewrite/src/java/formatting-utils.ts
+++ b/rewrite-javascript/rewrite/src/java/formatting-utils.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {J} from "../java";
+import {produce} from "immer";
+
+/**
+ * Applies the prefix from a removed element to the next element.
+ *
+ * This is used when removing elements from a list to preserve formatting:
+ * - If the next element has no comments (or only an inline trailing comment to remove),
+ *   uses the removed element's prefix whitespace
+ * - If the next element has comments to preserve, keeps the next element's whitespace
+ *   to maintain proper spacing (e.g., blank lines before comments)
+ * - Removes inline line comments (//...) that were on the removed element's line
+ *
+ * @param removedElement The element that was removed
+ * @param nextElement The element that follows the removed one
+ * @returns The next element with adjusted prefix, or the original if no changes needed
+ */
+export function applyRemovedElementPrefix<T extends J>(removedElement: J, nextElement: T): T {
+    if (!removedElement.prefix || !nextElement.prefix) {
+        return nextElement;
+    }
+
+    const removedPrefix = removedElement.prefix;
+    const currentPrefix = nextElement.prefix;
+    const currentComments = currentPrefix.comments || [];
+
+    // If the next element has no comments, just use the removed element's prefix entirely
+    if (currentComments.length === 0) {
+        if (currentPrefix === removedPrefix) {
+            return nextElement;
+        }
+        return produce(nextElement, draft => {
+            draft.prefix = removedPrefix;
+        });
+    }
+
+    // The next element has comments - check if we need to remove inline line comments
+    const currentWhitespace = currentPrefix.whitespace || '';
+    const hasLeadingNewline = /[\r\n]/.test(currentWhitespace);
+
+    let commentsToKeep = currentComments;
+    if (!hasLeadingNewline && currentComments.length > 0) {
+        // First comment has no leading newline - check if it's an inline line comment
+        const firstComment: any = currentComments[0];
+        const commentText = firstComment.text || firstComment.message || '';
+        const isLineComment = commentText.includes('//') || firstComment.multiline === false;
+
+        if (isLineComment) {
+            // Remove the inline line comment
+            commentsToKeep = currentComments.slice(1);
+        }
+    }
+
+    // If we still have comments after filtering, use removed element's whitespace with filtered comments
+    if (commentsToKeep.length > 0) {
+        return produce(nextElement, draft => {
+            draft.prefix = {
+                ...removedPrefix,
+                comments: commentsToKeep
+            };
+        });
+    }
+
+    // No comments left after filtering, use removed element's prefix entirely
+    return produce(nextElement, draft => {
+        draft.prefix = removedPrefix;
+    });
+}

--- a/rewrite-javascript/rewrite/src/javascript/migrate/es6/index.ts
+++ b/rewrite-javascript/rewrite/src/javascript/migrate/es6/index.ts
@@ -15,3 +15,4 @@
  */
 
 export {ModernizeOctalLiterals} from "./modernize-octal-literals";
+export {RemoveDuplicateObjectKeys} from "./remove-duplicate-object-keys";

--- a/rewrite-javascript/rewrite/src/javascript/migrate/es6/modernize-octal-literals.ts
+++ b/rewrite-javascript/rewrite/src/javascript/migrate/es6/modernize-octal-literals.ts
@@ -29,7 +29,7 @@ export class ModernizeOctalLiterals extends Recipe {
     async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
         return new class extends JavaScriptVisitor<ExecutionContext> {
 
-            protected async visitLiteral(literal: J.Literal, p: ExecutionContext): Promise<J | undefined> {
+            protected async visitLiteral(literal: J.Literal, _ctx: ExecutionContext): Promise<J | undefined> {
                 // Only process numeric literals
                 if (typeof literal.value !== 'number') {
                     return literal;

--- a/rewrite-javascript/rewrite/src/javascript/migrate/es6/remove-duplicate-object-keys.ts
+++ b/rewrite-javascript/rewrite/src/javascript/migrate/es6/remove-duplicate-object-keys.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Recipe} from "../../../recipe";
+import {TreeVisitor} from "../../../visitor";
+import {ExecutionContext} from "../../../execution";
+import {JavaScriptVisitor} from "../../visitor";
+import {J} from "../../../java";
+import {JS} from "../../tree";
+import {produce} from "immer";
+import {applyRemovedElementPrefix} from "../../../java/formatting-utils";
+
+export class RemoveDuplicateObjectKeys extends Recipe {
+    name = "org.openrewrite.javascript.migrate.es6.remove-duplicate-object-keys";
+    displayName = "Remove duplicate object keys";
+    description = "Remove duplicate keys in object literals, keeping only the last occurrence (last-wins semantics).";
+
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
+        return new class extends JavaScriptVisitor<ExecutionContext> {
+
+            protected async visitNewClass(newClass: J.NewClass, ctx: ExecutionContext): Promise<J | undefined> {
+                newClass = await super.visitNewClass(newClass, ctx) as J.NewClass;
+
+                // Only process object literals (NewClass with body but no class or arguments)
+                if (!newClass.body || newClass.class || (newClass.arguments?.elements && newClass.arguments.elements.length > 0)) {
+                    return newClass;
+                }
+
+                const statements = newClass.body.statements;
+                if (!statements || statements.length === 0) {
+                    return newClass;
+                }
+
+                // Build a map of property names to their last occurrence index
+                const propertyNameToLastIndex = new Map<string, number>();
+                const propertyNames: (string | null)[] = [];
+
+                for (let i = 0; i < statements.length; i++) {
+                    const stmt = statements[i];
+                    if (stmt.element.kind === JS.Kind.PropertyAssignment) {
+                        const prop = stmt.element as JS.PropertyAssignment;
+                        const propName = this.getPropertyName(prop);
+                        propertyNames.push(propName);
+
+                        if (propName !== null) {
+                            propertyNameToLastIndex.set(propName, i);
+                        }
+                    } else {
+                        propertyNames.push(null);
+                    }
+                }
+
+                // Check if there are any duplicates to remove
+                const indicesToRemove = new Set<number>();
+                for (let i = 0; i < propertyNames.length; i++) {
+                    const propName = propertyNames[i];
+                    if (propName !== null) {
+                        const lastIndex = propertyNameToLastIndex.get(propName)!;
+                        if (i < lastIndex) {
+                            indicesToRemove.add(i);
+                        }
+                    }
+                }
+
+                if (indicesToRemove.size === 0) {
+                    return newClass;
+                }
+
+                // Remove duplicate properties and adjust prefixes
+                return produce(newClass, draft => {
+                    const filteredStatements: typeof statements = [];
+                    let removedElement: J | undefined = undefined;
+
+                    for (let i = 0; i < statements.length; i++) {
+                        if (indicesToRemove.has(i)) {
+                            // Track the first removed element
+                            if (!removedElement && statements[i].element) {
+                                removedElement = statements[i].element;
+                            }
+                            continue;
+                        }
+
+                        const stmt = statements[i];
+
+                        // If we removed previous elements, apply the removed element's prefix to this one
+                        if (removedElement) {
+                            const adjustedElement = applyRemovedElementPrefix(removedElement, stmt.element);
+                            filteredStatements.push({
+                                ...stmt,
+                                element: adjustedElement
+                            });
+                            removedElement = undefined;
+                        } else {
+                            filteredStatements.push(stmt);
+                        }
+                    }
+
+                    draft.body!.statements = filteredStatements;
+                });
+            }
+
+            private getPropertyName(prop: JS.PropertyAssignment): string | null {
+                const name = prop.name.element;
+
+                // Handle identifier: { foo: 1 }
+                if (name.kind === J.Kind.Identifier) {
+                    return (name as J.Identifier).simpleName;
+                }
+
+                // Handle string literal: { "foo": 1 }
+                if (name.kind === J.Kind.Literal) {
+                    const literal = name as J.Literal;
+                    if (typeof literal.value === 'string') {
+                        return literal.value;
+                    }
+                }
+
+                // For computed properties { [expr]: 1 }, we can't statically determine the name
+                // So we return null and don't consider them for deduplication
+                return null;
+            }
+        }
+    }
+}

--- a/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
@@ -355,7 +355,7 @@ export function checkSyntaxErrors(program: ts.Program, sourceFile: ts.SourceFile
     // checking Parsing and Syntax Errors
     let syntaxErrors : [errorMsg: string, errorCode: number][] = [];
     if (diagnostics.length > 0) {
-        const errors = diagnostics.filter(d =>  (d.category === ts.DiagnosticCategory.Error) && isCriticalDiagnostic(d.code));
+        const errors = diagnostics.filter(d =>  (d.category === ts.DiagnosticCategory.Error) && isCriticalDiagnostic(d.code, sourceFile));
         if (errors.length > 0) {
             syntaxErrors = errors.map(e => {
                 let errorMsg;
@@ -385,10 +385,9 @@ const additionalCriticalCodes = new Set([
 const excludedCodes = new Set([
     1039, // Initializers are not allowed in ambient contexts.
     1064, // The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<{0}>'?
-    1101, // 'with' statements are not allowed in strict mode.
     1107, // Jump target cannot cross function boundary.
     1111, // Private field '{0}' must be declared in an enclosing class.
-    1121, // Octal literals are not allowed. Use the syntax '{0}'.
+    1117, // An object literal cannot have multiple properties with the same name.
     1155, // '{0}' declarations must be initialized.
     1166, // A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
     1170, // A computed property name in a type literal must refer to an expression whose type is a literal type or a 'unique symbol' type.
@@ -424,7 +423,25 @@ const excludedCodes = new Set([
     1432, // Top-level 'for await' loops are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
 ]);
 
-function isCriticalDiagnostic(code: number): boolean {
+// Errors to exclude only for JavaScript files (.js, .jsx, .mjs, .cjs)
+// TypeScript files (.ts, .tsx, .mts, .cts) should still report these as errors
+const jsOnlyExcludedCodes = new Set([
+    1101, // 'with' statements are not allowed in strict mode.
+    1121, // Octal literals are not allowed. Use the syntax '{0}'.
+    1125, // Hexadecimal digit expected.
+]);
+
+function isCriticalDiagnostic(code: number, sourceFile: ts.SourceFile): boolean {
+    // Check if this error should be excluded for JavaScript files
+    if (jsOnlyExcludedCodes.has(code)) {
+        const fileName = sourceFile.fileName.toLowerCase();
+        const isJavaScript = fileName.endsWith('.js') || fileName.endsWith('.jsx') ||
+                           fileName.endsWith('.mjs') || fileName.endsWith('.cjs');
+        if (isJavaScript) {
+            return false; // Not critical for JS files
+        }
+    }
+
     return (code > 1000 && code < 2000 && !excludedCodes.has(code)) || additionalCriticalCodes.has(code);
 }
 

--- a/rewrite-javascript/rewrite/test/javascript/migrate/es6/modernize-octal-literals.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/migrate/es6/modernize-octal-literals.test.ts
@@ -1,4 +1,4 @@
-// noinspection TypeScriptUnresolvedReference,JSOctalInteger,JSUnusedLocalSymbols
+// noinspection TypeScriptUnresolvedReference,JSUnusedLocalSymbols
 
 /*
  * Copyright 2025 the original author or authors.
@@ -18,7 +18,7 @@
 import {describe} from "@jest/globals";
 import {RecipeSpec} from "../../../../src/test";
 import {ModernizeOctalLiterals} from "../../../../src/javascript/migrate/es6/modernize-octal-literals";
-import {typescript} from "../../../../src/javascript";
+import {javascript} from "../../../../src/javascript";
 
 describe("modernize-octal-literals", () => {
     const spec = new RecipeSpec()
@@ -26,8 +26,8 @@ describe("modernize-octal-literals", () => {
 
     test("convert octal literal", () => {
         return spec.rewriteRun(
-            //language=typescript
-            typescript(
+            //language=javascript
+            javascript(
                 `const permissions = 0777;`,
                 `const permissions = 0o777;`
             )
@@ -36,8 +36,8 @@ describe("modernize-octal-literals", () => {
 
     test("convert multiple octal literals", () => {
         return spec.rewriteRun(
-            //language=typescript
-            typescript(
+            //language=javascript
+            javascript(
                 `
                 const permissions = 0777;
                 const readable = 0444;
@@ -54,8 +54,8 @@ describe("modernize-octal-literals", () => {
 
     test("convert various octal literals", () => {
         return spec.rewriteRun(
-            //language=typescript
-            typescript(
+            //language=javascript
+            javascript(
                 `
                 const a = 0755;
                 const b = 0644;
@@ -74,8 +74,8 @@ describe("modernize-octal-literals", () => {
 
     test("do not convert zero", () => {
         return spec.rewriteRun(
-            //language=typescript
-            typescript(
+            //language=javascript
+            javascript(
                 `const zero = 0;`
             )
         )
@@ -83,8 +83,8 @@ describe("modernize-octal-literals", () => {
 
     test("do not convert hexadecimal literals", () => {
         return spec.rewriteRun(
-            //language=typescript
-            typescript(
+            //language=javascript
+            javascript(
                 `const hex = 0xFF;`
             )
         )
@@ -92,8 +92,8 @@ describe("modernize-octal-literals", () => {
 
     test("do not convert binary literals", () => {
         return spec.rewriteRun(
-            //language=typescript
-            typescript(
+            //language=javascript
+            javascript(
                 `const binary = 0b1010;`
             )
         )
@@ -101,8 +101,8 @@ describe("modernize-octal-literals", () => {
 
     test("do not convert modern octal literals", () => {
         return spec.rewriteRun(
-            //language=typescript
-            typescript(
+            //language=javascript
+            javascript(
                 `const modernOctal = 0o777;`
             )
         )
@@ -113,8 +113,8 @@ describe("modernize-octal-literals", () => {
 
     test("convert octal in object literal", () => {
         return spec.rewriteRun(
-            //language=typescript
-            typescript(
+            //language=javascript
+            javascript(
                 `const config = { mode: 0755 };`,
                 `const config = { mode: 0o755 };`
             )
@@ -123,8 +123,8 @@ describe("modernize-octal-literals", () => {
 
     test("convert octal in array", () => {
         return spec.rewriteRun(
-            //language=typescript
-            typescript(
+            //language=javascript
+            javascript(
                 `const modes = [0644, 0755, 0777];`,
                 `const modes = [0o644, 0o755, 0o777];`
             )
@@ -133,8 +133,8 @@ describe("modernize-octal-literals", () => {
 
     test("convert octal in function call", () => {
         return spec.rewriteRun(
-            //language=typescript
-            typescript(
+            //language=javascript
+            javascript(
                 `chmod(file, 0755);`,
                 `chmod(file, 0o755);`
             )

--- a/rewrite-javascript/rewrite/test/javascript/migrate/es6/remove-duplicate-object-keys.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/migrate/es6/remove-duplicate-object-keys.test.ts
@@ -1,0 +1,190 @@
+// noinspection JSUnusedLocalSymbols,JSDuplicatedDeclaration
+
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {describe} from "@jest/globals";
+import {RecipeSpec} from "../../../../src/test";
+import {RemoveDuplicateObjectKeys} from "../../../../src/javascript/migrate/es6/remove-duplicate-object-keys";
+import {typescript} from "../../../../src/javascript";
+
+describe("remove-duplicate-object-keys", () => {
+    const spec = new RecipeSpec()
+    spec.recipe = new RemoveDuplicateObjectKeys();
+
+    test("remove duplicate key (last wins)", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const c = {foo: 1, foo: 2};`,
+                `const c = {foo: 2};`
+            )
+        )
+    })
+
+    test("remove multiple duplicates of same key", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const c = {foo: 1, foo: 2, foo: 3};`,
+                `const c = {foo: 3};`
+            )
+        )
+    })
+
+    test("remove duplicates of different keys", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const c = {foo: 1, bar: 2, foo: 3, bar: 4};`,
+                `const c = {foo: 3, bar: 4};`
+            )
+        )
+    })
+
+    test("keep unique keys", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const c = {foo: 1, bar: 2};`
+            )
+        )
+    })
+
+    test("remove duplicate string keys", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const c = {"foo": 1, "foo": 2};`,
+                `const c = {"foo": 2};`
+            )
+        )
+    })
+
+    test("remove duplicates mixing identifier and string keys", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const c = {foo: 1, "foo": 2};`,
+                `const c = {"foo": 2};`
+            )
+        )
+    })
+
+    test("preserve non-duplicate properties", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const c = {a: 1, b: 2, a: 3, c: 4};`,
+                `const c = {b: 2, a: 3, c: 4};`
+            )
+        )
+    })
+
+    test("do not remove computed properties", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const c = {[key]: 1, [key]: 2};`
+            )
+        )
+    })
+
+    test("handle empty object", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const c = {};`
+            )
+        )
+    })
+
+    test("remove duplicates in nested objects", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const c = {outer: {foo: 1, foo: 2}};`,
+                `const c = {outer: {foo: 2}};`
+            )
+        )
+    })
+
+    test("preserve comments on last occurrence", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const c = {foo: 1, /* comment */ foo: 2};`,
+                `const c = {/* comment */ foo: 2};`
+            )
+        )
+    })
+
+    test("remove inline comment on same line as removed duplicate", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const c = {
+                    foo: 1, // inline comment
+                    bar: 2, foo: 3
+                };`,
+                `const c = {
+                    bar: 2, foo: 3
+                };`
+            )
+        )
+    })
+
+    test("preserve comment on subsequent line after removed duplicate", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const c = {
+                    foo: 1,
+                    // comment about bar
+                    bar: 2,
+                    foo: 3
+                };`,
+                `const c = {
+                    // comment about bar
+                    bar: 2,
+                    foo: 3
+                };`
+            )
+        )
+    })
+
+    test("remove inline comment but preserve block comment on next line", () => {
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `
+                    const c = {
+                        foo: 1, // inline
+                        /* block comment */
+                        bar: 2,
+                        foo: 3
+                    };
+                `,
+                `
+                    const c = {
+                        /* block comment */
+                        bar: 2,
+                        foo: 3
+                    };
+                `
+            )
+        )
+    })
+});

--- a/rewrite-javascript/rewrite/test/javascript/parser/literal.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/literal.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {RecipeSpec} from "../../../src/test";
-import {JS, typescript} from "../../../src/javascript";
+import {JS, typescript, javascript} from "../../../src/javascript";
 import {J, Type} from "../../../src/java";
 import Literal = J.Literal;
 
@@ -23,7 +23,6 @@ const spec = new RecipeSpec();
 describe.each([
     ['1', Type.Primitive.Double],
     ['0o777', Type.Primitive.Double],
-    ['0777', Type.Primitive.Double],
     ['1.0', Type.Primitive.Double],
     ['123n', Type.Primitive.BigInt],
     ['"1"', Type.Primitive.String],
@@ -45,4 +44,38 @@ describe.each([
             expect(lit.type).toBe(expectedType);
         }
     }));
+});
+
+describe('Old-style octal literals (error 1121)', () => {
+    test('should parse in .js files', () => spec.rewriteRun({
+        ...javascript('0777'),
+        afterRecipe: (cu: JS.CompilationUnit) => {
+            expect(cu).toBeDefined();
+            expect(cu.statements).toHaveLength(1);
+            const lit = (cu.statements[0].element as JS.ExpressionStatement).expression as Literal;
+            expect(lit.valueSource).toBe('0777');
+            expect(lit.type).toBe(Type.Primitive.Double);
+        }
+    }));
+
+    test('should NOT parse in .ts files', () => {
+        return expect(spec.rewriteRun(typescript('0777'))).rejects.toThrow(/Octal literals are not allowed/);
+    });
+});
+
+describe('Malformed hex escape sequences (error 1125)', () => {
+    test('should parse in .js files', () => spec.rewriteRun({
+        ...javascript('/\\x-.*/'),
+        afterRecipe: (cu: JS.CompilationUnit) => {
+            expect(cu).toBeDefined();
+            expect(cu.statements).toHaveLength(1);
+            const lit = (cu.statements[0].element as JS.ExpressionStatement).expression as Literal;
+            expect(lit.valueSource).toBe('/\\x-.*/');
+            expect(lit.type).toBe(Type.Primitive.String);
+        }
+    }));
+
+    test('should NOT parse in .ts files', () => {
+        return expect(spec.rewriteRun(typescript('/\\x-.*/'))).rejects.toThrow(/Hexadecimal digit expected/);
+    });
 });

--- a/rewrite-javascript/rewrite/test/javascript/parser/object.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/object.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {RecipeSpec} from "../../../src/test";
-import {typescript} from "../../../src/javascript";
+import {javascript, typescript} from "../../../src/javascript";
 
 describe('object literal mapping', () => {
     const spec = new RecipeSpec();
@@ -29,6 +29,12 @@ describe('object literal mapping', () => {
         spec.rewriteRun(
             //language=typescript
             typescript('const c = { foo: 1 }')
+        ));
+
+    test('duplicate', () =>
+        spec.rewriteRun(
+            //language=javascript
+            javascript('const c = { foo: 1, foo: 2 }')
         ));
 
     test('multiple', () =>

--- a/rewrite-javascript/rewrite/test/javascript/parser/with.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/with.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {RecipeSpec} from "../../../src/test";
-import {typescript} from "../../../src/javascript";
+import {javascript} from "../../../src/javascript";
 
 describe('with mapping', () => {
     const spec = new RecipeSpec();
@@ -22,8 +22,8 @@ describe('with mapping', () => {
     // noinspection WithStatementJS
     test('with statement', () =>
         spec.rewriteRun(
-            //language=typescript
-            typescript(`
+            //language=javascript
+            javascript(`
                  with (0) {
                      console.log("aaa");
                  }
@@ -33,8 +33,8 @@ describe('with mapping', () => {
     // noinspection WithStatementJS
     test('with statement with comments', () =>
         spec.rewriteRun(
-            //language=typescript
-            typescript(`
+            //language=javascript
+            javascript(`
                  /*a*/with /*b*/ (/*c*/0 /*d*/) /*e*/{/*f*/
                      console.log("aaa");
                      /*g*/}/*h*/
@@ -44,8 +44,8 @@ describe('with mapping', () => {
     // noinspection TypeScriptUnresolvedReference,WithStatementJS
     test('with statement with try-catch', () =>
         spec.rewriteRun(
-            //language=typescript
-            typescript(`
+            //language=javascript
+            javascript(`
                 with (ctx) try {
                     return eval("(" + str + ")")
                 } catch (e) {
@@ -55,8 +55,8 @@ describe('with mapping', () => {
 
     test('with statement with empty body', () =>
         spec.rewriteRun(
-            //language=typescript
-            typescript(`
+            //language=javascript
+            javascript(`
                  with (0) {/*a*/}
              `)
         ));
@@ -64,8 +64,8 @@ describe('with mapping', () => {
     // noinspection WithStatementJS
     test('with statement with body without braces', () =>
         spec.rewriteRun(
-            //language=typescript
-            typescript(`
+            //language=javascript
+            javascript(`
                  with (0) 1;
              `)
         ));
@@ -73,8 +73,8 @@ describe('with mapping', () => {
     // noinspection TypeScriptUnresolvedReference
     test('with statement with await expr', () =>
         spec.rewriteRun(
-            //language=typescript
-            typescript(`
+            //language=javascript
+            javascript(`
                 export {};
                 // noinspection JSAnnotator
                 with (await obj?.foo) {
@@ -84,16 +84,16 @@ describe('with mapping', () => {
 
     test('with statement with empty expr and body', () =>
         spec.rewriteRun(
-            //language=typescript
-            typescript(`
+            //language=javascript
+            javascript(`
                  with({/*a*/}) {/*b*/}
              `)
         ));
 
     test('with statement with multiline statement', () =>
         spec.rewriteRun(
-            //language=typescript
-            typescript(`
+            //language=javascript
+            javascript(`
                  with ([]) {
                      console.log("aaa");
                      console.log("bbb")
@@ -104,8 +104,8 @@ describe('with mapping', () => {
     // noinspection TypeScriptUnresolvedReference,WithStatementJS
     test('with statement with internal with statements', () =>
         spec.rewriteRun(
-            //language=typescript
-            typescript(`
+            //language=javascript
+            javascript(`
                  with (bindingContext) {
                      with (data || {}) {
                          with (options.templateRenderingVariablesInScope || {}) {

--- a/rewrite-javascript/rewrite/test/javascript/remove-import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/remove-import.test.ts
@@ -520,7 +520,6 @@ describe('RemoveImport visitor', () => {
                     `,
                     `
                         import * as DiffGenerators from './diffgenerators/export';
-
                         // Gets the xml files and passes them into diff generators
                         class Foo {
                             doSomething() {


### PR DESCRIPTION
Legacy JS source files can contain incomplete `\x` hex code escape sequences, as in this regex example: `/\x-(.*)/`. The parser should not fail when parsing JS source files like this.

Additionally, the parser will now allow object literals with multiple properties of the same name. There is a corresponding `org.openrewrite.javascript.migrate.es6.remove-duplicate-object-keys` ES6 upgrade recipe to deduplicate these, as ES6 does not allow this anymore.
