### PR TITLE
Added formatting support for single/multiline comments in parameters / record header

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
@@ -242,7 +242,7 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
 
         if (c.getPrimaryConstructor() != null) {
             c = c.withPrimaryConstructor(ListUtils.map(c.getPrimaryConstructor(), (ix, param) -> {
-                if (param.getPrefix().getLastWhitespace().contains("\n")) {
+                if (param.getPrefix().getWhitespace().contains("\n") || (!param.getPrefix().getComments().isEmpty() && param.getPrefix().getComments().stream().noneMatch(comment -> comment.getSuffix().contains("\n")))) {
                     return param;
                 }
                 if (ix == 0 && param.getComments().isEmpty()) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -205,8 +205,9 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
         IndentType indentType = getCursor().getParent().getNearestMessage("indentType", IndentType.ALIGN);
         if (right.getElement() instanceof J) {
             J elem = (J) right.getElement();
-            if ((right.getAfter().getLastWhitespace().contains("\n") ||
-                    elem.getPrefix().getLastWhitespace().contains("\n"))) {
+            if (right.getAfter().getLastWhitespace().contains("\n") ||
+                    elem.getPrefix().getLastWhitespace().contains("\n") ||
+                    (elem.getPrefix().getWhitespace().contains("\n") && elem.getPrefix().getComments().stream().noneMatch(c -> c.getSuffix().contains("\n")))) {
                 switch (loc) {
                     case FOR_CONDITION:
                     case FOR_UPDATE: {

--- a/rewrite-java/src/test/java/org/openrewrite/java/format/AutoFormatTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/format/AutoFormatTest.java
@@ -2134,6 +2134,64 @@ class AutoFormatTest implements RewriteTest {
               ) {
               }
               """
+          ),
+          java(
+            """
+              record someRecord6(
+                                   String name,
+                                   /* some comment */ int age) {
+              }
+              """,
+            """
+              record someRecord6(
+                      String name,
+                      /* some comment */ int age) {
+              }
+              """
+          ),
+          java(
+            """
+              record someRecord7(
+                                   String name,
+                                   // some comment
+                                   int age) {
+              }
+              """,
+            """
+              record someRecord7(
+                      String name,
+                      // some comment
+                      int age) {
+              }
+              """
+          ),
+          java(
+            """
+              record someRecord8(
+                                   String name, // some comment
+                                   int age) {
+              }
+              """,
+            """
+              record someRecord8(
+                      String name, // some comment
+                      int age) {
+              }
+              """
+          ),
+          java(
+            """
+              record someRecord9(
+                                     String name,       /* some comment */ int age
+              ) {
+              }
+              """,
+            """
+              record someRecord9(
+                      String name,       /* some comment */ int age
+              ) {
+              }
+              """
           )
         );
     }
@@ -2299,6 +2357,78 @@ class AutoFormatTest implements RewriteTest {
               class Test5 {
                   void someMethod5(String name, int age
                   ) {
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              class Test6 {
+                  void someMethod6(
+                                       String name,
+                                       /* some comment */ int age) {
+                  }
+              }
+              """,
+            """
+              class Test6 {
+                  void someMethod6(
+                          String name,
+                          /* some comment */ int age) {
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              class Test7 {
+                  void someMethod7(
+                                       String name,
+                                       // some comment
+                                       int age) {
+                  }
+              }
+              """,
+            """
+              class Test7 {
+                  void someMethod7(
+                          String name,
+                          // some comment
+                          int age) {
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              class Test8 {
+                  void someMethod8(
+                                       String name, // some comment
+                                       int age) {
+                  }
+              }
+              """,
+            """
+              class Test8 {
+                  void someMethod8(
+                          String name, // some comment
+                          int age) {
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              class Test9 {
+                  void someMethod9(
+                                       String name,       /* some comment */ int age) {
+                  }
+              }
+              """,
+            """
+              class Test9 {
+                  void someMethod9(
+                          String name,       /* some comment */ int age) {
                   }
               }
               """


### PR DESCRIPTION
Add support for multiple ways of having comments in the fields / parameters.
We now support commented parameters / record fields where earlier we had: 

```
expected: 
  "package com.example;
  
  class Test {
      void method(
              String name,
              /* age parameter */ int age,
              boolean active) {
      }
  }"
 but was: 
  "package com.example;
  
  class Test {
      void method(
              String name,
                      /* age parameter */ int age,
              boolean active) {
      }
  }"
  ```