### PR TITLE
JavaScript - fix the order of properties in instanceOf RPC

### DIFF
--- a/rewrite-javascript/rewrite/src/java/rpc.ts
+++ b/rewrite-javascript/rewrite/src/java/rpc.ts
@@ -1088,8 +1088,8 @@ export class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
             expression: await q.receive(instanceOf.expression, expr => this.visitRightPadded(expr, q)),
             class: await q.receive(instanceOf.class, clazz => this.visit(clazz, q)),
             pattern: await q.receive(instanceOf.pattern, pattern => this.visit(pattern, q)),
-            modifier: await q.receive(instanceOf.modifier, mod => this.visit(mod, q)),
-            type: await q.receive(instanceOf.type, type => this.visitType(type, q))
+            type: await q.receive(instanceOf.type, type => this.visitType(type, q)),
+            modifier: await q.receive(instanceOf.modifier, mod => this.visit(mod, q))
         };
         return updateIfChanged(instanceOf, updates);
     }


### PR DESCRIPTION
## What's changed?

Fixing the order of fields one of the sides of RPC for JavaScript for `instanceOf` LST elements.

## What's your motivation?

Fixing
```
java.lang.ClassCastException: class org.openrewrite.java.tree.JavaType$Primitive cannot be cast to class org.openrewrite.java.tree.J$Modifier (org.openrewrite.java.tree.JavaType$Primitive and org.openrewrite.java.tree.J$Modifier are in unnamed module of loader 'app')
```
