### PR TITLE
Allow octal escapes for strings in JS sources

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/migrate/es6/modernize-octal-escape-sequences.ts
+++ b/rewrite-javascript/rewrite/src/javascript/migrate/es6/modernize-octal-escape-sequences.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Option, Recipe} from "../../../recipe";
+import {TreeVisitor} from "../../../visitor";
+import {ExecutionContext} from "../../../execution";
+import {JavaScriptVisitor} from "../../visitor";
+import {J} from "../../../java";
+import {produce} from "immer";
+
+export class ModernizeOctalEscapeSequences extends Recipe {
+    name = "org.openrewrite.javascript.migrate.es6.modernize-octal-escape-sequences";
+    displayName = "Modernize octal escape sequences";
+    description = "Convert old-style octal escape sequences (e.g., `\\0`, `\\123`) to modern hex escape sequences (e.g., `\\x00`, `\\x53`) or Unicode escape sequences (e.g., `\\u0000`, `\\u0053`).";
+
+    @Option({
+        displayName: "Use Unicode escapes",
+        description: "Use Unicode escape sequences (`\\uXXXX`) instead of hex escape sequences (`\\xXX`). Default is `false`.",
+        required: false,
+        example: "true"
+    })
+    useUnicodeEscapes: boolean;
+
+    constructor(options?: { useUnicodeEscapes?: boolean }) {
+        super(options);
+        this.useUnicodeEscapes ??= false;
+    }
+
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
+        const useUnicode = this.useUnicodeEscapes;
+        return new class extends JavaScriptVisitor<ExecutionContext> {
+
+            protected async visitLiteral(literal: J.Literal, _ctx: ExecutionContext): Promise<J | undefined> {
+                // Only process string literals
+                if (typeof literal.value !== 'string') {
+                    return literal;
+                }
+
+                const valueSource = literal.valueSource;
+                if (!valueSource) {
+                    return literal;
+                }
+
+                // Check if this string contains octal escape sequences
+                // Octal escape sequences: \0 through \377 (1-3 octal digits)
+                // Pattern: backslash followed by 1-3 octal digits (0-7)
+                // We need to be careful not to match already escaped sequences
+                const octalEscapePattern = /\\([0-7]{1,3})/g;
+
+                let hasOctalEscapes = false;
+                let modernized = valueSource;
+
+                // Replace all octal escape sequences with hex or Unicode equivalents
+                modernized = valueSource.replace(octalEscapePattern, (match, octalDigits) => {
+                    hasOctalEscapes = true;
+                    // Convert octal string to decimal number
+                    const decimalValue = parseInt(octalDigits, 8);
+
+                    if (useUnicode) {
+                        // Convert to Unicode escape sequence (4 hex digits, zero-padded)
+                        return `\\u${decimalValue.toString(16).padStart(4, '0')}`;
+                    } else {
+                        // Convert to hex escape sequence (2 hex digits, zero-padded)
+                        return `\\x${decimalValue.toString(16).padStart(2, '0')}`;
+                    }
+                });
+
+                if (hasOctalEscapes) {
+                    return produce(literal, draft => {
+                        draft.valueSource = modernized;
+                    });
+                }
+
+                return literal;
+            }
+        }
+    }
+}

--- a/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
@@ -429,6 +429,7 @@ const jsOnlyExcludedCodes = new Set([
     1101, // 'with' statements are not allowed in strict mode.
     1121, // Octal literals are not allowed. Use the syntax '{0}'.
     1125, // Hexadecimal digit expected.
+    1487, // Octal escape sequences are not allowed. Use the syntax '{0}'.
 ]);
 
 function isCriticalDiagnostic(code: number, sourceFile: ts.SourceFile): boolean {

--- a/rewrite-javascript/rewrite/test/javascript/migrate/es6/modernize-octal-escape-sequences.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/migrate/es6/modernize-octal-escape-sequences.test.ts
@@ -1,0 +1,274 @@
+// noinspection TypeScriptUnresolvedReference,JSUnusedLocalSymbols
+
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {describe} from "@jest/globals";
+import {RecipeSpec} from "../../../../src/test";
+import {ModernizeOctalEscapeSequences} from "../../../../src/javascript/migrate/es6/modernize-octal-escape-sequences";
+import {javascript} from "../../../../src/javascript";
+
+describe("modernize-octal-escape-sequences", () => {
+    const spec = new RecipeSpec()
+    spec.recipe = new ModernizeOctalEscapeSequences();
+
+    test("convert null character", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const nullChar = "\\0";`,
+                `const nullChar = "\\x00";`
+            )
+        )
+    })
+
+    test("convert single digit octal escapes", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const chars = "\\1\\2\\3\\7";`,
+                `const chars = "\\x01\\x02\\x03\\x07";`
+            )
+        )
+    })
+
+    test("convert two digit octal escapes", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const chars = "\\12\\77";`,
+                `const chars = "\\x0a\\x3f";`
+            )
+        )
+    })
+
+    test("convert three digit octal escapes", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const chars = "\\123\\377";`,
+                `const chars = "\\x53\\xff";`
+            )
+        )
+    })
+
+    test("convert mixed octal escapes", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const mixed = "\\0\\12\\123";`,
+                `const mixed = "\\x00\\x0a\\x53";`
+            )
+        )
+    })
+
+    test("convert octal escapes with regular text", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const message = "Hello\\0World";`,
+                `const message = "Hello\\x00World";`
+            )
+        )
+    })
+
+    test("convert multiple strings with octal escapes", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `
+                const a = "\\0";
+                const b = "\\123";
+                const c = "test\\7end";
+                `,
+                `
+                const a = "\\x00";
+                const b = "\\x53";
+                const c = "test\\x07end";
+                `
+            )
+        )
+    })
+
+    test("do not convert strings without octal escapes", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const normal = "Hello World";`
+            )
+        )
+    })
+
+    test("do not convert other escape sequences", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const escapes = "\\n\\t\\r\\\\";`
+            )
+        )
+    })
+
+    test("do not convert unicode escapes", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const unicode = "\\u0000\\u00FF";`
+            )
+        )
+    })
+
+    test("do not convert hex escapes", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const hex = "\\x00\\xFF";`
+            )
+        )
+    })
+
+    test("convert octal in template literal", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                "const template = `test\\0end`;",
+                "const template = `test\\x00end`;"
+            )
+        )
+    })
+
+    test("convert octal in object property", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const obj = { separator: "\\0" };`,
+                `const obj = { separator: "\\x00" };`
+            )
+        )
+    })
+
+    test("convert octal in array", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const delimiters = ["\\0", "\\1", "\\2"];`,
+                `const delimiters = ["\\x00", "\\x01", "\\x02"];`
+            )
+        )
+    })
+
+    test("convert octal in function call", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `split("\\0");`,
+                `split("\\x00");`
+            )
+        )
+    })
+
+    test("convert bell character", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const bell = "\\7";`,
+                `const bell = "\\x07";`
+            )
+        )
+    })
+
+    test("convert backspace character", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const backspace = "\\10";`,
+                `const backspace = "\\x08";`
+            )
+        )
+    })
+
+    test("do not convert numeric literals", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const num = 123;`
+            )
+        )
+    })
+});
+
+describe("modernize-octal-escape-sequences with useUnicodeEscapes option", () => {
+    const spec = new RecipeSpec()
+    spec.recipe = new ModernizeOctalEscapeSequences({useUnicodeEscapes: true});
+
+    test("convert null character to Unicode", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const nullChar = "\\0";`,
+                `const nullChar = "\\u0000";`
+            )
+        )
+    })
+
+    test("convert single digit octal escapes to Unicode", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const chars = "\\1\\2\\3\\7";`,
+                `const chars = "\\u0001\\u0002\\u0003\\u0007";`
+            )
+        )
+    })
+
+    test("convert two digit octal escapes to Unicode", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const chars = "\\12\\77";`,
+                `const chars = "\\u000a\\u003f";`
+            )
+        )
+    })
+
+    test("convert three digit octal escapes to Unicode", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const chars = "\\123\\377";`,
+                `const chars = "\\u0053\\u00ff";`
+            )
+        )
+    })
+
+    test("convert mixed octal escapes to Unicode", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const mixed = "\\0\\12\\123";`,
+                `const mixed = "\\u0000\\u000a\\u0053";`
+            )
+        )
+    })
+
+    test("convert octal escapes with regular text to Unicode", () => {
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const message = "Hello\\0World";`,
+                `const message = "Hello\\u0000World";`
+            )
+        )
+    })
+});

--- a/rewrite-javascript/rewrite/test/javascript/parser/literal.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/literal.test.ts
@@ -63,6 +63,23 @@ describe('Old-style octal literals (error 1121)', () => {
     });
 });
 
+describe('Old-style octal escapes (error 1487)', () => {
+    test('should parse in .js files', () => spec.rewriteRun({
+        ...javascript("'\\033[2J'"),
+        afterRecipe: (cu: JS.CompilationUnit) => {
+            expect(cu).toBeDefined();
+            expect(cu.statements).toHaveLength(1);
+            const lit = (cu.statements[0].element as JS.ExpressionStatement).expression as Literal;
+            expect(lit.valueSource).toBe("'\\033[2J'");
+            expect(lit.type).toBe(Type.Primitive.String);
+        }
+    }));
+
+    test('should NOT parse in .ts files', () => {
+        return expect(spec.rewriteRun(typescript("'\\033[2J'"))).rejects.toThrow(/Octal escape sequences are not allowed/);
+    });
+});
+
 describe('Malformed hex escape sequences (error 1125)', () => {
     test('should parse in .js files', () => spec.rewriteRun({
         ...javascript('/\\x-.*/'),


### PR DESCRIPTION
E.g. something like `'\\033[2J'` should be allowed for JS sources. There is a corresponding `ModernizeOctalEscapeSequences` recipe to translate these into hex or Unicode escapes.
