### PR TITLE
Run `licenseFormat` after `generateAntlrSources`

### DIFF
--- a/rewrite-hcl/build.gradle.kts
+++ b/rewrite-hcl/build.gradle.kts
@@ -14,6 +14,8 @@ tasks.register<JavaExec>("generateAntlrSources") {
     ) + fileTree("src/main/antlr").matching { include("**/*.g4") }.map { it.path }
 
     classpath = sourceSets["main"].runtimeClasspath
+
+    finalizedBy("licenseFormat")
 }
 
 dependencies {

--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -19,6 +19,8 @@ tasks.register<JavaExec>("generateAntlrSources") {
     ) + fileTree("src/main/antlr").matching { include("**/*.g4") }.map { it.path }
 
     classpath = antlrGeneration
+
+    finalizedBy("licenseFormat")
 }
 
 // Only need checkstyle for the classes that we use to load its configuration files

--- a/rewrite-json/build.gradle.kts
+++ b/rewrite-json/build.gradle.kts
@@ -12,6 +12,8 @@ tasks.register<JavaExec>("generateAntlrSources") {
     ) + fileTree("src/main/antlr").matching { include("**/*.g4") }.map { it.path }
 
     classpath = sourceSets["main"].runtimeClasspath
+
+    finalizedBy("licenseFormat")
 }
 
 dependencies {

--- a/rewrite-maven/build.gradle.kts
+++ b/rewrite-maven/build.gradle.kts
@@ -57,6 +57,8 @@ tasks.register<JavaExec>("generateAntlrSources") {
     ) + fileTree("src/main/antlr").matching { include("**/*.g4") }.map { it.path }
 
     classpath = sourceSets["main"].runtimeClasspath
+
+    finalizedBy("licenseFormat")
 }
 
 tasks.withType<Javadoc>().configureEach {

--- a/rewrite-protobuf/build.gradle.kts
+++ b/rewrite-protobuf/build.gradle.kts
@@ -16,6 +16,8 @@ tasks.register<JavaExec>("generateAntlrSources") {
     ) + fileTree("src/main/antlr").matching { include("**/*.g4") }.map { it.path }
 
     classpath = antlrGeneration
+
+    finalizedBy("licenseFormat")
 }
 
 dependencies {

--- a/rewrite-toml/build.gradle.kts
+++ b/rewrite-toml/build.gradle.kts
@@ -16,6 +16,8 @@ tasks.register<JavaExec>("generateAntlrSources") {
     ) + fileTree("src/main/antlr").matching { include("**/*.g4") }.map { it.path }
 
     classpath = antlrGeneration
+
+    finalizedBy("licenseFormat")
 }
 
 dependencies {

--- a/rewrite-xml/build.gradle.kts
+++ b/rewrite-xml/build.gradle.kts
@@ -16,6 +16,8 @@ tasks.register<JavaExec>("generateAntlrSources") {
     ) + fileTree("src/main/antlr").matching { include("**/*.g4") }.map { it.path }
 
     classpath = antlrGeneration
+
+    finalizedBy("licenseFormat")
 }
 
 dependencies {

--- a/rewrite-yaml/build.gradle.kts
+++ b/rewrite-yaml/build.gradle.kts
@@ -12,6 +12,8 @@ tasks.register<JavaExec>("generateAntlrSources") {
     ) + fileTree("src/main/antlr").matching { include("**/*.g4") }.map { it.path }
 
     classpath = sourceSets["main"].runtimeClasspath
+
+    finalizedBy("licenseFormat")
 }
 
 dependencies {


### PR DESCRIPTION
- Avoids breaking CI when this is omitted; as trialed on https://github.com/openrewrite/rewrite-docker/pull/21