### PR TITLE
JavaScript - Fix formatting of collapsed if with proper else block

### DIFF
--- a/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
@@ -300,6 +300,13 @@ describe('TabsAndIndentsVisitor', () => {
                 while (!areWeThereYet())
                  wait();
                 if (116 == 119) console.log("Close, but false. No changes");
+                function m(): void {
+                    if (condition())
+                        doSomething();
+                     else {
+                        doSomethingElse();
+                    }
+                }
                 `,
                 `
                 if (504 == 436)
@@ -309,6 +316,13 @@ describe('TabsAndIndentsVisitor', () => {
                 while (!areWeThereYet())
                     wait();
                 if (116 == 119) console.log("Close, but false. No changes");
+                function m(): void {
+                    if (condition())
+                        doSomething();
+                    else {
+                        doSomethingElse();
+                    }
+                }
                 `,
                 )
             // @formatter:on


### PR DESCRIPTION
## What's changed?

- Follow-up on #6186. Handling cases where `if` has collapsed (non-block) then-part, but a proper block in the else-part.

## What's your motivation?

Better formatting.
