### PR TITLE
Style Google Whitespaces

### DIFF
--- a/rewrite-java/src/main/resources/META-INF/rewrite/google-java-format.yml
+++ b/rewrite-java/src/main/resources/META-INF/rewrite/google-java-format.yml
@@ -28,17 +28,4 @@ styleConfigs:
   - org.openrewrite.java.style.SpacesStyle:
       # see https://google.github.io/styleguide/javaguide.html#s4.6.2-horizontal-whitespace
       beforeLeftBrace:
-        classLeftBrace: true
-        methodLeftBrace: true
-        ifLeftBrace: true
-        elseLeftBrace: true
-        forLeftBrace: true
-        whileLeftBrace: true
-        doLeftBrace: true
-        switchLeftBrace: true
-        tryLeftBrace: true
-        catchLeftBrace: true
-        finallyLeftBrace: true
-        synchronizedLeftBrace: true
         arrayInitializerLeftBrace: true
-        annotationArrayInitializerLeftBrace: false


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Fix Google Format Style for left braces where it differs from IntelliJ

## What's your motivation?
Make Google Formatter compliant to https://google.github.io/styleguide/javaguide.html#s4.6.2-horizontal-whitespace.
It misses the array initializer spaces

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
