### PR TITLE
JavaScript - BlankLinesVisitor not to attempt to preserve indent

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -1111,7 +1111,7 @@ export class BlankLinesVisitor<P> extends JavaScriptVisitor<P> {
             if (node.kind === JS.Kind.ExpressionStatement) {
                 this.ensurePrefixHasNewLine((node as JS.ExpressionStatement).expression);
             } else {
-                node.prefix.whitespace = "\n" + node.prefix.whitespace;
+                node.prefix.whitespace = "\n";
             }
         }
     }

--- a/rewrite-javascript/rewrite/test/javascript/format/blank-lines-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/blank-lines-visitor.test.ts
@@ -54,10 +54,9 @@ describe('BlankLinesVisitor', () => {
                 class B {
                 }
 
-                 class C {
+                class C {
                 }
                 `),
-            // TODO the space before `class C` seems excessive, not sure if it's the BlankLinkesVisitor's responsibility though
             // @formatter:on
         )
     });


### PR DESCRIPTION
## What's changed?

Minor change to one of the visitors of the JavaScript Autoformatter - the BlankLinesVisitor.
Making it not attempt to preserve indent, when it adds a new line character.
The indents are better handled by the subsequent `TabsAndIndentsVisitor`.

## What's your motivation?

Fix minor issue discovered when troubleshooting something else.
