### PR TITLE
Use Kotlin plugin version 2.1 but target 1.9

### DIFF
--- a/rewrite-kotlin/build.gradle.kts
+++ b/rewrite-kotlin/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
 
     implementation(project(":rewrite-java"))
 
-    implementation(platform(kotlin("bom", kotlinVersion)))
     implementation(kotlin("compiler-embeddable", kotlinVersion))
     implementation(kotlin("stdlib", kotlinVersion))
 


### PR DESCRIPTION
- Follows on from #6205 after failing to to run `:rewrite-kotlin:generatePomFileForNebulaPublication` due to `NoSuchMethodError: 'org.gradle.api.Project org.gradle.api.artifacts.ProjectDependency.getDependencyProject()'`