### PR TITLE
JavaScript - handling `function()` as expressions in autoformatting

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -1146,7 +1146,10 @@ export class TabsAndIndentsVisitor<P> extends JavaScriptVisitor<P> {
     protected async preVisit(tree: J, p: P): Promise<J | undefined> {
         let ret = await super.preVisit(tree, p)! as J;
 
-        let indentShouldIncrease = tree.kind === J.Kind.Block || this.cursor.parent?.parent?.parent?.value.kind == J.Kind.Case;
+        let indentShouldIncrease =
+            tree.kind === J.Kind.Block
+            || this.cursor.parent?.parent?.parent?.value.kind == J.Kind.Case
+            || (tree.kind === J.Kind.MethodDeclaration && this.cursor.parent?.value.kind === JS.Kind.StatementExpression);
 
         const previousIndent = this.currentIndent;
 

--- a/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
@@ -186,4 +186,22 @@ describe('AutoformatVisitor', () => {
                  `import {delta, gamma} from 'delta.js'`)
             // @formatter:on
         )});
+
+    test('anonymous function expression', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(
+                `const fn = function () {return 99;};`,
+                 // TODO the space after `const fn=` is excessive
+                 `
+                const fn = 
+                    function () {
+                        return 99;
+                    };
+                `
+            )
+            // @formatter:on
+        )
+    });
 });


### PR DESCRIPTION
## What's changed?

Another amendment to JavaScript autoformatting. Handling cases where `function() { ...}` is an expression, not a standalone statement on its own.

## What's your motivation?

Handle more real-life JS/TS code.