### PR TITLE
JavaScript - fixing parsing of whitespace before function expressions

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -3131,12 +3131,15 @@ export class JavaScriptParserVisitor {
     }
 
     visitFunctionExpression(node: ts.FunctionExpression): JS.StatementExpression {
+        const delegate = this.mapFunctionDeclaration(node);
         return {
             kind: JS.Kind.StatementExpression,
             id: randomId(),
-            prefix: emptySpace,
+            prefix: delegate.prefix,
             markers: emptyMarkers,
-            statement: this.mapFunctionDeclaration(node)
+            statement: produce(delegate, draft => {
+              draft.prefix = emptySpace;
+            })
         };
     }
 

--- a/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
@@ -192,9 +192,8 @@ describe('AutoformatVisitor', () => {
             //language=typescript
             typescript(
                 `const fn = function () {return 99;};`,
-                 // TODO the space after `const fn=` is excessive
                  `
-                const fn = 
+                const fn =
                     function () {
                         return 99;
                     };

--- a/rewrite-javascript/rewrite/test/javascript/parser/variable-declarations.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/variable-declarations.test.ts
@@ -252,4 +252,23 @@ describe('variable declaration mapping', () => {
                 }
             `)
         ));
+
+    test.each([
+        "const c =  function(): number { return 116; };",
+        "const c =  136;",
+        "const c =  (1 > 0) ? 116 : 119;"
+    ])('double space: %s', (code) =>
+        spec.rewriteRun({
+            //language=javascript
+            ...typescript(code),
+            afterRecipe: (cu: JS.CompilationUnit) => {
+                expect(cu.statements).toHaveLength(1);
+                cu.statements.forEach(statement => {
+                    const varDecl = statement.element as J.VariableDeclarations;
+                    const initializer = varDecl.variables[0].element.initializer!;
+                    expect(initializer.before.whitespace).toBe(" ");
+                    expect(initializer.element.prefix.whitespace).toBe("  ");
+                });
+            }
+        }));
 });


### PR DESCRIPTION
## What's changed?

Fixing how function expressions are parsed in JavaScript/TypeScript. Namely and preceding whitespace now goes to the the wrapping `StatementExpression`.

## What's your motivation?

- fixing a violation of the OpenRewrite rule that the whiteespace should go into the outermost element possible
- dealing with one corner case in the autoformatting: https://github.com/openrewrite/rewrite/pull/6213#discussion_r2472381214
