### PR TITLE
Do not derive relative links from index html when deriving metadata in MavenPomDownloader

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -412,7 +412,7 @@ public class MavenPomDownloader {
                 break;
             }
             String href = responseBody.substring(start, end).trim();
-            if (href.endsWith("/")) {
+            if (!href.startsWith("../") && href.endsWith("/")) {
                 //Only look for hrefs that have directories (the directory names are the versions)
                 versions.add(hrefToVersion(href, uri));
             }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -22,7 +22,6 @@ import okhttp3.tls.HeldCertificate;
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -614,6 +613,18 @@ class MavenPomDownloaderTest implements RewriteTest {
             MavenMetadata metaData = new MavenPomDownloader(emptyMap(), ctx)
               .downloadMetadata(new GroupArtifact("fred", "fred"), null, List.of(repository));
             assertThat(metaData.getVersioning().getVersions()).hasSize(3).containsAll(List.of("1.0.0", "1.1.0", "2.0.0"));
+        }
+
+        @Test
+        void deriveMetaDataFromHtmlBasedRepository() throws Exception {
+            MavenRepository repository = MavenRepository.builder()
+              .id("html-based")
+              .uri("https://central.sonatype.com/repository/maven-snapshots")
+              .knownToExist(true)
+              .deriveMetadataIfMissing(true)
+              .build();
+            assertThrows(MavenDownloadingException.class, () ->
+              new MavenPomDownloader(emptyMap(), ctx).downloadMetadata(new GroupArtifact("does.definitely.not", "exist"), null, List.of(repository)));
         }
 
         @SuppressWarnings("ConstantConditions")


### PR DESCRIPTION
Cli is failing to install with: 
<img width="1027" height="38" alt="Screenshot 2025-10-29 at 15 13 24" src="https://github.com/user-attachments/assets/f57dfd7e-3625-403f-ba90-9cf22241247f" />

This is due to the html body of the browsing page to have a url href that matches the lookup, but has nothing to do with versions: 
<img width="844" height="473" alt="Screenshot 2025-10-29 at 15 15 49" src="https://github.com/user-attachments/assets/d0fa9a7c-0961-4213-a814-c4c3a49f2b7a" />
<img width="575" height="196" alt="Screenshot 2025-10-29 at 15 16 28" src="https://github.com/user-attachments/assets/8e2f17ea-6cf2-4b5b-a3f2-9c28bf3d88e2" />

By checking if this is a relative url, we eliminate this possibility and the added test now passes