### PR TITLE
Type attribution issue on Gradle tasks after 9.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("org.openrewrite.build.root") version("latest.release")
-    id("org.openrewrite.build.java-base") version("latest.release")
+    id("org.openrewrite.build.root") version("2.5.6")
+    id("org.openrewrite.build.java-base") version("2.5.6")
     id("org.owasp.dependencycheck") version("latest.release")
 }
 


### PR DESCRIPTION
We're seeing a type attribution issue downstream after upgrading to Gradle 9.2.0
- https://github.com/openrewrite/rewrite-testing-frameworks/pull/836

This branch intentionally is using an older base & build gradle plugins from before
- https://github.com/openrewrite/rewrite/pull/6205

Ideally what we show here is that the test passes on these older versions, but then fails because we get `Object` after updating to the latest.