### PR TITLE
Fix Gradle 9 compatibility by using explicit Gradle 6.1.1 dependencies

### DIFF
--- a/rewrite-gradle-tooling-model/model/build.gradle.kts
+++ b/rewrite-gradle-tooling-model/model/build.gradle.kts
@@ -13,7 +13,9 @@ dependencies {
         // last version which supports java 8, which testGradle4 runs on
         testImplementation("org.assertj:assertj-core:3.27.4!!")
     }
-    implementation(gradleApi())
+    // Use compileOnly instead of implementation to avoid leaking gradleApi() to consumers
+    // This prevents Gradle 9's API from polluting rewrite-gradle's test classpath
+    compileOnly(gradleApi())
 
     // NOTE: this is latest.integration because we need to be able to release
     // rewrite-gradle-tooling-model BEFORE rewrite but also need to depend on

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleParserTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleParserTest.java
@@ -21,6 +21,8 @@ import org.openrewrite.Issue;
 import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.tree.ParseError;
 
@@ -29,6 +31,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openrewrite.gradle.Assertions.*;
 
 class GradleParserTest implements RewriteTest {
@@ -383,4 +386,27 @@ class GradleParserTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/pull/836")
+    @Test
+    void typeAttributionOnTasks() {
+        rewriteRun(
+          //language=groovy
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              tasks.withType(Test) {
+              }
+              """,
+            spec -> spec.beforeRecipe(cu -> {
+                JavaType tasksType = ((J.MethodInvocation) cu.getStatements().getLast()).getSelect().getType();
+                assertThat(TypeUtils.asFullyQualified(tasksType).getFullyQualifiedName()).isNotEqualTo("java.lang.Object");
+                assertTrue(TypeUtils.isAssignableTo("org.gradle.api.tasks.TaskContainer", tasksType), tasksType.toString());
+            })
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
Gradle 9 embeds Groovy 4.0.28, while RewriteGradleProject.groovy is compiled against Gradle 6.1.1 (Groovy 3.x). The Groovy version mismatch prevented proper type attribution during parsing.

**Solution:**
1. Replace `localGroovy()` with explicit `groovy-all:3.0.25` to maintain Groovy 3.x consistency
2. Replace `gradleApi()` with explicit Gradle 6.1.1 module dependencies to avoid pulling in Gradle 9's API
3. Add `gradle-tooling-api:6.1.1` for GradleConnector support without Gradle 9's full API
4. Change `rewrite-gradle-tooling-model/model` to use `compileOnly(gradleApi())` to prevent leaking Gradle 9 API
