### PR TITLE
Maven resolution order for scopes should be preserved deterministically

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/DependencyInsight.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/DependencyInsight.java
@@ -34,7 +34,6 @@ import org.openrewrite.semver.VersionComparator;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -116,7 +115,7 @@ public class DependencyInsight extends Recipe {
 
         return new MavenIsoVisitor<ExecutionContext>() {
             final DependencyGraph dependencyGraph = new DependencyGraph();
-            final Map<String, Map<ResolvedGroupArtifactVersion, List<DependencyGraph.DependencyPath>>> pathsByScope = new LinkedHashMap<>();
+            final Map<String, Map<ResolvedGroupArtifactVersion, List<DependencyGraph.DependencyPath>>> pathsByScope = new HashMap<>();
 
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
@@ -124,20 +123,16 @@ public class DependencyInsight extends Recipe {
                 if (requestedScope != null) {
                     List<ResolvedDependency> dependencies = getResolutionResult().getDependencies().get(requestedScope);
                     if (dependencies != null) {
-                        Map<ResolvedGroupArtifactVersion, List<DependencyGraph.DependencyPath>> projectPaths = new LinkedHashMap<>();
+                        Map<ResolvedGroupArtifactVersion, List<DependencyGraph.DependencyPath>> projectPaths = new HashMap<>();
                         dependencyGraph.collectMavenDependencyPaths(dependencies, projectPaths, requestedScope.name().toLowerCase());
                         pathsByScope.put(requestedScope.name().toLowerCase(), projectPaths);
                     }
                 } else {
-                    getResolutionResult().getDependencies().entrySet().stream()
-                            .sorted(Map.Entry.comparingByKey())
-                            .forEach(entry -> {
-                                Scope scope = entry.getKey();
-                                List<ResolvedDependency> dependencies = entry.getValue();
-                                Map<ResolvedGroupArtifactVersion, List<DependencyGraph.DependencyPath>> projectPaths = new LinkedHashMap<>();
-                                dependencyGraph.collectMavenDependencyPaths(dependencies, projectPaths, scope.name().toLowerCase());
-                                pathsByScope.put(scope.name().toLowerCase(), projectPaths);
-                            });
+                    getResolutionResult().getDependencies().forEach((scope, dependencies) -> {
+                        Map<ResolvedGroupArtifactVersion, List<DependencyGraph.DependencyPath>> projectPaths = new HashMap<>();
+                        dependencyGraph.collectMavenDependencyPaths(dependencies, projectPaths, scope.name().toLowerCase());
+                        pathsByScope.put(scope.name().toLowerCase(), projectPaths);
+                    });
                 }
                 return super.visitDocument(document, ctx);
             }


### PR DESCRIPTION
## What's changed?

Use a `LinkedHashMap` instead of a `HashMap` when mapping scope to dependencies.

## What's your motivation?

The usage of `HashMap` can lead to non-deterministic behavior when listing dependencies for scopes. The order should be preserved similar to the output of `mvn dependency:tree`.

## Anything in particular you'd like reviewers to focus on?

No