### PR TITLE
JavaScript - fix missing beforeSyntax, afterSyntax

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/print.ts
+++ b/rewrite-javascript/rewrite/src/javascript/print.ts
@@ -75,16 +75,16 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
     }
 
     override async visitExpressionStatement(statement: JS.ExpressionStatement, p: PrintOutputCapture): Promise<J | undefined> {
-        await this.visitSpace(statement.prefix, p);
-        await this.visitMarkers(statement.markers, p);
+        await this.beforeSyntax(statement, p);
         await this.visit(statement.expression, p);
+        await this.afterSyntax(statement, p);
         return statement;
     }
 
     override async visitStatementExpression(statementExpression: JS.StatementExpression, p: PrintOutputCapture): Promise<J | undefined> {
-        await this.visitSpace(statementExpression.prefix, p);
-        await this.visitMarkers(statementExpression.markers, p);
+        await this.beforeSyntax(statementExpression, p);
         await this.visit(statementExpression.statement, p);
+        await this.afterSyntax(statementExpression, p);
         return statementExpression;
     }
 


### PR DESCRIPTION
## What's changed?

Fix missing calls to `beforeSyntax` and `afterSyntax` in JavaScriptPrinter.

## What's your motivation?

I noticed they were missing when developing an unrelated functionality.
