### PR TITLE
Expanding TypeMatcher to actually use the matcher for `JavaType.Primitive`s. `FindFieldsOfType` should properly match against primitives now.

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindFieldsOfTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindFieldsOfTypeTest.java
@@ -169,4 +169,70 @@ class FindFieldsOfTypeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void findsMatchingPrimitive() {
+        rewriteRun(
+          spec -> spec.recipe(new FindFieldsOfType("boolean", null)),
+          //language=java
+          java(
+            """
+              public class A {
+                  private boolean x;
+                  private Boolean y;
+              }
+              """,
+            """
+              public class A {
+                  /*~~>*/private boolean x;
+                  private Boolean y;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findsMatchingPrimitiveObjects() {
+        rewriteRun(
+          spec -> spec.recipe(new FindFieldsOfType("java.lang.Boolean", null)),
+          //language=java
+          java(
+            """
+              public class A {
+                  private boolean x;
+                  private Boolean y;
+              }
+              """,
+            """
+              public class A {
+                  private boolean x;
+                  /*~~>*/private Boolean y;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findsMatchingPrimitiveObjectsFromSimpleName() {
+        rewriteRun(
+          spec -> spec.recipe(new FindFieldsOfType("Boolean", null)),
+          //language=java
+          java(
+            """
+              public class A {
+                  private boolean x;
+                  private Boolean y;
+              }
+              """,
+            """
+              public class A {
+                  private boolean x;
+                  /*~~>*/private Boolean y;
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/TypeMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/TypeMatcher.java
@@ -97,6 +97,10 @@ public class TypeMatcher implements Reference.Matcher {
             );
         }
 
+        if (type instanceof JavaType.Primitive && typeNameMatcher.matches(type.toString())) {
+            return true;
+        }
+
         return false;
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindFieldsOfType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindFieldsOfType.java
@@ -139,7 +139,7 @@ public class FindFieldsOfType extends Recipe {
                                           boolean matchOverrides) {
         if (type instanceof JavaType.Array) {
             return hasElementType(((JavaType.Array) type).getElemType(), fullyQualifiedName, matchOverrides);
-        } else if (type instanceof JavaType.FullyQualified) {
+        } else if (type instanceof JavaType.FullyQualified || type instanceof JavaType.Primitive) {
             return new TypeMatcher(fullyQualifiedName, matchOverrides).matches(type);
         } else if (type instanceof JavaType.GenericTypeVariable) {
             JavaType.GenericTypeVariable generic = (JavaType.GenericTypeVariable) type;


### PR DESCRIPTION
## What's changed?
- Previously when you tried to use `FindFieldsOfType` for `boolean` or similar primitive types that aren't considered `JavaType.FullyQualified`, it would not end up marking the fields. This change updates the `hasElementType` method to include `JavaType.Primitive`s and allows the `matches(..)` method in `TypeMatcher` to try to use the matcher it configured on `JavaType.Primitive` instances.

## What's your motivation?
It was making it impossible to find fields of primitive (non-object) types.

## Anything in particular you'd like reviewers to focus on?
The change in the `TypeMatcher`, I'm unsure if I should be opting for something safer / more thorough from the `JavaType.Primitive` methods or if this is fine.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
