### PR TITLE
JavaScript - fixing autoformatting for function as the first element

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -941,7 +941,8 @@ export class BlankLinesVisitor<P> extends JavaScriptVisitor<P> {
             tree = produce(tree as JS.StatementExpression, draft => {
                 this.ensurePrefixHasNewLine(draft);
             });
-        } else if (tree.kind === J.Kind.MethodDeclaration && this.cursor.value.kind != JS.Kind.StatementExpression) {
+        } else if (tree.kind === J.Kind.MethodDeclaration && this.cursor.value.kind != JS.Kind.StatementExpression
+            && (this.cursor.parent?.value.kind != JS.Kind.CompilationUnit || (this.cursor.parent?.value as JS.CompilationUnit).statements[0].element !== tree)) {
             tree = produce(tree as J.MethodDeclaration, draft => {
                 this.ensurePrefixHasNewLine(draft);
             });

--- a/rewrite-javascript/rewrite/test/javascript/format/blank-lines-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/blank-lines-visitor.test.ts
@@ -158,4 +158,20 @@ describe('BlankLinesVisitor', () => {
             // @formatter:on
         );
     });
+
+    test('just a function', () => {
+        spec.recipe = fromVisitor(new BlankLinesVisitor(blankLines()));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(
+                `
+                    function foo(x) {
+                        return x;
+                    }
+                    `
+                )
+            // @formatter:on
+        );
+    });
 });


### PR DESCRIPTION
## What's changed?

Fixing a special case of autoformatting in JavaScript - when a `function` is the first element in the source file.

## What's your motivation?

Better autoformatting.
