### PR TITLE
Prevent NPE when using Google Java format

### DIFF
--- a/rewrite-java/src/main/resources/META-INF/rewrite/google-java-format.yml
+++ b/rewrite-java/src/main/resources/META-INF/rewrite/google-java-format.yml
@@ -28,4 +28,17 @@ styleConfigs:
   - org.openrewrite.java.style.SpacesStyle:
       # see https://google.github.io/styleguide/javaguide.html#s4.6.2-horizontal-whitespace
       beforeLeftBrace:
-        arrayInitializerLeftBrace: true
+        classLeftBrace: true
+        methodLeftBrace: true
+        ifLeftBrace: true
+        elseLeftBrace: true
+        forLeftBrace: true
+        whileLeftBrace: true
+        doLeftBrace: true
+        switchLeftBrace: true
+        tryLeftBrace: true
+        catchLeftBrace: true
+        finallyLeftBrace: true
+        synchronizedLeftBrace: true
+        arrayInitializerLeftBrace: true # Differs from IntelliJ default
+        annotationArrayInitializerLeftBrace: false


### PR DESCRIPTION
- Follows #6202
- Fixes #6250

We saw this fail because the `spacesBefore` method takes a lowercase `boolean`, which fails if the uppercase Boolean is null:
https://github.com/openrewrite/rewrite/blob/68d0c3dde00a5be2183fa8b5af2fe2f67d8d6b80/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java#L193-L199

Alternatively we could look into how styles are loaded and merged, or how spaces are applied to handle nullable fields, but figured this is quickest to get a release out.