### PR TITLE
Add ability to get effective project and plugin repsoitories for Gradle

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/EffectiveGradlePluginRepositories.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/EffectiveGradlePluginRepositories.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.gradle.IsBuildGradle;
+import org.openrewrite.gradle.IsSettingsGradle;
+import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.gradle.marker.GradleSettings;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.maven.search.EffectiveMavenRepositoriesTable;
+import org.openrewrite.maven.tree.MavenRepository;
+
+import java.util.StringJoiner;
+
+import static org.openrewrite.PathUtils.separatorsToUnix;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class EffectiveGradlePluginRepositories extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "List effective Gradle plugin repositories";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Lists the Gradle plugin repositories that would be used for plugin resolution, in order of precedence. " +
+               "This includes Maven repositories defined in the settings.gradle pluginManagement section and build.gradle buildscript repositories as determined when the LST was produced.";
+    }
+
+    @Option(displayName = "Use markers",
+            description = "Whether to add markers for each effective Gradle plugin repository to the build or settings file. Default `false`.",
+            required = false)
+    @Nullable
+    Boolean useMarkers;
+
+    transient EffectiveMavenRepositoriesTable table = new EffectiveMavenRepositoriesTable(this);
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                Preconditions.or(new IsBuildGradle<>(), new IsSettingsGradle<>()),
+                new TreeVisitor<Tree, ExecutionContext>() {
+                    @Override
+                    public Tree preVisit(Tree tree, ExecutionContext ctx) {
+                        stopAfterPreVisit();
+                        if (!(tree instanceof SourceFile)) {
+                            return tree;
+                        }
+
+                        SourceFile sourceFile = (SourceFile) tree;
+                        StringJoiner repositories = new StringJoiner("\n");
+                        String path = separatorsToUnix(sourceFile.getSourcePath().toString());
+
+                        // Check if this is a build.gradle file with buildscript repositories
+                        if (IsBuildGradle.matches(sourceFile.getSourcePath())) {
+                            GradleProject gradleProject = sourceFile.getMarkers().findFirst(GradleProject.class).orElse(null);
+                            if (gradleProject != null) {
+                                for (MavenRepository repository : gradleProject.getBuildscript().getMavenRepositories()) {
+                                    repositories.add(repository.getUri());
+                                    table.insertRow(ctx, new EffectiveMavenRepositoriesTable.Row(
+                                            path,
+                                            repository.getUri()));
+                                }
+                            }
+                        }
+                        // Check if this is a settings.gradle file with pluginManagement repositories
+                        else {
+                            GradleSettings gradleSettings = sourceFile.getMarkers().findFirst(GradleSettings.class).orElse(null);
+                            if (gradleSettings != null) {
+                                for (MavenRepository repository : gradleSettings.getBuildscript().getMavenRepositories()) {
+                                    repositories.add(repository.getUri());
+                                    table.insertRow(ctx, new EffectiveMavenRepositoriesTable.Row(
+                                            path,
+                                            repository.getUri()));
+                                }
+                            }
+                        }
+
+                        if (Boolean.TRUE.equals(useMarkers) && repositories.length() > 0) {
+                            return SearchResult.found(sourceFile, repositories.toString());
+                        }
+
+                        return sourceFile;
+                    }
+                }
+        );
+    }
+}

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/EffectiveGradleRepositories.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/EffectiveGradleRepositories.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.gradle.IsBuildGradle;
+import org.openrewrite.gradle.IsSettingsGradle;
+import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.gradle.marker.GradleSettings;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.maven.search.EffectiveMavenRepositoriesTable;
+import org.openrewrite.maven.tree.MavenRepository;
+
+import java.util.StringJoiner;
+
+import static org.openrewrite.PathUtils.separatorsToUnix;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class EffectiveGradleRepositories extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "List effective Gradle project repositories";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Lists the Gradle project repositories that would be used for dependency resolution, in order of precedence. " +
+               "This includes Maven repositories defined in the Gradle build files and settings as determined when the LST was produced.";
+    }
+
+    @Option(displayName = "Use markers",
+            description = "Whether to add markers for each effective Gradle repository to the build file. Default `false`.",
+            required = false)
+    @Nullable
+    Boolean useMarkers;
+
+    transient EffectiveMavenRepositoriesTable table = new EffectiveMavenRepositoriesTable(this);
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new IsBuildGradle<>(),
+                new TreeVisitor<Tree, ExecutionContext>() {
+                    @Override
+                    public Tree preVisit(Tree tree, ExecutionContext ctx) {
+                        stopAfterPreVisit();
+                        if (!(tree instanceof SourceFile)) {
+                            return tree;
+                        }
+
+                        SourceFile sourceFile = (SourceFile) tree;
+                        StringJoiner repositories = new StringJoiner("\n");
+                        String path = separatorsToUnix(sourceFile.getSourcePath().toString());
+
+                        // Check if this is a build.gradle file
+                        GradleProject gradleProject = sourceFile.getMarkers().findFirst(GradleProject.class).orElse(null);
+                        if (gradleProject != null) {
+                            for (MavenRepository repository : gradleProject.getMavenRepositories()) {
+                                repositories.add(repository.getUri());
+                                table.insertRow(ctx, new EffectiveMavenRepositoriesTable.Row(
+                                        path,
+                                        repository.getUri()));
+                            }
+                        }
+
+                        if (Boolean.TRUE.equals(useMarkers) && repositories.length() > 0) {
+                            return SearchResult.found(sourceFile, repositories.toString());
+                        }
+
+                        return sourceFile;
+                    }
+                }
+        );
+    }
+}

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/EffectiveGradlePluginRepositoriesTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/EffectiveGradlePluginRepositoriesTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.Assertions.*;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.maven.search.EffectiveMavenRepositoriesTable.Row;
+
+class EffectiveGradlePluginRepositoriesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.beforeRecipe(withToolingApi())
+            .recipe(new EffectiveGradlePluginRepositories(true));
+    }
+
+    @DocumentExample
+    @Test
+    void pluginRepositories() {
+        rewriteRun(
+          settingsGradle(
+            """
+              rootProject.name = 'my-project'
+              """,
+            """
+              /*~~(https://plugins.gradle.org/m2)~~>*/rootProject.name = 'my-project'
+              """
+          ),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              """,
+            """
+              /*~~(https://plugins.gradle.org/m2)~~>*/plugins {
+                  id 'java'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void multiplePluginRepositoriesInSettingsGradle() {
+        rewriteRun(
+          settingsGradle(
+            """
+              pluginManagement {
+                  repositories {
+                      maven { url 'https://repo.spring.io/milestone' }
+                      gradlePluginPortal()
+                  }
+              }
+              """,
+            """
+              /*~~(https://repo.spring.io/milestone
+              https://plugins.gradle.org/m2)~~>*/pluginManagement {
+                  repositories {
+                      maven { url 'https://repo.spring.io/milestone' }
+                      gradlePluginPortal()
+                  }
+              }
+              """
+          ),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              """,
+            """
+              /*~~(https://repo.spring.io/milestone
+              https://plugins.gradle.org/m2)~~>*/plugins {
+                  id 'java'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void pluginRepositoryInSettingsGradleKts() {
+        rewriteRun(
+          settingsGradleKts(
+            """
+              pluginManagement {
+                  repositories {
+                      maven { url = uri("https://repo.spring.io/milestone") }
+                  }
+              }
+              """,
+            """
+              /*~~(https://repo.spring.io/milestone)~~>*/pluginManagement {
+                  repositories {
+                      maven { url = uri("https://repo.spring.io/milestone") }
+                  }
+              }
+              """
+          ),
+          buildGradleKts(
+            """
+              plugins {
+                  id("java")
+              }
+              """,
+            """
+              /*~~(https://repo.spring.io/milestone)~~>*/plugins {
+                  id("java")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void producesDataTable() {
+        rewriteRun(
+          spec -> spec
+            .recipe(new EffectiveGradlePluginRepositories(false))
+            .dataTable(Row.class, rows -> assertThat(rows).containsExactlyInAnyOrder(
+              new Row("settings.gradle", "https://repo.spring.io/milestone"),
+              new Row("settings.gradle", "https://plugins.gradle.org/m2"),
+              new Row("build.gradle", "https://repo.spring.io/milestone"),
+              new Row("build.gradle", "https://plugins.gradle.org/m2")
+            )),
+          settingsGradle(
+            """
+              pluginManagement {
+                  repositories {
+                      maven { url 'https://repo.spring.io/milestone' }
+                      gradlePluginPortal()
+                  }
+              }
+
+              include 'module'
+              """,
+            spec -> spec.path("settings.gradle")
+          ),
+          buildGradle(
+            """
+              buildscript {
+                  repositories {
+                      maven { url 'https://repo.spring.io/milestone' }
+                  }
+              }
+
+              plugins {
+                  id 'java'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+              """,
+            spec -> spec.path("build.gradle")
+          )
+        );
+    }
+
+    @Test
+    void noMarkersWhenDisabled() {
+        rewriteRun(
+          spec -> spec.recipe(new EffectiveGradlePluginRepositories(false)),
+          settingsGradle(
+            """
+              pluginManagement {
+                  repositories {
+                      maven { url 'https://repo.spring.io/milestone' }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void buildscriptRepositoriesInBuildGradle() {
+        rewriteRun(
+          buildGradle(
+            """
+              buildscript {
+                  repositories {
+                      maven { url 'https://repo.spring.io/milestone' }
+                  }
+              }
+
+              plugins {
+                  id 'java'
+              }
+              """,
+            """
+              /*~~(https://repo.spring.io/milestone
+              https://plugins.gradle.org/m2)~~>*/buildscript {
+                  repositories {
+                      maven { url 'https://repo.spring.io/milestone' }
+                  }
+              }
+
+              plugins {
+                  id 'java'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void buildscriptRepositoriesInBuildGradleKts() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              buildscript {
+                  repositories {
+                      maven { url = uri("https://repo.spring.io/milestone") }
+                  }
+              }
+
+              plugins {
+                  id("java")
+              }
+              """,
+            """
+              /*~~(https://repo.spring.io/milestone
+              https://plugins.gradle.org/m2)~~>*/buildscript {
+                  repositories {
+                      maven { url = uri("https://repo.spring.io/milestone") }
+                  }
+              }
+
+              plugins {
+                  id("java")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotAffectProjectRepositoriesInBuildGradle() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+
+              repositories {
+                  maven { url 'https://repo.spring.io/milestone' }
+              }
+              """,
+            """
+              /*~~(https://plugins.gradle.org/m2)~~>*/plugins {
+                  id 'java'
+              }
+
+              repositories {
+                  maven { url 'https://repo.spring.io/milestone' }
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/EffectiveGradleRepositoriesTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/EffectiveGradleRepositoriesTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.Assertions.*;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.maven.search.EffectiveMavenRepositoriesTable.Row;
+
+class EffectiveGradleRepositoriesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.beforeRecipe(withToolingApi())
+            .recipe(new EffectiveGradleRepositories(true));
+    }
+
+    @DocumentExample
+    @Test
+    void repositoryInBuildGradle() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+
+              repositories {
+                  maven { url 'https://repo.spring.io/milestone' }
+              }
+              """,
+            """
+              /*~~(https://repo.spring.io/milestone)~~>*/plugins {
+                  id 'java'
+              }
+
+              repositories {
+                  maven { url 'https://repo.spring.io/milestone' }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyRepositories() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void multipleRepositoriesInBuildGradle() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+
+              repositories {
+                  maven { url 'https://repo.spring.io/milestone' }
+                  mavenCentral()
+              }
+              """,
+            """
+              /*~~(https://repo.spring.io/milestone
+              https://repo.maven.apache.org/maven2/)~~>*/plugins {
+                  id 'java'
+              }
+
+              repositories {
+                  maven { url 'https://repo.spring.io/milestone' }
+                  mavenCentral()
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void repositoryInBuildGradleKts() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              plugins {
+                  id("java")
+              }
+
+              repositories {
+                  maven { url = uri("https://repo.spring.io/milestone") }
+              }
+              """,
+            """
+              /*~~(https://repo.spring.io/milestone)~~>*/plugins {
+                  id("java")
+              }
+
+              repositories {
+                  maven { url = uri("https://repo.spring.io/milestone") }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void repositoryInSettingsGradle() {
+        rewriteRun(
+          settingsGradle(
+            """
+              dependencyResolutionManagement {
+                  repositories {
+                      maven { url 'https://repo.spring.io/milestone' }
+                  }
+              }
+              """
+          ),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              """,
+            """
+              /*~~(https://repo.spring.io/milestone)~~>*/plugins {
+                  id 'java'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void repositoryInSettingsGradleKts() {
+        rewriteRun(
+          settingsGradleKts(
+            """
+              dependencyResolutionManagement {
+                  repositories {
+                      maven { url = uri("https://repo.spring.io/milestone") }
+                  }
+              }
+              """
+          ),
+          buildGradleKts(
+            """
+              plugins {
+                  id("java")
+              }
+              """,
+            """
+              /*~~(https://repo.spring.io/milestone)~~>*/plugins {
+                  id("java")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void producesDataTable() {
+        rewriteRun(
+          spec -> spec
+            .recipe(new EffectiveGradleRepositories(false))
+            .dataTable(Row.class, rows -> assertThat(rows).containsExactlyInAnyOrder(
+              new Row("build.gradle", "https://repo.spring.io/milestone"),
+              new Row("build.gradle", "https://repo.maven.apache.org/maven2/"),
+              new Row("module/build.gradle", "https://repo.spring.io/milestone"),
+              new Row("module/build.gradle", "https://repo.maven.apache.org/maven2/")
+            )),
+          settingsGradle(
+            """
+              pluginManagement {
+                  repositories {
+                      gradlePluginPortal()
+                  }
+              }
+
+              include 'module'
+              """
+          ),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+
+              repositories {
+                  maven { url 'https://repo.spring.io/milestone' }
+                  mavenCentral()
+              }
+              """,
+            spec -> spec.path("build.gradle")
+          ),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+
+              repositories {
+                  maven { url 'https://repo.spring.io/milestone' }
+                  mavenCentral()
+              }
+              """,
+            spec -> spec.path("module/build.gradle")
+          )
+        );
+    }
+
+    @Test
+    void noMarkersWhenDisabled() {
+        rewriteRun(
+          spec -> spec.recipe(new EffectiveGradleRepositories(false)),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+
+              repositories {
+                  maven { url 'https://repo.spring.io/milestone' }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Added `EffectiveGradleRepositories` (for project repositories) and `EffectiveGradlePluginRepositories` (for plugin repositories) in order to assist with discoverability of available repositories for Gradle dependency manipulation recipes.

## What's your motivation?
Maven has an equivalent `EffectiveMavenRepositories` (for project repositories; no parallel exists for plugin repositories at this time) recipe which helps a user identify what repositories are in scope for a given project, including data table support.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
Co-Authored-By Claude Code 🤖 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
