### PR TITLE
JavaScript - not attempting to add new lines in object literals

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -640,7 +640,7 @@ export class WrappingAndBracesVisitor<P> extends JavaScriptVisitor<P> {
         const b = await super.visitBlock(block, p) as J.Block;
         return produce(b, draft => {
             if (!draft.end.whitespace.includes("\n") && (draft.statements.length == 0 || !draft.statements[draft.statements.length - 1].after.whitespace.includes("\n"))) {
-                if (block.statements.length > 0) {
+                if (this.cursor.parent?.value.kind !== J.Kind.NewClass) {
                     draft.end = this.withNewlineSpace(draft.end);
                 }
             }
@@ -1023,7 +1023,7 @@ export class BlankLinesVisitor<P> extends JavaScriptVisitor<P> {
                     }
                     this.keepMaximumBlankLines(draft, this.style.keepMaximum.inCode);
                 }
-            } else if (parent?.kind === J.Kind.Block ||
+            } else if (parent?.kind === J.Kind.Block && grandparent?.kind !== J.Kind.NewClass ||
                       (parent?.kind === JS.Kind.CompilationUnit && (parent! as JS.CompilationUnit).statements[0].element.id != draft.id) ||
                       (parent?.kind === J.Kind.Case)) {
                 if (draft.kind != J.Kind.Case) {
@@ -1036,7 +1036,7 @@ export class BlankLinesVisitor<P> extends JavaScriptVisitor<P> {
     protected async visitBlock(block: J.Block, p: P): Promise<J.Block> {
         const b = await super.visitBlock(block, p) as J.Block;
         return produce(b, draft => {
-            if (block.statements.length > 0 || this.cursor.parent?.value.kind != J.Kind.NewClass) {
+            if (this.cursor.parent?.value.kind != J.Kind.NewClass) {
                 if (!draft.end.whitespace.includes("\n")) {
                     draft.end.whitespace = draft.end.whitespace.replace(/[ \t]+$/, '') + "\n";
                 }

--- a/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
@@ -190,11 +190,8 @@ describe('AutoformatVisitor', () => {
             // @formatter:off
             //language=typescript
             typescript("const x = { a: 1 };",
-                `
-                    const x = {
-                        a: 1
-                    };
-                    `
+                // TODO the leading space before `a` seems excessive
+                "const x = { a: 1};"
                     // @formatter:on
             ))
     });
@@ -315,5 +312,15 @@ describe('AutoformatVisitor', () => {
             )
             // @formatter:on
         )
+    });
+
+    test.each([
+        // @formatter:off
+        `const short = {name: "Ivan Almeida", age: 36};`,
+        `const long = {make: "Honda", model: "Jazz", year: 2008, color: "red", engine: "1.2L petrol", isRunning: true, favorite: true, parked: true};`,
+        // @formatter:on
+        ])('do not wrap object literals - %s', async (code) => {
+        // TODO we might eventually implement the "Chop down if long" setting for this
+        return spec.rewriteRun(typescript(code));
     });
 });


### PR DESCRIPTION
## What's changed?

Continuation of #6271.
Not attempting to format object literals in TS.

## What's your motivation?

Handle both types of cases:
- when people prefer multi-line formatting
- when people prefer single-line formatting

It's safer not to touch things.

The ideal solution would probably be to implement the `ChopIfTooLong` setting, but that's more involved.