### PR TITLE
Extending trailing comma support in GroovyParser

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleParserTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleParserTest.java
@@ -383,4 +383,175 @@ class GradleParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void trailingCommaWithClosures() {
+        GradleParser gradleParser = new GradleParser(new GradleParser.Builder());
+        Stream<SourceFile> sourceFileStream = gradleParser.parseInputs(List.of(Parser.Input.fromString(
+            // lang=groovy
+            """
+            foo('bar',) {}
+            foo('bar' , {} , )
+            foo('bar' , {} , ) {}
+            """
+        )), null, new InMemoryExecutionContext());
+        Optional<SourceFile> optionalSourceFile = sourceFileStream.findFirst();
+        assertThat(optionalSourceFile).isPresent();
+        SourceFile sourceFile = optionalSourceFile.get();
+        assertThat(sourceFile).isNotInstanceOf(ParseError.class);
+    }
+
+    @Test
+    void noTrailingCommaWithClosures() {
+        GradleParser gradleParser = new GradleParser(new GradleParser.Builder());
+        Stream<SourceFile> sourceFileStream = gradleParser.parseInputs(List.of(Parser.Input.fromString(
+            // lang=groovy
+            """
+            foo('bar') {}
+            foo('bar' , {} )
+            foo('bar' , {} ) {}
+            """
+        )), null, new InMemoryExecutionContext());
+        Optional<SourceFile> optionalSourceFile = sourceFileStream.findFirst();
+        assertThat(optionalSourceFile).isPresent();
+        SourceFile sourceFile = optionalSourceFile.get();
+        assertThat(sourceFile).isNotInstanceOf(ParseError.class);
+    }
+
+    @Test
+    void trailingCommaWithNamedParameters() {
+        GradleParser gradleParser = new GradleParser(new GradleParser.Builder());
+        Stream<SourceFile> sourceFileStream = gradleParser.parseInputs(List.of(Parser.Input.fromString(
+          // lang=groovy
+          """
+              foo(a: "Hello World with no extra space",)
+              foo(a: "Hello World with space before comma" ,)
+              foo(a: "Hello World with space after comma", )
+              foo(a: "Hello World with space before & after comma" , )
+              foo(a: "Hello World with space before and new line after comma" ,
+              )
+          """
+        )), null, new InMemoryExecutionContext());
+        Optional<SourceFile> optionalSourceFile = sourceFileStream.findFirst();
+        assertThat(optionalSourceFile).isPresent();
+        SourceFile sourceFile = optionalSourceFile.get();
+        assertThat(sourceFile).isNotInstanceOf(ParseError.class);
+    }
+
+    @Test
+    void noTrailingCommaWithNamedParameters() {
+        GradleParser gradleParser = new GradleParser(new GradleParser.Builder());
+        Stream<SourceFile> sourceFileStream = gradleParser.parseInputs(List.of(Parser.Input.fromString(
+          // lang=groovy
+          """
+              foo(a: "Hello World with no extra space")
+              foo(a: "Hello World with space after parameter" )
+              foo(a: "Hello World with new line after parameter"
+              )
+          """
+        )), null, new InMemoryExecutionContext());
+        Optional<SourceFile> optionalSourceFile = sourceFileStream.findFirst();
+        assertThat(optionalSourceFile).isPresent();
+        SourceFile sourceFile = optionalSourceFile.get();
+        assertThat(sourceFile).isNotInstanceOf(ParseError.class);
+    }
+
+    @Test
+    void trailingCommaWithNamedParametersAndClosures() {
+        GradleParser gradleParser = new GradleParser(new GradleParser.Builder());
+        Stream<SourceFile> sourceFileStream = gradleParser.parseInputs(List.of(Parser.Input.fromString(
+            // lang=groovy
+            """
+              foo(a: 'bar',) {}
+              foo(a: 'bar', {} , )
+              foo(a: 'bar', b: {} , )
+              foo('bar', b: {} , )
+              foo(a: 'bar', {} , ) {}
+              foo(a: 'bar', {} , {} , )
+              foo(a: 'bar', b: {} , ) {}
+              foo(a: 'bar', b: {} , {} , )
+              foo('bar', b: {} , ) {}
+              foo('bar', b: {} , {} , )
+            """
+        )), null, new InMemoryExecutionContext());
+        Optional<SourceFile> optionalSourceFile = sourceFileStream.findFirst();
+        assertThat(optionalSourceFile).isPresent();
+        SourceFile sourceFile = optionalSourceFile.get();
+        assertThat(sourceFile).isNotInstanceOf(ParseError.class);
+    }
+
+    @Test
+    void noTrailingCommaWithNamedParametersAndClosures() {
+        GradleParser gradleParser = new GradleParser(new GradleParser.Builder());
+        Stream<SourceFile> sourceFileStream = gradleParser.parseInputs(List.of(Parser.Input.fromString(
+            // lang=groovy
+            """
+              foo(a: 'bar') {}
+              foo(a: 'bar', {})
+              foo(a: 'bar', b: {})
+              foo('bar', b: {})
+              foo(a: 'bar', {} )
+              foo(a: 'bar', b: {} )
+              foo('bar', b: {} )
+              foo(a: 'bar', {} ) {}
+              foo(a: 'bar', {} , {} )
+              foo(a: 'bar', b: {} ) {}
+              foo(a: 'bar', b: {} , {} )
+              foo('bar', b: {} ) {}
+              foo('bar', b: {} , {} )
+            """
+        )), null, new InMemoryExecutionContext());
+        Optional<SourceFile> optionalSourceFile = sourceFileStream.findFirst();
+        assertThat(optionalSourceFile).isPresent();
+        SourceFile sourceFile = optionalSourceFile.get();
+        assertThat(sourceFile).isNotInstanceOf(ParseError.class);
+    }
+
+    @Test
+    void trailingCommaWithNamedParametersComplicated() {
+        GradleParser gradleParser = new GradleParser(new GradleParser.Builder());
+        Stream<SourceFile> sourceFileStream = gradleParser.parseInputs(List.of(Parser.Input.fromString(
+            // lang=groovy
+            """
+            task foo {
+              doLast {
+                bar.baz(
+                  a: 'fizbuz',
+                  b: 'buzfiz',
+                ) {
+                  c('d')
+                }
+              }
+            }
+            """
+        )), null, new InMemoryExecutionContext());
+        Optional<SourceFile> optionalSourceFile = sourceFileStream.findFirst();
+        assertThat(optionalSourceFile).isPresent();
+        SourceFile sourceFile = optionalSourceFile.get();
+        assertThat(sourceFile).isNotInstanceOf(ParseError.class);
+    }
+
+    @Test
+    void noTrailingCommaWithNamedParametersComplicated() {
+        GradleParser gradleParser = new GradleParser(new GradleParser.Builder());
+        Stream<SourceFile> sourceFileStream = gradleParser.parseInputs(List.of(Parser.Input.fromString(
+            // lang=groovy
+            """
+            task foo {
+              doLast {
+                bar.baz(
+                  a: 'fizbuz',
+                  b: 'buzfiz'
+                ) {
+                  c('d')
+                }
+              }
+            }
+            """
+        )), null, new InMemoryExecutionContext());
+        Optional<SourceFile> optionalSourceFile = sourceFileStream.findFirst();
+        assertThat(optionalSourceFile).isPresent();
+        SourceFile sourceFile = optionalSourceFile.get();
+        assertThat(sourceFile).isNotInstanceOf(ParseError.class);
+    }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -139,6 +139,88 @@ class GroovyParserTest implements RewriteTest {
               System.out.println("Hello World with space before comma" ,)
               System.out.println("Hello World with space after comma", )
               System.out.println("Hello World with space before & after comma" , )
+              System.out.println("Hello World with space before and new line after comma" ,
+              )
+              """
+          )
+        );
+    }
+
+    @Test
+    void trailingCommaInMethodCallAndClosures() {
+        rewriteRun(
+          groovy(
+            """
+              foo('bar',) {}
+              foo('bar', {} , )
+              foo('bar', {} , ) {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void trailingCommaInMethodCallWithNamedParametersAndClosures() {
+        rewriteRun(
+          groovy(
+            """
+              foo(a: 'bar',) {}
+              foo(a: 'bar', {} , )
+              foo(a: 'bar', b: {} , )
+              foo('bar', b: {} , )
+              foo(a: 'bar', {} , ) {}
+              foo(a: 'bar', b: {} , ) {}
+              foo('bar', b: {} , ) {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void noTrailingCommaInMethodCallWithNamedParametersAndClosures() {
+        rewriteRun(
+          groovy(
+            """
+              foo(a: 'bar') {}
+              foo(a: 'bar', {})
+              foo(a: 'bar', b: {})
+              foo('bar', b: {})
+              foo(a: 'bar', {} )
+              foo(a: 'bar', b: {} )
+              foo('bar', b: {} )
+              foo(a: 'bar', {} ) {}
+              foo(a: 'bar', b: {} ) {}
+              foo('bar', b: {} ) {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void trailingCommaInMethodCallWithNamedParameters() {
+        rewriteRun(
+          groovy(
+            """
+              foo(a: "Hello World with no extra space",)
+              foo(a: "Hello World with space before comma" ,)
+              foo(a: "Hello World with space after comma", )
+              foo(a: "Hello World with space before & after comma" , )
+              foo(a: "Hello World with space before and new line after comma" ,
+              )
+              """
+          )
+        );
+    }
+
+    @Test
+    void noTrailingCommaInMethodCallWithNamedParameters() {
+        rewriteRun(
+          groovy(
+            """
+              foo(a: "Hello World with no extra space")
+              foo(a: "Hello World with space after parameter" )
+              foo(a: "Hello World with new line after parameter"
+              )
               """
           )
         );


### PR DESCRIPTION
- Extending trailing comma support in GroovyParser (introduced in #5711 for #4614) to support method calls with closures and named parameters

## What's changed?
Currently the GroovyParser fails to parse method calls with named parameters and with Closure parameters.
These parsing issues block several Gradle recipes from executing blocking important use cases like Gradle 7 -> 8 upgrades.
This PR fixes that.

## What's your motivation?
To unblock the Gradle recipes.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files

Legal disclaimer:

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE APACHE LICENSE V.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.