### PR TITLE
JavaScript - adapt to new way of parsing  expressions in autoformatting

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -835,8 +835,8 @@ export class MinimumViableSpacingVisitor<P> extends JavaScriptVisitor<P> {
         const ret = await super.visitNewClass(newClass, p) as J.NewClass;
         return produce(ret, draft => {
             if (draft.class) {
-                if (draft.class.kind == JS.Kind.TypeTreeExpression) {
-                    this.ensureSpace((draft.class as Draft<JS.TypeTreeExpression>).prefix);
+                if (draft.class.kind == J.Kind.Identifier) {
+                    this.ensureSpace((draft.class as Draft<J.Identifier>).prefix);
                 }
             }
         });

--- a/rewrite-javascript/rewrite/test/javascript/format/minimum-viable-space-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/minimum-viable-space-visitor.test.ts
@@ -54,7 +54,7 @@ describe('MinimumViableSpacingVisitor', () => {
         });
     }
 
-    test.skip('basic', () => {
+    test('basic', () => {
         return spec.rewriteRun(
             // @formatter:off
             //language=typescript
@@ -86,7 +86,7 @@ describe('MinimumViableSpacingVisitor', () => {
         ))
     });
 
-    test.skip('throw new', () => {
+    test('throw new', () => {
         return spec.rewriteRun(
             // @formatter:off
             //language=typescript


### PR DESCRIPTION
## What's changed?

Changing JavaScript autoformatting logic to adapt to the new way of how `new ...` expressions are parsed introduced in https://github.com/openrewrite/rewrite/commit/7f271da7d468815511b9d3e92c5575d1ce461401

## What's your motivation?

Fix broken CI which saw `newTodoItem()` vs. `new TodoItem()`