### PR TITLE
Issue #5592: resolved ChangeMethodAccessLevelVisitor bug

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodAccessLevelTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodAccessLevelTest.java
@@ -447,8 +447,90 @@ class ChangeMethodAccessLevelTest implements RewriteTest {
               package com.abc;
 
               class DatabaseConfiguration {
-                  @SuppressWarnings("ALL") // comments
+                  @SuppressWarnings("ALL")
+                  // comments
                   static void dataSource() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removePublicModifierFromBeanMethodsPreservesSpacing() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodAccessLevel("com.abc.DatabaseConfiguration dataSource(..)", "package", null)),
+          java(
+            """
+              package org.springframework.context.annotation;
+              public @interface Bean {}
+              """
+          ),
+          java(
+            """
+              package org.springframework.context.annotation;
+              public @interface Primary {}
+              """
+          ),
+          java(
+            """
+              package a.b.c;
+              public class DataSource {}
+              """
+          ),
+          java(
+            """
+              package com.abc;
+              
+              import a.b.c.DataSource;
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Primary;
+              
+              public class DatabaseConfiguration {
+                  // primary comments
+                  @Primary
+                  @Bean
+                  public DataSource dataSource() {
+                      return new DataSource();
+                  }
+
+                  @Bean // comments
+                  public final DataSource dataSource(Integer i) {
+                      return new DataSource();
+                  }
+
+                  @Bean
+                  // comments
+                  public static DataSource dataSource(Double i) {
+                      return new DataSource();
+                  }
+              }
+              """,
+            """
+              package com.abc;
+              
+              import a.b.c.DataSource;
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Primary;
+              
+              public class DatabaseConfiguration {
+                  // primary comments
+                  @Primary
+                  @Bean
+                  DataSource dataSource() {
+                      return new DataSource();
+                  }
+
+                  @Bean // comments
+                  final DataSource dataSource(Integer i) {
+                      return new DataSource();
+                  }
+
+                  @Bean
+                  // comments
+                  static DataSource dataSource(Double i) {
+                      return new DataSource();
                   }
               }
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodAccessLevelVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodAccessLevelVisitor.java
@@ -118,14 +118,9 @@ public class ChangeMethodAccessLevelVisitor<P> extends JavaIsoVisitor<P> {
 
                     Space removedSpace = removedModifierPrefix.getAndSet(null);
                     if (removedSpace != null) {
-                        J.Modifier nextModifier = mod.withPrefix(mod.getPrefix().withComments(
+                        J.Modifier nextModifier = mod.withPrefix(removedSpace.withComments(
                                 ListUtils.concatAll(removedSpace.getComments(), mod.getComments())));
-
-                        // Also handle modifier's own comments if any
-                        if (!modifierComments.isEmpty()) {
-                            nextModifier = nextModifier.withComments(ListUtils.concatAll(new ArrayList<>(modifierComments), mod.getComments()));
-                            modifierComments.clear();
-                        }
+                        modifierComments.clear();
 
                         return nextModifier;
                     }


### PR DESCRIPTION
## What's changed?
Fixed ChangeMethodAccessLevelVisitor to preserve spacing from the removed access modifier 

## What's your motivation?
- Fixes: #5592

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
