### PR TITLE
JavaScript: Support `undefined` in `visitRightPadded()`

### DIFF
--- a/rewrite-javascript/rewrite/src/java/type-visitor.ts
+++ b/rewrite-javascript/rewrite/src/java/type-visitor.ts
@@ -232,7 +232,7 @@ export class TypeVisitor<P> {
         recipe?: (draft: Draft<T>) =>
             ValidImmerRecipeReturnType<Draft<T>> |
             PromiseLike<ValidImmerRecipeReturnType<Draft<T>>>
-    ): Promise<T> {
+    ): Promise<T | undefined> {
         if (recipe) {
             return produceAsync<T>(before, recipe);
         }

--- a/rewrite-javascript/rewrite/src/java/visitor.ts
+++ b/rewrite-javascript/rewrite/src/java/visitor.ts
@@ -17,7 +17,7 @@ import {Cursor, isTree, SourceFile} from "../tree";
 import {mapAsync, updateIfChanged} from "../util";
 import {produceAsync, TreeVisitor, ValidImmerRecipeReturnType} from "../visitor";
 import {Expression, isSpace, J, NameTree, Statement, TypedTree, TypeTree} from "./tree";
-import {createDraft, Draft, finishDraft} from "immer";
+import {createDraft, Draft, finishDraft, nothing} from "immer";
 import {Type} from "./type";
 
 const javaKindValues = new Set(Object.values(J.Kind));
@@ -1214,7 +1214,7 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
         return right ? this.visitRightPadded(right, p) : undefined;
     }
 
-    public async visitRightPadded<T extends J | boolean>(right: J.RightPadded<T>, p: P): Promise<J.RightPadded<T>> {
+    public async visitRightPadded<T extends J | boolean>(right: J.RightPadded<T>, p: P): Promise<J.RightPadded<T> | undefined> {
         return produceAsync<J.RightPadded<T>>(right, async draft => {
             this.cursor = new Cursor(right, this.cursor);
             if (isTree(right.element)) {
@@ -1223,6 +1223,9 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
             draft.after = await this.visitSpace(right.after, p);
             draft.markers = await this.visitMarkers(right.markers, p);
             this.cursor = this.cursor.parent!;
+            if (draft.element === undefined) {
+                return nothing;
+            }
         });
     }
 
@@ -1230,7 +1233,7 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
         return left ? this.visitLeftPadded(left, p) : undefined;
     }
 
-    public async visitLeftPadded<T extends J | J.Space | number | string | boolean>(left: J.LeftPadded<T>, p: P): Promise<J.LeftPadded<T>> {
+    public async visitLeftPadded<T extends J | J.Space | number | string | boolean>(left: J.LeftPadded<T>, p: P): Promise<J.LeftPadded<T> | undefined> {
         return produceAsync<J.LeftPadded<T>>(left, async draft => {
             this.cursor = new Cursor(left, this.cursor);
             draft.before = await this.visitSpace(left.before, p);
@@ -1241,6 +1244,9 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
             }
             draft.markers = await this.visitMarkers(left.markers, p);
             this.cursor = this.cursor.parent!;
+            if (draft.element === undefined) {
+                return nothing;
+            }
         });
     }
 
@@ -1249,13 +1255,13 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     public async visitContainer<T extends J>(container: J.Container<T>, p: P): Promise<J.Container<T>> {
-        return produceAsync<J.Container<T>>(container, async draft => {
+        return (await produceAsync<J.Container<T>>(container, async draft => {
             this.cursor = new Cursor(container, this.cursor);
             draft.before = await this.visitSpace(container.before, p);
             (draft.elements as J.RightPadded<J>[]) = await mapAsync(container.elements, e => this.visitRightPadded(e, p));
             draft.markers = await this.visitMarkers(container.markers, p);
             this.cursor = this.cursor.parent!;
-        });
+        }))!;
     }
 
     protected async produceJava<J2 extends J>(

--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -470,18 +470,18 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
     }
 
     private async spaceBeforeLeftPaddedElement<T extends J>(left: J.LeftPadded<T>, spaceBeforePadding: boolean, spaceBeforeElement: boolean): Promise<J.LeftPadded<T>> {
-        return produceAsync(left, async draft => {
+        return (await produceAsync(left, async draft => {
             if (draft.before.comments.length == 0) {
                 draft.before.whitespace = spaceBeforePadding ? " " : "";
             }
             draft.element = await this.spaceBefore(left.element, spaceBeforeElement) as Draft<T>;
-        });
+        }))!;
     }
 
     private async spaceBeforeRightPaddedElement<T extends J>(right: J.RightPadded<T>, spaceBefore: boolean): Promise<J.RightPadded<T>> {
-        return produceAsync(right, async draft => {
+        return (await produceAsync(right, async draft => {
             draft.element = await this.spaceBefore(right.element, spaceBefore) as Draft<T>;
-        });
+        }))!;
     }
 
     private async spaceBefore<T extends J>(j: T, spaceBefore: boolean): Promise<T> {
@@ -1209,7 +1209,7 @@ export class TabsAndIndentsVisitor<P> extends JavaScriptVisitor<P> {
         return await super.visit(tree, p) as R;
     }
 
-    public async visitLeftPadded<T extends J | J.Space | number | string | boolean>(left: J.LeftPadded<T>, p: P): Promise<J.LeftPadded<T>> {
+    public async visitLeftPadded<T extends J | J.Space | number | string | boolean>(left: J.LeftPadded<T>, p: P): Promise<J.LeftPadded<T> | undefined> {
         const ret = await super.visitLeftPadded(left, p);
         if (ret == undefined) {
             return ret;

--- a/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
@@ -557,14 +557,14 @@ class MarkerAttachmentVisitor extends JavaScriptVisitor<undefined> {
     /**
      * Propagates markers from element to RightPadded wrapper.
      */
-    public override async visitRightPadded<T extends J | boolean>(right: J.RightPadded<T>, p: undefined): Promise<J.RightPadded<T>> {
+    public override async visitRightPadded<T extends J | boolean>(right: J.RightPadded<T>, p: undefined): Promise<J.RightPadded<T> | undefined> {
         if (!isTree(right.element)) {
             return right;
         }
 
         const visitedElement = await this.visit(right.element as J, p);
         if (visitedElement && visitedElement !== right.element as Tree) {
-            return produceAsync<J.RightPadded<T>>(right, async (draft: any) => {
+            const result = await produceAsync<J.RightPadded<T>>(right, async (draft: any) => {
                 // Visit element first
                 if (right.element && (right.element as any).kind) {
                     // Check if element has a CaptureMarker
@@ -576,6 +576,7 @@ class MarkerAttachmentVisitor extends JavaScriptVisitor<undefined> {
                     }
                 }
             });
+            return result!;
         }
 
         return right;

--- a/rewrite-javascript/rewrite/src/javascript/templating/placeholder-replacement.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/placeholder-replacement.ts
@@ -93,7 +93,7 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
      * The base implementation will visit the element, which triggers our visit() override
      * for placeholder detection and replacement.
      */
-    override async visitRightPadded<T extends J | boolean>(right: J.RightPadded<T>, p: any): Promise<J.RightPadded<T>> {
+    override async visitRightPadded<T extends J | boolean>(right: J.RightPadded<T>, p: any): Promise<J.RightPadded<T> | undefined> {
         return super.visitRightPadded(right, p);
     }
 

--- a/rewrite-javascript/rewrite/src/json/rpc.ts
+++ b/rewrite-javascript/rewrite/src/json/rpc.ts
@@ -158,7 +158,7 @@ class JsonReceiver extends JsonVisitor<RpcReceiveQueue> {
     }
 
     public async visitSpace(space: Json.Space, q: RpcReceiveQueue): Promise<Json.Space> {
-        return produceAsync<Json.Space>(space, async draft => {
+        return (await produceAsync<Json.Space>(space, async draft => {
             draft.comments = await q.receiveListDefined(space.comments, async c => {
                 return await produceAsync(c, async draft => {
                     draft.multiline = await q.receive(c.multiline);
@@ -168,7 +168,7 @@ class JsonReceiver extends JsonVisitor<RpcReceiveQueue> {
                 })
             });
             draft.whitespace = await q.receive(space.whitespace);
-        });
+        }))!;
     }
 
     public async visitRightPadded<T extends Json>(right: Json.RightPadded<T>, p: RpcReceiveQueue): Promise<Json.RightPadded<T> | undefined> {

--- a/rewrite-javascript/rewrite/src/recipe/order-imports.ts
+++ b/rewrite-javascript/rewrite/src/recipe/order-imports.ts
@@ -63,7 +63,7 @@ export class OrderImports extends Recipe {
                 const cuWithImportsSorted = await produceAsync(cu, async draft => {
                     draft.statements = [...sortedImports, ...restStatements];
                 });
-                return produce(cuWithImportsSorted, draft => {
+                return produce(cuWithImportsSorted!, draft => {
                     for (let i = 0; i < importCount; i++) {
                        draft.statements[i].element.prefix.whitespace = i > 0 ? "\n" : "";
                     }

--- a/rewrite-javascript/rewrite/src/visitor.ts
+++ b/rewrite-javascript/rewrite/src/visitor.ts
@@ -15,7 +15,7 @@
  */
 import {emptyMarkers, Marker, Markers} from "./markers";
 import {Cursor, isSourceFile, rootCursor, SourceFile, Tree} from "./tree";
-import {createDraft, Draft, finishDraft, Objectish} from "immer";
+import {createDraft, Draft, finishDraft, nothing, Objectish} from "immer";
 import {mapAsync} from "./util";
 
 /* Not exported beyond the internal immer module */
@@ -23,15 +23,23 @@ export type ValidImmerRecipeReturnType<State> =
     | State
     | void
     | undefined
+    | typeof nothing
 
 export async function produceAsync<Base extends Objectish>(
     before: Promise<Base> | Base,
     recipe: (draft: Draft<Base>) => ValidImmerRecipeReturnType<Draft<Base>> |
         PromiseLike<ValidImmerRecipeReturnType<Draft<Base>>>
-): Promise<Base> {
+): Promise<Base | undefined> {
     const b: Base = await before;
     const draft = createDraft(b);
-    await recipe(draft);
+    const result = await recipe(draft);
+
+    // If recipe explicitly returned Immer's nothing, return undefined
+    if (result === nothing) {
+        return undefined;
+    }
+
+    // Otherwise, return the finished draft (void/undefined means use draft)
     return finishDraft(draft) as Base;
 }
 
@@ -128,9 +136,9 @@ export abstract class TreeVisitor<T extends Tree, P> {
         } else if ((markers.markers?.length || 0) === 0) {
             return markers;
         }
-        return produceAsync<Markers>(markers, async (draft) => {
+        return (await produceAsync<Markers>(markers, async (draft) => {
             draft.markers = await mapAsync(markers.markers, m => this.visitMarker(m, p))
-        });
+        }))!;
     }
 
     protected async visitMarker<M extends Marker>(marker: M, p: P): Promise<M> {
@@ -143,7 +151,7 @@ export abstract class TreeVisitor<T extends Tree, P> {
         recipe?:
             ((draft: Draft<T>) => ValidImmerRecipeReturnType<Draft<T>>) |
             ((draft: Draft<T>) => Promise<ValidImmerRecipeReturnType<Draft<T>>>)
-    ): Promise<T> {
+    ): Promise<T | undefined> {
         return produceAsync(before, async draft => {
             draft.markers = await this.visitMarkers(before.markers, p);
             if (recipe) {


### PR DESCRIPTION
When a `JavaVisitor` returns an `undefined` from a visitor method and that method was called from `visitRightPadded()` (or `visitLeftPadded()`), then the caller also needs to return `undefined`.

Fixing this required updating `produceAsync()` to also deal with "recipes" returning Immer's `nothing` symbol and `produceAsync()` can now also return `undefined`, which in turn required updating some callers.
