### PR TITLE
Cache the resolved dependencies result rather than recomputing it every time

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleDependencyConfiguration.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleDependencyConfiguration.java
@@ -162,14 +162,11 @@ public class GradleDependencyConfiguration implements Serializable, Attributed {
         return this;
     }
     private class LazyResolutionContext {
-        @Getter
-        private boolean resolveRequired;
-        @Nullable
-        private List<MavenRepository> repositories;
-        @Nullable
-        private ExecutionContext ctx;
-        @Nullable
-        private List<ResolvedDependency> resolved;
+        private @Getter boolean resolveRequired;
+        private @Nullable List<MavenRepository> repositories;
+        private @Nullable ExecutionContext ctx;
+        private @Nullable List<ResolvedDependency> resolved;
+
         public void markForReResolution(List<MavenRepository> repositories, ExecutionContext ctx) {
             this.repositories = repositories;
             this.resolveRequired = true;


### PR DESCRIPTION
## What's changed?
Cache the result of resolved dependencies. They only need to be recomputed when the direct resolved dependencies have been updated.

## What's your motivation?
Reduce memory pressure involved with repeated recomputing of resolved dependencies when nothing has changed.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
@kmccarp 

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
