### PR TITLE
null-safety for `before` in JRightPadded.withElements()

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JRightPadded.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JRightPadded.java
@@ -128,27 +128,29 @@ public class JRightPadded<T> {
     }
 
     public static <J2 extends J> List<JRightPadded<J2>> withElements(List<JRightPadded<J2>> before, List<J2> elements) {
-        // a cheaper check for the most common case when there are no changes
-        if (elements.size() == before.size()) {
-            boolean hasChanges = false;
-            for (int i = 0; i < before.size(); i++) {
-                if (before.get(i).getElement() != elements.get(i)) {
-                    hasChanges = true;
-                    break;
-                }
-            }
-            if (!hasChanges) {
-                return before;
-            }
-        } else if (elements.isEmpty()) {
-            return emptyList();
-        }
-
-        List<JRightPadded<J2>> after = new ArrayList<>(elements.size());
         Map<UUID, JRightPadded<J2>> beforeById = new HashMap<>((int) Math.ceil(elements.size() / 0.75));
-        for (JRightPadded<J2> j : before) {
-            if (beforeById.put(j.getElement().getId(), j) != null) {
-                throw new IllegalStateException("Duplicate key");
+        List<JRightPadded<J2>> after = new ArrayList<>(elements.size());
+        if (before != null) {
+            // a cheaper check for the most common case when there are no changes
+            if (elements.size() == before.size()) {
+                boolean hasChanges = false;
+                for (int i = 0; i < before.size(); i++) {
+                    if (before.get(i).getElement() != elements.get(i)) {
+                        hasChanges = true;
+                        break;
+                    }
+                }
+                if (!hasChanges) {
+                    return before;
+                }
+            } else if (elements.isEmpty()) {
+                return emptyList();
+            }
+
+            for (JRightPadded<J2> j : before) {
+                if (beforeById.put(j.getElement().getId(), j) != null) {
+                    throw new IllegalStateException("Duplicate key");
+                }
             }
         }
 

--- a/rewrite-java/src/test/java/org/openrewrite/java/tree/JRightPaddedTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/tree/JRightPaddedTest.java
@@ -66,4 +66,17 @@ class JRightPaddedTest {
         assertThat(JRightPadded.withElements(trees, List.of(t.withPrefix(Space.format(" ")))))
             .isNotSameAs(trees);
     }
+
+    @Test
+    void withElementsBeforeIsNull() {
+        // given
+        var t = new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY);
+        List<J.Empty> ts = List.of(t);
+
+        // when
+        List<JRightPadded<J.Empty>> rps = JRightPadded.withElements(null, ts);
+
+        // test
+        assertThat(rps.size()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
## What's changed?

Adding a null-safety check to the `JRightPadded.withElements` method.
The `before` is non-null in most of the cases, but it turns out with RPC it might be null.

## What's your motivation?

Fix recipe run failures like:
```
java.lang.NullPointerException: Cannot invoke "java.util.List.size()" because "before" is null
  org.openrewrite.java.tree.JRightPadded.withElements(JRightPadded.java:132)
  org.openrewrite.javascript.tree.JS$CompilationUnit.withImports(JS.java:144)
  org.openrewrite.javascript.tree.JS$CompilationUnit.withImports(JS.java:75)
  org.openrewrite.java.RemoveImport.preVisit(RemoveImport.java:116)
  org.openrewrite.java.RemoveImport.preVisit(RemoveImport.java:34)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:239)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:265)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:265)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:154)
  org.openrewrite.Preconditions$Check.visit(Preconditions.java:159)
  org.openrewrite.Preconditions$Check.visit(Preconditions.java:130)
  org.openrewrite.scheduling.RecipeRunCycle.lambda$editSources$7(RecipeRunCycle.java:210)
```
observed when running against `.ts` files.

