### PR TITLE
Adding `type` to `OptionDescriptor` for `rewrite-javascript` and changing the `@Option` annotation to use the interface without said field for simplifying usage.

### DIFF
--- a/rewrite-javascript/rewrite/package-lock.json
+++ b/rewrite-javascript/rewrite/package-lock.json
@@ -15,6 +15,7 @@
         "diff": "^7.0.0",
         "immer": "^10.1.1",
         "picomatch": "^4.0.3",
+        "reflect-metadata": "^0.2.2",
         "tmp-promise": "^3.0.3",
         "typescript": "^5.8.3",
         "vscode-jsonrpc": "^8.2.1"
@@ -85,6 +86,7 @@
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2997,9 +2999,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3526,6 +3528,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3805,9 +3813,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/rewrite-javascript/rewrite/package.json
+++ b/rewrite-javascript/rewrite/package.json
@@ -36,6 +36,7 @@
     "diff": "^7.0.0",
     "immer": "^10.1.1",
     "picomatch": "^4.0.3",
+    "reflect-metadata": "^0.2.2",
     "tmp-promise": "^3.0.3",
     "typescript": "^5.8.3",
     "vscode-jsonrpc": "^8.2.1"

--- a/rewrite-javascript/rewrite/src/recipe.ts
+++ b/rewrite-javascript/rewrite/src/recipe.ts
@@ -88,7 +88,7 @@ export abstract class Recipe {
     }
 
     async descriptor(): Promise<RecipeDescriptor> {
-        const optionsRecord: Record<string, OptionDescriptor> = (this as any).constructor[OPTIONS_KEY] || {}
+        const optionsRecord: Record<string, OptionAnnotationDescriptor> = (this as any).constructor[OPTIONS_KEY] || {}
         return {
             name: this.name,
             displayName: this.displayName,
@@ -101,6 +101,7 @@ export abstract class Recipe {
                 name: key,
                 value: (this as any)[key],
                 required: descriptor.required ?? true,
+                type: `${this.hasOwnProperty(key) ? typeof (this as any)[key] : ""}`,
                 ...descriptor
             }))
         }
@@ -231,19 +232,9 @@ export function Option(descriptor: OptionAnnotationDescriptor) {
                 configurable: true,
             });
         }
-        var updatedDescriptor: OptionDescriptor = {
-            ...descriptor,
-            type: ""
-        };
-        if (target.hasOwnProperty(propertyKey)) {
-            updatedDescriptor = {
-                ...updatedDescriptor,
-                type: `${typeof target[propertyKey]}`
-            }
-        }
 
         // Register the option metadata under the property key.
-        target.constructor[OPTIONS_KEY][propertyKey] = updatedDescriptor;
+        target.constructor[OPTIONS_KEY][propertyKey] = descriptor;
     };
 }
 

--- a/rewrite-javascript/rewrite/src/recipe.ts
+++ b/rewrite-javascript/rewrite/src/recipe.ts
@@ -138,12 +138,16 @@ export interface RecipeDescriptor {
     readonly options: ({ name: string, value?: any } & OptionDescriptor)[]
 }
 
-export interface OptionDescriptor {
+export interface OptionAnnotationDescriptor {
     readonly displayName: string
     readonly description: string
     readonly required?: boolean
     readonly example?: string
     readonly valid?: string[]
+}
+
+export interface OptionDescriptor extends OptionAnnotationDescriptor {
+    readonly type: string;
 }
 
 export abstract class ScanningRecipe<P> extends Recipe {
@@ -217,7 +221,7 @@ export class RecipeRegistry {
     }
 }
 
-export function Option(descriptor: OptionDescriptor) {
+export function Option(descriptor: OptionAnnotationDescriptor) {
     return function (target: any, propertyKey: string) {
         // Ensure the constructor has options storage.
         if (!target.constructor.hasOwnProperty(OPTIONS_KEY)) {
@@ -227,6 +231,7 @@ export function Option(descriptor: OptionDescriptor) {
                 configurable: true,
             });
         }
+        target.constructor[OPTIONS_KEY]["type"] = `${typeof target}`;
 
         // Register the option metadata under the property key.
         target.constructor[OPTIONS_KEY][propertyKey] = descriptor;

--- a/rewrite-javascript/rewrite/src/recipe.ts
+++ b/rewrite-javascript/rewrite/src/recipe.ts
@@ -231,10 +231,19 @@ export function Option(descriptor: OptionAnnotationDescriptor) {
                 configurable: true,
             });
         }
-        target.constructor[OPTIONS_KEY]["type"] = `${typeof target}`;
+        var updatedDescriptor: OptionDescriptor = {
+            ...descriptor,
+            type: ""
+        };
+        if (target.hasOwnProperty(propertyKey)) {
+            updatedDescriptor = {
+                ...updatedDescriptor,
+                type: `${typeof target[propertyKey]}`
+            }
+        }
 
         // Register the option metadata under the property key.
-        target.constructor[OPTIONS_KEY][propertyKey] = descriptor;
+        target.constructor[OPTIONS_KEY][propertyKey] = updatedDescriptor;
     };
 }
 

--- a/rewrite-javascript/rewrite/test/recipe.test.ts
+++ b/rewrite-javascript/rewrite/test/recipe.test.ts
@@ -40,7 +40,8 @@ describe("recipes", () => {
                     displayName: "Text",
                     name: "text",
                     required: true,
-                    value: undefined
+                    value: undefined,
+                    type: "string"
                 }
             ],
             recipeList: [],

--- a/rewrite-javascript/rewrite/tsconfig.json
+++ b/rewrite-javascript/rewrite/tsconfig.json
@@ -13,7 +13,8 @@
     "skipLibCheck": true,
     "rootDir": ".",
     "outDir": "./dist",
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
## What's changed?
Added `type` field to `OptionDescriptor` for JS/TS while not needing it to be set on the `@Option` annotation itself and instead retrieve the type of the field using `reflect-metadata`.

## What's your motivation?
Unlike the Java recipes, the TS/JS recipes were unable to provide information on the type of an option that was part of a recipe.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
