### PR TITLE
JavaScript - Adding `Expression.type`

### DIFF
--- a/rewrite-javascript/rewrite/src/java/tree.ts
+++ b/rewrite-javascript/rewrite/src/java/tree.ts
@@ -37,6 +37,7 @@ export namespace J {
 }
 
 export interface Expression extends J {
+    readonly type?: Type;
 }
 
 export interface MethodCall extends Expression {

--- a/rewrite-javascript/rewrite/test/javascript/parser/binary.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/binary.test.ts
@@ -27,7 +27,7 @@ describe('arithmetic operator mapping', () => {
                 '1 + 2'
             ),
             afterRecipe: (cu: JS.CompilationUnit) => {
-                const binary = (cu.statements[0].element as JS.ExpressionStatement).expression as J.Binary;
+                const binary = (cu.statements[0].element as JS.ExpressionStatement).expression;
                 expect(binary.type).toBe(Type.Primitive.Double);
             }
         }));
@@ -39,7 +39,7 @@ describe('arithmetic operator mapping', () => {
                 '"1" + 2'
             ),
             afterRecipe: (cu: JS.CompilationUnit) => {
-                const binary = (cu.statements[0].element as JS.ExpressionStatement).expression as J.Binary;
+                const binary = (cu.statements[0].element as JS.ExpressionStatement).expression;
                 expect(binary.type).toBe(Type.Primitive.String);
             }
         }));


### PR DESCRIPTION
## What's changed?

Adding `type` property to the abstract superclass `Expression` on the JavaScript side of the LST trees.

## What's your motivation?

- The same is present in Java LST: https://github.com/openrewrite/rewrite/blob/a98d83d698dda9971c93a0767b7f85d5866f306d/rewrite-java/src/main/java/org/openrewrite/java/tree/Expression.java#L27
- Otherwise it's cumbersome to write recipes when they need to check the type of an expression
