### PR TITLE
Revert "JavaScript - add explicit error when cursor.parentTree is not a function"

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
@@ -699,9 +699,6 @@ export class TemplateApplier {
     }
 
     private wrapTree(originalTree: J, resultToUse: J) {
-        if (this.cursor && (!("parentTree" in this.cursor) || typeof this.cursor?.parentTree !== "function")) {
-            throw new Error("Wrong cursor: " + JSON.stringify(this.cursor) + " when visiting " + JSON.stringify(originalTree));
-        }
         const parentTree = this.cursor?.parentTree()?.value;
 
         // Only apply wrapping logic if we have parent context


### PR DESCRIPTION
- Reverts openrewrite/rewrite#6343 as it didn't help.