### PR TITLE
Fix Groovy/Gradle parsing for GString-s where the interpolation prefix `'$'` is preceded by an even number of backslashes

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -15,7 +15,11 @@
  */
 package org.openrewrite.groovy;
 
+import java.util.stream.Stream;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -223,6 +227,34 @@ class GroovyParserTest implements RewriteTest {
               )
               """
           )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("escapedBackslashesAndInterpolationInGStringParams")
+    void escapedBackslashesAndInterpolationInGString(@Language("groovy") String groovy) {
+        rewriteRun(groovy(groovy));
+    }
+
+    /**
+     * Produces a stream of test expressions like `def a = "\\${System.getProperty('user.name')}"`
+     */
+    static Stream<String> escapedBackslashesAndInterpolationInGStringParams() {
+        return Stream.of(
+            "1 + 1",
+            "System.getProperty('user.name')"
+        ).flatMap(exp ->
+            """
+            %s
+            "%s"
+            "${%s}"
+            "\\${%s}"
+            "\\\\${%s}"
+            "\\\\\\${%s}"
+            "${%s}\\\\"
+            "\\t${%s}"
+            "${%s}\\t"
+            """.lines().map(s -> ("def a = " + s).formatted(exp))
         );
     }
 


### PR DESCRIPTION
Fix Groovy/Gradle parsing for GString-s where the interpolation prefix `'$'` is preceded by an even number of backslashes like in `def a = "\\${System.getProperty('user.name')}"` (in practice this happens often in gradle scripts dealing with windows paths).

## What's changed?
GroovyParserVisitor was changed to fix a GString related parsing issue related to escaping.
Some explicit exceptions were also added to help investigations in the future.

## What's your motivation?
To unblock Gradle recipes from being applied on Gradle build files that show this issue.

## Anything in particular you'd like reviewers to focus on?
Note that I changed the semantics of the `isEscaped()` private method slightly. This change allowed me to move an index check into the method as well (which previously had to be done at the calling side). This method was originally only used from one place, which was updated. This PR calls it from a second place as well.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files

#### Legal disclaimer:

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE APACHE LICENSE V.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
