### PR TITLE
Ensure proper "because" ordering for multiple Maven dependencies

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersionTest.java
@@ -248,4 +248,66 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void addMultipleManagedDependenciesWithBecause() {
+        rewriteRun(spec ->
+            spec.recipe(new UpgradeTransitiveDependencyVersion(
+              "org.apache.tomcat.embed", "*", "10.1.42", null, null, null, null, null, null, null, "CVE-2024-TOMCAT")),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-starter-tomcat</artifactId>
+                          <version>3.3.12</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <!-- CVE-2024-TOMCAT -->
+                          <dependency>
+                              <groupId>org.apache.tomcat.embed</groupId>
+                              <artifactId>tomcat-embed-core</artifactId>
+                              <version>10.1.42</version>
+                          </dependency>
+                          <!-- CVE-2024-TOMCAT -->
+                          <dependency>
+                              <groupId>org.apache.tomcat.embed</groupId>
+                              <artifactId>tomcat-embed-el</artifactId>
+                              <version>10.1.42</version>
+                          </dependency>
+                          <!-- CVE-2024-TOMCAT -->
+                          <dependency>
+                              <groupId>org.apache.tomcat.embed</groupId>
+                              <artifactId>tomcat-embed-websocket</artifactId>
+                              <version>10.1.42</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-starter-tomcat</artifactId>
+                          <version>3.3.12</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

The fix introduces `AddDependencyWithCommentVisitor`, which adds both the comment and dependency in a single atomic operation, ensuring they stay together. Additionally, when finding the  insertion position, the new logic skips over existing comments and inserts before any preceding comments that belong to an existing dependency, preventing new content from being inserted between a comment and its associated dependency.

## What's your motivation?

- The PR https://github.com/openrewrite/rewrite/pull/6160 introduced a "because" option to Maven's AddManagedDependency and UpgradeTransitiveDependencyVersion recipes, allowing a reason (e.g., CVE ID) to be added as an XML comment before managed dependencies. However, when multiple dependencies were added with "because" comments, the comments could become associated with the wrong dependencies due to how InsertDependencyComparator sorts dependencies alphabetically.

- This issue surfaced when adding tests in https://github.com/moderneinc/rewrite-java-security/pull/265. See the `@Disabled` test case.

## Anything in particular you'd like reviewers to focus on?

No