### PR TITLE
`GradleDependency` only needs to look at first order dependencies

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleDependency.java
@@ -1351,7 +1351,7 @@ public class GradleDependency implements Trait<J.MethodInvocation> {
 
             if (gdc != null) {
                 if (gdc.isCanBeResolved()) {
-                    for (ResolvedDependency resolvedDependency : gdc.getResolved()) {
+                    for (ResolvedDependency resolvedDependency : gdc.getDirectResolved()) {
                         if (matcher == null || matcher.matches(resolvedDependency.getGroupId(), resolvedDependency.getArtifactId())) {
                             Dependency req = resolvedDependency.getRequested();
                             if ((req.getGroupId() == null || req.getGroupId().equals(dependency.getGroupId())) &&
@@ -1363,7 +1363,7 @@ public class GradleDependency implements Trait<J.MethodInvocation> {
                 } else {
                     for (GradleDependencyConfiguration transitiveConfiguration : gradleProject.configurationsExtendingFrom(gdc, true)) {
                         if (transitiveConfiguration.isCanBeResolved()) {
-                            for (ResolvedDependency resolvedDependency : transitiveConfiguration.getResolved()) {
+                            for (ResolvedDependency resolvedDependency : transitiveConfiguration.getDirectResolved()) {
                                 if (matcher == null || matcher.matches(resolvedDependency.getGroupId(), resolvedDependency.getArtifactId())) {
                                     Dependency req = resolvedDependency.getRequested();
                                     if ((req.getGroupId() == null || req.getGroupId().equals(dependency.getGroupId())) &&


### PR DESCRIPTION
## What's changed?
The `GradleDependency` trait now only looks at first order resolved dependencies which also brings improved performance due to looking through less data.

## What's your motivation?
Noticed while working on the `DependencyGraph` changes and checking for usages of how `resolved` (flattened list) was utilized. The `GradleDependency` trait is looking at the `build.gradle(.kts)` file in which only first order dependencies are ever represented. As a direct result, that means that we only ever need to look at the first orders for the resolved list as well rather than the entire dependency tree.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
Leave it as it was, but that's not beneficial.

## Any additional context
N/A

### Checklist
- [ ] ~I've added unit tests to cover both positive and negative cases~
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
