### PR TITLE
Fix HttpSender.Response.getBody() InputStream performance and EOF handling

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/ipc/http/HttpSender.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ipc/http/HttpSender.java
@@ -442,7 +442,12 @@ public interface HttpSender {
             return new InputStream() {
                 @Override
                 public int read() throws IOException {
-                    return body == null ? 0 : body.read();
+                    return body == null ? -1 : body.read();
+                }
+
+                @Override
+                public int read(byte[] b, int off, int len) throws IOException {
+                    return body == null ? -1 : body.read(b, off, len);
                 }
 
                 @Override


### PR DESCRIPTION
## Problem

- Same issue as #6377: the `HttpSender.Response.getBody()` method returns an anonymous `InputStream` wrapper that only overrides the single-byte `read()` method. When consumers call the bulk `read(byte[], int, int)` method, Java's default `InputStream` implementation falls back to calling `read()` one byte at a time in a loop, resulting in extremely poor performance.

Additionally, the single-byte `read()` method incorrectly returns `0` when the body is null, but per the `InputStream` contract, `-1` should be returned to indicate end of stream.

## Solution

- Add `read(byte[] b, int off, int len)` override to delegate bulk reads to the underlying stream
- Fix EOF return value from `0` to `-1` per the [InputStream contract](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/io/InputStream.html)