### PR TITLE
Add recipe to add bulk read method to InputStream implementations

### DIFF
--- a/rewrite-java/src/test/java/org/openrewrite/java/cleanup/AddInputStreamBulkReadMethodTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/cleanup/AddInputStreamBulkReadMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ class AddInputStreamBulkReadMethodTest implements RewriteTest {
     }
 
     @Nested
-    class ShouldTransform {
+    class Transform {
 
         @DocumentExample
         @Test
@@ -583,7 +583,7 @@ class AddInputStreamBulkReadMethodTest implements RewriteTest {
     }
 
     @Nested
-    class ShouldNotTransform {
+    class NoChange {
 
         @Test
         void alreadyHasBulkReadMethod() {
@@ -693,7 +693,7 @@ class AddInputStreamBulkReadMethodTest implements RewriteTest {
     }
 
     @Nested
-    class ShouldMarkForReview {
+    class MarkForReview {
         // These tests verify that complex cases with identifiable delegates
         // get a search marker so developers can manually review them
 


### PR DESCRIPTION
Java's default `InputStream.read(byte[], int, int)` calls the single-byte `read()` in a loop, causing up to 350x slower performance for bulk reads.

This recipe detects InputStream subclasses that:
- Override `read()` but not `read(byte[], int, int)`
- Delegate to another `InputStream`

For simple delegation patterns, it adds the missing bulk read method. For complex bodies (side effects, transformations), it adds a search marker for manual review.

Handles both anonymous and named classes, ternary and if-statement null check styles, and skips FilterInputStream subclasses.

## What's changed?

Adding a recipe to detect and update (simple cases of) InputStream implementations that are missing the bulk read method.

## What's your motivation?
I found 3 such instances in OpenRewrite itself which caused huge performance gains when fixed.

## Anything in particular you'd like reviewers to focus on?
Is this recipe useful in its current form, should it maybe only detect? or is only fixing simple cases good too?

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
Not creating this recipe

## Any additional context

- https://github.com/openrewrite/rewrite/pull/6381
- https://github.com/openrewrite/rewrite/pull/6377

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
