### PR TITLE
JavaScript: New `AddDependency` recipe

### DIFF
--- a/rewrite-javascript/rewrite/src/index.ts
+++ b/rewrite-javascript/rewrite/src/index.ts
@@ -38,9 +38,10 @@ export async function activate(registry: RecipeRegistry): Promise<void> {
     const {ModernizeOctalEscapeSequences, ModernizeOctalLiterals, RemoveDuplicateObjectKeys} = await import("./javascript/migrate/es6/index.js");
     const {ExportAssignmentToExportDefault} = await import("./javascript/migrate/typescript/index.js");
     const {UseObjectPropertyShorthand, PreferOptionalChain, AddParseIntRadix} = await import("./javascript/cleanup/index.js");
-    const {AsyncCallbackInSyncArrayMethod, AutoFormat, UpgradeDependencyVersion, UpgradeTransitiveDependencyVersion, OrderImports, ChangeImport} = await import("./javascript/recipes/index.js");
+    const {AddDependency, AsyncCallbackInSyncArrayMethod, AutoFormat, UpgradeDependencyVersion, UpgradeTransitiveDependencyVersion, OrderImports, ChangeImport} = await import("./javascript/recipes/index.js");
     const {FindDependency} = await import("./javascript/search/index.js");
 
+    registry.register(AddDependency);
     registry.register(ExportAssignmentToExportDefault);
     registry.register(FindDependency);
     registry.register(OrderImports);

--- a/rewrite-javascript/rewrite/src/javascript/node-resolution-result.ts
+++ b/rewrite-javascript/rewrite/src/javascript/node-resolution-result.ts
@@ -89,6 +89,22 @@ export const enum NpmrcScope {
     Project = 'Project',     // .npmrc in project root
 }
 
+/**
+ * Represents a dependency scope in package.json that uses object structure {name: version}.
+ * Note: `bundledDependencies` is excluded because it's a string[] of package names, not a version map.
+ */
+export type DependencyScope = 'dependencies' | 'devDependencies' | 'peerDependencies' | 'optionalDependencies';
+
+/**
+ * All dependency scopes in package.json that use object structure {name: version}.
+ */
+export const allDependencyScopes: readonly DependencyScope[] = [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies'
+] as const;
+
 export const NpmrcKind = "org.openrewrite.javascript.marker.NodeResolutionResult$Npmrc" as const;
 
 /**

--- a/rewrite-javascript/rewrite/src/javascript/package-manager.ts
+++ b/rewrite-javascript/rewrite/src/javascript/package-manager.ts
@@ -14,7 +14,16 @@
  * limitations under the License.
  */
 
-import {PackageManager} from "./node-resolution-result";
+import {
+    createNodeResolutionResultMarker,
+    findNodeResolutionResult,
+    PackageJsonContent,
+    PackageLockContent,
+    PackageManager,
+    readNpmrcConfigs
+} from "./node-resolution-result";
+import {replaceMarkerByKind} from "../markers";
+import {Json} from "../json";
 import * as fs from "fs";
 import * as fsp from "fs/promises";
 import * as path from "path";
@@ -108,7 +117,7 @@ const LOCK_FILE_DETECTION: ReadonlyArray<LockFileDetectionConfig> = [
 /**
  * Result of running a package manager command.
  */
-export interface PackageManagerResult {
+interface PackageManagerResult {
     success: boolean;
     stdout?: string;
     stderr?: string;
@@ -118,7 +127,7 @@ export interface PackageManagerResult {
 /**
  * Options for running package manager install.
  */
-export interface InstallOptions {
+interface InstallOptions {
     /** Working directory */
     cwd: string;
 
@@ -165,13 +174,6 @@ export function getLockFileDetectionConfig(): ReadonlyArray<LockFileDetectionCon
 }
 
 /**
- * Gets the configuration for a package manager.
- */
-export function getPackageManagerConfig(pm: PackageManager): PackageManagerConfig {
-    return PACKAGE_MANAGER_CONFIGS[pm];
-}
-
-/**
  * Gets the lock file name for a package manager.
  */
 export function getLockFileName(pm: PackageManager): string {
@@ -186,139 +188,12 @@ export function getAllLockFileNames(): string[] {
 }
 
 /**
- * Checks if a file path is a lock file.
- */
-export function isLockFile(filePath: string): boolean {
-    const fileName = path.basename(filePath);
-    return getAllLockFileNames().includes(fileName);
-}
-
-/**
  * Runs the package manager install command.
- *
- * @param pm The package manager to use
- * @param options Install options
- * @returns Result of the install command
  */
-export function runInstall(pm: PackageManager, options: InstallOptions): PackageManagerResult {
+function runInstall(pm: PackageManager, options: InstallOptions): PackageManagerResult {
     const config = PACKAGE_MANAGER_CONFIGS[pm];
     const command = options.lockOnly ? config.installLockOnlyCommand : config.installCommand;
     const [cmd, ...args] = command;
-
-    try {
-        const result = spawnSync(cmd, args, {
-            cwd: options.cwd,
-            encoding: 'utf-8',
-            stdio: ['pipe', 'pipe', 'pipe'],
-            timeout: options.timeout ?? 120000,
-            env: options.env ? {...process.env, ...options.env} : process.env,
-        });
-
-        if (result.error) {
-            return {
-                success: false,
-                error: result.error.message,
-                stderr: result.stderr,
-            };
-        }
-
-        if (result.status !== 0) {
-            return {
-                success: false,
-                stdout: result.stdout,
-                stderr: result.stderr,
-                error: `Command exited with code ${result.status}`,
-            };
-        }
-
-        return {
-            success: true,
-            stdout: result.stdout,
-            stderr: result.stderr,
-        };
-    } catch (error: any) {
-        return {
-            success: false,
-            error: error.message,
-        };
-    }
-}
-
-/**
- * Options for adding/upgrading a package.
- */
-export interface AddPackageOptions {
-    /** Working directory */
-    cwd: string;
-
-    /** Package name to add/upgrade */
-    packageName: string;
-
-    /** Version constraint (e.g., "^5.0.0") */
-    version: string;
-
-    /** If true, only update lock file without installing to node_modules */
-    lockOnly?: boolean;
-
-    /** Timeout in milliseconds (default: 120000 = 2 minutes) */
-    timeout?: number;
-
-    /** Additional environment variables */
-    env?: Record<string, string>;
-}
-
-/**
- * Runs a package manager command to add or upgrade a package.
- * This updates both package.json and the lock file.
- *
- * @param pm The package manager to use
- * @param options Add package options
- * @returns Result of the command
- */
-export function runAddPackage(pm: PackageManager, options: AddPackageOptions): PackageManagerResult {
-    const packageSpec = `${options.packageName}@${options.version}`;
-
-    // Build command based on package manager
-    let cmd: string;
-    let args: string[];
-
-    switch (pm) {
-        case PackageManager.Npm:
-            cmd = 'npm';
-            args = ['install', packageSpec];
-            if (options.lockOnly) {
-                args.push('--package-lock-only');
-            }
-            break;
-        case PackageManager.YarnClassic:
-            cmd = 'yarn';
-            args = ['add', packageSpec];
-            if (options.lockOnly) {
-                args.push('--ignore-scripts');
-            }
-            break;
-        case PackageManager.YarnBerry:
-            cmd = 'yarn';
-            args = ['add', packageSpec];
-            if (options.lockOnly) {
-                args.push('--mode', 'skip-build');
-            }
-            break;
-        case PackageManager.Pnpm:
-            cmd = 'pnpm';
-            args = ['add', packageSpec];
-            if (options.lockOnly) {
-                args.push('--lockfile-only');
-            }
-            break;
-        case PackageManager.Bun:
-            cmd = 'bun';
-            args = ['add', packageSpec];
-            if (options.lockOnly) {
-                args.push('--ignore-scripts');
-            }
-            break;
-    }
 
     try {
         const result = spawnSync(cmd, args, {
@@ -390,46 +265,6 @@ export function runList(pm: PackageManager, cwd: string, timeout: number = 30000
 }
 
 /**
- * Checks if a package manager is available on the system.
- *
- * @param pm The package manager to check
- * @returns True if the package manager is available
- */
-export function isPackageManagerAvailable(pm: PackageManager): boolean {
-    const config = PACKAGE_MANAGER_CONFIGS[pm];
-    const cmd = config.installCommand[0];
-
-    try {
-        const result = spawnSync(cmd, ['--version'], {
-            encoding: 'utf-8',
-            stdio: ['pipe', 'pipe', 'pipe'],
-            timeout: 5000,
-        });
-        return result.status === 0;
-    } catch {
-        return false;
-    }
-}
-
-/**
- * Gets a human-readable name for a package manager.
- */
-export function getPackageManagerDisplayName(pm: PackageManager): string {
-    switch (pm) {
-        case PackageManager.Npm:
-            return 'npm';
-        case PackageManager.YarnClassic:
-            return 'Yarn Classic';
-        case PackageManager.YarnBerry:
-            return 'Yarn Berry';
-        case PackageManager.Pnpm:
-            return 'pnpm';
-        case PackageManager.Bun:
-            return 'Bun';
-    }
-}
-
-/**
  * Result of running install in a temporary directory.
  */
 export interface TempInstallResult {
@@ -439,6 +274,194 @@ export interface TempInstallResult {
     lockFileContent?: string;
     /** Error message (if failed) */
     error?: string;
+}
+
+/**
+ * Generic accumulator for dependency recipes that run package manager operations.
+ * Used by scanning recipes to track state across scanning and editing phases.
+ *
+ * @typeParam T The recipe-specific project update info type
+ */
+export interface DependencyRecipeAccumulator<T> {
+    /** Projects that need updating: packageJsonPath -> update info */
+    projectsToUpdate: Map<string, T>;
+
+    /** After running package manager, store the updated lock file content */
+    updatedLockFiles: Map<string, string>;
+
+    /** Updated package.json content (after npm install may have modified it) */
+    updatedPackageJsons: Map<string, string>;
+
+    /** Track which projects have been processed (npm install has run) */
+    processedProjects: Set<string>;
+
+    /** Track projects where npm install failed: packageJsonPath -> error message */
+    failedProjects: Map<string, string>;
+}
+
+/**
+ * Creates a new empty accumulator for dependency recipes.
+ */
+export function createDependencyRecipeAccumulator<T>(): DependencyRecipeAccumulator<T> {
+    return {
+        projectsToUpdate: new Map(),
+        updatedLockFiles: new Map(),
+        updatedPackageJsons: new Map(),
+        processedProjects: new Set(),
+        failedProjects: new Map()
+    };
+}
+
+/**
+ * Checks if a source path is a lock file and returns the updated content if available.
+ * This is a helper for dependency recipes that need to update lock files.
+ *
+ * @param sourcePath The source path to check
+ * @param acc The recipe accumulator containing updated lock file content
+ * @returns The updated lock file content if this is a lock file that was updated, undefined otherwise
+ */
+export function getUpdatedLockFileContent<T>(
+    sourcePath: string,
+    acc: DependencyRecipeAccumulator<T>
+): string | undefined {
+    for (const lockFileName of getAllLockFileNames()) {
+        if (sourcePath.endsWith(lockFileName)) {
+            // Find the corresponding package.json path
+            const packageJsonPath = sourcePath.replace(lockFileName, 'package.json');
+            const updateInfo = acc.projectsToUpdate.get(packageJsonPath);
+
+            if (updateInfo && acc.updatedLockFiles.has(sourcePath)) {
+                return acc.updatedLockFiles.get(sourcePath);
+            }
+            break;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Base interface for project update info used by dependency recipes.
+ * Recipes extend this with additional fields specific to their needs.
+ */
+export interface BaseProjectUpdateInfo {
+    /** Absolute path to the project directory */
+    projectDir: string;
+    /** Relative path to package.json (from source root) */
+    packageJsonPath: string;
+    /** The package manager used by this project */
+    packageManager: PackageManager;
+}
+
+/**
+ * Stores the result of a package manager install into the accumulator.
+ * This handles the common pattern of storing updated lock files and tracking failures.
+ *
+ * @param result The result from runInstallInTempDir
+ * @param acc The recipe accumulator
+ * @param updateInfo The project update info (must have packageJsonPath and packageManager)
+ * @param modifiedPackageJson The modified package.json content that was used for install
+ */
+export function storeInstallResult<T extends BaseProjectUpdateInfo>(
+    result: TempInstallResult,
+    acc: DependencyRecipeAccumulator<T>,
+    updateInfo: T,
+    modifiedPackageJson: string
+): void {
+    if (result.success) {
+        acc.updatedPackageJsons.set(updateInfo.packageJsonPath, modifiedPackageJson);
+
+        if (result.lockFileContent) {
+            const lockFileName = getLockFileName(updateInfo.packageManager);
+            const lockFilePath = updateInfo.packageJsonPath.replace('package.json', lockFileName);
+            acc.updatedLockFiles.set(lockFilePath, result.lockFileContent);
+        }
+    } else {
+        acc.failedProjects.set(updateInfo.packageJsonPath, result.error || 'Unknown error');
+    }
+}
+
+/**
+ * Runs the package manager install for a project if it hasn't been processed yet.
+ * Updates the accumulator's processedProjects set after running.
+ *
+ * @param sourcePath The source path (package.json path) being processed
+ * @param acc The recipe accumulator
+ * @param runInstall Function that performs the actual install (recipe-specific)
+ * @returns The failure message if install failed, undefined otherwise
+ */
+export async function runInstallIfNeeded<T>(
+    sourcePath: string,
+    acc: DependencyRecipeAccumulator<T>,
+    runInstall: () => Promise<void>
+): Promise<string | undefined> {
+    if (!acc.processedProjects.has(sourcePath)) {
+        await runInstall();
+        acc.processedProjects.add(sourcePath);
+    }
+    return acc.failedProjects.get(sourcePath);
+}
+
+/**
+ * Updates the NodeResolutionResult marker on a JSON document after a package manager operation.
+ * This recreates the marker based on the updated package.json and lock file content.
+ *
+ * @param doc The JSON document containing the marker
+ * @param updateInfo Project update info with paths and package manager
+ * @param acc The recipe accumulator containing updated content
+ * @returns The document with the updated marker, or unchanged if no existing marker
+ */
+export async function updateNodeResolutionMarker<T extends BaseProjectUpdateInfo>(
+    doc: Json.Document,
+    updateInfo: T & { originalPackageJson: string },
+    acc: DependencyRecipeAccumulator<T>
+): Promise<Json.Document> {
+    const existingMarker = findNodeResolutionResult(doc);
+    if (!existingMarker) {
+        return doc;
+    }
+
+    // Parse the updated package.json and lock file to create new marker
+    const updatedPackageJson = acc.updatedPackageJsons.get(updateInfo.packageJsonPath);
+    const lockFileName = getLockFileName(updateInfo.packageManager);
+    const updatedLockFile = acc.updatedLockFiles.get(
+        updateInfo.packageJsonPath.replace('package.json', lockFileName)
+    );
+
+    let packageJsonContent: PackageJsonContent;
+    let lockContent: PackageLockContent | undefined;
+
+    try {
+        packageJsonContent = JSON.parse(updatedPackageJson || updateInfo.originalPackageJson);
+    } catch {
+        return doc; // Failed to parse, keep original marker
+    }
+
+    if (updatedLockFile) {
+        try {
+            lockContent = JSON.parse(updatedLockFile);
+        } catch {
+            // Continue without lock file content
+        }
+    }
+
+    // Read npmrc configs from the project directory
+    const npmrcConfigs = await readNpmrcConfigs(updateInfo.projectDir);
+
+    // Create new marker
+    const newMarker = createNodeResolutionResultMarker(
+        existingMarker.path,
+        packageJsonContent,
+        lockContent,
+        existingMarker.workspacePackagePaths,
+        existingMarker.packageManager,
+        npmrcConfigs.length > 0 ? npmrcConfigs : undefined
+    );
+
+    // Replace the marker in the document
+    return {
+        ...doc,
+        markers: replaceMarkerByKind(doc.markers, newMarker)
+    };
 }
 
 /**

--- a/rewrite-javascript/rewrite/src/javascript/recipes/add-dependency.ts
+++ b/rewrite-javascript/rewrite/src/javascript/recipes/add-dependency.ts
@@ -1,0 +1,467 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Option, ScanningRecipe} from "../../recipe";
+import {ExecutionContext} from "../../execution";
+import {TreeVisitor} from "../../visitor";
+import {detectIndent, getMemberKeyName, isObject, Json, JsonParser, JsonVisitor, rightPadded, space} from "../../json";
+import {
+    allDependencyScopes,
+    DependencyScope,
+    findNodeResolutionResult,
+    PackageManager
+} from "../node-resolution-result";
+import {emptyMarkers, markupWarn} from "../../markers";
+import {TreePrinters} from "../../print";
+import {
+    createDependencyRecipeAccumulator,
+    DependencyRecipeAccumulator,
+    getUpdatedLockFileContent,
+    runInstallIfNeeded,
+    runInstallInTempDir,
+    storeInstallResult,
+    updateNodeResolutionMarker
+} from "../package-manager";
+import {randomId} from "../../uuid";
+import * as path from "path";
+
+/**
+ * Information about a project that needs updating
+ */
+interface ProjectUpdateInfo {
+    /** Absolute path to the project directory */
+    projectDir: string;
+    /** Relative path to package.json (from source root) */
+    packageJsonPath: string;
+    /** Original package.json content */
+    originalPackageJson: string;
+    /** The scope where the dependency should be added */
+    dependencyScope: DependencyScope;
+    /** Version constraint to apply */
+    newVersion: string;
+    /** The package manager used by this project */
+    packageManager: PackageManager;
+}
+
+type Accumulator = DependencyRecipeAccumulator<ProjectUpdateInfo>;
+
+/**
+ * Adds a new dependency to package.json and updates the lock file.
+ *
+ * This recipe:
+ * 1. Finds package.json files that don't already have the specified dependency
+ * 2. Adds the dependency to the specified scope (defaults to 'dependencies')
+ * 3. Runs the package manager to update the lock file
+ * 4. Updates the NodeResolutionResult marker with new dependency info
+ *
+ * If the dependency already exists in any scope, no changes are made.
+ * This matches the behavior of org.openrewrite.maven.AddDependency.
+ */
+export class AddDependency extends ScanningRecipe<Accumulator> {
+    readonly name = "org.openrewrite.javascript.dependencies.add-dependency";
+    readonly displayName = "Add npm dependency";
+    readonly description = "Adds a new dependency to `package.json` and updates the lock file by running the package manager.";
+
+    @Option({
+        displayName: "Package name",
+        description: "The name of the npm package to add (e.g., `lodash`, `@types/node`)",
+        example: "lodash"
+    })
+    packageName!: string;
+
+    @Option({
+        displayName: "Version",
+        description: "The version constraint to set (e.g., `^5.0.0`, `~2.1.0`, `3.0.0`)",
+        example: "^5.0.0"
+    })
+    version!: string;
+
+    @Option({
+        displayName: "Scope",
+        description: "The dependency scope: `dependencies`, `devDependencies`, `peerDependencies`, or `optionalDependencies`",
+        example: "dependencies",
+        required: false
+    })
+    scope?: DependencyScope;
+
+    initialValue(_ctx: ExecutionContext): Accumulator {
+        return createDependencyRecipeAccumulator();
+    }
+
+    private getTargetScope(): DependencyScope {
+        return this.scope ?? 'dependencies';
+    }
+
+    async scanner(acc: Accumulator): Promise<TreeVisitor<any, ExecutionContext>> {
+        const recipe = this;
+
+        return new class extends JsonVisitor<ExecutionContext> {
+            protected async visitDocument(doc: Json.Document, _ctx: ExecutionContext): Promise<Json | undefined> {
+                // Only process package.json files
+                if (!doc.sourcePath.endsWith('package.json')) {
+                    return doc;
+                }
+
+                const marker = findNodeResolutionResult(doc);
+                if (!marker) {
+                    return doc;
+                }
+
+                // Check if dependency already exists in any scope
+                for (const scope of allDependencyScopes) {
+                    const deps = marker[scope];
+                    if (deps?.some(d => d.name === recipe.packageName)) {
+                        // Dependency already exists, don't add again
+                        return doc;
+                    }
+                }
+
+                // Get the project directory and package manager
+                const projectDir = path.dirname(path.resolve(doc.sourcePath));
+                const pm = marker.packageManager ?? PackageManager.Npm;
+
+                acc.projectsToUpdate.set(doc.sourcePath, {
+                    projectDir,
+                    packageJsonPath: doc.sourcePath,
+                    originalPackageJson: await this.printDocument(doc),
+                    dependencyScope: recipe.getTargetScope(),
+                    newVersion: recipe.version,
+                    packageManager: pm
+                });
+
+                return doc;
+            }
+
+            private async printDocument(doc: Json.Document): Promise<string> {
+                return TreePrinters.print(doc);
+            }
+        };
+    }
+
+    async editorWithData(acc: Accumulator): Promise<TreeVisitor<any, ExecutionContext>> {
+        const recipe = this;
+
+        return new class extends JsonVisitor<ExecutionContext> {
+            protected async visitDocument(doc: Json.Document, ctx: ExecutionContext): Promise<Json | undefined> {
+                const sourcePath = doc.sourcePath;
+
+                // Handle package.json files
+                if (sourcePath.endsWith('package.json')) {
+                    const updateInfo = acc.projectsToUpdate.get(sourcePath);
+                    if (!updateInfo) {
+                        return doc; // This package.json doesn't need updating
+                    }
+
+                    // Run package manager install if needed, check for failure
+                    const failureMessage = await runInstallIfNeeded(sourcePath, acc, () =>
+                        recipe.runPackageManagerInstall(acc, updateInfo, ctx)
+                    );
+                    if (failureMessage) {
+                        return markupWarn(
+                            doc,
+                            `Failed to add ${recipe.packageName} to ${recipe.version}`,
+                            failureMessage
+                        );
+                    }
+
+                    // Add the dependency to the JSON AST (preserves formatting)
+                    const visitor = new AddDependencyVisitor(
+                        recipe.packageName,
+                        recipe.version,
+                        updateInfo.dependencyScope
+                    );
+                    const modifiedDoc = await visitor.visit(doc, undefined) as Json.Document;
+
+                    // Update the NodeResolutionResult marker
+                    return updateNodeResolutionMarker(modifiedDoc, updateInfo, acc);
+                }
+
+                // Handle lock files for all package managers
+                const updatedLockContent = getUpdatedLockFileContent(sourcePath, acc);
+                if (updatedLockContent) {
+                    return await new JsonParser({}).parseOne({
+                        text: updatedLockContent,
+                        sourcePath: doc.sourcePath
+                    }) as Json.Document;
+                }
+
+                return doc;
+            }
+        };
+    }
+
+    /**
+     * Runs the package manager in a temporary directory to update the lock file.
+     */
+    private async runPackageManagerInstall(
+        acc: Accumulator,
+        updateInfo: ProjectUpdateInfo,
+        _ctx: ExecutionContext
+    ): Promise<void> {
+        // Create modified package.json with the new dependency
+        const modifiedPackageJson = this.createModifiedPackageJson(
+            updateInfo.originalPackageJson,
+            updateInfo.dependencyScope
+        );
+
+        const result = await runInstallInTempDir(
+            updateInfo.projectDir,
+            updateInfo.packageManager,
+            modifiedPackageJson
+        );
+
+        storeInstallResult(result, acc, updateInfo, modifiedPackageJson);
+    }
+
+    /**
+     * Creates a modified package.json with the new dependency added.
+     */
+    private createModifiedPackageJson(
+        originalContent: string,
+        scope: DependencyScope
+    ): string {
+        const packageJson = JSON.parse(originalContent);
+
+        if (!packageJson[scope]) {
+            packageJson[scope] = {};
+        }
+
+        packageJson[scope][this.packageName] = this.version;
+
+        return JSON.stringify(packageJson, null, 2);
+    }
+}
+
+/**
+ * Visitor that adds a new dependency to a specific scope in package.json.
+ * If the scope doesn't exist, it creates it.
+ */
+class AddDependencyVisitor extends JsonVisitor<void> {
+    private readonly packageName: string;
+    private readonly version: string;
+    private readonly targetScope: DependencyScope;
+    private scopeFound = false;
+    private dependencyAdded = false;
+    private baseIndent: string = '    '; // Will be detected from document
+
+    constructor(packageName: string, version: string, targetScope: DependencyScope) {
+        super();
+        this.packageName = packageName;
+        this.version = version;
+        this.targetScope = targetScope;
+    }
+
+    protected async visitDocument(doc: Json.Document, p: void): Promise<Json | undefined> {
+        // Detect indentation from the document
+        this.baseIndent = detectIndent(doc);
+
+        const result = await super.visitDocument(doc, p) as Json.Document;
+
+        // If scope wasn't found, we need to add it to the document
+        if (!this.scopeFound && !this.dependencyAdded) {
+            return this.addScopeToDocument(result);
+        }
+
+        return result;
+    }
+
+    protected async visitMember(member: Json.Member, p: void): Promise<Json | undefined> {
+        const keyName = getMemberKeyName(member);
+
+        if (keyName === this.targetScope) {
+            this.scopeFound = true;
+            return this.addDependencyToScope(member);
+        }
+
+        return super.visitMember(member, p);
+    }
+
+    /**
+     * Adds the dependency to an existing scope object.
+     */
+    private addDependencyToScope(scopeMember: Json.Member): Json.Member {
+        const value = scopeMember.value;
+
+        if (!isObject(value)) {
+            return scopeMember;
+        }
+
+        const members = [...(value.members || [])];
+
+        // Determine the closing whitespace (goes before closing brace after last element)
+        let closingWhitespace = '\n    ';
+        if (members.length > 0) {
+            const lastMember = members[members.length - 1];
+            closingWhitespace = lastMember.after.whitespace;
+            // Update the last member's after to be empty (comma will be added by printer)
+            members[members.length - 1] = {
+                ...lastMember,
+                after: space('')
+            };
+        }
+
+        const newMember = this.createDependencyMemberWithAfter(closingWhitespace);
+        this.dependencyAdded = true;
+
+        members.push(newMember);
+
+        return {
+            ...scopeMember,
+            value: {
+                ...value,
+                members
+            } as Json.Object
+        };
+    }
+
+    /**
+     * Creates a new dependency member node.
+     */
+    private createDependencyMemberWithAfter(afterWhitespace: string): Json.RightPadded<Json.Member> {
+        // Dependencies inside a scope are indented twice (e.g., 8 spaces if base is 4)
+        const depIndent = this.baseIndent + this.baseIndent;
+
+        const keyLiteral: Json.Literal = {
+            kind: Json.Kind.Literal,
+            id: randomId(),
+            prefix: space('\n' + depIndent),
+            markers: emptyMarkers,
+            source: `"${this.packageName}"`,
+            value: this.packageName
+        };
+
+        const valueLiteral: Json.Literal = {
+            kind: Json.Kind.Literal,
+            id: randomId(),
+            prefix: space(' '),
+            markers: emptyMarkers,
+            source: `"${this.version}"`,
+            value: this.version
+        };
+
+        const member: Json.Member = {
+            kind: Json.Kind.Member,
+            id: randomId(),
+            prefix: space(''),
+            markers: emptyMarkers,
+            key: rightPadded(keyLiteral, space('')),
+            value: valueLiteral
+        };
+
+        return rightPadded(member, space(afterWhitespace));
+    }
+
+    /**
+     * Adds a new scope section to the document when the target scope doesn't exist.
+     */
+    private addScopeToDocument(doc: Json.Document): Json.Document {
+        const docValue = doc.value;
+
+        if (!isObject(docValue)) {
+            return doc;
+        }
+
+        const members = [...(docValue.members || [])];
+
+        // Get the trailing whitespace from the last member
+        let closingWhitespace = '\n';
+        if (members.length > 0) {
+            const lastMember = members[members.length - 1];
+            closingWhitespace = lastMember.after.whitespace;
+            // Update the last member's after to be empty (comma will be added by printer)
+            members[members.length - 1] = {
+                ...lastMember,
+                after: space('')
+            };
+        }
+
+        const scopeMember = this.createScopeMemberWithAfter(closingWhitespace);
+        this.dependencyAdded = true;
+
+        members.push(scopeMember);
+
+        return {
+            ...doc,
+            value: {
+                ...docValue,
+                members
+            } as Json.Object
+        };
+    }
+
+    /**
+     * Creates a new scope member with the dependency inside.
+     */
+    private createScopeMemberWithAfter(afterWhitespace: string): Json.RightPadded<Json.Member> {
+        // Dependencies inside a scope are indented twice (e.g., 8 spaces if base is 4)
+        const depIndent = this.baseIndent + this.baseIndent;
+
+        const keyLiteral: Json.Literal = {
+            kind: Json.Kind.Literal,
+            id: randomId(),
+            prefix: space('\n' + this.baseIndent),
+            markers: emptyMarkers,
+            source: `"${this.targetScope}"`,
+            value: this.targetScope
+        };
+
+        const depKeyLiteral: Json.Literal = {
+            kind: Json.Kind.Literal,
+            id: randomId(),
+            prefix: space('\n' + depIndent),
+            markers: emptyMarkers,
+            source: `"${this.packageName}"`,
+            value: this.packageName
+        };
+
+        const depValueLiteral: Json.Literal = {
+            kind: Json.Kind.Literal,
+            id: randomId(),
+            prefix: space(' '),
+            markers: emptyMarkers,
+            source: `"${this.version}"`,
+            value: this.version
+        };
+
+        const depMember: Json.Member = {
+            kind: Json.Kind.Member,
+            id: randomId(),
+            prefix: space(''),
+            markers: emptyMarkers,
+            key: rightPadded(depKeyLiteral, space('')),
+            value: depValueLiteral
+        };
+
+        const scopeObject: Json.Object = {
+            kind: Json.Kind.Object,
+            id: randomId(),
+            prefix: space(' '),
+            markers: emptyMarkers,
+            members: [rightPadded(depMember, space('\n' + this.baseIndent))]
+        };
+
+        const scopeMemberNode: Json.Member = {
+            kind: Json.Kind.Member,
+            id: randomId(),
+            prefix: space(''),
+            markers: emptyMarkers,
+            key: rightPadded(keyLiteral, space('')),
+            value: scopeObject
+        };
+
+        return rightPadded(scopeMemberNode, space(afterWhitespace));
+    }
+}

--- a/rewrite-javascript/rewrite/src/javascript/recipes/index.ts
+++ b/rewrite-javascript/rewrite/src/javascript/recipes/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export * from "./add-dependency";
 export * from "./async-callback-in-sync-array-method";
 export * from "./auto-format";
 export * from "./upgrade-dependency-version";

--- a/rewrite-javascript/rewrite/src/javascript/recipes/upgrade-transitive-dependency-version.ts
+++ b/rewrite-javascript/rewrite/src/javascript/recipes/upgrade-transitive-dependency-version.ts
@@ -19,19 +19,24 @@ import {ExecutionContext} from "../../execution";
 import {TreeVisitor} from "../../visitor";
 import {Json, JsonParser, JsonVisitor} from "../../json";
 import {
-    createNodeResolutionResultMarker,
+    allDependencyScopes,
     findNodeResolutionResult,
     NodeResolutionResultQueries,
-    PackageJsonContent,
-    PackageLockContent,
-    PackageManager,
-    readNpmrcConfigs
+    PackageManager
 } from "../node-resolution-result";
 import * as path from "path";
 import * as semver from "semver";
-import {markupWarn, replaceMarkerByKind} from "../../markers";
+import {markupWarn} from "../../markers";
 import {TreePrinters} from "../../print";
-import {getAllLockFileNames, getLockFileName, runInstallInTempDir} from "../package-manager";
+import {
+    createDependencyRecipeAccumulator,
+    DependencyRecipeAccumulator,
+    getUpdatedLockFileContent,
+    runInstallIfNeeded,
+    runInstallInTempDir,
+    storeInstallResult,
+    updateNodeResolutionMarker
+} from "../package-manager";
 import {applyOverrideToPackageJson, DependencyPathSegment, parseDependencyPath} from "../dependency-manager";
 
 /**
@@ -57,25 +62,7 @@ interface ProjectUpdateInfo {
     dependencyPathSegments?: DependencyPathSegment[];
 }
 
-/**
- * Accumulator for tracking state across scanning and editing phases
- */
-interface Accumulator {
-    /** Projects that need updating: packageJsonPath -> update info */
-    projectsToUpdate: Map<string, ProjectUpdateInfo>;
-
-    /** After running package manager, store the updated lock file content */
-    updatedLockFiles: Map<string, string>;
-
-    /** Updated package.json content (after npm install may have modified it) */
-    updatedPackageJsons: Map<string, string>;
-
-    /** Track which projects have been processed (npm install has run) */
-    processedProjects: Set<string>;
-
-    /** Track projects where npm install failed: packageJsonPath -> error message */
-    failedProjects: Map<string, string>;
-}
+type Accumulator = DependencyRecipeAccumulator<ProjectUpdateInfo>;
 
 /**
  * Upgrades the version of a transitive dependency by adding override entries to package.json.
@@ -98,14 +85,14 @@ export class UpgradeTransitiveDependencyVersion extends ScanningRecipe<Accumulat
 
     @Option({
         displayName: "Package name",
-        description: "The name of the npm package to upgrade (e.g., 'lodash', '@types/node')",
+        description: "The name of the npm package to upgrade (e.g., `lodash`, `@types/node`)",
         example: "lodash"
     })
     packageName!: string;
 
     @Option({
-        displayName: "New version",
-        description: "The new version constraint to set (e.g., '^5.0.0', '~2.1.0', '3.0.0')",
+        displayName: "Version",
+        description: "The version constraint to set (e.g., `^5.0.0`, `~2.1.0`, `3.0.0`)",
         example: "^5.0.0"
     })
     newVersion!: string;
@@ -119,13 +106,7 @@ export class UpgradeTransitiveDependencyVersion extends ScanningRecipe<Accumulat
     dependencyPath?: string;
 
     initialValue(_ctx: ExecutionContext): Accumulator {
-        return {
-            projectsToUpdate: new Map(),
-            updatedLockFiles: new Map(),
-            updatedPackageJsons: new Map(),
-            processedProjects: new Set(),
-            failedProjects: new Map()
-        };
+        return createDependencyRecipeAccumulator();
     }
 
     async scanner(acc: Accumulator): Promise<TreeVisitor<any, ExecutionContext>> {
@@ -148,8 +129,7 @@ export class UpgradeTransitiveDependencyVersion extends ScanningRecipe<Accumulat
                 const pm = marker.packageManager ?? PackageManager.Npm;
 
                 // Check if package is a direct dependency - if so, skip (use UpgradeDependencyVersion instead)
-                const scopes = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'] as const;
-                for (const scope of scopes) {
+                for (const scope of allDependencyScopes) {
                     const deps = marker[scope];
                     if (deps?.find(d => d.name === recipe.packageName)) {
                         // Package is a direct dependency, don't add override
@@ -218,14 +198,10 @@ export class UpgradeTransitiveDependencyVersion extends ScanningRecipe<Accumulat
                         return doc; // This package.json doesn't need updating
                     }
 
-                    // Run package manager install if we haven't processed this project yet
-                    if (!acc.processedProjects.has(sourcePath)) {
-                        await recipe.runPackageManagerInstall(acc, updateInfo, ctx);
-                        acc.processedProjects.add(sourcePath);
-                    }
-
-                    // Check if the install failed - if so, don't update, just add warning
-                    const failureMessage = acc.failedProjects.get(sourcePath);
+                    // Run package manager install if needed, check for failure
+                    const failureMessage = await runInstallIfNeeded(sourcePath, acc, () =>
+                        recipe.runPackageManagerInstall(acc, updateInfo, ctx)
+                    );
                     if (failureMessage) {
                         return markupWarn(
                             doc,
@@ -238,23 +214,16 @@ export class UpgradeTransitiveDependencyVersion extends ScanningRecipe<Accumulat
                     const modifiedDoc = await this.addOverrideEntry(doc, updateInfo);
 
                     // Update the NodeResolutionResult marker
-                    return recipe.updateMarker(modifiedDoc, updateInfo, acc);
+                    return updateNodeResolutionMarker(modifiedDoc, updateInfo, acc);
                 }
 
                 // Handle lock files for all package managers
-                for (const lockFileName of getAllLockFileNames()) {
-                    if (sourcePath.endsWith(lockFileName)) {
-                        // Find the corresponding package.json path
-                        const packageJsonPath = sourcePath.replace(lockFileName, 'package.json');
-                        const updateInfo = acc.projectsToUpdate.get(packageJsonPath);
-
-                        if (updateInfo && acc.updatedLockFiles.has(sourcePath)) {
-                            // Parse the updated lock file content and return it
-                            const updatedContent = acc.updatedLockFiles.get(sourcePath)!;
-                            return this.parseUpdatedLockFile(doc, updatedContent);
-                        }
-                        break;
-                    }
+                const updatedLockContent = getUpdatedLockFileContent(sourcePath, acc);
+                if (updatedLockContent) {
+                    return await new JsonParser({}).parseOne({
+                        text: updatedLockContent,
+                        sourcePath: doc.sourcePath
+                    }) as Json.Document;
                 }
 
                 return doc;
@@ -291,46 +260,15 @@ export class UpgradeTransitiveDependencyVersion extends ScanningRecipe<Accumulat
                 const newContent = JSON.stringify(modifiedPackageJson, null, indent);
 
                 // Re-parse with JsonParser to get proper AST
-                const parser = new JsonParser({});
-                const parsed: Json.Document[] = [];
-                for await (const sf of parser.parse({text: newContent, sourcePath: doc.sourcePath})) {
-                    parsed.push(sf as Json.Document);
-                }
+                const parsed = await new JsonParser({}).parseOne({
+                    text: newContent,
+                    sourcePath: doc.sourcePath
+                }) as Json.Document;
 
-                if (parsed.length > 0) {
-                    return {
-                        ...parsed[0],
-                        sourcePath: doc.sourcePath,
-                        markers: doc.markers
-                    };
-                }
-
-                return doc;
-            }
-
-            /**
-             * Parses updated lock file content and creates a new document.
-             */
-            private async parseUpdatedLockFile(
-                originalDoc: Json.Document,
-                updatedContent: string
-            ): Promise<Json.Document> {
-                const parser = new JsonParser({});
-                const parsed: Json.Document[] = [];
-
-                for await (const sf of parser.parse({text: updatedContent, sourcePath: originalDoc.sourcePath})) {
-                    parsed.push(sf as Json.Document);
-                }
-
-                if (parsed.length > 0) {
-                    return {
-                        ...parsed[0],
-                        sourcePath: originalDoc.sourcePath,
-                        markers: originalDoc.markers
-                    };
-                }
-
-                return originalDoc;
+                return {
+                    ...parsed,
+                    markers: doc.markers
+                };
             }
         };
     }
@@ -355,18 +293,7 @@ export class UpgradeTransitiveDependencyVersion extends ScanningRecipe<Accumulat
             modifiedPackageJson
         );
 
-        if (result.success) {
-            acc.updatedPackageJsons.set(updateInfo.packageJsonPath, modifiedPackageJson);
-
-            // Store the updated lock file content
-            if (result.lockFileContent) {
-                const lockFileName = getLockFileName(updateInfo.packageManager);
-                const lockFilePath = updateInfo.packageJsonPath.replace('package.json', lockFileName);
-                acc.updatedLockFiles.set(lockFilePath, result.lockFileContent);
-            }
-        } else {
-            acc.failedProjects.set(updateInfo.packageJsonPath, result.error || 'Unknown error');
-        }
+        storeInstallResult(result, acc, updateInfo, modifiedPackageJson);
     }
 
     /**
@@ -389,57 +316,4 @@ export class UpgradeTransitiveDependencyVersion extends ScanningRecipe<Accumulat
         return JSON.stringify(packageJson, null, 2);
     }
 
-    /**
-     * Updates the NodeResolutionResult marker with new dependency information.
-     */
-    private async updateMarker(
-        doc: Json.Document,
-        updateInfo: ProjectUpdateInfo,
-        acc: Accumulator
-    ): Promise<Json.Document> {
-        const existingMarker = findNodeResolutionResult(doc);
-        if (!existingMarker) {
-            return doc;
-        }
-
-        // Parse the updated package.json and lock file to create new marker
-        const updatedPackageJson = acc.updatedPackageJsons.get(updateInfo.packageJsonPath);
-        const lockFileName = getLockFileName(updateInfo.packageManager);
-        const updatedLockFile = acc.updatedLockFiles.get(
-            updateInfo.packageJsonPath.replace('package.json', lockFileName)
-        );
-
-        let packageJsonContent: PackageJsonContent;
-        let lockContent: PackageLockContent | undefined;
-
-        try {
-            packageJsonContent = JSON.parse(updatedPackageJson || updateInfo.originalPackageJson);
-        } catch {
-            return doc;
-        }
-
-        if (updatedLockFile) {
-            try {
-                lockContent = JSON.parse(updatedLockFile);
-            } catch {
-                // Continue without lock file content
-            }
-        }
-
-        const npmrcConfigs = await readNpmrcConfigs(updateInfo.projectDir);
-
-        const newMarker = createNodeResolutionResultMarker(
-            existingMarker.path,
-            packageJsonContent,
-            lockContent,
-            existingMarker.workspacePackagePaths,
-            existingMarker.packageManager,
-            npmrcConfigs.length > 0 ? npmrcConfigs : undefined
-        );
-
-        return {
-            ...doc,
-            markers: replaceMarkerByKind(doc.markers, newMarker)
-        };
-    }
 }

--- a/rewrite-javascript/rewrite/src/parser.ts
+++ b/rewrite-javascript/rewrite/src/parser.ts
@@ -57,6 +57,23 @@ export abstract class Parser {
 
     abstract parse(...sourcePaths: ParserInput[]): AsyncGenerator<SourceFile>
 
+    /**
+     * Parses a single input and returns the first source file.
+     * This is a convenience method for when you know you're parsing exactly one input.
+     *
+     * @param input The input to parse
+     * @returns The parsed source file
+     * @throws Error if the parser produces no results
+     */
+    async parseOne(input: ParserInput): Promise<SourceFile> {
+        const result = await this.parse(input).next();
+        if (result.done) {
+            const sourcePath = typeof input === 'string' ? input : input.sourcePath;
+            throw new Error(`Parser produced no results for: ${sourcePath}`);
+        }
+        return result.value;
+    }
+
     protected relativePath(sourcePath: ParserInput): string {
         const path = typeof sourcePath === "string" ? sourcePath : sourcePath.sourcePath;
         return isAbsolute(path) && this.relativeTo ? relative(this.relativeTo, path) : path;

--- a/rewrite-javascript/rewrite/test/javascript/package-json-parser.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/package-json-parser.test.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * <p>
- * https://docs.moderne.io/licensing/moderate-source-available-license
+ * https://docs.moderne.io/licensing/moderne-source-available-license
  * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rewrite-javascript/rewrite/test/javascript/recipes/add-dependency.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/recipes/add-dependency.test.ts
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    AddDependency,
+    findNodeResolutionResult,
+    npm,
+    packageJson,
+    packageLockJson,
+    typescript
+} from "../../../src/javascript";
+import {Json} from "../../../src/json";
+import {RecipeSpec} from "../../../src/test";
+import {withDir} from "tmp-promise";
+import {findMarker, MarkersKind} from "../../../src";
+
+describe("AddDependency", () => {
+
+    test("adds dependency to package.json", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new AddDependency({
+            packageName: "lodash",
+            version: "^4.17.21"
+        });
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    typescript(`const x = 1;`),
+                    packageJson(`
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0"
+                            }
+                        }
+                    `, `
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0",
+                                "lodash": "^4.17.21"
+                            }
+                        }
+                    `)
+                )
+            );
+        }, {unsafeCleanup: true});
+    });
+
+    // This is the same behavior as org.openrewrite.maven.AddDependency
+    test("does not modify when dependency already exists", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new AddDependency({
+            packageName: "uuid",
+            version: "^10.0.0"
+        });
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    typescript(`const x = 1;`),
+                    packageJson(`
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0"
+                            }
+                        }
+                    `)
+                )
+            );
+        }, {unsafeCleanup: true});
+    });
+
+    test("adds devDependency when scope is specified", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new AddDependency({
+            packageName: "@types/lodash",
+            version: "^4.17.0",
+            scope: "devDependencies"
+        });
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    typescript(`const x = 1;`),
+                    packageJson(`
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0"
+                            }
+                        }
+                    `, `
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0"
+                            },
+                            "devDependencies": {
+                                "@types/lodash": "^4.17.0"
+                            }
+                        }
+                    `)
+                )
+            );
+        }, {unsafeCleanup: true});
+    });
+
+    test("adds to existing devDependencies section", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new AddDependency({
+            packageName: "@types/lodash",
+            version: "^4.17.0",
+            scope: "devDependencies"
+        });
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    typescript(`const x = 1;`),
+                    packageJson(`
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "devDependencies": {
+                                "@types/node": "^20.0.0"
+                            }
+                        }
+                    `, `
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "devDependencies": {
+                                "@types/node": "^20.0.0",
+                                "@types/lodash": "^4.17.0"
+                            }
+                        }
+                    `)
+                )
+            );
+        }, {unsafeCleanup: true});
+    });
+
+    test("updates NodeResolutionResult marker after adding dependency", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new AddDependency({
+            packageName: "lodash",
+            version: "^4.17.21"
+        });
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    typescript(`const x = 1;`),
+                    {
+                        ...packageJson(`
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0"
+                            }
+                        }
+                    `, `
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0",
+                                "lodash": "^4.17.21"
+                            }
+                        }
+                    `), afterRecipe: async (doc: Json.Document) => {
+                            const marker = findNodeResolutionResult(doc);
+                            expect(marker).toBeDefined();
+                            expect(marker!.dependencies).toHaveLength(2);
+
+                            const lodashDep = marker!.dependencies.find(d => d.name === "lodash");
+                            expect(lodashDep).toBeDefined();
+                            expect(lodashDep!.versionConstraint).toBe("^4.17.21");
+                        }
+                    }
+                )
+            );
+        }, {unsafeCleanup: true});
+    });
+
+    test("adds peerDependency when scope is specified", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new AddDependency({
+            packageName: "react",
+            version: "^18.0.0",
+            scope: "peerDependencies"
+        });
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    typescript(`const x = 1;`),
+                    packageJson(`
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0"
+                            }
+                        }
+                    `, `
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0"
+                            },
+                            "peerDependencies": {
+                                "react": "^18.0.0"
+                            }
+                        }
+                    `)
+                )
+            );
+        }, {unsafeCleanup: true});
+    });
+
+    test("adds warning marker when package does not exist", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new AddDependency({
+            packageName: "this-package-does-not-exist-12345",
+            version: "^1.0.0"
+        });
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    typescript(`const x = 1;`),
+                    {
+                        ...packageJson(`
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0"
+                            }
+                        }
+                    `, `
+                        /*~~(Failed to add this-package-does-not-exist-12345 to ^1.0.0)~~>*/{
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0"
+                            }
+                        }
+                    `), afterRecipe: async (doc: Json.Document) => {
+                            const warnMarker = findMarker(doc, MarkersKind.MarkupWarn);
+                            expect(warnMarker).toBeDefined();
+                            expect((warnMarker as any).message).toContain("Failed to add this-package-does-not-exist-12345");
+                        }
+                    }
+                )
+            );
+        }, {unsafeCleanup: true});
+    });
+
+    test("updates package-lock.json when adding dependency", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new AddDependency({
+            packageName: "lodash",
+            version: "^4.17.21"
+        });
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    typescript(`const x = 1;`),
+                    packageJson(`
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0"
+                            }
+                        }
+                    `, `
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0",
+                                "lodash": "^4.17.21"
+                            }
+                        }
+                    `),
+                    packageLockJson(`
+                    {
+                        "name": "test-project",
+                        "version": "1.0.0",
+                        "lockfileVersion": 3,
+                        "requires": true,
+                        "packages": {
+                            "": {
+                                "name": "test-project",
+                                "version": "1.0.0",
+                                "dependencies": {
+                                    "uuid": "^9.0.0"
+                                }
+                            },
+                            "node_modules/uuid": {
+                                "version": "9.0.0",
+                                "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+                                "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+                            }
+                        }
+                    }
+                    `, (actual: string) => {
+                        const lockData = JSON.parse(actual);
+
+                        if (!lockData.packages) {
+                            throw new Error("Expected packages in lock file");
+                        }
+
+                        // The root package should now include lodash
+                        const rootPkg = lockData.packages[""];
+                        if (rootPkg?.dependencies?.["lodash"] !== "^4.17.21") {
+                            throw new Error(`Expected root dependency lodash to be ^4.17.21, got ${rootPkg?.dependencies?.["lodash"]}`);
+                        }
+
+                        // lodash should be in node_modules
+                        const lodashPkg = lockData.packages["node_modules/lodash"];
+                        if (!lodashPkg?.version?.startsWith("4.17.")) {
+                            throw new Error(`Expected lodash version to start with 4.17., got ${lodashPkg?.version}`);
+                        }
+
+                        return actual;
+                    })
+                )
+            );
+        }, {unsafeCleanup: true});
+    });
+
+    // Note - to be honest, I am not sure if this is the desired behavior
+    test("does not add if dependency exists in different scope", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new AddDependency({
+            packageName: "uuid",
+            version: "^10.0.0",
+            scope: "devDependencies"
+        });
+
+        await withDir(async (repo) => {
+            // uuid exists in dependencies, so shouldn't add to devDependencies
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    typescript(`const x = 1;`),
+                    packageJson(`
+                        {
+                            "name": "test-project",
+                            "version": "1.0.0",
+                            "dependencies": {
+                                "uuid": "^9.0.0"
+                            }
+                        }
+                    `)
+                )
+            );
+        }, {unsafeCleanup: true});
+    });
+});


### PR DESCRIPTION
Adds a new recipe for adding npm dependencies to `package.json`, along with refactoring to share code across dependency recipes.

### Changes

- **New `AddDependency` recipe**: Adds dependencies to `package.json` with lock file updates, supporting all dependency scopes (`dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`)
- **Shared accumulator pattern**: Extracted `DependencyRecipeAccumulator` and helpers (`storeInstallResult`, `runInstallIfNeeded`, `updateNodeResolutionMarker`) to `package-manager.ts` for reuse across dependency recipes
- **JSON type guards**: Added `isLiteral()`, `isObject()`, `isArray()`, `isIdentifier()`, `isMember()` to `json/tree.ts` for cleaner type narrowing
- **Centralized `DependencyScope` type**: Moved to `node-resolution-result.ts`, excluding `bundledDependencies` (which uses incompatible `string[]` structure)
- **Cleanup**: Removed unused exports from `package-manager.ts` (`runAddPackage`, `isLockFile`, `getPackageManagerConfig`, etc.)