### PR TITLE
Updated  toml parser to handle whitspaces incase of empty array.

### DIFF
--- a/rewrite-toml/src/main/java/org/openrewrite/toml/internal/TomlParserVisitor.java
+++ b/rewrite-toml/src/main/java/org/openrewrite/toml/internal/TomlParserVisitor.java
@@ -339,6 +339,13 @@ public class TomlParserVisitor extends TomlParserBaseVisitor<Toml> {
                 }
             }
 
+            if (values.isEmpty()) {
+                // Handle empty array - need to capture spacing between [ and ]
+                elements.add(TomlRightPadded.build(
+                        (Toml) new Toml.Empty(randomId(), Space.EMPTY, Markers.EMPTY)
+                ).withAfter(sourceBefore("]")));
+            }
+
             return new Toml.Array(
                     randomId(),
                     prefix,

--- a/rewrite-toml/src/test/java/org/openrewrite/toml/TomlParserTest.java
+++ b/rewrite-toml/src/test/java/org/openrewrite/toml/TomlParserTest.java
@@ -452,4 +452,41 @@ class TomlParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void multilineEmptySequence() {
+        rewriteRun(
+          toml(
+            """
+            dependencies = [
+            ]
+            """
+          )
+        );
+    }
+
+    @Test
+    void multilineEmptySequenceMultipleEmptyLines() {
+        rewriteRun(
+          toml(
+            """
+            dependencies = [
+            
+            
+            ]
+            """
+          )
+        );
+    }
+
+    @Test
+    void singleLineEmptySequenceWithSpaces() {
+        rewriteRun(
+          toml(
+            """
+            dependencies = [    ]
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
- Updated toml parser to hanld empty array with whitespaces.
- closes #6376 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
