### PR TITLE
Add new recipe able to change for a method definition the return type

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodDeclaredReturnType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodDeclaredReturnType.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeTree;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChangeMethodDeclaredReturnType extends Recipe {
+    @Option(displayName = "Method pattern",
+        description = MethodMatcher.METHOD_PATTERN_DESCRIPTION,
+        example = "org.mockito.Matchers anyVararg()")
+    String methodPattern;
+
+    @Option(displayName = "New method declared return type",
+        description = "The fully qualified new return type of the method declared/definition.",
+        example = "long")
+    String newReturnType;
+
+    @Override
+    public String getDisplayName() {
+        return "Change method definition return type";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Changes the return type of the method definition.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            private final MethodMatcher methodMatcher = new MethodMatcher(methodPattern, false);
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+
+                if (methodMatcher.matches(m.getMethodType())) {
+                    m = m.withReturnTypeExpression(TypeTree.build(newReturnType));
+                    //As the call to the following method don't work, then we should most probably use visitor: AddImport() !!
+                    // maybeAddImport(newReturnType);
+                    return autoFormat(m, ctx);
+                }
+                return m;
+            }
+        };
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/ChangeMethodDeclaredReturnTypeTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/ChangeMethodDeclaredReturnTypeTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class ChangeMethodDeclaredReturnTypeTest implements RewriteTest {
+    @Test
+    @DisplayName("Change the return type of the method and import the FQN.")
+    void shouldChangeReturnTypeAndAddMissingImportTest() {
+        String methodPattern = "Foo bar(..)";
+        String newFQNReturnType = "java.util.List<String>";
+
+        rewriteRun(spec -> spec
+            .recipe(new ChangeMethodDeclaredReturnType(methodPattern,newFQNReturnType))
+            .expectedCyclesThatMakeChanges(1).cycles(1),
+            // Remark: Even if we use autoformat, a space is still included before the return type modified !
+            // To get the import added, it is needed to execute in a 2nd recipe the AddImport() visitor !
+            //toRecipe(r -> new AddImport<>(newImport,null,false))))),
+            java("""
+                public class Foo {
+                  Object bar() {
+                      return null;
+                  }
+                }
+                """, """
+                  import java.util.List;
+                
+                  public class Foo {
+                        java.util.List<String> bar() {
+                          return null;
+                      }
+                  }
+                """));
+    }
+}


### PR DESCRIPTION
## What's changed?

- See issue: #6379
- Add a new recipe able to change for a method definition the return type

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
