### PR TITLE
Fixed parser issue to support flow style mappings in sequences.

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -748,10 +748,29 @@ public class YamlParser implements org.openrewrite.Parser {
             this.prefix = prefix;
         }
 
+        public MappingWithPrefix(UUID id, Markers markers, @Nullable String openingBracePrefix, List<Entry> entries, @Nullable String closingBracePrefix, @Nullable Anchor anchor, @Nullable Tag tag, String prefix) {
+            super(id, markers, openingBracePrefix, entries, closingBracePrefix, anchor, tag);
+            this.prefix = prefix;
+        }
+
         @Override
         public Mapping withPrefix(String prefix) {
             this.prefix = prefix;
             return this;
+        }
+
+        @Override
+        public MappingWithPrefix withClosingBracePrefix(@Nullable String closingBracePrefix) {
+            return new MappingWithPrefix(
+                    getId(),
+                    getMarkers(),
+                    getOpeningBracePrefix(),
+                    getEntries(),
+                    closingBracePrefix,
+                    getAnchor(),
+                    getTag(),
+                    this.prefix
+            );
         }
     }
 
@@ -842,7 +861,7 @@ public class YamlParser implements org.openrewrite.Parser {
                 if (mapping instanceof MappingWithPrefix) {
                     MappingWithPrefix mappingWithPrefix = (MappingWithPrefix) mapping;
                     return super.visitMapping(new Yaml.Mapping(mappingWithPrefix.getId(),
-                            mappingWithPrefix.getMarkers(), mappingWithPrefix.getOpeningBracePrefix(), mappingWithPrefix.getEntries(), null, mappingWithPrefix.getAnchor(), mappingWithPrefix.getTag()), p);
+                            mappingWithPrefix.getMarkers(), mappingWithPrefix.getOpeningBracePrefix(), mappingWithPrefix.getEntries(), mappingWithPrefix.getClosingBracePrefix(), mappingWithPrefix.getAnchor(), mappingWithPrefix.getTag()), p);
                 }
                 return super.visitMapping(mapping, p);
             }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -559,4 +559,63 @@ class YamlParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void flowStyleMappingsInSequences() {
+        rewriteRun(
+          yaml(
+            """
+              tasks:
+                - {"task_type": "Shell"}
+                - { "task_type": "Shell2"}
+              """
+          ),
+          yaml(
+            """
+              items:
+                - name: block-style
+                  type: mapping
+                - {"name": "flow-style", "type": "mapping"}
+                - key: another-block
+              """
+          ),
+          yaml(
+            """
+              items:
+                - {}
+                - {"key": "value"}
+              """
+          ),
+          yaml(
+            """
+              data:
+                - {"list": [1, 2, 3], "map": {"nested": "value"}}
+                - {"array": [{"inner": "map"}]}
+              """
+          ),
+          yaml(
+            """
+              items:
+                - {
+                    "key": "value",
+                    "another": "test"
+                  }
+              """
+          ),
+          yaml(
+            """
+              items:
+                - {"key": "value",}
+              """
+          ),
+          yaml(
+            """
+              defaults: &defaults {"type": "default", "enabled": true}
+              items:
+                - *defaults
+                - {"type": "custom"}
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
- Fixed the in YAML parser to handle flow style mappings in sequences.
- Created a overloaded method  for `withClosingBracePrefix` to return `MappingWithPrefix` instance.
- closes issue #6375 


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
