### PR TITLE
JavaScript - Refactor JavaScript tests not to use `@openrewrite/rewrite` in imports

### DIFF
--- a/rewrite-javascript/rewrite/fixtures/change-text.ts
+++ b/rewrite-javascript/rewrite/fixtures/change-text.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import {ReplacedText} from "./replaced-text";
-import {ExecutionContext, Option, Recipe, Transient, TreeVisitor} from "@openrewrite/rewrite";
-import {PlainText, PlainTextVisitor} from "@openrewrite/rewrite/text";
+import {ExecutionContext, Option, Recipe, Transient, TreeVisitor} from "../src";
+import {PlainText, PlainTextVisitor} from "../src/text";
 
 export class ChangeText extends Recipe {
     name = "org.openrewrite.example.text.change-text"

--- a/rewrite-javascript/rewrite/fixtures/change-version.ts
+++ b/rewrite-javascript/rewrite/fixtures/change-version.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ExecutionContext, Option, Recipe} from "@openrewrite/rewrite";
-import {Json, JsonVisitor} from "@openrewrite/rewrite/json";
+import {ExecutionContext, Option, Recipe} from "../src";
+import {Json, JsonVisitor} from "../src/json";
 
 export class ChangeVersion extends Recipe {
     name = "org.openrewrite.example.npm.change-version";

--- a/rewrite-javascript/rewrite/fixtures/create-text.ts
+++ b/rewrite-javascript/rewrite/fixtures/create-text.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ExecutionContext, Option, ScanningRecipe, SourceFile} from "@openrewrite/rewrite";
-import {PlainTextParser} from "@openrewrite/rewrite/text";
+import {ExecutionContext, Option, ScanningRecipe, SourceFile} from "../src";
+import {PlainTextParser} from "../src/text";
 
 export class CreateText extends ScanningRecipe<{ exists: boolean }> {
     name = "org.openrewrite.example.text.create-text";

--- a/rewrite-javascript/rewrite/fixtures/example-recipe.ts
+++ b/rewrite-javascript/rewrite/fixtures/example-recipe.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {RecipeRegistry} from "@openrewrite/rewrite";
+import {RecipeRegistry} from "../src";
 import {FindIdentifier} from "./search-recipe";
 import {CreateText} from "./create-text";
 import {ChangeText} from "./change-text";

--- a/rewrite-javascript/rewrite/fixtures/mark-class-types.ts
+++ b/rewrite-javascript/rewrite/fixtures/mark-class-types.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ExecutionContext, foundSearchResult, Recipe, TreeVisitor} from "@openrewrite/rewrite";
-import {JavaScriptVisitor} from "@openrewrite/rewrite/javascript";
-import {J, Type} from "@openrewrite/rewrite/java";
+import {ExecutionContext, foundSearchResult, Recipe, TreeVisitor} from "../src";
+import {JavaScriptVisitor} from "../src/javascript";
+import {J, Type} from "../src/java";
 
 export class MarkClassTypes extends Recipe {
     name = "org.openrewrite.example.javascript.mark-class-types"

--- a/rewrite-javascript/rewrite/fixtures/mark-primitive-types.ts
+++ b/rewrite-javascript/rewrite/fixtures/mark-primitive-types.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ExecutionContext, foundSearchResult, Recipe, TreeVisitor} from "@openrewrite/rewrite";
-import {JavaScriptVisitor} from "@openrewrite/rewrite/javascript";
-import {J, Type} from "@openrewrite/rewrite/java";
+import {ExecutionContext, foundSearchResult, Recipe, TreeVisitor} from "../src";
+import {JavaScriptVisitor} from "../src/javascript";
+import {J, Type} from "../src/java";
 
 export class MarkPrimitiveTypes extends Recipe {
     name = "org.openrewrite.example.javascript.mark-primitive-types"

--- a/rewrite-javascript/rewrite/fixtures/mark-types.ts
+++ b/rewrite-javascript/rewrite/fixtures/mark-types.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ExecutionContext, foundSearchResult, Recipe, TreeVisitor} from "@openrewrite/rewrite";
-import {JavaScriptVisitor} from "@openrewrite/rewrite/javascript";
-import {J, Type} from "@openrewrite/rewrite/java";
+import {ExecutionContext, foundSearchResult, Recipe, TreeVisitor} from "../src";
+import {JavaScriptVisitor} from "../src/javascript";
+import {J, Type} from "../src/java";
 
 export class MarkTypes extends Recipe {
     name = "org.openrewrite.example.javascript.mark-types"

--- a/rewrite-javascript/rewrite/fixtures/modify-all-trees.ts
+++ b/rewrite-javascript/rewrite/fixtures/modify-all-trees.ts
@@ -15,16 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    ExecutionContext,
-    marker,
-    Marker,
-    randomId,
-    Recipe,
-    RecipeRegistry,
-    Tree,
-    TreeVisitor
-} from "@openrewrite/rewrite";
+import {ExecutionContext, marker, Marker, randomId, Recipe, RecipeRegistry, Tree, TreeVisitor} from "../src";
 
 export function activate(registry: RecipeRegistry) {
     registry.register(ModifyAllTrees);

--- a/rewrite-javascript/rewrite/fixtures/path-precondition.ts
+++ b/rewrite-javascript/rewrite/fixtures/path-precondition.ts
@@ -13,15 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    check,
-    ExecutionContext,
-    foundSearchResult,
-    isSourceFile,
-    Option,
-    Recipe,
-    TreeVisitor
-} from "@openrewrite/rewrite";
+import {check, ExecutionContext, foundSearchResult, isSourceFile, Option, Recipe, TreeVisitor} from "../src";
 import {FindIdentifier} from "./search-recipe";
 
 /**

--- a/rewrite-javascript/rewrite/fixtures/recipe-with-recipe-list.ts
+++ b/rewrite-javascript/rewrite/fixtures/recipe-with-recipe-list.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {ChangeText} from "./change-text";
-import {Recipe} from "@openrewrite/rewrite";
+import {Recipe} from "../src";
 
 export class RecipeWithRecipeList extends Recipe {
     name = "org.openrewrite.example.text.with-recipe-list"

--- a/rewrite-javascript/rewrite/fixtures/remote-path-precondition.ts
+++ b/rewrite-javascript/rewrite/fixtures/remote-path-precondition.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {check, ExecutionContext, Option, Recipe, TreeVisitor} from "@openrewrite/rewrite";
+import {check, ExecutionContext, Option, Recipe, TreeVisitor} from "../src";
 import {FindIdentifier} from "./search-recipe";
-import {hasSourcePath} from "@openrewrite/rewrite/javascript";
+import {hasSourcePath} from "../src/javascript";
 
 /**
  * A recipe that finds identifiers in files matching a specific path

--- a/rewrite-javascript/rewrite/fixtures/replace-id.ts
+++ b/rewrite-javascript/rewrite/fixtures/replace-id.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import {createDraft, finishDraft} from "immer";
-import {ExecutionContext, Markers, randomId, Recipe, TreeVisitor} from "@openrewrite/rewrite";
-import {JavaScriptVisitor} from "@openrewrite/rewrite/javascript";
-import {J} from "@openrewrite/rewrite/java";
+import {ExecutionContext, Markers, randomId, Recipe, TreeVisitor} from "../src";
+import {JavaScriptVisitor} from "../src/javascript";
+import {J} from "../src/java";
 
 export class ReplaceId extends Recipe {
     name = "org.openrewrite.example.javascript.replace-id"

--- a/rewrite-javascript/rewrite/fixtures/replaced-text.ts
+++ b/rewrite-javascript/rewrite/fixtures/replaced-text.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Column, DataTable} from "@openrewrite/rewrite";
+import {Column, DataTable} from "../src";
 
 export class ReplacedText {
     @Column({

--- a/rewrite-javascript/rewrite/fixtures/scanning-editor.ts
+++ b/rewrite-javascript/rewrite/fixtures/scanning-editor.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ExecutionContext, ScanningRecipe, TreeVisitor} from "@openrewrite/rewrite";
-import {PlainText, PlainTextVisitor} from "@openrewrite/rewrite/text";
+import {ExecutionContext, ScanningRecipe, TreeVisitor} from "../src";
+import {PlainText, PlainTextVisitor} from "../src/text";
 
 /**
  * A test recipe that uses the accumulator in the editor phase.

--- a/rewrite-javascript/rewrite/fixtures/search-recipe.ts
+++ b/rewrite-javascript/rewrite/fixtures/search-recipe.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ExecutionContext, foundSearchResult, Option, Recipe, TreeVisitor} from "@openrewrite/rewrite";
-import {JavaScriptVisitor} from "@openrewrite/rewrite/javascript";
-import {J} from "@openrewrite/rewrite/java";
+import {ExecutionContext, foundSearchResult, Option, Recipe, TreeVisitor} from "../src";
+import {JavaScriptVisitor} from "../src/javascript";
+import {J} from "../src/java";
 
 export class FindIdentifier extends Recipe {
     name = "org.openrewrite.example.javascript.find-identifier"

--- a/rewrite-javascript/rewrite/test/preconditions.test.ts
+++ b/rewrite-javascript/rewrite/test/preconditions.test.ts
@@ -15,12 +15,11 @@
  */
 import {RecipeSpec} from "../src/test";
 import {javascript} from "../src/javascript";
-import {FindIdentifierWithPathPrecondition, ConditionalFindIdentifier} from "../fixtures/path-precondition";
+import {ConditionalFindIdentifier, FindIdentifierWithPathPrecondition} from "../fixtures/path-precondition";
 
 describe('Preconditions', () => {
     test('visitor precondition - should only mark identifiers in matching path', async () => {
         const spec = new RecipeSpec();
-        // @ts-expect-error Fixtures import from dist while types are from src, causing expected type mismatch
         spec.recipe = new FindIdentifierWithPathPrecondition({
             requiredPath: 'test.js',
             identifier: 'foo'
@@ -40,7 +39,6 @@ describe('Preconditions', () => {
 
     test('boolean precondition - should mark when true', async () => {
         const spec = new RecipeSpec();
-        // @ts-expect-error Fixtures import from dist while types are from src, causing expected type mismatch
         spec.recipe = new ConditionalFindIdentifier({
             shouldSearch: true,
             identifier: 'bar'
@@ -53,7 +51,6 @@ describe('Preconditions', () => {
 
     test('boolean precondition - should not mark when false', async () => {
         const spec = new RecipeSpec();
-        // @ts-expect-error Fixtures import from dist while types are from src, causing expected type mismatch
         spec.recipe = new ConditionalFindIdentifier({
             shouldSearch: false,
             identifier: 'bar'

--- a/rewrite-javascript/rewrite/test/recipe.test.ts
+++ b/rewrite-javascript/rewrite/test/recipe.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {RecipeRegistry} from "@openrewrite/rewrite";
+import {RecipeRegistry} from "../src";
 import {describe} from "@jest/globals";
 import {activate} from "../fixtures/example-recipe";
 import {ChangeText} from "../fixtures/change-text";

--- a/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
@@ -16,17 +16,24 @@
  * limitations under the License.
  */
 import {afterEach, beforeEach, describe, expect, test} from "@jest/globals";
-import {Cursor, RecipeRegistry, rootCursor} from "@openrewrite/rewrite";
-import {RewriteRpc} from "@openrewrite/rewrite/rpc";
-import {PlainText, text} from "@openrewrite/rewrite/text";
-import {json} from "@openrewrite/rewrite/json";
-import {RecipeSpec} from "@openrewrite/rewrite/test";
+import {Cursor, RecipeRegistry, rootCursor} from "../../src";
+import {RewriteRpc} from "../../src/rpc";
+import {PlainText, text} from "../../src/text";
+import {json, Json} from "../../src/json";
+import {RecipeSpec} from "../../src/test";
 import {PassThrough} from "node:stream";
 import * as rpc from "vscode-jsonrpc/node";
 import {activate} from "../../fixtures/example-recipe";
-import {findNodeResolutionResult, javascript, JavaScriptVisitor, JS, npm, packageJson, typescript} from "@openrewrite/rewrite/javascript";
-import {Json} from "@openrewrite/rewrite/json";
-import {J} from "@openrewrite/rewrite/java";
+import {
+    findNodeResolutionResult,
+    javascript,
+    JavaScriptVisitor,
+    JS,
+    npm,
+    packageJson,
+    typescript
+} from "../../src/javascript";
+import {J} from "../../src/java";
 import {withDir} from "tmp-promise";
 
 describe("Rewrite RPC", () => {

--- a/rewrite-javascript/rewrite/test/test/rewrite-test.test.ts
+++ b/rewrite-javascript/rewrite/test/test/rewrite-test.test.ts
@@ -1,7 +1,7 @@
 import {describe} from "@jest/globals";
-import {RecipeSpec} from "@openrewrite/rewrite/test";
-import {text} from "@openrewrite/rewrite/text";
-import {json} from "@openrewrite/rewrite/json";
+import {RecipeSpec} from "../../src/test";
+import {text} from "../../src/text";
+import {json} from "../../src/json";
 import {ChangeText} from "../../fixtures/change-text";
 
 describe("rewrite test", () => {


### PR DESCRIPTION
## What's changed?

Refactoring the test code we have at:
- rewrite-javascript/rewrite/test
- rewrite-javascript/rewrite/fixtures

not to use `@openrewrite/rewrite` in their import statements.

## What's your motivation?

Otherwise it's easy to run into incompatibility issues when `src/` and `dist/` are mixed and the TypeScript compiler fails to match what is what, e.g.
> Type 'Promise<import("/Users/greg/git/rewrite/rewrite-javascript/rewrite/src/visitor").TreeVisitor<any, import("/Users/greg/git/rewrite/rewrite-javascript/rewrite/src/execution").ExecutionContext>>' is not assignable to type 'Promise<import("/Users/greg/git/rewrite/rewrite-javascript/rewrite/dist/visitor").TreeVisitor<any, import("/Users/greg/git/rewrite/rewrite-javascript/rewrite/dist/execution").ExecutionContext>>'.
