### PR TITLE
Add count column to `DependencyInsight` rather than listing per row

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
@@ -446,11 +446,13 @@ class DependencyInsightTest implements RewriteTest {
             .dataTable(DependenciesInUse.Row.class, rows -> {
                 assertThat(rows).isNotEmpty();
                 assertThat(rows).anyMatch(row ->
+                    "compileClasspath".equals(row.getScope()) &&
                     "spring-boot-starter-web".equals(row.getArtifactId()) &&
-                    row.getDepth() == 0);
+                    row.getCount() == 1);
                 assertThat(rows).anyMatch(row ->
+                    "compileClasspath".equals(row.getScope()) &&
                     "spring-boot".equals(row.getArtifactId()) &&
-                    row.getDepth() == 4);
+                    row.getCount() == 10);
             }),
           buildGradle(
             """
@@ -524,13 +526,15 @@ class DependencyInsightTest implements RewriteTest {
             .dataTable(DependenciesInUse.Row.class, rows -> {
                 assertThat(rows).isNotEmpty();
                 assertThat(rows).anyMatch(row ->
+                  "compileClasspath".equals(row.getScope()) &&
                     "com.fasterxml.jackson.datatype".equals(row.getGroupId()) &&
                     "jackson-datatype-jsr310".equals(row.getArtifactId()) &&
-                    row.getDepth() == 2);
+                    row.getCount() == 1);
                 assertThat(rows).anyMatch(row ->
+                  "compileClasspath".equals(row.getScope()) &&
                     "com.fasterxml.jackson.core".equals(row.getGroupId()) &&
                     "jackson-core".equals(row.getArtifactId()) &&
-                    row.getDepth() == 3);
+                    row.getCount() == 11);
             })
             .dataTable(ExplainDependenciesInUse.Row.class, rows -> {
                 assertThat(rows).isNotEmpty();

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/graph/DependencyGraph.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/graph/DependencyGraph.java
@@ -31,6 +31,9 @@ import static java.util.Collections.emptySet;
 public class DependencyGraph {
     @Nullable Node root;
 
+    @Getter
+    int size = 0;
+
     /**
      * Append a leaf-to-root dependency path to this dependency graph.
      */
@@ -47,6 +50,8 @@ public class DependencyGraph {
         } else if (!root.getId().equals(id)) {
             throw new IllegalStateException("Dependency path is for a different root");
         }
+
+        size++;
 
         Node parent = root;
         while (iterator.hasNext()) {
@@ -101,6 +106,10 @@ public class DependencyGraph {
         if (prefix.length() > 0) {
             prefix.setLength(prefix.length() - 5);
         }
+    }
+
+    public boolean isEmpty() {
+        return size == 0;
     }
 
     private static String formatDependency(ResolvedGroupArtifactVersion gav) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/table/DependenciesInUse.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/table/DependenciesInUse.java
@@ -62,8 +62,8 @@ public class DependenciesInUse extends DataTable<DependenciesInUse.@NonNull Row>
                               "specified in the POM.")
         String scope;
 
-        @Column(displayName = "Depth",
-                description = "How many levels removed from a direct dependency. This will be 0 for direct dependencies.")
-        Integer depth;
+        @Column(displayName = "Count",
+                description = "How many times does this dependency appear.")
+        Integer count;
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/table/ExplainDependenciesInUse.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/table/ExplainDependenciesInUse.java
@@ -69,6 +69,10 @@ public class ExplainDependenciesInUse extends DataTable<ExplainDependenciesInUse
                               "specified in the POM.")
         String scope;
 
+        @Column(displayName = "Count",
+                description = "How many times does this dependency appear.")
+        Integer count;
+
         @Column(displayName = "Dependency graph",
                 description = "The dependency paths that requested the dependency.")
         String dependencyGraph;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/DependencyInsightTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/DependencyInsightTest.java
@@ -320,13 +320,15 @@ class DependencyInsightTest implements RewriteTest {
             .dataTable(DependenciesInUse.Row.class, rows -> {
                 assertThat(rows).isNotEmpty();
                 assertThat(rows).anyMatch(row ->
-                  "com.fasterxml.jackson.datatype".equals(row.getGroupId()) &&
+                  "compileClasspath".equals(row.getScope()) &&
+                    "com.fasterxml.jackson.datatype".equals(row.getGroupId()) &&
                     "jackson-datatype-jsr310".equals(row.getArtifactId()) &&
-                    row.getDepth() == 2);
+                    row.getCount() == 1);
                 assertThat(rows).anyMatch(row ->
-                  "com.fasterxml.jackson.core".equals(row.getGroupId()) &&
+                  "compileClasspath".equals(row.getScope()) &&
+                    "com.fasterxml.jackson.core".equals(row.getGroupId()) &&
                     "jackson-core".equals(row.getArtifactId()) &&
-                    row.getDepth() == 3);
+                    row.getCount() == 11);
             })
             .dataTable(ExplainDependenciesInUse.Row.class, rows -> {
                 assertThat(rows).isNotEmpty();


### PR DESCRIPTION
## What's changed?
Only write a single row per matching dependency with a count representing the number of occurrences that dependency appears within the dependency tree.

## What's your motivation?
* Using the `openrewrite/rewrite-third-party` as a basis searching for `com.fasterxml*:*` would return back 12k rows. 
* Using the OpenRewrite organization (39 repositories) as a basis, searching for `com.fasterxml*:*` would return back 1.8m rows.

Given the dependency tree is very dense in this manner, working over a relatively simple selector meant that anything but programmatic tooling would be unable to process or work with the returned data set for a very small organization. As a result, this meant that we needed to change our opinion about attempting to store a record for each occurrence.

## Any additional context
Additional usages that will need to be adapted
- https://github.com/openrewrite/rewrite-java-dependencies/blob/main/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumJUnitVersion.java
- https://github.com/openrewrite/rewrite-java-dependencies/blob/main/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumDependencyVersion.java

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
