### PR TITLE
Allow Kotlin method invocation type to be considered valid if null

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/Assertions.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/Assertions.java
@@ -377,7 +377,10 @@ public final class Assertions {
             // Avoid over-reporting the same problem by checking the invocation only when its elements are well-formed
             if (mi == method) {
                 JavaType.Method type = mi.getMethodType();
-                if (!isWellFormedType(type, seenTypes)) {
+                if (type == null) {
+                  // Allow null method type for method invocations due to:
+                  // https://github.com/openrewrite/rewrite/issues/6408
+                } else if (!isWellFormedType(type, seenTypes)) {
                     mi = SearchResult.found(mi, "MethodInvocation type is missing or malformed");
                 } else if (!type.getName().equals(mi.getSimpleName()) && !type.isConstructor() && isValidated(mi)) {
                     mi = SearchResult.found(mi, "type information has a different method name '" + type.getName() + "'");

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AssertionsTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AssertionsTest.java
@@ -19,12 +19,19 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.java.search.FindMissingTypes.MissingTypeResult;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JContainer;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.tree.ParseError;
 
+import java.util.List;
 import java.util.Optional;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 import static org.openrewrite.test.RewriteTest.toRecipe;
@@ -70,5 +77,20 @@ class AssertionsTest implements RewriteTest {
         assertThat(sf.isPresent()).isTrue();
         //noinspection OptionalGetWithoutIsPresent
         assertThat(sf.get()).isInstanceOf(ParseError.class);
+    }
+
+    @Test
+    void allowNullTypeForMethodInvocation() {
+        J.MethodInvocation mi = new J.MethodInvocation(
+          Tree.randomId(),
+          Space.EMPTY,
+          Markers.EMPTY,
+          null,
+          null,
+          new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), "test", null, null),
+          JContainer.empty(),
+          null); // null type
+        List<MissingTypeResult> missingTypes = Assertions.findMissingTypes(mi);
+        assertThat(missingTypes).isEmpty();
     }
 }


### PR DESCRIPTION
## What's changed?

This allows the type of a Kotlin `MethodInvocation` to be  considered valid if null, as already anticipated by the [by the KotlinTreeParseVisitor](https://github.com/openrewrite/rewrite/blob/e118585d5a7081be8315c669127177e8b100002f/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java#L2018).

## What's your motivation?

- Fix/workaround for https://github.com/openrewrite/rewrite/issues/6408

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?

@timtebeek has context from Slack
@Laurens-W

## Have you considered any alternatives or workarounds?

I tried to find a way to force the parser to resolve the type, but the issue appears to be deep in the bowels of the Jetbrains FIR.

## Any additional context

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
