### PR TITLE
Fixed groovy parser issue to handle slashy string delimters as escape characters.

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1748,7 +1748,7 @@ public class GroovyParserVisitor {
                     String value = sourceSubstring(cursor, delimiter.close);
                     // There could be a closer GString before the end of the closing delimiter, so shorten the string if needs be
                     int indexNextSign = source.indexOf("$", cursor);
-                    while (isEscaped(indexNextSign)) {
+                    while (isEscaped(indexNextSign, delimiter)) {
                         indexNextSign = source.indexOf("$", indexNextSign + 1);
                     }
                     if (indexNextSign != -1 && indexNextSign < (cursor + value.length())) {
@@ -2756,6 +2756,32 @@ public class GroovyParserVisitor {
             index--;
         }
         return backslashCount % 2 != 0;
+    }
+
+    /**
+     * Determines if a $ character in a GString is escaped based on the delimiter type.
+     * For slashy strings, $$ escapes a dollar sign and $ followed by the closing delimiter is treated as literal.
+     * For other string types, backslash escaping is used.
+     */
+    private boolean isEscaped(int index, Delimiter delimiter) {
+        if (index < 0) {
+            return false;
+        }
+
+        // Slashy-type strings use different escaping: $$ for literal $ and $ before closing delimiter
+        if (delimiter.isSlashyStringDelimiter() || delimiter.isDollarSlashyStringDelimiter()) {
+            if (index + 1 < source.length()) {
+                if (source.charAt(index + 1) == '$') {
+                    return true; // $$ escapes a dollar sign
+                }
+                // For slashy strings (not dollar-slashy), $ before closing delimiter is also literal
+                return delimiter.isSlashyStringDelimiter() && source.startsWith(delimiter.close, index + 1);
+            }
+            return false;
+        }
+
+        // Regular strings use backslash escaping
+        return isEscaped(index);
     }
 
     /**

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/Delimiter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/Delimiter.java
@@ -48,4 +48,12 @@ public enum Delimiter {
         }
         return null;
     }
+
+    public boolean isSlashyStringDelimiter() {
+        return this == SLASHY_STRING || this == PATTERN_SLASHY_STRING;
+    }
+
+    public boolean isDollarSlashyStringDelimiter() {
+        return this == DOLLAR_SLASHY_STRING || this == PATTERN_DOLLAR_SLASHY_STRING;
+    }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -195,9 +195,9 @@ class LiteralTest implements RewriteTest {
     void gStringMultiPropertyAccess() {
         rewriteRun(
           groovy(
-                """
-            "$System.env.BAR_BAZ"
             """
+              "$System.env.BAR_BAZ"
+              """
           )
         );
     }
@@ -206,9 +206,9 @@ class LiteralTest implements RewriteTest {
     void emptyGString() {
         rewriteRun(
           groovy(
-                """
-            "${}"
             """
+              "${}"
+              """
           )
         );
     }
@@ -217,9 +217,9 @@ class LiteralTest implements RewriteTest {
     void nestedGString() {
         rewriteRun(
           groovy(
-                """
-            " ${ " ${ " " } " } "
             """
+              " ${ " ${ " " } " } "
+              """
           )
         );
     }
@@ -228,9 +228,9 @@ class LiteralTest implements RewriteTest {
     void gStringInterpolateString() {
         rewriteRun(
           groovy(
-                """
-            " ${""}\\n${" "} "
             """
+              " ${""}\\n${" "} "
+              """
           )
         );
     }
@@ -401,10 +401,10 @@ class LiteralTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-            "\\\\\\\\n\\\\t"
-            '\\\\n\\t'
-            ///\\\\n\\t///
-            """
+              "\\\\\\\\n\\\\t"
+              '\\\\n\\t'
+              ///\\\\n\\t///
+              """
           )
         );
     }
@@ -414,9 +414,9 @@ class LiteralTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-            '\t'
-            '	'
-            """
+              '\t'
+              '	'
+              """
           )
         );
     }
@@ -451,6 +451,73 @@ class LiteralTest implements RewriteTest {
             """
               "".replaceAll('\\\\', '/')
               "a\\b".replaceAll('\\\\', '/')
+              """
+          )
+        );
+    }
+
+    @Test
+    void slashyStrings() {
+        rewriteRun(
+          groovy(
+            """
+              def text = "irrelevant"
+              def glassfishVersion = "1"
+              println text =~ /^.*ClassPath Element.*glassfish-embedded-all-${glassfishVersion}.jar.*$/
+              """
+          ),
+          groovy(
+            """
+              def pattern = /Price: $$\\d+/
+              """
+          ),
+          groovy(
+            """
+              def pattern = /test$/
+              """
+          ),
+          groovy(
+            """
+              def pattern = /$$foo $${bar} $$$$/
+              """
+          )
+        );
+    }
+
+    @Test
+    void dollarSlashyStrings() {
+        rewriteRun(
+          groovy(
+            """
+              def version = "1.0"
+              def path = $/C:\\Program Files\\App-${version}\\bin/$
+              """
+          ),
+          groovy(
+            """
+              def text = $/Price: $$100/$
+              """
+          ),
+          groovy(
+            """
+              def path = $/C:/path/to/file/$
+              """
+          )
+        );
+    }
+
+    @Test
+    void patternSlashyStrings() {
+        rewriteRun(
+          groovy(
+            """
+              def version = "3.0"
+              def pattern = ~/version-${version}\\.jar/
+              """
+          ),
+          groovy(
+            """
+              def pattern = ~/$$\\d+\\.\\d+/
               """
           )
         );


### PR DESCRIPTION
## What's changed?
- Updated groovy parser to to handle salshy string delimiters as non-escaping characters.
- closes #6395 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
