### PR TITLE
WiP: An interesting investigation point regarding finding the actual latest for LATEST / RELEASE to use for comparison

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/ExactVersion.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/ExactVersion.java
@@ -53,6 +53,8 @@ public class ExactVersion extends LatestRelease {
             versionOnly = pattern.substring(0, hyphenIndex);
         }
         if (versionOnly.startsWith("latest") ||
+            versionOnly.equals("LATEST") ||
+            versionOnly.equals("RELEASE") ||
             versionOnly.contains("x") ||
             versionOnly.contains("^") ||
             versionOnly.contains("~") ||


### PR DESCRIPTION
Something I was poking around at with getting the actual LATEST / RELEASE when those comparators end up being what we use and then comparing the actual LATEST / RELEASE with what the POM had to decide if it should be marked.

This is just a WiP, not intended to be merged, but more as a point of investigation.