### PR TITLE
Prevent unexpected but not technically invalid paths in tests

### DIFF
--- a/rewrite-test/src/main/java/org/openrewrite/test/Dir.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/Dir.java
@@ -28,14 +28,14 @@ public class Dir implements Iterable<SourceSpec<?>>, SourceSpecs {
     private final Consumer<SourceSpec<SourceFile>> spec;
     private final SourceSpecs[] sourceSpecs;
 
-    public Dir(String dir, SourceSpecs[] sourceSpecs, Consumer<SourceSpec<SourceFile>> spec) {
+    public Dir(String dir, Consumer<SourceSpec<SourceFile>> spec, SourceSpecs... sourceSpecs) {
         // Prevent invalid paths such as `<project>` passed into `mavenProject(...)` where `pomXml` should be used
         if (!dir.matches("[- \\w/\\\\]+")) {
             throw new IllegalArgumentException("Invalid directory: " + dir);
         }
         this.dir = dir;
-        this.sourceSpecs = sourceSpecs;
         this.spec = spec;
+        this.sourceSpecs = sourceSpecs;
     }
 
     @Override


### PR DESCRIPTION
- We saw this pop up in https://github.com/openrewrite/rewrite/pull/6431/commits/00a76efc170381d41edafc16c55d56b5130883c9 ; there `mavenProject` was accidentally passed a first argument of XML, which then is treated as a directory by that name. It also means there were no further files in that Maven project, leading to a silent failure to execute the test.

Linux allows just about any character to be used in file paths, so the `Paths.get(String)` we use in `Dir` just always returns a `Path` instance, even for weird cases like the above.

I figured lock this down a bit, not from a security point of view, but to guard against unexpectedly skipped tests as described. Figured we should allow directory separators, regular characters, dashes and spaces, but not much else that I could immediately think of. 