### PR TITLE
Followup to BOM handling changes in #6420: `isCharsetBomMarked()` call should be inside the try block as that is the only method that can throw `UnsupportedOperationException`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
@@ -48,14 +48,18 @@ public interface SourceFile extends Tree {
         }
 
         // Restore BOM if the source file originally had one
-        if (isCharsetBomMarked() && !(this instanceof Quark) && !(this instanceof Binary)) {
-            try {
-                if (!readFromInput.isEmpty() && readFromInput.charAt(0) != '\uFEFF') {
-                    readFromInput = '\uFEFF' + readFromInput;
-                }
-            } catch (UnsupportedOperationException e) {
-                // Defensive fallback for any other SourceFile implementations that don't support charset operations
+        // should be in sync with the BOM restore logic in Tree.print()
+        try {
+            if (!(this instanceof Quark) &&
+                !(this instanceof Binary) &&
+                isCharsetBomMarked() &&
+                !readFromInput.isEmpty() &&
+                readFromInput.charAt(0) != '\uFEFF'
+            ) {
+                readFromInput = '\uFEFF' + readFromInput;
             }
+        } catch (UnsupportedOperationException e) {
+            // Defensive fallback for any other SourceFile implementations that don't support charset operations
         }
 
         return printed.equals(readFromInput);

--- a/rewrite-core/src/main/java/org/openrewrite/Tree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Tree.java
@@ -83,6 +83,7 @@ public interface Tree {
         this.<P>printer(cursor).visit(this, out, cursor);
 
         // Restore BOM if the source file originally had one
+        // should be in sync with the BOM restore logic in SourceFile.printEqualsInput()
         if (this instanceof SourceFile &&
             !(this instanceof Quark) &&
             !(this instanceof Binary)) {

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
@@ -500,17 +500,6 @@ class XmlParserTest implements RewriteTest {
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/1382")
-    @Test
-    void utf8BOM() {
-        rewriteRun(
-          xml(
-            """
-              %s<?xml version="1.0" encoding="UTF-8"?><test></test>
-              """.formatted("\uFEFF")
-          )
-        );
-    }
-
     @ParameterizedTest
     @MethodSource
     void testUtf8WithAndWithoutBom(@Language("xml") String xml, boolean hasBom) {
@@ -527,6 +516,8 @@ class XmlParserTest implements RewriteTest {
 
         assertThat(checked).isNotInstanceOf(ParseError.class);
         assertThat(checked).isSameAs(parsed);
+
+        rewriteRun(xml(xml));
     }
 
     static Stream<Arguments> testUtf8WithAndWithoutBom() {
@@ -536,6 +527,12 @@ class XmlParserTest implements RewriteTest {
               """, false),
             Arguments.of("""
               \uFEFF<?xml version="1.0" encoding="UTF-8"?><a />
+              """, true),
+            Arguments.of("""
+              <?xml version="1.0" encoding="UTF-8"?><test></test>
+              """, false),
+            Arguments.of("""
+              \uFEFF<?xml version="1.0" encoding="UTF-8"?><test></test>
               """, true)
         );
     }


### PR DESCRIPTION
- Followup to BOM handling changes in #6420: `isCharsetBomMarked()` call should be inside the try block as that is the only method that can throw `UnsupportedOperationException`.
Also, some minor test improvements.

## What's changed?
`SourceFile.printEqualsInput()` was changed to follow more closely the BOM restore implementation in `Tree.print()`

## What's your motivation?
- Make sure the change done in #6420 doesn't introduce any regressions where `SourceFile.isCharsetBomMarked()` thows `UnsupportedOperationException`.

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files

## Legal disclaimer:

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE APACHE LICENSE V.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
