### PR TITLE
Java11Parser: Make support for `var` as variable name in lambda parameters more robust by relying on the javac AST instead of manual parsing

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1573,14 +1573,13 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
             // `node.declaredUsingVar()` was only added around 11.0.15
             int nextTokenIdx = indexOfNextNonWhitespace(cursor, source);
             boolean nextTokenStartsWithVar = source.startsWith("var", nextTokenIdx);
-            if (nextTokenStartsWithVar && Character.isWhitespace(source.charAt(nextTokenIdx + 3))) {
-                int nextNextTokenIdx = indexOfNextNonWhitespace(cursor + 3, source);
-                boolean nextNextTokenIsArrow = source.startsWith("->", nextNextTokenIdx);
-                if (!nextNextTokenIsArrow) {
-                    typeExpr = new J.Identifier(randomId(), sourceBefore("var"),
-                        Markers.build(singletonList(JavaVarKeyword.build())), emptyList(), "var",
-                        typeMapping.type(vartype), null);
-                }
+            if (nextTokenStartsWithVar &&
+                node.getStartPosition() <= nextTokenIdx &&
+                nextTokenIdx + 3 < node.getPreferredPosition()
+            ) {
+                typeExpr = new J.Identifier(randomId(), sourceBefore("var"),
+                    Markers.build(singletonList(JavaVarKeyword.build())), emptyList(), "var",
+                    typeMapping.type(vartype), null);
             }
         }
 

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/VariableDeclarationsTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/VariableDeclarationsTest.java
@@ -298,9 +298,14 @@ class VariableDeclarationsTest implements RewriteTest {
       "vari",
       "(vari)",
       "var",
+      "  var  ",
       "(var)",
+      "(  var  )",
       "(var var)",
-      "(Object var)"
+      "(  var var  )",
+      "(  @Deprecated  var var  )",
+      "(Object var)",
+      "(  Object var  )"
     })
     void lambdaParameterVariableDeclarations(String variableDeclaration) {
         rewriteRun(
@@ -325,10 +330,15 @@ class VariableDeclarationsTest implements RewriteTest {
     @ValueSource(strings = {
       "i, j",
       "i, var",
+      "  i  , var  ",
       "var, i",
+      "  var  , i  ",
       "var i, var j",
+      "  var i  , var j  ",
       "var i, var var",
-      "var var, var i"
+      "  var i  , var var  ",
+      "var var, var i",
+      "  var var  , var i  "
     })
     void multiLambdaParametersVariableDeclarations(String variableDeclarations) {
         rewriteRun(


### PR DESCRIPTION
Java11Parser: Make support for `var` as variable name in lambda parameters more robust by relying on the javac AST instead of manual parsing

## What's changed?
- To address some of the concerns raised on #6443 this PR changes `ReloadableJava11ParserVisitor` support for `var`.

## What's your motivation?
To make the implementation more robust.

## Anyone you would like to review specifically?
@timtebeek, @sambsnyd 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files

#### Legal disclaimer:

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE APACHE LICENSE V.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
