### PR TITLE
Allow links and backticks at start of displaynames and descriptions

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplaceContentValidator.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplaceContentValidator.java
@@ -65,7 +65,7 @@ public class RecipeMarketplaceContentValidator {
         if (displayName.isEmpty()) {
             validation = validation.and(Validated.invalid(property, displayName, "Display must not be empty"));
         }
-        if (!Character.isUpperCase(displayName.charAt(0))) {
+        if (doesNotStartWithUppercase(displayName)) {
             validation = validation.and(Validated.invalid(property, displayName, "Display name must be sentence cased"));
         }
         if (displayName.endsWith(".")) {
@@ -80,7 +80,7 @@ public class RecipeMarketplaceContentValidator {
         }
         Validated<RecipeMarketplace> validation = Validated.none();
         String property = recipe + ".description";
-        if (!Character.isUpperCase(description.charAt(0))) {
+        if (doesNotStartWithUppercase(description)) {
             validation = validation.and(Validated.invalid(property, description, "Description must be sentence cased"));
         }
         if (!description.endsWith(".")) {
@@ -88,5 +88,14 @@ public class RecipeMarketplaceContentValidator {
         }
 
         return validation;
+    }
+
+    private static boolean doesNotStartWithUppercase(String text) {
+        char firstChar = text.charAt(0);
+        if (Character.isUpperCase(firstChar)) {
+            return false;
+        }
+        return Character.isLetter(firstChar) || !Character.isUpperCase(text.charAt(1));
+        // Allow backticks, links, etc. at the start of the text, provided the next character is uppercase
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceContentValidatorTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceContentValidatorTest.java
@@ -16,13 +16,25 @@
 package org.openrewrite.marketplace;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.openrewrite.Validated;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RecipeMarketplaceContentValidatorTest {
 
-    @Test
+    private static final String VALID_DISPLAY_NAME = "Remove unnecessary parentheses";
+    private static final String VALID_DESCRIPTION = "Removes unnecessary parentheses from code.";
+
+    @ParameterizedTest
+    @CsvSource({
+      VALID_DISPLAY_NAME  + ',' + VALID_DESCRIPTION,
+      VALID_DISPLAY_NAME  + ',' + "`Removes` unnecessary parentheses from code.",
+      VALID_DISPLAY_NAME  + ',' + "[Removes](link) unnecessary parentheses from code.",
+      "`Remove` unnecessary parentheses"  + ',' + VALID_DESCRIPTION,
+      "[Remove](link) unnecessary parentheses"  + ',' + VALID_DESCRIPTION,
+    })
     void validMarketplace() {
         RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv("""
           name,displayName,description,category,ecosystem,packageName


### PR DESCRIPTION
Fixes failures seen downstream in rewrite-github-actions for `PreferTemurinDistributions`.