### PR TITLE
Fix Add Plugin visitor

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
@@ -360,7 +360,7 @@ public class AddPluginVisitor extends JavaIsoVisitor<ExecutionContext> {
         }.reduce(cu, new AtomicBoolean());
         if (!hasPluginsBlock.get()) {
             J.Block block = (J.Block) cu.getStatements().get(0);
-            if (cu.getSourcePath().endsWith(Paths.get("settings.gradle")) &&
+            if (cu.getSourcePath().endsWith(Paths.get("settings.gradle.kts")) &&
                     !block.getStatements().isEmpty() &&
                     block.getStatements().get(0) instanceof J.MethodInvocation &&
                     "pluginManagement".equals(((J.MethodInvocation) block.getStatements().get(0)).getSimpleName())) {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Check for the right file to be present

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
The plugins block was being added as the first entry in a gradle kotlin settings file which left it non compiling when plugin management is also defined

- Closes #6479
- Closes #6478

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
