### PR TITLE
Accept exit code of 1 for Javascript RPC server

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -152,7 +152,7 @@ public class RewriteRpcProcess extends Thread {
                     process.waitFor(2, TimeUnit.SECONDS);
                 }
                 int exitCode = process.exitValue();
-                if (exitCode != 0 && exitCode != 143) { // 143 = SIGTERM
+                if (exitCode != 0 && exitCode != 1 && exitCode != 143) { // 143 = SIGTERM
                     throw new RuntimeException("JavaScript Rewrite RPC process crashed with exit code: " + exitCode);
                 }
             } catch (InterruptedException e) {


### PR DESCRIPTION
## What's changed?
Allow an exit code of 1 to be accepted without throwing an exception.

## What's your motivation?
On Windows, there isn't an equivalent of SIGTERM, so most programs will exit abruptly with an exit code of 1 instead equivalent to a SIGKILL.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
We could potentially not check the exit code at all. I'm not sure if that would be better or not though.

## Any additional context
N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
