### PR TITLE
Allow `InMemoryDiffEntry` to print with the correct `MarkerPrinter`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/InMemoryDiffEntry.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/InMemoryDiffEntry.java
@@ -35,6 +35,7 @@ import org.openrewrite.quark.Quark;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
@@ -243,7 +244,8 @@ public class InMemoryDiffEntry extends DiffEntry implements AutoCloseable {
                 new PrintOutputCapture<>(0) :
                 new PrintOutputCapture<>(0, markerPrinter);
 
-        return sourceFile.printAllAsBytes(out);
+        Charset charset = sourceFile.getCharset() == null ? StandardCharsets.UTF_8 : sourceFile.getCharset();
+        return sourceFile.printAll(out).getBytes(charset);
     }
 
     @Value


### PR DESCRIPTION
## What's changed?

Fixed `InMemoryDiffEntry.printAllAsBytes()` to correctly preserve the `MarkerPrinter` when generating diffs. Changed from calling `sourceFile.printAllAsBytes(out)` to `sourceFile.printAll(out).getBytes(charset)`.

## What's your motivation?

The `FENCED` MarkerPrinter was being ignored when generating diffs via `Result.diff()`. Both `diff` and `fencedMarkerDiff` were returning identical output with `/*~~>*/` markers (`DEFAULT` printer) instead of the expected `{{uuid}}...{{uuid}}` format (`FENCED` printer).

`SourceFile.printAllAsBytes(P p)` treats the `PrintOutputCapture` as a generic `P` parameter, which then gets wrapped in a `new PrintOutputCapture` with the `DEFAULT` `MarkerPrinter` inside `printAll(P p)`. The fix calls `printAll(PrintOutputCapture<P> out)` directly, which correctly uses the capture object.

## Anything in particular you'd like reviewers to focus on?

N/A

## Anyone you would like to review specifically?

@shanman190 @jkschneider

## Have you considered any alternatives or workarounds?

N/A

## Any additional context

None.

## Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/recipes/recipes-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
