### PR TITLE
Integrate `RecipeMarketplace` into `RewriteRpc`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -25,7 +25,9 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.config.OptionDescriptor;
+import org.openrewrite.internal.RecipeLoader;
 import org.openrewrite.marketplace.RecipeBundle;
+import org.openrewrite.marketplace.RecipeListing;
 import org.openrewrite.marketplace.RecipeMarketplace;
 import org.openrewrite.rpc.internal.PreparedRecipeCache;
 import org.openrewrite.rpc.request.*;
@@ -67,7 +69,6 @@ public class RewriteRpc {
     private final AtomicReference<@Nullable PrintStream> log = new AtomicReference<>();
     private final AtomicReference<TraceGetObject> traceGetObject = new AtomicReference<>(
             new TraceGetObject(false, false));
-    private final AtomicReference<PrepareRecipe.@Nullable Loader> recipeLoader = new AtomicReference<>();
 
     final PreparedRecipeCache preparedRecipes = new PreparedRecipeCache();
 
@@ -143,7 +144,14 @@ public class RewriteRpc {
                 }
             }
         });
-        jsonRpc.rpc("PrepareRecipe", new PrepareRecipe.Handler(preparedRecipes, recipeLoader));
+        jsonRpc.rpc("PrepareRecipe", new PrepareRecipe.Handler(preparedRecipes, (id, opts) -> {
+            RecipeListing listing = marketplace.findRecipe(id);
+            if (listing != null) {
+                return listing.prepare(opts);
+            }
+            // Fall back to loading by class name if not found in marketplace
+            return new RecipeLoader(null).load(id, opts);
+        }));
         jsonRpc.rpc("Print", new Print.Handler(this::getObject));
 
         jsonRpc.bind();
@@ -166,11 +174,6 @@ public class RewriteRpc {
 
     public RewriteRpc log(@Nullable PrintStream logFile) {
         this.log.set(logFile);
-        return this;
-    }
-
-    public RewriteRpc recipeLoader(PrepareRecipe.@Nullable Loader recipeLoader) {
-        this.recipeLoader.set(recipeLoader);
         return this;
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipe.java
@@ -19,14 +19,11 @@ import io.moderne.jsonrpc.JsonRpcMethod;
 import io.moderne.jsonrpc.internal.SnowflakeId;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.Recipe;
 import org.openrewrite.ScanningRecipe;
-import org.openrewrite.internal.RecipeLoader;
 import org.openrewrite.rpc.internal.PreparedRecipeCache;
 
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyList;
 
@@ -42,15 +39,11 @@ public class PrepareRecipe implements RpcRequest {
     @RequiredArgsConstructor
     public static class Handler extends JsonRpcMethod<PrepareRecipe> {
         private final PreparedRecipeCache preparedRecipes;
-        private final AtomicReference<@Nullable Loader> recipeLoader;
+        private final Loader recipeLoader;
 
         @Override
         protected Object handle(PrepareRecipe request) throws Exception {
-            Loader loader = recipeLoader.get();
-            if (loader == null) {
-                loader = (recipeId, options) -> new RecipeLoader(null).load(recipeId, options);
-            }
-            Recipe recipe = loader.load(request.id, request.getOptions());
+            Recipe recipe = recipeLoader.load(request.id, request.getOptions());
             String instanceId = SnowflakeId.generateId();
             preparedRecipes.getInstantiated().put(instanceId, recipe);
             return new PrepareRecipeResponse(

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.*;
 import org.openrewrite.config.Environment;
 import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.internal.RecipeLoader;
 import org.openrewrite.marketplace.*;
 import org.openrewrite.table.TextMatches;
 import org.openrewrite.test.RewriteTest;
@@ -240,7 +241,8 @@ class RewriteRpcTest implements RewriteTest {
 
                 @Override
                 public Recipe prepare(RecipeListing listing, Map<String, Object> options) {
-                    return requireNonNull(marketplace.findRecipe(listing.getName())).prepare(options);
+                    // Use RecipeLoader to instantiate directly, avoiding recursive marketplace lookup
+                    return new RecipeLoader(null).load(listing.getName(), options);
                 }
             };
         }

--- a/rewrite-javascript/rewrite/fixtures/example-recipe.ts
+++ b/rewrite-javascript/rewrite/fixtures/example-recipe.ts
@@ -27,6 +27,7 @@ import {MarkPrimitiveTypes} from "./mark-primitive-types";
 import {MarkClassTypes} from "./mark-class-types";
 import {ScanningEditor} from "./scanning-editor";
 import {ReplaceAssignment} from "./replace-assignment";
+import {JavaChangeMethodName} from "./java-change-method-name";
 
 export async function activate(marketplace: RecipeMarketplace): Promise<void> {
     await marketplace.install(ChangeText, JavaScript);
@@ -42,4 +43,5 @@ export async function activate(marketplace: RecipeMarketplace): Promise<void> {
     await marketplace.install(MarkClassTypes, JavaScript);
     await marketplace.install(ScanningEditor, JavaScript);
     await marketplace.install(ReplaceAssignment, JavaScript);
+    await marketplace.install(JavaChangeMethodName, JavaScript);
 }

--- a/rewrite-javascript/rewrite/fixtures/java-change-method-name.ts
+++ b/rewrite-javascript/rewrite/fixtures/java-change-method-name.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {ExecutionContext, isSourceFile, Recipe, SourceFile, Tree, TreeVisitor} from "@openrewrite/rewrite";
+import {RewriteRpc} from "@openrewrite/rewrite/rpc";
+import {JS} from "@openrewrite/rewrite/javascript";
+
+/**
+ * A JavaScript recipe that delegates to the Java ChangeMethodName recipe.
+ * This tests the round-trip: Java -> JS (this recipe) -> Java (ChangeMethodName) -> JS -> Java
+ *
+ * Note: We use editor() instead of recipeList() because recipeList() would cause
+ * the nested recipe to be re-prepared when RpcRecipe.getRecipeList() is called,
+ * which would send the request back to JS instead of using the already-prepared Java recipe.
+ */
+export class JavaChangeMethodName extends Recipe {
+    name = "org.openrewrite.example.java.change-method-name";
+    displayName = "Change method name (via Java)";
+    description = "Delegates to the Java ChangeMethodName recipe to test npm ecosystem recipe invocation.";
+
+    private javaRecipe?: Recipe;
+
+    constructor(private readonly options: {
+        methodPattern: string;
+        newMethodName: string;
+        matchOverrides?: boolean;
+        ignoreDefinition?: boolean;
+    }) {
+        super();
+    }
+
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
+        const rpc = RewriteRpc.get();
+        if (!rpc) {
+            throw new Error("RewriteRpc not available - cannot delegate to Java recipe");
+        }
+
+        // Prepare the Java recipe via RPC (this goes to Java and back)
+        if (!this.javaRecipe) {
+            this.javaRecipe = await rpc.prepareRecipe(
+                "org.openrewrite.java.ChangeMethodName",
+                this.options
+            );
+        }
+
+        // Get the Java recipe's editor visitor
+        const javaEditor = await this.javaRecipe!.editor();
+
+        // Wrap it to only apply to JavaScript/TypeScript files (not JSON)
+        return new class extends TreeVisitor<Tree, ExecutionContext> {
+            async isAcceptable(sourceFile: SourceFile, _ctx: ExecutionContext): Promise<boolean> {
+                // Only apply to JS/TS files, not JSON
+                return sourceFile.kind === JS.Kind.CompilationUnit;
+            }
+
+            protected async preVisit(tree: Tree, ctx: ExecutionContext): Promise<Tree | undefined> {
+                if (isSourceFile(tree) && tree.kind !== JS.Kind.CompilationUnit) {
+                    return tree;
+                }
+                // Delegate to the Java recipe's visitor
+                return javaEditor.visit(tree, ctx, this.cursor);
+            }
+        }();
+    }
+}

--- a/rewrite-javascript/rewrite/src/rpc/index.ts
+++ b/rewrite-javascript/rewrite/src/rpc/index.ts
@@ -21,8 +21,7 @@ import {updateIfChanged} from "../util";
 
 export * from "./queue";
 export * from "../reference";
-// rewrite-rpc is not exported here to avoid circular dependency
-// Import directly from "./rewrite-rpc" if needed
+export {RewriteRpc} from "./rewrite-rpc";
 
 RpcCodecs.registerCodec(TreeKind.Checksum, {
     async rpcReceive(before: Checksum, q: RpcReceiveQueue): Promise<Checksum> {

--- a/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
@@ -20,7 +20,6 @@ import {randomId, UUID} from "../../uuid";
 import {SourceFile} from "../../tree";
 import {Parsers} from "../../parser";
 import {withMetrics} from "./metrics";
-import {DEFAULT_EXCLUSIONS, ProjectParser} from "../../javascript";
 import {replaceMarkerByKind} from "../../markers";
 
 /**
@@ -64,6 +63,9 @@ export class ParseProject {
                 metricsCsv,
                 (context) => async (request) => {
                     context.target = request.projectPath;
+
+                    // Dynamic import to break circular dependency
+                    const {DEFAULT_EXCLUSIONS, ProjectParser} = await import("../../javascript/index.js");
 
                     const projectPath = path.resolve(request.projectPath);
                     const exclusions = request.exclusions ?? DEFAULT_EXCLUSIONS;

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -18,15 +18,13 @@ package org.openrewrite.javascript.rpc;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.SourceFile;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.marketplace.RecipeMarketplace;
 import org.openrewrite.rpc.RewriteRpc;
 import org.openrewrite.rpc.RewriteRpcProcess;
 import org.openrewrite.rpc.RewriteRpcProcessManager;
-import org.openrewrite.rpc.request.PrepareRecipe;
-
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.SourceFile;
 import org.openrewrite.tree.ParsingEventListener;
 import org.openrewrite.tree.ParsingExecutionContextView;
 
@@ -211,7 +209,6 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
 
         private @Nullable Integer maxHeapSize;
         private @Nullable Path workingDirectory;
-        private PrepareRecipe.@Nullable Loader recipeLoader;
 
         public Builder marketplace(RecipeMarketplace marketplace) {
             this.marketplace = marketplace;
@@ -320,11 +317,6 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
             return this;
         }
 
-        public Builder recipeLoader(PrepareRecipe.Loader recipeLoader) {
-            this.recipeLoader = recipeLoader;
-            return this;
-        }
-
         @Override
         public JavaScriptRewriteRpc get() {
             Stream<@Nullable String> cmd;
@@ -391,8 +383,7 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
                         String.join(" ", cmdArr), process.environment())
                         .livenessCheck(process::getLivenessCheck)
                         .timeout(timeout)
-                        .log(log == null ? null : new PrintStream(Files.newOutputStream(log, StandardOpenOption.APPEND, StandardOpenOption.CREATE)))
-                        .recipeLoader(recipeLoader);
+                        .log(log == null ? null : new PrintStream(Files.newOutputStream(log, StandardOpenOption.APPEND, StandardOpenOption.CREATE)));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }


### PR DESCRIPTION
Adds an integration test, which tests that a JS recipe can call a Java recipe loaded via marketplace.
