### PR TITLE
In yaml `CopyValue`, invoke `UnfoldProperties` after `MergeYaml`

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CopyValue.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CopyValue.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.yaml.tree.Yaml;
@@ -27,7 +28,6 @@ import java.nio.file.Path;
 
 import static java.util.Collections.singletonList;
 
-@SuppressWarnings("LanguageMismatch")
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class CopyValue extends ScanningRecipe<CopyValue.Accumulator> {
@@ -101,8 +101,10 @@ public class CopyValue extends ScanningRecipe<CopyValue.Accumulator> {
 
     @Data
     public static class Accumulator {
+        @Language("yml")
         @Nullable
         String snippet;
+
         Path path;
     }
 
@@ -147,7 +149,8 @@ public class CopyValue extends ScanningRecipe<CopyValue.Accumulator> {
         if (acc.snippet == null) {
             return TreeVisitor.noop();
         }
-        return Preconditions.check(new FindSourceFiles(newFilePath == null ? acc.path.toString() : newFilePath),
+        return Preconditions.check(
+                new FindSourceFiles(newFilePath == null ? acc.path.toString() : newFilePath),
                 new YamlIsoVisitor<ExecutionContext>() {
                     @Override
                     public Yaml.Documents visitDocuments(Yaml.Documents documents, ExecutionContext ctx) {

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CopyValueTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CopyValueTest.java
@@ -17,29 +17,17 @@ package org.openrewrite.yaml;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
 class CopyValueTest implements RewriteTest {
 
-    @Override
-    public void defaults(RecipeSpec spec) {
-        InMemoryExecutionContext ctx = new InMemoryExecutionContext();
-        ctx.putMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, false);
-        spec.executionContext(ctx);
-    }
-
     @DocumentExample
     @Test
     void changeCurrentFileWhenNull() {
         rewriteRun(
-          spec -> spec.recipe(
-            new CopyValue("$.source", null, "$.destination", null)
-          ),
+          spec -> spec.recipe(new CopyValue("$.source", null, "$.destination", null, null)),
           yaml(
             """
               source: value
@@ -48,8 +36,7 @@ class CopyValueTest implements RewriteTest {
             """
               source: value
               destination: value
-              """,
-            spec -> spec.path("a.yml")
+              """
           )
         );
     }
@@ -57,9 +44,7 @@ class CopyValueTest implements RewriteTest {
     @Test
     void changeOnlyMatchingFile() {
         rewriteRun(
-          spec -> spec.recipe(
-            new CopyValue("$.source", "a.yml", "$.destination", null)
-          ),
+          spec -> spec.recipe(new CopyValue("$.source", "a.yml", "$.destination", null, null)),
           yaml(
             """
               source: value
@@ -84,9 +69,7 @@ class CopyValueTest implements RewriteTest {
     @Test
     void copyComplexValue() {
         rewriteRun(
-          spec -> spec.recipe(
-            new CopyValue("$.source", null, "$.destination", null)
-          ),
+          spec -> spec.recipe(new CopyValue("$.source", null, "$.destination", null, null)),
           yaml(
             """
               source:
@@ -107,9 +90,7 @@ class CopyValueTest implements RewriteTest {
     @Test
     void copyToOtherFile() {
         rewriteRun(
-          spec -> spec.recipe(
-            new CopyValue("$.source", "a.yml", "$.destination", "b.yml")
-          ),
+          spec -> spec.recipe(new CopyValue("$.source", "a.yml", "$.destination", "b.yml", null)),
           yaml(
             """
               source: value
@@ -131,9 +112,7 @@ class CopyValueTest implements RewriteTest {
     @Test
     void createNewKeysFalse() {
         rewriteRun(
-          spec -> spec.recipe(
-            new CopyValue("$.source", null, "$.destination", null, false)
-          ),
+          spec -> spec.recipe(new CopyValue("$.source", null, "$.destination", null, false)),
           yaml(
             """
               source:
@@ -147,9 +126,7 @@ class CopyValueTest implements RewriteTest {
     @Test
     void mergeNewKeys() {
         rewriteRun(
-          spec -> spec.recipe(
-            new CopyValue("$.a.b", null, "$.c.e", null, null)
-          ),
+          spec -> spec.recipe(new CopyValue("$.a.b", null, "$.c.e", null, null)),
           yaml(
             """
               a:

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -1657,7 +1657,7 @@ class MergeYamlTest implements RewriteTest {
                 null,
                 null
               ),
-              new CopyValue("$.spec.level1.level2", null, "$.spec.empty.initially", null))
+              new CopyValue("$.spec.level1.level2", null, "$.spec.empty.initially", null, null))
             .expectedCyclesThatMakeChanges(2),
           yaml(
             """


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Call `org.openrewrite.yaml.UnfoldProperties` after MergeYaml in `org.openrewrite.yaml.CopyValue`

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
CopyValue adds new keys to the end of the yaml file. While this is syntacticly correct, it would be better to fold those new keys into the existing keys where appropriate. 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
