### PR TITLE
Altering check for `AddDependency` to compare versions differently when direct vs indirect dependency.

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -228,13 +228,11 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                     for (ResolvedDependency d : dependencies.get(Scope.Compile)) {
                         if (hasAcceptableTransitivity(d, acc) &&
                             groupId.equals(d.getGroupId()) &&
-                            artifactId.equals(d.getArtifactId())
+                            artifactId.equals(d.getArtifactId()) &&
+                            (d.isTransitive() ||
+                                    (d.isDirect() && version.equals(d.getVersion())))
                         ) {
-                            if ((d.isDirect() && version.equals(d.getVersion())) ||
-                                    (!d.isDirect() && vc.isValid(null, d.getVersion()))
-                            ) {
-                                return maven;
-                            }
+                            return maven;
                         }
                     }
                 }


### PR DESCRIPTION
## What's changed?
Changing the version check for initial compile scope check in `AddDependency` wherein now, if a direct dependency, it will check version vs requested, as `AddDependencyVisitor` can sort out the actual version needed, while if a transitive dependency, it will allow it, which can mean things like `3.x` will allow non-latest from transitive dependencies.

## What's your motivation?
Failure in rewrite-spring pipeline

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
