### PR TITLE
Groovy - Fixing parsing of `assert :` syntax

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2429,7 +2429,7 @@ public class GroovyParserVisitor {
             Space space = whitespace();
             J.FieldAccess qualid = TypeTree.build(name()).withPrefix(space);
             JLeftPadded<J.Identifier> alias = null;
-            if (sourceStartsWith("as")) {
+            if (sourceStartsWith("as", "\n", " ")) {
                 alias = padLeft(sourceBefore("as"), new J.Identifier(randomId(), whitespace(), Markers.EMPTY, emptyList(), name(), null, null));
             }
             return maybeSemicolon(new J.Import(randomId(), importPrefix, Markers.EMPTY, statik, qualid, alias));

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AssertTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AssertTest.java
@@ -48,4 +48,19 @@ class AssertTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/6374")
+    @Test
+    void withMessageAndSpaceBeforeColon() {
+        rewriteRun(
+          groovy(
+            """
+              import java.util.Collection
+
+              assert args : "Expecting directory"
+              def homePath = args[0]
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

An amendment to the Groovy parser pertaining to parsing `as` and `assert` syntax. Make sure the latter is not confused with the former.

TBH, I am aware this new code is not perfect either (there are other options other than newline or space to happen after `as`), but still I find it better than before the change. This pattern is already used in other places.

## What's your motivation?

- fixes #6374
