### PR TITLE
Skip managed dependency check for plugin dependencies

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -168,7 +168,9 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
                     maybeUpdateModel();
                     return t;
                 }
-                if (isOldDependencyTag || isPluginDependencyTag(oldGroupId, oldArtifactId) || isAnnotationProcessorPathTag(oldGroupId, oldArtifactId)) {
+                boolean isPluginDependency = isPluginDependencyTag(oldGroupId, oldArtifactId);
+                boolean isAnnotationProcessorPath = isAnnotationProcessorPathTag(oldGroupId, oldArtifactId);
+                if (isOldDependencyTag || isPluginDependency || isAnnotationProcessorPath) {
                     String groupId = newGroupId;
                     if (groupId != null) {
                         t = changeChildTagValue(t, "groupId", groupId, ctx);
@@ -193,8 +195,9 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
                             boolean configuredToChangeManagedDependency = changeManagedDependency == null || changeManagedDependency; // True by default
 
                             boolean versionTagPresent = versionTag.isPresent();
-                            boolean oldDependencyManaged = isDependencyManaged(scope, oldGroupId, oldArtifactId);
-                            boolean newDependencyManaged = isDependencyManaged(scope, groupId, artifactId);
+                            // dependencyManagement does not apply to plugin dependencies or annotation processor paths
+                            boolean oldDependencyManaged = isOldDependencyTag && isDependencyManaged(scope, oldGroupId, oldArtifactId);
+                            boolean newDependencyManaged = isOldDependencyTag && isDependencyManaged(scope, groupId, artifactId);
                             if (versionTagPresent) {
                                 // If the previous dependency had a version but the new artifact is managed, removed the version tag.
                                 if (!configuredToOverrideManageVersion && newDependencyManaged || (oldDependencyManaged && configuredToChangeManagedDependency)) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -2089,4 +2089,89 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/6533")
+    @Test
+    void pluginDependencyShouldNotUseManagedVersion() {
+        // Plugin dependencies should always have an explicit version since dependencyManagement
+        // does not apply to plugin dependencies in Maven
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
+            "javax.activation",
+            "javax.activation-api",
+            "jakarta.activation",
+            "jakarta.activation-api",
+            "2.1.0",
+            null
+          )),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.test</groupId>
+                  <artifactId>test-app</artifactId>
+                  <version>1.0.0</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>jakarta.activation</groupId>
+                              <artifactId>jakarta.activation-api</artifactId>
+                              <version>2.1.0</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <artifactId>kotlin-maven-plugin</artifactId>
+                              <groupId>org.jetbrains.kotlin</groupId>
+                              <version>1.9.0</version>
+                              <dependencies>
+                                  <dependency>
+                                      <groupId>javax.activation</groupId>
+                                      <artifactId>javax.activation-api</artifactId>
+                                      <version>1.2.0</version>
+                                  </dependency>
+                              </dependencies>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.test</groupId>
+                  <artifactId>test-app</artifactId>
+                  <version>1.0.0</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>jakarta.activation</groupId>
+                              <artifactId>jakarta.activation-api</artifactId>
+                              <version>2.1.0</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <artifactId>kotlin-maven-plugin</artifactId>
+                              <groupId>org.jetbrains.kotlin</groupId>
+                              <version>1.9.0</version>
+                              <dependencies>
+                                  <dependency>
+                                      <groupId>jakarta.activation</groupId>
+                                      <artifactId>jakarta.activation-api</artifactId>
+                                      <version>2.1.0</version>
+                                  </dependency>
+                              </dependencies>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Fix `ChangeDependencyGroupIdAndArtifactId` to not use managed dependency versions for plugin dependencies
- Maven's `<dependencyManagement>` does not apply to plugin dependencies or annotation processor paths
- Previously the recipe would incorrectly remove the version tag, causing Maven build failures

## What's Changed
Modified the managed dependency check to only apply when processing regular dependencies (not plugin dependencies or annotation processor paths):
```java
// dependencyManagement does not apply to plugin dependencies or annotation processor paths
boolean oldDependencyManaged = isOldDependencyTag && isDependencyManaged(scope, oldGroupId, oldArtifactId);
boolean newDependencyManaged = isOldDependencyTag && isDependencyManaged(scope, groupId, artifactId);
```

## Test plan
- [x] Added test case `pluginDependencyShouldNotUseManagedVersion` that verifies plugin dependencies retain explicit versions
- [x] All 53 existing tests in `ChangeDependencyGroupIdAndArtifactIdTest` pass
- [x] Related tests `changePluginDependencyGroupIdAndArtifactId` and `changeAnnotationProcessorPathGroupIdAndArtifactId` still pass

- Fixes #6533

🤖 Generated with [Claude Code](https://claude.ai/code)