### PR TITLE
RPC - Don't close process.getInputStream() on failure

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
@@ -221,6 +221,22 @@ public class StringUtils {
         }
     }
 
+    public static String readFullyWithoutClosing(InputStream is, Charset charset) {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            byte[] buffer = new byte[4096];
+            int n;
+            while ((n = is.read(buffer)) != -1) {
+                bos.write(buffer, 0, n);
+            }
+
+            byte[] bytes = bos.toByteArray();
+            return new String(bytes, charset);
+        } catch (IOException e) {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+
     public static String capitalize(String value) {
         if (value.isEmpty()) {
             return value;

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -34,6 +34,7 @@ import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedHashMap;
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.openrewrite.internal.StringUtils.readFully;
+import static org.openrewrite.internal.StringUtils.readFullyWithoutClosing;
 
 /**
  * A client for spawning and communicating with a subprocess that implements Rewrite RPC.
@@ -95,18 +97,16 @@ public class RewriteRpcProcess extends Thread {
     public @Nullable RuntimeException getLivenessCheck() {
         if (process != null && !process.isAlive()) {
             int exitCode = process.exitValue();
-            String errorOutput = "", stdOutput = "";
+            String message = "JavaScript RPC process shut down early with exit code " + exitCode;
 
-            // Read any remaining output from the process
-            try (InputStream errorStream = process.getErrorStream();
-                 InputStream inputStream = process.getInputStream()) {
-                errorOutput = readFully(errorStream);
-                stdOutput = readFully(inputStream);
-            } catch (IOException | UnsupportedOperationException e) {
-                // Ignore errors reading final output
+            String errorOutput = "", stdOutput = "";
+            try {
+                errorOutput = readFullyWithoutClosing(process.getErrorStream(), StandardCharsets.UTF_8);
+                stdOutput = readFullyWithoutClosing(process.getInputStream(), StandardCharsets.UTF_8);
+            } catch (UnsupportedOperationException e) {
+                message += "\nError retrieving output/error stream: " + e.getMessage();
             }
 
-            String message = "JavaScript RPC process shut down early with exit code " + exitCode;
             if (!stdOutput.isEmpty()) {
                 message += "\nStandard output:\n  " + stdOutput.replace("\n", "\n  ");
             }


### PR DESCRIPTION
## What's changed?

Slightly changing the handling of **unhappy** path in the RPC framework.
Namely, when printing out stdout and stderr in case of errors, don't close the input streams.
Also adding slightly more defensive reporting of errors.

## What's your motivation?

Make a step towards understanding the random failures of RPC in tests manifesting themselves as:

> java.lang.IllegalStateException: JavaScript RPC process shut down early with exit code 217
