### PR TITLE
Python: Remove `Location` enums

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/java/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/java/__init__.py
@@ -93,8 +93,4 @@ __all__ = [
     'Wildcard',
     'Yield',
     'Unknown',
-
-    # Templating
-    'CoordinateBuilder',
-    'JavaCoordinates',
 ]

--- a/rewrite-python/rewrite/src/rewrite/java/extensions.py
+++ b/rewrite-python/rewrite/src/rewrite/java/extensions.py
@@ -13,19 +13,19 @@ T = TypeVar('T')
 J2 = TypeVar('J2', bound=J)
 
 
-def visit_container(v: 'JavaVisitor', container: Optional[JContainer[J2]], loc: JContainer.Location, p: P) -> Optional[JContainer[J2]]:
+def visit_container(v: 'JavaVisitor', container: Optional[JContainer[J2]], p: P) -> Optional[JContainer[J2]]:
     if container is None:
         return None
 
     v.cursor = Cursor(v.cursor, container)
-    before = v.visit_space(container.before, loc.before_location, p)
-    js = list_map(lambda el: v.visit_right_padded(el, loc.element_location, p), container.padding.elements)
+    before = v.visit_space(container.before, p)
+    js = list_map(lambda el: v.visit_right_padded(el, p), container.padding.elements)
     v.cursor = v.cursor.parent
 
     return container if js is container.padding.elements and before is container.before else JContainer(before, js, container.markers)
 
 
-def visit_right_padded(v: 'JavaVisitor', right: Optional[JRightPadded[T]], loc: JRightPadded.Location, p: P) -> Optional[JRightPadded[T]]:
+def visit_right_padded(v: 'JavaVisitor', right: Optional[JRightPadded[T]], p: P) -> Optional[JRightPadded[T]]:
     if right is None:
         return None
 
@@ -39,17 +39,17 @@ def visit_right_padded(v: 'JavaVisitor', right: Optional[JRightPadded[T]], loc: 
         return None
 
     right = right.replace(element=t)
-    right = right.replace(after=v.visit_space(right.after, loc, p))
+    right = right.replace(after=v.visit_space(right.after, p))
     right = right.replace(markers=v.visit_markers(right.markers, p))
     return right
 
 
-def visit_left_padded(v: 'JavaVisitor', left: Optional[JLeftPadded[T]], loc: JLeftPadded.Location, p: P) -> Optional[JLeftPadded[T]]:
+def visit_left_padded(v: 'JavaVisitor', left: Optional[JLeftPadded[T]], p: P) -> Optional[JLeftPadded[T]]:
     if left is None:
         return None
 
     v.cursor = Cursor(v.cursor, left)
-    before = v.visit_space(left.before, loc.before_location, p)
+    before = v.visit_space(left.before, p)
     t = left.element
     if isinstance(t, Tree):
         t = v.visit_and_cast(t, T, p)
@@ -63,7 +63,7 @@ def visit_left_padded(v: 'JavaVisitor', left: Optional[JLeftPadded[T]], loc: JLe
     return JLeftPadded(before, t, left.markers)
 
 
-def visit_space(v: 'JavaVisitor', space: Optional[Space], loc: Space.Location, p: P) -> Space:
+def visit_space(v: 'JavaVisitor', space: Optional[Space], p: P) -> Space:
     # FIXME support Javadoc
     return space
 

--- a/rewrite-python/rewrite/src/rewrite/java/support_types.py
+++ b/rewrite-python/rewrite/src/rewrite/java/support_types.py
@@ -147,232 +147,9 @@ class Space:
     EMPTY: ClassVar[Space]
     SINGLE_SPACE: ClassVar[Space]
 
-    class Location(Enum):
-        ANNOTATED_TYPE_PREFIX = auto()
-        ANNOTATIONS = auto()
-        ANNOTATION_ARGUMENTS = auto()
-        ANNOTATION_ARGUMENT_SUFFIX = auto()
-        ANNOTATION_PREFIX = auto()
-        ANY = auto()
-        ARRAY_ACCESS_PREFIX = auto()
-        ARRAY_INDEX_SUFFIX = auto()
-        ARRAY_TYPE_PREFIX = auto()
-        ASSERT_DETAIL = auto()
-        ASSERT_DETAIL_PREFIX = auto()
-        ASSERT_PREFIX = auto()
-        ASSIGNMENT = auto()
-        ASSIGNMENT_OPERATION_OPERATOR = auto()
-        ASSIGNMENT_OPERATION_PREFIX = auto()
-        ASSIGNMENT_PREFIX = auto()
-        BINARY_OPERATOR = auto()
-        BINARY_PREFIX = auto()
-        BLOCK_END = auto()
-        BLOCK_PREFIX = auto()
-        BLOCK_STATEMENT_SUFFIX = auto()
-        BREAK_PREFIX = auto()
-        CASE = auto()
-        CASE_BODY = auto()
-        CASE_EXPRESSION = auto()
-        CASE_PREFIX = auto()
-        CASE_SUFFIX = auto()
-        CATCH_ALTERNATIVE_SUFFIX = auto()
-        CATCH_PREFIX = auto()
-        CLASS_DECLARATION_PREFIX = auto()
-        CLASS_KIND = auto()
-        COMPILATION_UNIT_EOF = auto()
-        COMPILATION_UNIT_PREFIX = auto()
-        CONTINUE_PREFIX = auto()
-        CONTROL_PARENTHESES_PREFIX = auto()
-        DIMENSION = auto()
-        DIMENSION_PREFIX = auto()
-        DIMENSION_SUFFIX = auto()
-        DO_WHILE_PREFIX = auto()
-        ELSE_PREFIX = auto()
-        EMPTY_PREFIX = auto()
-        ENUM_VALUE_PREFIX = auto()
-        ENUM_VALUE_SET_PREFIX = auto()
-        ENUM_VALUE_SUFFIX = auto()
-        ERRONEOUS_PREFIX = auto()
-        EXPRESSION_PREFIX = auto()
-        EXTENDS = auto()
-        FIELD_ACCESS_NAME = auto()
-        FIELD_ACCESS_PREFIX = auto()
-        FOREACH_ITERABLE_SUFFIX = auto()
-        FOREACH_VARIABLE_SUFFIX = auto()
-        FOR_BODY_SUFFIX = auto()
-        FOR_CONDITION_SUFFIX = auto()
-        FOR_CONTROL_PREFIX = auto()
-        FOR_EACH_CONTROL_PREFIX = auto()
-        FOR_EACH_LOOP_PREFIX = auto()
-        FOR_INIT_SUFFIX = auto()
-        FOR_PREFIX = auto()
-        FOR_UPDATE_SUFFIX = auto()
-        IDENTIFIER_PREFIX = auto()
-        IF_ELSE_SUFFIX = auto()
-        IF_PREFIX = auto()
-        IF_THEN_SUFFIX = auto()
-        IMPLEMENTS = auto()
-        IMPLEMENTS_SUFFIX = auto()
-        IMPORT_ALIAS_PREFIX = auto()
-        IMPORT_PREFIX = auto()
-        IMPORT_SUFFIX = auto()
-        INSTANCEOF_PREFIX = auto()
-        INSTANCEOF_SUFFIX = auto()
-        INTERSECTION_TYPE_PREFIX = auto()
-        LABEL_PREFIX = auto()
-        LABEL_SUFFIX = auto()
-        LAMBDA_ARROW_PREFIX = auto()
-        LAMBDA_PARAMETER = auto()
-        LAMBDA_PARAMETERS_PREFIX = auto()
-        LAMBDA_PREFIX = auto()
-        LANGUAGE_EXTENSION = auto()
-        LITERAL_PREFIX = auto()
-        MEMBER_REFERENCE_CONTAINING = auto()
-        MEMBER_REFERENCE_NAME = auto()
-        MEMBER_REFERENCE_PREFIX = auto()
-        METHOD_DECLARATION_DEFAULT_VALUE = auto()
-        METHOD_DECLARATION_PARAMETERS = auto()
-        METHOD_DECLARATION_PARAMETER_SUFFIX = auto()
-        METHOD_DECLARATION_PREFIX = auto()
-        METHOD_INVOCATION_ARGUMENTS = auto()
-        METHOD_INVOCATION_ARGUMENT_SUFFIX = auto()
-        METHOD_INVOCATION_NAME = auto()
-        METHOD_INVOCATION_PREFIX = auto()
-        METHOD_SELECT_SUFFIX = auto()
-        MODIFIER_PREFIX = auto()
-        MULTI_CATCH_PREFIX = auto()
-        NAMED_VARIABLE_SUFFIX = auto()
-        NEW_ARRAY_INITIALIZER = auto()
-        NEW_ARRAY_INITIALIZER_SUFFIX = auto()
-        NEW_ARRAY_PREFIX = auto()
-        NEW_CLASS_ARGUMENTS = auto()
-        NEW_CLASS_ARGUMENTS_SUFFIX = auto()
-        NEW_CLASS_ENCLOSING_SUFFIX = auto()
-        NEW_CLASS_PREFIX = auto()
-        NEW_PREFIX = auto()
-        NULLABLE_TYPE_PREFIX = auto()
-        NULLABLE_TYPE_SUFFIX = auto()
-        PACKAGE_PREFIX = auto()
-        PACKAGE_SUFFIX = auto()
-        PARAMETERIZED_TYPE_PREFIX = auto()
-        PARENTHESES_PREFIX = auto()
-        PARENTHESES_SUFFIX = auto()
-        PERMITS = auto()
-        PERMITS_SUFFIX = auto()
-        PRIMITIVE_PREFIX = auto()
-        RECORD_STATE_VECTOR = auto()
-        RECORD_STATE_VECTOR_SUFFIX = auto()
-        RETURN_PREFIX = auto()
-        STATEMENT_PREFIX = auto()
-        STATIC_IMPORT = auto()
-        STATIC_INIT_SUFFIX = auto()
-        SWITCH_EXPRESSION_PREFIX = auto()
-        SWITCH_PREFIX = auto()
-        SYNCHRONIZED_PREFIX = auto()
-        TERNARY_FALSE = auto()
-        TERNARY_PREFIX = auto()
-        TERNARY_TRUE = auto()
-        THROWS = auto()
-        THROWS_SUFFIX = auto()
-        THROW_PREFIX = auto()
-        TRY_FINALLY = auto()
-        TRY_PREFIX = auto()
-        TRY_RESOURCE = auto()
-        TRY_RESOURCES = auto()
-        TRY_RESOURCE_SUFFIX = auto()
-        TYPE_BOUNDS = auto()
-        TYPE_BOUND_SUFFIX = auto()
-        TYPE_CAST_PREFIX = auto()
-        TYPE_PARAMETERS = auto()
-        TYPE_PARAMETERS_PREFIX = auto()
-        TYPE_PARAMETER_SUFFIX = auto()
-        UNARY_OPERATOR = auto()
-        UNARY_PREFIX = auto()
-        UNKNOWN_PREFIX = auto()
-        UNKNOWN_SOURCE_PREFIX = auto()
-        VARARGS = auto()
-        VARIABLE_DECLARATIONS_PREFIX = auto()
-        VARIABLE_INITIALIZER = auto()
-        VARIABLE_PREFIX = auto()
-        WHILE_BODY_SUFFIX = auto()
-        WHILE_CONDITION = auto()
-        WHILE_PREFIX = auto()
-        WILDCARD_BOUND = auto()
-        WILDCARD_PREFIX = auto()
-        YIELD_PREFIX = auto()
-
 
 Space.EMPTY = Space([], '')
 Space.SINGLE_SPACE = Space([], ' ')
-
-
-@dataclass
-class CoordinateBuilder:
-    tree: J
-
-    def before(self, loc: Space.Location) -> JavaCoordinates:
-        return JavaCoordinates(self.tree, loc, JavaCoordinates.Mode.BEFORE)
-
-    def after(self, loc: Space.Location) -> JavaCoordinates:
-        return JavaCoordinates(self.tree, loc, JavaCoordinates.Mode.AFTER)
-
-    def replace(self, loc: Optional[Space.Location] = None) -> JavaCoordinates:
-        return JavaCoordinates(self.tree, loc, JavaCoordinates.Mode.REPLACE)
-
-
-@dataclass
-class _ExpressionCoordinateBuilder(CoordinateBuilder):
-    def after(self, loc: Optional[Space.Location] = None) -> JavaCoordinates:
-        return JavaCoordinates(self.tree, loc or Space.Location.EXPRESSION_PREFIX, JavaCoordinates.Mode.AFTER)
-
-    def before(self, loc: Optional[Space.Location] = None) -> JavaCoordinates:
-        return JavaCoordinates(self.tree, loc or Space.Location.EXPRESSION_PREFIX, JavaCoordinates.Mode.BEFORE)
-
-    def replace(self, loc: Optional[Space.Location] = None) -> JavaCoordinates:
-        return JavaCoordinates(self.tree, loc or Space.Location.EXPRESSION_PREFIX, JavaCoordinates.Mode.REPLACE)
-
-
-@dataclass
-class _StatementCoordinateBuilder(CoordinateBuilder):
-    def after(self, loc: Optional[Space.Location] = None) -> JavaCoordinates:
-        return JavaCoordinates(self.tree, loc or Space.Location.STATEMENT_PREFIX, JavaCoordinates.Mode.AFTER)
-
-    def before(self, loc: Optional[Space.Location] = None) -> JavaCoordinates:
-        return JavaCoordinates(self.tree, loc or Space.Location.STATEMENT_PREFIX, JavaCoordinates.Mode.BEFORE)
-
-    def replace(self, loc: Optional[Space.Location] = None) -> JavaCoordinates:
-        return JavaCoordinates(self.tree, loc or Space.Location.STATEMENT_PREFIX, JavaCoordinates.Mode.REPLACE)
-
-
-@dataclass
-class _BlockCoordinateBuilder(_StatementCoordinateBuilder):
-    def first_statement(self) -> JavaCoordinates:
-        if not self.tree.statements:
-            return self.last_statement()
-        return self.tree.statements[0].get_coordinates().before()
-
-    def last_statement(self) -> JavaCoordinates:
-        return self.before(Space.Location.BLOCK_END)
-
-
-CoordinateBuilder.Expression = _ExpressionCoordinateBuilder  # type: ignore
-CoordinateBuilder.Statement = _StatementCoordinateBuilder  # type: ignore
-CoordinateBuilder.Block = _BlockCoordinateBuilder  # type: ignore
-
-
-@dataclass
-class JavaCoordinates:
-    tree: J
-    loc: Space.Location
-    mode: Mode
-
-    def is_replacement(self) -> bool:
-        return self.mode == JavaCoordinates.Mode.REPLACE
-
-    class Mode(Enum):
-        AFTER = 0,
-        BEFORE = 1,
-        REPLACE = 2,
 
 
 class JavaSourceFile(J, SourceFile):
@@ -380,13 +157,11 @@ class JavaSourceFile(J, SourceFile):
 
 
 class Expression(J):
-    def get_coordinates(self) -> CoordinateBuilder.Expression:  # type: ignore
-        return CoordinateBuilder.Expression(self)  # type: ignore
+    pass
 
 
 class Statement(J):
-    def get_coordinates(self) -> CoordinateBuilder.Statement:  # type: ignore
-        return CoordinateBuilder.Statement(self)  # type: ignore
+    pass
 
 
 class TypedTree(J):
@@ -603,52 +378,6 @@ class JRightPadded(Generic[T]):
 
         return after
 
-    class Location(Enum):
-        ANNOTATION_ARGUMENT = Space.Location.ANNOTATION_ARGUMENT_SUFFIX
-        ARRAY_INDEX = Space.Location.ARRAY_INDEX_SUFFIX
-        BLOCK_STATEMENT = Space.Location.BLOCK_STATEMENT_SUFFIX
-        CASE = Space.Location.CASE_SUFFIX
-        CASE_BODY = Space.Location.CASE_BODY
-        CASE_EXPRESSION = Space.Location.CASE_EXPRESSION
-        CATCH_ALTERNATIVE = Space.Location.CATCH_ALTERNATIVE_SUFFIX
-        DIMENSION = Space.Location.DIMENSION_SUFFIX
-        ENUM_VALUE = Space.Location.ENUM_VALUE_SUFFIX
-        FOREACH_ITERABLE = Space.Location.FOREACH_ITERABLE_SUFFIX
-        FOREACH_VARIABLE = Space.Location.FOREACH_VARIABLE_SUFFIX
-        FOR_BODY = Space.Location.FOR_BODY_SUFFIX
-        FOR_CONDITION = Space.Location.FOR_CONDITION_SUFFIX
-        FOR_INIT = Space.Location.FOR_INIT_SUFFIX
-        FOR_UPDATE = Space.Location.FOR_UPDATE_SUFFIX
-        IF_ELSE = Space.Location.IF_ELSE_SUFFIX
-        IF_THEN = Space.Location.IF_THEN_SUFFIX
-        IMPLEMENTS = Space.Location.IMPLEMENTS_SUFFIX
-        IMPORT = Space.Location.IMPORT_SUFFIX
-        INSTANCEOF = Space.Location.INSTANCEOF_SUFFIX
-        LABEL = Space.Location.LABEL_SUFFIX
-        LAMBDA_PARAM = Space.Location.LAMBDA_PARAMETER
-        LANGUAGE_EXTENSION = Space.Location.LANGUAGE_EXTENSION
-        MEMBER_REFERENCE_CONTAINING = Space.Location.MEMBER_REFERENCE_CONTAINING
-        METHOD_DECLARATION_PARAMETER = Space.Location.METHOD_DECLARATION_PARAMETER_SUFFIX
-        METHOD_INVOCATION_ARGUMENT = Space.Location.METHOD_INVOCATION_ARGUMENT_SUFFIX
-        METHOD_SELECT = Space.Location.METHOD_SELECT_SUFFIX
-        NAMED_VARIABLE = Space.Location.NAMED_VARIABLE_SUFFIX
-        NEW_ARRAY_INITIALIZER = Space.Location.NEW_ARRAY_INITIALIZER_SUFFIX
-        NEW_CLASS_ARGUMENTS = Space.Location.NEW_CLASS_ARGUMENTS_SUFFIX
-        NEW_CLASS_ENCLOSING = Space.Location.NEW_CLASS_ENCLOSING_SUFFIX
-        NULLABLE = Space.Location.NULLABLE_TYPE_SUFFIX
-        PACKAGE = Space.Location.PACKAGE_SUFFIX
-        PARENTHESES = Space.Location.PARENTHESES_SUFFIX
-        PERMITS = Space.Location.PERMITS_SUFFIX
-        RECORD_STATE_VECTOR = Space.Location.RECORD_STATE_VECTOR_SUFFIX
-        STATIC_INIT = Space.Location.STATIC_INIT_SUFFIX
-        THROWS = Space.Location.THROWS_SUFFIX
-        TRY_RESOURCE = Space.Location.TRY_RESOURCE_SUFFIX
-        TYPE_BOUND = Space.Location.TYPE_BOUND_SUFFIX
-        TYPE_PARAMETER = Space.Location.TYPE_PARAMETER_SUFFIX
-        WHILE_BODY = Space.Location.WHILE_BODY_SUFFIX
-
-        def __init__(self, after_location: Space.Location):
-            self.after_location = after_location
 
 
 @dataclass(frozen=True)
@@ -683,31 +412,6 @@ class JLeftPadded(Generic[T]):
         """Replace fields on this JLeftPadded, returning self if nothing changed."""
         return replace_if_changed(self, **kwargs)
 
-    class Location(Enum):
-        ARRAY_TYPE_DIMENSION = Space.Location.DIMENSION_PREFIX
-        ASSERT_DETAIL = Space.Location.ASSERT_DETAIL_PREFIX
-        ASSIGNMENT = Space.Location.ASSIGNMENT
-        ASSIGNMENT_OPERATION_OPERATOR = Space.Location.ASSIGNMENT_OPERATION_OPERATOR
-        BINARY_OPERATOR = Space.Location.BINARY_OPERATOR
-        CLASS_KIND = Space.Location.CLASS_KIND
-        DIMENSION_PREFIX = Space.Location.CLASS_KIND
-        EXTENDS = Space.Location.EXTENDS
-        FIELD_ACCESS_NAME = Space.Location.FIELD_ACCESS_NAME
-        IMPORT_ALIAS_PREFIX = Space.Location.IMPORT_ALIAS_PREFIX
-        LANGUAGE_EXTENSION = Space.Location.LANGUAGE_EXTENSION
-        MEMBER_REFERENCE_NAME = Space.Location.MEMBER_REFERENCE_NAME
-        METHOD_DECLARATION_DEFAULT_VALUE = Space.Location.METHOD_DECLARATION_DEFAULT_VALUE
-        STATIC_IMPORT = Space.Location.STATIC_IMPORT
-        TERNARY_FALSE = Space.Location.TERNARY_FALSE
-        TERNARY_TRUE = Space.Location.TERNARY_TRUE
-        TRY_FINALLY = Space.Location.TRY_FINALLY
-        UNARY_OPERATOR = Space.Location.UNARY_OPERATOR
-        VARIABLE_INITIALIZER = Space.Location.VARIABLE_INITIALIZER
-        WHILE_CONDITION = Space.Location.WHILE_CONDITION
-        WILDCARD_BOUND = Space.Location.WILDCARD_BOUND
-
-        def __init__(self, before_location: Space.Location):
-            self.before_location = before_location
 
 
 @dataclass(frozen=True)
@@ -794,25 +498,3 @@ class JContainer(Generic[J2]):
             cls._EMPTY = JContainer(Space.EMPTY, [], Markers.EMPTY)
         return cls._EMPTY  # type: ignore
 
-    class Location(Enum):
-        ANNOTATION_ARGUMENTS = (Space.Location.ANNOTATION_ARGUMENTS, JRightPadded.Location.ANNOTATION_ARGUMENT)
-        CASE = (Space.Location.CASE, JRightPadded.Location.CASE)
-        CASE_EXPRESSION = (Space.Location.CASE_EXPRESSION, JRightPadded.Location.CASE_EXPRESSION)
-        IMPLEMENTS = (Space.Location.IMPLEMENTS, JRightPadded.Location.IMPLEMENTS)
-        LANGUAGE_EXTENSION = (Space.Location.LANGUAGE_EXTENSION, JRightPadded.Location.LANGUAGE_EXTENSION)
-        METHOD_DECLARATION_PARAMETERS = (
-            Space.Location.METHOD_DECLARATION_PARAMETERS, JRightPadded.Location.METHOD_DECLARATION_PARAMETER)
-        METHOD_INVOCATION_ARGUMENTS = (
-            Space.Location.METHOD_INVOCATION_ARGUMENTS, JRightPadded.Location.METHOD_INVOCATION_ARGUMENT)
-        NEW_ARRAY_INITIALIZER = (Space.Location.NEW_ARRAY_INITIALIZER, JRightPadded.Location.NEW_ARRAY_INITIALIZER)
-        NEW_CLASS_ARGUMENTS = (Space.Location.NEW_CLASS_ARGUMENTS, JRightPadded.Location.NEW_CLASS_ARGUMENTS)
-        PERMITS = (Space.Location.PERMITS, JRightPadded.Location.PERMITS)
-        RECORD_STATE_VECTOR = (Space.Location.RECORD_STATE_VECTOR, JRightPadded.Location.RECORD_STATE_VECTOR)
-        THROWS = (Space.Location.THROWS, JRightPadded.Location.THROWS)
-        TRY_RESOURCES = (Space.Location.TRY_RESOURCES, JRightPadded.Location.TRY_RESOURCE)
-        TYPE_BOUNDS = (Space.Location.TYPE_BOUNDS, JRightPadded.Location.TYPE_BOUND)
-        TYPE_PARAMETERS = (Space.Location.TYPE_PARAMETERS, JRightPadded.Location.TYPE_PARAMETER)
-
-        def __init__(self, before_location: Space.Location, element_location: JRightPadded.Location):
-            self.before_location = before_location
-            self.element_location = element_location

--- a/rewrite-python/rewrite/src/rewrite/java/tree.py
+++ b/rewrite-python/rewrite/src/rewrite/java/tree.py
@@ -661,9 +661,6 @@ class Block(Statement):
     def accept_java(self, v: JavaVisitor[P], p: P) -> J:
         return v.visit_block(self, p)
 
-    def get_coordinates(self) -> CoordinateBuilder.Block:
-        return CoordinateBuilder.Block(self)
-
 # noinspection PyShadowingBuiltins,PyShadowingNames,DuplicatedCode
 @dataclass(frozen=True, eq=False)
 class Break(Statement):

--- a/rewrite-python/rewrite/src/rewrite/java/visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/java/visitor.py
@@ -43,7 +43,7 @@ class JavaVisitor(TreeVisitor[J, P]):
         """Visit a statement. Override to intercept all statements."""
         return stmt
 
-    def visit_space(self, space: Optional[Space], loc: Optional[Any], p: P) -> Space:
+    def visit_space(self, space: Optional[Space], p: P) -> Space:
         """Visit a space (whitespace and comments)."""
         if space is None:
             return Space.EMPTY
@@ -58,13 +58,12 @@ class JavaVisitor(TreeVisitor[J, P]):
     def visit_left_padded(
         self,
         left: Optional[JLeftPadded],
-        loc: Optional[Any],
         p: P,
     ) -> Optional[JLeftPadded]:
         """Visit a left-padded element."""
         if left is None:
             return None
-        before = self.visit_space(left.before, loc, p)
+        before = self.visit_space(left.before, p)
         element = left.element
         if isinstance(element, J):
             element = self.visit(element, p)
@@ -77,7 +76,6 @@ class JavaVisitor(TreeVisitor[J, P]):
     def visit_right_padded(
         self,
         right: Optional[JRightPadded],
-        loc: Optional[Any],
         p: P,
     ) -> Optional[JRightPadded]:
         """Visit a right-padded element."""
@@ -88,7 +86,7 @@ class JavaVisitor(TreeVisitor[J, P]):
             element = self.visit(element, p)
             if element is None:
                 return None
-        after = self.visit_space(right.after, loc, p)
+        after = self.visit_space(right.after, p)
         if element is right.element and after is right.after:
             return right
         return right.replace(element=element, after=after)
@@ -96,15 +94,14 @@ class JavaVisitor(TreeVisitor[J, P]):
     def visit_container(
         self,
         container: Optional[JContainer],
-        loc: Optional[Any],
         p: P,
     ) -> Optional[JContainer]:
         """Visit a container of elements."""
         if container is None:
             return None
-        before = self.visit_space(container.before, loc, p)
+        before = self.visit_space(container.before, p)
         elements = list_map(
-            lambda e: self.visit_right_padded(e, loc, p),
+            lambda e: self.visit_right_padded(e, p),
             container.padding.elements
         )
         # Filter out None elements (deleted by visitor)
@@ -119,7 +116,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_annotated_type(self, annotated_type: j.AnnotatedType, p: P) -> J:
         annotated_type = annotated_type.replace(
-            prefix=self.visit_space(annotated_type.prefix, Space.Location.ANNOTATED_TYPE_PREFIX, p)
+            prefix=self.visit_space(annotated_type.prefix, p)
         )
         temp_expr = self.visit_expression(annotated_type, p)
         if not isinstance(temp_expr, j.AnnotatedType):
@@ -136,7 +133,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_annotation(self, annotation: j.Annotation, p: P) -> J:
         annotation = annotation.replace(
-            prefix=self.visit_space(annotation.prefix, Space.Location.ANNOTATION_PREFIX, p)
+            prefix=self.visit_space(annotation.prefix, p)
         )
         temp_expr = self.visit_expression(annotation, p)
         if not isinstance(temp_expr, j.Annotation):
@@ -147,13 +144,13 @@ class JavaVisitor(TreeVisitor[J, P]):
             annotation_type=self.visit_and_cast(annotation.annotation_type, j.NameTree, p)
         )
         annotation = annotation.replace(
-            arguments=self.visit_container(annotation.padding.arguments, JContainer.Location.ANNOTATION_ARGUMENTS, p)
+            arguments=self.visit_container(annotation.padding.arguments, p)
         )
         return annotation
 
     def visit_array_access(self, array_access: j.ArrayAccess, p: P) -> J:
         array_access = array_access.replace(
-            prefix=self.visit_space(array_access.prefix, Space.Location.ARRAY_ACCESS_PREFIX, p)
+            prefix=self.visit_space(array_access.prefix, p)
         )
         temp_expr = self.visit_expression(array_access, p)
         if not isinstance(temp_expr, j.ArrayAccess):
@@ -170,17 +167,17 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_array_dimension(self, array_dimension: j.ArrayDimension, p: P) -> J:
         array_dimension = array_dimension.replace(
-            prefix=self.visit_space(array_dimension.prefix, Space.Location.DIMENSION_PREFIX, p)
+            prefix=self.visit_space(array_dimension.prefix, p)
         )
         array_dimension = array_dimension.replace(markers=self.visit_markers(array_dimension.markers, p))
         array_dimension = array_dimension.padding.replace(
-            index=self.visit_right_padded(array_dimension.padding.index, JRightPadded.Location.ARRAY_INDEX, p)
+            index=self.visit_right_padded(array_dimension.padding.index, p)
         )
         return array_dimension
 
     def visit_array_type(self, array_type: j.ArrayType, p: P) -> J:
         array_type = array_type.replace(
-            prefix=self.visit_space(array_type.prefix, Space.Location.ARRAY_TYPE_PREFIX, p)
+            prefix=self.visit_space(array_type.prefix, p)
         )
         temp_expr = self.visit_expression(array_type, p)
         if not isinstance(temp_expr, j.ArrayType):
@@ -195,13 +192,13 @@ class JavaVisitor(TreeVisitor[J, P]):
                 annotations=list_map(lambda a: self.visit_and_cast(a, j.Annotation, p), array_type.annotations)
             )
         array_type = array_type.padding.replace(
-            dimension=self.visit_left_padded(array_type.padding.dimension, JLeftPadded.Location.ARRAY_TYPE_DIMENSION, p)
+            dimension=self.visit_left_padded(array_type.padding.dimension, p)
         )
         return array_type
 
     def visit_assert(self, assert_: j.Assert, p: P) -> J:
         assert_ = assert_.replace(
-            prefix=self.visit_space(assert_.prefix, Space.Location.ASSERT_PREFIX, p)
+            prefix=self.visit_space(assert_.prefix, p)
         )
         temp_stmt = self.visit_statement(assert_, p)
         if not isinstance(temp_stmt, j.Assert):
@@ -213,13 +210,13 @@ class JavaVisitor(TreeVisitor[J, P]):
         )
         if assert_.detail:
             assert_ = assert_.replace(
-                detail=self.visit_left_padded(assert_.detail, JLeftPadded.Location.ASSERT_DETAIL, p)
+                detail=self.visit_left_padded(assert_.detail, p)
             )
         return assert_
 
     def visit_assignment(self, assignment: j.Assignment, p: P) -> J:
         assignment = assignment.replace(
-            prefix=self.visit_space(assignment.prefix, Space.Location.ASSIGNMENT_PREFIX, p)
+            prefix=self.visit_space(assignment.prefix, p)
         )
         temp_stmt = self.visit_statement(assignment, p)
         if not isinstance(temp_stmt, j.Assignment):
@@ -234,13 +231,13 @@ class JavaVisitor(TreeVisitor[J, P]):
             variable=self.visit_and_cast(assignment.variable, Expression, p)
         )
         assignment = assignment.padding.replace(
-            assignment=self.visit_left_padded(assignment.padding.assignment, JLeftPadded.Location.ASSIGNMENT, p)
+            assignment=self.visit_left_padded(assignment.padding.assignment, p)
         )
         return assignment
 
     def visit_assignment_operation(self, assign_op: j.AssignmentOperation, p: P) -> J:
         assign_op = assign_op.replace(
-            prefix=self.visit_space(assign_op.prefix, Space.Location.ASSIGNMENT_OPERATION_PREFIX, p)
+            prefix=self.visit_space(assign_op.prefix, p)
         )
         temp_stmt = self.visit_statement(assign_op, p)
         if not isinstance(temp_stmt, j.AssignmentOperation):
@@ -255,7 +252,7 @@ class JavaVisitor(TreeVisitor[J, P]):
             variable=self.visit_and_cast(assign_op.variable, Expression, p)
         )
         assign_op = assign_op.padding.replace(
-            operator=self.visit_left_padded(assign_op.padding.operator, JLeftPadded.Location.ASSIGNMENT_OPERATION_OPERATOR, p)
+            operator=self.visit_left_padded(assign_op.padding.operator, p)
         )
         assign_op = assign_op.replace(
             assignment=self.visit_and_cast(assign_op.assignment, Expression, p)
@@ -264,7 +261,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_binary(self, binary: j.Binary, p: P) -> J:
         binary = binary.replace(
-            prefix=self.visit_space(binary.prefix, Space.Location.BINARY_PREFIX, p)
+            prefix=self.visit_space(binary.prefix, p)
         )
         temp_expr = self.visit_expression(binary, p)
         if not isinstance(temp_expr, j.Binary):
@@ -275,7 +272,7 @@ class JavaVisitor(TreeVisitor[J, P]):
             left=self.visit_and_cast(binary.left, Expression, p)
         )
         binary = binary.padding.replace(
-            operator=self.visit_left_padded(binary.padding.operator, JLeftPadded.Location.BINARY_OPERATOR, p)
+            operator=self.visit_left_padded(binary.padding.operator, p)
         )
         binary = binary.replace(
             right=self.visit_and_cast(binary.right, Expression, p)
@@ -284,7 +281,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_block(self, block: j.Block, p: P) -> J:
         block = block.replace(
-            prefix=self.visit_space(block.prefix, Space.Location.BLOCK_PREFIX, p)
+            prefix=self.visit_space(block.prefix, p)
         )
         temp_stmt = self.visit_statement(block, p)
         if not isinstance(temp_stmt, j.Block):
@@ -292,22 +289,22 @@ class JavaVisitor(TreeVisitor[J, P]):
         block = temp_stmt
         block = block.replace(markers=self.visit_markers(block.markers, p))
         block = block.padding.replace(
-            static=self.visit_right_padded(block.padding.static, JRightPadded.Location.STATIC_INIT, p)
+            static=self.visit_right_padded(block.padding.static, p)
         )
         block = block.padding.replace(
             statements=list_map(
-                lambda stmt: self.visit_right_padded(stmt, JRightPadded.Location.BLOCK_STATEMENT, p),
+                lambda stmt: self.visit_right_padded(stmt, p),
                 block.padding.statements
             )
         )
         block = block.replace(
-            end=self.visit_space(block.end, Space.Location.BLOCK_END, p)
+            end=self.visit_space(block.end, p)
         )
         return block
 
     def visit_break(self, break_: j.Break, p: P) -> J:
         break_ = break_.replace(
-            prefix=self.visit_space(break_.prefix, Space.Location.BREAK_PREFIX, p)
+            prefix=self.visit_space(break_.prefix, p)
         )
         temp_stmt = self.visit_statement(break_, p)
         if not isinstance(temp_stmt, j.Break):
@@ -322,7 +319,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_case(self, case: j.Case, p: P) -> J:
         case = case.replace(
-            prefix=self.visit_space(case.prefix, Space.Location.CASE_PREFIX, p)
+            prefix=self.visit_space(case.prefix, p)
         )
         temp_stmt = self.visit_statement(case, p)
         if not isinstance(temp_stmt, j.Case):
@@ -330,19 +327,19 @@ class JavaVisitor(TreeVisitor[J, P]):
         case = temp_stmt
         case = case.replace(markers=self.visit_markers(case.markers, p))
         case = case.replace(
-            case_labels=self.visit_container(case.padding.case_labels, JContainer.Location.CASE_EXPRESSION, p)
+            case_labels=self.visit_container(case.padding.case_labels, p)
         )
         case = case.replace(
-            statements=self.visit_container(case.padding.statements, JContainer.Location.CASE, p)
+            statements=self.visit_container(case.padding.statements, p)
         )
         case = case.padding.replace(
-            body=self.visit_right_padded(case.padding.body, JRightPadded.Location.CASE_BODY, p)
+            body=self.visit_right_padded(case.padding.body, p)
         )
         return case
 
     def visit_class_declaration(self, class_decl: j.ClassDeclaration, p: P) -> J:
         class_decl = class_decl.replace(
-            prefix=self.visit_space(class_decl.prefix, Space.Location.CLASS_DECLARATION_PREFIX, p)
+            prefix=self.visit_space(class_decl.prefix, p)
         )
         temp_stmt = self.visit_statement(class_decl, p)
         if not isinstance(temp_stmt, j.ClassDeclaration):
@@ -362,19 +359,19 @@ class JavaVisitor(TreeVisitor[J, P]):
             name=self.visit_and_cast(class_decl.name, j.Identifier, p)
         )
         class_decl = class_decl.replace(
-            type_parameters=self.visit_container(class_decl.padding.type_parameters, JContainer.Location.TYPE_PARAMETERS, p)
+            type_parameters=self.visit_container(class_decl.padding.type_parameters, p)
         )
         class_decl = class_decl.replace(
-            primary_constructor=self.visit_container(class_decl.padding.primary_constructor, JContainer.Location.RECORD_STATE_VECTOR, p)
+            primary_constructor=self.visit_container(class_decl.padding.primary_constructor, p)
         )
         class_decl = class_decl.padding.replace(
-            extends=self.visit_left_padded(class_decl.padding.extends, JLeftPadded.Location.EXTENDS, p)
+            extends=self.visit_left_padded(class_decl.padding.extends, p)
         )
         class_decl = class_decl.replace(
-            implements=self.visit_container(class_decl.padding.implements, JContainer.Location.IMPLEMENTS, p)
+            implements=self.visit_container(class_decl.padding.implements, p)
         )
         class_decl = class_decl.replace(
-            permits=self.visit_container(class_decl.padding.permits, JContainer.Location.PERMITS, p)
+            permits=self.visit_container(class_decl.padding.permits, p)
         )
         class_decl = class_decl.replace(
             body=self.visit_and_cast(class_decl.body, j.Block, p)
@@ -383,7 +380,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_class_declaration_kind(self, kind: j.ClassDeclaration.Kind, p: P) -> J:
         kind = kind.replace(
-            prefix=self.visit_space(kind.prefix, Space.Location.CLASS_KIND, p)
+            prefix=self.visit_space(kind.prefix, p)
         )
         kind = kind.replace(markers=self.visit_markers(kind.markers, p))
         kind = kind.replace(
@@ -393,7 +390,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_continue(self, continue_: j.Continue, p: P) -> J:
         continue_ = continue_.replace(
-            prefix=self.visit_space(continue_.prefix, Space.Location.CONTINUE_PREFIX, p)
+            prefix=self.visit_space(continue_.prefix, p)
         )
         temp_stmt = self.visit_statement(continue_, p)
         if not isinstance(temp_stmt, j.Continue):
@@ -408,7 +405,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_control_parentheses(self, control_parens: j.ControlParentheses, p: P) -> J:
         control_parens = control_parens.replace(
-            prefix=self.visit_space(control_parens.prefix, Space.Location.CONTROL_PARENTHESES_PREFIX, p)
+            prefix=self.visit_space(control_parens.prefix, p)
         )
         temp_expr = self.visit_expression(control_parens, p)
         if not isinstance(temp_expr, j.ControlParentheses):
@@ -416,13 +413,13 @@ class JavaVisitor(TreeVisitor[J, P]):
         control_parens = temp_expr
         control_parens = control_parens.replace(markers=self.visit_markers(control_parens.markers, p))
         control_parens = control_parens.padding.replace(
-            tree=self.visit_right_padded(control_parens.padding.tree, JRightPadded.Location.PARENTHESES, p)
+            tree=self.visit_right_padded(control_parens.padding.tree, p)
         )
         return control_parens
 
     def visit_do_while_loop(self, do_while: j.DoWhileLoop, p: P) -> J:
         do_while = do_while.replace(
-            prefix=self.visit_space(do_while.prefix, Space.Location.DO_WHILE_PREFIX, p)
+            prefix=self.visit_space(do_while.prefix, p)
         )
         temp_stmt = self.visit_statement(do_while, p)
         if not isinstance(temp_stmt, j.DoWhileLoop):
@@ -430,16 +427,16 @@ class JavaVisitor(TreeVisitor[J, P]):
         do_while = temp_stmt
         do_while = do_while.replace(markers=self.visit_markers(do_while.markers, p))
         do_while = do_while.padding.replace(
-            body=self.visit_right_padded(do_while.padding.body, JRightPadded.Location.WHILE_BODY, p)
+            body=self.visit_right_padded(do_while.padding.body, p)
         )
         do_while = do_while.padding.replace(
-            while_condition=self.visit_left_padded(do_while.padding.while_condition, JLeftPadded.Location.WHILE_CONDITION, p)
+            while_condition=self.visit_left_padded(do_while.padding.while_condition, p)
         )
         return do_while
 
     def visit_empty(self, empty: j.Empty, p: P) -> J:
         empty = empty.replace(
-            prefix=self.visit_space(empty.prefix, Space.Location.EMPTY_PREFIX, p)
+            prefix=self.visit_space(empty.prefix, p)
         )
         temp_stmt = self.visit_statement(empty, p)
         if not isinstance(temp_stmt, j.Empty):
@@ -454,7 +451,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_enum_value(self, enum_value: j.EnumValue, p: P) -> J:
         enum_value = enum_value.replace(
-            prefix=self.visit_space(enum_value.prefix, Space.Location.ENUM_VALUE_PREFIX, p)
+            prefix=self.visit_space(enum_value.prefix, p)
         )
         enum_value = enum_value.replace(markers=self.visit_markers(enum_value.markers, p))
         enum_value = enum_value.replace(
@@ -471,7 +468,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_enum_value_set(self, enum_set: j.EnumValueSet, p: P) -> J:
         enum_set = enum_set.replace(
-            prefix=self.visit_space(enum_set.prefix, Space.Location.ENUM_VALUE_SET_PREFIX, p)
+            prefix=self.visit_space(enum_set.prefix, p)
         )
         temp_stmt = self.visit_statement(enum_set, p)
         if not isinstance(temp_stmt, j.EnumValueSet):
@@ -480,7 +477,7 @@ class JavaVisitor(TreeVisitor[J, P]):
         enum_set = enum_set.replace(markers=self.visit_markers(enum_set.markers, p))
         enum_set = enum_set.padding.replace(
             enums=list_map(
-                lambda e: self.visit_right_padded(e, JRightPadded.Location.ENUM_VALUE, p),
+                lambda e: self.visit_right_padded(e, p),
                 enum_set.padding.enums
             )
         )
@@ -488,7 +485,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_field_access(self, field_access: j.FieldAccess, p: P) -> J:
         field_access = field_access.replace(
-            prefix=self.visit_space(field_access.prefix, Space.Location.FIELD_ACCESS_PREFIX, p)
+            prefix=self.visit_space(field_access.prefix, p)
         )
         temp_stmt = self.visit_statement(field_access, p)
         if not isinstance(temp_stmt, j.FieldAccess):
@@ -503,13 +500,13 @@ class JavaVisitor(TreeVisitor[J, P]):
             target=self.visit_and_cast(field_access.target, Expression, p)
         )
         field_access = field_access.padding.replace(
-            name=self.visit_left_padded(field_access.padding.name, JLeftPadded.Location.FIELD_ACCESS_NAME, p)
+            name=self.visit_left_padded(field_access.padding.name, p)
         )
         return field_access
 
     def visit_for_each_loop(self, for_each: j.ForEachLoop, p: P) -> J:
         for_each = for_each.replace(
-            prefix=self.visit_space(for_each.prefix, Space.Location.FOR_EACH_LOOP_PREFIX, p)
+            prefix=self.visit_space(for_each.prefix, p)
         )
         temp_stmt = self.visit_statement(for_each, p)
         if not isinstance(temp_stmt, j.ForEachLoop):
@@ -520,26 +517,26 @@ class JavaVisitor(TreeVisitor[J, P]):
             control=self.visit_and_cast(for_each.control, j.ForEachLoop.Control, p)
         )
         for_each = for_each.padding.replace(
-            body=self.visit_right_padded(for_each.padding.body, JRightPadded.Location.FOR_BODY, p)
+            body=self.visit_right_padded(for_each.padding.body, p)
         )
         return for_each
 
     def visit_for_each_control(self, control: j.ForEachLoop.Control, p: P) -> J:
         control = control.replace(
-            prefix=self.visit_space(control.prefix, Space.Location.FOR_EACH_CONTROL_PREFIX, p)
+            prefix=self.visit_space(control.prefix, p)
         )
         control = control.replace(markers=self.visit_markers(control.markers, p))
         control = control.padding.replace(
-            variable=self.visit_right_padded(control.padding.variable, JRightPadded.Location.FOREACH_VARIABLE, p)
+            variable=self.visit_right_padded(control.padding.variable, p)
         )
         control = control.padding.replace(
-            iterable=self.visit_right_padded(control.padding.iterable, JRightPadded.Location.FOREACH_ITERABLE, p)
+            iterable=self.visit_right_padded(control.padding.iterable, p)
         )
         return control
 
     def visit_for_loop(self, for_loop: j.ForLoop, p: P) -> J:
         for_loop = for_loop.replace(
-            prefix=self.visit_space(for_loop.prefix, Space.Location.FOR_PREFIX, p)
+            prefix=self.visit_space(for_loop.prefix, p)
         )
         temp_stmt = self.visit_statement(for_loop, p)
         if not isinstance(temp_stmt, j.ForLoop):
@@ -550,27 +547,27 @@ class JavaVisitor(TreeVisitor[J, P]):
             control=self.visit_and_cast(for_loop.control, j.ForLoop.Control, p)
         )
         for_loop = for_loop.padding.replace(
-            body=self.visit_right_padded(for_loop.padding.body, JRightPadded.Location.FOR_BODY, p)
+            body=self.visit_right_padded(for_loop.padding.body, p)
         )
         return for_loop
 
     def visit_for_control(self, control: j.ForLoop.Control, p: P) -> J:
         control = control.replace(
-            prefix=self.visit_space(control.prefix, Space.Location.FOR_CONTROL_PREFIX, p)
+            prefix=self.visit_space(control.prefix, p)
         )
         control = control.replace(markers=self.visit_markers(control.markers, p))
         control = control.padding.replace(
             init=list_map(
-                lambda i: self.visit_right_padded(i, JRightPadded.Location.FOR_INIT, p),
+                lambda i: self.visit_right_padded(i, p),
                 control.padding.init
             )
         )
         control = control.padding.replace(
-            condition=self.visit_right_padded(control.padding.condition, JRightPadded.Location.FOR_CONDITION, p)
+            condition=self.visit_right_padded(control.padding.condition, p)
         )
         control = control.padding.replace(
             update=list_map(
-                lambda u: self.visit_right_padded(u, JRightPadded.Location.FOR_UPDATE, p),
+                lambda u: self.visit_right_padded(u, p),
                 control.padding.update
             )
         )
@@ -578,7 +575,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_identifier(self, ident: j.Identifier, p: P) -> J:
         ident = ident.replace(
-            prefix=self.visit_space(ident.prefix, Space.Location.IDENTIFIER_PREFIX, p)
+            prefix=self.visit_space(ident.prefix, p)
         )
         temp_expr = self.visit_expression(ident, p)
         if not isinstance(temp_expr, j.Identifier):
@@ -593,7 +590,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_if(self, if_: j.If, p: P) -> J:
         if_ = if_.replace(
-            prefix=self.visit_space(if_.prefix, Space.Location.IF_PREFIX, p)
+            prefix=self.visit_space(if_.prefix, p)
         )
         temp_stmt = self.visit_statement(if_, p)
         if not isinstance(temp_stmt, j.If):
@@ -604,7 +601,7 @@ class JavaVisitor(TreeVisitor[J, P]):
             if_condition=self.visit_and_cast(if_.if_condition, j.ControlParentheses, p)
         )
         if_ = if_.padding.replace(
-            then_part=self.visit_right_padded(if_.padding.then_part, JRightPadded.Location.IF_THEN, p)
+            then_part=self.visit_right_padded(if_.padding.then_part, p)
         )
         if if_.else_part:
             if_ = if_.replace(
@@ -614,17 +611,17 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_else(self, else_: j.If.Else, p: P) -> J:
         else_ = else_.replace(
-            prefix=self.visit_space(else_.prefix, Space.Location.ELSE_PREFIX, p)
+            prefix=self.visit_space(else_.prefix, p)
         )
         else_ = else_.replace(markers=self.visit_markers(else_.markers, p))
         else_ = else_.padding.replace(
-            body=self.visit_right_padded(else_.padding.body, JRightPadded.Location.IF_ELSE, p)
+            body=self.visit_right_padded(else_.padding.body, p)
         )
         return else_
 
     def visit_import(self, import_: j.Import, p: P) -> J:
         import_ = import_.replace(
-            prefix=self.visit_space(import_.prefix, Space.Location.IMPORT_PREFIX, p)
+            prefix=self.visit_space(import_.prefix, p)
         )
         temp_stmt = self.visit_statement(import_, p)
         if not isinstance(temp_stmt, j.Import):
@@ -632,20 +629,20 @@ class JavaVisitor(TreeVisitor[J, P]):
         import_ = temp_stmt
         import_ = import_.replace(markers=self.visit_markers(import_.markers, p))
         import_ = import_.padding.replace(
-            static=self.visit_left_padded(import_.padding.static, JLeftPadded.Location.STATIC_IMPORT, p)
+            static=self.visit_left_padded(import_.padding.static, p)
         )
         import_ = import_.replace(
             qualid=self.visit_and_cast(import_.qualid, j.FieldAccess, p)
         )
         if import_.padding.alias:
             import_ = import_.padding.replace(
-                alias=self.visit_left_padded(import_.padding.alias, JLeftPadded.Location.IMPORT_ALIAS_PREFIX, p)
+                alias=self.visit_left_padded(import_.padding.alias, p)
             )
         return import_
 
     def visit_instance_of(self, instance_of: j.InstanceOf, p: P) -> J:
         instance_of = instance_of.replace(
-            prefix=self.visit_space(instance_of.prefix, Space.Location.INSTANCEOF_PREFIX, p)
+            prefix=self.visit_space(instance_of.prefix, p)
         )
         temp_expr = self.visit_expression(instance_of, p)
         if not isinstance(temp_expr, j.InstanceOf):
@@ -653,7 +650,7 @@ class JavaVisitor(TreeVisitor[J, P]):
         instance_of = temp_expr
         instance_of = instance_of.replace(markers=self.visit_markers(instance_of.markers, p))
         instance_of = instance_of.padding.replace(
-            expression=self.visit_right_padded(instance_of.padding.expression, JRightPadded.Location.INSTANCEOF, p)
+            expression=self.visit_right_padded(instance_of.padding.expression, p)
         )
         instance_of = instance_of.replace(
             clazz=self.visit_and_cast(instance_of.clazz, J, p)
@@ -666,7 +663,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_label(self, label: j.Label, p: P) -> J:
         label = label.replace(
-            prefix=self.visit_space(label.prefix, Space.Location.LABEL_PREFIX, p)
+            prefix=self.visit_space(label.prefix, p)
         )
         temp_stmt = self.visit_statement(label, p)
         if not isinstance(temp_stmt, j.Label):
@@ -674,7 +671,7 @@ class JavaVisitor(TreeVisitor[J, P]):
         label = temp_stmt
         label = label.replace(markers=self.visit_markers(label.markers, p))
         label = label.padding.replace(
-            label=self.visit_right_padded(label.padding.label, JRightPadded.Location.LABEL, p)
+            label=self.visit_right_padded(label.padding.label, p)
         )
         label = label.replace(
             statement=self.visit_and_cast(label.statement, Statement, p)
@@ -683,7 +680,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_lambda(self, lambda_: j.Lambda, p: P) -> J:
         lambda_ = lambda_.replace(
-            prefix=self.visit_space(lambda_.prefix, Space.Location.LAMBDA_PREFIX, p)
+            prefix=self.visit_space(lambda_.prefix, p)
         )
         temp_stmt = self.visit_statement(lambda_, p)
         if not isinstance(temp_stmt, j.Lambda):
@@ -698,7 +695,7 @@ class JavaVisitor(TreeVisitor[J, P]):
             parameters=self.visit_and_cast(lambda_.parameters, j.Lambda.Parameters, p)
         )
         lambda_ = lambda_.replace(
-            arrow=self.visit_space(lambda_.arrow, Space.Location.LAMBDA_ARROW_PREFIX, p)
+            arrow=self.visit_space(lambda_.arrow, p)
         )
         lambda_ = lambda_.replace(
             body=self.visit_and_cast(lambda_.body, J, p)
@@ -707,12 +704,12 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_lambda_parameters(self, params: j.Lambda.Parameters, p: P) -> J:
         params = params.replace(
-            prefix=self.visit_space(params.prefix, Space.Location.LAMBDA_PARAMETERS_PREFIX, p)
+            prefix=self.visit_space(params.prefix, p)
         )
         params = params.replace(markers=self.visit_markers(params.markers, p))
         params = params.padding.replace(
             parameters=list_map(
-                lambda param: self.visit_right_padded(param, JRightPadded.Location.LAMBDA_PARAM, p),
+                lambda param: self.visit_right_padded(param, p),
                 params.padding.parameters
             )
         )
@@ -720,7 +717,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_literal(self, literal: j.Literal, p: P) -> J:
         literal = literal.replace(
-            prefix=self.visit_space(literal.prefix, Space.Location.LITERAL_PREFIX, p)
+            prefix=self.visit_space(literal.prefix, p)
         )
         temp_expr = self.visit_expression(literal, p)
         if not isinstance(temp_expr, j.Literal):
@@ -731,7 +728,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_member_reference(self, member_ref: j.MemberReference, p: P) -> J:
         member_ref = member_ref.replace(
-            prefix=self.visit_space(member_ref.prefix, Space.Location.MEMBER_REFERENCE_PREFIX, p)
+            prefix=self.visit_space(member_ref.prefix, p)
         )
         temp_expr = self.visit_expression(member_ref, p)
         if not isinstance(temp_expr, j.MemberReference):
@@ -739,19 +736,19 @@ class JavaVisitor(TreeVisitor[J, P]):
         member_ref = temp_expr
         member_ref = member_ref.replace(markers=self.visit_markers(member_ref.markers, p))
         member_ref = member_ref.padding.replace(
-            containing=self.visit_right_padded(member_ref.padding.containing, JRightPadded.Location.MEMBER_REFERENCE_CONTAINING, p)
+            containing=self.visit_right_padded(member_ref.padding.containing, p)
         )
         member_ref = member_ref.replace(
-            type_parameters=self.visit_container(member_ref.padding.type_parameters, JContainer.Location.TYPE_PARAMETERS, p)
+            type_parameters=self.visit_container(member_ref.padding.type_parameters, p)
         )
         member_ref = member_ref.padding.replace(
-            reference=self.visit_left_padded(member_ref.padding.reference, JLeftPadded.Location.MEMBER_REFERENCE_NAME, p)
+            reference=self.visit_left_padded(member_ref.padding.reference, p)
         )
         return member_ref
 
     def visit_method_declaration(self, method: j.MethodDeclaration, p: P) -> J:
         method = method.replace(
-            prefix=self.visit_space(method.prefix, Space.Location.METHOD_DECLARATION_PREFIX, p)
+            prefix=self.visit_space(method.prefix, p)
         )
         temp_stmt = self.visit_statement(method, p)
         if not isinstance(temp_stmt, j.MethodDeclaration):
@@ -776,24 +773,24 @@ class JavaVisitor(TreeVisitor[J, P]):
             name=self.visit_and_cast(method.padding.name, j.Identifier, p)
         )
         method = method.replace(
-            parameters=self.visit_container(method.padding.parameters, JContainer.Location.METHOD_DECLARATION_PARAMETERS, p)
+            parameters=self.visit_container(method.padding.parameters, p)
         )
         if method.padding.throws:
             method = method.replace(
-                throws=self.visit_container(method.padding.throws, JContainer.Location.THROWS, p)
+                throws=self.visit_container(method.padding.throws, p)
             )
         if method.body:
             method = method.replace(
                 body=self.visit_and_cast(method.body, j.Block, p)
             )
         method = method.padding.replace(
-            default_value=self.visit_left_padded(method.padding.default_value, JLeftPadded.Location.METHOD_DECLARATION_DEFAULT_VALUE, p)
+            default_value=self.visit_left_padded(method.padding.default_value, p)
         )
         return method
 
     def visit_method_invocation(self, method: j.MethodInvocation, p: P) -> J:
         method = method.replace(
-            prefix=self.visit_space(method.prefix, Space.Location.METHOD_INVOCATION_PREFIX, p)
+            prefix=self.visit_space(method.prefix, p)
         )
         temp_stmt = self.visit_statement(method, p)
         if not isinstance(temp_stmt, j.MethodInvocation):
@@ -805,22 +802,22 @@ class JavaVisitor(TreeVisitor[J, P]):
         method = temp_expr
         method = method.replace(markers=self.visit_markers(method.markers, p))
         method = method.padding.replace(
-            select=self.visit_right_padded(method.padding.select, JRightPadded.Location.METHOD_SELECT, p)
+            select=self.visit_right_padded(method.padding.select, p)
         )
         method = method.replace(
-            type_parameters=self.visit_container(method.padding.type_parameters, JContainer.Location.TYPE_PARAMETERS, p)
+            type_parameters=self.visit_container(method.padding.type_parameters, p)
         )
         method = method.replace(
             name=self.visit_and_cast(method.name, j.Identifier, p)
         )
         method = method.replace(
-            arguments=self.visit_container(method.padding.arguments, JContainer.Location.METHOD_INVOCATION_ARGUMENTS, p)
+            arguments=self.visit_container(method.padding.arguments, p)
         )
         return method
 
     def visit_modifier(self, modifier: j.Modifier, p: P) -> J:
         modifier = modifier.replace(
-            prefix=self.visit_space(modifier.prefix, Space.Location.MODIFIER_PREFIX, p)
+            prefix=self.visit_space(modifier.prefix, p)
         )
         modifier = modifier.replace(markers=self.visit_markers(modifier.markers, p))
         modifier = modifier.replace(
@@ -830,12 +827,12 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_multi_catch(self, multi_catch: j.MultiCatch, p: P) -> J:
         multi_catch = multi_catch.replace(
-            prefix=self.visit_space(multi_catch.prefix, Space.Location.MULTI_CATCH_PREFIX, p)
+            prefix=self.visit_space(multi_catch.prefix, p)
         )
         multi_catch = multi_catch.replace(markers=self.visit_markers(multi_catch.markers, p))
         multi_catch = multi_catch.padding.replace(
             alternatives=list_map(
-                lambda alt: self.visit_right_padded(alt, JRightPadded.Location.CATCH_ALTERNATIVE, p),
+                lambda alt: self.visit_right_padded(alt, p),
                 multi_catch.padding.alternatives
             )
         )
@@ -843,7 +840,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_new_array(self, new_array: j.NewArray, p: P) -> J:
         new_array = new_array.replace(
-            prefix=self.visit_space(new_array.prefix, Space.Location.NEW_ARRAY_PREFIX, p)
+            prefix=self.visit_space(new_array.prefix, p)
         )
         temp_expr = self.visit_expression(new_array, p)
         if not isinstance(temp_expr, j.NewArray):
@@ -858,13 +855,13 @@ class JavaVisitor(TreeVisitor[J, P]):
             dimensions=list_map(lambda d: self.visit_and_cast(d, j.ArrayDimension, p), new_array.dimensions)
         )
         new_array = new_array.replace(
-            initializer=self.visit_container(new_array.padding.initializer, JContainer.Location.NEW_ARRAY_INITIALIZER, p)
+            initializer=self.visit_container(new_array.padding.initializer, p)
         )
         return new_array
 
     def visit_new_class(self, new_class: j.NewClass, p: P) -> J:
         new_class = new_class.replace(
-            prefix=self.visit_space(new_class.prefix, Space.Location.NEW_CLASS_PREFIX, p)
+            prefix=self.visit_space(new_class.prefix, p)
         )
         temp_stmt = self.visit_statement(new_class, p)
         if not isinstance(temp_stmt, j.NewClass):
@@ -877,17 +874,17 @@ class JavaVisitor(TreeVisitor[J, P]):
         new_class = new_class.replace(markers=self.visit_markers(new_class.markers, p))
         if new_class.padding.enclosing:
             new_class = new_class.padding.replace(
-                enclosing=self.visit_right_padded(new_class.padding.enclosing, JRightPadded.Location.NEW_CLASS_ENCLOSING, p)
+                enclosing=self.visit_right_padded(new_class.padding.enclosing, p)
             )
         new_class = new_class.replace(
-            new=self.visit_space(new_class.new, Space.Location.NEW_PREFIX, p)
+            new=self.visit_space(new_class.new, p)
         )
         if new_class.clazz:
             new_class = new_class.replace(
                 clazz=self.visit_and_cast(new_class.clazz, j.TypeTree, p)
             )
         new_class = new_class.replace(
-            arguments=self.visit_container(new_class.padding.arguments, JContainer.Location.NEW_CLASS_ARGUMENTS, p)
+            arguments=self.visit_container(new_class.padding.arguments, p)
         )
         if new_class.body:
             new_class = new_class.replace(
@@ -897,7 +894,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_parameterized_type(self, parameterized_type: j.ParameterizedType, p: P) -> J:
         parameterized_type = parameterized_type.replace(
-            prefix=self.visit_space(parameterized_type.prefix, Space.Location.PARAMETERIZED_TYPE_PREFIX, p)
+            prefix=self.visit_space(parameterized_type.prefix, p)
         )
         temp_expr = self.visit_expression(parameterized_type, p)
         if not isinstance(temp_expr, j.ParameterizedType):
@@ -908,13 +905,13 @@ class JavaVisitor(TreeVisitor[J, P]):
             clazz=self.visit_and_cast(parameterized_type.clazz, j.NameTree, p)
         )
         parameterized_type = parameterized_type.replace(
-            type_parameters=self.visit_container(parameterized_type.padding.type_parameters, JContainer.Location.TYPE_PARAMETERS, p)
+            type_parameters=self.visit_container(parameterized_type.padding.type_parameters, p)
         )
         return parameterized_type
 
     def visit_parentheses(self, parens: j.Parentheses, p: P) -> J:
         parens = parens.replace(
-            prefix=self.visit_space(parens.prefix, Space.Location.PARENTHESES_PREFIX, p)
+            prefix=self.visit_space(parens.prefix, p)
         )
         temp_expr = self.visit_expression(parens, p)
         if not isinstance(temp_expr, j.Parentheses):
@@ -922,13 +919,13 @@ class JavaVisitor(TreeVisitor[J, P]):
         parens = temp_expr
         parens = parens.replace(markers=self.visit_markers(parens.markers, p))
         parens = parens.padding.replace(
-            tree=self.visit_right_padded(parens.padding.tree, JRightPadded.Location.PARENTHESES, p)
+            tree=self.visit_right_padded(parens.padding.tree, p)
         )
         return parens
 
     def visit_primitive(self, primitive: j.Primitive, p: P) -> J:
         primitive = primitive.replace(
-            prefix=self.visit_space(primitive.prefix, Space.Location.PRIMITIVE_PREFIX, p)
+            prefix=self.visit_space(primitive.prefix, p)
         )
         temp_expr = self.visit_expression(primitive, p)
         if not isinstance(temp_expr, j.Primitive):
@@ -939,7 +936,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_return(self, return_: j.Return, p: P) -> J:
         return_ = return_.replace(
-            prefix=self.visit_space(return_.prefix, Space.Location.RETURN_PREFIX, p)
+            prefix=self.visit_space(return_.prefix, p)
         )
         temp_stmt = self.visit_statement(return_, p)
         if not isinstance(temp_stmt, j.Return):
@@ -954,7 +951,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_switch(self, switch: j.Switch, p: P) -> J:
         switch = switch.replace(
-            prefix=self.visit_space(switch.prefix, Space.Location.SWITCH_PREFIX, p)
+            prefix=self.visit_space(switch.prefix, p)
         )
         temp_stmt = self.visit_statement(switch, p)
         if not isinstance(temp_stmt, j.Switch):
@@ -971,7 +968,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_switch_expression(self, switch_expr: j.SwitchExpression, p: P) -> J:
         switch_expr = switch_expr.replace(
-            prefix=self.visit_space(switch_expr.prefix, Space.Location.SWITCH_EXPRESSION_PREFIX, p)
+            prefix=self.visit_space(switch_expr.prefix, p)
         )
         temp_expr = self.visit_expression(switch_expr, p)
         if not isinstance(temp_expr, j.SwitchExpression):
@@ -988,7 +985,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_synchronized(self, sync: j.Synchronized, p: P) -> J:
         sync = sync.replace(
-            prefix=self.visit_space(sync.prefix, Space.Location.SYNCHRONIZED_PREFIX, p)
+            prefix=self.visit_space(sync.prefix, p)
         )
         temp_stmt = self.visit_statement(sync, p)
         if not isinstance(temp_stmt, j.Synchronized):
@@ -1005,7 +1002,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_ternary(self, ternary: j.Ternary, p: P) -> J:
         ternary = ternary.replace(
-            prefix=self.visit_space(ternary.prefix, Space.Location.TERNARY_PREFIX, p)
+            prefix=self.visit_space(ternary.prefix, p)
         )
         temp_stmt = self.visit_statement(ternary, p)
         if not isinstance(temp_stmt, j.Ternary):
@@ -1020,16 +1017,16 @@ class JavaVisitor(TreeVisitor[J, P]):
             condition=self.visit_and_cast(ternary.condition, Expression, p)
         )
         ternary = ternary.padding.replace(
-            true_part=self.visit_left_padded(ternary.padding.true_part, JLeftPadded.Location.TERNARY_TRUE, p)
+            true_part=self.visit_left_padded(ternary.padding.true_part, p)
         )
         ternary = ternary.padding.replace(
-            false_part=self.visit_left_padded(ternary.padding.false_part, JLeftPadded.Location.TERNARY_FALSE, p)
+            false_part=self.visit_left_padded(ternary.padding.false_part, p)
         )
         return ternary
 
     def visit_throw(self, throw: j.Throw, p: P) -> J:
         throw = throw.replace(
-            prefix=self.visit_space(throw.prefix, Space.Location.THROW_PREFIX, p)
+            prefix=self.visit_space(throw.prefix, p)
         )
         temp_stmt = self.visit_statement(throw, p)
         if not isinstance(temp_stmt, j.Throw):
@@ -1043,7 +1040,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_try(self, try_: j.Try, p: P) -> J:
         try_ = try_.replace(
-            prefix=self.visit_space(try_.prefix, Space.Location.TRY_PREFIX, p)
+            prefix=self.visit_space(try_.prefix, p)
         )
         temp_stmt = self.visit_statement(try_, p)
         if not isinstance(temp_stmt, j.Try):
@@ -1051,7 +1048,7 @@ class JavaVisitor(TreeVisitor[J, P]):
         try_ = temp_stmt
         try_ = try_.replace(markers=self.visit_markers(try_.markers, p))
         try_ = try_.replace(
-            resources=self.visit_container(try_.padding.resources, JContainer.Location.TRY_RESOURCES, p)
+            resources=self.visit_container(try_.padding.resources, p)
         )
         try_ = try_.replace(
             body=self.visit_and_cast(try_.body, j.Block, p)
@@ -1061,13 +1058,13 @@ class JavaVisitor(TreeVisitor[J, P]):
         )
         if try_.padding.finally_:
             try_ = try_.replace(
-                finally_=self.visit_left_padded(try_.padding.finally_, JLeftPadded.Location.TRY_FINALLY, p)
+                finally_=self.visit_left_padded(try_.padding.finally_, p)
             )
         return try_
 
     def visit_try_resource(self, resource: j.Try.Resource, p: P) -> J:
         resource = resource.replace(
-            prefix=self.visit_space(resource.prefix, Space.Location.TRY_RESOURCE, p)
+            prefix=self.visit_space(resource.prefix, p)
         )
         resource = resource.replace(markers=self.visit_markers(resource.markers, p))
         resource = resource.replace(
@@ -1077,7 +1074,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_catch(self, catch: j.Try.Catch, p: P) -> J:
         catch = catch.replace(
-            prefix=self.visit_space(catch.prefix, Space.Location.CATCH_PREFIX, p)
+            prefix=self.visit_space(catch.prefix, p)
         )
         catch = catch.replace(markers=self.visit_markers(catch.markers, p))
         catch = catch.replace(
@@ -1090,7 +1087,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_type_cast(self, type_cast: j.TypeCast, p: P) -> J:
         type_cast = type_cast.replace(
-            prefix=self.visit_space(type_cast.prefix, Space.Location.TYPE_CAST_PREFIX, p)
+            prefix=self.visit_space(type_cast.prefix, p)
         )
         temp_expr = self.visit_expression(type_cast, p)
         if not isinstance(temp_expr, j.TypeCast):
@@ -1107,7 +1104,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_type_parameter(self, type_param: j.TypeParameter, p: P) -> J:
         type_param = type_param.replace(
-            prefix=self.visit_space(type_param.prefix, Space.Location.TYPE_PARAMETER_PREFIX, p)
+            prefix=self.visit_space(type_param.prefix, p)
         )
         type_param = type_param.replace(markers=self.visit_markers(type_param.markers, p))
         type_param = type_param.replace(
@@ -1120,13 +1117,13 @@ class JavaVisitor(TreeVisitor[J, P]):
             name=self.visit_and_cast(type_param.name, j.Identifier, p)
         )
         type_param = type_param.replace(
-            bounds=self.visit_container(type_param.padding.bounds, JContainer.Location.TYPE_BOUND, p)
+            bounds=self.visit_container(type_param.padding.bounds, p)
         )
         return type_param
 
     def visit_type_parameters(self, type_params: j.TypeParameters, p: P) -> J:
         type_params = type_params.replace(
-            prefix=self.visit_space(type_params.prefix, Space.Location.TYPE_PARAMETERS_PREFIX, p)
+            prefix=self.visit_space(type_params.prefix, p)
         )
         type_params = type_params.replace(markers=self.visit_markers(type_params.markers, p))
         type_params = type_params.replace(
@@ -1134,7 +1131,7 @@ class JavaVisitor(TreeVisitor[J, P]):
         )
         type_params = type_params.padding.replace(
             type_parameters=list_map(
-                lambda tp: self.visit_right_padded(tp, JRightPadded.Location.TYPE_PARAMETER, p),
+                lambda tp: self.visit_right_padded(tp, p),
                 type_params.padding.type_parameters
             )
         )
@@ -1142,7 +1139,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_unary(self, unary: j.Unary, p: P) -> J:
         unary = unary.replace(
-            prefix=self.visit_space(unary.prefix, Space.Location.UNARY_PREFIX, p)
+            prefix=self.visit_space(unary.prefix, p)
         )
         temp_stmt = self.visit_statement(unary, p)
         if not isinstance(temp_stmt, j.Unary):
@@ -1154,7 +1151,7 @@ class JavaVisitor(TreeVisitor[J, P]):
         unary = temp_expr
         unary = unary.replace(markers=self.visit_markers(unary.markers, p))
         unary = unary.padding.replace(
-            operator=self.visit_left_padded(unary.padding.operator, JLeftPadded.Location.UNARY_OPERATOR, p)
+            operator=self.visit_left_padded(unary.padding.operator, p)
         )
         unary = unary.replace(
             expression=self.visit_and_cast(unary.expression, Expression, p)
@@ -1163,7 +1160,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_variable_declarations(self, var_decls: j.VariableDeclarations, p: P) -> J:
         var_decls = var_decls.replace(
-            prefix=self.visit_space(var_decls.prefix, Space.Location.VARIABLE_DECLARATIONS_PREFIX, p)
+            prefix=self.visit_space(var_decls.prefix, p)
         )
         temp_stmt = self.visit_statement(var_decls, p)
         if not isinstance(temp_stmt, j.VariableDeclarations):
@@ -1182,11 +1179,11 @@ class JavaVisitor(TreeVisitor[J, P]):
             )
         if var_decls.varargs:
             var_decls = var_decls.replace(
-                varargs=self.visit_space(var_decls.varargs, Space.Location.VARARGS, p)
+                varargs=self.visit_space(var_decls.varargs, p)
             )
         var_decls = var_decls.padding.replace(
             variables=list_map(
-                lambda v: self.visit_right_padded(v, JRightPadded.Location.NAMED_VARIABLE, p),
+                lambda v: self.visit_right_padded(v, p),
                 var_decls.padding.variables
             )
         )
@@ -1194,7 +1191,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_variable(self, variable: j.VariableDeclarations.NamedVariable, p: P) -> J:
         variable = variable.replace(
-            prefix=self.visit_space(variable.prefix, Space.Location.VARIABLE_PREFIX, p)
+            prefix=self.visit_space(variable.prefix, p)
         )
         variable = variable.replace(markers=self.visit_markers(variable.markers, p))
         variable = variable.replace(
@@ -1202,18 +1199,18 @@ class JavaVisitor(TreeVisitor[J, P]):
         )
         variable = variable.replace(
             dimensions_after_name=list_map(
-                lambda d: self.visit_left_padded(d, JLeftPadded.Location.VARIABLE_INITIALIZER, p),
+                lambda d: self.visit_left_padded(d, p),
                 variable.dimensions_after_name
             )
         )
         variable = variable.padding.replace(
-            initializer=self.visit_left_padded(variable.padding.initializer, JLeftPadded.Location.VARIABLE_INITIALIZER, p)
+            initializer=self.visit_left_padded(variable.padding.initializer, p)
         )
         return variable
 
     def visit_while_loop(self, while_loop: j.WhileLoop, p: P) -> J:
         while_loop = while_loop.replace(
-            prefix=self.visit_space(while_loop.prefix, Space.Location.WHILE_PREFIX, p)
+            prefix=self.visit_space(while_loop.prefix, p)
         )
         temp_stmt = self.visit_statement(while_loop, p)
         if not isinstance(temp_stmt, j.WhileLoop):
@@ -1224,13 +1221,13 @@ class JavaVisitor(TreeVisitor[J, P]):
             condition=self.visit_and_cast(while_loop.condition, j.ControlParentheses, p)
         )
         while_loop = while_loop.padding.replace(
-            body=self.visit_right_padded(while_loop.padding.body, JRightPadded.Location.WHILE_BODY, p)
+            body=self.visit_right_padded(while_loop.padding.body, p)
         )
         return while_loop
 
     def visit_wildcard(self, wildcard: j.Wildcard, p: P) -> J:
         wildcard = wildcard.replace(
-            prefix=self.visit_space(wildcard.prefix, Space.Location.WILDCARD_PREFIX, p)
+            prefix=self.visit_space(wildcard.prefix, p)
         )
         temp_expr = self.visit_expression(wildcard, p)
         if not isinstance(temp_expr, j.Wildcard):
@@ -1238,7 +1235,7 @@ class JavaVisitor(TreeVisitor[J, P]):
         wildcard = temp_expr
         wildcard = wildcard.replace(markers=self.visit_markers(wildcard.markers, p))
         wildcard = wildcard.padding.replace(
-            bound=self.visit_left_padded(wildcard.padding.bound, JLeftPadded.Location.WILDCARD_BOUND, p)
+            bound=self.visit_left_padded(wildcard.padding.bound, p)
         )
         if wildcard.bounded_type:
             wildcard = wildcard.replace(
@@ -1248,7 +1245,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_yield(self, yield_: j.Yield, p: P) -> J:
         yield_ = yield_.replace(
-            prefix=self.visit_space(yield_.prefix, Space.Location.YIELD_PREFIX, p)
+            prefix=self.visit_space(yield_.prefix, p)
         )
         temp_stmt = self.visit_statement(yield_, p)
         if not isinstance(temp_stmt, j.Yield):
@@ -1262,7 +1259,7 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_unknown(self, unknown: j.Unknown, p: P) -> J:
         unknown = unknown.replace(
-            prefix=self.visit_space(unknown.prefix, Space.Location.UNKNOWN_PREFIX, p)
+            prefix=self.visit_space(unknown.prefix, p)
         )
         temp_stmt = self.visit_statement(unknown, p)
         if not isinstance(temp_stmt, j.Unknown):
@@ -1280,14 +1277,14 @@ class JavaVisitor(TreeVisitor[J, P]):
 
     def visit_unknown_source(self, source: j.Unknown.Source, p: P) -> J:
         source = source.replace(
-            prefix=self.visit_space(source.prefix, Space.Location.UNKNOWN_SOURCE_PREFIX, p)
+            prefix=self.visit_space(source.prefix, p)
         )
         source = source.replace(markers=self.visit_markers(source.markers, p))
         return source
 
     def visit_erroneous(self, erroneous: j.Erroneous, p: P) -> J:
         erroneous = erroneous.replace(
-            prefix=self.visit_space(erroneous.prefix, Space.Location.ERRONEOUS_PREFIX, p)
+            prefix=self.visit_space(erroneous.prefix, p)
         )
         temp_stmt = self.visit_statement(erroneous, p)
         if not isinstance(temp_stmt, j.Erroneous):

--- a/rewrite-python/rewrite/src/rewrite/python/extensions.py
+++ b/rewrite-python/rewrite/src/rewrite/python/extensions.py
@@ -1,7 +1,6 @@
 from typing import Optional, TypeVar, TYPE_CHECKING
 
 from rewrite.java.tree import extensions, J, JContainer, JRightPadded, JLeftPadded, Space
-from .support_types import PyContainer, PyRightPadded, PyLeftPadded, PySpace
 
 if TYPE_CHECKING:
     from .visitor import PythonVisitor
@@ -10,25 +9,17 @@ T = TypeVar('T')
 J2 = TypeVar('J2', bound=J)
 
 
-# noinspection PyUnusedLocal
-def visit_container(v: 'PythonVisitor', container: Optional[JContainer[J2]],
-                    loc: PyContainer.Location, p) -> Optional[JContainer[J2]]:
-    return extensions.visit_container(v, container, JContainer.Location.LANGUAGE_EXTENSION, p)
+def visit_container(v: 'PythonVisitor', container: Optional[JContainer[J2]], p) -> Optional[JContainer[J2]]:
+    return extensions.visit_container(v, container, p)
 
 
-# noinspection PyUnusedLocal
-def visit_right_padded(v: 'PythonVisitor', right: Optional[JRightPadded[T]],
-                       loc: PyRightPadded.Location, p) -> Optional[JRightPadded[T]]:
-    return extensions.visit_right_padded(v, right, JRightPadded.Location.LANGUAGE_EXTENSION, p)
+def visit_right_padded(v: 'PythonVisitor', right: Optional[JRightPadded[T]], p) -> Optional[JRightPadded[T]]:
+    return extensions.visit_right_padded(v, right, p)
 
 
-# noinspection PyUnusedLocal
-def visit_left_padded(v: 'PythonVisitor', left: Optional[JLeftPadded[T]],
-                      loc: PyLeftPadded.Location, p) -> Optional[JLeftPadded[T]]:
-    return extensions.visit_left_padded(v, left, JLeftPadded.Location.LANGUAGE_EXTENSION, p)
+def visit_left_padded(v: 'PythonVisitor', left: Optional[JLeftPadded[T]], p) -> Optional[JLeftPadded[T]]:
+    return extensions.visit_left_padded(v, left, p)
 
 
-# noinspection PyUnusedLocal
-def visit_space(v: 'PythonVisitor', space: Optional[Space],
-                loc: PySpace.Location, p):
-    return extensions.visit_space(v, space, Space.Location.LANGUAGE_EXTENSION, p)
+def visit_space(v: 'PythonVisitor', space: Optional[Space], p):
+    return extensions.visit_space(v, space, p)

--- a/rewrite-python/rewrite/src/rewrite/python/support_types.py
+++ b/rewrite-python/rewrite/src/rewrite/python/support_types.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import replace, dataclass
-from enum import Enum, auto
 from typing import TypeVar, Any, Optional, TYPE_CHECKING
 
-from rewrite import TreeVisitor, Markers
+from rewrite import TreeVisitor
 from rewrite.java.tree import J
-from ..java import Comment
 
 if TYPE_CHECKING:
     from .visitor import PythonVisitor
@@ -27,138 +24,6 @@ class Py(J):
         return v.is_adaptable_to(PythonVisitor)
 
 
-class PySpace:
-    class Location(Enum):
-        ASSERT_STATEMENT_EXPRESSION_SUFFIX = auto()
-        ASSERT_STATEMENT_PREFIX = auto()
-        ASYNC_PREFIX = auto()
-        AWAIT_PREFIX = auto()
-        BINARY_NEGATION = auto()
-        BINARY_OPERATOR = auto()
-        BINARY_PREFIX = auto()
-        CHAINED_ASSIGNMENT_PREFIX = auto()
-        CHAINED_ASSIGNMENT_VARIABLE_SUFFIX = auto()
-        COLLECTION_LITERAL_ELEMENT_SUFFIX = auto()
-        COLLECTION_LITERAL_PREFIX = auto()
-        COMPILATION_UNIT_STATEMENT_PREFIX = auto()
-        COMPREHENSION_EXPRESSION_CLAUSE_ASYNC_SUFFIX = auto()
-        COMPREHENSION_EXPRESSION_CLAUSE_ITERATED_LIST = auto()
-        COMPREHENSION_EXPRESSION_CLAUSE_PREFIX = auto()
-        COMPREHENSION_EXPRESSION_CONDITION_PREFIX = auto()
-        COMPREHENSION_EXPRESSION_PREFIX = auto()
-        COMPREHENSION_EXPRESSION_SUFFIX = auto()
-        COMPREHENSION_IN = auto()
-        DEL_PREFIX = auto()
-        DEL_TARGET_SUFFIX = auto()
-        DICT_ENTRY = auto()
-        DICT_ENTRY_KEY_SUFFIX = auto()
-        DICT_LITERAL_ELEMENT_SUFFIX = auto()
-        DICT_LITERAL_PREFIX = auto()
-        ELSE_WRAPPER_ELSE_BLOCK_PREFIX = auto()
-        ELSE_WRAPPER_PREFIX = auto()
-        ERROR_FROM_EXPRESSION_FROM_PREFIX = auto()
-        ERROR_FROM_PREFIX = auto()
-        EXCEPTION_TYPE_PREFIX = auto()
-        EXPRESSION_TYPE_TREE_PREFIX = auto()
-        FORMATTED_STRING_PREFIX = auto()
-        FORMATTED_STRING_VALUE_DEBUG_SUFFIX = auto()
-        FORMATTED_STRING_VALUE_PREFIX = auto()
-        KEY_VALUE_PREFIX = auto()
-        KEY_VALUE_SUFFIX = auto()
-        LITERAL_TYPE_PREFIX = auto()
-        MATCH_CASE_GUARD = auto()
-        MATCH_CASE_PATTERN_CHILDREN_PREFIX = auto()
-        MATCH_CASE_PATTERN_PREFIX = auto()
-        MATCH_CASE_PREFIX = auto()
-        MATCH_PATTERN_ELEMENT_SUFFIX = auto()
-        MATCH_PATTERN_PREFIX = auto()
-        MULTI_IMPORT_FROM_SUFFIX = auto()
-        MULTI_IMPORT_NAME_PREFIX = auto()
-        MULTI_IMPORT_NAME_SUFFIX = auto()
-        MULTI_IMPORT_PREFIX = auto()
-        NAMED_ARGUMENT = auto()
-        NAMED_ARGUMENT_PREFIX = auto()
-        PASS_PREFIX = auto()
-        SLICE_PREFIX = auto()
-        SLICE_START_SUFFIX = auto()
-        SLICE_STEP_SUFFIX = auto()
-        SLICE_STOP_SUFFIX = auto()
-        SPECIAL_PARAMETER_PREFIX = auto()
-        STATEMENT_EXPRESSION_PREFIX = auto()
-        STAR_PREFIX = auto()
-        TOP_LEVEL_STATEMENT = auto()
-        TRAILING_ELSE_WRAPPER_PREFIX = auto()
-        TYPE_ALIAS_PREFIX = auto()
-        TYPE_ALIAS_VALUE = auto()
-        TYPE_HINTED_EXPRESSION_PREFIX = auto()
-        TYPE_HINT_PREFIX = auto()
-        UNION_TYPES_SUFFIX = auto()
-        UNION_TYPE_PREFIX = auto()
-        VARIABLE_SCOPE_NAME_SUFFIX = auto()
-        VARIABLE_SCOPE_PREFIX = auto()
-        YIELD_EXPRESSION_SUFFIX = auto()
-        YIELD_FROM_PREFIX = auto()
-        YIELD_PREFIX = auto()
-
-
 T = TypeVar('T')
 J2 = TypeVar('J2', bound=J)
-
-
-class PyRightPadded:
-    class Location(Enum):
-        ASSERT_STATEMENT_EXPRESSIONS = PySpace.Location.ASSERT_STATEMENT_EXPRESSION_SUFFIX
-        CHAINED_ASSIGNMENT_VARIABLES = PySpace.Location.CHAINED_ASSIGNMENT_VARIABLE_SUFFIX
-        COLLECTION_LITERAL_ELEMENT = PySpace.Location.COLLECTION_LITERAL_ELEMENT_SUFFIX
-        COMPILATION_UNIT_STATEMENTS = PySpace.Location.COMPILATION_UNIT_STATEMENT_PREFIX
-        COMPREHENSION_EXPRESSION_CLAUSE_ASYNC = PySpace.Location.COMPREHENSION_EXPRESSION_CLAUSE_ASYNC_SUFFIX
-        DEL_TARGETS = PySpace.Location.DEL_TARGET_SUFFIX
-        DICT_LITERAL_ELEMENT = PySpace.Location.DICT_LITERAL_ELEMENT_SUFFIX
-        FORMATTED_STRING_VALUE_DEBUG = PySpace.Location.FORMATTED_STRING_VALUE_DEBUG_SUFFIX
-        FORMATTED_STRING_VALUE_EXPRESSION = PySpace.Location.FORMATTED_STRING_VALUE_PREFIX
-        KEY_VALUE_KEY = PySpace.Location.DICT_ENTRY_KEY_SUFFIX
-        KEY_VALUE_KEY_SUFFIX = PySpace.Location.KEY_VALUE_SUFFIX
-        MATCH_CASE_PATTERN_CHILD = PySpace.Location.MATCH_PATTERN_ELEMENT_SUFFIX
-        MULTI_IMPORT_FROM = PySpace.Location.MULTI_IMPORT_FROM_SUFFIX
-        MULTI_IMPORT_NAME = PySpace.Location.MULTI_IMPORT_NAME_SUFFIX
-        SLICE_START = PySpace.Location.SLICE_START_SUFFIX
-        SLICE_STEP = PySpace.Location.SLICE_STEP_SUFFIX
-        SLICE_STOP = PySpace.Location.SLICE_STOP_SUFFIX
-        TOP_LEVEL_STATEMENT_SUFFIX = PySpace.Location.TOP_LEVEL_STATEMENT
-        UNION_TYPE_TYPES = PySpace.Location.UNION_TYPES_SUFFIX
-        VARIABLE_SCOPE_NAMES = PySpace.Location.VARIABLE_SCOPE_NAME_SUFFIX
-        YIELD_EXPRESSIONS = PySpace.Location.YIELD_EXPRESSION_SUFFIX
-
-        def __init__(self, after_location: PySpace.Location):
-            self.after_location = after_location
-
-
-class PyLeftPadded:
-    class Location(Enum):
-        BINARY_OPERATOR = PySpace.Location.BINARY_OPERATOR
-        COMPREHENSION_EXPRESSION_CLAUSE_ITERATED_LIST = PySpace.Location.COMPREHENSION_EXPRESSION_CLAUSE_ITERATED_LIST
-        ERROR_FROM_FROM = PySpace.Location.ERROR_FROM_EXPRESSION_FROM_PREFIX
-        MATCH_CASE_GUARD = PySpace.Location.MATCH_CASE_GUARD
-        NAMED_ARGUMENT_VALUE = PySpace.Location.NAMED_ARGUMENT
-        TRAILING_ELSE_WRAPPER_ELSE_BLOCK = PySpace.Location.ELSE_WRAPPER_ELSE_BLOCK_PREFIX
-        TYPE_ALIAS_VALUE = PySpace.Location.TYPE_ALIAS_VALUE
-        YIELD_FROM = PySpace.Location.YIELD_FROM_PREFIX
-
-        def __init__(self, before_location: PySpace.Location):
-            self.before_location = before_location
-
-
-class PyContainer:
-    class Location(Enum):
-        COLLECTION_LITERAL_ELEMENTS = (
-        PySpace.Location.COLLECTION_LITERAL_PREFIX, PyRightPadded.Location.COLLECTION_LITERAL_ELEMENT)
-        DICT_LITERAL_ELEMENTS = (PySpace.Location.DICT_LITERAL_PREFIX, PyRightPadded.Location.DICT_LITERAL_ELEMENT)
-        MATCH_CASE_PATTERN_CHILDREN = (
-        PySpace.Location.MATCH_CASE_PATTERN_CHILDREN_PREFIX, PyRightPadded.Location.MATCH_CASE_PATTERN_CHILD)
-        MULTI_IMPORT_NAMES = (PySpace.Location.MULTI_IMPORT_NAME_PREFIX, PyRightPadded.Location.MULTI_IMPORT_NAME)
-
-        def __init__(self, before_location: PySpace.Location, element_location: PyRightPadded.Location):
-            self.before_location = before_location
-            self.element_location = element_location
-
 

--- a/rewrite-python/rewrite/src/rewrite/python/visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/visitor.py
@@ -25,7 +25,7 @@ from rewrite.java.support_types import (
     Space,
 )
 from rewrite.java.visitor import JavaVisitor
-from rewrite.python.support_types import Py, PySpace
+from rewrite.python.support_types import Py
 from rewrite.tree import SourceFile
 from rewrite.utils import list_map
 
@@ -88,7 +88,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_async(self, async_: Async, p: P) -> J:
         """Visit an async statement."""
         async_ = async_.replace(
-            prefix=self.visit_space(async_.prefix, PySpace.Location.ASYNC_PREFIX, p)
+            prefix=self.visit_space(async_.prefix, p)
         )
         temp_stmt = cast(Statement, self.visit_statement(async_, p))
         if not isinstance(temp_stmt, type(async_)):
@@ -103,7 +103,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_await(self, await_: Await, p: P) -> J:
         """Visit an await expression."""
         await_ = await_.replace(
-            prefix=self.visit_space(await_.prefix, PySpace.Location.AWAIT_PREFIX, p)
+            prefix=self.visit_space(await_.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(await_, p))
         if not isinstance(temp_expr, type(await_)):
@@ -118,7 +118,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_python_binary(self, binary: Binary, p: P) -> J:
         """Visit a Python-specific binary expression."""
         binary = binary.replace(
-            prefix=self.visit_space(binary.prefix, PySpace.Location.BINARY_PREFIX, p)
+            prefix=self.visit_space(binary.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(binary, p))
         if not isinstance(temp_expr, type(binary)):
@@ -129,10 +129,10 @@ class PythonVisitor(JavaVisitor[P]):
             left=self.visit_and_cast(binary.left, Expression, p)
         )
         binary = binary.padding.replace(
-            operator=self.visit_left_padded(binary.padding.operator, None, p)
+            operator=self.visit_left_padded(binary.padding.operator, p)
         )
         binary = binary.replace(
-            negation=self.visit_space(binary.negation, PySpace.Location.BINARY_NEGATION, p)
+            negation=self.visit_space(binary.negation, p)
         )
         binary = binary.replace(
             right=self.visit_and_cast(binary.right, Expression, p)
@@ -142,7 +142,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_chained_assignment(self, chained: ChainedAssignment, p: P) -> J:
         """Visit a chained assignment statement."""
         chained = chained.replace(
-            prefix=self.visit_space(chained.prefix, PySpace.Location.CHAINED_ASSIGNMENT_PREFIX, p)
+            prefix=self.visit_space(chained.prefix, p)
         )
         temp_stmt = cast(Statement, self.visit_statement(chained, p))
         if not isinstance(temp_stmt, type(chained)):
@@ -151,7 +151,7 @@ class PythonVisitor(JavaVisitor[P]):
         chained = chained.replace(markers=self.visit_markers(chained.markers, p))
         chained = chained.padding.replace(variables=
             list_map(
-                lambda v: self.visit_right_padded(v, None, p),
+                lambda v: self.visit_right_padded(v, p),
                 chained.padding.variables
             )
         )
@@ -163,7 +163,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_collection_literal(self, collection: CollectionLiteral, p: P) -> J:
         """Visit a collection literal (list, set, tuple)."""
         collection = collection.replace(
-            prefix=self.visit_space(collection.prefix, PySpace.Location.COLLECTION_LITERAL_PREFIX, p)
+            prefix=self.visit_space(collection.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(collection, p))
         if not isinstance(temp_expr, type(collection)):
@@ -171,33 +171,33 @@ class PythonVisitor(JavaVisitor[P]):
         collection = cast("CollectionLiteral", temp_expr)
         collection = collection.replace(markers=self.visit_markers(collection.markers, p))
         collection = collection.replace(
-            elements=self.visit_container(collection.padding.elements, None, p)
+            elements=self.visit_container(collection.padding.elements, p)
         )
         return collection
 
     def visit_compilation_unit(self, cu: CompilationUnit, p: P) -> J:
         """Visit a Python compilation unit (module)."""
-        cu = cu.replace(prefix=self.visit_space(cu.prefix, Space.Location.ANY, p))
+        cu = cu.replace(prefix=self.visit_space(cu.prefix, p))
         cu = cu.replace(markers=self.visit_markers(cu.markers, p))
         cu = cu.padding.replace(imports=
             list_map(
-                lambda v: self.visit_right_padded(v, None, p),
+                lambda v: self.visit_right_padded(v, p),
                 cu.padding.imports
             )
         )
         cu = cu.padding.replace(statements=
             list_map(
-                lambda v: self.visit_right_padded(v, None, p),
+                lambda v: self.visit_right_padded(v, p),
                 cu.padding.statements
             )
         )
-        cu = cu.replace(eof=self.visit_space(cu.eof, Space.Location.ANY, p))
+        cu = cu.replace(eof=self.visit_space(cu.eof, p))
         return cu
 
     def visit_comprehension_expression(self, comp: ComprehensionExpression, p: P) -> J:
         """Visit a comprehension expression."""
         comp = comp.replace(
-            prefix=self.visit_space(comp.prefix, PySpace.Location.COMPREHENSION_EXPRESSION_PREFIX, p)
+            prefix=self.visit_space(comp.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(comp, p))
         if not isinstance(temp_expr, type(comp)):
@@ -218,14 +218,14 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_comprehension_clause(self, clause: ComprehensionExpression.Clause, p: P) -> ComprehensionExpression.Clause:
         """Visit a comprehension clause."""
         clause = clause.replace(
-            prefix=self.visit_space(clause.prefix, None, p)
+            prefix=self.visit_space(clause.prefix, p)
         )
         clause = clause.replace(markers=self.visit_markers(clause.markers, p))
         clause = clause.replace(
             iterator_variable=self.visit_and_cast(clause.iterator_variable, Expression, p)
         )
         clause = clause.padding.replace(
-            iterated_list=self.visit_left_padded(clause.padding.iterated_list, None, p)
+            iterated_list=self.visit_left_padded(clause.padding.iterated_list, p)
         )
         clause = clause.replace(
             conditions=list_map(
@@ -238,7 +238,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_comprehension_condition(self, condition: ComprehensionExpression.Condition, p: P) -> ComprehensionExpression.Condition:
         """Visit a comprehension condition."""
         condition = condition.replace(
-            prefix=self.visit_space(condition.prefix, None, p)
+            prefix=self.visit_space(condition.prefix, p)
         )
         condition = condition.replace(markers=self.visit_markers(condition.markers, p))
         condition = condition.replace(
@@ -249,7 +249,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_del(self, del_: Del, p: P) -> J:
         """Visit a del statement."""
         del_ = del_.replace(
-            prefix=self.visit_space(del_.prefix, PySpace.Location.DEL_PREFIX, p)
+            prefix=self.visit_space(del_.prefix, p)
         )
         temp_stmt = cast(Statement, self.visit_statement(del_, p))
         if not isinstance(temp_stmt, type(del_)):
@@ -258,7 +258,7 @@ class PythonVisitor(JavaVisitor[P]):
         del_ = del_.replace(markers=self.visit_markers(del_.markers, p))
         del_ = del_.padding.replace(targets=
             list_map(
-                lambda t: self.visit_right_padded(t, None, p),
+                lambda t: self.visit_right_padded(t, p),
                 del_.padding.targets
             )
         )
@@ -267,7 +267,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_dict_literal(self, dict_lit: DictLiteral, p: P) -> J:
         """Visit a dictionary literal."""
         dict_lit = dict_lit.replace(
-            prefix=self.visit_space(dict_lit.prefix, PySpace.Location.DICT_LITERAL_PREFIX, p)
+            prefix=self.visit_space(dict_lit.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(dict_lit, p))
         if not isinstance(temp_expr, type(dict_lit)):
@@ -275,14 +275,14 @@ class PythonVisitor(JavaVisitor[P]):
         dict_lit = cast("DictLiteral", temp_expr)
         dict_lit = dict_lit.replace(markers=self.visit_markers(dict_lit.markers, p))
         dict_lit = dict_lit.replace(
-            elements=self.visit_container(dict_lit.padding.elements, None, p)
+            elements=self.visit_container(dict_lit.padding.elements, p)
         )
         return dict_lit
 
     def visit_error_from(self, error_from: ErrorFrom, p: P) -> J:
         """Visit an error from expression (raise X from Y)."""
         error_from = error_from.replace(
-            prefix=self.visit_space(error_from.prefix, None, p)
+            prefix=self.visit_space(error_from.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(error_from, p))
         if not isinstance(temp_expr, type(error_from)):
@@ -293,14 +293,14 @@ class PythonVisitor(JavaVisitor[P]):
             error=self.visit_and_cast(error_from.error, Expression, p)
         )
         error_from = error_from.replace(
-            from_=self.visit_left_padded(error_from.padding.from_, None, p)
+            from_=self.visit_left_padded(error_from.padding.from_, p)
         )
         return error_from
 
     def visit_exception_type(self, exc_type: ExceptionType, p: P) -> J:
         """Visit an exception type in an except clause."""
         exc_type = exc_type.replace(
-            prefix=self.visit_space(exc_type.prefix, None, p)
+            prefix=self.visit_space(exc_type.prefix, p)
         )
         exc_type = exc_type.replace(markers=self.visit_markers(exc_type.markers, p))
         exc_type = exc_type.replace(
@@ -326,7 +326,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_expression_type_tree(self, expr_tree: ExpressionTypeTree, p: P) -> J:
         """Visit an expression used as a type tree."""
         expr_tree = expr_tree.replace(
-            prefix=self.visit_space(expr_tree.prefix, None, p)
+            prefix=self.visit_space(expr_tree.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(expr_tree, p))
         if not isinstance(temp_expr, type(expr_tree)):
@@ -341,7 +341,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_formatted_string(self, f_string: FormattedString, p: P) -> J:
         """Visit an f-string."""
         f_string = f_string.replace(
-            prefix=self.visit_space(f_string.prefix, PySpace.Location.FORMATTED_STRING_PREFIX, p)
+            prefix=self.visit_space(f_string.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(f_string, p))
         if not isinstance(temp_expr, type(f_string)):
@@ -359,11 +359,11 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_formatted_string_value(self, value: FormattedString.Value, p: P) -> J:
         """Visit a value embedded in an f-string."""
         value = value.replace(
-            prefix=self.visit_space(value.prefix, None, p)
+            prefix=self.visit_space(value.prefix, p)
         )
         value = value.replace(markers=self.visit_markers(value.markers, p))
         value = value.padding.replace(
-            expression=self.visit_right_padded(value.padding.expression, None, p)
+            expression=self.visit_right_padded(value.padding.expression, p)
         )
         if value.format is not None:
             value = value.replace(
@@ -374,7 +374,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_key_value(self, kv: KeyValue, p: P) -> J:
         """Visit a key-value pair."""
         kv = kv.replace(
-            prefix=self.visit_space(kv.prefix, None, p)
+            prefix=self.visit_space(kv.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(kv, p))
         if not isinstance(temp_expr, type(kv)):
@@ -382,7 +382,7 @@ class PythonVisitor(JavaVisitor[P]):
         kv = cast("KeyValue", temp_expr)
         kv = kv.replace(markers=self.visit_markers(kv.markers, p))
         kv = kv.padding.replace(
-            key=self.visit_right_padded(kv.padding.key, None, p)
+            key=self.visit_right_padded(kv.padding.key, p)
         )
         kv = kv.replace(
             value=self.visit_and_cast(kv.value, Expression, p)
@@ -392,7 +392,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_literal_type(self, lit_type: LiteralType, p: P) -> J:
         """Visit a literal used as a type annotation."""
         lit_type = lit_type.replace(
-            prefix=self.visit_space(lit_type.prefix, None, p)
+            prefix=self.visit_space(lit_type.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(lit_type, p))
         if not isinstance(temp_expr, type(lit_type)):
@@ -407,7 +407,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_match_case(self, case: MatchCase, p: P) -> J:
         """Visit a match case."""
         case = case.replace(
-            prefix=self.visit_space(case.prefix, PySpace.Location.MATCH_CASE_PREFIX, p)
+            prefix=self.visit_space(case.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(case, p))
         if not isinstance(temp_expr, type(case)):
@@ -419,25 +419,25 @@ class PythonVisitor(JavaVisitor[P]):
         )
         if case.padding.guard is not None:
             case = case.padding.replace(
-                guard=self.visit_left_padded(case.padding.guard, None, p)
+                guard=self.visit_left_padded(case.padding.guard, p)
             )
         return case
 
     def visit_match_case_pattern(self, pattern: MatchCase.Pattern, p: P) -> MatchCase.Pattern:
         """Visit a match case pattern."""
         pattern = pattern.replace(
-            prefix=self.visit_space(pattern.prefix, None, p)
+            prefix=self.visit_space(pattern.prefix, p)
         )
         pattern = pattern.replace(markers=self.visit_markers(pattern.markers, p))
         pattern = pattern.replace(
-            children=self.visit_container(pattern.padding.children, None, p)
+            children=self.visit_container(pattern.padding.children, p)
         )
         return pattern
 
     def visit_multi_import(self, multi: MultiImport, p: P) -> J:
         """Visit a multi-name import statement."""
         multi = multi.replace(
-            prefix=self.visit_space(multi.prefix, PySpace.Location.MULTI_IMPORT_PREFIX, p)
+            prefix=self.visit_space(multi.prefix, p)
         )
         temp_stmt = cast(Statement, self.visit_statement(multi, p))
         if not isinstance(temp_stmt, type(multi)):
@@ -446,17 +446,17 @@ class PythonVisitor(JavaVisitor[P]):
         multi = multi.replace(markers=self.visit_markers(multi.markers, p))
         if multi.padding.from_ is not None:
             multi = multi.padding.replace(
-                _from=self.visit_right_padded(multi.padding.from_, None, p)
+                _from=self.visit_right_padded(multi.padding.from_, p)
             )
         multi = multi.replace(
-            names=self.visit_container(multi.padding.names, None, p)
+            names=self.visit_container(multi.padding.names, p)
         )
         return multi
 
     def visit_named_argument(self, named: NamedArgument, p: P) -> J:
         """Visit a named argument."""
         named = named.replace(
-            prefix=self.visit_space(named.prefix, PySpace.Location.NAMED_ARGUMENT_PREFIX, p)
+            prefix=self.visit_space(named.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(named, p))
         if not isinstance(temp_expr, type(named)):
@@ -467,14 +467,14 @@ class PythonVisitor(JavaVisitor[P]):
             name=self.visit_and_cast(named.name, J, p)
         )
         named = named.padding.replace(
-            value=self.visit_left_padded(named.padding.value, None, p)
+            value=self.visit_left_padded(named.padding.value, p)
         )
         return named
 
     def visit_pass(self, pass_: Pass, p: P) -> J:
         """Visit a pass statement."""
         pass_ = pass_.replace(
-            prefix=self.visit_space(pass_.prefix, PySpace.Location.PASS_PREFIX, p)
+            prefix=self.visit_space(pass_.prefix, p)
         )
         temp_stmt = cast(Statement, self.visit_statement(pass_, p))
         if not isinstance(temp_stmt, type(pass_)):
@@ -486,7 +486,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_slice(self, slice_: Slice, p: P) -> J:
         """Visit a slice expression."""
         slice_ = slice_.replace(
-            prefix=self.visit_space(slice_.prefix, PySpace.Location.SLICE_PREFIX, p)
+            prefix=self.visit_space(slice_.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(slice_, p))
         if not isinstance(temp_expr, type(slice_)):
@@ -495,22 +495,22 @@ class PythonVisitor(JavaVisitor[P]):
         slice_ = slice_.replace(markers=self.visit_markers(slice_.markers, p))
         if slice_.padding.start is not None:
             slice_ = slice_.padding.replace(
-                start=self.visit_right_padded(slice_.padding.start, None, p)
+                start=self.visit_right_padded(slice_.padding.start, p)
             )
         if slice_.padding.stop is not None:
             slice_ = slice_.padding.replace(
-                stop=self.visit_right_padded(slice_.padding.stop, None, p)
+                stop=self.visit_right_padded(slice_.padding.stop, p)
             )
         if slice_.padding.step is not None:
             slice_ = slice_.padding.replace(
-                step=self.visit_right_padded(slice_.padding.step, None, p)
+                step=self.visit_right_padded(slice_.padding.step, p)
             )
         return slice_
 
     def visit_special_parameter(self, special: SpecialParameter, p: P) -> J:
         """Visit a special parameter (*args or **kwargs)."""
         special = special.replace(
-            prefix=self.visit_space(special.prefix, None, p)
+            prefix=self.visit_space(special.prefix, p)
         )
         special = special.replace(markers=self.visit_markers(special.markers, p))
         if special.type_hint is not None:
@@ -522,7 +522,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_star(self, star: Star, p: P) -> J:
         """Visit a star expression (*x or **x)."""
         star = star.replace(
-            prefix=self.visit_space(star.prefix, None, p)
+            prefix=self.visit_space(star.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(star, p))
         if not isinstance(temp_expr, type(star)):
@@ -552,7 +552,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_trailing_else_wrapper(self, wrapper: TrailingElseWrapper, p: P) -> J:
         """Visit a trailing else wrapper."""
         wrapper = wrapper.replace(
-            prefix=self.visit_space(wrapper.prefix, None, p)
+            prefix=self.visit_space(wrapper.prefix, p)
         )
         temp_stmt = cast(Statement, self.visit_statement(wrapper, p))
         if not isinstance(temp_stmt, type(wrapper)):
@@ -563,14 +563,14 @@ class PythonVisitor(JavaVisitor[P]):
             statement=self.visit_and_cast(wrapper.statement, Statement, p)
         )
         wrapper = wrapper.padding.replace(
-            else_block=self.visit_left_padded(wrapper.padding.else_block, None, p)
+            else_block=self.visit_left_padded(wrapper.padding.else_block, p)
         )
         return wrapper
 
     def visit_type_alias(self, alias: TypeAlias, p: P) -> J:
         """Visit a type alias statement."""
         alias = alias.replace(
-            prefix=self.visit_space(alias.prefix, PySpace.Location.TYPE_ALIAS_PREFIX, p)
+            prefix=self.visit_space(alias.prefix, p)
         )
         temp_stmt = cast(Statement, self.visit_statement(alias, p))
         if not isinstance(temp_stmt, type(alias)):
@@ -581,14 +581,14 @@ class PythonVisitor(JavaVisitor[P]):
             name=self.visit_and_cast(alias.name, J, p)
         )
         alias = alias.padding.replace(
-            value=self.visit_left_padded(alias.padding.value, None, p)
+            value=self.visit_left_padded(alias.padding.value, p)
         )
         return alias
 
     def visit_type_hint(self, hint: TypeHint, p: P) -> J:
         """Visit a type hint annotation."""
         hint = hint.replace(
-            prefix=self.visit_space(hint.prefix, PySpace.Location.TYPE_HINT_PREFIX, p)
+            prefix=self.visit_space(hint.prefix, p)
         )
         hint = hint.replace(markers=self.visit_markers(hint.markers, p))
         hint = hint.replace(
@@ -599,7 +599,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_type_hinted_expression(self, hinted: TypeHintedExpression, p: P) -> J:
         """Visit a type-hinted expression."""
         hinted = hinted.replace(
-            prefix=self.visit_space(hinted.prefix, None, p)
+            prefix=self.visit_space(hinted.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(hinted, p))
         if not isinstance(temp_expr, type(hinted)):
@@ -617,7 +617,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_union_type(self, union: UnionType, p: P) -> J:
         """Visit a union type."""
         union = union.replace(
-            prefix=self.visit_space(union.prefix, PySpace.Location.UNION_TYPE_PREFIX, p)
+            prefix=self.visit_space(union.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(union, p))
         if not isinstance(temp_expr, type(union)):
@@ -626,7 +626,7 @@ class PythonVisitor(JavaVisitor[P]):
         union = union.replace(markers=self.visit_markers(union.markers, p))
         union = union.padding.replace(types=
             list_map(
-                lambda t: self.visit_right_padded(t, None, p),
+                lambda t: self.visit_right_padded(t, p),
                 union.padding.types
             )
         )
@@ -635,7 +635,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_variable_scope(self, scope: VariableScope, p: P) -> J:
         """Visit a variable scope declaration (global/nonlocal)."""
         scope = scope.replace(
-            prefix=self.visit_space(scope.prefix, None, p)
+            prefix=self.visit_space(scope.prefix, p)
         )
         temp_stmt = cast(Statement, self.visit_statement(scope, p))
         if not isinstance(temp_stmt, type(scope)):
@@ -644,7 +644,7 @@ class PythonVisitor(JavaVisitor[P]):
         scope = scope.replace(markers=self.visit_markers(scope.markers, p))
         scope = scope.padding.replace(names=
             list_map(
-                lambda n: self.visit_right_padded(n, None, p),
+                lambda n: self.visit_right_padded(n, p),
                 scope.padding.names
             )
         )
@@ -653,7 +653,7 @@ class PythonVisitor(JavaVisitor[P]):
     def visit_yield_from(self, yield_from: YieldFrom, p: P) -> J:
         """Visit a yield from expression."""
         yield_from = yield_from.replace(
-            prefix=self.visit_space(yield_from.prefix, PySpace.Location.YIELD_FROM_PREFIX, p)
+            prefix=self.visit_space(yield_from.prefix, p)
         )
         temp_expr = cast(Expression, self.visit_expression(yield_from, p))
         if not isinstance(temp_expr, type(yield_from)):


### PR DESCRIPTION
This mechanism from the Java implementation won't be used in the Python code.