### PR TITLE
Remove artifact that is not published from the rewrite-bom

### DIFF
--- a/rewrite-bom/build.gradle.kts
+++ b/rewrite-bom/build.gradle.kts
@@ -11,7 +11,8 @@ dependencies {
                 it != project &&
                         !it.name.contains("benchmark") &&
                         !it.name.contains("tck") &&
-                        it.name != "tools"
+                        it.name != "tools" &&
+                        it.name != "rewrite-gradle-tooling-model"
             }
             .sortedBy { it.name }
             .forEach { api(it) }


### PR DESCRIPTION
## What's changed?
Remove `rewrite-gradle-tooling-model` as it's not a published artifact.

## What's your motivation?
- Fixes gh-6518

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
