### PR TITLE
Revert "Fixed situation where a changing a managed dependency that does not have an explicit `version` tag would fail to add a `version` tag when providing the `newVersion` option."

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -147,7 +147,7 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
 
             @Override
             public Xml visitDocument(Xml.Document document, ExecutionContext ctx) {
-                isNewDependencyPresent = checkIfNewDependencyPresent(newGroupId, newArtifactId, newVersion);
+                isNewDependencyPresent = checkIfNewDependencyPresents(newGroupId, newArtifactId, newVersion);
                 if (!oldGroupId.contains("*") && !oldArtifactId.contains("*") &&
                         (changeManagedDependency == null || changeManagedDependency)) {
                     doAfterVisit(new ChangeManagedDependencyGroupIdAndArtifactId(
@@ -170,26 +170,16 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
                 }
                 boolean isPluginDependency = isPluginDependencyTag(oldGroupId, oldArtifactId);
                 boolean isAnnotationProcessorPath = isAnnotationProcessorPathTag(oldGroupId, oldArtifactId);
-                boolean deferUpdate = false;
                 if (isOldDependencyTag || isPluginDependency || isAnnotationProcessorPath) {
-                    ResolvedPom rp = getResolutionResult().getPom();
                     String groupId = newGroupId;
                     if (groupId != null) {
-                        Optional<Xml.Tag> groupIdTag = t.getChild("groupId");
-                        Optional<String> groupIdValue = t.getChildValue("groupId");
-                        if (groupIdTag.isPresent() && !groupId.equals(rp.getValue(groupIdValue.orElse(null)))) {
-                            t = changeChildTagValue(t, "groupId", groupId, ctx);
-                        }
+                        t = changeChildTagValue(t, "groupId", groupId, ctx);
                     } else {
                         groupId = t.getChildValue("groupId").orElseThrow(NoSuchElementException::new);
                     }
                     String artifactId = newArtifactId;
                     if (artifactId != null) {
-                        Optional<Xml.Tag> artifactIdTag = t.getChild("artifactId");
-                        Optional<String> artifactIdValue = t.getChildValue("artifactId");
-                        if (artifactIdTag.isPresent() && !artifactId.equals(rp.getValue(artifactIdValue.orElse(null)))) {
-                            t = changeChildTagValue(t, "artifactId", artifactId, ctx);
-                        }
+                        t = changeChildTagValue(t, "artifactId", artifactId, ctx);
                     } else {
                         artifactId = t.getChildValue("artifactId").orElseThrow(NoSuchElementException::new);
                     }
@@ -202,37 +192,33 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
                             Scope scope = scopeTag.map(xml -> Scope.fromName(xml.getValue().orElse("compile"))).orElse(Scope.Compile);
                             Optional<Xml.Tag> versionTag = t.getChild("version");
 
-                            boolean configuredToOverrideManagedVersion = overrideManagedVersion != null && overrideManagedVersion; // False by default
+                            boolean configuredToOverrideManageVersion = overrideManagedVersion != null && overrideManagedVersion; // False by default
                             boolean configuredToChangeManagedDependency = changeManagedDependency == null || changeManagedDependency; // True by default
 
                             boolean versionTagPresent = versionTag.isPresent();
                             // dependencyManagement does not apply to plugin dependencies or annotation processor paths
-                            boolean oldDependencyDefinedManaged = isOldDependencyTag && canAffectManagedDependency(getResolutionResult(), scope, oldGroupId, oldArtifactId);
+                            boolean oldDependencyManaged = isOldDependencyTag && isDependencyManaged(scope, oldGroupId, oldArtifactId);
                             boolean newDependencyManaged = isOldDependencyTag && isDependencyManaged(scope, groupId, artifactId);
-
                             if (versionTagPresent) {
                                 // If the previous dependency had a version but the new artifact is managed, removed the version tag.
-                                if (!configuredToOverrideManagedVersion && newDependencyManaged || (oldDependencyDefinedManaged && configuredToChangeManagedDependency)) {
+                                if (!configuredToOverrideManageVersion && newDependencyManaged || (oldDependencyManaged && configuredToChangeManagedDependency)) {
                                     t = (Xml.Tag) new RemoveContentVisitor<>(versionTag.get(), false, true).visit(t, ctx);
                                 } else {
                                     // Otherwise, change the version to the new value.
                                     t = changeChildTagValue(t, "version", resolvedNewVersion, ctx);
                                 }
-                            } else if (configuredToOverrideManagedVersion || (!newDependencyManaged && !(oldDependencyDefinedManaged && configuredToChangeManagedDependency))) {
-                                // If the version is not present, add the version if we are explicitly overriding a managed version or if no managed version exists.
+                            } else if (configuredToOverrideManageVersion || !newDependencyManaged) {
+                                //If the version is not present, add the version if we are explicitly overriding a managed version or if no managed version exists.
                                 Xml.Tag newVersionTag = Xml.Tag.build("<version>" + resolvedNewVersion + "</version>");
                                 //noinspection ConstantConditions
                                 t = (Xml.Tag) new AddToTagVisitor<ExecutionContext>(t, newVersionTag, new MavenTagInsertionComparator(t.getChildren())).visitNonNull(t, ctx, getCursor().getParent());
-                            } else if (!newDependencyManaged) {
-                                // We leave it up to the managed dependency update to call `maybeUpdateModel()` instead to avoid interim dependency resolution failure
-                                deferUpdate = true;
                             }
                         } catch (MavenDownloadingException e) {
                             return e.warn(tag);
                         }
                     }
 
-                    if (t != tag && !deferUpdate) {
+                    if (t != tag) {
                         maybeUpdateModel();
                     }
                 }
@@ -241,7 +227,7 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
                 return t;
             }
 
-            private boolean checkIfNewDependencyPresent(@Nullable String groupId, @Nullable String artifactId, @Nullable String version) {
+            private boolean checkIfNewDependencyPresents(@Nullable String groupId, @Nullable String artifactId, @Nullable String version) {
                 if ((groupId == null) || (artifactId == null)) {
                     return false;
                 }
@@ -258,23 +244,6 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
                     if (groupId.equals(managedDependency.getGroupId()) && artifactId.equals(managedDependency.getArtifactId())) {
                         return scope.isInClasspathOf(managedDependency.getScope());
                     }
-                }
-                return false;
-            }
-
-            private boolean canAffectManagedDependency(MavenResolutionResult result, Scope scope, String groupId, String artifactId) {
-                // We're only going to be able to effect managed dependencies that are either direct or are brought in as direct via a local parent
-                // `ChangeManagedDependencyGroupIdAndArtifactId` cannot manipulate BOM imported managed dependencies nor direct dependencies from remote parents
-                Pom requestedPom = result.getPom().getRequested();
-                for (ManagedDependency requestedManagedDependency : requestedPom.getDependencyManagement()) {
-                    if (groupId.equals(requestedManagedDependency.getGroupId()) && artifactId.equals(requestedManagedDependency.getArtifactId())) {
-                        if (requestedManagedDependency instanceof ManagedDependency.Defined) {
-                            return scope.isInClasspathOf(Scope.fromName(((ManagedDependency.Defined) requestedManagedDependency).getScope()));
-                        }
-                    }
-                }
-                if (result.parentPomIsProjectPom() && result.getParent() != null) {
-                    return canAffectManagedDependency(result.getParent(), scope, groupId, artifactId);
                 }
                 return false;
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
@@ -26,7 +26,6 @@ import org.openrewrite.maven.tree.ResolvedManagedDependency;
 import org.openrewrite.maven.tree.ResolvedPom;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
-import org.openrewrite.xml.AddToTagVisitor;
 import org.openrewrite.xml.RemoveContentVisitor;
 import org.openrewrite.xml.tree.Xml;
 
@@ -129,7 +128,7 @@ public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
 
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-                isNewDependencyPresent = checkIfNewDependencyPresent(newGroupId, newArtifactId, newVersion);
+                isNewDependencyPresent = checkIfNewDependencyPresents(newGroupId, newArtifactId, newVersion);
                 return super.visitDocument(document, ctx);
             }
 
@@ -155,9 +154,6 @@ public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
                                 }
                                 String resolvedNewVersion = resolveSemverVersion(ctx, newGroupId, resolvedArtifactId, getResolutionResult().getPom().getValue(versionTag.get().getValue().orElse(null)));
                                 t = changeChildTagValue(t, "version", resolvedNewVersion, ctx);
-                            } else {
-                                Xml.Tag newChild = Xml.Tag.build("<version>" + newVersion + "</version>");
-                                t = (Xml.Tag) new AddToTagVisitor<ExecutionContext>(t, newChild, new MavenTagInsertionComparator(t.getChildren())).visitNonNull(t, ctx, getCursor().getParentOrThrow());
                             }
                         } catch (MavenDownloadingException e) {
                             return e.warn(t);
@@ -175,7 +171,7 @@ public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
                 return t;
             }
 
-            private boolean checkIfNewDependencyPresent(@Nullable String groupId, @Nullable String artifactId, @Nullable String version) {
+            private boolean checkIfNewDependencyPresents(@Nullable String groupId, @Nullable String artifactId, @Nullable String version) {
                 if ((groupId == null) || (artifactId == null)) {
                     return false;
                 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -538,8 +538,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
             null,
             "swagger-annotations-jakarta",
             null,
-            null
-          )),
+            null)),
           pomXml(
             """
               <project>
@@ -588,8 +587,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
             "jakarta.activation",
             "jakarta.activation-api",
             "1.2.x",
-            null
-          )),
+            null)),
           pomXml(
             """
               <project>
@@ -625,189 +623,6 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                   </dependencyManagement>
               </project>
               """
-          )
-        );
-    }
-
-    @Test
-    void doesNotAddVersionNumberTagToDirectDependencyIfAbleToOnManagedDependency() {
-        rewriteRun(
-          spec -> spec.recipe(
-            new ChangeDependencyGroupIdAndArtifactId(
-              "com.fasterxml.jackson.core",
-              "jackson-core",
-              "org.apache.commons",
-              "commons-csv",
-              "1.14.1",
-              null
-            )
-          ),
-          //language=xml
-          pomXml(
-            """
-              <project>
-                <groupId>com.example</groupId>
-                <artifactId>project</artifactId>
-                <version>1</version>
-                <parent>
-                  <groupId>com.fasterxml.jackson</groupId>
-                  <artifactId>jackson-bom</artifactId>
-                  <version>2.20.0</version>
-                </parent>
-                <dependencyManagement>
-                  <dependencies>
-                    <dependency>
-                      <groupId>com.fasterxml.jackson.core</groupId>
-                      <artifactId>jackson-core</artifactId>
-                    </dependency>
-                  </dependencies>
-                </dependencyManagement>
-                <dependencies>
-                  <dependency>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                  </dependency>
-                </dependencies>
-              </project>
-              """,
-            """
-              <project>
-                <groupId>com.example</groupId>
-                <artifactId>project</artifactId>
-                <version>1</version>
-                <parent>
-                  <groupId>com.fasterxml.jackson</groupId>
-                  <artifactId>jackson-bom</artifactId>
-                  <version>2.20.0</version>
-                </parent>
-                <dependencyManagement>
-                  <dependencies>
-                    <dependency>
-                      <groupId>org.apache.commons</groupId>
-                      <artifactId>commons-csv</artifactId>
-                      <version>1.14.1</version>
-                    </dependency>
-                  </dependencies>
-                </dependencyManagement>
-                <dependencies>
-                  <dependency>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-csv</artifactId>
-                  </dependency>
-                </dependencies>
-              </project>
-              """
-          )
-        );
-    }
-
-    @Test
-    void doesNotAddVersionNumberTagToDirectDependencyIfAbleToOnParentManagedDependency() {
-        rewriteRun(
-          spec -> spec.recipes(
-            new ChangeDependencyGroupIdAndArtifactId(
-              "com.fasterxml.jackson.core",
-              "jackson-core",
-              "org.apache.commons",
-              "commons-csv",
-              "1.14.1",
-              null,
-              null,
-              true
-            )
-          ),
-          mavenProject("project",
-            //language=xml
-            pomXml(
-              """
-                <project>
-                  <groupId>com.example</groupId>
-                  <artifactId>project</artifactId>
-                  <version>1</version>
-                  <parent>
-                    <groupId>com.fasterxml.jackson</groupId>
-                    <artifactId>jackson-bom</artifactId>
-                    <version>2.20.0</version>
-                  </parent>
-                  <modules>
-                    <module>child-project</module>
-                  </modules>
-                  <dependencyManagement>
-                    <dependencies>
-                      <dependency>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-core</artifactId>
-                      </dependency>
-                    </dependencies>
-                  </dependencyManagement>
-                </project>
-                """,
-              """
-                <project>
-                  <groupId>com.example</groupId>
-                  <artifactId>project</artifactId>
-                  <version>1</version>
-                  <parent>
-                    <groupId>com.fasterxml.jackson</groupId>
-                    <artifactId>jackson-bom</artifactId>
-                    <version>2.20.0</version>
-                  </parent>
-                  <modules>
-                    <module>child-project</module>
-                  </modules>
-                  <dependencyManagement>
-                    <dependencies>
-                      <dependency>
-                        <groupId>org.apache.commons</groupId>
-                        <artifactId>commons-csv</artifactId>
-                        <version>1.14.1</version>
-                      </dependency>
-                    </dependencies>
-                  </dependencyManagement>
-                </project>
-                """
-            ),
-            mavenProject("child-project",
-              //language=xml
-              pomXml(
-                """
-                  <project>
-                    <groupId>com.example</groupId>
-                    <artifactId>child-project</artifactId>
-                    <version>1</version>
-                    <parent>
-                      <groupId>com.example</groupId>
-                      <artifactId>project</artifactId>
-                      <version>1</version>
-                    </parent>
-                    <dependencies>
-                      <dependency>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-core</artifactId>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """,
-                """
-                  <project>
-                    <groupId>com.example</groupId>
-                    <artifactId>child-project</artifactId>
-                    <version>1</version>
-                    <parent>
-                      <groupId>com.example</groupId>
-                      <artifactId>project</artifactId>
-                      <version>1</version>
-                    </parent>
-                    <dependencies>
-                      <dependency>
-                        <groupId>org.apache.commons</groupId>
-                        <artifactId>commons-csv</artifactId>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """
-              )
-            )
           )
         );
     }
@@ -910,7 +725,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
             "javax.activation-api",
             "jakarta.activation",
             "jakarta.activation-api",
-            "1.2.1",
+            "1.2.2",
             null,
             true,
             false
@@ -938,7 +753,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                           <dependency>
                               <groupId>jakarta.activation</groupId>
                               <artifactId>jakarta.activation-api</artifactId>
-                              <version>1.2.2</version>
+                              <version>1.2.1</version>
                           </dependency>
                       </dependencies>
                   </dependencyManagement>
@@ -954,7 +769,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                       <dependency>
                           <groupId>jakarta.activation</groupId>
                           <artifactId>jakarta.activation-api</artifactId>
-                          <version>1.2.1</version>
+                          <version>1.2.2</version>
                       </dependency>
                   </dependencies>
                   <dependencyManagement>
@@ -967,7 +782,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                           <dependency>
                               <groupId>jakarta.activation</groupId>
                               <artifactId>jakarta.activation-api</artifactId>
-                              <version>1.2.2</version>
+                              <version>1.2.1</version>
                           </dependency>
                       </dependencies>
                   </dependencyManagement>
@@ -978,7 +793,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
     }
 
     @Test
-    void updatesManagedAndDirect() {
+    void managedToUnmanaged() {
         rewriteRun(
           spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
             "javax.activation",
@@ -1124,7 +939,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                               <groupId>org.springframework.cloud</groupId>
                               <artifactId>spring-cloud-dependencies</artifactId>
                               <version>2021.0.0</version>
-                              <type>pom</type>
+                              <type>bom</type>
                               <scope>import</scope>
                           </dependency>
                       </dependencies>
@@ -1148,7 +963,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                               <groupId>org.springframework.cloud</groupId>
                               <artifactId>spring-cloud-dependencies</artifactId>
                               <version>2021.0.0</version>
-                              <type>pom</type>
+                              <type>bom</type>
                               <scope>import</scope>
                           </dependency>
                       </dependencies>
@@ -1165,194 +980,6 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                   </dependencies>
               </project>
               """
-          )
-        );
-    }
-
-    @Test
-    void managedToUnmanagedExternalizedDepMgmtWithDirectVersion() {
-        rewriteRun(
-          spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
-            "org.springframework.cloud",
-            "spring-cloud-starter-sleuth",
-            "io.micrometer",
-            "micrometer-tracing-bridge-brave",
-            "1.0.12",
-            null
-          )),
-          pomXml(
-            """
-              <project>
-                  <dependencyManagement>
-                      <dependencies>
-                          <dependency>
-                              <groupId>org.springframework.cloud</groupId>
-                              <artifactId>spring-cloud-dependencies</artifactId>
-                              <version>2021.0.0</version>
-                              <type>pom</type>
-                              <scope>import</scope>
-                          </dependency>
-                      </dependencies>
-                  </dependencyManagement>
-                  <groupId>com.mycompany.app</groupId>
-                  <artifactId>sample</artifactId>
-                  <version>1</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.springframework.cloud</groupId>
-                          <artifactId>spring-cloud-starter-sleuth</artifactId>
-                          <version>3.1.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """,
-            """
-              <project>
-                  <dependencyManagement>
-                      <dependencies>
-                          <dependency>
-                              <groupId>org.springframework.cloud</groupId>
-                              <artifactId>spring-cloud-dependencies</artifactId>
-                              <version>2021.0.0</version>
-                              <type>pom</type>
-                              <scope>import</scope>
-                          </dependency>
-                      </dependencies>
-                  </dependencyManagement>
-                  <groupId>com.mycompany.app</groupId>
-                  <artifactId>sample</artifactId>
-                  <version>1</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>io.micrometer</groupId>
-                          <artifactId>micrometer-tracing-bridge-brave</artifactId>
-                          <version>1.0.12</version>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """
-          )
-        );
-    }
-
-    @Test
-    void parentAndBomManagedToJustParentManaged() {
-        rewriteRun(
-          spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
-            "org.springframework.cloud",
-            "spring-cloud-starter-sleuth",
-            "io.micrometer",
-            "micrometer-tracing-bridge-brave",
-            "1.0.12",
-            null
-          )),
-          mavenProject(
-            "parent",
-            //language=xml
-            pomXml(
-              """
-                <project>
-                    <groupId>com.mycompany.app</groupId>
-                    <artifactId>parent</artifactId>
-                    <version>1</version>
-                    <modules>
-                        <module>child</module>
-                    </modules>
-                    <dependencyManagement>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.springframework.cloud</groupId>
-                                <artifactId>spring-cloud-starter-sleuth</artifactId>
-                                <version>3.1.1</version>
-                            </dependency>
-                        </dependencies>
-                    </dependencyManagement>
-                </project>
-                """,
-              """
-                <project>
-                    <groupId>com.mycompany.app</groupId>
-                    <artifactId>parent</artifactId>
-                    <version>1</version>
-                    <modules>
-                        <module>child</module>
-                    </modules>
-                    <dependencyManagement>
-                        <dependencies>
-                            <dependency>
-                                <groupId>io.micrometer</groupId>
-                                <artifactId>micrometer-tracing-bridge-brave</artifactId>
-                                <version>1.0.12</version>
-                            </dependency>
-                        </dependencies>
-                    </dependencyManagement>
-                </project>
-                """
-            ),
-            mavenProject(
-              "child",
-              //language=xml
-              pomXml(
-                """
-                  <project>
-                      <groupId>com.mycompany.app</groupId>
-                      <artifactId>child</artifactId>
-                      <version>1</version>
-                      <parent>
-                          <groupId>com.mycompany.app</groupId>
-                          <artifactId>parent</artifactId>
-                          <version>1</version>
-                      </parent>
-                      <dependencyManagement>
-                          <dependencies>
-                              <dependency>
-                                  <groupId>org.springframework.cloud</groupId>
-                                  <artifactId>spring-cloud-dependencies</artifactId>
-                                  <version>2021.0.0</version>
-                                  <type>pom</type>
-                                  <scope>import</scope>
-                              </dependency>
-                          </dependencies>
-                      </dependencyManagement>
-                      <dependencies>
-                          <dependency>
-                              <groupId>org.springframework.cloud</groupId>
-                              <artifactId>spring-cloud-starter-sleuth</artifactId>
-                          </dependency>
-                      </dependencies>
-                  </project>
-                  """,
-                """
-                  <project>
-                      <groupId>com.mycompany.app</groupId>
-                      <artifactId>child</artifactId>
-                      <version>1</version>
-                      <parent>
-                          <groupId>com.mycompany.app</groupId>
-                          <artifactId>parent</artifactId>
-                          <version>1</version>
-                      </parent>
-                      <dependencyManagement>
-                          <dependencies>
-                              <dependency>
-                                  <groupId>org.springframework.cloud</groupId>
-                                  <artifactId>spring-cloud-dependencies</artifactId>
-                                  <version>2021.0.0</version>
-                                  <type>pom</type>
-                                  <scope>import</scope>
-                              </dependency>
-                          </dependencies>
-                      </dependencyManagement>
-                      <dependencies>
-                          <dependency>
-                              <groupId>io.micrometer</groupId>
-                              <artifactId>micrometer-tracing-bridge-brave</artifactId>
-                          </dependency>
-                      </dependencies>
-                  </project>
-                  """
-              )
-            )
           )
         );
     }
@@ -1569,7 +1196,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                               <groupId>org.springframework.cloud</groupId>
                               <artifactId>spring-cloud-dependencies</artifactId>
                               <version>2021.0.0</version>
-                              <type>pom</type>
+                              <type>bom</type>
                               <scope>import</scope>
                           </dependency>
                       </dependencies>
@@ -1594,7 +1221,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                               <groupId>org.springframework.cloud</groupId>
                               <artifactId>spring-cloud-dependencies</artifactId>
                               <version>2021.0.0</version>
-                              <type>pom</type>
+                              <type>bom</type>
                               <scope>import</scope>
                           </dependency>
                       </dependencies>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactIdTest.java
@@ -347,78 +347,6 @@ class ChangeManagedDependencyGroupIdAndArtifactIdTest implements RewriteTest {
     }
 
     @Test
-    void changeManagedDependencyMissingExplicitVersion() {
-        rewriteRun(
-          spec -> spec.recipe(
-            new ChangeManagedDependencyGroupIdAndArtifactId(
-              "com.fasterxml.jackson.core",
-              "jackson-core",
-              "org.apache.commons",
-              "commons-csv",
-              "1.14.1",
-              null
-            )
-          ),
-          //language=xml
-          pomXml(
-            """
-              <project>
-                <groupId>com.example</groupId>
-                <artifactId>project</artifactId>
-                <version>1</version>
-                <parent>
-                  <groupId>com.fasterxml.jackson</groupId>
-                  <artifactId>jackson-bom</artifactId>
-                  <version>2.20.0</version>
-                </parent>
-                <dependencyManagement>
-                  <dependencies>
-                    <dependency>
-                      <groupId>com.fasterxml.jackson.core</groupId>
-                      <artifactId>jackson-core</artifactId>
-                    </dependency>
-                  </dependencies>
-                </dependencyManagement>
-                <dependencies>
-                  <dependency>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                  </dependency>
-                </dependencies>
-              </project>
-              """,
-            """
-              <project>
-                <groupId>com.example</groupId>
-                <artifactId>project</artifactId>
-                <version>1</version>
-                <parent>
-                  <groupId>com.fasterxml.jackson</groupId>
-                  <artifactId>jackson-bom</artifactId>
-                  <version>2.20.0</version>
-                </parent>
-                <dependencyManagement>
-                  <dependencies>
-                    <dependency>
-                      <groupId>org.apache.commons</groupId>
-                      <artifactId>commons-csv</artifactId>
-                      <version>1.14.1</version>
-                    </dependency>
-                  </dependencies>
-                </dependencyManagement>
-                <dependencies>
-                  <dependency>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                  </dependency>
-                </dependencies>
-              </project>
-              """
-          )
-        );
-    }
-
-    @Test
     void latestPatchMangedDependency() {
         rewriteRun(
           spec -> spec.recipe(new ChangeManagedDependencyGroupIdAndArtifactId(
@@ -519,47 +447,6 @@ class ChangeManagedDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                       </dependencyManagement>
                     </profile>
                   </profiles>
-              </project>
-              """
-          )
-        );
-    }
-
-    @Test
-    void doesNotMakeChangeWhenChangingBomImportManagedDependency() {
-        rewriteRun(
-          spec -> spec.recipe(new ChangeManagedDependencyGroupIdAndArtifactId(
-            "org.springframework.cloud",
-            "spring-cloud-starter-sleuth",
-            "io.micrometer",
-            "micrometer-tracking-bridge-brave",
-            "1.0.12",
-            null
-          )),
-          //language=xml
-          pomXml(
-            """
-              <project>
-                  <groupId>com.mycompany.app</groupId>
-                  <artifactId>sample</artifactId>
-                  <version>1</version>
-                  <dependencyManagement>
-                      <dependencies>
-                          <dependency>
-                              <groupId>org.springframework.cloud</groupId>
-                              <artifactId>spring-cloud-dependencies</artifactId>
-                              <version>2021.0.0</version>
-                              <type>pom</type>
-                              <scope>import</scope>
-                          </dependency>
-                      </dependencies>
-                  </dependencyManagement>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.springframework.cloud</groupId>
-                          <artifactId>spring-cloud-starter-sleuth</artifactId>
-                      </dependency>
-                  </dependencies>
               </project>
               """
           )

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveManagedDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveManagedDependencyTest.java
@@ -240,7 +240,7 @@ class RemoveManagedDependencyTest implements RewriteTest {
                               <artifactId>micrometer-bom</artifactId>
                               <version>1.9.9</version>
                               <scope>import</scope>
-                              <type>pom</type>
+                              <type>bom</type>
                           </dependency>
                       </dependencies>
                   </dependencyManagement>


### PR DESCRIPTION
- Reverts openrewrite/rewrite#6105 as three tests are failling:
```
- org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactIdTest  
    - doesNotAddVersionNumberTagToDirectDependencyIfAbleToOnParentManagedDependency()  
    - doesNotAddVersionNumberTagToDirectDependencyIfAbleToOnManagedDependency()  
- org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactIdTest  
    - changeManagedDependencyMissingExplicitVersion()
```