### PR TITLE
Fix flaky test by isolating Maven tests that modify user.home

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSecuritySettingsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSecuritySettingsTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.openrewrite.InMemoryExecutionContext;
 
 import java.io.IOException;
@@ -29,6 +30,7 @@ import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Isolated("Modifies user.home system property")
 @Execution(ExecutionMode.SAME_THREAD)
 class MavenSecuritySettingsTest {
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.Parser;
@@ -49,6 +50,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings({"HttpUrlsUsage", "ConstantConditions", "OptionalGetWithoutIsPresent"})
+@Isolated("Modifies user.home system property")
 @Execution(ExecutionMode.SAME_THREAD)
 class MavenSettingsTest {
 


### PR DESCRIPTION
## Summary
- Added `@Isolated` annotation to `MavenSecuritySettingsTest` and `MavenSettingsTest` to prevent flaky test failures

## Problem
The `rewrite-maven` module has parallel test execution enabled. `MavenSecuritySettingsTest` and `MavenSettingsTest` modify the global `user.home` system property during tests. While these classes had `@Execution(ExecutionMode.SAME_THREAD)`, this only prevents tests *within the same class* from running concurrently—other test classes can still run in parallel.

When `ChangePluginGroupIdAndArtifactIdTest` ran concurrently with `MavenSecuritySettingsTest`, it could pick up the modified `user.home` pointing to a temp directory with an empty `.m2` directory, causing an "EOF in prolog" parse error when trying to read `settings.xml`.

## Solution
Added `@Isolated` annotation to both test classes. This ensures they run completely alone with no other tests executing concurrently across the entire test suite.