### PR TITLE
Fix loading of YAML recipes on Windows

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleResolver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleResolver.java
@@ -19,9 +19,9 @@ import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 
@@ -36,12 +36,23 @@ public class YamlRecipeBundleResolver implements RecipeBundleResolver {
 
     @Override
     public RecipeBundleReader resolve(RecipeBundle bundle) {
-        try (InputStream is = Files.exists(Paths.get(bundle.getPackageName())) ?
-                Files.newInputStream(Paths.get(bundle.getPackageName())) :
-                URI.create(bundle.getPackageName()).toURL().openStream()) {
-            return new YamlRecipeBundleReader(bundle, is, URI.create(bundle.getPackageName()), properties);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        try {
+            Path path = Paths.get(bundle.getPackageName());
+            if (Files.exists(path)) {
+                try (InputStream is = Files.newInputStream(path)) {
+                    return new YamlRecipeBundleReader(bundle, is, path.toUri(), properties);
+                }
+            }
+        } catch (Exception ignored) {
+        }
+
+        try {
+            URI resource = URI.create(bundle.getPackageName());
+            try (InputStream is = resource.toURL().openStream()) {
+                return new YamlRecipeBundleReader(bundle, is, resource, properties);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 }


### PR DESCRIPTION
## What's changed?
Fixed loading of YAML recipes on Windows.

## What's your motivation?
Encountering exceptions of the form:
```
java.net.URISyntaxException: Illegal character in opaque part at index 2: C:\Users\<user>\AppData\Local\Temp\junit-3051091767566314365\recipe.yaml

java.nio.file.InvalidPathException: Illegal char <:> at index 4: file:///C:/Users/<user>/AppData/Local/Temp/junit-7133895390291097111/recipe.yaml
```

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
N/A

### Checklist
- [ ] ~I've added unit tests to cover both positive and negative cases~
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
