### PR TITLE
Minor update to one of the tests - following lodash release

### DIFF
--- a/rewrite-javascript/rewrite/test/javascript/recipes/upgrade-dependency-version.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/recipes/upgrade-dependency-version.test.ts
@@ -444,13 +444,13 @@ describe("UpgradeDependencyVersion", () => {
     });
 
     test("skips npm install when resolved version already satisfies new constraint", async () => {
-        // Scenario: package.json has ^4.17.20, npm resolves to 4.17.21 (latest)
-        // If we upgrade to ^4.17.21, the resolved version 4.17.21 already satisfies it,
+        // Scenario: package.json has ^4.17.20, npm resolves to 4.17.23 (latest)
+        // If we upgrade to ^4.17.23, the resolved version 4.17.23 already satisfies it,
         // so we should only update package.json, not run npm install
         const spec = new RecipeSpec();
         spec.recipe = new UpgradeDependencyVersion({
             packageName: "lodash",
-            newVersion: "^4.17.21"
+            newVersion: "^4.17.23"
         });
 
         await withDir(async (repo) => {
@@ -458,7 +458,7 @@ describe("UpgradeDependencyVersion", () => {
                 npm(
                     repo.path,
                     typescript(`const x = 1;`),
-                    // package.json should be updated from ^4.17.20 to ^4.17.21
+                    // package.json should be updated from ^4.17.20 to ^4.17.23
                     {
                         ...packageJson(`
                             {
@@ -473,7 +473,7 @@ describe("UpgradeDependencyVersion", () => {
                                 "name": "test-project",
                                 "version": "1.0.0",
                                 "dependencies": {
-                                    "lodash": "^4.17.21"
+                                    "lodash": "^4.17.23"
                                 }
                             }
                         `),
@@ -481,10 +481,10 @@ describe("UpgradeDependencyVersion", () => {
                             // Verify marker was updated with new versionConstraint
                             const marker = findNodeResolutionResult(doc);
                             expect(marker).toBeDefined();
-                            expect(marker!.dependencies[0].versionConstraint).toBe("^4.17.21");
-                            // The resolved version should still be 4.17.21 (unchanged)
+                            expect(marker!.dependencies[0].versionConstraint).toBe("^4.17.23");
+                            // The resolved version should still be 4.17.23 (unchanged)
                             // This proves we didn't run npm install - just updated the constraint
-                            expect(marker!.resolvedDependencies?.[0]?.version).toBe("4.17.21");
+                            expect(marker!.resolvedDependencies?.[0]?.version).toBe("4.17.23");
                         }
                     }
                 )


### PR DESCRIPTION
## What's changed?

Changing one of the tests in `upgrade-dependency-version.test.ts` to name current lodash version.

## What's your motivation?

Fix broken CI after lodash released its first version for several years
<img width="770" height="155" alt="image" src="https://github.com/user-attachments/assets/89cc7c03-bd0a-418a-af92-d5ea8d475f02" />
