### PR TITLE
Load dependent recipes in a declarative from an existing `RecipeMarkeplace`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -24,6 +24,9 @@ import org.openrewrite.*;
 import org.openrewrite.internal.ObjectMappers;
 import org.openrewrite.internal.PropertyPlaceholderHelper;
 import org.openrewrite.internal.RecipeLoader;
+import org.openrewrite.marketplace.RecipeBundleResolver;
+import org.openrewrite.marketplace.RecipeListing;
+import org.openrewrite.marketplace.RecipeMarketplace;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.style.Style;
 import org.yaml.snakeyaml.LoaderOptions;
@@ -84,6 +87,34 @@ public class YamlResourceLoader implements ResourceLoader {
                     .filter(type -> type.getSpec().equals(spec))
                     .findAny()
                     .orElse(null);
+        }
+    }
+
+    public YamlResourceLoader(InputStream yamlInput, URI source, Properties properties, RecipeMarketplace marketplace, Collection<RecipeBundleResolver> resolvers) {
+        this.source = source;
+        this.dependencyResourceLoaders = emptyList();
+        this.mapper = ObjectMappers.propertyBasedMapper(getClass().getClassLoader());
+        this.recipeLoader = (recipeName, options) -> {
+            RecipeListing listing = marketplace.findRecipe(recipeName);
+            if (listing == null) {
+                throw new IllegalStateException("Unable to find recipe " + recipeName + " listed in " + source);
+            }
+            return listing.prepare(resolvers, options == null ? emptyMap() : options);
+        };
+
+        maybeAddKotlinModule(mapper);
+
+        try {
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            int nRead;
+            byte[] data = new byte[8192];
+            while ((nRead = yamlInput.read(data, 0, data.length)) != -1) {
+                buffer.write(data, 0, nRead);
+            }
+            this.yamlSource = propertyPlaceholderHelper.replacePlaceholders(
+                    new String(buffer.toByteArray(), StandardCharsets.UTF_8), properties);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleReader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleReader.java
@@ -23,6 +23,7 @@ import org.openrewrite.config.YamlResourceLoader;
 
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
 
@@ -33,8 +34,8 @@ public class YamlRecipeBundleReader implements RecipeBundleReader {
     private final @Getter RecipeBundle bundle;
     private final YamlResourceLoader yamlLoader;
 
-    public YamlRecipeBundleReader(RecipeBundle bundle, InputStream yamlLoader, URI source, Properties properties) {
-        this.yamlLoader = new YamlResourceLoader(yamlLoader, source, properties);
+    public YamlRecipeBundleReader(RecipeBundle bundle, InputStream yamlLoader, URI source, Properties properties, RecipeMarketplace marketplace, Collection<RecipeBundleResolver> resolvers) {
+        this.yamlLoader = new YamlResourceLoader(yamlLoader, source, properties, marketplace, resolvers);
         this.bundle = bundle;
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleResolver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleResolver.java
@@ -17,17 +17,19 @@ package org.openrewrite.marketplace;
 
 import lombok.RequiredArgsConstructor;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.Properties;
 
 @RequiredArgsConstructor
 public class YamlRecipeBundleResolver implements RecipeBundleResolver {
     private final Properties properties;
+    private final RecipeMarketplace marketplace;
+    private final Collection<RecipeBundleResolver> resolvers;
 
     @Override
     public String getEcosystem() {
@@ -40,7 +42,7 @@ public class YamlRecipeBundleResolver implements RecipeBundleResolver {
             Path path = Paths.get(bundle.getPackageName());
             if (Files.exists(path)) {
                 try (InputStream is = Files.newInputStream(path)) {
-                    return new YamlRecipeBundleReader(bundle, is, path.toUri(), properties);
+                    return new YamlRecipeBundleReader(bundle, is, path.toUri(), properties, marketplace, resolvers);
                 }
             }
         } catch (Exception ignored) {
@@ -49,7 +51,7 @@ public class YamlRecipeBundleResolver implements RecipeBundleResolver {
         try {
             URI resource = URI.create(bundle.getPackageName());
             try (InputStream is = resource.toURL().openStream()) {
-                return new YamlRecipeBundleReader(bundle, is, resource, properties);
+                return new YamlRecipeBundleReader(bundle, is, resource, properties, marketplace, resolvers);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
## What's changed?
Fixed loading of external, declarative YAML recipes that need to load recipes from dependent recipe bundles.

## What's your motivation?
Prior to this, loading YAML recipes would work for dependent recipes that were already on the classpath, but not those that were external and needed to be retrieved.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
N/A

### Checklist
- [ ] ~I've added unit tests to cover both positive and negative cases~
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
