### PR TITLE
`UpgradeDependencyVersion` now upgrades literal versions in Spring dependency management plugin entries

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -560,6 +560,21 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 });
             }
 
+            // Handle Spring dependency management plugin entries (dependency, dependencySet, mavenBom)
+            SpringDependencyManagementPluginEntry springDepMgmtEntry = new SpringDependencyManagementPluginEntry.Matcher()
+                    .groupId(groupId)
+                    .artifactId(artifactId)
+                    .get(getCursor())
+                    .orElse(null);
+            if (springDepMgmtEntry != null) {
+                // Only update if the version is NOT a variable (variables are handled by UpdateProperties/UpdateVariable)
+                String versionVar = springDepMgmtEntry.getVersionVariable();
+                if (versionVar == null) {
+                    m = springDepMgmtEntry.withGroupArtifactVersion(
+                            dependencyMatcher, null, null, newVersion, versionPattern, metadataFailures, ctx).getTree();
+                }
+            }
+
             if ("ext".equals(method.getSimpleName()) && getCursor().firstEnclosingOrThrow(SourceFile.class).getSourcePath().endsWith("settings.gradle")) {
                 // rare case that gradle versions are set via settings.gradle ext block (only possible for Groovy DSL)
                 m = (J.MethodInvocation) new JavaIsoVisitor<ExecutionContext>() {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -2308,4 +2308,121 @@ class UpgradeDependencyVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void upgradesSpringDependencyManagementPluginMavenBomLiteralVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.springframework.cloud", "spring-cloud-dependencies", "2023.0.x", null)),
+          buildGradle(
+            //language=groovy
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+              repositories { mavenCentral() }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom "org.springframework.cloud:spring-cloud-dependencies:2021.0.8"
+                  }
+              }
+              """,
+            //language=groovy
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+              repositories { mavenCentral() }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.6"
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void upgradesSpringDependencyManagementPluginMavenBomLiteralVersionKotlin() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.springframework.cloud", "spring-cloud-dependencies", "2023.0.x", null)),
+          buildGradleKts(
+            """
+              plugins {
+                  java
+                  id("io.spring.dependency-management") version "1.1.7"
+              }
+              repositories { mavenCentral() }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom("org.springframework.cloud:spring-cloud-dependencies:2021.0.8")
+                  }
+              }
+              """,
+            """
+              plugins {
+                  java
+                  id("io.spring.dependency-management") version "1.1.7"
+              }
+              repositories { mavenCentral() }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.6")
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void upgradesSpringDependencyManagementPluginDependencyLiteralVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("com.google.guava", "guava", "30.x", "-jre")),
+          buildGradle(
+            //language=groovy
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+              repositories { mavenCentral() }
+
+              dependencyManagement {
+                  dependencies {
+                      dependency 'com.google.guava:guava:29.0-jre'
+                  }
+              }
+
+              dependencies {
+                  implementation 'com.google.guava:guava'
+              }
+              """,
+            //language=groovy
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+              repositories { mavenCentral() }
+
+              dependencyManagement {
+                  dependencies {
+                      dependency 'com.google.guava:guava:30.1.1-jre'
+                  }
+              }
+
+              dependencies {
+                  implementation 'com.google.guava:guava'
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

This fixes an issue where `UpgradeDependencyVersion` would not upgrade literal version strings in the Spring dependency management plugin's `dependencyManagement` block (e.g., `mavenBom "group:artifact:version"` or `dependency "group:artifact:version"`).

Previously, the recipe would only upgrade these entries if the version was specified via a variable reference. Now it also handles literal versions by invoking `SpringDependencyManagementPluginEntry.withGroupArtifactVersion()` in the visitor phase.

## What's your motivation?

- Fixes moderneinc/customer-requests#1724

Customers using the Spring dependency management plugin with literal versions in their `dependencyManagement` blocks were not seeing those versions upgraded.

## Anything in particular you'd like reviewers to focus on?

The fix is quite small - just adding handling for `SpringDependencyManagementPluginEntry` in the `UpdateGradle.visitMethodInvocation()` method, similar to how `GradleMultiDependency` is already handled.

## Have you considered any alternatives or workarounds?

No workarounds available - the recipe simply didn't handle this case.