### PR TITLE
Update strictly version in dependency constraints instead of removing

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -1094,7 +1094,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                         return ((J.Literal) arg).withValue(gav.toString())
                                 .withValueSource(quote + gav.toString() + quote);
                     } else if (arg instanceof J.Lambda) {
-                        arg = (Expression) new RemoveVersionVisitor().visitNonNull(arg, ctx);
+                        arg = (Expression) new UpdateVersionVisitor(gav.getVersion()).visitNonNull(arg, ctx);
                     }
                     if (because != null) {
                         Expression arg2 = (Expression) new UpdateBecauseTextVisitor(because)
@@ -1114,23 +1114,31 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
         }
     }
 
-    @SuppressWarnings("NullableProblems")
-    private static class RemoveVersionVisitor extends JavaIsoVisitor<ExecutionContext> {
+    /**
+     * Updates version constraint methods (strictly, require, prefer) with a new version
+     * instead of removing the version block entirely.
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false)
+    private static class UpdateVersionVisitor extends JavaIsoVisitor<ExecutionContext> {
+        String newVersion;
 
         @Override
-        public J.@Nullable Return visitReturn(J.Return _return, ExecutionContext ctx) {
-            J.Return r = super.visitReturn(_return, ctx);
-            if (r.getExpression() == null) {
-                return null;
-            }
-            return r;
-        }
-
-        @Override
-        public J.@Nullable MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
-            if ("version".equals(m.getSimpleName()) && m.getArguments().size() == 1 && m.getArguments().get(0) instanceof J.Lambda) {
-                return null;
+            String methodName = m.getSimpleName();
+            // Update version constraint methods: strictly, require, prefer
+            if ("strictly".equals(methodName) || "require".equals(methodName) || "prefer".equals(methodName)) {
+                return m.withArguments(ListUtils.map(m.getArguments(), arg -> {
+                    if (arg instanceof J.Literal) {
+                        J.Literal literal = (J.Literal) arg;
+                        String valueSource = literal.getValueSource();
+                        char quote = valueSource != null ? valueSource.charAt(0) : '\'';
+                        return literal.withValue(newVersion)
+                                .withValueSource(quote + newVersion + quote);
+                    }
+                    return arg;
+                }));
             }
             return m;
         }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -692,8 +692,52 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/moderneinc/customer-requests/issues/382")
     @Test
-    void removeOtherVersionConstraint() {
+    void updateStrictlyVersionConstraint() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+
+              dependencies {
+                  implementation 'org.openrewrite:rewrite-java:7.0.0'
+
+                  constraints {
+                      implementation('com.fasterxml.jackson.core:jackson-core:2.12.0') {
+                          version {
+                              strictly('2.12.0')
+                          }
+                          because 'security'
+                      }
+                  }
+              }
+              """,
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+
+              dependencies {
+                  implementation 'org.openrewrite:rewrite-java:7.0.0'
+
+                  constraints {
+                      implementation('com.fasterxml.jackson.core:jackson-core:2.12.5') {
+                          version {
+                              strictly('2.12.5')
+                          }
+                          because 'CVE-2024-BAD'
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/382")
+    @Test
+    void updateStrictlyVersionConstraintWithoutVersionInString() {
         rewriteRun(
           buildGradle(
             """
@@ -723,6 +767,9 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
                   constraints {
                       implementation('com.fasterxml.jackson.core:jackson-core:2.12.5') {
                           because 'CVE-2024-BAD'
+                          version {
+                              strictly('2.12.5')
+                          }
                       }
                   }
               }


### PR DESCRIPTION
## Summary
- When upgrading a dependency constraint with a `version { strictly() }` block, the recipe now updates the strictly version instead of removing the block entirely
- This preserves the user's intent to enforce a specific version after the upgrade
- Adds support for updating `strictly()`, `require()`, and `prefer()` version constraint methods

- Fixes https://github.com/moderneinc/customer-requests/issues/382

## Test plan
- [x] Added test `updateStrictlyVersionConstraint` - verifies strictly version is updated when both string and strictly have versions
- [x] Added test `updateStrictlyVersionConstraintWithoutVersionInString` - verifies strictly version is updated when only strictly has the version
- [x] All existing `UpgradeTransitiveDependencyVersionTest` tests pass
- [x] Full `rewrite-gradle:check` passes