### PR TITLE
Fix NPE in JavaScriptPrinter.visitFunctionType when space is null

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -640,7 +640,7 @@ export class JavaScriptParserVisitor {
         return {
             kind: J.Kind.RightPadded,
             element: t,
-            after: trailing,
+            after: trailing ?? emptySpace,
             markers: markers ?? emptyMarkers
         };
     }
@@ -673,7 +673,7 @@ export class JavaScriptParserVisitor {
     private leftPadded<T extends J | J.Space | number | string | boolean>(before: J.Space, t: T, markers?: Markers): J.LeftPadded<T> {
         return {
             kind: J.Kind.LeftPadded,
-            before: before,
+            before: before ?? emptySpace,
             element: t,
             markers: markers ?? emptyMarkers
         };


### PR DESCRIPTION
## Summary
- Fix NullPointerException in JavaScriptPrinter when visiting FunctionType with null spaces
- The TypeScript parser's `leftPadded()` and `rightPadded()` helper methods could receive undefined space values
- Added null protection to default undefined spaces to `emptySpace`

## Test plan
- [x] Existing function-type parser tests pass
- [x] All parser tests pass (705 tests)

- Fixes moderneinc/customer-requests#880