### PR TITLE
Add null safety to XmlParserVisitor to prevent crashes

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
@@ -218,17 +218,11 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
                     List<Xml.CharData> piTexts = c.PI_TEXT().stream()
                             .map(piText -> convert(piText, (cdata, p) -> charData(cdata.getText(), false, p)))
                             .collect(toList());
-                    Xml.CharData piText;
-                    if (piTexts.isEmpty()) {
-                        // Handle edge case where no PI_TEXT tokens are present (e.g., during error recovery)
-                        piText = new Xml.CharData(randomId(), "", Markers.EMPTY, false, "", "");
-                    } else {
-                        piText = piTexts.get(0);
-                        if (piTexts.size() > 1) {
-                            StringBuilder sb = new StringBuilder();
-                            piTexts.forEach(it -> sb.append(it.getText()));
-                            piText = piText.withText(sb.toString());
-                        }
+                    Xml.CharData piText = piTexts.get(0);
+                    if (piTexts.size() > 1) {
+                        StringBuilder sb = new StringBuilder();
+                        piTexts.forEach(it -> sb.append(it.getText()));
+                        piText = piText.withText(sb.toString());
                     }
 
                     return new Xml.ProcessingInstruction(
@@ -342,31 +336,23 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
                         beforeTagDelimiterPrefix = prefix(ctx.SLASH_CLOSE());
                         advanceCursor(ctx.SLASH_CLOSE().getSymbol().getStopIndex() + 1);
                     } else {
-                        TerminalNode close0 = ctx.CLOSE(0);
-                        if (close0 != null) {
-                            beforeTagDelimiterPrefix = prefix(close0);
-                            advanceCursor(close0.getSymbol().getStopIndex() + 1);
-                        } else {
-                            beforeTagDelimiterPrefix = "";
-                        }
+                        beforeTagDelimiterPrefix = prefix(ctx.CLOSE(0));
+                        advanceCursor(ctx.CLOSE(0).getSymbol().getStopIndex() + 1);
 
                         content = ctx.content().stream()
                                 .map(this::visit)
-                                .filter(java.util.Objects::nonNull)
                                 .map(Content.class::cast)
                                 .collect(toList());
 
-                        TerminalNode open1 = ctx.OPEN(1);
-                        String closeTagPrefix = open1 != null ? prefix(open1) : "";
+                        String closeTagPrefix = prefix(ctx.OPEN(1));
                         advanceCursor(codePointCursor + 2);
 
-                        TerminalNode close1 = ctx.CLOSE(1);
                         closeTag = new Xml.Tag.Closing(
                                 randomId(),
                                 closeTagPrefix,
                                 Markers.EMPTY,
                                 convert(ctx.Name(1), (n, p) -> n.getText()),
-                                close1 != null ? prefix(close1) : ""
+                                prefix(ctx.CLOSE(1))
                         );
                         advanceCursor(codePointCursor + 1);
                     }
@@ -404,9 +390,7 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
             Xml.Ident name = convert(c.Name(), (n, p) -> new Xml.Ident(randomId(), p, Markers.EMPTY, n.getText()));
             Xml.Ident externalId = null;
             List<Xml.Ident> internalSubset = null;
-            Token externalIdStart = c.externalid() != null ? c.externalid().getStart() : null;
-            Token dtdCloseSymbol = c.DTD_CLOSE() != null ? c.DTD_CLOSE().getSymbol() : null;
-            if (externalIdStart != null && dtdCloseSymbol != null && !externalIdStart.equals(dtdCloseSymbol)) {
+            if (!c.externalid().getStart().equals(c.DTD_CLOSE().getSymbol())) {
                 if (c.externalid().Name() != null) {
                     externalId = convert(c.externalid(),
                             (n, p) -> new Xml.Ident(randomId(), p, Markers.EMPTY, n.Name().getText()));
@@ -417,33 +401,31 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
             }
 
             Xml.DocTypeDecl.ExternalSubsets externalSubsets = null;
-            if (c.intsubset() != null && c.DTD_SUBSET_OPEN() != null) {
+            if (c.intsubset() != null) {
                 String subsetPrefix = prefix(c.DTD_SUBSET_OPEN());
                 advanceCursor(c.DTD_SUBSET_OPEN().getSymbol().getStopIndex() + 1);
 
                 List<Xml.Element> elements = new ArrayList<>();
                 List<ParseTree> children = c.intsubset().children;
-                if (children != null) {
-                    for (int i = 0; i < children.size(); i++) {
-                        ParserRuleContext element = (ParserRuleContext) children.get(i);
-                        // Markup declarations are not fully implemented.
-                        // n.getText() includes element subsets.
-                        Xml.Ident ident = convert(element, (n, p) -> new Xml.Ident(randomId(), p, Markers.EMPTY, n.getText()));
+                for (int i = 0; i < children.size(); i++) {
+                    ParserRuleContext element = (ParserRuleContext) children.get(i);
+                    // Markup declarations are not fully implemented.
+                    // n.getText() includes element subsets.
+                    Xml.Ident ident = convert(element, (n, p) -> new Xml.Ident(randomId(), p, Markers.EMPTY, n.getText()));
 
-                        String beforeElementTag = "";
-                        if (i == children.size() - 1 && c.DTD_SUBSET_CLOSE() != null) {
-                            beforeElementTag = prefix(c.DTD_SUBSET_CLOSE());
-                            advanceCursor(c.DTD_SUBSET_CLOSE().getSymbol().getStopIndex() + 1);
-                        }
-
-                        elements.add(
-                                new Xml.Element(
-                                        randomId(),
-                                        prefix(element),
-                                        Markers.EMPTY,
-                                        singletonList(ident),
-                                        beforeElementTag));
+                    String beforeElementTag = "";
+                    if (i == children.size() - 1) {
+                        beforeElementTag = prefix(c.DTD_SUBSET_CLOSE());
+                        advanceCursor(c.DTD_SUBSET_CLOSE().getSymbol().getStopIndex() + 1);
                     }
+
+                    elements.add(
+                            new Xml.Element(
+                                    randomId(),
+                                    prefix(element),
+                                    Markers.EMPTY,
+                                    singletonList(ident),
+                                    beforeElementTag));
                 }
                 externalSubsets = new Xml.DocTypeDecl.ExternalSubsets(randomId(), subsetPrefix, Markers.EMPTY, elements);
             }


### PR DESCRIPTION
## Summary

This PR adds tests for XML parsing behavior reported in customer issues:

- Test for comment/element preservation (whitespace between comments and elements)
- Test for XML prolog preservation

The original defensive code changes that added null safety were reverted because:
1. The XmlParser already wraps parsing in try-catch and converts exceptions to `ParseError`
2. The defensive changes could mask parsing errors and produce non-idempotent output
3. NPE/IndexOutOfBoundsException during parsing of malformed XML should result in a clear `ParseError` indicating the file failed to parse

Related to https://github.com/moderneinc/customer-requests/issues/857

## Test plan

- [x] Existing XML parser tests pass
- [x] New tests verify correct behavior for comment/element preservation and XML prolog handling