### PR TITLE
JavaScript: Add `OmitColon` marker for TypeScript YAML parser

### DIFF
--- a/rewrite-javascript/rewrite/src/yaml/index.ts
+++ b/rewrite-javascript/rewrite/src/yaml/index.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 export * from "./assertions";
+export * from "./markers";
 export * from "./parser";
 export * from "./tree";
 export * from "./visitor";
 
 import "./print";
 import "./rpc";
+import "./markers";

--- a/rewrite-javascript/rewrite/src/yaml/markers.ts
+++ b/rewrite-javascript/rewrite/src/yaml/markers.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Marker} from "../markers";
+import {randomId} from "../uuid";
+import {Yaml} from "./tree";
+import {RpcCodecs, RpcReceiveQueue, RpcSendQueue} from "../rpc";
+import {updateIfChanged} from "../util";
+
+declare module "./tree" {
+    namespace Yaml {
+        export const Markers: {
+            readonly OmitColon: "org.openrewrite.yaml.marker.OmitColon";
+        };
+    }
+}
+
+// At runtime actually attach it to Yaml
+(Yaml as any).Markers = {
+    OmitColon: "org.openrewrite.yaml.marker.OmitColon"
+} as const;
+
+/**
+ * Marker indicating that a mapping entry should be printed without a colon.
+ * This is used for flow mappings like { "key", "key2" } where entries lack explicit colons.
+ */
+export interface OmitColon extends Marker {
+    readonly kind: typeof Yaml.Markers.OmitColon;
+}
+
+/**
+ * Creates an OmitColon marker.
+ */
+export function omitColon(): OmitColon {
+    return {
+        kind: Yaml.Markers.OmitColon,
+        id: randomId()
+    };
+}
+
+/**
+ * Registers an RPC codec for any marker without additional properties.
+ */
+function registerMarkerCodec<M extends Marker>(kind: M["kind"]) {
+    RpcCodecs.registerCodec(kind, {
+        async rpcReceive(before: M, q: RpcReceiveQueue): Promise<M> {
+            return updateIfChanged(before, {
+                id: await q.receive(before.id),
+            } as Partial<M>);
+        },
+
+        async rpcSend(after: M, q: RpcSendQueue): Promise<void> {
+            await q.getAndSend(after, a => a.id);
+        }
+    });
+}
+
+registerMarkerCodec(Yaml.Markers.OmitColon);

--- a/rewrite-javascript/rewrite/src/yaml/parser.ts
+++ b/rewrite-javascript/rewrite/src/yaml/parser.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {emptyMarkers, markers, MarkersKind, ParseExceptionResult} from "../markers";
+import {omitColon} from "./markers";
 import {Parser, ParserInput, parserInputRead, Parsers} from "../parser";
 import {randomId} from "../uuid";
 import {SourceFile} from "../tree";
@@ -639,12 +640,15 @@ class YamlCstReader {
             value = this.createEmptyScalar(afterColonSpace);
         }
 
+        // In flow mappings like { "MV7", "7J04" }, entries may lack explicit colons
+        const entryMarkers = seenColon ? emptyMarkers : markers(omitColon());
+
         return {
             entry: {
                 kind: Yaml.Kind.MappingEntry,
                 id: randomId(),
                 prefix,
-                markers: emptyMarkers,
+                markers: entryMarkers,
                 key,
                 beforeMappingValueIndicator,
                 value

--- a/rewrite-javascript/rewrite/src/yaml/print.ts
+++ b/rewrite-javascript/rewrite/src/yaml/print.ts
@@ -17,7 +17,8 @@ import {PrintOutputCapture, TreePrinters} from "../print";
 import {YamlVisitor} from "./visitor";
 import {printTag, Yaml} from "./tree";
 import {Cursor} from "../tree";
-import {Markers} from "../markers";
+import {findMarker, Markers} from "../markers";
+import "./markers"; // Ensures Yaml.Markers is defined
 
 class YamlPrinter extends YamlVisitor<PrintOutputCapture> {
 
@@ -88,7 +89,9 @@ class YamlPrinter extends YamlVisitor<PrintOutputCapture> {
         await this.beforeSyntax(entry, p);
         await this.visit(entry.key, p);
         p.append(entry.beforeMappingValueIndicator);
-        p.append(':');
+        if (!findMarker(entry, Yaml.Markers.OmitColon)) {
+            p.append(':');
+        }
         await this.visit(entry.value, p);
         this.afterSyntax(entry, p);
         return entry;

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/marker/OmitColon.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/marker/OmitColon.java
@@ -18,6 +18,9 @@ package org.openrewrite.yaml.marker;
 import lombok.Value;
 import lombok.With;
 import org.openrewrite.marker.Marker;
+import org.openrewrite.rpc.RpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
 
 import java.util.UUID;
 
@@ -27,6 +30,16 @@ import java.util.UUID;
  */
 @Value
 @With
-public class OmitColon implements Marker {
+public class OmitColon implements Marker, RpcCodec<OmitColon> {
     UUID id;
+
+    @Override
+    public void rpcSend(OmitColon after, RpcSendQueue q) {
+        q.getAndSend(after, Marker::getId);
+    }
+
+    @Override
+    public OmitColon rpcReceive(OmitColon before, RpcReceiveQueue q) {
+        return before.withId(q.receiveAndGet(before.getId(), UUID::fromString));
+    }
 }


### PR DESCRIPTION
- Ports the `OmitColon` marker feature from commit 936436249 (PR #6604) to TypeScript, fixing idempotency issues with flow mappings that lack explicit colons.

- Add `src/yaml/markers.ts` with `OmitColon` marker definition, helper function, and RPC codec
- Update YAML parser to detect flow mapping entries without colons (e.g., `{ "MV7", "7J04" }`)
- Update YAML printer to skip colon when `OmitColon` marker is present
- Add RPC codec to Java `OmitColon` marker for cross-language compatibility
- Add 7 new test cases for flow mappings and single-brace template syntax
