### PR TITLE
Keep trailing newlines in literal/folded YAML scalar values

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteKey.java
@@ -55,12 +55,26 @@ public class DeleteKey extends Recipe {
         return Preconditions.check(new FindSourceFiles(filePattern), new YamlIsoVisitor<ExecutionContext>() {
 
             @Override
-            public  Yaml.Sequence.@Nullable Entry visitSequenceEntry(Yaml.Sequence.Entry entry, ExecutionContext ctx) {
-                if (matcher.matches(getCursor()) || matcher.matches(new Cursor(getCursor(), entry.getBlock()))) {
-                    removeUnused(getCursor().getParent());
-                    return null;
+            public Yaml.Sequence visitSequence(Yaml.Sequence sequence, ExecutionContext ctx) {
+                Yaml.Sequence s = super.visitSequence(sequence, ctx);
+                AtomicReference<@Nullable String> copyFirstPrefix = new AtomicReference<>();
+                s = s.withEntries(ListUtils.map(s.getEntries(), (i, e) -> {
+                    if (matcher.matches(new Cursor(getCursor(), e)) || matcher.matches(new Cursor(getCursor(), e.getBlock()))) {
+                        if (i == 0) {
+                            copyFirstPrefix.set(e.getPrefix());
+                        }
+                        removeUnused(getCursor());
+                        return null;
+                    }
+                    return e;
+                }));
+
+                if (!s.getEntries().isEmpty() && copyFirstPrefix.get() != null) {
+                    //noinspection DataFlowIssue
+                    s = s.withEntries(ListUtils.mapFirst(s.getEntries(), e -> e.withPrefix(copyFirstPrefix.get())));
                 }
-                return super.visitSequenceEntry(entry, ctx);
+
+                return s;
             }
 
             @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -310,10 +310,6 @@ public class YamlParser implements org.openrewrite.Parser {
                             case FOLDED:
                             case LITERAL:
                                 scalarValue = reader.readStringFromBuffer(valueStart + 1, event.getEndMark().getIndex() - 1);
-                                if (scalarValue.endsWith("\n")) {
-                                    newLine = "\n";
-                                    scalarValue = scalarValue.substring(0, scalarValue.length() - 1);
-                                }
                                 break;
                             default:
                                 scalarValue = reader.readStringFromBuffer(valueStart + 1, event.getEndMark().getIndex() - 1);

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/IndentsVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/IndentsVisitor.java
@@ -99,6 +99,14 @@ public class IndentsVisitor<P> extends YamlIsoVisitor<P> {
                 getCursor().putMessage("lastIndent", indent + style.getIndentSize());
             } else {
                 y = y.withPrefix(indentComments(y.getPrefix(), indent));
+                // For entries following literal/folded scalars (whose prefix has no line break
+                // because the newline is at the end of the scalar value), we still need to
+                // update lastIndent for any nested content. The entry's actual indent is
+                // computed from its prefix.
+                int entryIndent = findIndent(y.getPrefix());
+                if (entryIndent > 0) {
+                    getCursor().putMessage("lastIndent", entryIndent);
+                }
             }
         } else if (y instanceof Yaml.Scalar && y.getMarkers().findFirst(MultilineScalarChanged.class).isPresent()) {
             int indentValue = indent;

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -729,4 +729,75 @@ class YamlParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void literalScalarTrailingNewlineInValue() {
+        // Literal (|) and folded (>) scalars should keep trailing newlines in their value
+        // The next entry's prefix should be just indentation, not include the newline
+        rewriteRun(
+          yaml(
+            """
+              parent:
+                message: |
+                  line1
+                  line2
+                next: value
+              """,
+            spec -> spec.afterRecipe(docs -> new YamlIsoVisitor<Integer>() {
+                @Override
+                public Yaml.Scalar visitScalar(Yaml.Scalar scalar, Integer ctx) {
+                    if (scalar.getStyle() == Yaml.Scalar.Style.LITERAL) {
+                        // Literal scalar value should end with newline
+                        assertThat(scalar.getValue()).endsWith("\n");
+                    }
+                    return super.visitScalar(scalar, ctx);
+                }
+
+                @Override
+                public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, Integer ctx) {
+                    if ("next".equals(entry.getKey().getValue())) {
+                        // Entry following literal scalar has prefix with just indentation (no leading newline)
+                        assertThat(entry.getPrefix()).isEqualTo("  ");
+                    }
+                    return super.visitMappingEntry(entry, ctx);
+                }
+            }.visit(docs, 0))
+          )
+        );
+    }
+
+    @Test
+    void foldedScalarTrailingNewlineInValue() {
+        // Folded (>) scalars should also keep trailing newlines in their value
+        rewriteRun(
+          yaml(
+            """
+              parent:
+                description: >
+                  This is a folded
+                  multiline string.
+                status: active
+              """,
+            spec -> spec.afterRecipe(docs -> new YamlIsoVisitor<Integer>() {
+                @Override
+                public Yaml.Scalar visitScalar(Yaml.Scalar scalar, Integer ctx) {
+                    if (scalar.getStyle() == Yaml.Scalar.Style.FOLDED) {
+                        // Folded scalar value should end with newline
+                        assertThat(scalar.getValue()).endsWith("\n");
+                    }
+                    return super.visitScalar(scalar, ctx);
+                }
+
+                @Override
+                public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, Integer ctx) {
+                    if ("status".equals(entry.getKey().getValue())) {
+                        // Entry following folded scalar has prefix with just indentation (no leading newline)
+                        assertThat(entry.getPrefix()).isEqualTo("  ");
+                    }
+                    return super.visitMappingEntry(entry, ctx);
+                }
+            }.visit(docs, 0))
+          )
+        );
+    }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/ScalarTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/ScalarTest.java
@@ -54,7 +54,9 @@ class ScalarTest implements RewriteTest {
                     @Override
                     public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, Object o) {
                         if ("baz".equals(entry.getKey().getValue())) {
-                            assertThat(entry.getPrefix()).isEqualTo("\n  ");
+                            // After a literal/folded scalar, the trailing newline is kept in the
+                            // scalar value, so the next entry's prefix is just indentation
+                            assertThat(entry.getPrefix()).isEqualTo("  ");
                         }
                         return super.visitMappingEntry(entry, o);
                     }


### PR DESCRIPTION
Aligns the Java YAML parser behavior with the TypeScript parser for literal (`|`) and folded (`>`) scalars.

### Changes

- **YamlParser**: Remove newline stripping from literal/folded scalar values - the trailing newline is now part of the scalar value rather than being prepended to the next element's prefix
- **IndentsVisitor**: Update lastIndent tracking for mapping entries whose prefix has no leading newline (entries following literal/folded scalars)
- **DeleteKey**: Add prefix propagation when deleting sequence entries to preserve proper formatting
