### PR TITLE
Support both tag and digest in Docker

### DIFF
--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerPrinter.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerPrinter.java
@@ -84,7 +84,8 @@ public class DockerPrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
         if (from.getTag() != null) {
             p.append(":");
             visit(from.getTag(), p);
-        } else if (from.getDigest() != null) {
+        }
+        if (from.getDigest() != null) {
             p.append("@");
             visit(from.getDigest(), p);
         }


### PR DESCRIPTION
Previously we were print idempotent, but not modeled correctly on this particular aspect, as discovered on
- #6616