### PR TITLE
Allow Gradle AddDependency to work with explicit configuration without Java sources

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
@@ -181,9 +181,10 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(Scanned acc) {
-        // Allow when configuration is explicitly provided OR when source files were scanned
+        // Allow when configuration is explicitly provided, when onlyIfUsing is not set (default to "implementation"),
+        // or when source files were scanned
         boolean hasExplicitConfiguration = !StringUtils.isBlank(configuration);
-        return Preconditions.check(hasExplicitConfiguration || !acc.configurationsByProject.isEmpty(),
+        return Preconditions.check(hasExplicitConfiguration || onlyIfUsing == null || !acc.configurationsByProject.isEmpty(),
                 Preconditions.check(new IsBuildGradle<>(), new JavaIsoVisitor<ExecutionContext>() {
 
                     @Override
@@ -198,10 +199,10 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                         if (!maybeGp.isPresent()) {
                             return s;
                         }
-                        // When configuration needs to be inferred, require JavaProject and source set info
-                        if (!hasExplicitConfiguration) {
+                        // When configuration needs to be inferred and onlyIfUsing is set, require JavaProject and source set info
+                        if (!hasExplicitConfiguration && onlyIfUsing != null) {
                             if (!maybeJp.isPresent() ||
-                                    (onlyIfUsing != null && !acc.usingType.getOrDefault(maybeJp.get(), false)) ||
+                                    !acc.usingType.getOrDefault(maybeJp.get(), false) ||
                                     !acc.configurationsByProject.containsKey(maybeJp.get())) {
                                 return s;
                             }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -1374,6 +1374,39 @@ class AddDependencyTest implements RewriteTest {
         );
     }
 
+    @Test
+    void addWithNoTypeFilterAndNoJavaSourcesDefaultsToImplementation() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", null, null)),
+          mavenProject("project",
+            buildGradle(
+              """
+                plugins {
+                    id 'java'
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+                """,
+              """
+                plugins {
+                    id 'java'
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    implementation "com.google.guava:guava:29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
     @Issue("https://github.com/moderneinc/customer-requests/issues/792")
     @Nested
     class AddToJVMTestSuite {


### PR DESCRIPTION
## What's changed?

Modified `AddDependency` in rewrite-gradle to allow adding dependencies when an explicit configuration is provided, even without Java source files being scanned. Previously, the recipe required Java sources to determine which configuration to use. Now, when configuration is explicitly set (e.g., "implementation"), the recipe bypasses the scan phase requirement and adds the dependency directly.

## What's your motivation?

The behavior of the Maven and the Gradle `AddDependency` behavior differs. That's specifically problematic when you use the convenience `AddDependency` recipe from rewrite-java-dependencies.

## Have you considered any alternatives or workarounds?

The alternative is requiring callers to fully integrate with the scan phase by overriding `getInitialValue()` and `getScanner()`, but this adds significant complexity for recipes that already know which configuration they want to target.

## Any additional context

This aligns with how Maven's `AddDependency` works - it allows adding dependencies when `onlyIfUsing` is `null` without requiring scan phase data.
