### PR TITLE
Fix NPE in ProtoParser for malformed syntax declarations

### DIFF
--- a/rewrite-protobuf/src/test/java/org/openrewrite/protobuf/ProtoParserTest.java
+++ b/rewrite-protobuf/src/test/java/org/openrewrite/protobuf/ProtoParserTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.SourceFile;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.text.PlainText;
+import org.openrewrite.tree.ParseError;
 
 import java.util.List;
 
@@ -30,6 +31,15 @@ class ProtoParserTest implements RewriteTest {
     void noNullsForProto3Files() {
         List<SourceFile> sources = ProtoParser.builder().build().parse("syntax = \"proto3\";").toList();
         assertThat(sources).singleElement().isInstanceOf(PlainText.class);
+    }
+
+    @Test
+    void malformedSyntaxDoesNotThrowNPE() {
+        List<SourceFile> sources = ProtoParser.builder().build().parse("syntax = proto2;").toList();
+        assertThat(sources).singleElement().satisfiesAnyOf(
+                s -> assertThat(s).isInstanceOf(PlainText.class),
+                s -> assertThat(s).isInstanceOf(ParseError.class)
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Replace fragile `sourceStr.contains("proto3")` check with proper ANTLR parse tree inspection
- Guard against null `stringLiteral()` / `StringLiteral()` from ANTLR error recovery
- Fall back to `PlainText` instead of throwing NPE for unparseable syntax declarations

## Problem

A `NullPointerException` in `ProtoParserVisitor.visitSyntax()` was observed 11 times in Colruyt's environment:
```
java.lang.NullPointerException: null
  org.openrewrite.protobuf.internal.ProtoParserVisitor.visitSyntax(ProtoParserVisitor.java:415)
  org.openrewrite.protobuf.internal.ProtoParserVisitor.visitProto(ProtoParserVisitor.java:313)
```

The old code used `sourceStr.contains("proto3")` to decide whether to skip full parsing. Proto files with malformed syntax declarations that don't contain "proto3" would bypass this check and proceed to the visitor, which would NPE on `ctx.stringLiteral().StringLiteral().getText()` when ANTLR error recovery produced null context children.

## Solution

Parse the ANTLR tree first, then inspect the syntax context node directly:
1. If `stringLiteral()` is null → fall back to PlainText (malformed syntax)
2. If `StringLiteral()` is null → fall back to PlainText (ANTLR error recovery)
3. If the literal contains "proto3" → fall back to PlainText (existing behavior)
4. Reuse the already-parsed `protoCtx` for the visitor instead of parsing twice

## Test plan

- [x] Existing tests pass
- [x] New `malformedSyntaxDoesNotThrowNPE` test added

- Fixes moderneinc/customer-requests#854