### PR TITLE
Fix Groovy parser for closure parameters with default values

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LambdaTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LambdaTest.java
@@ -98,6 +98,21 @@ class LambdaTest implements RewriteTest {
         );
     }
 
+    @Test
+    void closureParameterWithDefaultValue() {
+        rewriteRun(
+          groovy(
+            """
+              javadoc {
+                  options {
+                      group = 'WDK Language' -> 'com.symphony.bdk.workflow*'
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/2168")
     @Test
     void closureNoArguments() {


### PR DESCRIPTION
- Fix `visitClosureExpression` in `GroovyParserVisitor` to handle closure parameters that have default values (e.g., `group = 'WDK Language' -> body`)
- Previously the parser did not consume the `= <defaultValue>` portion from the source, causing cursor desync and garbled output
- Add test case `closureParameterWithDefaultValue` in `LambdaTest` covering this syntax as seen in Gradle build scripts

```groovy
javadoc {
    options {
        group = 'WDK Language' -> 'com.symphony.bdk.workflow*'
    }
}
```