### PR TITLE
Fix JSON parser handling of special characters inside strings

### DIFF
--- a/rewrite-json/src/main/java/org/openrewrite/json/internal/JsonParserVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/internal/JsonParserVisitor.java
@@ -325,39 +325,45 @@ public class JsonParserVisitor extends JSON5BaseVisitor<Json> {
     private int positionOfNext(String untilDelim, @Nullable Character stop) {
         boolean inMultiLineComment = false;
         boolean inSingleLineComment = false;
+        char stringQuote = 0; // 0 = not in string, '"' or '\'' = in that string type
 
         int delimIndex = cursor;
         for (; delimIndex < source.length() - untilDelim.length() + 1; delimIndex++) {
+            char c = source.charAt(delimIndex);
+
+            if (stringQuote != 0) {
+                if (c == '\\' && delimIndex + 1 < source.length()) {
+                    delimIndex++;
+                } else if (c == stringQuote) {
+                    stringQuote = 0;
+                }
+                continue;
+            }
+
             if (inSingleLineComment) {
-                if (source.charAt(delimIndex) == '\n') {
+                if (c == '\n') {
                     inSingleLineComment = false;
                 }
-            } else {
-                if (inMultiLineComment) {
-                    if (source.charAt(delimIndex) == '*' && source.charAt(delimIndex + 1) == '/') {
-                        inMultiLineComment = false;
-                        delimIndex += 2;
-                    }
-                } else if (source.charAt(delimIndex) == '/' && source.length() - untilDelim.length() > delimIndex + 1) {
-                    int next = source.charAt(delimIndex + 1);
-                    if (next == '/') {
-                        inSingleLineComment = true;
-                        delimIndex++;
-                    } else if (next == '*') {
-                        inMultiLineComment = true;
-                        delimIndex++;
-                    }
+            } else if (inMultiLineComment) {
+                if (c == '*' && delimIndex + 1 < source.length() && source.charAt(delimIndex + 1) == '/') {
+                    inMultiLineComment = false;
+                    delimIndex++;
                 }
-
-                if (!inMultiLineComment && !inSingleLineComment) {
-                    if (stop != null && source.charAt(delimIndex) == stop) {
-                        return -1; // reached stop word before finding the delimiter
-                    }
-
-                    if (source.startsWith(untilDelim, delimIndex)) {
-                        break; // found it!
-                    }
+            } else if (c == '"' || c == '\'') {
+                stringQuote = c;
+            } else if (c == '/' && source.length() - untilDelim.length() > delimIndex + 1) {
+                char next = source.charAt(delimIndex + 1);
+                if (next == '/') {
+                    inSingleLineComment = true;
+                    delimIndex++;
+                } else if (next == '*') {
+                    inMultiLineComment = true;
+                    delimIndex++;
                 }
+            } else if (stop != null && c == stop) {
+                return -1;
+            } else if (source.startsWith(untilDelim, delimIndex)) {
+                break;
             }
         }
 

--- a/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
@@ -211,4 +211,106 @@ class JsonParserTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/852")
+    @Test
+    void stringWithDoubleAsterisk() {
+        rewriteRun(
+          json(
+            """
+              {"pattern": "**/*.java"}
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/852")
+    @Test
+    void stringWithDelimitersInside() {
+        rewriteRun(
+          json(
+            """
+              {
+                  "message": "Hello: World, how are {you}?",
+                  "array": ["item: one, two"]
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/852")
+    @Test
+    void stringWithCommentLikeSequences() {
+        rewriteRun(
+          json(
+            """
+              {
+                  "url": "https://example.com/path",
+                  "code": "/* not a comment */",
+                  "regex": "// pattern"
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/852")
+    @Test
+    void stringWithEscapedQuotes() {
+        rewriteRun(
+          json(
+            """
+              {"nested": "He said \\"Hello\\""}
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/852")
+    @Test
+    void stringWithPrintfAndTemplates() {
+        rewriteRun(
+          json(
+            """
+              {
+                  "printf": "Hello %s, count: %d",
+                  "freemarker": "<#if x>value</#if>"
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/852")
+    @Test
+    void singleQuotedStringsWithSpecialChars() {
+        rewriteRun(
+          json(
+            """
+              {
+                  'pattern': '**/*.java',
+                  'url': 'https://example.com'
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/852")
+    @Test
+    void complexNestedWithSpecialStrings() {
+        rewriteRun(
+          json(
+            """
+              {
+                  "config": {
+                      "patterns": ["**/*.java", "src/**/*.ts"],
+                      "message": "Build: { status: 'ok' }"
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Fix `positionOfNext()` method to track string literal boundaries
- Add proper escape sequence handling for both single and double quoted strings
- Add 7 new test cases covering the reported issues

## Problem

The JSON parser's `positionOfNext()` method was not tracking whether it was inside a string literal. This caused special characters like `**`, `/*`, `//`, `:`, `,`, `{`, `}` inside strings to be incorrectly interpreted as structural delimiters or comment markers.

This led to idempotency failures for JSON files containing:
- Glob patterns like `**/*.java`
- URLs with protocols like `https://`
- Comment-like sequences in strings (`/* */`, `//`)
- FreeMarker templates (`<#if>`)
- Printf templates (`%s`)
- Delimiters inside string values

## Solution

Modified `positionOfNext()` to:
1. Track when inside double-quoted strings (`"..."`)
2. Track when inside single-quoted strings (`'...'` for JSON5)
3. Handle escape sequences properly (e.g., `\"` doesn't end the string)
4. Skip delimiter/comment detection when inside strings

## Test plan

- [x] New tests added covering all reported issue types
- [ ] Existing tests pass (requires CI with all Java toolchains)

- Fixes moderneinc/customer-requests#852