### PR TITLE
Fix `TypeUtils#isAssignableToGeneric()`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateGenericsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateGenericsTest.java
@@ -406,6 +406,47 @@ class JavaTemplateGenericsTest implements RewriteTest {
     }
 
     @Test
+    void templateShouldNotMatchWhenWildcardCaptureBreaksAfterTemplate() {
+        // Simulates the AssertJMapRules.AbstractMapAssertContainsExactlyInAnyOrderEntriesOf Refaster rule.
+        // The before template matches mapAssert.isEqualTo(map), but when the map assert's value type
+        // is a wildcard (? extends Class<?>), the after template's containsExactlyInAnyOrderEntriesOf()
+        // produces uncompilable code due to Java's wildcard capture rules.
+        var beforeTemplate = JavaTemplate
+          .builder("#{mapAssert:any(org.assertj.core.api.AbstractMapAssert<?, ?, K, V>)}.isEqualTo(#{map:any(java.util.Map<? extends K, ? extends V>)})")
+          .bindType("org.assertj.core.api.AbstractMapAssert<?, ?, K, V>")
+          .genericTypes("K", "V")
+          .javaParser(JavaParser.fromJavaVersion().classpath("assertj-core"))
+          .build();
+
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  return beforeTemplate.matches(getCursor()) ? SearchResult.found(method) : super.visitMethodInvocation(method, ctx);
+              }
+          })),
+          java(
+            """
+              import java.util.Collections;
+              import java.util.Map;
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class Test {
+                  Map<String, ? extends Class<?>> getArgumentDefinitions() {
+                      return Collections.singletonMap("arg", String.class);
+                  }
+                  void test() {
+                      // V binds to "? extends Class<?>" — containsExactlyInAnyOrderEntriesOf would not compile
+                      assertThat(getArgumentDefinitions()).isEqualTo(Collections.singletonMap("arg", String.class));
+                  }
+              }
+              """
+            // No expected output — the template should NOT match, so no SearchResult marker
+          )
+        );
+    }
+
+    @Test
     void memberReferenceToLambda() {
         //noinspection Convert2MethodRef
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -524,6 +524,12 @@ public class TypeUtils {
         if (isWildcard(to) || context.getInference() == TO) {
             // If target "to" wildcard is unbounded, it accepts anything
             if (to.getBounds().isEmpty()) {
+                // A named type variable (e.g. V) should not bind to a wildcard (e.g. ? extends Class<?>),
+                // as this produces uncompilable code when the variable is later used in generic positions
+                // that create nested wildcard captures (e.g. Map<? extends K, ? extends V>).
+                if (!isWildcard(to) && isWildcard(from)) {
+                    return false;
+                }
                 return true;
             }
 


### PR DESCRIPTION
Prevent named type variables from binding to wildcards during inference.

### Summary

`TypeUtils.isAssignableToGeneric()` incorrectly allows an unbounded named type variable (e.g. `V`) to bind to a wildcard type (e.g. `? extends Class<?>`) during template matching. This causes Refaster-based recipes to match code where the after template produces uncompilable output due to nested wildcard captures.

### Problem

When a `JavaTemplate` before-template like:
```
#{mapAssert:any(AbstractMapAssert<?, ?, K, V>)}.isEqualTo(#{map:any(Map<? extends K, ? extends V>)})
```
is matched against code where the receiver has type `MapAssert<String, ? extends Class<?>>`, the type variable `V` binds to `? extends Class<?>`. The after-template then substitutes this into `containsExactlyInAnyOrderEntriesOf(Map<? extends K, ? extends V>)`, creating a double wildcard capture (`? extends (? extends Class<?>)`) that Java's type system cannot resolve — producing a compilation error.

The root cause is in `isAssignableToGeneric()` at the early return for unbounded types:
```java
if (to.getBounds().isEmpty()) {
    return true; // ← allows V to bind to "? extends Class<?>"
}
```
This block is entered via the `context.getInference() == TO` condition, which applies to both wildcards and named type variables. The "unbounded accepts anything" logic is correct for wildcards (`?`) but not for named type variables (`V`) when the source is itself a wildcard.

### Fix

- Added a guard in `isAssignableToGeneric()` that returns `false` when a named type variable (not a wildcard) would bind to a wildcard type
- Added a test case in `JavaTemplateGenericsTest` that reproduces the real-world failure from the `AssertJMapRules.AbstractMapAssertContainsExactlyInAnyOrderEntriesOf` Refaster rule against a `Map<String, ? extends Class<?>>` assertion

### Real-world impact

This bug caused the `org.openrewrite.java.testing.assertj.Assertj` recipe to produce 4 compilation errors when run against [finos/symphony-bdk-java](https://github.com/finos/symphony-bdk-java), where `SlashCommandPattern.getArgumentDefinitions()` returns `Map<String, ? extends Class<?>>`.
