### PR TITLE
Optimize `RecipeStack` to eliminate `Stack` copying

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipePath.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipePath.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scheduling;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Recipe;
+
+import java.util.AbstractList;
+
+/**
+ * A persistent linked-list representing a path from the root recipe to a descendant.
+ * Each child holds a reference to its parent, so creating a child path is O(1)
+ * instead of copying the entire path.
+ */
+class RecipePath extends AbstractList<Recipe> {
+    private final Recipe recipe;
+    private final @Nullable RecipePath parent;
+    private final int size;
+
+    public RecipePath(Recipe recipe) {
+        this(recipe, null);
+    }
+
+    private RecipePath(Recipe recipe, @Nullable RecipePath parent) {
+        this.recipe = recipe;
+        this.parent = parent;
+        this.size = (parent == null) ? 1 : parent.size + 1;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public Recipe get(int index) {
+        if (index < 0 || index >= size) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
+        }
+        // Walk back from this node to find the element at the given index
+        RecipePath current = this;
+        for (int i = size - 1; i > index; i--) {
+            assert current.parent != null;
+            current = current.parent;
+        }
+        return current.recipe;
+    }
+
+    Recipe leaf() {
+        return recipe;
+    }
+
+    RecipePath child(Recipe childRecipe) {
+        return new RecipePath(childRecipe, this);
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -84,7 +84,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         if (isScanningRequired()) {
             return sourceSetEditor.apply(sourceSet, sourceFile ->
                     allRecipeStack.reduce(sourceSet, recipe, ctx, (source, recipeStack) -> {
-                        Recipe recipe = recipeStack.peek();
+                        Recipe recipe = recipeStack.get(recipeStack.size() - 1);
                         if (source == null) {
                             return null;
                         }
@@ -126,7 +126,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
     public LSS generateSources(LSS sourceSet) {
         if (isScanningRequired()) {
             List<SourceFile> generatedInThisCycle = allRecipeStack.reduce(sourceSet, recipe, ctx, (acc, recipeStack) -> {
-                Recipe recipe = recipeStack.peek();
+                Recipe recipe = recipeStack.get(recipeStack.size() - 1);
                 if (recipe instanceof ScanningRecipe) {
                     assert acc != null;
                     //noinspection unchecked
@@ -178,7 +178,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
     protected @Nullable SourceFile editSource(LSS sourceSet, SourceFile sourceFile) {
         recipeRunStats.recordSourceVisited(sourceFile);
         return allRecipeStack.reduce(sourceSet, recipe, ctx, (source, recipeStack) -> {
-            Recipe recipe = recipeStack.peek();
+            Recipe recipe = recipeStack.get(recipeStack.size() - 1);
             if (source == null) {
                 return null;
             }
@@ -237,10 +237,10 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         }, sourceFile);
     }
 
-    protected void recordSourceFileResultAndSearchResults(@Nullable SourceFile before, @Nullable SourceFile after, Stack<Recipe> recipeStack, ExecutionContext ctx) {
+    protected void recordSourceFileResultAndSearchResults(@Nullable SourceFile before, @Nullable SourceFile after, List<Recipe> recipeStack, ExecutionContext ctx) {
         String beforePath = (before == null) ? "" : before.getSourcePath().toString();
         String afterPath = (after == null) ? "" : after.getSourcePath().toString();
-        Recipe recipe = recipeStack.peek();
+        Recipe recipe = recipeStack.get(recipeStack.size() - 1);
         Long effortSeconds = (recipe.getEstimatedEffortPerOccurrence() == null || Result.isLocalAndHasNoChanges(before, after)) ?
                 0L : recipe.getEstimatedEffortPerOccurrence().getSeconds();
 

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeSchedulerTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeSchedulerTest.java
@@ -232,7 +232,7 @@ class RecipeSchedulerTest implements RewriteTest {
                     @Override
                     protected void recordSourceFileResultAndSearchResults(
                             @Nullable SourceFile before, @Nullable SourceFile after,
-                            java.util.Stack<Recipe> recipeStack, ExecutionContext ctx) {
+                            java.util.List<Recipe> recipeStack, ExecutionContext ctx) {
                         if (before instanceof PlainText) {
                             beforeContents.add(((PlainText) before).getText());
                         }
@@ -279,7 +279,7 @@ class RecipeSchedulerTest implements RewriteTest {
                     @Override
                     protected void recordSourceFileResultAndSearchResults(
                             @Nullable SourceFile before, @Nullable SourceFile after,
-                            java.util.Stack<Recipe> recipeStack, ExecutionContext ctx) {
+                            java.util.List<Recipe> recipeStack, ExecutionContext ctx) {
                         // Track files that were generated (before is null)
                         if (before == null && after != null) {
                             generatedPaths.add(after.getSourcePath().toString());


### PR DESCRIPTION
- Introduce immutable `RecipePath`, a persistent linked-list where each child holds a pointer to its parent, making child creation O(1) instead of O(D) copy
- Replace `Stack<Stack<Recipe>>` with `ArrayDeque<RecipePath>`, eliminating per-node `Stack` allocation and `addAll()` copying in `recurseRecipeList()`
- Remove synchronized `java.util.Stack` usage in favor of unsynchronized `ArrayDeque`
- Widen `RecipeRunCycle.recordSourceFileResultAndSearchResults` parameter from `Stack<Recipe>` to `List<Recipe>`, since `RecipePath` implements `AbstractList<Recipe>` and is safely shared as an immutable value
- Use `ListIterator` for reverse traversal of recipe lists to avoid index-based random access
