### PR TITLE
Improve performance of `JavaTemplate$Matcher#find()`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
@@ -105,8 +105,16 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <J2 extends J> J2 apply(Cursor scope, JavaCoordinates coordinates, Object... parameters) {
+        return doApply(scope, coordinates, true, parameters);
+    }
+
+    <J2 extends J> J2 applyWithoutFormatting(Cursor scope, JavaCoordinates coordinates, Object... parameters) {
+        return doApply(scope, coordinates, false, parameters);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <J2 extends J> J2 doApply(Cursor scope, JavaCoordinates coordinates, boolean autoFormat, Object... parameters) {
         if (!(scope.getValue() instanceof J)) {
             throw new IllegalArgumentException("`scope` must point to a J instance.");
         }
@@ -116,7 +124,7 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
         onAfterVariableSubstitution.accept(substitutedTemplate);
 
         //noinspection ConstantConditions
-        J2 result = (J2) new JavaTemplateJavaExtension(templateParser, substitutions, substitutedTemplate, coordinates)
+        J2 result = (J2) new JavaTemplateJavaExtension(templateParser, substitutions, substitutedTemplate, coordinates, autoFormat)
                 .getMixin()
                 .visit(scope.getValue(), 0, scope.getParentOrThrow());
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplateSemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplateSemanticallyEqual.java
@@ -52,7 +52,7 @@ class JavaTemplateSemanticallyEqual extends SemanticallyEqual {
 
         J[] parameters = createTemplateParameters(template.getCode(), template.getGenericTypes());
         try {
-            J templateTree = template.apply(input, coordinates, (Object[]) parameters);
+            J templateTree = template.applyWithoutFormatting(input, coordinates, (Object[]) parameters);
             return matchTemplate(templateTree, input);
         } catch (RuntimeException e) {
             // FIXME this is just a workaround, as template matching finds many new corner cases in `JavaTemplate` which we need to fix

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -46,15 +46,24 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             Markers.EMPTY, new JRightPadded<>(false, Space.EMPTY, Markers.EMPTY),
             emptyList(), Space.format(" "));
 
+    private final boolean autoFormat;
+
     public JavaTemplateJavaExtension(JavaTemplateParser templateParser, Substitutions substitutions,
-                                     String substitutedTemplate, JavaCoordinates coordinates) {
+                                     String substitutedTemplate, JavaCoordinates coordinates,
+                                     boolean autoFormat) {
         super(templateParser, substitutions, substitutedTemplate, coordinates);
+        this.autoFormat = autoFormat;
     }
 
     @Override
     public TreeVisitor<? extends J, Integer> getMixin() {
         return new JavaVisitor<Integer>() {
             private boolean substituted;
+
+            @Override
+            public <J2 extends J> J2 autoFormat(J2 j, @Nullable J stopAfter, Integer p, Cursor parent) {
+                return autoFormat ? super.autoFormat(j, stopAfter, p, parent) : j;
+            }
 
             @Override
             public J visitAnnotation(J.Annotation annotation, Integer p) {


### PR DESCRIPTION
For some reason we were formatting the template tree each time `JavaTemplate$Matcher#find()` got called. For Refaster-based recipes which heavily rely on this, that ended up being quite expensive, so now the auto-formatting is completely disabled for that code path.
