### PR TITLE
Python recipe marketplace installer

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleReader.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleReader.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.marketplace;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.openrewrite.Recipe;
+import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.python.rpc.PythonRewriteRpc;
+import org.openrewrite.marketplace.RecipeBundle;
+import org.openrewrite.marketplace.RecipeBundleReader;
+import org.openrewrite.marketplace.RecipeListing;
+import org.openrewrite.marketplace.RecipeMarketplace;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class PipRecipeBundleReader implements RecipeBundleReader {
+    private final @Getter RecipeBundle bundle;
+    private final PythonRewriteRpc rpc;
+
+    @Override
+    public RecipeMarketplace read() {
+        return rpc.getMarketplace(bundle);
+    }
+
+    @Override
+    public RecipeDescriptor describe(RecipeListing listing) {
+        return rpc.prepareRecipe(listing.getName()).getDescriptor();
+    }
+
+    @Override
+    public Recipe prepare(RecipeListing listing, Map<String, Object> options) {
+        return rpc.prepareRecipe(listing.getName(), options);
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.marketplace;
+
+import lombok.RequiredArgsConstructor;
+import org.openrewrite.python.rpc.InstallRecipesResponse;
+import org.openrewrite.python.rpc.PythonRewriteRpc;
+import org.openrewrite.marketplace.RecipeBundle;
+import org.openrewrite.marketplace.RecipeBundleReader;
+import org.openrewrite.marketplace.RecipeBundleResolver;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@RequiredArgsConstructor
+public class PipRecipeBundleResolver implements RecipeBundleResolver {
+    private final PythonRewriteRpc rpc;
+
+    @Override
+    public String getEcosystem() {
+        return "pip";
+    }
+
+    @Override
+    public RecipeBundleReader resolve(RecipeBundle bundle) {
+        Path pkgPath = Paths.get(bundle.getPackageName());
+        InstallRecipesResponse response;
+        if (Files.exists(pkgPath)) {
+            response = rpc.installRecipes(pkgPath.toFile());
+        } else {
+            response = rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
+        }
+        if (response.getVersion() != null) {
+            bundle.setVersion(response.getVersion());
+        }
+        return new PipRecipeBundleReader(bundle, rpc);
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/InstallRecipesByFile.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/InstallRecipesByFile.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.rpc;
+
+import lombok.Value;
+import org.openrewrite.rpc.request.RpcRequest;
+
+import java.nio.file.Path;
+
+@Value
+class InstallRecipesByFile implements RpcRequest {
+    Path recipes;
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/InstallRecipesByPackage.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/InstallRecipesByPackage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.rpc;
+
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.rpc.request.RpcRequest;
+
+@Value
+class InstallRecipesByPackage implements RpcRequest {
+    Package recipes;
+
+    @Value
+    public static class Package {
+        String packageName;
+
+        @Nullable
+        String version;
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/InstallRecipesResponse.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/InstallRecipesResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.rpc;
+
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+
+@Value
+public class InstallRecipesResponse {
+    int recipesInstalled;
+    @Nullable String version;
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -97,6 +97,46 @@ public class PythonRewriteRpc extends RewriteRpc {
     }
 
     /**
+     * Install recipes from a local file path (e.g., a local pip package).
+     *
+     * @param recipes Path to the local package directory
+     * @return Response with installation details
+     */
+    public InstallRecipesResponse installRecipes(File recipes) {
+        return send(
+                "InstallRecipes",
+                new InstallRecipesByFile(recipes.getAbsoluteFile().toPath()),
+                InstallRecipesResponse.class
+        );
+    }
+
+    /**
+     * Install recipes from a package name.
+     *
+     * @param packageName The package name to install
+     * @return Response with installation details
+     */
+    public InstallRecipesResponse installRecipes(String packageName) {
+        return installRecipes(packageName, null);
+    }
+
+    /**
+     * Install recipes from a package name with a specific version.
+     *
+     * @param packageName The package name to install
+     * @param version     Optional version specification
+     * @return Response with installation details
+     */
+    public InstallRecipesResponse installRecipes(String packageName, @Nullable String version) {
+        return send(
+                "InstallRecipes",
+                new InstallRecipesByPackage(
+                        new InstallRecipesByPackage.Package(packageName, version)),
+                InstallRecipesResponse.class
+        );
+    }
+
+    /**
      * Parses an entire Python project directory.
      * Discovers and parses all relevant source files.
      *


### PR DESCRIPTION
## Summary
- Add `InstallRecipes` RPC method to install Python recipe packages from local paths or package specifications
- Implement `PipRecipeBundleResolver` and `PipRecipeBundleReader` for marketplace integration
- Use Python entry points (`openrewrite.recipes` group) to discover and activate recipe packages