### PR TITLE
Support positional literal notation for Gradle dependencies

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
@@ -513,4 +513,148 @@ class DependencyUseStringNotationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void positionalLiteralNotation() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              plugins {
+                  `java-library`
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation("com.google.guava", "guava", "30.1.1-jre")
+              }
+              """,
+            """
+              plugins {
+                  `java-library`
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation("com.google.guava:guava:30.1.1-jre")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void positionalLiteralNotationWithoutVersion() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              plugins {
+                  `java-library`
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation("com.google.guava", "guava")
+              }
+              """,
+            """
+              plugins {
+                  `java-library`
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation("com.google.guava:guava")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void positionalLiteralNotationWithVariableVersion() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              plugins {
+                  `java-library`
+              }
+
+              val guavaVersion = "30.1.1-jre"
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation("com.google.guava", "guava", guavaVersion)
+              }
+              """,
+            """
+              plugins {
+                  `java-library`
+              }
+
+              val guavaVersion = "30.1.1-jre"
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation("com.google.guava:guava:$guavaVersion")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void positionalLiteralNotationWithLambda() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              plugins {
+                  `java-library`
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation("com.google.guava", "guava", "30.1.1-jre") {
+                      exclude(group = "com.google.code.findbugs", module = "jsr305")
+                  }
+              }
+              """,
+            """
+              plugins {
+                  `java-library`
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation("com.google.guava:guava:30.1.1-jre") {
+                      exclude(group = "com.google.code.findbugs", module = "jsr305")
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -395,6 +395,100 @@ class UpgradeDependencyVersionTest implements RewriteTest {
         );
     }
 
+    @Test
+    void positionalLiteralNotation() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              plugins {
+                `java-library`
+              }
+
+              repositories {
+                mavenCentral()
+              }
+
+              dependencies {
+                implementation("com.google.guava", "guava", "29.0-jre")
+              }
+              """,
+            """
+              plugins {
+                `java-library`
+              }
+
+              repositories {
+                mavenCentral()
+              }
+
+              dependencies {
+                implementation("com.google.guava", "guava", "30.1.1-jre")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void positionalLiteralNotationWithVariableVersion() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              plugins {
+                `java-library`
+              }
+
+              val guavaVersion = "29.0-jre"
+
+              repositories {
+                mavenCentral()
+              }
+
+              dependencies {
+                implementation("com.google.guava", "guava", guavaVersion)
+              }
+              """,
+            """
+              plugins {
+                `java-library`
+              }
+
+              val guavaVersion = "30.1.1-jre"
+
+              repositories {
+                mavenCentral()
+              }
+
+              dependencies {
+                implementation("com.google.guava", "guava", guavaVersion)
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void positionalLiteralNotationWithoutVersion() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              plugins {
+                `java-library`
+              }
+
+              repositories {
+                mavenCentral()
+              }
+
+              dependencies {
+                implementation("com.google.guava", "guava")
+              }
+              """
+            // No change expected - no version to upgrade
+          )
+        );
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"$guavaVersion", "${guavaVersion}"})
     void mapNotationGStringInterpolation(String stringInterpolationReference) {


### PR DESCRIPTION
## Problem

Gradle supports a positional argument notation for declaring dependencies:
```kotlin
implementation("com.google.guava", "guava", "30.1.1-jre")
```

This form is deprecated in Gradle 9.1 and will fail in Gradle 10. The `DependencyUseStringNotation` recipe and `GradleDependency` trait did not recognize this notation.

## Solution

- Update `DependencyUseStringNotation` to convert positional notation to the recommended string notation (`"group:artifact:version"`)
- Update `GradleDependency` trait to parse and manipulate dependencies declared with positional notation
- Handle variations: with/without version, literal vs variable versions, and trailing lambda closures