### PR TITLE
Fix DeleteProperty losing newlines when deleting entries with block scalars

### DIFF
--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/DeletePropertyKeyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/DeletePropertyKeyTest.java
@@ -495,6 +495,30 @@ class DeletePropertyKeyTest implements RewriteTest {
     }
 
     @Test
+    void globPatternWithFoldedBlockScalarInSequence() {
+        rewriteRun(
+          spec -> spec.recipe(new DeleteProperty("acme.items.last-name", null, null, null)),
+          yaml(
+            """
+              acme:
+                items:
+                  - first-name: John
+                    last-name: >-
+                      Doe
+                  - first-name: Jane
+                    last-name: Smith
+              """,
+            """
+              acme:
+                items:
+                  - first-name: John
+                  - first-name: Jane
+              """
+          )
+        );
+    }
+
+    @Test
     void globPatternWithFoldedBlockScalarHigherParent() {
         rewriteRun(
           spec -> spec.recipe(new DeleteProperty("acme.my-project.*.last-name", null, null, null)),


### PR DESCRIPTION
## Summary
- Fixed bug where deleting YAML entries with block scalar values (`>-` or `|`) caused loss of newlines between entries
- Block scalar content in YAML includes trailing newlines that serve as separators; these were being lost when entries were deleted
- Added proper newline restoration for both sibling entries and parent mapping entries

## Test plan
- [x] Added test `globPatternWithFoldedBlockScalar` that reproduces the issue
- [x] All existing DeletePropertyKeyTest tests continue to pass (22 tests)
- [x] Full rewrite-yaml test suite passes