### PR TITLE
RPC - Remove mention of JavaScript for Python RPC server error message

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -134,7 +134,7 @@ public class RewriteRpcProcess extends Thread {
                 // Ignore errors reading final stdout
             }
 
-            String message = "JavaScript RPC process shut down early with exit code " + exitCode;
+            String message = "RPC process shut down early with exit code " + exitCode;
             String errorOutput = accumulatedStderr.toString();
             if (!stdOutput.isEmpty()) {
                 message += "\nStandard output:\n  " + stdOutput.replace("\n", "\n  ");


### PR DESCRIPTION
## What's changed?

Minor amendment to the error message for RPC server. Namely, don't mention JavaScript because the RPC server is now reused by Python as well. 

## What's your motivation?

Avoid confusion in error messages.