### PR TITLE
Improving `AddCommentToImport` when it comes to comments that get added at the beginning of the file

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/AddCommentToImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddCommentToImport.java
@@ -70,12 +70,13 @@ public class AddCommentToImport extends Recipe {
                     foundImport = true;
                     String prefixWhitespace = anImport.getPrefix().getWhitespace();
                     Matcher newlineMatcher = Pattern.compile("\\R").matcher(comment.trim());
+                    String adjustedPrefixWhitespace = prefixWhitespace.isEmpty() ? lineSeparator() : prefixWhitespace;
                     String newCommentText = comment.trim()
-                            .replaceAll("\\R", prefixWhitespace + " * ")
+                            .replaceAll("\\R", adjustedPrefixWhitespace + " * ")
                             .replace("*/", "*");
                     String formattedCommentText = newlineMatcher.find() ? lineSeparator() + " * " + newCommentText + lineSeparator() + " " : " " + newCommentText + " ";
                     if (doesNotHaveComment(formattedCommentText, anImport.getComments())) {
-                        TextComment textComment = new TextComment(true, formattedCommentText, prefixWhitespace, Markers.EMPTY);
+                        TextComment textComment = new TextComment(true, formattedCommentText, adjustedPrefixWhitespace, Markers.EMPTY);
                         return autoFormat(anImport.withComments(ListUtils.concat(anImport.getComments(), textComment)), ctx);
                     }
                 }
@@ -85,7 +86,8 @@ public class AddCommentToImport extends Recipe {
             private boolean doesNotHaveComment(String lookFor, List<Comment> comments) {
                 for (Comment c : comments) {
                     if (c instanceof TextComment &&
-                            lookFor.trim().equals(((TextComment) c).getText().trim())) {
+                            lookFor.trim().replaceAll("\\R", "\n")
+                                    .equals(((TextComment) c).getText().trim().replaceAll("\\R", "\n"))) {
                         return false;
                     }
                 }

--- a/rewrite-java/src/test/java/org/openrewrite/java/AddCommentToImportTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/AddCommentToImportTest.java
@@ -165,6 +165,27 @@ class AddCommentToImportTest implements RewriteTest {
     }
 
     @Test
+    void addSingleLineCommentAtTopOfFile() {
+        rewriteRun(
+          spec -> spec.recipe(new AddCommentToImport(SHORT_COMMENT, "foo..*")),
+          //language=java
+          java(
+            """
+              import foo.Foo;
+              import foo.Bar;
+              class OtherOne {}
+              """,
+            """
+              /* Short comment to add */
+              import foo.Foo;
+              import foo.Bar;
+              class OtherOne {}
+              """
+          )
+        );
+    }
+
+    @Test
     void addLongComment() {
         rewriteRun(
           spec -> spec.recipe(new AddCommentToImport(LONG_COMMENT, "foo..*")),
@@ -201,6 +222,47 @@ class AddCommentToImportTest implements RewriteTest {
             """
               package blah;
               /* Existing Comment */
+              /*
+               * This is a very long comment to add.
+               * The comment uses multiple lines.
+               */
+              import foo.Foo;
+              import foo.Bar;
+              class OtherTwo {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void addLongCommentAtTopOfFile() {
+        rewriteRun(
+          spec -> spec.recipe(new AddCommentToImport(LONG_COMMENT, "foo..*")),
+          //language=java
+          java(
+            """
+              import foo.Foo;
+              import foo.Bar;
+              class OtherOne {}
+              """,
+            """
+              /*
+               * This is a very long comment to add.
+               * The comment uses multiple lines.
+               */
+              import foo.Foo;
+              import foo.Bar;
+              class OtherOne {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              import foo.Foo;
+              import foo.Bar;
+              class OtherTwo {}
+              """,
+            """
               /*
                * This is a very long comment to add.
                * The comment uses multiple lines.


### PR DESCRIPTION
## What's changed?
When comments get added to imports at the very beginning of the file, it will now add a line separator as the comment's suffix so that it doesn't appear on the same line as the import

## What's your motivation?
The formatting looked a bit off

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
