### PR TITLE
Fix AddDependency adding versions for deps managed by upgraded parent

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -2369,4 +2369,5 @@ class ChangeParentPomTest implements RewriteTest {
           )
         );
     }
+
 }


### PR DESCRIPTION
## Summary

- Store fresh `ResolvedPom` instances in `ExecutionContext` when `UpdateMavenModel` updates a POM
- Overlay fresh POMs onto `projectPoms` before re-resolution so child POMs see updated parent data  
- Check fresh POMs from `ExecutionContext` in `AddDependencyVisitor` when determining if a version is managed

## Problem

When a recipe like `ChangeParentPom` or `UpgradeDependencyVersion` modifies a project parent POM (e.g., upgrading a BOM import version from Spring Boot 3.4.4 to 4.0.2), the changes were not visible to subsequent `AddDependency` calls on child POMs. This caused `AddDependency` to incorrectly add explicit versions for dependencies that were actually managed by the upgraded parent's dependency management.

For example, in a multi-module project with:
- `corp-parent` importing `spring-boot-dependencies:3.4.4`
- `demo` child module inheriting from `corp-parent`

When `UpgradeDependencyVersion` upgrades the BOM to 4.0.2, then `AddDependency` adds `spring-security-test`, it would incorrectly add `<version>6.4.2</version>` because the child's marker still saw the old 3.4.4 dependency management.

## Solution

The root cause was that `projectPoms` (`Map<Path, Pom>`) was built at parse time and never updated when recipes modified POMs. When `UpdateMavenModel` re-resolved a modified parent, it used stale `projectPoms` data, so the child POM's marker still had outdated dependency management information.

The fix has three parts:

1. **UpdateMavenModel** now stores fresh `ResolvedPom` instances in the `ExecutionContext` when it updates a POM, keyed by GAV
2. **UpdateMavenModel.updateResult()** overlays fresh POMs onto `projectPoms` before creating the `MavenPomDownloader`, so re-resolution sees the updated parent data
3. **AddDependencyVisitor** now checks fresh POMs from `ExecutionContext` when determining if a version is managed, walking up the parent chain

Also enhanced `Assertions.withLocalRepository()` to generate `maven-metadata-local.xml` files, which are needed for version resolution in `ChangeParentPom` tests.

## Test plan

- [x] Existing tests pass
- [x] New test `omitVersionWhenManagedByUpgradedProjectCorporateParentWithBomImport` reproduces and verifies the fix
- [x] Additional tests for multi-module and external parent scenarios

- Fixes moderneinc/customer-requests#1788