### PR TITLE
Fix OOME when calling getDescriptor on recipes with preconditions

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -318,6 +318,11 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
         }
 
         @Override
+        protected RecipeDescriptor createRecipeDescriptor() {
+            return delegate.getDescriptor();
+        }
+
+        @Override
         public void onComplete(ExecutionContext ctx) {
             delegate.onComplete(ctx);
         }
@@ -433,6 +438,11 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
         @Override
         public List<DataTableDescriptor> getDataTableDescriptors() {
             return delegate.getDataTableDescriptors();
+        }
+
+        @Override
+        protected RecipeDescriptor createRecipeDescriptor() {
+            return delegate.getDescriptor();
         }
 
         @Override


### PR DESCRIPTION
## Summary
- Override `createRecipeDescriptor()` in `BellwetherDecoratedRecipe` and `BellwetherDecoratedScanningRecipe` to delegate to the underlying recipe's descriptor
- Prevents exponential growth in decorator instances when building recipe descriptors

## Context
The "Singleton precondition" commit (v8.72.4) added many delegating methods to `BellwetherDecoratedRecipe` but didn't override `createRecipeDescriptor()`. The base `Recipe.createRecipeDescriptor()` implementation calls `getRecipeList()`, which in `BellwetherDecoratedRecipe` wraps sub-recipes in new decorator instances. When those wrapped recipes' descriptors are accessed, they trigger more wrapping, causing exponential growth.

## Test plan
- [x] Added test verifying wrapped recipe returns underlying descriptor
- [x] Existing DeclarativeRecipeTest tests pass
- [x] Verified fix resolves OOME in downstream project (rewrite-devcenter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)