### PR TITLE
Fix StackOverflowError in Validated.Both and redundant validation traversal

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -449,12 +449,7 @@ public abstract class Recipe implements Cloneable {
 
     @SuppressWarnings("unused")
     public Validated<Object> validate(ExecutionContext ctx) {
-        Validated<Object> validated = validate();
-
-        for (Recipe recipe : getRecipeList()) {
-            validated = validated.and(recipe.validate(ctx));
-        }
-        return validated;
+        return validate();
     }
 
     /**
@@ -474,9 +469,6 @@ public abstract class Recipe implements Cloneable {
             } catch (IllegalAccessException e) {
                 validated = Validated.invalid(field.getName(), null, "Unable to access " + clazz.getName() + "." + field.getName(), e);
             }
-        }
-        for (Recipe recipe : getRecipeList()) {
-            validated = validated.and(recipe.validate());
         }
         return validated;
     }

--- a/rewrite-core/src/main/java/org/openrewrite/Validated.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Validated.java
@@ -374,10 +374,22 @@ public interface Validated<T> extends Iterable<Validated<T>> {
 
         @Override
         public Iterator<Validated<T>> iterator() {
-            return Stream.concat(
-                    stream(left.spliterator(), false),
-                    stream(right.spliterator(), false)
-            ).iterator();
+            List<Validated<T>> result = new ArrayList<>();
+            Deque<Validated<T>> stack = new ArrayDeque<>();
+            stack.push(this);
+            while (!stack.isEmpty()) {
+                Validated<T> current = stack.pop();
+                if (current instanceof Both) {
+                    Both<T> both = (Both<T>) current;
+                    stack.push(both.right);
+                    stack.push(both.left);
+                } else {
+                    for (Validated<T> v : current) {
+                        result.add(v);
+                    }
+                }
+            }
+            return result.iterator();
         }
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeValidationTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeValidationTest.java
@@ -20,6 +20,10 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RecipeValidationTest {
@@ -28,6 +32,36 @@ class RecipeValidationTest {
     void validate() {
         assertThat(new JSpecifyAnnotatedRecipeOptions(null).validate().isValid())
           .isTrue();
+    }
+
+    @Test
+    void deepBothChainDoesNotOverflow() {
+        Validated<Object> chain = Validated.none();
+        for (int i = 0; i < 25_000; i++) {
+            chain = chain.and(Validated.valid("field" + i, i));
+        }
+        // Would throw StackOverflowError before the fix
+        List<Validated.Invalid<Object>> failures = chain.failures();
+        assertThat(failures).isEmpty();
+    }
+
+    @Test
+    void validateAllWithManyChildRecipesDoesNotOverflow() {
+        // Simulates a large composite recipe like MigrateToJava25 with 15,000+ sub-recipes.
+        // Before the fix, validate() would .and() all children's validations into one deep
+        // Both chain, and Both.iterator() would recurse that chain on the call stack.
+        Recipe[] children = new Recipe[15_000];
+        for (int i = 0; i < children.length; i++) {
+            children[i] = new FailingRecipe("child" + i);
+        }
+        Recipe root = new ParentRecipe(children);
+
+        Collection<Validated<Object>> all = root.validateAll();
+
+        long failureCount = all.stream()
+                .flatMap(v -> v.failures().stream())
+                .count();
+        assertThat(failureCount).isEqualTo(15_000);
     }
 
     @Value
@@ -44,5 +78,56 @@ class RecipeValidationTest {
         String displayName = "Validate nullable JSpecify annotations";
 
         String description = "NullUtils should see these annotations.";
+    }
+
+    static class FailingRecipe extends Recipe {
+        private final String id;
+
+        FailingRecipe(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Failing recipe " + id;
+        }
+
+        @Override
+        public String getDescription() {
+            return "A recipe that always fails validation.";
+        }
+
+        @Override
+        public String getName() {
+            return "test.FailingRecipe." + id;
+        }
+
+        @Override
+        public Validated<Object> validate() {
+            return Validated.invalid(id, null, "always fails");
+        }
+    }
+
+    static class ParentRecipe extends Recipe {
+        private final List<Recipe> children;
+
+        ParentRecipe(Recipe... children) {
+            this.children = Arrays.asList(children);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Parent recipe";
+        }
+
+        @Override
+        public String getDescription() {
+            return "A recipe with children.";
+        }
+
+        @Override
+        public List<Recipe> getRecipeList() {
+            return children;
+        }
     }
 }


### PR DESCRIPTION
## Problem

When running large composite recipes (e.g. `MigrateToJava25` with 15,000+ validations), `Validated.Both.iterator()` causes a `StackOverflowError`.

Two issues contribute:

1. **`Both.iterator()` is recursive** — It uses `Stream.concat(stream(left.spliterator()), stream(right.spliterator()))`. Since `spliterator()` calls `iterator()`, a deep `Both` chain (built by repeated `.and()` calls) causes O(depth) stack recursion and overflows.

2. **`Recipe.validate()` and `validate(ctx)` redundantly traverse the full sub-tree** — Both methods iterated `getRecipeList()` recursively, even though `validateAll()` already handles the tree walk. This caused every sub-recipe's validation to be visited multiple times and built unnecessarily deep `Both` chains.

## Solution

**`Validated.Both.iterator()`**: Replaced recursive `Stream.concat(spliterator())` with an iterative approach using an explicit `Deque` as a stack. Same traversal order, but the work happens on the heap instead of the call stack.

**`Recipe.validate()` / `validate(ctx)`**: Removed the `for (Recipe recipe : getRecipeList())` loops. The tree traversal into sub-recipes is already handled by `validateAll()`, so `validate()` now only validates the current recipe's own fields/state. This matches what `DeclarativeRecipe.validate()` already does.

### Semantic change to discuss

This changes the contract of `Recipe.validate()`: previously calling `recipe.validate()` on a parent recipe returned a single `Validated` containing the validations of the **entire sub-tree**. After this change, it only returns the current recipe's **own** validation. The sub-tree traversal is exclusively handled by `validateAll()`.

Any code that calls `recipe.validate()` directly (rather than `validateAll()`) on a composite recipe would no longer see child recipe failures. Is this the intended behavior, or should callers always be using `validateAll()` for composite recipes?

Note: all existing `validate()` overrides in subclasses (50+ across modules) call `super.validate()` and add their own checks — they all continue to work correctly since they only care about their own recipe's validation result from super.