### PR TITLE
Fix RPC serialization for `J.Literal.UnicodeEscape`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaReceiver.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaReceiver.java
@@ -335,7 +335,11 @@ public class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
         return literal
                 .withValue(q.receive(literal.getValue()))
                 .withValueSource(q.receive(literal.getValueSource()))
-                .withUnicodeEscapes(q.receiveList(literal.getUnicodeEscapes(), s -> s))
+                .withUnicodeEscapes(q.receiveList(literal.getUnicodeEscapes(), s -> {
+                    int valueSourceIndex = q.receive(s != null ? s.getValueSourceIndex() : 0);
+                    String codePoint = q.receive(s != null ? s.getCodePoint() : null);
+                    return new J.Literal.UnicodeEscape(valueSourceIndex, codePoint);
+                }))
                 .withType(q.receive(literal.getType(), t -> (JavaType.Primitive) visitType(t, q)));
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaSender.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaSender.java
@@ -329,6 +329,8 @@ public class JavaSender extends JavaVisitor<RpcSendQueue> {
         q.getAndSend(literal, J.Literal::getValue);
         q.getAndSend(literal, J.Literal::getValueSource);
         q.getAndSendList(literal, J.Literal::getUnicodeEscapes, s -> s.getValueSourceIndex() + s.getCodePoint(), s -> {
+            q.getAndSend(s, J.Literal.UnicodeEscape::getValueSourceIndex);
+            q.getAndSend(s, J.Literal.UnicodeEscape::getCodePoint);
         });
         q.getAndSend(literal, a -> asRef(a.getType()), type -> visitType(getValueNonNull(type), q));
         return literal;

--- a/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
@@ -496,9 +496,13 @@ class PythonRpcReceiver:
         return replace_if_changed(ident, annotations=annotations, simple_name=simple_name, type=type_, field_type=field_type)
 
     def _visit_literal(self, lit, q: RpcReceiveQueue):
+        from rewrite.java.tree import Literal
         value = q.receive(lit.value)
         value_source = q.receive(lit.value_source)
-        unicode_escapes = q.receive_list(lit.unicode_escapes)
+        unicode_escapes = q.receive_list(lit.unicode_escapes, lambda s: Literal.UnicodeEscape(
+            q.receive(s.value_source_index if s else 0),
+            q.receive(s.code_point if s else None),
+        ))
         type_ = q.receive(lit.type)
         return replace_if_changed(lit, value=value, value_source=value_source, unicode_escapes=unicode_escapes, type=type_)
 

--- a/rewrite-python/rewrite/src/rewrite/rpc/python_sender.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_sender.py
@@ -452,7 +452,10 @@ class PythonRpcSender:
         q.get_and_send(lit, lambda x: x.value_source)
         q.get_and_send_list(lit, lambda x: x.unicode_escapes,
                             lambda s: str(s.value_source_index) + s.code_point,
-                            None)
+                            lambda s: (
+                                q.get_and_send(s, lambda u: u.value_source_index),
+                                q.get_and_send(s, lambda u: u.code_point),
+                            ))
         q.get_and_send(lit, lambda x: x.type, lambda t: self._visit_type(t, q))
 
     def _visit_import(self, imp, q: 'RpcSendQueue') -> None:

--- a/rewrite-python/src/test/java/.editorconfig
+++ b/rewrite-python/src/test/java/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.java]
+indent_size = 4
+ij_continuation_indent_size = 2


### PR DESCRIPTION
- Fix `ClassCastException` (`LinkedHashMap` cannot be cast to `UnicodeEscape`) during RPC deserialization of `J.Literal` unicode escapes
- Add explicit `onChange` callbacks in sender/receiver for `UnicodeEscape` fields (`valueSourceIndex`, `codePoint`) across Java, TypeScript, and Python RPC implementations
- Previously the sender/receiver used no-op or identity lambdas, causing `UnicodeEscape` objects to be sent as raw maps instead of being properly serialized field-by-field
- Add integration tests for JavaScript and Python that parse source with unicode surrogate pair escapes and assert the `UnicodeEscape` entries are correctly round-tripped
