### PR TITLE
Python - fix the test_remove_decorator test case

### DIFF
--- a/rewrite-python/rewrite/tests/python/all/format/normalize_format_test.py
+++ b/rewrite-python/rewrite/tests/python/all/format/normalize_format_test.py
@@ -28,7 +28,7 @@ def test_remove_decorator():
             def f(n):
                 return n
             """,
-            after_recipe=assert_prefix(lambda cu: cu.statements[1], Space([], '\n'))
+            after_recipe=assert_prefix(lambda cu: cu.statements[1], Space([], '\n\n\n'))
         ),
         spec=RecipeSpec()
         .with_recipes(


### PR DESCRIPTION
## What's changed?

Fixing one of the tests in the Python AutoFormatter test suite.
Follow-up to #6707.

## What's your motivation?

It's failing (BTW, not sure why it wasn't flagged before).

