### PR TITLE
Exclude transitive kotlin-stdlib from kotlin-metadata-jvm

### DIFF
--- a/rewrite-kotlin/build.gradle.kts
+++ b/rewrite-kotlin/build.gradle.kts
@@ -18,7 +18,9 @@ dependencies {
     implementation(kotlin("compiler-embeddable", kotlinVersion))
     implementation(kotlin("stdlib", kotlinVersion))
 
-    testImplementation("org.jetbrains.kotlin:kotlin-metadata-jvm:2.1.0")
+    testImplementation("org.jetbrains.kotlin:kotlin-metadata-jvm:2.1.0") {
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+    }
 
     testImplementation("org.junit-pioneer:junit-pioneer:latest.release")
     testImplementation(project(":rewrite-test"))
@@ -43,7 +45,6 @@ recipeDependencies {
     testParserClasspath("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.1")
     testParserClasspath("org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.6.3")
 }
-
 
 java {
     toolchain {


### PR DESCRIPTION
## Summary
- Exclude transitive `kotlin-stdlib` from `kotlin-metadata-jvm:2.1.0` to prevent it from overriding the parser's embedded `kotlin-stdlib:1.9.25`, which was causing Kotlin test failures with "module was compiled with an incompatible version of Kotlin" metadata version errors
- Remove extra blank line flagged in review

- Fixes CI for #6561

🤖 Generated with [Claude Code](https://claude.com/claude-code)