### PR TITLE
Fixing `@ToBeRemoved` annotations with invalid date

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/MergeSpacesVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/MergeSpacesVisitor.java
@@ -1766,7 +1766,7 @@ public class MergeSpacesVisitor extends GroovyVisitor<Object> {
         return u.withMarkers(visitMarkers(u.getMarkers(), newErroneous.getMarkers()));
     }
 
-    @ToBeRemoved(after = "2026-02-30", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
+    @ToBeRemoved(after = "2026-03-01", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
     private static <S extends Style> S getStyle(Class<S> styleClass, List<NamedStyles> styles, Supplier<S> defaultStyle) {
         S style = NamedStyles.merge(styleClass, styles);
         if (style != null) {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/SpacesVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/SpacesVisitor.java
@@ -71,7 +71,7 @@ public class SpacesVisitor<P> extends org.openrewrite.java.format.SpacesVisitor<
         return super.visitSpace(space, loc, ctx);
     }
 
-    @ToBeRemoved(after = "2026-02-30", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
+    @ToBeRemoved(after = "2026-03-01", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
     private static <S extends Style> @Nullable S getStyle(Class<S> styleClass, List<NamedStyles> styles) {
         S style = NamedStyles.merge(styleClass, styles);
         if (style != null) {
@@ -80,7 +80,7 @@ public class SpacesVisitor<P> extends org.openrewrite.java.format.SpacesVisitor<
         return null;
     }
 
-    @ToBeRemoved(after = "2026-02-30", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
+    @ToBeRemoved(after = "2026-03-01", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
     private static <S extends Style> S getStyle(Class<S> styleClass, List<NamedStyles> styles, Supplier<S> defaultStyle) {
         S style = NamedStyles.merge(styleClass, styles);
         if (style != null) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
@@ -119,7 +119,7 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
         return (J) tree;
     }
 
-    @ToBeRemoved(after = "2026-02-30", reason = "Replace me with org.openrewrite.style.StyleHelper.addStyleMarker now available in parent runtime")
+    @ToBeRemoved(after = "2026-03-01", reason = "Replace me with org.openrewrite.style.StyleHelper.addStyleMarker now available in parent runtime")
     private static <T extends SourceFile> T addStyleMarker(T t, List<NamedStyles> styles) {
         if (!styles.isEmpty()) {
             Set<NamedStyles> newNamedStyles = new HashSet<>(styles);

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/BlankLinesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/BlankLinesVisitor.java
@@ -361,7 +361,7 @@ public class BlankLinesVisitor<P> extends JavaIsoVisitor<P> {
         return super.postVisit(tree, p);
     }
 
-    @ToBeRemoved(after = "2026-02-30", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
+    @ToBeRemoved(after = "2026-03-01", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
     private static <S extends Style> S getStyle(Class<S> styleClass, List<NamedStyles> styles, Supplier<S> defaultStyle) {
         S style = NamedStyles.merge(styleClass, styles);
         if (style != null) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/MergeSpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/MergeSpacesVisitor.java
@@ -1610,7 +1610,7 @@ public class MergeSpacesVisitor extends JavaVisitor<Object> {
         return u.withMarkers(visitMarkers(u.getMarkers(), newErroneous.getMarkers()));
     }
 
-    @ToBeRemoved(after = "2026-02-30", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
+    @ToBeRemoved(after = "2026-03-01", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
     private static <S extends Style> S getStyle(Class<S> styleClass, List<NamedStyles> styles, Supplier<S> defaultStyle) {
         S style = NamedStyles.merge(styleClass, styles);
         if (style != null) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaksVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaksVisitor.java
@@ -95,7 +95,7 @@ public class NormalizeLineBreaksVisitor<P> extends JavaIsoVisitor<P> {
         return super.visit(tree, p);
     }
 
-    @ToBeRemoved(after = "2026-02-30", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
+    @ToBeRemoved(after = "2026-03-01", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
     private static <S extends Style> S getStyle(Class<S> styleClass, List<NamedStyles> styles, Supplier<S> defaultStyle) {
         S style = NamedStyles.merge(styleClass, styles);
         if (style != null) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeTabsOrSpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeTabsOrSpacesVisitor.java
@@ -155,7 +155,7 @@ public class NormalizeTabsOrSpacesVisitor<P> extends JavaIsoVisitor<P> {
         return super.visit(tree, p);
     }
 
-    @ToBeRemoved(after = "2026-02-30", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
+    @ToBeRemoved(after = "2026-03-01", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
     private static <S extends Style> S getStyle(Class<S> styleClass, List<NamedStyles> styles, Supplier<S> defaultStyle) {
         S style = NamedStyles.merge(styleClass, styles);
         if (style != null) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
@@ -966,7 +966,7 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
         OPEN, CLOSE, BEFORE_SEPARATOR, AFTER_SEPARATOR, EMPTY
     }
 
-    @ToBeRemoved(after = "2026-02-30", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
+    @ToBeRemoved(after = "2026-03-01", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
     private static <S extends Style> @Nullable S getStyle(Class<S> styleClass, List<NamedStyles> styles) {
         S style = NamedStyles.merge(styleClass, styles);
         if (style != null) {
@@ -975,7 +975,7 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
         return null;
     }
 
-    @ToBeRemoved(after = "2026-02-30", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
+    @ToBeRemoved(after = "2026-03-01", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
     private static <S extends Style> S getStyle(Class<S> styleClass, List<NamedStyles> styles, Supplier<S> defaultStyle) {
         S style = NamedStyles.merge(styleClass, styles);
         if (style != null) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -834,7 +834,7 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
         }
     }
 
-    @ToBeRemoved(after = "2026-02-30", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
+    @ToBeRemoved(after = "2026-03-01", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
     private static <S extends Style> S getStyle(Class<S> styleClass, List<NamedStyles> styles, Supplier<S> defaultStyle) {
         S style = NamedStyles.merge(styleClass, styles);
         if (style != null) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/WrappingAndBracesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/WrappingAndBracesVisitor.java
@@ -646,7 +646,7 @@ public class WrappingAndBracesVisitor<P> extends JavaIsoVisitor<P> {
         }
     }
 
-    @ToBeRemoved(after = "2026-02-30", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
+    @ToBeRemoved(after = "2026-03-01", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
     private static <S extends Style> S getStyle(Class<S> styleClass, List<NamedStyles> styles, Supplier<S> defaultStyle) {
         S style = NamedStyles.merge(styleClass, styles);
         if (style != null) {

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/MergeSpacesVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/MergeSpacesVisitor.java
@@ -2200,7 +2200,7 @@ public class MergeSpacesVisitor extends KotlinVisitor<Object> {
         return u.withMarkers(visitMarkers(u.getMarkers(), newErroneous.getMarkers()));
     }
 
-    @ToBeRemoved(after = "2026-02-30", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
+    @ToBeRemoved(after = "2026-03-01", reason = "Replace me with org.openrewrite.style.StyleHelper.getStyle now available in parent runtime")
     private static <S extends Style> @Nullable S getStyle(Class<S> styleClass, List<NamedStyles> styles) {
         S style = NamedStyles.merge(styleClass, styles);
         if (style != null) {


### PR DESCRIPTION
## What's changed?

Replacing `2026-02-30` with `2026-03-01` in `@ToBeRemoved` annotations.

## What's your motivation?

Fix:
```
java.time.format.DateTimeParseException: Text '2026-02-30' could not be parsed: Invalid date 'FEBRUARY 30'
  java.base/java.time.format.DateTimeFormatter.createError(DateTimeFormatter.java:2023)
  java.base/java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1958)
  java.base/java.time.LocalDate.parse(LocalDate.java:430)
  java.base/java.time.LocalDate.parse(LocalDate.java:415)
  org.openrewrite.java.recipes.RemoveToBeRemoved$1.getAfterDate(RemoveToBeRemoved.java:96)
```
error reported by Moderne.
