### PR TITLE
Python: Fix f-string parsing for debug = with format spec

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -3484,10 +3484,10 @@ class ParserVisitor(ast.NodeVisitor):
 
                 # format specifier
                 if tok.type == token.OP and tok.string == ':':
-                    # After conversion handling: _token_idx points to ':' (need to advance)
+                    # After conversion or debug handling: _token_idx points to ':' (need to advance)
                     # After scanning loop only: _token_idx already points past ':' (don't advance)
-                    if conv is not None:
-                        self._token_idx += 1  # advance past ':' (only needed after conversion)
+                    if conv is not None or debug is not None:
+                        self._token_idx += 1  # advance past ':' (needed after conversion or debug specifier)
                     format_spec, tok, _ = self.__map_fstring(
                         cast(ast.JoinedStr, value.format_spec), Space.EMPTY, self._tokens[self._token_idx],
                         _start=_start, _middle=_middle, _end=_end)

--- a/rewrite-python/rewrite/tests/python/all/tree/fstring_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/fstring_test.py
@@ -159,6 +159,14 @@ def test_debug_with_trailing_whitespace():
     RecipeSpec().rewrite_run(python("a = f'{1= !a}'"))
 
 
+def test_debug_with_format_spec():
+    # language=python
+    RecipeSpec().rewrite_run(python("a = f'{last_error=:#x}'"))
+    # debug `=` with format spec after other expressions
+    # language=python
+    RecipeSpec().rewrite_run(python("""a = f"kernel32.{name} ({last_error=:#x})" """))
+
+
 def test_all_specifiers():
     # language=python
     RecipeSpec().rewrite_run(python("a = f'{1=!a:0>6}'"))


### PR DESCRIPTION
## Summary

- Fix f-string parser failing on `{var=:#x}` (debug `=` + format spec, no conversion)
- The `:` token was not advanced past before parsing the format spec, causing the parser to get stuck
- Added test covering both standalone and embedded `{var=:fmt}` patterns

## Test plan

- [x] New test `test_debug_with_format_spec` passes
- [x] All 41 existing f-string tests pass (no regressions)
- [x] Reproduces the original error parsing `streamlink/src/streamlink_cli/console/windows.py`