### PR TITLE
Fix anchor on MappingStart in sequence entry losing prefix

### DIFF
--- a/rewrite-javascript/rewrite/test/yaml/parser.test.ts
+++ b/rewrite-javascript/rewrite/test/yaml/parser.test.ts
@@ -485,6 +485,17 @@ describe('Flow mappings without colons (OmitColon marker)', () => {
     });
 });
 
+describe('Anchors on sequence entries', () => {
+
+    test('anchor on mapping in sequence entry', async () => {
+        const yaml = `- k: v
+- &b
+  k2: v2`;
+        const result = await parseAndPrint(yaml);
+        expect(result).toBe(yaml);
+    });
+});
+
 describe('Single-brace template syntax', () => {
 
     test('quoted single-brace templates roundtrip', async () => {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -246,14 +246,7 @@ public class YamlParser implements org.openrewrite.Parser {
                         if (mappingStartEvent.getAnchor() != null) {
                             anchor = buildYamlAnchor(reader, lastEnd, fmt, mappingStartEvent.getAnchor(), event.getEndMark().getIndex(), false);
                             anchors.put(mappingStartEvent.getAnchor(), anchor);
-
-                            // dashPrefixIndex could be 0 (if anchoring a sequence item) or greater than 0 (if anchoring entire list)
-                            int dashPrefixIndex = commentAwareIndexOf('-', fmt);
                             lastEnd = lastEnd + mappingStartEvent.getAnchor().length() + fmt.length() + 1;
-
-                            if (dashPrefixIndex > 0) {
-                                fmt = fmt.substring(0, dashPrefixIndex);
-                            }
                         }
 
                         String fullPrefix = reader.readStringFromBuffer(lastEnd, event.getEndMark().getIndex() - 1);

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -762,6 +762,19 @@ class YamlParserTest implements RewriteTest {
     }
 
     @Test
+    void anchorOnMappingInSequenceEntry() {
+        rewriteRun(
+          yaml(
+            """
+              - k: v
+              - &b
+                k2: v2
+              """
+          )
+        );
+    }
+
+    @Test
     void literalScalarTrailingNewlineInValue() {
         // Literal (|) and folded (>) scalars should keep trailing newlines in their value
         // The next entry's prefix should be just indentation, not include the newline


### PR DESCRIPTION
## Summary
- Fix YAML parser losing the dash prefix when an anchor appears on a `MappingStart` event inside a sequence entry (e.g. `- &b\n  k2: v2`)
- The dash-index truncation of `fmt` in the `MappingStart` anchor handling was incorrectly stripping the `-` from the format string, causing `SequenceBuilder` to create entries with `isDash=false`
- Add tests for both Java and TypeScript parsers

## Test plan
- [x] New test `anchorOnMappingInSequenceEntry` passes
- [x] Full `:rewrite-yaml:test` suite passes with no regressions
- [x] TypeScript parser test added (already handled this case correctly)