### PR TITLE
Remove all nulls in a single pass

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
@@ -215,8 +215,7 @@ public final class ListUtils {
         }
 
         if (newLs != ls && nullEncountered) {
-            //noinspection StatementWithEmptyBody
-            while (newLs.remove(null)) ;
+            newLs.removeIf(Objects::isNull);
         }
 
         //noinspection NullableProblems


### PR DESCRIPTION
Avoids repeatedly looping over the collection for as many nulls as are present. Delegates to Collection.removeIf with
```java
    default boolean removeIf(Predicate<? super E> filter) {
        Objects.requireNonNull(filter);
        boolean removed = false;
        final Iterator<E> each = iterator();
        while (each.hasNext()) {
            if (filter.test(each.next())) {
                each.remove();
                removed = true;
            }
        }
        return removed;
    }
```