### PR TITLE
Python: Fix parsing of byte strings `b''`

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -254,7 +254,7 @@ class PythonTypeMapping:
 
     def _constant_type(self, node: ast.Constant) -> Optional[JavaType]:
         """Get the type for a constant/literal node."""
-        if isinstance(node.value, str):
+        if isinstance(node.value, (str, bytes)):
             return JavaType.Primitive.String
         elif isinstance(node.value, bool):
             return JavaType.Primitive.Boolean

--- a/rewrite-python/rewrite/tests/python/all/tree/literal_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/literal_test.py
@@ -44,9 +44,9 @@ def test_large_int():
     RecipeSpec().rewrite_run(python("assert 0xC03A0019", after_recipe=check_first_literal_type(JavaType.Primitive.Int)))
 
 
-# def test_byte_string_concatenation():
-#     # language=python
-#     RecipeSpec().rewrite_run(python("assert b'hello' b'world'", after_recipe=check_first_literal_type(JavaType.Primitive.String)))
+def test_byte_string_concatenation():
+    # language=python
+    RecipeSpec().rewrite_run(python("assert b'hello' b'world'", after_recipe=check_first_literal_type(JavaType.Primitive.String)))
 
 
 def test_bigint():


### PR DESCRIPTION
## What's changed?

Minor fix to how byte strings, i.e. `b''` are parsed in Python.

That builds on #6722.

## What's your motivation?

To fix a broken (commented out) test.