### PR TITLE
Python: in tests the `before_recipe` hook to run after idempotence check

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/test/rewrite_test.py
+++ b/rewrite-python/rewrite/src/rewrite/test/rewrite_test.py
@@ -178,6 +178,12 @@ class RecipeSpec:
                 self._expect_parse_print_idempotence(parsed)
             all_parsed.extend(parsed)
 
+        # Apply before_recipe hooks (after idempotence check, before recipe execution)
+        all_parsed = [
+            (spec, spec.before_recipe(sf) or sf) if spec.before_recipe else (spec, sf)
+            for spec, sf in all_parsed
+        ]
+
         # Run the recipe
         source_files = [sf for _, sf in all_parsed]
         lss = InMemoryLargeSourceSet(source_files)
@@ -220,12 +226,6 @@ class RecipeSpec:
             # Parse the source
             source = dedent(spec.before)
             parsed = self._parse_python(source, source_path)
-
-            # Call before_recipe hook if provided
-            if spec.before_recipe:
-                modified = spec.before_recipe(parsed)
-                if modified is not None:
-                    parsed = modified
 
             result.append((spec, parsed))
 

--- a/rewrite-python/rewrite/tests/test_rewrite_test.py
+++ b/rewrite-python/rewrite/tests/test_rewrite_test.py
@@ -216,7 +216,6 @@ class TestRecipeSpecHooks:
         assert len(called) == 1
         assert called[0][0] == "after"
 
-    @pytest.mark.skip(reason="The test has been failing for unknown reason, disabling on 2026-02-10")
     def test_before_recipe_can_modify_ast(self):
         """Test that before_recipe can modify the parsed AST."""
         from rewrite import random_id


### PR DESCRIPTION
## What's changed?

Fixing the Python recipe testing framework to execute the `before_recipe` hooks after the parsing idempotence check.
Otherwise the hook might hinder the idempotence check.
Mimicking how it's done for Java.

## What's your motivation?

The direct driver is fixing the broken test case.
