### PR TITLE
Complete Java 24 compatibility fix by backporting UnknownType workaround

### DIFF
--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
@@ -46,7 +46,7 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
     private final JavaTypeCache typeCache;
 
     public JavaType type(@Nullable Type type) {
-        if (type == null || type instanceof Type.ErrorType || type instanceof Type.PackageType || type instanceof Type.UnknownType ||
+        if (type == null || type instanceof Type.ErrorType || type instanceof Type.PackageType || isUnknownType(type) ||
                 type instanceof NullType) {
             return JavaType.Class.Unknown.getInstance();
         }
@@ -465,7 +465,7 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
         }
 
         if (selectType == null || selectType instanceof Type.ErrorType || symbol == null || symbol.kind == Kinds.Kind.ERR ||
-            symbol.type instanceof Type.UnknownType) {
+            isUnknownType(symbol.type)) {
             return null;
         }
 
@@ -530,7 +530,7 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
                     exceptionTypes.add(javaType);
                 }
             }
-        } else if (selectType instanceof Type.UnknownType) {
+        } else if (isUnknownType(selectType)) {
             returnType = JavaType.Unknown.getInstance();
         }
 
@@ -750,5 +750,13 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
             return annotationElementValue(((Attribute.Enum) value).value);
         }
         return JavaType.Unknown.getInstance();
+    }
+
+    /**
+     * Check for the `UnknownType` which existed up until JDK 22; starting with JDK 23 only the `ErrorType` is used.
+     * Uses reflection to avoid compile-time dependency on the class, which was removed in JDK 24.
+     */
+    public static boolean isUnknownType(@Nullable Type type) {
+        return type != null && type.getClass().getName().equals("com.sun.tools.javac.code.Type$UnknownType");
     }
 }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeSignatureBuilder.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeSignatureBuilder.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
 
+import static org.openrewrite.java.isolated.ReloadableJava21TypeMapping.isUnknownType;
 
 class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     @Nullable
@@ -41,7 +42,7 @@ class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     private String signature(@Nullable Type type) {
-        if (type == null || type instanceof Type.UnknownType || type instanceof NullType) {
+        if (type == null || isUnknownType(type) || type instanceof NullType) {
             return "{undefined}";
         } else if (type instanceof Type.IntersectionClassType) {
             return intersectionSignature(type);
@@ -299,7 +300,7 @@ class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
             return resolvedArgumentTypes.toString();
         } else if (selectType instanceof Type.ForAll) {
             return methodArgumentSignature(((Type.ForAll) selectType).qtype);
-        } else if (selectType instanceof Type.JCNoType || selectType instanceof Type.UnknownType) {
+        } else if (selectType instanceof Type.JCNoType || isUnknownType(selectType)) {
             return "{undefined}";
         }
 


### PR DESCRIPTION
- This completes the Java 24 compatibility work started in PR #6725 by backporting the isUnknownType() helper method that was removed during the May 2025 simplification (commit 08b08ab76).

Background:
- April 2025: JDK 24 support added with reflection-based workarounds
- May 2025: Workarounds removed in "simplification" (commit 08b08ab76)
- February 2026: DocCommentTable fix backported in PR #6725
- This PR: Backports the missing UnknownType fix

Problem:
Java 24 removed the Type.UnknownType class from javac internals. Direct instanceof Type.UnknownType checks cause NoClassDefFoundError at runtime on Java 24.

Solution:
Use reflection to check the class name at runtime instead of compile-time instanceof checks. This allows the code to work on both Java 21-23 (where the class exists) and Java 24+ (where it doesn't).

Changes:
- ReloadableJava21TypeMapping.java: Added isUnknownType() helper, replaced 3 instanceof checks
- ReloadableJava21TypeSignatureBuilder.java: Replaced 2 instanceof checks

Testing:
Verified on spring-petclinic project with Java 24.0.2. Type attribution works correctly, ChangeType and ChangePackage recipes execute successfully, and migrated code compiles without errors.

- Fixes: #6644
- Related: #6725, commit 08b08ab76