### PR TITLE
Fall back to RecipeLoader when ecosystem resolver is missing

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -160,9 +160,15 @@ public class RewriteRpc {
         jsonRpc.rpc("PrepareRecipe", new PrepareRecipe.Handler(preparedRecipes, (id, opts) -> {
             RecipeListing listing = marketplace.findRecipe(id);
             if (listing != null) {
-                return listing.prepare(resolvers, opts);
+                try {
+                    return listing.prepare(resolvers, opts);
+                } catch (IllegalStateException e) {
+                    // Resolver not available for this ecosystem (e.g., Maven resolver not
+                    // provided to this RPC endpoint). Fall through to class-based loading.
+                }
             }
             // Fall back to loading by class name if not found in marketplace
+            // or if no resolver is available for the recipe's ecosystem
             return new RecipeLoader(null).load(id, opts);
         }));
         jsonRpc.rpc("Print", new Print.Handler(this::getObject));


### PR DESCRIPTION
## Summary
- When the `PrepareRecipe` handler finds a recipe in the marketplace but `listing.prepare()` throws because no resolver matches the bundle's ecosystem, it now catches the exception and falls through to `RecipeLoader`
- This fixes recipe runs on Node.js repositories where JS recipes use preconditions like `usesType()` or `usesMethod()` that call back to the Java side to prepare Java recipes — without a Maven resolver wired into the RPC endpoint, these callbacks previously failed with "No available resolver for 'maven' ecosystem"

## Test plan
- [x] Added `prepareRecipeFallsBackToRecipeLoaderWhenResolverMissing` test that installs a recipe listing with a `"maven"` ecosystem bundle into a marketplace with only a `"runtime"` resolver, then verifies `prepareRecipe` succeeds via the `RecipeLoader` fallback
- [x] All existing `RewriteRpcTest` tests continue to pass