### PR TITLE
Python: Include `pyproject.toml` in ParseProject results

### DIFF
--- a/rewrite-python/src/integTest/java/org/openrewrite/python/ParseProjectIntegTest.java
+++ b/rewrite-python/src/integTest/java/org/openrewrite/python/ParseProjectIntegTest.java
@@ -22,7 +22,9 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.SourceFile;
+import org.openrewrite.python.marker.PythonResolutionResult;
 import org.openrewrite.python.rpc.PythonRewriteRpc;
+import org.openrewrite.toml.tree.Toml;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -158,6 +160,36 @@ class ParseProjectIntegTest {
                 .collect(Collectors.toList());
 
         assertThat(sources).hasSize(1);
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void includesPyprojectToml() throws IOException {
+        Path projectDir = tempDir.resolve("with_pyproject");
+        Files.createDirectories(projectDir);
+
+        Files.writeString(projectDir.resolve("main.py"), "x = 1");
+        Files.writeString(projectDir.resolve("pyproject.toml"), """
+                [project]
+                name = "myapp"
+                version = "1.0.0"
+                dependencies = ["requests>=2.28.0"]
+                """);
+
+        List<SourceFile> sources = client()
+                .parseProject(projectDir, new InMemoryExecutionContext())
+                .collect(Collectors.toList());
+
+        assertThat(sources)
+                .extracting(sf -> sf.getSourcePath().getFileName().toString())
+                .contains("main.py", "pyproject.toml");
+
+        SourceFile pyproject = sources.stream()
+                .filter(sf -> sf.getSourcePath().getFileName().toString().equals("pyproject.toml"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(pyproject).isInstanceOf(Toml.Document.class);
+        assertThat(pyproject.getMarkers().findFirst(PythonResolutionResult.class)).isPresent();
     }
 
     private PythonRewriteRpc client() {


### PR DESCRIPTION
## Summary
- Wire `PyProjectTomlParser` into `PythonRewriteRpc.parseProject()` so that `pyproject.toml` is parsed and returned alongside `.py` files
- The parsed `pyproject.toml` is a `Toml.Document` with a `PythonResolutionResult` marker attached
- Subset of #6716 — just the pyproject.toml integration, without legacy manifest support (requirements.txt, setup.cfg, setup.py)

## Test plan
- [x] `./gradlew :rewrite-python:integTest --tests "*ParseProjectIntegTest.includesPyprojectToml*"` passes
- [x] Existing `ParseProjectIntegTest` tests still pass