### PR TITLE
Fix htmlIndexToVersioning() HTML title attribute handling

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -411,7 +411,7 @@ public class MavenPomDownloader {
         int start = responseBody.indexOf("<a href=\"");
         while (start > 0) {
             start += 9;
-            int end = responseBody.indexOf("\">", start);
+            int end = responseBody.indexOf("\"", start);
             if (end < 0) {
                 break;
             }


### PR DESCRIPTION
## Summary

- Fixes #6739: `MavenPomDownloader.htmlIndexToVersioning()` was corrupting version strings when parsing HTML directory listings that include `title` attributes on anchor tags.

The method searched for `">` to delimit the `href` attribute value, which overshoots when additional attributes follow (e.g., `title="..."`). This resulted in corrupted version strings like `1.0.0/" title="1.0.0` instead of `1.0.0/`. Changed the search to look for the closing quote directly, which correctly terminates at the href attribute boundary regardless of other attributes.

Includes test case covering HTML with title attributes on anchor tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)