### PR TITLE
Add regression tests for XML parser idempotency issues

### DIFF
--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
@@ -648,4 +648,122 @@ class XmlParserTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/857")
+    @Test
+    void commentInPrologFollowedByBlankLinesThenRootElement() {
+        rewriteRun(
+          xml(
+            """
+              <!--
+                Copyright (c) 2022 Example Corp. All rights reserved.
+              -->
+
+              <root>
+                  <child/>
+              </root>
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/857")
+    @Test
+    void xmlDeclWithStandaloneNo() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+              <root>
+                  <child/>
+              </root>
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/857")
+    @Test
+    void xmlDeclFollowedByCommentThenBlankLinesThenRoot() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <!--
+                License header
+              -->
+
+              <Definitions>
+                  <child/>
+              </Definitions>
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/857")
+    @Test
+    void commentWithTripleDashInsideElement() {
+        rewriteRun(
+          xml(
+            """
+              <!-- header -->
+
+              <root>
+              \t<!---
+              \t\tAttribute Dictionary description
+              \t-->
+              \t<child/>
+              </root>
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/857")
+    @Test
+    void xmlDeclAfterCommentIsParseError() {
+        XmlParser parser = XmlParser.builder().build();
+        String input = """
+              <!--
+                Copyright (c) 2022 Example Corp. All rights reserved.
+              -->
+              <?xml version="1.0" encoding="UTF-8"?>
+              <root/>
+              """;
+        SourceFile sf = parser.parse(input).findFirst().orElseThrow();
+        assertThat(sf).isInstanceOf(ParseError.class);
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/857")
+    @Test
+    void xmlDeclFollowedByCommentThenRoot() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <!-- comment -->
+
+              <Definitions>
+                  <child/>
+              </Definitions>
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/857")
+    @Test
+    void wsdlStyleXmlDeclStandaloneNo() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+              <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+                  <wsdl:types/>
+              </wsdl:definitions>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Adds regression tests for XML parser failure patterns reported in moderneinc/customer-requests#857.

Analysis of the raw data revealed:
- **Non-JSP idempotency failures** (whitespace loss, content truncation) — no longer reproduce, fixed by cursor refactoring in #6094
- **`<?xml?>` after comments** (25 AEM `.content.xml` files) — correctly produces `ParseError` for malformed XML

All tests pass on the current parser, confirming these issues are resolved. Tests cover:
- Comment in prolog + blank lines + root element
- xmldecl + comment + blank lines + root element
- xmldecl with `standalone="no"`
- Comment with triple-dash inside element content
- xmldecl after comment → clean `ParseError`
- WSDL-style xmldecl