### PR TITLE
Redirect pip install output away from console

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -29,6 +29,7 @@ import org.openrewrite.tree.ParsingExecutionContextView;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -466,8 +467,26 @@ public class PythonRewriteRpc extends RewriteRpc {
                         "--target=" + pipPackagesPath.toAbsolutePath().normalize(),
                         "openrewrite"
                 );
-                pb.inheritIO();
+                pb.redirectErrorStream(true);
+                if (log != null) {
+                    File logFile = log.toAbsolutePath().normalize().toFile();
+                    pb.redirectOutput(ProcessBuilder.Redirect.appendTo(logFile));
+                }
                 Process process = pb.start();
+                if (log == null) {
+                    // Drain stdout+stderr to prevent pipe buffer from filling and blocking
+                    Thread drainer = new Thread(() -> {
+                        try (InputStream is = process.getInputStream()) {
+                            byte[] buf = new byte[4096];
+                            //noinspection StatementWithEmptyBody
+                            while (is.read(buf) != -1) {
+                            }
+                        } catch (IOException ignored) {
+                        }
+                    });
+                    drainer.setDaemon(true);
+                    drainer.start();
+                }
                 boolean completed = process.waitFor(2, TimeUnit.MINUTES);
 
                 if (!completed) {


### PR DESCRIPTION
## Summary
- `bootstrapOpenrewrite()` used `pb.inheritIO()` which leaked pip install output to the parent process's stdout/stderr
- When a log file is configured, pip output now appends to it
- When no log file is configured, a daemon thread drains the pipe to prevent buffer blocking

## Test plan
- [ ] Verify pip install output no longer appears on console during Python RPC startup
- [ ] Verify pip install output appears in `python-rpc.log` when log path is configured