### PR TITLE
Fall back to uv lock when no lock file exists for pyproject.toml

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonDependencyParser.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonDependencyParser.java
@@ -312,6 +312,9 @@ public class PythonDependencyParser {
      */
     private static PythonResolutionResult.@Nullable PackageManager detectPackageManager(Map<String, Toml.Table> tables) {
         for (String tableName : tables.keySet()) {
+            if ("tool.poetry".equals(tableName) || tableName.startsWith("tool.poetry.")) {
+                return PythonResolutionResult.PackageManager.Poetry;
+            }
             if ("tool.pdm".equals(tableName) || tableName.startsWith("tool.pdm.")) {
                 return PythonResolutionResult.PackageManager.Pdm;
             }

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/UvLockParser.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/UvLockParser.java
@@ -59,9 +59,13 @@ public class UvLockParser {
     }
 
     static @Nullable Path findLockFile(Path startDir, @Nullable Path boundary) {
+        return findLockFile(startDir, boundary, "uv.lock");
+    }
+
+    static @Nullable Path findLockFile(Path startDir, @Nullable Path boundary, String filename) {
         Path dir = startDir;
         while (dir != null) {
-            Path lockFile = dir.resolve("uv.lock");
+            Path lockFile = dir.resolve(filename);
             if (Files.isRegularFile(lockFile)) {
                 return lockFile;
             }
@@ -74,9 +78,17 @@ public class UvLockParser {
     }
 
     /**
+     * Check whether a poetry.lock or pdm.lock file exists near the given directory.
+     */
+    public static boolean hasAlternativeLockFile(Path startDir, @Nullable Path boundary) {
+        return findLockFile(startDir, boundary, "poetry.lock") != null ||
+               findLockFile(startDir, boundary, "pdm.lock") != null;
+    }
+
+    /**
      * Parse uv.lock content into a list of resolved dependencies.
      */
-    static List<ResolvedDependency> parse(String content) {
+    public static List<ResolvedDependency> parse(String content) {
         TomlParser parser = new TomlParser();
         Parser.Input input = Parser.Input.fromString(
                 Paths.get("uv.lock"),

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/PythonDependencyParserTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/PythonDependencyParserTest.java
@@ -246,6 +246,42 @@ class PythonDependencyParserTest {
         assertThat(testGroup.get(0).getName()).isEqualTo("coverage");
     }
 
+    @Test
+    void detectsPoetryPackageManager() {
+        String toml = """
+          [project]
+          name = "poetry-project"
+          version = "1.0.0"
+
+          [tool.poetry]
+          name = "poetry-project"
+          """;
+
+        Toml.Document doc = parseToml(toml);
+        PythonResolutionResult marker = PythonDependencyParser.createMarker(doc, null);
+
+        assertThat(marker).isNotNull();
+        assertThat(marker.getPackageManager()).isEqualTo(PythonResolutionResult.PackageManager.Poetry);
+    }
+
+    @Test
+    void detectsPoetryFromSubTable() {
+        String toml = """
+          [project]
+          name = "poetry-project"
+          version = "1.0.0"
+
+          [tool.poetry.dependencies]
+          python = "^3.10"
+          """;
+
+        Toml.Document doc = parseToml(toml);
+        PythonResolutionResult marker = PythonDependencyParser.createMarker(doc, null);
+
+        assertThat(marker).isNotNull();
+        assertThat(marker.getPackageManager()).isEqualTo(PythonResolutionResult.PackageManager.Poetry);
+    }
+
     private static Toml.Document parseToml(String content) {
         TomlParser parser = new TomlParser();
         Parser.Input input = Parser.Input.fromString(

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/UvLockParserTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/UvLockParserTest.java
@@ -160,4 +160,37 @@ class UvLockParserTest {
         Path found = UvLockParser.findLockFile(tempDir, tempDir);
         assertThat(found).isNull();
     }
+
+    @Test
+    void hasAlternativeLockFileDetectsPoetryLock(@TempDir Path tempDir) throws IOException {
+        Files.write(tempDir.resolve("poetry.lock"), "".getBytes());
+        assertThat(UvLockParser.hasAlternativeLockFile(tempDir, null)).isTrue();
+    }
+
+    @Test
+    void hasAlternativeLockFileDetectsPdmLock(@TempDir Path tempDir) throws IOException {
+        Files.write(tempDir.resolve("pdm.lock"), "".getBytes());
+        assertThat(UvLockParser.hasAlternativeLockFile(tempDir, null)).isTrue();
+    }
+
+    @Test
+    void hasAlternativeLockFileReturnsFalseWhenNoneExist(@TempDir Path tempDir) {
+        assertThat(UvLockParser.hasAlternativeLockFile(tempDir, tempDir)).isFalse();
+    }
+
+    @Test
+    void hasAlternativeLockFileWalksUpToParent(@TempDir Path tempDir) throws IOException {
+        Files.write(tempDir.resolve("poetry.lock"), "".getBytes());
+        Path subDir = tempDir.resolve("subproject");
+        Files.createDirectories(subDir);
+        assertThat(UvLockParser.hasAlternativeLockFile(subDir, null)).isTrue();
+    }
+
+    @Test
+    void hasAlternativeLockFileRespectsBoundary(@TempDir Path tempDir) throws IOException {
+        Files.write(tempDir.resolve("poetry.lock"), "".getBytes());
+        Path boundary = tempDir.resolve("boundary");
+        Files.createDirectories(boundary);
+        assertThat(UvLockParser.hasAlternativeLockFile(boundary, boundary)).isFalse();
+    }
 }


### PR DESCRIPTION
## Summary
- `PyProjectTomlParser` now runs `uv lock` as a subprocess to resolve dependencies when no pre-existing `uv.lock` is found, bringing parity with `RequirementsTxtParser` and `SetupCfgParser`
- Projects managed by Poetry or PDM are skipped (detected via `[tool.poetry]` sections, `poetry.lock`, or `pdm.lock`)
- Poetry detection added to `PythonDependencyParser.detectPackageManager`
- `UvLockParser.hasAlternativeLockFile()` checks for `poetry.lock`/`pdm.lock` using generalized `findLockFile`

## Test plan
- [x] `PythonDependencyParserTest` — Poetry detection from `[tool.poetry]` and subtables
- [x] `UvLockParserTest` — `hasAlternativeLockFile` for poetry.lock, pdm.lock, boundary respect, parent walk
- [x] `PyProjectTomlParserTest` — Skip logic for poetry.lock, pdm.lock, and `[tool.poetry]` tool section
- [x] All 37 tests pass across 3 test classes