### PR TITLE
Lazily initialize RPC in pip and npm recipe bundle resolvers

### DIFF
--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleResolver.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleResolver.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.javascript.marketplace;
 
-import lombok.RequiredArgsConstructor;
 import org.openrewrite.javascript.rpc.InstallRecipesResponse;
 import org.openrewrite.javascript.rpc.JavaScriptRewriteRpc;
 import org.openrewrite.marketplace.RecipeBundle;
@@ -26,9 +25,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-@RequiredArgsConstructor
 public class NpmRecipeBundleResolver implements RecipeBundleResolver {
-    private final JavaScriptRewriteRpc rpc;
+    private volatile JavaScriptRewriteRpc rpc;
+
+    public NpmRecipeBundleResolver() {
+    }
+
+    public NpmRecipeBundleResolver(JavaScriptRewriteRpc rpc) {
+        this.rpc = rpc;
+    }
 
     @Override
     public String getEcosystem() {
@@ -37,6 +42,11 @@ public class NpmRecipeBundleResolver implements RecipeBundleResolver {
 
     @Override
     public RecipeBundleReader resolve(RecipeBundle bundle) {
+        JavaScriptRewriteRpc rpc = this.rpc;
+        if (rpc == null) {
+            rpc = JavaScriptRewriteRpc.getOrStart();
+            this.rpc = rpc;
+        }
         Path pkgPath = Paths.get(bundle.getPackageName());
         InstallRecipesResponse response;
         if (Files.exists(pkgPath)) {

--- a/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.python.marketplace;
 
-import lombok.RequiredArgsConstructor;
 import org.openrewrite.python.rpc.InstallRecipesResponse;
 import org.openrewrite.python.rpc.PythonRewriteRpc;
 import org.openrewrite.marketplace.RecipeBundle;
@@ -26,9 +25,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-@RequiredArgsConstructor
 public class PipRecipeBundleResolver implements RecipeBundleResolver {
-    private final PythonRewriteRpc rpc;
+    private volatile PythonRewriteRpc rpc;
+
+    public PipRecipeBundleResolver() {
+    }
+
+    public PipRecipeBundleResolver(PythonRewriteRpc rpc) {
+        this.rpc = rpc;
+    }
 
     @Override
     public String getEcosystem() {
@@ -37,6 +42,11 @@ public class PipRecipeBundleResolver implements RecipeBundleResolver {
 
     @Override
     public RecipeBundleReader resolve(RecipeBundle bundle) {
+        PythonRewriteRpc rpc = this.rpc;
+        if (rpc == null) {
+            rpc = PythonRewriteRpc.getOrStart();
+            this.rpc = rpc;
+        }
         Path pkgPath = Paths.get(bundle.getPackageName());
         InstallRecipesResponse response;
         if (Files.exists(pkgPath)) {


### PR DESCRIPTION
## Summary

- Make the `rpc` field in `PipRecipeBundleResolver` and `NpmRecipeBundleResolver` volatile and lazily initialized on first `resolve()` call
- Add no-arg constructors so callers can defer RPC process creation entirely
- Preserve existing constructors for backward compatibility

## Problem

The pip and npm recipe bundle resolvers eagerly start their RPC processes (which trigger `pip install openrewrite` / `npm install`) at construction time. In environments where the system cannot reach pypi.org or npmjs.org (e.g., behind corporate proxies with SSL inspection), this causes the entire recipe run to fail — even when no pip or npm recipes are being resolved.

## Solution

Change the `rpc` field from `final` to `volatile` and lazily call `getOrStart()` on the first `resolve()` invocation. This means the RPC process is only bootstrapped when a recipe from that ecosystem actually needs to be resolved.

## Test plan

- [ ] Existing tests pass
- [ ] `mod run` with a Java-only recipe no longer attempts `pip install` when Python is on PATH

- Fixes moderneinc/customer-requests#1890