### PR TITLE
Fix DeclarativeRecipe descriptor leaking PreconditionBellwether

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -590,7 +590,7 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
     @Override
     protected RecipeDescriptor createRecipeDescriptor() {
         List<RecipeDescriptor> recipeList = new ArrayList<>();
-        for (Recipe childRecipe : getRecipeList()) {
+        for (Recipe childRecipe : this.recipeList) {
             recipeList.add(childRecipe.getDescriptor());
         }
         return new RecipeDescriptor(getName(), getDisplayName(), getInstanceName(), getDescription() != null ? getDescription() : "",


### PR DESCRIPTION
## Problem

`DeclarativeRecipe.createRecipeDescriptor()` uses `getRecipeList()` which injects `PreconditionBellwether` and `BellwetherDecoratedRecipe` wrappers into the descriptor when preconditions are present. These are internal runtime wrappers that should never appear in recipe descriptors.

This bug has been latent since `createRecipeDescriptor()` was first introduced (March 2023), but was harmless when descriptors were only used for display purposes within a single JVM. It became a hard failure with the polyglot RPC execution path, where descriptors are serialized across process boundaries. When the receiving side tries to resolve `org.openrewrite.config.DeclarativeRecipe$PreconditionBellwether` as a recipe, it fails validation:

```
Recipe validation error in org.openrewrite.config.DeclarativeRecipe$PreconditionBellwether: 
Unable to find recipe org.openrewrite.config.DeclarativeRecipe$PreconditionBellwether
```

The bellwether entry in the descriptor also carried no useful precondition information — no reference to the actual precondition recipe, no options — just an opaque internal class name. The `BellwetherDecoratedRecipe` wrappers delegated all descriptor methods to the underlying recipe, making them identical to unwrapped descriptors.

## Solution

Change `createRecipeDescriptor()` to iterate over `this.recipeList` (the raw authored recipe list) instead of `getRecipeList()` (which wraps recipes with bellwether decorators at runtime). This ensures descriptors reflect the authored recipe definition, not the runtime execution plan.