### PR TITLE
Filter duplicate generated files in ScanningRecipe.generate()

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/LargeSourceSet.java
+++ b/rewrite-core/src/main/java/org/openrewrite/LargeSourceSet.java
@@ -99,4 +99,17 @@ public interface LargeSourceSet {
      */
     @Nullable
     SourceFile getBefore(Path sourcePath);
+
+    /**
+     * Called when a recipe's {@code generate()} produces a file whose path collides with
+     * an existing source file or with another generated file. The generated file is silently
+     * dropped. Implementations may override this to detect the collision (e.g. the test
+     * framework raises an assertion failure).
+     *
+     * @param sourcePath    The colliding source path.
+     * @param existingFile  {@code true} if the collision is with an existing source file,
+     *                      {@code false} if it's with another generated file.
+     */
+    default void onGenerateCollision(Path sourcePath, boolean existingFile) {
+    }
 }

--- a/rewrite-test/src/main/java/org/openrewrite/test/LargeSourceSetCheckingExpectedCycles.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/LargeSourceSetCheckingExpectedCycles.java
@@ -21,6 +21,7 @@ import org.openrewrite.Result;
 import org.openrewrite.SourceFile;
 import org.openrewrite.internal.InMemoryLargeSourceSet;
 
+import java.nio.file.Path;
 import java.util.*;
 
 import static java.util.Collections.emptyMap;
@@ -53,6 +54,15 @@ class LargeSourceSetCheckingExpectedCycles extends InMemoryLargeSourceSet {
     @Override
     protected InMemoryLargeSourceSet withChanges(@Nullable Map<SourceFile, List<Recipe>> deletions, List<SourceFile> mapped) {
         return new LargeSourceSetCheckingExpectedCycles(this, deletions, mapped);
+    }
+
+    @Override
+    public void onGenerateCollision(Path sourcePath, boolean existingFile) {
+        if (existingFile) {
+            fail("Recipe generated a source file that already exists in the source set: " + sourcePath);
+        } else {
+            fail("Recipe generated multiple source files at the same path: " + sourcePath);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Problem

`ScanningRecipe.generate()` can return source files whose paths collide with files already in the source set. The framework adds these without any collision check, producing "new file" diffs that fail to apply because the file already exists.

We hit this with `SeparateApplicationYamlByProfile` in rewrite-spring: when a repo has both `application.yml` (with a dev profile section) and an existing `application-dev.yml`, the recipe generates a new `application-dev.yml` that collides with the existing one.

## Solution

Silently filter out generated files whose `sourcePath` collides with an existing file, a previously generated file, or a duplicate within the same `generate()` batch. A `LargeSourceSet.onGenerateCollision()` callback allows the test framework to raise an assertion failure, helping recipe authors catch this during development.

- Closes #6771