### PR TITLE
Restore TypeTable support for Kotlin K2

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTableAnnotationSupport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTableAnnotationSupport.java
@@ -536,6 +536,12 @@ class AnnotationDeserializer {
                         case 't':
                             sb.append('\t');
                             break;
+                        case 'b':
+                            sb.append('\b');
+                            break;
+                        case 'f':
+                            sb.append('\f');
+                            break;
                         case '|':
                             sb.append('|');
                             break; // TypeTable-specific escape

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -300,15 +300,8 @@ public class KotlinParser implements Parser {
         }
 
         public Builder classpathFromResources(ExecutionContext ctx, String... classpath) {
-            // K2 requires full class files; the type-transformed (.tt) stubs from
-            // JavaParser.dependenciesFromResources are not readable by K2's FIR compiler.
-            // Strip version suffixes and resolve full jars from the classpath instead.
-            List<String> stripped = new ArrayList<>(classpath.length);
-            for (String name : classpath) {
-                stripped.add(name.replaceAll("-\\d+$", ""));
-            }
-            this.artifactNames = stripped;
-            this.classpath = null;
+            this.artifactNames = null;
+            this.classpath = JavaParser.dependenciesFromResources(ctx, classpath);
             return this;
         }
 

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinParserTypeTableTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinParserTypeTableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+/**
+ * Verifies that TypeTable-sourced classpath entries work with the Kotlin K2 compiler.
+ */
+class KotlinParserTypeTableTest implements RewriteTest {
+
+    @Test
+    void typeTableClasspathWithCoroutinesViaClasspathFromResources() {
+        rewriteRun(
+          spec -> spec.parser(KotlinParser.builder()
+            .classpathFromResources(new InMemoryExecutionContext(), "kotlinx-coroutines-core-jvm")),
+          kotlin(
+            """
+              import kotlinx.coroutines.channels.ReceiveChannel
+
+              fun <T> pollChannel(channel: ReceiveChannel<T>): T? {
+                  @Suppress("DEPRECATION")
+                  return channel.poll()
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The K2 upgrade unnecessarily bypassed TypeTable classpath resolution. The real issue was a deserialization bug: missing escape sequence handlers for `\b` (backspace) and `\f` (form feed) caused these control characters to be converted to literal characters in `@kotlin.Metadata` annotations, making them unreadable by K2's FIR compiler.

## Changes

- Fixed `TypeTableAnnotationSupport.parseStringValue()` to handle `\b` and `\f` escape sequences
- Restored `KotlinParser.classpathFromResources()` to use `JavaParser.dependenciesFromResources()` (TypeTable path)
- Added test verifying TypeTable-sourced classpath works with K2

## Testing

All existing Kotlin tests pass with TypeTable stubs now working correctly with K2.