### PR TITLE
Add prefix to the block after resolutionStrategy block when non existing

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyConstraintToRule.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyConstraintToRule.java
@@ -380,7 +380,14 @@ public class DependencyConstraintToRule extends Recipe {
                             .map(J.MethodInvocation.class::cast)
                             .findFirst()
                             .orElseThrow(() -> new IllegalStateException("Unable to create a new configurations.all block"));
-                    return cu.withStatements(ListUtils.insert(cu.getStatements(), m, insertionIndex));
+                    List<Statement> newStatements = ListUtils.insert(cu.getStatements(), m, insertionIndex);
+                    if (insertionIndex == 0) {
+                        newStatements = ListUtils.map(newStatements, (i, stat) ->
+                                i == 1 && stat.getPrefix().getWhitespace().isEmpty()
+                                        ? stat.withPrefix(stat.getPrefix().withWhitespace("\n\n"))
+                                        : stat);
+                    }
+                    return cu.withStatements(newStatements);
                 } else {
                     K.CompilationUnit cu = (K.CompilationUnit) sourceFile;
                     assert cu != null;
@@ -425,7 +432,14 @@ public class DependencyConstraintToRule extends Recipe {
                     final int finalInsertionIndex = insertionIndex;
                     return cu.withStatements(ListUtils.mapFirst(cu.getStatements(), arg -> {
                         if (arg == block) {
-                            return block.withStatements(ListUtils.insert(block.getStatements(), m, finalInsertionIndex));
+                            List<Statement> newStatements = ListUtils.insert(block.getStatements(), m, finalInsertionIndex);
+                            if (finalInsertionIndex == 0) {
+                                newStatements = ListUtils.map(newStatements, (i, stat) ->
+                                        i == 1 && stat.getPrefix().getWhitespace().isEmpty()
+                                                ? stat.withPrefix(stat.getPrefix().withWhitespace("\n\n"))
+                                                : stat);
+                            }
+                            return block.withStatements(newStatements);
                         }
                         return arg;
                     }));


### PR DESCRIPTION
## Fix missing newline when inserting `configurations.all` block at file start

### Problem

When running `UpgradeTransitiveDependencyVersion` (which calls `DependencyConstraintToRule` for projects using the Spring Dependency Management plugin) on a standalone Gradle file that only contains a `dependencies {}` block at the very beginning of the file, the inserted `configurations.all {}` block would be concatenated directly with the existing content without proper spacing.

**Before (broken output):**
```groovy
configurations.all {
    resolutionStrategy.eachDependency { details ->
        // ...
    }
}dependencies {
    implementation 'org.springframework.boot:spring-boot-starter-web'
}
```

Notice `}dependencies {` on the same line.

**After (correct output):**
```groovy
configurations.all {
    resolutionStrategy.eachDependency { details ->
        // ...
    }
}

dependencies {
    implementation 'org.springframework.boot:spring-boot-starter-web'
}
```

### Cause

When the `configurations.all {}` block is inserted at index 0 (the beginning of the file), the original first statement (`dependencies {}`) had an empty prefix (no leading whitespace). After insertion, this empty prefix remained, causing the blocks to run together.

### Fix

In `DependencyConstraintToRule.MaybeAddEachDependency`, after inserting the new block at index 0, check if the statement at index 1 has an empty whitespace prefix and add `"\n\n"` if so.

This fix is applied to both:
- Groovy DSL (`G.CompilationUnit`)
- Kotlin DSL (`K.CompilationUnit`)
