### PR TITLE
Fix Python RPC server crash on Windows due to hardcoded /tmp log path

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -27,6 +27,7 @@ import logging
 import os
 import select
 import sys
+import tempfile
 import traceback
 import threading
 from pathlib import Path
@@ -35,7 +36,7 @@ from uuid import uuid4
 
 # Configure logging - log to file by default to avoid filling stderr buffer
 # (which can cause deadlock if parent process doesn't read stderr)
-_default_log_file = '/tmp/python-rpc.log'
+_default_log_file = os.path.join(tempfile.gettempdir(), 'python-rpc.log')
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(levelname)s - %(message)s',


### PR DESCRIPTION
## Summary
- Use `tempfile.gettempdir()` instead of hardcoded `/tmp` for the default RPC log file path, fixing a `FileNotFoundError` on Windows where `/tmp` doesn't exist.

## Test plan
- [ ] Verify Python RPC server starts successfully on Windows CI
- [x] Verify logging still works on Linux/macOS