### PR TITLE
Fix resolution of dated snapshots as input

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -534,16 +534,16 @@ public class MavenPomDownloader {
             }
         }
 
+        GroupArtifactVersion originalGav = gav;
+        gav = resolveNamedVersion(gav, containingPom, repositories, ctx);
+        String versionMaybeDatedSnapshot = datedSnapshotVersion(gav, containingPom, repositories, ctx);
+        gav = handleSnapshotTimestampVersion(gav);
         Iterable<MavenRepository> normalizedRepos = distinctNormalizedRepositories(repositories, containingPom, gav.getVersion());
 
         Timer.Sample sample = Timer.start();
         Timer.Builder timer = Timer.builder("rewrite.maven.download").tag("type", "pom");
 
         Map<MavenRepository, String> repositoryResponses = new LinkedHashMap<>();
-        GroupArtifactVersion originalGav = gav;
-        gav = resolveNamedVersion(gav, containingPom, repositories, ctx);
-        String versionMaybeDatedSnapshot = datedSnapshotVersion(gav, containingPom, repositories, ctx);
-        gav = handleSnapshotTimestampVersion(gav);
         List<String> uris = new ArrayList<>();
 
         // Keep the repo and resolved GAV of the found JAR to avoid throwing if JAR is found


### PR DESCRIPTION
## What's changed?
`MavenPomDownloader.download()` now normalizes the GAV version (via `resolveNamedVersion`, `datedSnapshotVersion`, and `handleSnapshotTimestampVersion`) **before** passing it to `distinctNormalizedRepositories`. Previously, the version was passed raw, and normalization happened after.

This also re-enables the `dontFetchSnapshotsFromReleaseRepos` test that was `@Disabled`.

## What's your motivation?
When a dated snapshot version like `3.28.0-20260220.175218-20` is passed to `download()`, `distinctNormalizedRepositories` captures it as the `acceptsVersion` for its lazy repository filter. Since the dated version doesn't end with `-SNAPSHOT`, `repositoryAcceptsVersion` treats it as a release and checks the `releases` flag. Snapshot-only repositories (e.g. Sonatype snapshots with `releases=false, snapshots=true`) are incorrectly excluded, causing resolution to fail.

The inner filter at line 556 uses the version _after_ `handleSnapshotTimestampVersion` (i.e. `3.28.0-SNAPSHOT`), so it correctly checks the snapshots flag — but by then the snapshot-only repo has already been filtered out by the outer lazy iterator.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
The reordering of the four lines before `distinctNormalizedRepositories`. `resolveNamedVersion` and `datedSnapshotVersion` both call `downloadMetadata` internally, which uses its own `distinctNormalizedRepositories(repositories, containingPom, null)` — the `null` acceptsVersion means all repos pass that filter, so the reordering doesn't affect metadata resolution.

Moving the existing normalization calls before `distinctNormalizedRepositories` was the simplest fix — no new code, no duplicated logic, just a reorder.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
