### PR TITLE
Add test for ChangeParentPom retaining managed version from grandparent

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -1564,6 +1564,69 @@ class ChangeParentPomTest implements RewriteTest {
               )
             );
         }
+
+        @Issue("https://github.com/openrewrite/rewrite/issues/6770")
+        @Test
+        void bringsDownRemovedManagedVersionFromGrandparent() {
+            rewriteRun(
+              spec -> spec.recipe(new ChangeParentPom(
+                "org.springframework.boot", "org.springframework.boot",
+                "spring-boot-starter-parent", "spring-boot-starter-parent",
+                "4.0.2",
+                null, null, null, null, null)),
+              pomXml(
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany</groupId>
+                      <artifactId>child</artifactId>
+                      <version>1.0.0-SNAPSHOT</version>
+                      <parent>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-starter-parent</artifactId>
+                          <version>3.5.9</version>
+                          <relativePath/>
+                      </parent>
+                      <dependencies>
+                        <dependency>
+                          <groupId>org.springframework.retry</groupId>
+                          <artifactId>spring-retry</artifactId>
+                        </dependency>
+                      </dependencies>
+                  </project>
+                  """,
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany</groupId>
+                      <artifactId>child</artifactId>
+                      <version>1.0.0-SNAPSHOT</version>
+                      <parent>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-starter-parent</artifactId>
+                          <version>4.0.2</version>
+                          <relativePath/>
+                      </parent>
+                      <dependencyManagement>
+                          <dependencies>
+                              <dependency>
+                                  <groupId>org.springframework.retry</groupId>
+                                  <artifactId>spring-retry</artifactId>
+                                  <version>2.0.12</version>
+                              </dependency>
+                          </dependencies>
+                      </dependencyManagement>
+                      <dependencies>
+                        <dependency>
+                          <groupId>org.springframework.retry</groupId>
+                          <artifactId>spring-retry</artifactId>
+                        </dependency>
+                      </dependencies>
+                  </project>
+                  """
+              )
+            );
+        }
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/1753")


### PR DESCRIPTION
## Context

- In https://github.com/openrewrite/rewrite/issues/6770 it was reported that `ChangeParentPom` would not add an explicit version for `spring-retry` when upgrading `spring-boot-starter-parent` from 3.5.9 to 4.0.2, since Spring Boot 4 no longer manages `spring-retry`.

## What this PR does

Adds a test `bringsDownRemovedManagedVersionFromGrandparent` that verifies `ChangeParentPom` correctly retains managed versions even when the dependency management comes through a grandparent POM (e.g. `spring-boot-starter-parent` → `spring-boot-dependencies`).

The test confirms that `ChangeParentPom` **does** correctly:
1. Detect that `spring-retry` is managed by `spring-boot-starter-parent:3.5.9` (via `spring-boot-dependencies:3.5.9`)
2. Detect that `spring-boot-starter-parent:4.0.2` no longer manages `spring-retry`
3. Add `spring-retry` with explicit version to `<dependencyManagement>` in the child POM

This is a regression test complementing the existing `bringsDownRemovedManagedVersion` test which only covers the single-level parent case (`spring-boot-dependencies` directly).