### PR TITLE
Python: Add type attribution tests and fix method declaration/type hint types

### DIFF
--- a/rewrite-python/rewrite/pyproject.toml
+++ b/rewrite-python/rewrite/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10"
 dependencies = [
     "cbor2>=5.6.5",
     "more_itertools>=10.0.0",
-    "ty-types>=0.0.18.dev0",  # Type inference CLI for Python type attribution
+    "ty-types>=0.0.19.dev20260223093555",  # Type inference CLI for Python type attribution
     "parso>=0.7.1,<0.8",  # Python 2/3 parser with CST support (0.8+ dropped Python 2.7 grammar)
 ]
 

--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -2182,7 +2182,7 @@ class ParserVisitor(ast.NodeVisitor):
             None,
             body,
             None,
-            self.__as_method_type(self._type_mapping.type(node)),
+            self._type_mapping.method_declaration_type(node),
         )
 
     def __map_decorator(self, decorator) -> j.Annotation:
@@ -2871,7 +2871,7 @@ class ParserVisitor(ast.NodeVisitor):
                      enumerate(slices)],
                     Markers.EMPTY
                 ),
-                None
+                self._type_mapping.type(node)
             )
         elif isinstance(node, ast.BinOp):
             # Type unions using `|` was added in Python 3.10

--- a/rewrite-python/rewrite/tests/python/all/tree/assign_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/assign_test.py
@@ -169,8 +169,8 @@ def test_assign_method_call_type_attribution():
                     if not assignment.type._type_parameters:
                         errors.append("Parameterized._type_parameters is empty")
                 elif isinstance(assignment.type, JavaType.Class):
-                    if assignment.type._fully_qualified_name != 'list':
-                        errors.append(f"Assignment.type fqn is '{assignment.type._fully_qualified_name}', expected 'list'")
+                    if not assignment.type._fully_qualified_name.startswith('list'):
+                        errors.append(f"Assignment.type fqn is '{assignment.type._fully_qualified_name}', expected to start with 'list'")
                 else:
                     errors.append(f"Assignment.type is {type(assignment.type).__name__}, expected Parameterized or Class")
                 return assignment
@@ -178,7 +178,7 @@ def test_assign_method_call_type_attribution():
             def visit_method_invocation(self, method, p):
                 if not isinstance(method, MethodInvocation):
                     return method
-                if method.simple_name != 'split':
+                if method.name.simple_name != 'split':
                     return method
                 # method_type should be populated
                 if method.method_type is None:
@@ -194,11 +194,11 @@ def test_assign_method_call_type_attribution():
                 if method.method_type is not None and method.method_type._return_type is not None:
                     rt = method.method_type._return_type
                     if isinstance(rt, Parameterized):
-                        if rt._type._fully_qualified_name != 'list':
-                            errors.append(f"return_type fqn is '{rt._type._fully_qualified_name}', expected 'list'")
+                        if not rt._type._fully_qualified_name.startswith('list'):
+                            errors.append(f"return_type fqn is '{rt._type._fully_qualified_name}', expected to start with 'list'")
                     elif isinstance(rt, JavaType.Class):
-                        if rt._fully_qualified_name != 'list':
-                            errors.append(f"return_type fqn is '{rt._fully_qualified_name}', expected 'list'")
+                        if not rt._fully_qualified_name.startswith('list'):
+                            errors.append(f"return_type fqn is '{rt._fully_qualified_name}', expected to start with 'list'")
                     else:
                         errors.append(f"return_type is {type(rt).__name__}, expected Parameterized or Class")
                 return method

--- a/rewrite-python/rewrite/tests/python/all/tree/class_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/class_test.py
@@ -1,4 +1,17 @@
+import shutil
+
+import pytest
+
+from rewrite.java.support_types import JavaType
+from rewrite.java.tree import Assignment
+from rewrite.python.tree import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
+
+requires_ty_cli = pytest.mark.skipif(
+    shutil.which('ty-types') is None,
+    reason="ty-types CLI is not installed"
+)
 
 
 def test_empty():
@@ -110,3 +123,39 @@ def test_starred_base():
             ...
         """
     ))
+
+
+@requires_ty_cli
+def test_class_instance_type_attribution():
+    """Verify that x = Foo() assigns a type with fqn 'Foo'."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_assignment(self, assignment, p):
+                if not isinstance(assignment, Assignment):
+                    return assignment
+                if assignment.type is None:
+                    errors.append("Assignment.type is None for Foo()")
+                elif isinstance(assignment.type, JavaType.Class):
+                    if assignment.type._fully_qualified_name != 'Foo':
+                        errors.append(f"Assignment.type fqn is '{assignment.type._fully_qualified_name}', expected 'Foo'")
+                else:
+                    # Accept any non-None type
+                    pass
+                return assignment
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        class Foo:
+            pass
+        x = Foo()
+        """,
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)

--- a/rewrite-python/rewrite/tests/python/all/tree/collection_literal_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/collection_literal_test.py
@@ -1,10 +1,21 @@
+import shutil
 from typing import cast
 
 import pytest
 
 from rewrite.java import MethodDeclaration, Return
+from rewrite.java.support_types import JavaType
+from rewrite.java.tree import Assignment
 from rewrite.python import CollectionLiteral, CompilationUnit
+from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
+
+Parameterized = JavaType.Parameterized
+
+requires_ty_cli = pytest.mark.skipif(
+    shutil.which('ty-types') is None,
+    reason="ty-types CLI is not installed"
+)
 
 
 def test_empty_tuple():
@@ -94,3 +105,67 @@ def test_list_of_tuples_with_double_parens():
     "a": 0
 }), ((set(), {}))]
 """))
+
+
+@requires_ty_cli
+def test_list_literal_type_attribution():
+    """Verify that [1, 2, 3] has type list."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_assignment(self, assignment, p):
+                if not isinstance(assignment, Assignment):
+                    return assignment
+                if assignment.type is None:
+                    errors.append("Assignment.type is None for list literal")
+                elif isinstance(assignment.type, Parameterized):
+                    if not assignment.type._type._fully_qualified_name.startswith('list'):
+                        errors.append(f"Parameterized base fqn is '{assignment.type._type._fully_qualified_name}', expected to start with 'list'")
+                elif isinstance(assignment.type, JavaType.Class):
+                    if not assignment.type._fully_qualified_name.startswith('list'):
+                        errors.append(f"Class fqn is '{assignment.type._fully_qualified_name}', expected to start with 'list'")
+                return assignment
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        "x = [1, 2, 3]",
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)
+
+
+@requires_ty_cli
+def test_dict_literal_type_attribution():
+    """Verify that {"a": 1} has type dict."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_assignment(self, assignment, p):
+                if not isinstance(assignment, Assignment):
+                    return assignment
+                if assignment.type is None:
+                    errors.append("Assignment.type is None for dict literal")
+                elif isinstance(assignment.type, Parameterized):
+                    if not assignment.type._type._fully_qualified_name.startswith('dict'):
+                        errors.append(f"Parameterized base fqn is '{assignment.type._type._fully_qualified_name}', expected to start with 'dict'")
+                elif isinstance(assignment.type, JavaType.Class):
+                    if not assignment.type._fully_qualified_name.startswith('dict'):
+                        errors.append(f"Class fqn is '{assignment.type._fully_qualified_name}', expected to start with 'dict'")
+                return assignment
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        'x = {"a": 1}',
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)

--- a/rewrite-python/rewrite/tests/python/all/tree/def_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/def_test.py
@@ -1,6 +1,17 @@
+import shutil
+
 import pytest
 
+from rewrite.java.support_types import JavaType
+from rewrite.java.tree import MethodDeclaration
+from rewrite.python.tree import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
+
+requires_ty_cli = pytest.mark.skipif(
+    shutil.which('ty-types') is None,
+    reason="ty-types CLI is not installed"
+)
 
 
 def test_async_def():
@@ -11,3 +22,41 @@ def test_async_def():
             pass
         """
     ))
+
+
+@requires_ty_cli
+def test_async_def_type_attribution():
+    """Verify that async def main() -> int has a method_type with a return_type.
+
+    Note: ty-types correctly reports the return type as CoroutineType (the actual
+    runtime return type of an async function), not int (the annotated return type).
+    """
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_method_declaration(self, method, p):
+                if not isinstance(method, MethodDeclaration):
+                    return method
+                if method.name.simple_name != 'main':
+                    return method
+                if method.method_type is None:
+                    errors.append("MethodDeclaration.method_type is None for async def main()")
+                else:
+                    if method.method_type._return_type is None:
+                        errors.append("method_type.return_type is None")
+                return method
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        async def main() -> int:
+            return 0
+        """,
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)

--- a/rewrite-python/rewrite/tests/python/all/tree/field_access_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/field_access_test.py
@@ -1,4 +1,16 @@
+import shutil
+
+import pytest
+
+from rewrite.java.tree import FieldAccess
+from rewrite.python.tree import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
+
+requires_ty_cli = pytest.mark.skipif(
+    shutil.which('ty-types') is None,
+    reason="ty-types CLI is not installed"
+)
 
 
 # noinspection PyUnresolvedReferences
@@ -11,3 +23,34 @@ def test_attribute():
 def test_nested_attribute():
     # language=python
     RecipeSpec().rewrite_run(python("a = foo.bar.baz"))
+
+
+@requires_ty_cli
+def test_field_access_type_attribution():
+    """Verify that os.path has a non-None FieldAccess.type."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_field_access(self, field_access, p):
+                if not isinstance(field_access, FieldAccess):
+                    return field_access
+                if field_access.name.simple_name != 'path':
+                    return field_access
+                if field_access.type is None:
+                    errors.append("FieldAccess.type is None for os.path")
+                return field_access
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        import os
+        x = os.path
+        """,
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)

--- a/rewrite-python/rewrite/tests/python/all/tree/for_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/for_test.py
@@ -1,4 +1,16 @@
+import shutil
+
+import pytest
+
+from rewrite.java.tree import ForEachLoop, Identifier
+from rewrite.python.tree import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
+
+requires_ty_cli = pytest.mark.skipif(
+    shutil.which('ty-types') is None,
+    reason="ty-types CLI is not installed"
+)
 
 
 def test_for():
@@ -61,3 +73,34 @@ def test_async():
             pass
         """
     ))
+
+
+@requires_ty_cli
+def test_for_loop_variable_type_attribution():
+    """Verify that the loop control variable in 'for x in [1, 2, 3]' has a type."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_for_each_loop(self, for_each, p):
+                if not isinstance(for_each, ForEachLoop):
+                    return for_each
+                variable = for_each.control.variable
+                if isinstance(variable, Identifier):
+                    if variable.type is None:
+                        errors.append("ForEachLoop control variable Identifier.type is None")
+                return for_each
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        for x in [1, 2, 3]:
+            pass
+        """,
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)

--- a/rewrite-python/rewrite/tests/python/all/tree/import_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/import_test.py
@@ -1,6 +1,18 @@
+import shutil
+
+import pytest
+
 from rewrite.java import Import
+from rewrite.java.support_types import JavaType
+from rewrite.java.tree import MethodInvocation
 from rewrite.python import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
+
+requires_ty_cli = pytest.mark.skipif(
+    shutil.which('ty-types') is None,
+    reason="ty-types CLI is not installed"
+)
 
 
 def _assert_single_j_import(cu: CompilationUnit) -> None:
@@ -85,3 +97,88 @@ def test_crlf():
         import bar
         """.replace('\n', '\r\n')
     ))
+
+
+def _check_getcwd_declaring_type(source_file, errors):
+    """Shared checker: verify getcwd() method_type.declaring_type.fqn == 'os'."""
+    assert isinstance(source_file, CompilationUnit)
+
+    class TypeChecker(PythonVisitor):
+        def visit_method_invocation(self, method, p):
+            if not isinstance(method, MethodInvocation):
+                return method
+            if method.name.simple_name != 'getcwd':
+                return method
+            if method.method_type is None:
+                errors.append("MethodInvocation.method_type is None for getcwd()")
+            else:
+                if method.method_type.declaring_type is None:
+                    errors.append("method_type.declaring_type is None")
+                elif method.method_type.declaring_type._fully_qualified_name != 'os':
+                    errors.append(
+                        f"declaring_type fqn is '{method.method_type.declaring_type._fully_qualified_name}', expected 'os'"
+                    )
+            return method
+
+    TypeChecker().visit(source_file, None)
+
+
+@requires_ty_cli
+def test_qualified_import_type_attribution():
+    """import os; os.getcwd() → declaring_type.fqn == 'os'."""
+    errors = []
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        import os
+        x = os.getcwd()
+        """,
+        after_recipe=lambda sf: _check_getcwd_declaring_type(sf, errors),
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)
+
+
+@requires_ty_cli
+@pytest.mark.xfail(reason="from-import direct calls do not yet populate declaring_type")
+def test_from_import_type_attribution():
+    """from os import getcwd; getcwd() → declaring_type.fqn == 'os'."""
+    errors = []
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        from os import getcwd
+        x = getcwd()
+        """,
+        after_recipe=lambda sf: _check_getcwd_declaring_type(sf, errors),
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)
+
+
+@requires_ty_cli
+def test_aliased_import_type_attribution():
+    """import os as o; o.getcwd() → declaring_type.fqn == 'os'."""
+    errors = []
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        import os as o
+        x = o.getcwd()
+        """,
+        after_recipe=lambda sf: _check_getcwd_declaring_type(sf, errors),
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)
+
+
+@requires_ty_cli
+def test_aliased_from_import_type_attribution():
+    """from os import getcwd as gwd; gwd() → declaring_type.fqn == 'os'."""
+    errors = []
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        from os import getcwd as gwd
+        x = gwd()
+        """,
+        after_recipe=lambda sf: _check_getcwd_declaring_type(sf, errors),
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)

--- a/rewrite-python/rewrite/tests/python/all/tree/lambda_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/lambda_test.py
@@ -1,4 +1,16 @@
+import shutil
+
+import pytest
+
+from rewrite.java.tree import Assignment, Lambda
+from rewrite.python.tree import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
+
+requires_ty_cli = pytest.mark.skipif(
+    shutil.which('ty-types') is None,
+    reason="ty-types CLI is not installed"
+)
 
 
 def test_no_parameters():
@@ -57,3 +69,31 @@ def test_multiple_complex():
         lambda a, b=20, /, c=30: 1
         lambda a, b, /, c, *, d, e: 0
     '''))
+
+
+@requires_ty_cli
+def test_lambda_type_attribution():
+    """Verify that lambda x: x + 1 has a non-None type."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_assignment(self, assignment, p):
+                if not isinstance(assignment, Assignment):
+                    return assignment
+                # Check the RHS is a Lambda with a type
+                if isinstance(assignment.assignment, Lambda):
+                    if assignment.assignment.type is None:
+                        errors.append("Lambda.type is None")
+                return assignment
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        "l = lambda x: x + 1",
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)

--- a/rewrite-python/rewrite/tests/python/all/tree/method_invocation_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/method_invocation_test.py
@@ -1,6 +1,17 @@
+import shutil
+
 import pytest
 
+from rewrite.java.support_types import JavaType
+from rewrite.java.tree import MethodInvocation
+from rewrite.python.tree import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
+
+requires_ty_cli = pytest.mark.skipif(
+    shutil.which('ty-types') is None,
+    reason="ty-types CLI is not installed"
+)
 
 
 def test_no_select():
@@ -84,3 +95,115 @@ def test_keyword_argument():
 def test_no_name():
     # language=python
     RecipeSpec().rewrite_run(python("v = (a)()"))
+
+
+@requires_ty_cli
+def test_builtin_function_type_attribution():
+    """Verify type attribution on a builtin function call like len()."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_method_invocation(self, method, p):
+                if not isinstance(method, MethodInvocation):
+                    return method
+                if method.name.simple_name != 'len':
+                    return method
+                if method.method_type is None:
+                    errors.append("MethodInvocation.method_type is None for len()")
+                else:
+                    if method.method_type.name != 'len':
+                        errors.append(f"method_type.name is '{method.method_type.name}', expected 'len'")
+                    if method.method_type._return_type is None:
+                        errors.append("method_type.return_type is None")
+                    elif method.method_type._return_type != JavaType.Primitive.Int:
+                        errors.append(f"method_type.return_type is {method.method_type._return_type}, expected Primitive.Int")
+                return method
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        'x = len("hello")',
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)
+
+
+@requires_ty_cli
+def test_string_method_type_attribution():
+    """Verify type attribution on a string method call like str.upper()."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_method_invocation(self, method, p):
+                if not isinstance(method, MethodInvocation):
+                    return method
+                if method.name.simple_name != 'upper':
+                    return method
+                if method.method_type is None:
+                    errors.append("MethodInvocation.method_type is None for upper()")
+                else:
+                    if method.method_type.declaring_type is not None:
+                        dt = method.method_type.declaring_type
+                        if dt._fully_qualified_name != 'str':
+                            errors.append(f"declaring_type fqn is '{dt._fully_qualified_name}', expected 'str'")
+                    if method.method_type._return_type is None:
+                        errors.append("method_type.return_type is None")
+                    elif method.method_type._return_type != JavaType.Primitive.String:
+                        errors.append(f"method_type.return_type is {method.method_type._return_type}, expected Primitive.String")
+                return method
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        'x = "hello".upper()',
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)
+
+
+@requires_ty_cli
+def test_stdlib_function_type_attribution():
+    """Verify type attribution on a stdlib function call like os.getcwd()."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_method_invocation(self, method, p):
+                if not isinstance(method, MethodInvocation):
+                    return method
+                if method.name.simple_name != 'getcwd':
+                    return method
+                if method.method_type is None:
+                    errors.append("MethodInvocation.method_type is None for os.getcwd()")
+                else:
+                    if method.method_type.declaring_type is not None:
+                        dt = method.method_type.declaring_type
+                        if dt._fully_qualified_name != 'os':
+                            errors.append(f"declaring_type fqn is '{dt._fully_qualified_name}', expected 'os'")
+                    if method.method_type._return_type is None:
+                        errors.append("method_type.return_type is None")
+                    elif method.method_type._return_type != JavaType.Primitive.String:
+                        errors.append(f"method_type.return_type is {method.method_type._return_type}, expected Primitive.String")
+                return method
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        import os
+        x = os.getcwd()
+        """,
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)

--- a/rewrite-python/rewrite/tests/python/all/tree/ternary_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/ternary_test.py
@@ -1,6 +1,47 @@
+import shutil
+
+import pytest
+
+from rewrite.java.support_types import JavaType
+from rewrite.java.tree import Ternary
+from rewrite.python.tree import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
+
+requires_ty_cli = pytest.mark.skipif(
+    shutil.which('ty-types') is None,
+    reason="ty-types CLI is not installed"
+)
 
 
 def test_simple():
     # language=python
     RecipeSpec().rewrite_run(python("assert True if True else False"))
+
+
+@requires_ty_cli
+def test_ternary_type_attribution():
+    """Verify that '1 if True else 2' has type Int."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_ternary(self, ternary, p):
+                if not isinstance(ternary, Ternary):
+                    return ternary
+                if ternary.type is None:
+                    errors.append("Ternary.type is None")
+                elif ternary.type != JavaType.Primitive.Int:
+                    errors.append(f"Ternary.type is {ternary.type}, expected Primitive.Int")
+                return ternary
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        "x = 1 if True else 2",
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)

--- a/rewrite-python/rewrite/tests/python/all/tree/type_hint_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/type_hint_test.py
@@ -1,4 +1,19 @@
+import shutil
+
+import pytest
+
+from rewrite.java.support_types import JavaType
+from rewrite.java.tree import VariableDeclarations
+from rewrite.python.tree import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
+
+Parameterized = JavaType.Parameterized
+
+requires_ty_cli = pytest.mark.skipif(
+    shutil.which('ty-types') is None,
+    reason="ty-types CLI is not installed"
+)
 
 
 def test_primitive_type_hint():
@@ -173,3 +188,127 @@ def f(x: "Union[str]") -> None:
     ...
 '''
     ))
+
+
+@requires_ty_cli
+def test_list_int_param_type_attribution():
+    """Verify List[int] parameter type is Parameterized with base list and type param Int."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_variable_declarations(self, var_decls, p):
+                if not isinstance(var_decls, VariableDeclarations):
+                    return var_decls
+                # Look for the parameter 'n' with type hint List[int]
+                for v in var_decls.variables:
+                    if v.name.simple_name != 'n':
+                        continue
+                    vt = var_decls.type_expression
+                    if vt is None:
+                        continue
+                    t = vt.type if hasattr(vt, 'type') else None
+                    if t is None:
+                        errors.append("List[int] parameter type is None")
+                    elif isinstance(t, Parameterized):
+                        if not t._type._fully_qualified_name.startswith('list'):
+                            errors.append(f"Parameterized base fqn is '{t._type._fully_qualified_name}', expected to start with 'list'")
+                    elif isinstance(t, JavaType.Class):
+                        if not t._fully_qualified_name.startswith('list'):
+                            errors.append(f"Class fqn is '{t._fully_qualified_name}', expected to start with 'list'")
+                return var_decls
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        from typing import List
+
+        def test(n: List[int]):
+            return n[0] + 1
+        """,
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)
+
+
+@requires_ty_cli
+def test_dict_str_int_type_attribution():
+    """Verify Dict[str, int] variable type is Parameterized with base dict."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_variable_declarations(self, var_decls, p):
+                if not isinstance(var_decls, VariableDeclarations):
+                    return var_decls
+                for v in var_decls.variables:
+                    if v.name.simple_name != 'foo':
+                        continue
+                    vt = var_decls.type_expression
+                    if vt is None:
+                        continue
+                    t = vt.type if hasattr(vt, 'type') else None
+                    if t is None:
+                        errors.append("Dict[str, int] variable type is None")
+                    elif isinstance(t, Parameterized):
+                        if t._type._fully_qualified_name != 'dict':
+                            errors.append(f"Parameterized base fqn is '{t._type._fully_qualified_name}', expected 'dict'")
+                    elif isinstance(t, JavaType.Class):
+                        if t._fully_qualified_name != 'dict':
+                            errors.append(f"Class fqn is '{t._fully_qualified_name}', expected 'dict'")
+                return var_decls
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        from typing import Dict
+        foo: Dict[str, int] = {}
+        """,
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)
+
+
+@requires_ty_cli
+def test_optional_str_type_attribution():
+    """Verify Optional[str] variable type resolves to str or a union containing str."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_variable_declarations(self, var_decls, p):
+                if not isinstance(var_decls, VariableDeclarations):
+                    return var_decls
+                for v in var_decls.variables:
+                    if v.name.simple_name != 'foo':
+                        continue
+                    vt = var_decls.type_expression
+                    if vt is None:
+                        continue
+                    t = vt.type if hasattr(vt, 'type') else None
+                    if t is None:
+                        errors.append("Optional[str] variable type is None")
+                    # Accept any non-None type (could be str, union, etc.)
+                return var_decls
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        from typing import Optional
+        foo: Optional[str] = None
+        """,
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)

--- a/rewrite-python/rewrite/tests/python/all/tree/unary_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/unary_test.py
@@ -1,6 +1,17 @@
+import shutil
+
 import pytest
 
+from rewrite.java.support_types import JavaType
+from rewrite.java.tree import Unary
+from rewrite.python.tree import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
+
+requires_ty_cli = pytest.mark.skipif(
+    shutil.which('ty-types') is None,
+    reason="ty-types CLI is not installed"
+)
 
 
 def test_bool_ops():
@@ -15,3 +26,33 @@ def test_arithmetic_ops():
     RecipeSpec().rewrite_run(python("assert -1"))
     # language=python
     RecipeSpec().rewrite_run(python("assert ~1"))
+
+
+@requires_ty_cli
+def test_not_type_attribution():
+    """Verify that 'not True' has type Boolean."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_unary(self, unary, p):
+                if not isinstance(unary, Unary):
+                    return unary
+                if unary.operator != Unary.Type.Not:
+                    return unary
+                if unary.type is None:
+                    errors.append("Unary(Not).type is None")
+                elif unary.type != JavaType.Primitive.Boolean:
+                    errors.append(f"Unary(Not).type is {unary.type}, expected Primitive.Boolean")
+                return unary
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        "x = not True",
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -1137,6 +1137,27 @@ greet("World")
             _cleanup_mapping(mapping, tmpdir, client)
 
 
+@requires_ty_types_cli
+class TestTypingAliases:
+    """Tests for typing module type aliases (e.g. typing.Text → str)."""
+
+    def test_typing_text_resolves_to_str(self):
+        """typing.Text (deprecated alias for str) should resolve to Primitive.String.
+
+        ty-types resolves typing.Text to str at the type level, so our type_mapping
+        receives className='str' and maps it to JavaType.Primitive.String automatically.
+        """
+        source = 'from typing import Text\nx: Text = "hello"\nx\n'
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            name_node = tree.body[2].value  # bare 'x' expression
+            result = mapping.type(name_node)
+            assert result == JavaType.Primitive.String, \
+                f"typing.Text should resolve to Primitive.String, got {result}"
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+
 class TestCyclicTypeResolution:
     """Tests that cyclic type references don't cause infinite recursion."""
 


### PR DESCRIPTION
## Summary

- Add type attribution tests to 13 existing Python parser test files, covering method invocations, binary ops, type hints, collection literals, imports, field access, class instances, method declarations, async defs, for loops, unary ops, ternaries, and lambdas (24 new tests total)
- Add `method_declaration_type()` to `type_mapping.py` that builds `JavaType.Method` for function/method declarations — uses structured descriptor data from ty-types when available, falls back to resolving parameter annotations individually
- Add type attribution to `ParameterizedType` nodes (e.g., `List[int]`) in the parser visitor
- Fix pre-existing `assign_test.py` bug: `method.simple_name` → `method.name.simple_name`, and FQN assertions to use `startswith` for types that include type parameters
- Bump `ty-types` dependency to `>=0.0.19.dev20260223093555` which now populates `parameters` and `returnType` on function descriptors

## Test plan

- [x] All 572 tree tests pass (including 24 new type attribution tests)
- [x] 1 expected failure: `from-import` declaring_type is None (genuine type mapping gap for direct function imports)
- [x] Verified with ty-types 0.0.19.dev20260223093555 that function descriptors now include `parameters` and `returnType`