### PR TITLE
Python: Add parameter `field_type` attribution and call-site type arguments

### DIFF
--- a/rewrite-python/rewrite/pyproject.toml
+++ b/rewrite-python/rewrite/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10"
 dependencies = [
     "cbor2>=5.6.5",
     "more_itertools>=10.0.0",
-    "ty-types>=0.0.19.dev20260223093555",  # Type inference CLI for Python type attribution
+    "ty-types>=0.0.19.dev20260223102528",  # Type inference CLI for Python type attribution
     "parso>=0.7.1,<0.8",  # Python 2/3 parser with CST support (0.8+ dropped Python 2.7 grammar)
 ]
 

--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -338,7 +338,8 @@ class ParserVisitor(ast.NodeVisitor):
     def map_arg(self, node, default=None, vararg=False, kwarg=False):
         prefix = self.__source_before('**') if kwarg else self.__whitespace()
         vararg_prefix = self.__source_before('*') if vararg else None
-        name = self.__convert_name(node.arg, self._type_mapping.type(node))
+        expr_type, field_type = self._type_mapping.param_type_info(node)
+        name = self.__convert_name(node.arg, expr_type, field_type)
         after_name = self.__source_before(':') if node.annotation else Space.EMPTY
         type_expression = self.__convert_type(node.annotation) if node.annotation else None
         initializer = self.__pad_left(self.__source_before('='), self.__convert(default)) if default else None
@@ -359,7 +360,7 @@ class ParserVisitor(ast.NodeVisitor):
                 cast(j.Identifier, name),
                 [],
                 initializer,
-                self.__as_variable_type(self._type_mapping.type(node))
+                field_type
             ), after_name)],
         )
 
@@ -3039,12 +3040,13 @@ class ParserVisitor(ast.NodeVisitor):
             return t
         return None
 
-    def __convert_name(self, name: str, name_type: Optional[JavaType] = None) -> NameTree:
+    def __convert_name(self, name: str, name_type: Optional[JavaType] = None,
+                        field_type: Optional[JavaType.Variable] = None) -> NameTree:
         def ident_or_field(parts: List[str]) -> NameTree:
             if len(parts) == 1:
                 space, actual_name = self.__consume_identifier(parts[-1])
                 return j.Identifier(random_id(), space, Markers.EMPTY, [], actual_name,
-                                    name_type, None)
+                                    name_type, field_type)
             else:
                 return j.FieldAccess(
                     random_id(),
@@ -3055,7 +3057,7 @@ class ParserVisitor(ast.NodeVisitor):
                         self.__source_before('.'),
                         (lambda s, n: j.Identifier(random_id(), s, Markers.EMPTY, [], n,
                                      name_type,
-                                     None))(*self.__consume_identifier(parts[-1])),
+                                     field_type))(*self.__consume_identifier(parts[-1])),
                     ),
                     name_type
                 )

--- a/rewrite-python/rewrite/tests/python/all/tree/method_declaration_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/method_declaration_test.py
@@ -3,7 +3,7 @@ import shutil
 import pytest
 
 from rewrite.java.support_types import JavaType
-from rewrite.java.tree import MethodDeclaration
+from rewrite.java.tree import MethodDeclaration, VariableDeclarations
 from rewrite.python.tree import CompilationUnit
 from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
@@ -168,6 +168,45 @@ def test_line_break_after_last_param():
 
 
 @requires_ty_cli
+def test_generic_function_type_params():
+    """Verify method_type.declared_formal_type_names for def identity[T](x: T) -> T."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_method_declaration(self, method, p):
+                if not isinstance(method, MethodDeclaration):
+                    return method
+                if method.name.simple_name != 'identity':
+                    return method
+                if method.method_type is None:
+                    errors.append("MethodDeclaration.method_type is None")
+                else:
+                    mt = method.method_type
+                    if mt._declared_formal_type_names is None:
+                        errors.append("method_type._declared_formal_type_names is None")
+                    elif mt._declared_formal_type_names != ['T']:
+                        errors.append(f"method_type._declared_formal_type_names is {mt._declared_formal_type_names}, expected ['T']")
+                    if mt._parameter_names is not None and 'x' not in mt._parameter_names:
+                        errors.append(f"parameter_names {mt._parameter_names} does not contain 'x'")
+                return method
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        def identity[T](x: T) -> T:
+            return x
+        """,
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)
+
+
+@requires_ty_cli
 def test_method_declaration_type_attribution():
     """Verify method_type on a function with typed parameters and return type."""
     errors = []
@@ -211,6 +250,46 @@ def test_method_declaration_type_attribution():
     RecipeSpec(type_attribution=True).rewrite_run(python(
         """\
         def foo(a: int, b: str) -> bool:
+            return True
+        """,
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)
+
+
+@requires_ty_cli
+def test_param_identifier_field_type():
+    """Verify J.Identifier.field_type is JavaType.Variable for typed parameters."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_variable_declarations(self, vd, p):
+                if not isinstance(vd, VariableDeclarations):
+                    return vd
+                for named_var in vd.variables:
+                    ident = named_var.name
+                    if ident.simple_name not in ('x', 'y'):
+                        continue
+                    if ident.field_type is None:
+                        errors.append(f"Identifier '{ident.simple_name}' has field_type=None")
+                    elif not isinstance(ident.field_type, JavaType.Variable):
+                        errors.append(f"Identifier '{ident.simple_name}' field_type is {type(ident.field_type)}, expected JavaType.Variable")
+                    else:
+                        if ident.field_type._name != ident.simple_name:
+                            errors.append(f"field_type._name is '{ident.field_type._name}', expected '{ident.simple_name}'")
+                        if ident.field_type._type is None:
+                            errors.append(f"field_type._type is None for '{ident.simple_name}'")
+                return vd
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        def greet(x: int, y: str) -> bool:
             return True
         """,
         after_recipe=check_types,


### PR DESCRIPTION
## Summary
- Add `param_type_info()` to `PythonTypeMapping` so function parameter `J.Identifier` nodes get `JavaType.Variable` field_type (matching how `visit_Name` and `visit_Attribute` already work)
- Use call signature `returnTypeId` for call-site-specific return types (e.g., `int` for `identity(42)` instead of generic `T`)
- Populate `_declared_formal_type_names` on method invocation types from function descriptor type parameters
- Bump `ty-types` to `0.0.19.dev20260223102528` for `callSignature` `typeArguments`/`returnTypeId` support

## Test plan
- [x] `test_param_identifier_field_type` — verifies `J.Identifier.field_type` is `JavaType.Variable` for typed function parameters
- [x] `test_generic_call_site_return_type` — verifies `identity(42)` gets `Primitive.Int` return type and `['T']` declared formal type names
- [x] `test_generic_class_type_params` — verifies type parameters on generic class `Box[T]`
- [x] All 416 tree tests pass with no regressions