### PR TITLE
Fix exponential overcounting in composite recipe listings

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeListing.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeListing.java
@@ -26,8 +26,6 @@ import org.openrewrite.config.RecipeDescriptor;
 import java.time.Duration;
 import java.util.*;
 
-import static java.util.Collections.singleton;
-
 @Getter
 @RequiredArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
@@ -92,10 +90,9 @@ public class RecipeListing implements Comparable<RecipeListing> {
 
     public static RecipeListing fromDescriptor(RecipeDescriptor descriptor, RecipeBundle bundle) {
         int recipeCount = 1;
-        RecipeDescriptor d = descriptor;
-        for (Queue<RecipeDescriptor> queue = new LinkedList<>(singleton(descriptor)); !queue.isEmpty();
-             d = queue.poll()) {
-            recipeCount += d.getRecipeList().size();
+        for (Queue<RecipeDescriptor> queue = new LinkedList<>(descriptor.getRecipeList()); !queue.isEmpty(); ) {
+            RecipeDescriptor d = queue.poll();
+            recipeCount++;
             queue.addAll(d.getRecipeList());
         }
 


### PR DESCRIPTION
## Summary
- The BFS loop in `RecipeListing.fromDescriptor` processed the root descriptor twice (once from the pre-initialized `d` variable and again when polled from the queue), causing each level of the tree to be re-expanded exponentially
- Deeply nested composites like `UpgradeToJava25` reported 30k+ recipes instead of ~468
- Fixed by starting the queue with the root's children and counting one vertex per poll