### PR TITLE
Update expected jackson-jakarta-rs-json-provider version in test

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -3427,7 +3427,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                       <dependency>
                           <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
                           <artifactId>jackson-jakarta-rs-json-provider</artifactId>
-                          <version>2.21.0</version>
+                          <version>2.21.1</version>
                       </dependency>
                   </dependencies>
               </project>


### PR DESCRIPTION
## Summary
- Update expected version from `2.21.0` to `2.21.1` in `versionNotDroppedWhenTransitiveDependencyHasManagedVersion` test, since the test uses a `2.x` version pattern that resolves to the latest available release on Maven Central.

## Test plan
- [x] `versionNotDroppedWhenTransitiveDependencyHasManagedVersion` test passes