### PR TITLE
Add RemoveUnnecessaryExclusions recipe

### DIFF
--- a/rewrite-maven/src/main/resources/META-INF/rewrite/maven.yml
+++ b/rewrite-maven/src/main/resources/META-INF/rewrite/maven.yml
@@ -26,6 +26,7 @@ recipeList:
   - org.openrewrite.maven.OrderPomElements
   - org.openrewrite.maven.RemoveDuplicateDependencies
   - org.openrewrite.maven.RemoveRedundantDependencyVersions
+  - org.openrewrite.maven.cleanup.RemoveUnnecessaryExclusions
   - org.openrewrite.maven.RemoveRedundantProperties:
       onlyIfValuesMatch: true
   - org.openrewrite.maven.plugin.DependencyPluginGoalResolveSources
@@ -154,3 +155,15 @@ recipeList:
       filePattern: "**/mvnw.cmd"
   - org.openrewrite.DeleteSourceFiles:
       filePattern: "**/.mvn/wrapper/**"
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.maven.cleanup.RemoveUnnecessaryExclusions
+displayName: Remove unnecessary exclusions
+description: Remove exclusions that are not necessary because the excluded dependency is not a transitive dependency of the project.
+recipeList:
+  - org.openrewrite.maven.RemoveExclusion:
+      groupId: "*"
+      artifactId: "*"
+      exclusionGroupId: "*"
+      exclusionArtifactId: "*"
+      onlyIneffective: true

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/cleanup/RemoveUnnecessaryExclusionsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/cleanup/RemoveUnnecessaryExclusionsTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.cleanup;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class RemoveUnnecessaryExclusionsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResource("/META-INF/rewrite/maven.yml", "org.openrewrite.maven.cleanup.RemoveUnnecessaryExclusions");
+    }
+
+    @DocumentExample
+    @Test
+    void removeIneffectiveExclusion() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>29.0-jre</version>
+                    <exclusions>
+                      <exclusion>
+                        <groupId>commons-lang</groupId>
+                        <artifactId>commons-lang</artifactId>
+                      </exclusion>
+                    </exclusions>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>29.0-jre</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void retainEffectiveExclusion() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>29.0-jre</version>
+                    <exclusions>
+                      <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                      </exclusion>
+                    </exclusions>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeOnlyIneffectiveExclusionsKeepEffective() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>29.0-jre</version>
+                    <exclusions>
+                      <exclusion>
+                        <groupId>commons-lang</groupId>
+                        <artifactId>commons-lang</artifactId>
+                      </exclusion>
+                      <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                      </exclusion>
+                    </exclusions>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>29.0-jre</version>
+                    <exclusions>
+                      <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                      </exclusion>
+                    </exclusions>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a declarative YAML recipe `org.openrewrite.maven.cleanup.RemoveUnnecessaryExclusions` that removes Maven dependency exclusions which are not necessary because the excluded dependency is not actually a transitive dependency of the project
- Wraps the existing `RemoveExclusion` recipe with `onlyIneffective: true` and wildcard matchers
- Adds the new recipe to `org.openrewrite.maven.BestPractices`

## Test plan
- [x] New `RemoveUnnecessaryExclusionsTest` with 3 test cases: removes ineffective exclusion, retains effective exclusion, mixed scenario
- [x] Existing `RemoveExclusionTest` passes (no regressions)