### PR TITLE
Handle null class body in KotlinPrinter

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -728,7 +728,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
                 visitContainer("where", typeConstraints.getPadding().getConstraints(), JContainer.Location.TYPE_PARAMETERS, ",", "", p);
             }
 
-            if (!classDecl.getBody().getMarkers().findFirst(OmitBraces.class).isPresent()) {
+            if (classDecl.getBody() != null && !classDecl.getBody().getMarkers().findFirst(OmitBraces.class).isPresent()) {
                 visit(classDecl.getBody(), p);
             }
             afterSyntax(classDecl, p);


### PR DESCRIPTION
## Summary

- Fix NPE in `KotlinPrinter.visitClassDeclaration0` when printing a class declaration with null body
- This crash occurs when a context-sensitive `JavaTemplate` is applied inside a Kotlin class: the `BlockStatementTemplateGenerator` creates a stripped-down class via `withBody(null)` and prints it to build the template context, but the Kotlin printer didn't handle null body
- Add regression test that applies a context-sensitive template inside a Kotlin class method

## Test plan

- [x] New test `KotlinTemplateTest.addStatementToMethodInClass` reproduces the NPE without the fix and passes with it
- [x] All existing `KotlinTemplateTest` tests pass