### PR TITLE
Python: Support ternary comparisons in PatternMatchingComparator

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/template/comparator.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/comparator.py
@@ -158,6 +158,8 @@ class PatternMatchingComparator:
             return self._compare_assignment(pattern, cast(j.Assignment, target), cursor)
         elif isinstance(pattern, j.Parentheses):
             return self._compare_parentheses(pattern, cast(j.Parentheses, target), cursor)
+        elif isinstance(pattern, j.Ternary):
+            return self._compare_ternary(pattern, cast(j.Ternary, target), cursor)
         elif isinstance(pattern, j.Return):
             return self._compare_return(pattern, cast(j.Return, target), cursor)
         elif isinstance(pattern, py.ExpressionStatement):
@@ -343,6 +345,21 @@ class PatternMatchingComparator:
             return False
 
         return self._compare(pattern.assignment, target.assignment, cursor)
+
+    def _compare_ternary(
+        self,
+        pattern: j.Ternary,
+        target: j.Ternary,
+        cursor: 'Cursor'
+    ) -> bool:
+        """Compare two ternary (conditional) expressions."""
+        if not self._compare(pattern.condition, target.condition, cursor):
+            return False
+
+        if not self._compare(pattern.true_part, target.true_part, cursor):
+            return False
+
+        return self._compare(pattern.false_part, target.false_part, cursor)
 
     def _compare_parentheses(
         self,

--- a/rewrite-python/rewrite/tests/python/template/test_comparator.py
+++ b/rewrite-python/rewrite/tests/python/template/test_comparator.py
@@ -590,6 +590,70 @@ class TestDictLiteralMatching:
         assert result is None
 
 
+class TestTernaryMatching:
+    """Tests for ternary (conditional) expression comparison."""
+
+    def setup_method(self):
+        TemplateEngine.clear_cache()
+
+    def teardown_method(self):
+        TemplateEngine.clear_cache()
+
+    def test_placeholder_ternary_captures(self):
+        """{a} if {cond} else {b} should capture all three parts."""
+        captures = {'a': capture('a'), 'cond': capture('cond'), 'b': capture('b')}
+        pattern_tree = TemplateEngine.get_template_tree("{a} if {cond} else {b}", captures)
+        target_tree = TemplateEngine.get_template_tree("x if flag else y", {})
+        cursor = _make_cursor(target_tree)
+
+        comparator = PatternMatchingComparator(captures)
+        result = comparator.match(pattern_tree, target_tree, cursor)
+        assert result is not None
+        assert 'a' in result
+        assert 'cond' in result
+        assert 'b' in result
+
+    def test_concrete_ternary_match(self):
+        """x if True else y should match x if True else y."""
+        pattern_tree = TemplateEngine.get_template_tree("x if True else y", {})
+        target_tree = TemplateEngine.get_template_tree("x if True else y", {})
+        cursor = _make_cursor(target_tree)
+
+        comparator = PatternMatchingComparator({})
+        result = comparator.match(pattern_tree, target_tree, cursor)
+        assert result is not None
+
+    def test_ternary_condition_mismatch(self):
+        """x if True else y should not match x if False else y."""
+        pattern_tree = TemplateEngine.get_template_tree("x if True else y", {})
+        target_tree = TemplateEngine.get_template_tree("x if False else y", {})
+        cursor = _make_cursor(target_tree)
+
+        comparator = PatternMatchingComparator({})
+        result = comparator.match(pattern_tree, target_tree, cursor)
+        assert result is None
+
+    def test_ternary_true_part_mismatch(self):
+        """x if True else y should not match z if True else y."""
+        pattern_tree = TemplateEngine.get_template_tree("x if True else y", {})
+        target_tree = TemplateEngine.get_template_tree("z if True else y", {})
+        cursor = _make_cursor(target_tree)
+
+        comparator = PatternMatchingComparator({})
+        result = comparator.match(pattern_tree, target_tree, cursor)
+        assert result is None
+
+    def test_ternary_false_part_mismatch(self):
+        """x if True else y should not match x if True else z."""
+        pattern_tree = TemplateEngine.get_template_tree("x if True else y", {})
+        target_tree = TemplateEngine.get_template_tree("x if True else z", {})
+        cursor = _make_cursor(target_tree)
+
+        comparator = PatternMatchingComparator({})
+        result = comparator.match(pattern_tree, target_tree, cursor)
+        assert result is None
+
+
 class TestDefaultFallthrough:
     """Tests for the default comparison behavior on unrecognized types."""
 


### PR DESCRIPTION
## Summary
- Add `_compare_ternary` method to `PatternMatchingComparator` to properly compare `j.Ternary` (conditional expression) nodes by recursively comparing condition, true_part, and false_part
- Previously, ternary expressions fell through to the default case which returned `True` without deep comparison, causing incorrect matches

## Test plan
- [x] New `TestTernaryMatching` tests: placeholder captures, concrete match, condition/true_part/false_part mismatches
- [x] All 42 existing comparator tests still pass