### PR TITLE
Make DeclarativeRecipe.accumulator thread-safe with ThreadLocal

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -603,6 +603,11 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
     }
 
     @Override
+    public void onComplete(ExecutionContext ctx) {
+        accumulator.remove();
+    }
+
+    @Override
     public DeclarativeRecipe clone() {
         DeclarativeRecipe cloned = (DeclarativeRecipe) super.clone();
         cloned.accumulator = new ThreadLocal<>();


### PR DESCRIPTION
## What's Changed

`DeclarativeRecipe.accumulator` is a mutable field that gets set during the scan phase via `getInitialValue()`. When the same `DeclarativeRecipe` instance is shared across concurrent recipe runs (e.g. via a recipe cache in the Moderne worker), one run's scan phase overwrites the accumulator set by another run. This causes the second run to use stale or null accumulator state during the edit phase, resulting in precondition scanning recipes producing incorrect results — typically **0 file changes** for the losing run.

## Changes

- Changed `accumulator` field from `Accumulator` to `ThreadLocal<Accumulator>` so each run thread gets its own independent accumulator
- Updated `getInitialValue()` to use `accumulator.set(acc)` 
- Updated `orVisitors()` to use `accumulator.get()` with a null guard
- Overrode `clone()` to create a fresh `ThreadLocal` for cloned instances

## How to Reproduce

1. Configure a worker with a recipe cache that returns the same `DeclarativeRecipe` instance for the same recipe ID
2. Run the same recipe (e.g. `UpgradeSpringBoot_3_4`) concurrently via two paths — one direct catalog run, one wrapped in a builder/YAML declarative recipe
3. Both paths resolve to the same underlying recipe instances from the cache
4. The catalog run produces correct results; the builder run produces 0 file changes

## Test Plan

- [x] `rewrite-core:test` passes
- [x] Verified concurrent catalog + builder runs against local Moderne stack — builder run now produces results instead of 0 changes