### PR TITLE
Python: Fix tuple parsing for parenthesized element with trailing comma

### DIFF
--- a/rewrite-python/rewrite/tests/python/all/tree/collection_literal_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/collection_literal_test.py
@@ -44,6 +44,23 @@ def test_single_element_tuple_with_trailing_comma():
     RecipeSpec().rewrite_run(python("t = (1 , )"))
 
 
+def test_single_element_tuple_with_trailing_comma_outside_parens():
+    # language=python - parenthesized expression with trailing comma outside
+    RecipeSpec().rewrite_run(python('("a"),\n'))
+
+
+def test_single_element_tuple_with_trailing_comma_outside_parens_multiline():
+    # language=python - multi-line parenthesized string with trailing comma outside
+    RecipeSpec().rewrite_run(python(
+        """\
+(
+    "Part 1"
+    " Part 2"
+),
+"""
+    ))
+
+
 def test_tuple_with_first_element_in_parens():
     # language=python
     RecipeSpec().rewrite_run(python("x = (1) // 2, 0"))

--- a/rewrite-python/rewrite/tests/python/all/tree/type_hint_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/type_hint_test.py
@@ -88,6 +88,16 @@ def test_variable_with_parameterized_type_hint_in_quotes():
     RecipeSpec().rewrite_run(python("""foo: Dict["Foo", str] = None"""))
 
 
+def test_literal_string_type_hint_with_assignment():
+    # language=python - parenthesized string with trailing comma (tuple) before Literal type hint
+    RecipeSpec().rewrite_run(python(
+        """\
+("a"),
+y: Literal["test"] = "value"
+"""
+    ))
+
+
 def test_variable_with_quoted_type_hint():
     # language=python
     RecipeSpec().rewrite_run(python("""foo: 'Foo' = None"""))


### PR DESCRIPTION
## Summary

- Fixes parser crash (`'NoneType' object has no attribute 'value_source'`) when parsing files containing single-element tuples where parentheses wrap the element and the trailing comma is outside, e.g. `("a"),`
- The parser incorrectly identified `(` as the tuple's opening paren in such expressions, causing the token index to progressively fall behind the AST position, eventually crashing when encountering string literals in type annotations like `Literal["..."]`
- Adds token-level analysis for single-element tuples: checks whether `)` is followed by `,` with no `,` inside the parens, distinguishing `("a"),` (grouping parens + implicit tuple) from `("a",)` (tuple parens)

## Test plan
- [x] Added `test_literal_string_type_hint_with_assignment` — minimal reproduction of the original crash
- [x] Added `test_single_element_tuple_with_trailing_comma_outside_parens` — inline case
- [x] Added `test_single_element_tuple_with_trailing_comma_outside_parens_multiline` — multi-line string concatenation case
- [x] All 833 existing Python parser tests pass (422 tree tests, 411 others)
- [x] Verified the original failing file (`preview_long_strings.py`) parses successfully