### PR TITLE
Python: Handle RPC deserialization errors in `PythonRewriteRpc#parseProject()`

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -272,7 +272,8 @@ def parse_python_source(source: str, path: str = "<unknown>", relative_to: Optio
         local_objects[obj_id] = cu
         return {
             'id': obj_id,
-            'sourceFileType': 'org.openrewrite.python.tree.Py$CompilationUnit'
+            'sourceFileType': 'org.openrewrite.python.tree.Py$CompilationUnit',
+            'sourcePath': str(source_path)
         }
     except ImportError as e:
         logger.exception(f"Failed to import parser: {e}")
@@ -319,7 +320,7 @@ def _create_parse_error(path: str, message: str, source: str = '') -> dict:
 
     obj_id = str(parse_error.id)
     local_objects[obj_id] = parse_error
-    return {'id': obj_id, 'sourceFileType': 'org.openrewrite.tree.ParseError'}
+    return {'id': obj_id, 'sourceFileType': 'org.openrewrite.tree.ParseError', 'sourcePath': path}
 
 
 def _infer_project_root(inputs: list) -> Optional[str]:

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProjectResponse.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProjectResponse.java
@@ -40,5 +40,10 @@ class ParseProjectResponse extends ArrayList<ParseProjectResponse.Item> {
          * Example: org.openrewrite.python.tree.Py$CompilationUnit
          */
         String sourceFileType;
+
+        /**
+         * The relative source path of the file.
+         */
+        String sourcePath;
     }
 }


### PR DESCRIPTION
## Summary

- Catch exceptions from `getObject()` in `PythonRewriteRpc.parseProject()`'s Spliterator and emit a `ParseError` instead of aborting the entire parse stream
- Add `sourcePath` to `ParseProjectResponse.Item` (both Python and Java sides) so the `ParseError` identifies which file failed
- Matches the existing error-handling pattern in `RewriteRpc.parse()`

## Context

When an RPC deserialization error occurs (e.g., `UnsupportedOperationException: Unknown state type END_OF_OBJECT`), the exception propagated uncaught from `tryAdvance()` and killed the entire project parse operation. With this fix, the failing source file is represented as a `ParseError` and parsing continues with the remaining files.