### PR TITLE
Python: Fix pattern matching false positives and add template auto-parenthesization

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/template/comparator.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/comparator.py
@@ -146,6 +146,9 @@ class PatternMatchingComparator:
             return self._compare_identifier(pattern, cast(j.Identifier, target))
         elif isinstance(pattern, j.Literal):
             return self._compare_literal(pattern, cast(j.Literal, target))
+        elif isinstance(pattern, j.Empty):
+            # Two Empty sentinel nodes always match (used for absent values)
+            return True
         elif isinstance(pattern, j.MethodInvocation):
             return self._compare_method_invocation(pattern, cast(j.MethodInvocation, target), cursor)
         elif isinstance(pattern, j.FieldAccess):
@@ -162,6 +165,8 @@ class PatternMatchingComparator:
             return self._compare_ternary(pattern, cast(j.Ternary, target), cursor)
         elif isinstance(pattern, j.Return):
             return self._compare_return(pattern, cast(j.Return, target), cursor)
+        elif isinstance(pattern, j.ArrayAccess):
+            return self._compare_array_access(pattern, cast(j.ArrayAccess, target), cursor)
         elif isinstance(pattern, py.ExpressionStatement):
             return self._compare_expression_statement(pattern, cast(py.ExpressionStatement, target), cursor)
         elif isinstance(pattern, py.Binary):
@@ -171,10 +176,12 @@ class PatternMatchingComparator:
         elif isinstance(pattern, py.DictLiteral):
             return self._compare_dict_literal(pattern, cast(py.DictLiteral, target), cursor)
         else:
-            # Default: no deep comparison, types matched
+            # Default: unhandled node type — reject the match to prevent
+            # false positives.  If a pattern uses a node type that reaches
+            # this branch, a specific comparator method should be added.
             if self._debug:
-                print(f"No specific comparison for {type(pattern).__name__}, assuming match")
-            return True
+                print(f"No specific comparison for {type(pattern).__name__}, rejecting match")
+            return False
 
     def _capture_node(self, name: str, target: J) -> bool:
         """
@@ -360,6 +367,18 @@ class PatternMatchingComparator:
             return False
 
         return self._compare(pattern.false_part, target.false_part, cursor)
+
+    def _compare_array_access(
+        self,
+        pattern: j.ArrayAccess,
+        target: j.ArrayAccess,
+        cursor: 'Cursor'
+    ) -> bool:
+        """Compare two array/subscript accesses."""
+        if not self._compare(pattern.indexed, target.indexed, cursor):
+            return False
+
+        return self._compare(pattern.dimension.index, target.dimension.index, cursor)
 
     def _compare_parentheses(
         self,


### PR DESCRIPTION
## Summary

Two fixes in the Python template system discovered while running cleanup recipes across 11 open-source Python projects:

- **PatternMatchingComparator**: The default fallthrough for unhandled node types returned `True`, causing false positive matches. For example, `pattern("{x} == None")` would match `x == b"hello"` because `ArrayAccess` nodes weren't handled and any two nodes of an unrecognized type silently matched. Changed to `return False` and added explicit handlers for `Empty` (sentinel) and `ArrayAccess` nodes.

- **PlaceholderReplacementVisitor**: Template substitution didn't account for operator precedence, producing semantically incorrect output. For example, `template("{a} and {b}")` with `b` captured as `x or y` would produce `a and x or y` instead of `a and (x or y)`. Added auto-parenthesization in `visit_binary`, `visit_python_binary`, and `visit_unary` that wraps substituted expressions when they have lower precedence than the surrounding context.

## Test plan

- [ ] 15 new unit tests in `test_comparator.py` and `test_replacement.py` covering:
  - ArrayAccess matching (positive, index mismatch, indexed mismatch)
  - Empty sentinel node matching
  - Unhandled node type rejection
  - Auto-parenthesization for `or` in `and`, `and` in `and` (no parens), arithmetic precedence, Python `in` operator, `not` with `and`/`or` operands, `not` with identifiers/comparisons (no parens)
- [ ] All 1020 existing framework tests pass
- [ ] All 713 downstream recipe tests pass