### PR TITLE
Python: register all existing recipes

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/__init__.py
@@ -108,9 +108,29 @@ def activate(marketplace: RecipeMarketplace) -> None:
         marketplace: The RecipeMarketplace to install recipes into
     """
     from rewrite.decorators import get_recipe_category
-    from rewrite.python.recipes import RemovePass
+    from rewrite.python.recipes import (
+        RemovePass,
+        ChangeImport,
+        ChangeType,
+        ChangeMethodName,
+        ChangePackage,
+        DeleteMethodArgument,
+        ReorderMethodArguments,
+        AddLiteralMethodArgument,
+    )
 
-    # Install all Python recipes with their categories
-    category = get_recipe_category(RemovePass)
-    if category is not None:
-        marketplace.install(RemovePass, category)
+    for recipe_class in [
+        RemovePass,
+        ChangeImport,
+        ChangeType,
+        ChangeMethodName,
+        ChangePackage,
+        DeleteMethodArgument,
+        ReorderMethodArguments,
+        AddLiteralMethodArgument,
+    ]:
+        category = get_recipe_category(recipe_class)
+        if category is not None:
+            marketplace.install(recipe_class, category)
+        else:
+            marketplace.install(recipe_class, Python)

--- a/rewrite-python/rewrite/src/rewrite/python/recipes/add_literal_method_argument.py
+++ b/rewrite-python/rewrite/src/rewrite/python/recipes/add_literal_method_argument.py
@@ -21,9 +21,12 @@ from dataclasses import field
 from typing import Any, Optional
 
 from rewrite import ExecutionContext, Recipe, TreeVisitor, option
+from rewrite.decorators import categorize
+from rewrite.marketplace import Python
 from rewrite.rpc.java_recipe import prepare_java_recipe, JavaRecipeVisitor, PreparedJavaRecipe
 
 
+@categorize(Python)
 class AddLiteralMethodArgument(Recipe):
     """
     Add a literal argument to method invocations matching a pattern.
@@ -58,9 +61,9 @@ class AddLiteralMethodArgument(Recipe):
 
     def __init__(
         self,
-        method_pattern: str,
-        argument_index: int,
-        literal: str
+        method_pattern: str = "",
+        argument_index: int = 0,
+        literal: str = ""
     ):
         self.method_pattern = method_pattern
         self.argument_index = argument_index

--- a/rewrite-python/rewrite/src/rewrite/python/recipes/change_method_name.py
+++ b/rewrite-python/rewrite/src/rewrite/python/recipes/change_method_name.py
@@ -21,9 +21,12 @@ from dataclasses import field
 from typing import Any, Optional
 
 from rewrite import ExecutionContext, Recipe, TreeVisitor, option
+from rewrite.decorators import categorize
+from rewrite.marketplace import Python
 from rewrite.rpc.java_recipe import prepare_java_recipe, JavaRecipeVisitor, PreparedJavaRecipe
 
 
+@categorize(Python)
 class ChangeMethodName(Recipe):
     """
     Rename method invocations matching a pattern.
@@ -65,8 +68,8 @@ class ChangeMethodName(Recipe):
 
     def __init__(
         self,
-        method_pattern: str,
-        new_method_name: str,
+        method_pattern: str = "",
+        new_method_name: str = "",
         match_overrides: bool = False,
         ignore_definition: bool = False
     ):

--- a/rewrite-python/rewrite/src/rewrite/python/recipes/change_package.py
+++ b/rewrite-python/rewrite/src/rewrite/python/recipes/change_package.py
@@ -21,9 +21,12 @@ from dataclasses import field
 from typing import Any, Optional
 
 from rewrite import ExecutionContext, Recipe, TreeVisitor, option
+from rewrite.decorators import categorize
+from rewrite.marketplace import Python
 from rewrite.rpc.java_recipe import prepare_java_recipe, JavaRecipeVisitor, PreparedJavaRecipe
 
 
+@categorize(Python)
 class ChangePackage(Recipe):
     """
     Change package/module references from one name to another.
@@ -58,8 +61,8 @@ class ChangePackage(Recipe):
 
     def __init__(
         self,
-        old_package_name: str,
-        new_package_name: str,
+        old_package_name: str = "",
+        new_package_name: str = "",
         recursive: bool = True
     ):
         self.old_package_name = old_package_name

--- a/rewrite-python/rewrite/src/rewrite/python/recipes/change_type.py
+++ b/rewrite-python/rewrite/src/rewrite/python/recipes/change_type.py
@@ -22,9 +22,12 @@ from dataclasses import field
 from typing import Any, Optional
 
 from rewrite import ExecutionContext, Recipe, TreeVisitor, option
+from rewrite.decorators import categorize
+from rewrite.marketplace import Python
 from rewrite.rpc.java_recipe import prepare_java_recipe, JavaRecipeVisitor, PreparedJavaRecipe
 
 
+@categorize(Python)
 class ChangeType(Recipe):
     """
     Change a type reference from one fully qualified name to another.
@@ -63,8 +66,8 @@ class ChangeType(Recipe):
 
     def __init__(
         self,
-        old_fully_qualified_type_name: str,
-        new_fully_qualified_type_name: str,
+        old_fully_qualified_type_name: str = "",
+        new_fully_qualified_type_name: str = "",
         ignore_definition: bool = False
     ):
         self.old_fully_qualified_type_name = old_fully_qualified_type_name

--- a/rewrite-python/rewrite/src/rewrite/python/recipes/delete_method_argument.py
+++ b/rewrite-python/rewrite/src/rewrite/python/recipes/delete_method_argument.py
@@ -21,9 +21,12 @@ from dataclasses import field
 from typing import Any, Optional
 
 from rewrite import ExecutionContext, Recipe, TreeVisitor, option
+from rewrite.decorators import categorize
+from rewrite.marketplace import Python
 from rewrite.rpc.java_recipe import prepare_java_recipe, JavaRecipeVisitor, PreparedJavaRecipe
 
 
+@categorize(Python)
 class DeleteMethodArgument(Recipe):
     """
     Remove an argument from method invocations matching a pattern.
@@ -51,8 +54,8 @@ class DeleteMethodArgument(Recipe):
 
     def __init__(
         self,
-        method_pattern: str,
-        argument_index: int
+        method_pattern: str = "",
+        argument_index: int = 0
     ):
         self.method_pattern = method_pattern
         self.argument_index = argument_index

--- a/rewrite-python/rewrite/src/rewrite/python/recipes/reorder_method_arguments.py
+++ b/rewrite-python/rewrite/src/rewrite/python/recipes/reorder_method_arguments.py
@@ -22,9 +22,12 @@ from importlib.metadata import metadata
 from typing import Any, List, Optional
 
 from rewrite import ExecutionContext, Recipe, TreeVisitor, option
+from rewrite.decorators import categorize
+from rewrite.marketplace import Python
 from rewrite.rpc.java_recipe import prepare_java_recipe, JavaRecipeVisitor, PreparedJavaRecipe
 
 
+@categorize(Python)
 class ReorderMethodArguments(Recipe):
     """
     Reorder arguments in method invocations matching a pattern.
@@ -59,8 +62,8 @@ class ReorderMethodArguments(Recipe):
 
     def __init__(
             self,
-            method_pattern: str,
-            new_parameter_names: List[str],
+            method_pattern: str = "",
+            new_parameter_names: Optional[List[str]] = None,
             old_parameter_names: Optional[List[str]] = None
     ):
         self.method_pattern = method_pattern


### PR DESCRIPTION
## What's changed?

Adding all existing recipes under rewrite-python to the modules `activate()` function.

## What's your motivation?

So that these recipes are installed.
Some recipe libraries already started depending on them and if they are not activated, then the execution might fail with:
```
Caused by io.moderne.jsonrpc.JsonRpcException: {code=-32603, message='Recipe not found: org.openrewrite.python.ChangeImport'}
  io.moderne.jsonrpc.JsonRpc$1.compute(JsonRpc.java:78)
  java.base/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:194)
```