### PR TITLE
Python: Fix cross-type literal matching in pattern comparator

### DIFF
--- a/rewrite-python/rewrite/tests/python/template/test_comparator.py
+++ b/rewrite-python/rewrite/tests/python/template/test_comparator.py
@@ -128,6 +128,86 @@ class TestLiteralMatching:
         assert result is None
 
 
+class TestCrossTypeLiteralMatching:
+    """Tests that literals of different Python types never match each other."""
+
+    def setup_method(self):
+        TemplateEngine.clear_cache()
+
+    def teardown_method(self):
+        TemplateEngine.clear_cache()
+
+    def test_none_does_not_match_bytes_literal(self):
+        """None should not match b''."""
+        pattern_tree = TemplateEngine.get_template_tree("None", {})
+        target_tree = TemplateEngine.get_template_tree('b""', {})
+        cursor = _make_cursor(target_tree)
+
+        comparator = PatternMatchingComparator({})
+        result = comparator.match(pattern_tree, target_tree, cursor)
+        assert result is None
+
+    def test_none_does_not_match_nonempty_bytes(self):
+        """None should not match b'hello'."""
+        pattern_tree = TemplateEngine.get_template_tree("None", {})
+        target_tree = TemplateEngine.get_template_tree('b"hello"', {})
+        cursor = _make_cursor(target_tree)
+
+        comparator = PatternMatchingComparator({})
+        result = comparator.match(pattern_tree, target_tree, cursor)
+        assert result is None
+
+    def test_none_does_not_match_empty_string(self):
+        """None should not match ''."""
+        pattern_tree = TemplateEngine.get_template_tree("None", {})
+        target_tree = TemplateEngine.get_template_tree('""', {})
+        cursor = _make_cursor(target_tree)
+
+        comparator = PatternMatchingComparator({})
+        result = comparator.match(pattern_tree, target_tree, cursor)
+        assert result is None
+
+    def test_none_does_not_match_zero(self):
+        """None should not match 0."""
+        pattern_tree = TemplateEngine.get_template_tree("None", {})
+        target_tree = TemplateEngine.get_template_tree("0", {})
+        cursor = _make_cursor(target_tree)
+
+        comparator = PatternMatchingComparator({})
+        result = comparator.match(pattern_tree, target_tree, cursor)
+        assert result is None
+
+    def test_none_matches_none(self):
+        """None should match None."""
+        pattern_tree = TemplateEngine.get_template_tree("None", {})
+        target_tree = TemplateEngine.get_template_tree("None", {})
+        cursor = _make_cursor(target_tree)
+
+        comparator = PatternMatchingComparator({})
+        result = comparator.match(pattern_tree, target_tree, cursor)
+        assert result is not None
+
+    def test_none_does_not_match_ellipsis(self):
+        """None should not match ... (Ellipsis) — both have value=None internally."""
+        pattern_tree = TemplateEngine.get_template_tree("None", {})
+        target_tree = TemplateEngine.get_template_tree("...", {})
+        cursor = _make_cursor(target_tree)
+
+        comparator = PatternMatchingComparator({})
+        result = comparator.match(pattern_tree, target_tree, cursor)
+        assert result is None
+
+    def test_bytes_does_not_match_string(self):
+        """b'hello' should not match 'hello'."""
+        pattern_tree = TemplateEngine.get_template_tree('b"hello"', {})
+        target_tree = TemplateEngine.get_template_tree('"hello"', {})
+        cursor = _make_cursor(target_tree)
+
+        comparator = PatternMatchingComparator({})
+        result = comparator.match(pattern_tree, target_tree, cursor)
+        assert result is None
+
+
 class TestMethodInvocationMatching:
     """Tests for method invocation comparison."""
 


### PR DESCRIPTION
## Summary
- Strengthens `_compare_literal` in `PatternMatchingComparator` to prevent cross-type false positives
- Adds value type checking before value equality (`type(pattern.value) != type(target.value)`)
- Falls back to `value_source` comparison when both values are `None` (disambiguates `None` keyword from `...` and unicode-escaped literals which all store `value=None`)
- Prevents patterns like `{x} == None` from incorrectly matching byte string comparisons like `x == b""`

## Context
Running `PythonBestPractices` across 12 open-source projects showed `NoneCompare` and `RemoveNoneFromDefaultGet` incorrectly transforming byte string literals:
- `assert response.content == b"Hello"` → `assert response.content is None`
- `body += message.get("body", b"")` → `body += message.get("body")`

## Test plan
- [x] 7 new cross-type literal matching tests (`TestCrossTypeLiteralMatching`)
- [x] All 1027 existing framework tests pass
- [x] All 717 recipe tests pass