### PR TITLE
Python: Enable build cache and Develocity reporting for pytest

### DIFF
--- a/rewrite-python/build.gradle.kts
+++ b/rewrite-python/build.gradle.kts
@@ -1,5 +1,7 @@
 @file:Suppress("UnstableApiUsage")
 
+import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports
+import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect
 import nl.javadude.gradle.plugins.license.LicenseExtension
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -163,12 +165,20 @@ val pytestTest by tasks.registering(Exec::class) {
     dependsOn(pythonInstall)
 
     workingDir = pythonDir
-    commandLine(pythonExe.absolutePath, "-m", "pytest", "tests/", "-v")
+    commandLine(pythonExe.absolutePath, "-m", "pytest", "tests/", "-v",
+        "--junitxml=build/test-results/pytest/junit.xml")
 
     inputs.dir(pythonDir.resolve("src"))
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.dir(pythonDir.resolve("tests"))
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.file(pythonDir.resolve("pyproject.toml"))
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.file(pythonDir.resolve("build/test-results/pytest/junit.xml"))
+    outputs.cacheIf { true }
 }
+
+ImportJUnitXmlReports.register(tasks, pytestTest, JUnitXmlDialect.GENERIC)
 
 tasks.named("check") {
     dependsOn(testing.suites.named("py2CompatibilityTest"))


### PR DESCRIPTION
## Summary
- Enable Gradle remote build cache for the `pytestTest` task by declaring outputs, path sensitivity, and `cacheIf { true }` — matching the pattern used by `npmTest` in rewrite-javascript
- Produce JUnit XML via `--junitxml` and register it with Develocity via `ImportJUnitXmlReports` so pytest results appear in build scans

## Test plan
- [ ] Verify CI build succeeds and `pytestTest` task runs
- [ ] Check the Develocity build scan for pytest test results
- [ ] On a second CI run with no Python changes, verify `pytestTest` is cached (UP-TO-DATE or FROM-CACHE)