### PR TITLE
JavaScript: Add Develocity test reporting for Jest

### DIFF
--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -2,6 +2,8 @@
 
 import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.npm.task.NpmTask
+import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports
+import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect
 import nl.javadude.gradle.plugins.license.LicenseExtension
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -111,6 +113,8 @@ val npmTest = tasks.register<NpmTask>("npmTest") {
 
     args = listOf("run", "ci:test")
 }
+
+ImportJUnitXmlReports.register(tasks, npmTest, JUnitXmlDialect.GENERIC)
 
 tasks.named("check") {
     dependsOn(npmTest)


### PR DESCRIPTION
## Summary
- Register the existing Jest JUnit XML report with Develocity via `ImportJUnitXmlReports` so JS test results appear in build scans
- Matches the pattern added for pytest in #6819
- No changes to Jest config needed — `jest-junit` reporter was already configured and producing `build/test-results/jest/junit.xml`

## Test plan
- [ ] Verify CI build succeeds
- [ ] Check the Develocity build scan for Jest test results under `:rewrite-javascript:npmTest`