### PR TITLE
Remove reflective validation from ReplaceStringLiteralWithConstant

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ReplaceStringLiteralWithConstant.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ReplaceStringLiteralWithConstant.java
@@ -69,25 +69,6 @@ public class ReplaceStringLiteralWithConstant extends Recipe {
         if (StringUtils.isBlank(fullyQualifiedConstantName)) {
             return result.and(invalid(CONSTANT_FQN_PARAM, fullyQualifiedConstantName, "The constant's fully qualified name may not be empty or blank."));
         }
-        if (StringUtils.isBlank(literalValue)) {
-            try {
-                Object constantValue = getConstantValueByFullyQualifiedName(fullyQualifiedConstantName);
-                if (constantValue == null) {
-                    return result.and(invalid(CONSTANT_FQN_PARAM, fullyQualifiedConstantName, "Provided constant should not be null."));
-                }
-                if (!(constantValue instanceof String)) {
-                    // currently, we only support string literals, also see visitor implementation
-                    return result.and(invalid(CONSTANT_FQN_PARAM, fullyQualifiedConstantName, "Unsupported type of constant provided. Only literals can be replaced."));
-                }
-                return result;
-            } catch (ClassNotFoundException e) {
-                return result.and(invalid(CONSTANT_FQN_PARAM, fullyQualifiedConstantName, "No class for specified name was found."));
-            } catch (NoSuchFieldException e) {
-                return result.and(invalid(CONSTANT_FQN_PARAM, fullyQualifiedConstantName, "No field with specified name was found."));
-            } catch (IllegalAccessException e) {
-                return result.and(invalid(CONSTANT_FQN_PARAM, fullyQualifiedConstantName, "Unable to access specified field."));
-            }
-        }
         return result;
     }
 


### PR DESCRIPTION
## What's Changed

`ReplaceStringLiteralWithConstant.validate()` used `Class.forName()` to reflectively verify the target constant when `literalValue` was not provided. This fails when the target class isn't on the recipe classpath, producing validation errors like:

```
fullyQualifiedConstantName was 'org.springframework.http.MediaType.TEXT_HTML_VALUE'
but it No class for specified name was found.
```

This is the common case — `rewrite-spring` doesn't depend on `spring-web`, so `org.springframework.http.MediaType` and `org.springframework.http.HttpHeaders` are never on the recipe classpath.

The runtime already handles this gracefully: `getLiteralValue()` catches `ClassNotFoundException` and returns `null`, and `getVisitor()` returns a noop. Validation should not reject the recipe for a condition the runtime handles.

## Fix

Remove the reflective validation block from `validate()`. Keep only the `fullyQualifiedConstantName` blank check. The reflective fallback in `getLiteralValue()` is retained as a best-effort mechanism for when the class happens to be on the classpath.

- Related: https://github.com/openrewrite/rewrite-spring/pull/947

## Test plan

- [x] All `ReplaceStringLiteralWithConstantTest` tests pass (11 tests)
- [x] Compilation succeeds