### PR TITLE
Python: Serialize large integers as strings in RPC

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/send_queue.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/send_queue.py
@@ -316,7 +316,14 @@ class RpcSendQueue:
             return None
         if isinstance(obj, bool):
             return obj
-        if isinstance(obj, (int, str)):
+        if isinstance(obj, int):
+            # Integers exceeding Java's long range cannot be serialized as
+            # JSON numbers (Jackson's StreamReadConstraints rejects them).
+            # Convert to string — the original source is preserved in valueSource.
+            if obj > 9223372036854775807 or obj < -9223372036854775808:
+                return str(obj)
+            return obj
+        if isinstance(obj, str):
             return obj
         if isinstance(obj, float):
             # Special float values (inf, nan) are not valid JSON


### PR DESCRIPTION
## Summary

Convert Python integers exceeding Java's `long` range (`±2^63`) to strings in `_get_primitive_value` before JSON serialization, avoiding Jackson's `StreamReadConstraints.getMaxNumberLength()` limit (default 1000 digits).

## Context

Python integers have no size limit. When a literal like `P = 0xFFFF...FFFF` (a 1026-char hex / 1234-digit decimal number) is serialized via `_get_primitive_value`, it was sent as a raw JSON number. Jackson 2.15+ rejects numbers exceeding 1000 digits, causing deserialization failure. The error was then silently dropped by the JSON-RPC layer (fix in moderneinc/jsonrpc#14), causing the caller to hang indefinitely.

The literal's `valueSource` field already carries the original hex string, so printing is unaffected by converting the value to a string.