### PR TITLE
JavaScript and Python: unique file names for `version.txt` files

### DIFF
--- a/rewrite-javascript/.gitignore
+++ b/rewrite-javascript/.gitignore
@@ -4,4 +4,4 @@ rpc.*.log
 /.rewrite
 /.working-dir
 
-src/main/resources/META-INF/version.txt
+src/main/resources/META-INF/rewrite-javascript-version.txt

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -72,7 +72,7 @@ fun extractVersionFromJar(): String? {
     if (!jarFile.exists()) return null
 
     return zipTree(jarFile).matching {
-        include("META-INF/version.txt")
+        include("META-INF/rewrite-javascript-version.txt")
     }.singleFile.readText().trim()
 }
 
@@ -129,7 +129,7 @@ val npmBuild = tasks.register<NpmTask>("npmBuild") {
         .withPathSensitivity(PathSensitivity.RELATIVE)
     outputs.dir(file("rewrite/dist/"))
 
-    val versionTxt = file("src/main/resources/META-INF/version.txt")
+    val versionTxt = file("src/main/resources/META-INF/rewrite-javascript-version.txt")
     outputs.file(versionTxt)
     doLast {
         versionTxt.writeText(datedSnapshotVersion)
@@ -138,7 +138,7 @@ val npmBuild = tasks.register<NpmTask>("npmBuild") {
     args = listOf("run", "build")
 }
 
-// Because each of these sees version.txt as an input
+// Because each of these sees rewrite-javascript-version.txt as an input
 listOf("sourcesJar", "processResources", "licenseMain", "assemble").forEach {
     tasks.named(it) {
         dependsOn(npmBuild)
@@ -240,7 +240,7 @@ tasks.named("publish") {
 
 extensions.configure<LicenseExtension> {
     header = file("${rootProject.projectDir}/gradle/msalLicenseHeader.txt")
-    exclude("**/version.txt")
+    exclude("**/rewrite-javascript-version.txt")
 //    includePatterns.addAll(
 //        listOf("**/*.ts")
 //    )

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -333,7 +333,7 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
                         recipeInstallDir == null ? null : "--recipe-install-dir=" + recipeInstallDir.toAbsolutePath().normalize()
                 );
             } else {
-                String version = StringUtils.readFully(getClass().getResourceAsStream("/META-INF/version.txt"));
+                String version = StringUtils.readFully(getClass().getResourceAsStream("/META-INF/rewrite-javascript-version.txt"));
                 cmd = Stream.of(
                         npxPath.toString(),
                         // For SNAPSHOT versions, assume npm link has been run and don't use --package

--- a/rewrite-python/.gitignore
+++ b/rewrite-python/.gitignore
@@ -1,1 +1,1 @@
-src/main/resources/META-INF/version.txt
+src/main/resources/META-INF/rewrite-python-version.txt

--- a/rewrite-python/build.gradle.kts
+++ b/rewrite-python/build.gradle.kts
@@ -222,12 +222,12 @@ val pythonVersion: String = if (System.getenv("CI") != null) {
     project.version.toString().replace("-SNAPSHOT", ".dev0")
 }
 
-// Write version.txt resource so PythonRewriteRpc can pin the pip package version
+// Write rewrite-python-version.txt resource so PythonRewriteRpc can pin the pip package version
 val generateVersionTxt by tasks.registering {
     group = "python"
-    description = "Generate META-INF/version.txt for RPC version pinning"
+    description = "Generate META-INF/rewrite-python-version.txt for RPC version pinning"
 
-    val versionTxt = file("src/main/resources/META-INF/version.txt")
+    val versionTxt = file("src/main/resources/META-INF/rewrite-python-version.txt")
     inputs.property("version", pythonVersion)
     outputs.file(versionTxt)
 
@@ -401,6 +401,6 @@ val printTestClasspath by tasks.registering {
 }
 
 extensions.configure<LicenseExtension> {
-    exclude("**/version.txt")
+    exclude("**/rewrite-python-version.txt")
 }
 

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -542,7 +542,7 @@ public class PythonRewriteRpc extends RewriteRpc {
             // version takes precedence. For release/CI builds, always use pipPackagesPath
             // to ensure the correct pinned version.
             String version = StringUtils.readFully(
-                    PythonRewriteRpc.class.getResourceAsStream("/META-INF/version.txt")).trim();
+                    PythonRewriteRpc.class.getResourceAsStream("/META-INF/rewrite-python-version.txt")).trim();
             boolean isDevBuild = version.isEmpty() || version.endsWith(".dev0");
             boolean interpreterHasRewrite = isDevBuild && pipPackagesPath != null && canImportRewrite(pythonPath);
             boolean usePipPackagesPath = pipPackagesPath != null && !interpreterHasRewrite;


### PR DESCRIPTION
## What's changed?

Rename the special `version.txt` files baked into `rewrite-python` and `rewrite-javascript` JAR files.
New names are unique - different for JS and Python.

## What's your motivation?

Prevent JavaScript RPC server from reading the Python one (and vice versa).

The following has been observed in CI of one of the derived projects:
```
Error output:
      npm error code ETARGET
      npm error notarget No matching version found for @openrewrite/rewrite@8.75.0.dev20260226090025.
      npm error notarget In most cases you or one of your dependencies are requesting
      npm error notarget a package version that doesn't exist.
      npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-02-26T12_23_59_857Z-debug-0.log
```