### PR TITLE
Fix `IllegalArgumentException` in `Input.getRelativePath` for relative paths

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -678,7 +678,7 @@ public class KotlinParser implements Parser {
 
     static class SourcePathFromSourceTextResolver {
         private static final Pattern packagePattern = Pattern.compile("^package\\s+(\\S+)");
-        private static final Pattern classPattern = Pattern.compile("(class|interface|enum class)\\s*(<[^>]*>)?\\s+(\\w+)");
+        private static final Pattern classPattern = Pattern.compile("(class|interface|data class|enum class)\\s*(<[^>]*>)?\\s+(\\w+)");
         private static final Pattern publicClassPattern = Pattern.compile("public\\s+" + classPattern.pattern());
 
         private static Optional<String> matchClassPattern(Pattern pattern, String source) {


### PR DESCRIPTION
## What's Changed

When a `Parser$Input` has a relative path (e.g. synthetic `dependsOn` stubs created by `KotlinParser.determinePath()` via `Paths.get(pkg, prefix + className + ".kt")`), calling `getRelativePath(relativeTo)` with an absolute `relativeTo` path causes `Path.relativize()` to throw `IllegalArgumentException: 'other' is different type of Path` on JDK 21+.

This happens because JDK 21+ strictly enforces that both paths must be of the same type (both absolute or both relative) in `Path.relativize()`.

The fix returns relative paths as-is since they're already relative and don't need relativization.

- Fixes https://github.com/openrewrite/rewrite-gradle-plugin/issues/424