### PR TITLE
Python: Fix template apply losing indentation in nested contexts

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/format/tabs_and_indents_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/format/tabs_and_indents_visitor.py
@@ -63,6 +63,11 @@ class TabsAndIndentsVisitor(PythonVisitor[P]):
                     if indent != 0:
                         c.put_message("last_indent", indent)
 
+            for next_parent in parent.get_path():
+                if isinstance(next_parent, J):
+                    self.pre_visit(next_parent, p)
+                    break
+
         return super().visit(tree, p)
 
     def pre_visit(self, tree: T, p: P) -> Optional[T]:

--- a/rewrite-python/rewrite/tests/python/all/format/auto_format_subtree_test.py
+++ b/rewrite-python/rewrite/tests/python/all/format/auto_format_subtree_test.py
@@ -14,12 +14,14 @@
 
 """Tests for auto_format when applied to sub-trees with a cursor.
 
-When a recipe calls auto_format(node, p, cursor=self.cursor) on a node
-that is not the root CompilationUnit, the formatter must preserve the
-node's own indentation level and only adjust its children.  Previously,
-TabsAndIndentsVisitor.visit() called pre_visit() on the root element
-during setup, which set indent_type=INDENT on the cursor and caused an
-extra indentation level to be added to the node's own prefix.
+When a recipe calls auto_format(node, p, cursor=self.cursor.parent) on a
+node that is not the root CompilationUnit, the formatter must preserve the
+node's own indentation level and only adjust its children.
+
+The cursor parameter to auto_format (and visit() in general) is the
+*parent* cursor.  The visitor creates a child cursor for the tree being
+visited: Cursor(parent, tree).  Passing self.cursor.parent provides the
+correct parent context for the node being formatted.
 """
 
 from typing import Any, Optional
@@ -60,7 +62,7 @@ class _AutoFormatIfRecipe(Recipe):
                 if isinstance(if_stmt.then_part, Block):
                     stmts = if_stmt.then_part.statements
                     if len(stmts) == 1 and isinstance(stmts[0], py_tree.Pass):
-                        return auto_format(if_stmt, p, cursor=self.cursor)
+                        return auto_format(if_stmt, p, cursor=self.cursor.parent)
                 return if_stmt
 
         return Visitor()

--- a/rewrite-python/rewrite/tests/python/template/test_template_indentation.py
+++ b/rewrite-python/rewrite/tests/python/template/test_template_indentation.py
@@ -1,0 +1,153 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for template apply preserving indentation in nested contexts.
+
+When a template replaces a compound statement (e.g., try -> with) inside
+a function body, the replacement must inherit the original statement's
+indentation. The template engine's apply_coordinates() calls auto_format
+which must receive the correct cursor context to compute indentation.
+"""
+
+from typing import Any, Optional
+
+from rewrite import ExecutionContext, Recipe, TreeVisitor
+from rewrite.java import tree as j
+from rewrite.python import tree as py_tree
+from rewrite.python.template import template, capture
+from rewrite.python.visitor import PythonVisitor
+from rewrite.test import RecipeSpec, python
+
+
+# Template: replace a try/except:pass with a with-statement
+_exc = capture('exc')
+_body = capture('body')
+_with_template = template(
+    'with suppress({exc}):\n    {body}',
+    exc=_exc,
+    body=_body,
+)
+
+
+class _ReplaceTryWithWith(Recipe):
+    """Replaces try/except <Exc>: pass with: with suppress(<Exc>): <body>."""
+
+    @property
+    def name(self) -> str:
+        return "test.ReplaceTryWithWith"
+
+    @property
+    def display_name(self) -> str:
+        return "Test replace try with with-statement"
+
+    @property
+    def description(self) -> str:
+        return "Replaces single-except try/pass with a with-statement."
+
+    def editor(self) -> TreeVisitor[Any, ExecutionContext]:
+        class Visitor(PythonVisitor[ExecutionContext]):
+            def visit_try(
+                self, try_stmt: j.Try, p: ExecutionContext
+            ) -> Optional[j.Try]:
+                try_stmt = super().visit_try(try_stmt, p)
+
+                if len(try_stmt.catches) != 1:
+                    return try_stmt
+                catch = try_stmt.catches[0]
+                if len(catch.body.statements) != 1:
+                    return try_stmt
+                if not isinstance(catch.body.statements[0], py_tree.Pass):
+                    return try_stmt
+
+                body_stmts = try_stmt.body.statements
+                if len(body_stmts) != 1:
+                    return try_stmt
+
+                vd = catch.parameter.tree
+                te = vd.type_expression
+                if te is None:
+                    return try_stmt
+                if isinstance(te, py_tree.ExceptionType):
+                    exc_expr = te.expression
+                else:
+                    exc_expr = te
+
+                values = {
+                    'exc': exc_expr,
+                    'body': body_stmts[0],
+                }
+                return _with_template.apply(self.cursor, values=values)
+
+        return Visitor()
+
+
+def test_template_replace_try_at_top_level():
+    """Template replacement at top level preserves zero indentation."""
+    spec = RecipeSpec(recipe=_ReplaceTryWithWith())
+    spec.rewrite_run(
+        python(
+            "try:\n"
+            "    do_stuff()\n"
+            "except KeyError:\n"
+            "    pass",
+            #
+            "with suppress(KeyError):\n"
+            "    do_stuff()",
+        )
+    )
+
+
+def test_template_replace_try_inside_function():
+    """Template replacement inside a function must preserve indentation.
+
+    The with-statement should be at column 4 (inside the function body),
+    and its body at column 8.
+    """
+    spec = RecipeSpec(recipe=_ReplaceTryWithWith())
+    spec.rewrite_run(
+        python(
+            "def f():\n"
+            "    try:\n"
+            "        do_stuff()\n"
+            "    except KeyError:\n"
+            "        pass",
+            #
+            "def f():\n"
+            "    with suppress(KeyError):\n"
+            "        do_stuff()",
+        )
+    )
+
+
+def test_template_replace_try_inside_class_method():
+    """Template replacement inside a class method must preserve indentation.
+
+    The with-statement should be at column 8 (inside the method body).
+    """
+    spec = RecipeSpec(recipe=_ReplaceTryWithWith())
+    spec.rewrite_run(
+        python(
+            "class Foo:\n"
+            "    def bar(self):\n"
+            "        try:\n"
+            "            do_stuff()\n"
+            "        except KeyError:\n"
+            "            pass",
+            #
+            "class Foo:\n"
+            "    def bar(self):\n"
+            "        with suppress(KeyError):\n"
+            "            do_stuff()",
+        )
+    )


### PR DESCRIPTION
## Summary

- Fixes template-based statement replacement (e.g., `try` → `with`) losing indentation when inside a function or method body
- Restores the `pre_visit` setup call in `TabsAndIndentsVisitor.visit()` that was removed in #6842
- Fixes `auto_format` callers to pass `self.cursor.parent` (the parent cursor) instead of `self.cursor`, honoring the `visit(tree, p, parent)` contract

- The previous fix (#6842) removed the `pre_visit` setup to work around doubled indentation, but the root cause was that the test recipe was violating the visitor contract by passing the cursor AT the node instead of its parent. The `pre_visit` setup is needed to establish `indent_type` on the parent cursor so child indentation is computed correctly by the template engine's `auto_format` call.

## Test plan

- [x] New `test_template_indentation.py` — template replacement at top level, inside function, inside class method
- [x] Existing `auto_format_subtree_test.py` — updated to use `self.cursor.parent`, all pass
- [x] All 373 template + format tests pass
- [x] All 588 Python format + integration tests pass
- [x] Downstream `UseContextlibSuppress.test_return_in_try_body` passes with this fix installed