### PR TITLE
Make sure `AddToGitignore` keeps the newline at the end of the file

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/AddToGitignore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/AddToGitignore.java
@@ -126,6 +126,7 @@ public class AddToGitignore extends ScanningRecipe<AtomicBoolean> {
 
             private String mergeGitignoreEntries(String existing, String newEntries) {
                 String separator = existing.contains("\r\n") ? "\r\n" : "\n";
+                boolean endsWithNewline = existing.isEmpty() || existing.endsWith("\n");
 
                 Set<String> existingRules = new LinkedHashSet<>();
                 Set<String> existingWildcardPatterns = new LinkedHashSet<>();
@@ -181,7 +182,8 @@ public class AddToGitignore extends ScanningRecipe<AtomicBoolean> {
 
                 result.addAll(linesToAdd);
 
-                return String.join(separator, result);
+                String joined = String.join(separator, result);
+                return endsWithNewline ? joined + separator : joined;
             }
 
             private String normalizeRule(String rule) {

--- a/rewrite-core/src/test/java/org/openrewrite/AddToGitignoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/AddToGitignoreTest.java
@@ -448,6 +448,30 @@ class AddToGitignoreTest implements RewriteTest {
     }
 
     @Test
+    void addEntryToFileEndingWithNewline() {
+        rewriteRun(
+          spec -> spec.recipe(new AddToGitignore("*.log", null)),
+          text(
+            "*.tmp\n.DS_Store\n",
+            "*.tmp\n.DS_Store\n\n*.log\n",
+            spec -> spec.path(".gitignore").noTrim()
+          )
+        );
+    }
+
+    @Test
+    void addEntryToFileEndingWithWindowsNewline() {
+        rewriteRun(
+          spec -> spec.recipe(new AddToGitignore("*.log", null)),
+          text(
+            "*.tmp\r\n.DS_Store\r\n",
+            "*.tmp\r\n.DS_Store\r\n\r\n*.log\r\n",
+            spec -> spec.path(".gitignore").noTrim()
+          )
+        );
+    }
+
+    @Test
     void doNotAddSuperfluousEntriesWithMultiplePatterns() {
         rewriteRun(
           spec -> spec.recipe(new AddToGitignore("""


### PR DESCRIPTION
## What's changed?

A cosmetic bug fix to `org.openrewrite.AddToGitignore`.
Now it no longer removes newline characters at the end of the file.

## What's your motivation?

I just noticed someone ran the recipe and it garbled the file endings.
- e.g. https://github.com/openrewrite/rewrite-migrate-java/pull/995/changes