### PR TITLE
RecipeListing withers now preserve metadata map

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeListing.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeListing.java
@@ -33,7 +33,6 @@ public class RecipeListing implements Comparable<RecipeListing> {
     /**
      * The marketplace that this listing belongs to.
      */
-    @With
     private final @Nullable RecipeMarketplace marketplace;
 
     private final @EqualsAndHashCode.Include String name;
@@ -61,8 +60,27 @@ public class RecipeListing implements Comparable<RecipeListing> {
 
     private final Map<String, Object> metadata = new LinkedHashMap<>();
 
-    @With(AccessLevel.PACKAGE)
     private final RecipeBundle bundle;
+
+    public RecipeListing withMarketplace(@Nullable RecipeMarketplace marketplace) {
+        if (this.marketplace == marketplace) {
+            return this;
+        }
+        RecipeListing copy = new RecipeListing(marketplace, name, displayName, description,
+                estimatedEffortPerOccurrence, options, dataTables, recipeCount, bundle);
+        copy.metadata.putAll(this.metadata);
+        return copy;
+    }
+
+    RecipeListing withBundle(RecipeBundle bundle) {
+        if (this.bundle == bundle) {
+            return this;
+        }
+        RecipeListing copy = new RecipeListing(marketplace, name, displayName, description,
+                estimatedEffortPerOccurrence, options, dataTables, recipeCount, bundle);
+        copy.metadata.putAll(this.metadata);
+        return copy;
+    }
 
     private RecipeBundleReader resolve(Collection<RecipeBundleResolver> resolvers) {
         for (RecipeBundleResolver resolver : resolvers) {


### PR DESCRIPTION
## Summary
- Lombok's `@With` on `RecipeListing` fields generated withers that called the all-args constructor, which left the `metadata` map empty
- Replaced `@With` on `marketplace` and `bundle` with hand-written methods that copy metadata into the new instance

## Test plan
- [x] Added `mergePreservesMetadata` test verifying metadata survives a category merge (which calls `withMarketplace`)