### PR TITLE
Python: Fix RPC `write_message` to use binary mode on Windows

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1380,14 +1380,15 @@ def read_message() -> Optional[dict]:
 
 
 def write_message(response: dict):
-    """Write a JSON-RPC message to stdout."""
-    content = json.dumps(response)
-    content_bytes = content.encode('utf-8')
+    """Write a JSON-RPC message to stdout.
 
-    sys.stdout.write(f"Content-Length: {len(content_bytes)}\r\n")
-    sys.stdout.write("\r\n")
-    sys.stdout.write(content)
-    sys.stdout.flush()
+    Uses unbuffered binary I/O to avoid line-ending translation on Windows
+    that would corrupt the JSON-RPC protocol headers. Mirrors the pattern
+    used by read_message() which uses os.read() on the read side.
+    """
+    content_bytes = json.dumps(response).encode('utf-8')
+    header = f"Content-Length: {len(content_bytes)}\r\n\r\n".encode('utf-8')
+    os.write(sys.stdout.fileno(), header + content_bytes)
 
 
 def main():


### PR DESCRIPTION
## Problem

The `write_message()` function in the Python RPC server was using text mode (`sys.stdout.write()`) to send JSON-RPC protocol messages. On Windows, Python's text mode translates every `\n` → `\r\n`, so the explicit `\r\n` in the protocol headers becomes `\r\r\n`:

```
Expected: b'Content-Length: 5\r\n\r\nhello'
Actual:   b'Content-Length: 5\r\r\n\r\r\nhello'
```

This corrupts the JSON-RPC headers, causing Java to fail to parse responses from Python, resulting in a 10-second `GetObject` timeout during LST building on Windows.

On Linux, text mode performs no translation, so the bug only manifests on Windows.

## Verification

Confirmed via CI on `windows-latest` vs `ubuntu-latest`: https://github.com/openrewrite/rewrite/actions/runs/22570095714

## Solution

Use `os.write(sys.stdout.fileno(), ...)` (unbuffered binary I/O) instead, mirroring the pattern already used by `read_message()` and `read_message_with_timeout()` which use `os.read()` on the read side.