### PR TITLE
Python: Update `ty-types` dependency to released 0.0.19

### DIFF
--- a/rewrite-python/rewrite/pyproject.toml
+++ b/rewrite-python/rewrite/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10"
 dependencies = [
     "cbor2>=5.6.5",
     "more_itertools>=10.0.0",
-    "ty-types>=0.0.19.dev20260224073439",  # Type inference CLI for Python type attribution
+    "ty-types>=0.0.19",  # Type inference CLI for Python type attribution
     "parso>=0.7.1,<0.8",  # Python 2/3 parser with CST support (0.8+ dropped Python 2.7 grammar)
 ]
 


### PR DESCRIPTION
## Summary
- Update `ty-types` dependency from dev pre-release (`>=0.0.19.dev20260224073439`) to the stable release (`>=0.0.19`)