### PR TITLE
Ensure ImportLayoutStyles can be merged

### DIFF
--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -93,7 +93,7 @@ tasks.withType<Javadoc>().configureEach {
     //   symbol:   method onConstructor_()
     //   location: @interface AllArgsConstructor
     // 1 error
-    exclude("**/JavaParser**", "**/ChangeMethodTargetToStatic**", "**/J.java")
+    exclude("**/JavaParser**", "**/ChangeMethodTargetToStatic**", "**/J.java", "**/ImportLayoutStyle**")
 }
 
 tasks.named<ShadowJar>("shadowJar").configure {

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/CheckstyleConfigLoader.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/CheckstyleConfigLoader.java
@@ -33,7 +33,6 @@ import java.util.*;
 import java.util.stream.Stream;
 
 import static java.lang.Boolean.parseBoolean;
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.*;
 import static org.openrewrite.java.style.Checkstyle.defaultBlockPolicy;
 import static org.openrewrite.java.style.Checkstyle.defaultOperatorWrapStyleOption;
@@ -93,7 +92,7 @@ public class CheckstyleConfigLoader {
                                 parenPadStyle(conf))
                         .filter(Objects::nonNull)
                         .flatMap(Set::stream)
-                        .collect(toSet()));
+                        .collect(toCollection(LinkedHashSet::new)));
     }
 
     private static @Nullable Set<DefaultComesLastStyle> defaultComesLast(Map<String, List<Module>> conf) {
@@ -269,7 +268,7 @@ public class CheckstyleConfigLoader {
                     boolean dot = false;
                     boolean inc = true;
                     boolean dec = true;
-                    boolean bnoc = true;
+                    boolean bnot = true;
                     boolean lnot = true;
                     boolean unaryPlus = true;
                     boolean unaryMinus = true;
@@ -285,7 +284,7 @@ public class CheckstyleConfigLoader {
                         dot = tokens.contains("DOT");
                         inc = tokens.contains("INC");
                         dec = tokens.contains("DEC");
-                        bnoc = tokens.contains("BNOT");
+                        bnot = tokens.contains("BNOT");
                         lnot = tokens.contains("LNOT");
                         unaryPlus = tokens.contains("UNARY_PLUS");
                         unaryMinus = tokens.contains("UNARY_MINUS");
@@ -301,7 +300,7 @@ public class CheckstyleConfigLoader {
                             dot,
                             inc,
                             dec,
-                            bnoc,
+                            bnot,
                             lnot,
                             unaryPlus,
                             unaryMinus
@@ -657,7 +656,9 @@ public class CheckstyleConfigLoader {
                         builder.importAllOthers();
                     }
 
-                    return builder.build();
+                    return builder.build()
+                            .withClassCountToUseStarImport(null)
+                            .withNameCountToUseStarImport(null);
                 })
                 .collect(toSet());
     }
@@ -690,8 +691,8 @@ public class CheckstyleConfigLoader {
                 .map(module -> new ImportLayoutStyle(
                         Integer.MAX_VALUE,
                         Integer.MAX_VALUE,
-                        emptyList(),
-                        emptyList()
+                        null,
+                        null
                 ))
                 .collect(toSet());
     }
@@ -1072,7 +1073,9 @@ public class CheckstyleConfigLoader {
                         builder.importStaticAllOthers();
                     }
 
-                    return builder.build();
+                    return builder.build()
+                            .withClassCountToUseStarImport(null)
+                            .withNameCountToUseStarImport(null);
                 })
                 .collect(toSet());
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.style;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -26,9 +27,11 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.With;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
@@ -48,6 +51,7 @@ import java.util.regex.Pattern;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.*;
+import static org.openrewrite.internal.ListUtils.concatAll;
 import static org.openrewrite.internal.StreamUtils.distinctBy;
 
 /**
@@ -62,47 +66,63 @@ import static org.openrewrite.internal.StreamUtils.distinctBy;
  * <li>layout - An ordered list of import groupings which define exactly how imports should be organized within a compilation unit.</li>
  * <li>packagesToFold - An ordered list of packages which are folded when 1 or more types are in use.</li>
  */
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode
+@AllArgsConstructor(onConstructor_ = @__({@JsonCreator}))
+@With
 @Getter
 @JsonDeserialize(using = Deserializer.class)
 @JsonSerialize(using = Serializer.class)
 public class ImportLayoutStyle implements JavaStyle {
 
-    @EqualsAndHashCode.Include
-    private final int classCountToUseStarImport;
+    private final @Nullable Integer classCountToUseStarImport;
 
-    @EqualsAndHashCode.Include
-    private final int nameCountToUseStarImport;
+    private final @Nullable Integer nameCountToUseStarImport;
 
-    @EqualsAndHashCode.Include
-    private final List<Block> layout;
+    private final @Nullable List<Block> layout;
 
-    @EqualsAndHashCode.Include
-    private final List<Block> packagesToFold;
+    private final @Nullable List<Block> packagesToFold;
 
-    private final List<Block> blocksNoCatchalls;
-    private final List<Block> blocksOnlyCatchalls;
+    public int getClassCountToUseStarImport() {
+        return classCountToUseStarImport != null ? classCountToUseStarImport : 5;
+    }
 
-    public ImportLayoutStyle(int classCountToUseStarImport, int nameCountToUseStarImport, List<Block> layout, List<Block> packagesToFold) {
-        this.classCountToUseStarImport = classCountToUseStarImport;
-        this.nameCountToUseStarImport = nameCountToUseStarImport;
-        this.layout = layout.isEmpty() ? IntelliJ.importLayout().getLayout() : layout;
-        this.packagesToFold = packagesToFold;
+    public int getNameCountToUseStarImport() {
+        return nameCountToUseStarImport != null ? nameCountToUseStarImport : 3;
+    }
 
-        // Divide the blocks into those that accept imports from any package ("catchalls") and those that accept imports from only specific packages
-        Map<Boolean, List<Block>> blockGroups = layout.stream()
-                .collect(partitioningBy(block -> block instanceof Block.AllOthers));
-        blocksNoCatchalls = blockGroups.get(false);
-        blocksOnlyCatchalls = blockGroups.get(true);
+    public List<Block> getLayout() {
+        return layout == null || layout.isEmpty() ? IntelliJ.importLayout().getLayout() : layout;
+    }
+
+    public List<Block> getPackagesToFold() {
+        return packagesToFold != null ? packagesToFold : emptyList();
     }
 
     /**
-     * ImportLayoutStyles cannot meaningfully be merged.
-     * Accepts the higher priority style outright.
+     * Merges two ImportLayoutStyles by combining their non-null fields.
+     * <p>
+     * Different Checkstyle modules configure different aspects of import layout:
+     * <ul>
+     *   <li>{@code AvoidStarImport} configures star import thresholds but not layout</li>
+     *   <li>{@code ImportOrder} and {@code CustomImportOrder} configure layout but not star import thresholds</li>
+     * </ul>
+     * This merge preserves explicitly configured (non-null) values from both styles rather than
+     * discarding one entirely. For each field, the higher priority's value is used if non-null,
+     * otherwise the lower priority's value is kept. Packages to fold are combined from both styles.
      */
     @Override
     public Style merge(Style higherPriority) {
-        return higherPriority;
+        if (!(higherPriority instanceof ImportLayoutStyle)) {
+            return this;
+        }
+        ImportLayoutStyle hp = (ImportLayoutStyle) higherPriority;
+
+        return new ImportLayoutStyle(
+                hp.classCountToUseStarImport != null ? hp.classCountToUseStarImport : this.classCountToUseStarImport,
+                hp.nameCountToUseStarImport != null ? hp.nameCountToUseStarImport : this.nameCountToUseStarImport,
+                hp.layout != null ? hp.layout : this.layout,
+                concatAll(this.packagesToFold, hp.packagesToFold)
+        );
     }
 
     /**
@@ -121,7 +141,7 @@ public class ImportLayoutStyle implements JavaStyle {
 
         if (originalImports.isEmpty()) {
             paddedToAdd = pkg == null ? paddedToAdd : paddedToAdd.withElement(paddedToAdd.getElement().withPrefix(Space.format("\n\n")));
-            paddedToAdd = isPackageAlwaysFolded(packagesToFold, paddedToAdd.getElement()) ? paddedToAdd.withElement(paddedToAdd.getElement().withQualid(
+            paddedToAdd = isPackageAlwaysFolded(getPackagesToFold(), paddedToAdd.getElement()) ? paddedToAdd.withElement(paddedToAdd.getElement().withQualid(
                     paddedToAdd.getElement().getQualid().withName(
                             paddedToAdd.getElement().getQualid().getName().withSimpleName("*")
                     )
@@ -141,7 +161,7 @@ public class ImportLayoutStyle implements JavaStyle {
         // the import to add at most. we don't even want to star fold other non-adjacent imports in the same
         // block that should be star folded according to the layout style (minimally invasive change).
         List<JRightPadded<J.Import>> ideallyOrdered =
-                new ImportLayoutStyle(Integer.MAX_VALUE, Integer.MAX_VALUE, layout, packagesToFold)
+                new ImportLayoutStyle(Integer.MAX_VALUE, Integer.MAX_VALUE, getLayout(), getPackagesToFold())
                         .orderImports(ListUtils.concat(originalImports, paddedToAdd), new HashSet<>());
 
         JRightPadded<J.Import> before = null;
@@ -242,8 +262,8 @@ public class ImportLayoutStyle implements JavaStyle {
             }
         }
 
-        if (isFoldable && (((paddedToAdd.getElement().isStatic() && nameCountToUseStarImport <= sameCount) ||
-                (!paddedToAdd.getElement().isStatic() && classCountToUseStarImport <= sameCount)) || isPackageAlwaysFolded(packagesToFold, paddedToAdd.getElement()))) {
+        if (isFoldable && (((paddedToAdd.getElement().isStatic() && getNameCountToUseStarImport() <= sameCount) ||
+                (!paddedToAdd.getElement().isStatic() && getClassCountToUseStarImport() <= sameCount)) || isPackageAlwaysFolded(getPackagesToFold(), paddedToAdd.getElement()))) {
             starFold.set(true);
             if (insertPosition != starFoldFrom.get()) {
                 // if we're adding to the middle of a group of imports that are getting star folded,
@@ -302,7 +322,7 @@ public class ImportLayoutStyle implements JavaStyle {
     }
 
     private Block block(JRightPadded<J.Import> anImport) {
-        for (Block block : layout) {
+        for (Block block : getLayout()) {
             if (block.accept(anImport)) {
                 return block;
             }
@@ -322,17 +342,24 @@ public class ImportLayoutStyle implements JavaStyle {
         ImportLayoutConflictDetection importLayoutConflictDetection = new ImportLayoutConflictDetection(classpath, originalImports);
         List<JRightPadded<J.Import>> orderedImports = new ArrayList<>();
 
+        List<Block> effectiveLayout = getLayout();
+        // Divide the blocks into those that accept imports from any package ("catchalls") and those that accept imports from only specific packages
+        Map<Boolean, List<Block>> blockGroups = effectiveLayout.stream()
+                .collect(partitioningBy(block -> block instanceof Block.AllOthers));
+        List<Block> noCatchalls = blockGroups.get(false);
+        List<Block> onlyCatchalls = blockGroups.get(true);
+
         // Allocate imports to blocks, preferring to put imports into non-catchall blocks
         nextImport:
         for (JRightPadded<J.Import> anImport : originalImports) {
-            for (Block block : blocksNoCatchalls) {
+            for (Block block : noCatchalls) {
                 if (block.accept(anImport)) {
                     layoutState.claimImport(block, anImport);
                     continue nextImport;
                 }
             }
 
-            for (Block block : blocksOnlyCatchalls) {
+            for (Block block : onlyCatchalls) {
                 if (block.accept(anImport)) {
                     layoutState.claimImport(block, anImport);
                     continue nextImport;
@@ -343,14 +370,14 @@ public class ImportLayoutStyle implements JavaStyle {
         int importIndex = 0;
         int extraLineSpaceCount = 0;
         String prevWhitespace = "";
-        for (Block block : layout) {
+        for (Block block : effectiveLayout) {
             if (block instanceof Block.BlankLines) {
                 extraLineSpaceCount = 0;
                 for (int i = 0; i < ((Block.BlankLines) block).getCount(); i++) {
                     extraLineSpaceCount += 1;
                 }
             } else {
-                List<JRightPadded<J.Import>> blockOrdering = block.orderedImports(layoutState, classCountToUseStarImport, nameCountToUseStarImport, importLayoutConflictDetection, packagesToFold);
+                List<JRightPadded<J.Import>> blockOrdering = block.orderedImports(layoutState, getClassCountToUseStarImport(), getNameCountToUseStarImport(), importLayoutConflictDetection, getPackagesToFold());
                 for (JRightPadded<J.Import> orderedImport : blockOrdering) {
                     boolean whitespaceContainsCRLF = orderedImport.getElement().getPrefix().getWhitespace().contains("\r\n");
                     Space prefix;
@@ -777,11 +804,11 @@ public class ImportLayoutStyle implements JavaStyle {
     public String toString() {
         StringBuilder s = new StringBuilder();
         s.append("classWildcards=")
-                .append(classCountToUseStarImport)
+                .append(getClassCountToUseStarImport())
                 .append(", staticWildcards=")
-                .append(nameCountToUseStarImport)
+                .append(getNameCountToUseStarImport())
                 .append('\n');
-        for (Block block : layout) {
+        for (Block block : getLayout()) {
             s.append(block).append("\n");
         }
         return s.toString();

--- a/rewrite-java/src/test/java/org/openrewrite/java/style/CheckstyleConfigLoaderTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/style/CheckstyleConfigLoaderTest.java
@@ -16,6 +16,9 @@
 package org.openrewrite.java.style;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.style.NamedStyles;
+
+import java.util.Collections;
 
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -1001,5 +1004,104 @@ class CheckstyleConfigLoaderTest {
 
         assertThat(checkstyle.getStyles()).anySatisfy(style ->
                 assertThat(style).isInstanceOf(HideUtilityClassConstructorStyle.class));
+    }
+
+    @Test
+    void avoidStarImportAndImportOrderMergeTogether() throws Exception {
+        var checkstyle = loadCheckstyleConfig("""
+            <!DOCTYPE module PUBLIC
+                "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+                "https://checkstyle.org/dtds/configuration_1_2.dtd">
+            <module name="Checker">
+                <module name="TreeWalker">
+                    <module name="AvoidStarImport"/>
+                    <module name="ImportOrder">
+                        <property name="groups" value="java.,javax.,org.,com."/>
+                        <property name="option" value="top"/>
+                        <property name="separated" value="true"/>
+                    </module>
+                </module>
+            </module>
+        """, emptyMap());
+
+        // After merging, the single ImportLayoutStyle should combine:
+        // - star import thresholds from AvoidStarImport (MAX_VALUE)
+        // - layout ordering from ImportOrder (statics on top, grouped)
+        ImportLayoutStyle merged = NamedStyles.merge(ImportLayoutStyle.class,
+                Collections.singletonList(checkstyle));
+        assertThat(merged).isNotNull();
+        assertThat(merged.getClassCountToUseStarImport()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(merged.getNameCountToUseStarImport()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(merged.getLayout()).isNotEmpty();
+        // The layout should contain the ImportOrder groups, not just IntelliJ defaults
+        assertThat(merged.getLayout().stream()
+                .filter(b -> b instanceof ImportLayoutStyle.Block.ImportPackage &&
+                        !(b instanceof ImportLayoutStyle.Block.AllOthers))
+                .count()).isGreaterThan(0);
+    }
+
+    @Test
+    void avoidStarImportAndCustomImportOrderMergeTogether() throws Exception {
+        var checkstyle = loadCheckstyleConfig("""
+            <!DOCTYPE module PUBLIC
+                "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+                "https://checkstyle.org/dtds/configuration_1_2.dtd">
+            <module name="Checker">
+                <module name="TreeWalker">
+                    <module name="AvoidStarImport"/>
+                    <module name="CustomImportOrder">
+                        <property name="customImportOrderRules"
+                            value="STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE"/>
+                    </module>
+                </module>
+            </module>
+        """, emptyMap());
+
+        ImportLayoutStyle merged = NamedStyles.merge(ImportLayoutStyle.class,
+                Collections.singletonList(checkstyle));
+        assertThat(merged).isNotNull();
+        assertThat(merged.getClassCountToUseStarImport()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(merged.getNameCountToUseStarImport()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(merged.getLayout()).isNotEmpty();
+    }
+
+    @Test
+    void allThreeImportLayoutStyleRulesMergeTogether() throws Exception {
+        var checkstyle = loadCheckstyleConfig("""
+            <!DOCTYPE module PUBLIC
+                "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+                "https://checkstyle.org/dtds/configuration_1_2.dtd">
+            <module name="Checker">
+                <module name="TreeWalker">
+                    <module name="CustomImportOrder">
+                        <property name="customImportOrderRules"
+                            value="STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE"/>
+                    </module>
+                    <module name="AvoidStarImport"/>
+                    <module name="ImportOrder">
+                        <property name="groups" value="java.,javax.,org.,com."/>
+                        <property name="option" value="top"/>
+                        <property name="separated" value="true"/>
+                    </module>
+                </module>
+            </module>
+        """, emptyMap());
+
+        // All three produce ImportLayoutStyle. After merging:
+        // - AvoidStarImport contributes star import thresholds (MAX_VALUE)
+        // - ImportOrder contributes layout (comes last, so its layout wins over CustomImportOrder)
+        // - CustomImportOrder's layout is superseded by ImportOrder's
+        ImportLayoutStyle merged = NamedStyles.merge(ImportLayoutStyle.class,
+                Collections.singletonList(checkstyle));
+        assertThat(merged).isNotNull();
+        // Star thresholds from AvoidStarImport
+        assertThat(merged.getClassCountToUseStarImport()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(merged.getNameCountToUseStarImport()).isEqualTo(Integer.MAX_VALUE);
+        // Layout from ImportOrder (not IntelliJ defaults, not CustomImportOrder)
+        assertThat(merged.getLayout()).isNotEmpty();
+        assertThat(merged.getLayout().stream()
+                .filter(b -> b instanceof ImportLayoutStyle.Block.ImportPackage &&
+                        !(b instanceof ImportLayoutStyle.Block.AllOthers))
+                .count()).isGreaterThan(0);
     }
 }

--- a/rewrite-java/src/test/java/org/openrewrite/java/style/ImportLayoutStyleTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/style/ImportLayoutStyleTest.java
@@ -94,7 +94,7 @@ class ImportLayoutStyleTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/4196")
     void addImportInPresenceOfDuplicateOtherImport() {
         ImportLayoutStyle style = new ImportLayoutStyle(
-          Integer.MAX_VALUE, Integer.MAX_VALUE, emptyList(), emptyList());
+          Integer.MAX_VALUE, Integer.MAX_VALUE, null, null);
         JRightPadded<J.Import> import1 = new JRightPadded<>(
           new J.Import(
             randomId(),


### PR DESCRIPTION
Typically an import layout style comes from autodetection. On top of that may be layered explicit configuration or further layout styles parsed from checkstyle. Implement merge such that this is tractable