### PR TITLE
JavaScript: Fix three found JS/TS parse failures

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
@@ -408,6 +408,7 @@ const excludedCodes = new Set([
     1308, // 'await' expressions are only allowed within async functions and at the top levels of modules.
     1314, // Global module exports may only appear in module files.
     1315, // Global module exports may only appear in declaration files.
+    1320, // Type of 'await' operand must either be a valid promise or must not contain a callable 'then' member.
     1324, // Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', 'node18', 'node20', 'nodenext', or 'preserve'.
     1329, // '{0}' accepts too few arguments to be used as a decorator here. Did you mean to call it first and write '@{0}()'?
     1335, // 'unique symbol' types are not allowed here.

--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -2079,7 +2079,10 @@ export class JavaScriptParserVisitor {
 
     visitCallExpression(node: ts.CallExpression): J.MethodInvocation | JS.FunctionCall {
         const prefix = this.prefix(node);
-        const typeArguments = node.typeArguments && this.mapTypeArguments(this.prefix(this.findChildNode(node, ts.SyntaxKind.LessThanToken)!), node.typeArguments);
+        const ltToken = this.findChildNode(node, ts.SyntaxKind.LessThanToken);
+        const typeArguments = node.typeArguments && ltToken
+            ? this.mapTypeArguments(this.prefix(ltToken), node.typeArguments)
+            : undefined;
 
         let select: J.RightPadded<Expression> | undefined;
         let name: J.Identifier = {

--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -166,26 +166,30 @@ export class JavaScriptTypeMapping {
                                 this.populateClassType(classType, declaredType);
                             }
 
-                            // Resolve type arguments
+                            // Shell-cache: Create parameterized type wrapper with empty typeParameters
+                            // BEFORE resolving type arguments, to prevent infinite recursion
+                            // when type argument resolution cycles back to this parameterized type
+                            const parameterized = {
+                                kind: Type.Kind.Parameterized,
+                                type: classType,
+                                typeParameters: [],
+                                fullyQualifiedName: classType.fullyQualifiedName,
+                                toJSON: function () {
+                                    return Type.signature(this);
+                                }
+                            } as Type.Parameterized;
+                            this.typeCache.set(signature, parameterized);
+
+                            // Resolve type arguments (may recursively reference this parameterized type)
                             const typeParameters: Type[] = [];
                             for (const typeArg of typeRef.typeArguments!) {
                                 const resolvedArg = this.getType(typeArg as ts.Type);
                                 typeParameters.push(resolvedArg);
                             }
 
-                            // Create the parameterized type wrapper
-                            const parameterized = {
-                                kind: Type.Kind.Parameterized,
-                                type: classType,
-                                typeParameters: typeParameters,
-                                fullyQualifiedName: classType.fullyQualifiedName,
-                                toJSON: function () {
-                                    return Type.signature(this);
-                                }
-                            } as Type.Parameterized;
+                            // Update the shell with resolved type parameters
+                            (parameterized as any).typeParameters = typeParameters;
 
-                            // Cache the parameterized type
-                            this.typeCache.set(signature, parameterized);
                             return parameterized;
                         }
                     }
@@ -287,7 +291,9 @@ export class JavaScriptTypeMapping {
             }
         }
 
-        // For non-object types, we can create them directly without recursion concerns
+        // Pre-cache as unknownType before resolving type aliases to prevent infinite
+        // recursion when alias resolution cycles back through getType with different type.ids
+        this.typeCache.set(signature, Type.unknownType);
         const result = this.createPrimitiveOrUnknownType(type);
         this.typeCache.set(signature, result);
         return result;

--- a/rewrite-javascript/rewrite/test/javascript/parser/parse-error-recovery.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/parse-error-recovery.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {RecipeSpec} from "../../../src/test";
+import {typescript} from "../../../src/javascript";
+
+describe('parse error recovery', () => {
+    const spec = new RecipeSpec();
+
+    test('TS 1320: await on non-promise is not a fatal parse error', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript(
+                'async function f() {\n' +
+                '    const x = { then: 42 };\n' +
+                '    await x;\n' +
+                '}'
+            )
+        ));
+
+    test('mutually recursive generic types do not cause stack overflow', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript(
+                'interface A<T> {\n' +
+                '    b: B<T>;\n' +
+                '}\n' +
+                'interface B<T> {\n' +
+                '    a: A<T>;\n' +
+                '}\n' +
+                'const x: A<string> = {} as any;'
+            )
+        ));
+
+    test('self-referencing parameterized type does not overflow', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript(
+                'interface Wrapper<T> {\n' +
+                '    value: T;\n' +
+                '}\n' +
+                'interface Self {\n' +
+                '    ref: Wrapper<Self>;\n' +
+                '}\n' +
+                'const x: Wrapper<Self> = {} as any;'
+            )
+        ));
+
+    test('recursive type alias with parameterized types does not overflow', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript(
+                'type ConfigExports<T> = Config<T> | Promise<Config<T>> | (() => Config<T>);\n' +
+                'interface Config<T = object> {\n' +
+                '    extends?: ConfigExports<T>;\n' +
+                '    value?: T;\n' +
+                '}\n' +
+                'const c: Config = { value: {} };'
+            )
+        ));
+});


### PR DESCRIPTION
## Summary
- Exclude TS error 1320 ("await operand must be a valid promise") from fatal parse errors — this is a semantic type-checking error, not a syntax error, and was blocking 4 postcss test files
- Shell-cache parameterized type wrappers in `getType()` before resolving type arguments, and pre-cache before type alias resolution, to prevent infinite recursion with cyclic generic types (e.g. VitePress config types from google/zx)
- Handle missing `LessThanToken` in `visitCallExpression` when TypeScript's error recovery produces `typeArguments` without the actual `<` token (fastify)

## Test plan
- New `parse-error-recovery.test.ts` with 4 tests covering: await-on-non-promise parsing, mutually recursive generics, self-referencing parameterized types, and recursive type aliases
- Full parser test suite (64 suites, 625 tests) passes with no regressions