### PR TITLE
Add diagnostic data table to UpgradePluginVersion

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
@@ -23,6 +23,7 @@ import org.openrewrite.gradle.*;
 import org.openrewrite.gradle.internal.ChangeStringLiteral;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.gradle.marker.GradleSettings;
+import org.openrewrite.gradle.table.GradlePluginVersionResolutions;
 import org.openrewrite.gradle.trait.GradlePlugin;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
@@ -33,9 +34,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.internal.MavenPomDownloader;
 import org.openrewrite.maven.table.MavenMetadataFailures;
-import org.openrewrite.maven.tree.Dependency;
-import org.openrewrite.maven.tree.GroupArtifact;
-import org.openrewrite.maven.tree.GroupArtifactVersion;
+import org.openrewrite.maven.tree.*;
 import org.openrewrite.properties.PropertiesVisitor;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.semver.Semver;
@@ -56,6 +55,9 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
 
     @EqualsAndHashCode.Exclude
     transient MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);
+
+    @EqualsAndHashCode.Exclude
+    transient GradlePluginVersionResolutions versionResolutions = new GradlePluginVersionResolutions(this);
 
     @Option(displayName = "Plugin id",
             description = "The `ID` part of `plugin { ID }`, as a glob expression.",
@@ -133,13 +135,40 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
             @Nullable
             private GradleSettings gradleSettings;
 
+            private String sourcePath = "";
+
             @Override
             public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
                 if (tree instanceof SourceFile) {
                     gradleProject = tree.getMarkers().findFirst(GradleProject.class).orElse(null);
                     gradleSettings = tree.getMarkers().findFirst(GradleSettings.class).orElse(null);
+                    sourcePath = ((SourceFile) tree).getSourcePath().toString();
                 }
                 return super.visit(tree, ctx);
+            }
+
+            private String reposDescription() {
+                if (gradleSettings != null) {
+                    return "settings.buildscript: " + repoUris(gradleSettings.getBuildscript().getMavenRepositories());
+                }
+                if (gradleProject != null) {
+                    return "project.buildscript: " + repoUris(gradleProject.getBuildscript().getMavenRepositories());
+                }
+                return "none (no GradleProject or GradleSettings marker)";
+            }
+
+            private String repoUris(List<MavenRepository> repos) {
+                if (repos.isEmpty()) {
+                    return "[]";
+                }
+                StringBuilder sb = new StringBuilder("[");
+                for (int i = 0; i < repos.size(); i++) {
+                    if (i > 0) {
+                        sb.append(", ");
+                    }
+                    sb.append(repos.get(i).getUri());
+                }
+                return sb.append("]").toString();
             }
 
             @Override
@@ -177,6 +206,11 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                                     .select(new GroupArtifactVersion(pluginId, pluginId + ".gradle.plugin", currentVersion), "classpath", newVersion, versionPattern, ctx);
                         }
                         acc.pluginIdToNewVersion.put(pluginId, resolvedVersion);
+                        versionResolutions.insertRow(ctx, new GradlePluginVersionResolutions.Row(
+                                sourcePath, pluginId, currentVersion,
+                                resolvedVersion != null ? resolvedVersion : "",
+                                reposDescription(),
+                                resolvedVersion != null ? "resolved" : "no newer version found"));
                     } else if (versionArgs.get(0) instanceof G.GString) {
                         G.GString gString = (G.GString) versionArgs.get(0);
                         if (gString.getStrings().isEmpty() || !(gString.getStrings().get(0) instanceof G.GString.Value)) {
@@ -191,6 +225,11 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                         acc.versionPropNameToPluginId.put(versionVariableName, pluginId);
                         assert resolvedPluginVersion != null;
                         acc.pluginIdToNewVersion.put(pluginId, resolvedPluginVersion);
+                        versionResolutions.insertRow(ctx, new GradlePluginVersionResolutions.Row(
+                                sourcePath, pluginId, "(GString: " + versionVariableName + ")",
+                                resolvedPluginVersion,
+                                reposDescription(),
+                                "resolved via GString variable"));
                     } else if (versionArgs.get(0) instanceof J.Identifier) {
                         J.Identifier identifier = (J.Identifier) versionArgs.get(0);
                         String versionVariableName = identifier.getSimpleName();
@@ -200,9 +239,24 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                         acc.versionPropNameToPluginId.put(versionVariableName, pluginId);
                         assert resolvedPluginVersion != null;
                         acc.pluginIdToNewVersion.put(pluginId, resolvedPluginVersion);
+                        versionResolutions.insertRow(ctx, new GradlePluginVersionResolutions.Row(
+                                sourcePath, pluginId, "(variable: " + versionVariableName + ")",
+                                resolvedPluginVersion,
+                                reposDescription(),
+                                "resolved via variable"));
+                    } else {
+                        versionResolutions.insertRow(ctx, new GradlePluginVersionResolutions.Row(
+                                sourcePath, pluginId, "(unknown expression type: " + versionArgs.get(0).getClass().getSimpleName() + ")",
+                                "",
+                                reposDescription(),
+                                "version argument is not a literal, GString, or identifier"));
                     }
                 } catch (MavenDownloadingException e) {
-                    // continue
+                    versionResolutions.insertRow(ctx, new GradlePluginVersionResolutions.Row(
+                            sourcePath, pluginId, literalValue(versionArgs.get(0)) != null ? literalValue(versionArgs.get(0)) : "",
+                            "",
+                            reposDescription(),
+                            "MavenDownloadingException: " + e.getMessage()));
                 }
                 return m;
             }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/table/GradlePluginVersionResolutions.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/table/GradlePluginVersionResolutions.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.table;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+@JsonIgnoreType
+public class GradlePluginVersionResolutions extends DataTable<GradlePluginVersionResolutions.Row> {
+    public GradlePluginVersionResolutions(Recipe recipe) {
+        super(recipe, "Gradle plugin version resolutions",
+                "Records the version resolution attempts made by UpgradePluginVersion, " +
+                        "including which repositories were used and what version was resolved.");
+    }
+
+    @Value
+    public static class Row {
+        @Column(displayName = "Source path",
+                description = "The source file where the plugin version was found.")
+        String sourcePath;
+
+        @Column(displayName = "Plugin id",
+                description = "The plugin id that was being resolved.")
+        String pluginId;
+
+        @Column(displayName = "Current version",
+                description = "The current version of the plugin before resolution.")
+        String currentVersion;
+
+        @Column(displayName = "Resolved version",
+                description = "The version that was resolved, or empty if resolution failed.")
+        String resolvedVersion;
+
+        @Column(displayName = "Repositories",
+                description = "The Maven repositories used for version resolution.")
+        String repositories;
+
+        @Column(displayName = "Message",
+                description = "Additional diagnostic information, such as error messages.")
+        String message;
+    }
+}


### PR DESCRIPTION
## Problem

When `UpgradePluginVersion` fails to resolve a version within a composite recipe chain (like `UpgradeSpringBoot_3_5`), there is no diagnostic output to help identify the cause. The `MavenDownloadingException` catch block silently swallows the exception, and there is no record of which repositories were queried or what the resolution result was.

- This made debugging customer-requests#1919 (Sunbit notification-service) significantly harder — the recipe silently does nothing and there's no data table to inspect.

## Solution

Add a `GradlePluginVersionResolutions` data table that records every version resolution attempt in the scanner phase:

- **Source path** — which build file was being scanned
- **Plugin id** — which plugin was being resolved
- **Current version** — the version found in the build file
- **Resolved version** — what version was resolved (empty if failed)
- **Repositories** — which Maven repositories were used (`settings.buildscript` vs `project.buildscript`, with URIs)
- **Message** — diagnostic info: success, no newer version, or the `MavenDownloadingException` message

This makes it possible to diagnose version resolution failures on the platform by downloading the data table from a recipe run, without needing to reproduce locally.