### PR TITLE
Fix GradleWrapperTest after Gradle 9.4.0 got released

### DIFF
--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-wrapper/versions.csv
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-wrapper/versions.csv
@@ -1,4 +1,5 @@
 version,gradlew,gradlewBat
+9.4.0,e5083bb6,9af86e4b
 9.4.0-milestone-4,e5083bb6,9af86e4b
 9.4.0-milestone-3,e5083bb6,9af86e4b
 9.4.0-milestone-2,e5083bb6,9af86e4b


### PR DESCRIPTION
## What's changed?

Adding 9.4.0 to known Gradle versions as it has been released earlier today.

## What's your motivation?

Fix broken CI, where `GradleWrapperTest` fails with:
```
GradleWrapperTest > listGradleWrappers() FAILED
    java.lang.NullPointerException: Cannot invoke "org.openrewrite.gradle.internal.GradleWrapperScriptLoader$Version.getGradlewChecksum()" because "this.resolved" is null
        at org.openrewrite.gradle.internal.GradleWrapperScriptLoader$Nearest.gradlew(GradleWrapperScriptLoader.java:69)
```