### PR TITLE
Minor amendment to Python tests - delete `venv`, `uv.lock` symlinks after tests

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/Assertions.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/Assertions.java
@@ -47,6 +47,7 @@ public final class Assertions {
      */
     public static SourceSpecs uv(Path relativeTo, SourceSpecs... sources) {
         String pyprojectContent = null;
+        SourceSpec<Toml.Document> pyprojectSpec = null;
 
         // First pass: find pyproject.toml content and write it
         for (SourceSpecs multiSpec : sources) {
@@ -55,6 +56,8 @@ public final class Assertions {
                 Path sourcePath = spec.getSourcePath();
                 if (sourcePath != null && "pyproject.toml".equals(sourcePath.toFile().getName())) {
                     pyprojectContent = spec.getBefore();
+                    //noinspection unchecked
+                    pyprojectSpec = (SourceSpec<Toml.Document>) multiSpec;
                     try {
                         Path pyproject = relativeTo.resolve(sourcePath);
                         Files.write(pyproject, requireNonNull(pyprojectContent).getBytes(StandardCharsets.UTF_8));
@@ -84,6 +87,16 @@ public final class Assertions {
             } catch (IOException e) {
                 throw new UncheckedIOException("Failed to create symlink for .venv", e);
             }
+
+            // Delete symlinks after recipe run so JUnit's @TempDir cleanup
+            // doesn't warn about symlinks pointing outside the temp directory
+            pyprojectSpec.afterRecipe(doc -> {
+                try {
+                    Files.deleteIfExists(venvTarget);
+                    Files.deleteIfExists(lockFileTarget);
+                } catch (IOException ignored) {
+                }
+            });
         }
 
         return SourceSpecs.dir(relativeTo.toString(), sources);


### PR DESCRIPTION
## What's changed?

Removing `venv`, `uv.lock` symlinks after some of the Python tests.

## What's your motivation?

To save us from warnings being printed out when executing them, e.g.
```
WARNING: Deleting symbolic link from location inside of temp dir (/tmp/junit-4993433042930029754/uv.lock) to location outside of temp dir (/tmp/openrewrite-python-workspaces/QbrGqW7Ph2tyPyzs/uv.lock) but not the target file/directory
DependencyInsightTest > findTransitiveDependencyWithDataTable(Path) STANDARD_ERROR
```