### PR TITLE
Use downloads.gradle.org for Gradle distribution downloads

### DIFF
--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelBuilder.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelBuilder.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -78,11 +79,12 @@ public class OpenRewriteModelBuilder {
     public static OpenRewriteModel forProjectDirectory(File projectDir, @Nullable File buildFile, @Nullable String initScript) throws IOException {
         DefaultGradleConnector connector = (DefaultGradleConnector) GradleConnector.newConnector();
         if (System.getProperty("org.openrewrite.test.gradleVersion") != null) {
-            connector.useGradleVersion(System.getProperty("org.openrewrite.test.gradleVersion"));
+            String version = System.getProperty("org.openrewrite.test.gradleVersion");
+            connector.useDistribution(URI.create("https://downloads.gradle.org/distributions/gradle-" + version + "-bin.zip"));
         } else if (Files.exists(projectDir.toPath().resolve("gradle/wrapper/gradle-wrapper.properties"))) {
             connector.useBuildDistribution();
         } else {
-            connector.useGradleVersion("8.12");
+            connector.useDistribution(URI.create("https://downloads.gradle.org/distributions/gradle-8.12-bin.zip"));
         }
         connector
                 // Uncomment to hit breakpoints inside OpenRewriteModelBuilder in unit tests


### PR DESCRIPTION
## Summary

- `OpenRewriteModelBuilder` uses the Gradle Tooling API's `useGradleVersion()` to configure which Gradle version to use for tests. Internally, this constructs a download URL using `services.gradle.org/distributions/`, which has been unreliable and timing out in CI.
- Switch to `useDistribution(URI)` with explicit `downloads.gradle.org` URLs, which is the stable distribution host that Gradle recommends.

This fixes the CI failure in `AddExplicitDependencyVersionTest.kotlinDslNoChangeWhenVersionAlreadyDeclared()` where the Gradle distribution download from `services.gradle.org` was timing out after 10 seconds.