### PR TITLE
JavaScript: Don't remove double negations

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -149,6 +149,22 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
     }
 
     @Test
+    void doubleNegationPreservedForTruthinessCoercion() {
+        rewriteRun(
+          groovy(
+            """
+              class A {
+                  def m(String s) {
+                      boolean a = !!s
+                      boolean b = !(!s)
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doubleNegatedBinaryWithParentheses() {
         rewriteRun(
           groovy(

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.cleanup;
 
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
@@ -192,7 +193,9 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
         } else if (isLiteralFalse(expr)) {
             j = ((J.Literal) expr).withValue(true).withValueSource("true");
         } else if (expr instanceof J.Unary && ((J.Unary) expr).getOperator() == J.Unary.Type.Not) {
-            j = ((J.Unary) expr).getExpression();
+            if (canSimplifyDoubleNegation(((J.Unary) expr).getExpression())) {
+                j = ((J.Unary) expr).getExpression();
+            }
         } else if (expr instanceof J.Parentheses) {
             J parenthesized = ((J.Parentheses<?>) expr).getTree();
             if (parenthesized instanceof J.Binary) {
@@ -204,7 +207,7 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
             } else if (parenthesized instanceof J.Unary) {
                 J.Unary unary1 = (J.Unary) parenthesized;
                 J.Unary.Type operator = unary1.getOperator();
-                if (operator == J.Unary.Type.Not) {
+                if (operator == J.Unary.Type.Not && canSimplifyDoubleNegation(unary1.getExpression())) {
                     j = unary1.getExpression().withPrefix(j.getPrefix());
                 }
             } else if (parenthesized instanceof J.Ternary) {
@@ -425,6 +428,20 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
                         .withPrefix(Space.EMPTY)
                         .withMarkers(Markers.EMPTY),
                 JavaType.Primitive.Boolean);
+    }
+
+    /**
+     * In Java, {@code !} only applies to boolean expressions, so {@code !!x} is always
+     * equivalent to {@code x}. In other languages like JavaScript/TypeScript and Groovy,
+     * {@code !!x} is an idiomatic boolean coercion that converts any truthy/falsy value
+     * to a strict boolean. In those cases, simplifying {@code !!x} to {@code x} changes
+     * semantics when {@code x} is not boolean-typed.
+     */
+    private boolean canSimplifyDoubleNegation(Expression innerExpression) {
+        if (getCursor().firstEnclosing(SourceFile.class) instanceof J.CompilationUnit) {
+            return true;
+        }
+        return innerExpression.getType() == JavaType.Primitive.Boolean;
     }
 
     /**

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript.cleanup;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor;
+import org.openrewrite.javascript.rpc.JavaScriptRewriteRpc;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.javascript.Assertions.javascript;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+@SuppressWarnings("JSUnusedLocalSymbols")
+@Timeout(60)
+class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(() -> new SimplifyBooleanExpressionVisitor()));
+    }
+
+    @AfterEach
+    void after() {
+        JavaScriptRewriteRpc.shutdownCurrent();
+    }
+
+    @Test
+    void doubleNegationPreservedForBooleanCoercion() {
+        rewriteRun(
+          javascript(
+            """
+              const x = "hello";
+              const y = !!x;
+              """
+          )
+        );
+    }
+
+    @Test
+    void doubleNegationWithParensPreservedForBooleanCoercion() {
+        rewriteRun(
+          javascript(
+            """
+              const x = "hello";
+              const y = !(!x);
+              """
+          )
+        );
+    }
+
+    @Test
+    void simplifyBooleanLiterals() {
+        rewriteRun(
+          javascript(
+            """
+              const a = !false;
+              const b = !true;
+              """,
+            """
+              const a = true;
+              const b = false;
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?

Amending the `SimplifyBooleanExpressionVisitor` not to remove double negations from non-Java code. Unless the underlying type is already boolean.

## What's your motivation?

In some languages, which include JavaScript and Groovy, the `!!` is an established technique of coercing values of different types into a truthy/falsey value. Therefore it's wrong to remove the `!!`. Example
```
function getDisplayName(user) {
    const name = user.name;       // could be undefined, null, or ""
    return !!name ? name : "Anonymous";
}
```