### PR TITLE
C#: Add MSAL license header to files under rewrite-csharp

### DIFF
--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -1,7 +1,11 @@
 @file:Suppress("UnstableApiUsage")
 
+import com.hierynomus.gradle.license.tasks.LicenseCheck
+import com.hierynomus.gradle.license.tasks.LicenseFormat
+import nl.javadude.gradle.plugins.license.LicenseExtension
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Calendar
 
 plugins {
     id("org.openrewrite.build.language-library")
@@ -177,3 +181,32 @@ val csharpPublish by tasks.registering(Exec::class) {
 tasks.named("publish") {
     dependsOn(csharpPublish)
 }
+
+// ============================================
+// License Header Configuration
+// ============================================
+
+extensions.configure<LicenseExtension> {
+    header = file("${rootProject.projectDir}/gradle/msalLicenseHeader.txt")
+}
+
+val licenseCsharp by tasks.registering(LicenseCheck::class) {
+    group = "license"
+    description = "Check license headers on C# files"
+    source = fileTree(csharpDir) { include("**/*.cs") }
+    header = file("${rootProject.projectDir}/gradle/msalLicenseHeader.txt")
+    mapping("cs", "SLASHSTAR_STYLE")
+    ext["year"] = Calendar.getInstance().get(Calendar.YEAR)
+}
+
+val licenseFormatCsharp by tasks.registering(LicenseFormat::class) {
+    group = "license"
+    description = "Apply license headers to C# files"
+    source = fileTree(csharpDir) { include("**/*.cs") }
+    header = file("${rootProject.projectDir}/gradle/msalLicenseHeader.txt")
+    mapping("cs", "SLASHSTAR_STYLE")
+    ext["year"] = Calendar.getInstance().get(Calendar.YEAR)
+}
+
+tasks.named("licenseMain") { dependsOn(licenseCsharp) }
+tasks.named("licenseFormatMain") { dependsOn(licenseFormatCsharp) }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using System.Text.RegularExpressions;
 using OpenRewrite.Core;
 using OpenRewrite.Java;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using OpenRewrite.Java;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Java;
 
 namespace OpenRewrite.CSharp;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core;
 using OpenRewrite.Core.Rpc;
 using OpenRewrite.Java;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Linq.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Linq.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core;
 using OpenRewrite.Java;
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/PreprocessorSourceTransformer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/PreprocessorSourceTransformer.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.CSharp;
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core;
 using OpenRewrite.Core.Rpc;
 using OpenRewrite.Java;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpSender.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpSender.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core;
 using OpenRewrite.Core.Rpc;
 using OpenRewrite.Java;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Loader;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using System.Diagnostics;
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/CategoryDescriptor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/CategoryDescriptor.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.Core;
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Cursor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Cursor.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.Core;
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Core/ExecutionContext.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/ExecutionContext.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.Core;
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Core/IRecipeActivator.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/IRecipeActivator.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.Core;
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Core/MarkerPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/MarkerPrinter.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.Core;
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Markers.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Markers.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core.Rpc;
 
 namespace OpenRewrite.Core;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Markup.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Markup.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core.Rpc;
 
 namespace OpenRewrite.Core;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/OmitBraces.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/OmitBraces.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core.Rpc;
 
 namespace OpenRewrite.Core;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/OptionAttribute.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/OptionAttribute.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using JetBrains.Annotations;
 
 namespace OpenRewrite.Core;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/OptionDescriptor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/OptionDescriptor.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using JetBrains.Annotations;
 
 namespace OpenRewrite.Core;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/PointerMemberAccess.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/PointerMemberAccess.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core.Rpc;
 
 namespace OpenRewrite.Core;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/PrintOutputCapture.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/PrintOutputCapture.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using System.Text;
 
 namespace OpenRewrite.Core;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Recipe.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Recipe.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using System.Reflection;
 using JetBrains.Annotations;
 using OpenRewrite.Java;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipeDescriptor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipeDescriptor.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using JetBrains.Annotations;
 
 namespace OpenRewrite.Core;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipeMarketplace.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipeMarketplace.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.Core;
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipesThatMadeChanges.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipesThatMadeChanges.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using Newtonsoft.Json;
 
 namespace OpenRewrite.Core;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/IRpcCodec.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/IRpcCodec.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.Core.Rpc;
 
 public interface IRpcCodec

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/Reference.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/Reference.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace Rewrite.Core.Rpc;
 
 public class Reference

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcObjectData.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcObjectData.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using System.Text.Json.Serialization;
 
 namespace OpenRewrite.Core.Rpc;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using Rewrite.Core.Rpc;
 using static OpenRewrite.Core.Rpc.RpcObjectData;
 using static OpenRewrite.Core.Rpc.RpcObjectData.ObjectState;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcVisitor.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.CSharp.Rpc;
 using OpenRewrite.Java;
 

--- a/rewrite-csharp/csharp/OpenRewrite/Core/SearchResult.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/SearchResult.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core.Rpc;
 using OpenRewrite.Java;
 

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Space.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Space.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.Core;
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Core/TrailingComma.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/TrailingComma.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core.Rpc;
 using OpenRewrite.Java.Rpc;
 

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Tree.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Tree.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.Core;
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Core/TreeVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/TreeVisitor.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.Core;
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Java/J.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/J.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core;
 using OpenRewrite.Core.Rpc;
 

--- a/rewrite-csharp/csharp/OpenRewrite/Java/JavaType.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/JavaType.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.Java;
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Java/JavaVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/JavaVisitor.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core;
 
 namespace OpenRewrite.Java;

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaReceiver.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core;
 using OpenRewrite.Core.Rpc;
 using Space = OpenRewrite.Core.Space;

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaSender.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaSender.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core;
 using OpenRewrite.Core.Rpc;
 using static Rewrite.Core.Rpc.Reference;

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Search/LocalUsesType.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Search/LocalUsesType.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core;
 
 namespace OpenRewrite.Java.Search;

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Search/Preconditions.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Search/Preconditions.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core.Rpc;
 using OpenRewrite.CSharp.Rpc;
 using ExecutionContext = OpenRewrite.Core.ExecutionContext;

--- a/rewrite-csharp/csharp/OpenRewrite/Program.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Program.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using System.Diagnostics;
 using OpenRewrite.CSharp;
 using OpenRewrite.CSharp.Rpc;

--- a/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core;
 using OpenRewrite.CSharp;
 using Rewrite.Core;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/CSharpSyntaxFragments.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/CSharpSyntaxFragments.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Recipe/RecipeTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Recipe/RecipeTest.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Core;
 using OpenRewrite.CSharp;
 using OpenRewrite.Java;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/SolutionParserTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/SolutionParserTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.CSharp;
 
 namespace OpenRewrite.Tests;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/SourceTestCase.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/SourceTestCase.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 ﻿namespace OpenRewrite.Tests;
 
 public record SourceTestCase(string Name, string SourceText)

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/ArrayAccessTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/ArrayAccessTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/ArrayTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/ArrayTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/AsyncTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/AsyncTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/AttributeListTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/AttributeListTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/AwaitStatementTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/AwaitStatementTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/BinaryTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/BinaryTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/BlockTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/BlockTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/CSharpSyntaxFragmentTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/CSharpSyntaxFragmentTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/CastTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/CastTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/ClassDeclarationTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/ClassDeclarationTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/EmptyContainerTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/EmptyContainerTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/EnumDeclarationTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/EnumDeclarationTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/IdentifierTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/IdentifierTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/InterfaceTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/InterfaceTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/InterpolatedStringTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/InterpolatedStringTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/InvocationExpressionTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/InvocationExpressionTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/LambdaTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/LambdaTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/LiteralTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/LiteralTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/LockTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/LockTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/MemberReferenceTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/MemberReferenceTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/MethodDeclarationTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/MethodDeclarationTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/MethodInvocationTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/MethodInvocationTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/NamespaceTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/NamespaceTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/NewClassTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/NewClassTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/ParenthesesTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/ParenthesesTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/PointerTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/PointerTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/PropertyDeclarationTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/PropertyDeclarationTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/RecordDeclarationTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/RecordDeclarationTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/SemicolonSpacingTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/SemicolonSpacingTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/StatementTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/StatementTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/StructDeclarationTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/StructDeclarationTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/SwitchTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/SwitchTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/TernaryTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/TernaryTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/TupleTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/TupleTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/UsingDirectiveTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/UsingDirectiveTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/VariableDeclarationsTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/VariableDeclarationsTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/YieldTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/YieldTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/WorkingSetDiscovery.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/WorkingSetDiscovery.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.Tests;
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/WorkingSetDiscoveryTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/WorkingSetDiscoveryTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenRewrite.Tests;
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/WorkingSetRoundTripTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/WorkingSetRoundTripTests.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using Microsoft.CodeAnalysis;
 using OpenRewrite.CSharp;
 


### PR DESCRIPTION
## What's changed?

Adding the license header to C# files under rewrite-csharp.

## What's your motivation?

Avoid confusion about the relevant license.