### PR TITLE
Fix `StackOverflowError` in `DefaultJavaTypeSignatureBuilder` for cyclic types

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/internal/DefaultJavaTypeSignatureBuilderTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/internal/DefaultJavaTypeSignatureBuilderTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.internal;
 
 import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTypeSignatureBuilderTest;
@@ -27,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class DefaultJavaTypeSignatureBuilderTest implements JavaTypeSignatureBuilderTest {
 
@@ -100,5 +102,28 @@ class DefaultJavaTypeSignatureBuilderTest implements JavaTypeSignatureBuilderTes
     @Override
     public DefaultJavaTypeSignatureBuilder signatureBuilder() {
         return new DefaultJavaTypeSignatureBuilder();
+    }
+
+    @Test
+    void cyclicParameterizedWithMultiCatch() {
+        JavaType.Class listType = JavaType.ShallowClass.build("java.util.List");
+        JavaType.Parameterized parameterized = new JavaType.Parameterized(null, listType, null);
+        JavaType.MultiCatch multiCatch = new JavaType.MultiCatch(List.of(parameterized));
+        // Create a cycle: Parameterized -> MultiCatch -> Parameterized
+        parameterized.unsafeSet(listType, List.of(multiCatch));
+
+        String sig = signatureBuilder().signature(parameterized);
+        assertThat(sig).isNotNull();
+    }
+
+    @Test
+    void cyclicParameterizedSelfReferencing() {
+        JavaType.Class mapType = JavaType.ShallowClass.build("java.util.Map");
+        JavaType.Parameterized parameterized = new JavaType.Parameterized(null, mapType, null);
+        // Parameterized references itself as a type parameter
+        parameterized.unsafeSet(mapType, List.of(JavaType.Primitive.String, parameterized));
+
+        String sig = signatureBuilder().signature(parameterized);
+        assertThat(sig).isNotNull();
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/DefaultJavaTypeSignatureBuilder.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/DefaultJavaTypeSignatureBuilder.java
@@ -116,7 +116,9 @@ public class DefaultJavaTypeSignatureBuilder implements JavaTypeSignatureBuilder
         JavaType.Intersection it = (JavaType.Intersection) type;
         StringJoiner bounds = new StringJoiner(" & ");
         for (JavaType bound : it.getBounds()) {
-            bounds.add(signature(bound));
+            if (parameterizedStack == null || !parameterizedStack.contains(bound)) {
+                bounds.add(signature(bound));
+            }
         }
         return bounds.toString();
     }
@@ -128,19 +130,24 @@ public class DefaultJavaTypeSignatureBuilder implements JavaTypeSignatureBuilder
         if (parameterizedStack == null) {
             parameterizedStack = newSetFromMap(new IdentityHashMap<>());
         }
-        parameterizedStack.add(pt);
-
-        String baseType = signature(pt.getType());
-        StringBuilder s = new StringBuilder(baseType);
-
-        StringJoiner typeParameters = new StringJoiner(", ", "<", ">");
-        for (JavaType typeParameter : pt.getTypeParameters()) {
-            typeParameters.add(signature(typeParameter));
+        if (!parameterizedStack.add(pt)) {
+            return classSignature(pt.getType());
         }
-        s.append(typeParameters);
 
-        parameterizedStack.remove(pt);
-        return s.toString();
+        try {
+            String baseType = signature(pt.getType());
+            StringBuilder s = new StringBuilder(baseType);
+
+            StringJoiner typeParameters = new StringJoiner(", ", "<", ">");
+            for (JavaType typeParameter : pt.getTypeParameters()) {
+                typeParameters.add(signature(typeParameter));
+            }
+            s.append(typeParameters);
+
+            return s.toString();
+        } finally {
+            parameterizedStack.remove(pt);
+        }
     }
 
     @Override
@@ -191,11 +198,16 @@ public class DefaultJavaTypeSignatureBuilder implements JavaTypeSignatureBuilder
     private String multiCatchSignature(Object type) {
         JavaType.MultiCatch multiCatch = (JavaType.MultiCatch) type;
         StringBuilder s = new StringBuilder();
-        for (int i = 0; i < multiCatch.getThrowableTypes().size(); i++) {
-            if (i > 0) {
+        List<JavaType> throwableTypes = multiCatch.getThrowableTypes();
+        for (int i = 0; i < throwableTypes.size(); i++) {
+            JavaType throwableType = throwableTypes.get(i);
+            if (parameterizedStack != null && parameterizedStack.contains(throwableType)) {
+                continue;
+            }
+            if (i > 0 && s.length() > 0) {
                 s.append('|');
             }
-            s.append(signature(multiCatch.getThrowableTypes().get(i)));
+            s.append(signature(throwableType));
         }
         return s.toString();
     }


### PR DESCRIPTION
## Summary

- Fix `parameterizedSignature()` to check `parameterizedStack.add()` return value and short-circuit on cycle detection, preventing infinite recursion through `Parameterized` → `MultiCatch` → `Parameterized` chains
- Use `try/finally` to ensure stack cleanup even on exceptions
- Add cycle protection to `multiCatchSignature()` and `intersectionSignature()` for types already on the parameterized stack
- Add tests for cyclic `Parameterized→MultiCatch→Parameterized` and self-referencing `Parameterized` types

The root cause was found in production rpc.log files showing a tight `parameterizedSignature` → `multiCatchSignature` → `parameterizedSignature` loop. The old code called `parameterizedStack.add(pt)` without checking the return value.

## Test plan

- [x] `./gradlew :rewrite-java-test:test --tests "org.openrewrite.java.internal.DefaultJavaTypeSignatureBuilderTest"` — new cyclic type tests pass
- [x] `./gradlew :rewrite-java:test --tests "*TypeSignature*"` — no regressions in existing type signature tests