### PR TITLE
C#: `nugetApiKey` check on publishing

### DIFF
--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -177,9 +177,11 @@ val csharpPublish by tasks.registering(Exec::class) {
     }
 }
 
-// Wire into the main publish task
-tasks.named("publish") {
-    dependsOn(csharpPublish)
+// Wire into the main publish task only when the NuGet API key is available
+if (project.hasProperty("nugetApiKey")) {
+    tasks.named("publish") {
+        dependsOn(csharpPublish)
+    }
 }
 
 // ============================================


### PR DESCRIPTION
## What's changed?

Adding a condition to the `publish` task in rewrite-csharp.

## What's your motivation?

Fix broken `publishSnapshots` flow which errors out with:
```
Caused by: org.gradle.api.GradleException: nugetApiKey property is required for NuGet publishing
	at Build_gradle$csharpPublish$2$1.execute(build.gradle.kts:170)
```