### PR TITLE
Handle new ty-types 0.0.21 descriptor kinds and enriched fields

### DIFF
--- a/rewrite-python/rewrite/pyproject.toml
+++ b/rewrite-python/rewrite/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10"
 dependencies = [
     "cbor2>=5.6.5",
     "more_itertools>=10.0.0",
-    "ty-types>=0.0.19",  # Type inference CLI for Python type attribution
+    "ty-types>=0.0.21",  # Type inference CLI for Python type attribution
     "parso>=0.7.1,<0.8",  # Python 2/3 parser with CST support (0.8+ dropped Python 2.7 grammar)
 ]
 

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -435,7 +435,7 @@ class PythonTypeMapping:
             module_name = descriptor.get('moduleName', '')
             return self._create_class_type(module_name)
 
-        elif kind in ('function', 'boundMethod'):
+        elif kind in ('function', 'boundMethod', 'callable', 'wrapperDescriptor'):
             # Use structured return type if available
             return_type_id = descriptor.get('returnType')
             if return_type_id is not None:
@@ -502,7 +502,7 @@ class PythonTypeMapping:
                     if member_type_id is None:
                         continue
                     member_desc = self._type_registry.get(member_type_id)
-                    if member_desc and member_desc.get('kind') in ('function', 'boundMethod'):
+                    if member_desc and member_desc.get('kind') in ('function', 'boundMethod', 'callable', 'wrapperDescriptor'):
                         method = self._create_method_from_descriptor(member_desc, class_type)
                         if method:
                             methods.append(method)
@@ -555,6 +555,25 @@ class PythonTypeMapping:
                 return self._create_class_type(name)
             return _UNKNOWN
 
+        elif kind == 'knownInstance':
+            class_name = descriptor.get('className', '')
+            if class_name:
+                return self._create_class_type(f"typing.{class_name}")
+            return _UNKNOWN
+
+        elif kind == 'typeAlias':
+            # Resolve through to the underlying value type when available
+            value_type_id = descriptor.get('valueType')
+            if value_type_id is not None:
+                result = self._resolve_type(value_type_id)
+                if result is not None:
+                    return result
+            # Fall back to creating a class from the alias name
+            name = descriptor.get('name', '')
+            if name:
+                return self._create_class_type(name)
+            return _UNKNOWN
+
         elif kind == 'typeVar':
             name = descriptor.get('name', '')
             if not name:
@@ -571,6 +590,17 @@ class PythonTypeMapping:
                 bound_type = self._resolve_type(upper_bound_id)
                 if bound_type is not None:
                     bounds = [bound_type]
+            # Use constraints as bounds if no upper bound
+            if bounds is None:
+                constraint_ids = descriptor.get('constraints', [])
+                if constraint_ids:
+                    resolved_constraints = []
+                    for c_id in constraint_ids:
+                        c_type = self._resolve_type(c_id)
+                        if c_type is not None:
+                            resolved_constraints.append(c_type)
+                    if resolved_constraints:
+                        bounds = resolved_constraints
             return JavaType.GenericTypeVariable(_name=name, _variance=variance, _bounds=bounds)
 
         else:
@@ -624,7 +654,7 @@ class PythonTypeMapping:
     def _is_variable_descriptor(self, descriptor: Dict[str, Any]) -> bool:
         """Check if a type descriptor represents a variable (not a function, class, or module)."""
         kind = descriptor.get('kind')
-        return kind not in ('function', 'boundMethod', 'module', 'classLiteral')
+        return kind not in ('function', 'boundMethod', 'callable', 'wrapperDescriptor', 'module', 'classLiteral')
 
     def name_type_info(self, node: ast.Name) -> Tuple[Optional[JavaType], Optional[JavaType.Variable]]:
         """Get expression type and variable type for a name reference.
@@ -685,7 +715,7 @@ class PythonTypeMapping:
         type_id = self._lookup_type_id(node)
         if type_id is not None:
             descriptor = self._type_registry.get(type_id)
-            if descriptor and descriptor.get('kind') in ('function', 'boundMethod'):
+            if descriptor and descriptor.get('kind') in ('function', 'boundMethod', 'callable', 'wrapperDescriptor'):
                 # If the descriptor has parameters/returnType, use them directly
                 params = descriptor.get('parameters')
                 ret_id = descriptor.get('returnType')
@@ -906,7 +936,14 @@ class PythonTypeMapping:
                     kind = descriptor.get('kind')
                     if kind == 'module':
                         return self._create_class_type(descriptor.get('moduleName', ''))
-                    elif kind in ('function', 'boundMethod'):
+                    elif kind in ('function', 'boundMethod', 'callable', 'wrapperDescriptor'):
+                        # boundMethod has className — use it for declaring type
+                        class_name = descriptor.get('className')
+                        if class_name:
+                            module_name = descriptor.get('moduleName')
+                            if module_name and module_name != 'builtins':
+                                return self._create_class_type(f"{module_name}.{class_name}")
+                            return self._create_class_type(class_name)
                         module_name = descriptor.get('moduleName')
                         if module_name and module_name != 'builtins':
                             return self._create_class_type(module_name)
@@ -1020,6 +1057,14 @@ class PythonTypeMapping:
         elif kind == 'classLiteral':
             class_name = descriptor.get('className', '')
             return self._create_class_type(class_name)
+
+        elif kind == 'boundMethod':
+            class_name = descriptor.get('className')
+            if class_name:
+                module_name = descriptor.get('moduleName')
+                if module_name and module_name != 'builtins':
+                    return self._create_class_type(f"{module_name}.{class_name}")
+                return self._create_class_type(class_name)
 
         return None
 

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -1517,3 +1517,332 @@ handler: typing.Callable[[int], str] = lambda x: str(x)
                 f"Expected typing.Callable to resolve to a Class, got Unknown"
         finally:
             _cleanup_mapping(mapping, tmpdir, client)
+
+
+class TestCallableDescriptor:
+    """Tests for the callable kind descriptor (Callable[[int], str])."""
+
+    def test_callable_with_return_type(self):
+        """A callable descriptor with returnType should resolve to the return type."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[200] = {
+            'kind': 'callable',
+            'parameters': [
+                {'name': '', 'kind': 'positionalOnly', 'typeId': 201, 'hasDefault': False},
+            ],
+            'returnType': 202,
+        }
+        mapping._type_registry[201] = {'kind': 'instance', 'className': 'int'}
+        mapping._type_registry[202] = {'kind': 'instance', 'className': 'str'}
+
+        result = mapping._resolve_type(200)
+        assert result == JavaType.Primitive.String
+
+    def test_callable_without_return_type(self):
+        """A callable descriptor without returnType should return Unknown."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[200] = {
+            'kind': 'callable',
+            'parameters': [],
+        }
+
+        result = mapping._resolve_type(200)
+        assert isinstance(result, JavaType.Unknown)
+
+    def test_callable_is_not_variable(self):
+        """Callable descriptors should not be treated as variables."""
+        mapping = PythonTypeMapping("", file_path=None)
+        descriptor = {'kind': 'callable', 'parameters': [], 'returnType': None}
+        assert not mapping._is_variable_descriptor(descriptor)
+
+
+class TestWrapperDescriptor:
+    """Tests for the wrapperDescriptor kind."""
+
+    def test_wrapper_descriptor_with_return_type(self):
+        """A wrapperDescriptor with returnType should resolve to the return type."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[300] = {
+            'kind': 'wrapperDescriptor',
+            'descriptorKind': 'Get',
+            'parameters': [
+                {'name': 'self', 'kind': 'positionalOrKeyword', 'typeId': 301, 'hasDefault': False},
+            ],
+            'returnType': 302,
+        }
+        mapping._type_registry[301] = {'kind': 'instance', 'className': 'MyClass'}
+        mapping._type_registry[302] = {'kind': 'instance', 'className': 'int'}
+
+        result = mapping._resolve_type(300)
+        assert result == JavaType.Primitive.Int
+
+    def test_wrapper_descriptor_is_not_variable(self):
+        """wrapperDescriptor should not be treated as a variable."""
+        mapping = PythonTypeMapping("", file_path=None)
+        descriptor = {'kind': 'wrapperDescriptor', 'descriptorKind': 'Set'}
+        assert not mapping._is_variable_descriptor(descriptor)
+
+
+class TestKnownInstanceDescriptor:
+    """Tests for the knownInstance kind."""
+
+    def test_known_instance_resolves_to_class(self):
+        """A knownInstance with className should resolve to a class type."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[400] = {
+            'kind': 'knownInstance',
+            'className': 'TypeVar',
+        }
+
+        result = mapping._resolve_type(400)
+        assert isinstance(result, JavaType.Class)
+        assert result._fully_qualified_name == 'typing.TypeVar'
+
+    def test_known_instance_special_form(self):
+        """A knownInstance for _SpecialForm should resolve correctly."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[400] = {
+            'kind': 'knownInstance',
+            'className': '_SpecialForm',
+        }
+
+        result = mapping._resolve_type(400)
+        assert isinstance(result, JavaType.Class)
+        assert 'typing' in result._fully_qualified_name
+
+    def test_known_instance_empty_classname_returns_unknown(self):
+        """A knownInstance without className should return Unknown."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[400] = {
+            'kind': 'knownInstance',
+            'className': '',
+        }
+
+        result = mapping._resolve_type(400)
+        assert isinstance(result, JavaType.Unknown)
+
+
+class TestTypeAliasDescriptor:
+    """Tests for the enriched typeAlias kind."""
+
+    def test_type_alias_with_value_type(self):
+        """A typeAlias with valueType should resolve to the underlying type."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[500] = {
+            'kind': 'typeAlias',
+            'name': 'MyAlias',
+            'valueType': 501,
+        }
+        mapping._type_registry[501] = {'kind': 'instance', 'className': 'int'}
+
+        result = mapping._resolve_type(500)
+        assert result == JavaType.Primitive.Int
+
+    def test_type_alias_without_value_type(self):
+        """A typeAlias without valueType should fall back to class from name."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[500] = {
+            'kind': 'typeAlias',
+            'name': 'MyAlias',
+        }
+
+        result = mapping._resolve_type(500)
+        assert isinstance(result, JavaType.Class)
+        assert result._fully_qualified_name == 'MyAlias'
+
+    def test_type_alias_with_class_value_type(self):
+        """A typeAlias pointing to a class should resolve to that class."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[500] = {
+            'kind': 'typeAlias',
+            'name': 'StringList',
+            'valueType': 501,
+            'typeParameters': [],
+        }
+        mapping._type_registry[501] = {
+            'kind': 'instance',
+            'className': 'list',
+        }
+
+        result = mapping._resolve_type(500)
+        assert isinstance(result, JavaType.Class)
+        assert result._fully_qualified_name == 'list'
+
+
+class TestTypeVarConstraints:
+    """Tests for typeVar constraints field."""
+
+    def test_typevar_with_constraints(self):
+        """A typeVar with constraints should have them as bounds."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[600] = {
+            'kind': 'typeVar',
+            'name': 'T',
+            'variance': 'invariant',
+            'constraints': [601, 602],
+        }
+        mapping._type_registry[601] = {'kind': 'instance', 'className': 'int'}
+        mapping._type_registry[602] = {'kind': 'instance', 'className': 'str'}
+
+        result = mapping._resolve_type(600)
+        assert isinstance(result, JavaType.GenericTypeVariable)
+        assert result.name == 'T'
+        assert len(result.bounds) == 2
+        assert result.bounds[0] is JavaType.Primitive.Int
+        assert result.bounds[1] is JavaType.Primitive.String
+
+    def test_typevar_upper_bound_takes_precedence_over_constraints(self):
+        """upperBound should be used instead of constraints when both present."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[600] = {
+            'kind': 'typeVar',
+            'name': 'T',
+            'variance': 'invariant',
+            'upperBound': 601,
+            'constraints': [602, 603],
+        }
+        mapping._type_registry[601] = {'kind': 'instance', 'className': 'float'}
+        mapping._type_registry[602] = {'kind': 'instance', 'className': 'int'}
+        mapping._type_registry[603] = {'kind': 'instance', 'className': 'str'}
+
+        result = mapping._resolve_type(600)
+        assert isinstance(result, JavaType.GenericTypeVariable)
+        assert len(result.bounds) == 1
+        assert result.bounds[0] is JavaType.Primitive.Double  # float -> Double
+
+
+class TestBoundMethodClassName:
+    """Tests for the boundMethod className field."""
+
+    def test_bound_method_declaring_type_from_classname(self):
+        """boundMethod with className should resolve declaring type."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[700] = {
+            'kind': 'boundMethod',
+            'name': 'method',
+            'className': 'MyClass',
+            'moduleName': 'mymod',
+            'parameters': [],
+            'returnType': 701,
+        }
+        mapping._type_registry[701] = {'kind': 'instance', 'className': 'str'}
+
+        result = mapping._declaring_type_from_descriptor(mapping._type_registry[700])
+        assert result is not None
+        assert isinstance(result, JavaType.Class)
+        assert result._fully_qualified_name == 'mymod.MyClass'
+
+    def test_bound_method_declaring_type_builtins_no_module(self):
+        """boundMethod from builtins should use just className."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[700] = {
+            'kind': 'boundMethod',
+            'name': 'upper',
+            'className': 'str',
+            'moduleName': 'builtins',
+            'parameters': [],
+            'returnType': 701,
+        }
+        mapping._type_registry[701] = {'kind': 'instance', 'className': 'str'}
+
+        result = mapping._declaring_type_from_descriptor(mapping._type_registry[700])
+        assert result is not None
+        assert result._fully_qualified_name == 'str'
+
+
+@requires_ty_types_cli
+class TestNewDescriptorsWithTyTypes:
+    """Integration tests for new ty-types 0.0.20 descriptor kinds using live ty-types."""
+
+    def test_callable_annotation_resolves(self):
+        """A Callable[[int], str] annotation should resolve."""
+        source = '''from typing import Callable
+my_func: Callable[[int], str] = str
+my_func
+'''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            name_node = tree.body[2].value  # bare 'my_func' expression
+            result = mapping.type(name_node)
+            # The type of my_func should be a callable — resolve to its return type (str)
+            # or to a class type. Either way, not Unknown.
+            assert result is not None
+            assert not isinstance(result, JavaType.Unknown), \
+                "Callable annotation should not resolve to Unknown"
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_bound_method_has_classname_declaring_type(self):
+        """Bound method on user class should produce declaring type from className."""
+        source = '''class Calculator:
+    def add(self, a: int, b: int) -> int:
+        return a + b
+
+c = Calculator()
+c.add(1, 2)
+'''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            call = tree.body[2].value  # c.add(1, 2)
+            result = mapping.method_invocation_type(call)
+            assert result is not None
+            assert result._name == 'add'
+            assert result._declaring_type is not None
+            assert result._declaring_type._fully_qualified_name.endswith('Calculator')
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_typevar_with_constraints_from_ty_types(self):
+        """TypeVar with constraints should produce GenericTypeVariable with bounds."""
+        source = '''from typing import TypeVar
+T = TypeVar('T', int, str)
+x: T
+'''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            # Look up the type of 'x' which should be T
+            name_node = tree.body[2].target  # x in 'x: T'
+            result = mapping.type(name_node)
+            # T should be a GenericTypeVariable
+            if isinstance(result, JavaType.GenericTypeVariable):
+                assert result.name == 'T'
+                # With constraints, bounds should have int and str
+                assert len(result.bounds) >= 1
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_type_alias_resolves_through_value(self):
+        """A type alias should resolve through to its value type."""
+        source = '''type MyInt = int
+x: MyInt = 42
+x
+'''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            name_node = tree.body[2].value  # bare 'x'
+            result = mapping.type(name_node)
+            # x: MyInt should resolve to int
+            assert result is not None
+            # Could be Primitive.Int or a Class('int') or Class('MyInt')
+            # The key is it shouldn't be Unknown
+            assert not isinstance(result, JavaType.Unknown), \
+                "type alias should not resolve to Unknown"
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_known_instance_typevar_resolves_to_class(self):
+        """The TypeVar constructor name should resolve to a class, not Unknown."""
+        source = '''from typing import TypeVar
+TypeVar
+'''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            name_node = tree.body[1].value  # bare 'TypeVar'
+            result = mapping.type(name_node)
+            assert result is not None
+            assert not isinstance(result, JavaType.Unknown), \
+                "TypeVar name should resolve to a Class via knownInstance"
+            assert isinstance(result, JavaType.Class)
+            assert 'typing' in result._fully_qualified_name
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)


### PR DESCRIPTION
## Summary
- Handle `callable` and `wrapperDescriptor` descriptor kinds: resolve `returnType`, use in method signatures and declaring type resolution
- Handle `knownInstance` kind: map `className` to `typing.{className}` class type (e.g., `TypeVar` → `typing.TypeVar`)
- Handle enriched `typeAlias`: resolve through `valueType` to underlying type instead of just using the alias name
- Use `boundMethod.className` to derive accurate declaring types for method calls
- Use `typeVar.constraints` as bounds when no `upperBound` is present
- Bump `ty-types` dependency from `>=0.0.19` to `>=0.0.21`

## Test plan
- 20 new tests added (unit + integration against live ty-types)
- All 103 tests pass on ty-types 0.0.21
- Unit tests use synthetic registries to verify each new descriptor kind in isolation
- Integration tests (`TestNewDescriptorsWithTyTypes`) verify end-to-end against the live ty-types binary