### PR TITLE
Improved C# RPC server bootstrapping

### DIFF
--- a/rewrite-csharp/.gitignore
+++ b/rewrite-csharp/.gitignore
@@ -1,0 +1,1 @@
+src/main/resources/META-INF/rewrite-csharp-version.txt

--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -115,7 +115,7 @@ tasks.withType<Test> {
 }
 
 // ============================================
-// NuGet Publishing Tasks
+// NuGet Version & Version File
 // ============================================
 
 // Generate a NuGet-compatible version for CI builds
@@ -129,6 +129,30 @@ val nugetVersion: String = if (System.getenv("CI") != null) {
 } else {
     project.version.toString().replace("-SNAPSHOT", "-dev")
 }
+
+val generateVersionTxt by tasks.registering {
+    group = "csharp"
+    description = "Generate META-INF/rewrite-csharp-version.txt for RPC version pinning"
+
+    val versionTxt = file("src/main/resources/META-INF/rewrite-csharp-version.txt")
+    inputs.property("version", nugetVersion)
+    outputs.file(versionTxt)
+
+    doLast {
+        versionTxt.parentFile.mkdirs()
+        versionTxt.writeText(nugetVersion)
+    }
+}
+
+listOf("sourcesJar", "processResources", "licenseMain", "assemble").forEach {
+    tasks.named(it) {
+        dependsOn(generateVersionTxt)
+    }
+}
+
+// ============================================
+// NuGet Publishing Tasks
+// ============================================
 
 // Task to pack the C# project as a NuGet tool package
 // Version is injected via /p:Version so the .csproj is never modified

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -6925,7 +6925,11 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     }
                 }
             }
-            if (!merged) break; // Stop processing further where clauses — remaining text will be in body prefix
+            if (!merged)
+            {
+                _cursor = cursorBeforeClause; // Rewind so unmatched clause text is captured in body prefix
+                break;
+            }
             whereOrder++;
         }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
@@ -157,44 +157,102 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitUsingDirective(UsingDirective usingDirective, P p)
     {
-        Visit(usingDirective.NamespaceOrType, p);
+        var visited = Visit(usingDirective.NamespaceOrType, p);
+        if (visited is TypeTree tt && !ReferenceEquals(tt, usingDirective.NamespaceOrType))
+        {
+            return usingDirective.WithNamespaceOrType(tt);
+        }
         return usingDirective;
     }
 
     public virtual J VisitPropertyDeclaration(PropertyDeclaration prop, P p)
     {
-        Visit(prop.TypeExpression, p);
+        var changed = false;
+
+        TypeTree newTypeExpr = prop.TypeExpression;
+        var visitedType = Visit(prop.TypeExpression, p);
+        if (visitedType is TypeTree tt && !ReferenceEquals(tt, prop.TypeExpression))
+        {
+            newTypeExpr = tt;
+            changed = true;
+        }
+
+        Block? newAccessors = prop.Accessors;
         if (prop.Accessors != null)
         {
-            Visit(prop.Accessors, p);
+            var visitedAccessors = Visit(prop.Accessors, p);
+            if (visitedAccessors is Block b && !ReferenceEquals(b, prop.Accessors))
+            {
+                newAccessors = b;
+                changed = true;
+            }
         }
+
+        JLeftPadded<Expression>? newExprBody = prop.ExpressionBody;
         if (prop.ExpressionBody != null)
         {
-            Visit(prop.ExpressionBody.Element, p);
+            var visitedExpr = Visit(prop.ExpressionBody.Element, p);
+            if (visitedExpr is Expression e && !ReferenceEquals(e, prop.ExpressionBody.Element))
+            {
+                newExprBody = prop.ExpressionBody.WithElement(e);
+                changed = true;
+            }
         }
-        return prop;
+
+        return changed
+            ? prop.WithTypeExpression(newTypeExpr).WithAccessors(newAccessors).WithExpressionBody(newExprBody)
+            : prop;
     }
 
     public virtual J VisitAccessorDeclaration(AccessorDeclaration accessor, P p)
     {
+        var changed = false;
+
+        Block? newBody = accessor.Body;
         if (accessor.Body != null)
         {
-            Visit(accessor.Body, p);
+            var visited = Visit(accessor.Body, p);
+            if (visited is Block b && !ReferenceEquals(b, accessor.Body))
+            {
+                newBody = b;
+                changed = true;
+            }
         }
+
+        JLeftPadded<Expression>? newExprBody = accessor.ExpressionBody;
         if (accessor.ExpressionBody != null)
         {
-            Visit(accessor.ExpressionBody.Element, p);
+            var visited = Visit(accessor.ExpressionBody.Element, p);
+            if (visited is Expression e && !ReferenceEquals(e, accessor.ExpressionBody.Element))
+            {
+                newExprBody = accessor.ExpressionBody.WithElement(e);
+                changed = true;
+            }
         }
-        return accessor;
+
+        return changed
+            ? accessor.WithBody(newBody).WithExpressionBody(newExprBody)
+            : accessor;
     }
 
     public virtual J VisitAttributeList(AttributeList attrList, P p)
     {
+        var newAttrs = new List<JRightPadded<Annotation>>();
+        bool changed = false;
         foreach (var paddedAttr in attrList.Attributes)
         {
-            Visit(paddedAttr.Element, p);
+            var visited = Visit(paddedAttr.Element, p);
+            if (visited is Annotation a)
+            {
+                if (!ReferenceEquals(a, paddedAttr.Element)) changed = true;
+                newAttrs.Add(paddedAttr.WithElement(a));
+            }
+            else
+            {
+                newAttrs.Add(paddedAttr);
+            }
         }
-        return attrList;
+        return changed ? attrList.WithAttributes(newAttrs) : attrList;
     }
 
     public virtual J VisitNamedExpression(NamedExpression ne, P p)
@@ -219,10 +277,30 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitDeclarationExpression(DeclarationExpression de, P p)
     {
+        var changed = false;
+
+        TypeTree? newTypeExpr = de.TypeExpression;
         if (de.TypeExpression != null)
-            Visit(de.TypeExpression, p);
-        Visit(de.Variables, p);
-        return de;
+        {
+            var visited = Visit(de.TypeExpression, p);
+            if (visited is TypeTree tt && !ReferenceEquals(tt, de.TypeExpression))
+            {
+                newTypeExpr = tt;
+                changed = true;
+            }
+        }
+
+        Expression newVariables = de.Variables;
+        var visitedVars = Visit(de.Variables, p);
+        if (visitedVars is Expression vv && !ReferenceEquals(vv, de.Variables))
+        {
+            newVariables = vv;
+            changed = true;
+        }
+
+        return changed
+            ? de.WithTypeExpression(newTypeExpr).WithVariables(newVariables)
+            : de;
     }
 
     public virtual J VisitIsPattern(IsPattern isPattern, P p)
@@ -251,47 +329,98 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitSizeOf(SizeOf sizeOf, P p)
     {
-        Visit(sizeOf.Expression, p);
+        var visited = Visit(sizeOf.Expression, p);
+        if (visited is Expression e && !ReferenceEquals(e, sizeOf.Expression))
+        {
+            return sizeOf.WithExpression(e);
+        }
         return sizeOf;
     }
 
     public virtual J VisitUnsafeStatement(UnsafeStatement unsafeStatement, P p)
     {
-        Visit(unsafeStatement.Block, p);
+        var visited = Visit(unsafeStatement.Block, p);
+        if (visited is Block b && !ReferenceEquals(b, unsafeStatement.Block))
+        {
+            return unsafeStatement.WithBlock(b);
+        }
         return unsafeStatement;
     }
 
     public virtual J VisitPointerType(PointerType pointerType, P p)
     {
-        Visit(pointerType.ElementType.Element, p);
+        var visited = Visit(pointerType.ElementType.Element, p);
+        if (visited is TypeTree tt && !ReferenceEquals(tt, pointerType.ElementType.Element))
+        {
+            return pointerType.WithElementType(pointerType.ElementType.WithElement(tt));
+        }
         return pointerType;
     }
 
     public virtual J VisitFixedStatement(FixedStatement fixedStatement, P p)
     {
-        Visit(fixedStatement.Declarations, p);
-        Visit(fixedStatement.Block, p);
-        return fixedStatement;
+        var changed = false;
+
+        ControlParentheses<VariableDeclarations> newDecl = fixedStatement.Declarations;
+        var visitedDecl = Visit(fixedStatement.Declarations, p);
+        if (visitedDecl is ControlParentheses<VariableDeclarations> vd && !ReferenceEquals(vd, fixedStatement.Declarations))
+        {
+            newDecl = vd;
+            changed = true;
+        }
+
+        Block newBlock = fixedStatement.Block;
+        var visitedBlock = Visit(fixedStatement.Block, p);
+        if (visitedBlock is Block b && !ReferenceEquals(b, fixedStatement.Block))
+        {
+            newBlock = b;
+            changed = true;
+        }
+
+        return changed
+            ? fixedStatement.WithDeclarations(newDecl).WithBlock(newBlock)
+            : fixedStatement;
     }
 
     public virtual J VisitExternAlias(ExternAlias externAlias, P p)
     {
-        Visit(externAlias.Identifier.Element, p);
+        var visited = Visit(externAlias.Identifier.Element, p);
+        if (visited is Identifier id && !ReferenceEquals(id, externAlias.Identifier.Element))
+        {
+            return externAlias.WithIdentifier(externAlias.Identifier.WithElement(id));
+        }
         return externAlias;
     }
 
     public virtual J VisitInitializerExpression(InitializerExpression initializerExpression, P p)
     {
+        var newExprs = new List<JRightPadded<Expression>>();
+        bool changed = false;
         foreach (var expr in initializerExpression.Expressions.Elements)
         {
-            Visit(expr.Element, p);
+            var visited = Visit(expr.Element, p);
+            if (visited is Expression e)
+            {
+                if (!ReferenceEquals(e, expr.Element)) changed = true;
+                newExprs.Add(expr.WithElement(e));
+            }
+            else
+            {
+                newExprs.Add(expr);
+            }
         }
-        return initializerExpression;
+        return changed
+            ? initializerExpression.WithExpressions(initializerExpression.Expressions.WithElements(newExprs))
+            : initializerExpression;
     }
 
     public virtual J VisitNullSafeExpression(NullSafeExpression nullSafeExpression, P p)
     {
-        Visit(nullSafeExpression.Expression, p);
+        var visited = Visit(nullSafeExpression.Expression, p);
+        if (visited is Expression e && !ReferenceEquals(e, nullSafeExpression.Expression))
+        {
+            return nullSafeExpression.WithExpressionPadded(nullSafeExpression.ExpressionPadded.WithElement(e));
+        }
         return nullSafeExpression;
     }
 
@@ -299,9 +428,24 @@ public class CSharpVisitor<P> : JavaVisitor<P>
     {
         if (defaultExpression.TypeOperator != null)
         {
+            var newElements = new List<JRightPadded<TypeTree>>();
+            bool changed = false;
             foreach (var paddedType in defaultExpression.TypeOperator.Elements)
             {
-                Visit(paddedType.Element, p);
+                var visited = Visit(paddedType.Element, p);
+                if (visited is TypeTree tt)
+                {
+                    if (!ReferenceEquals(tt, paddedType.Element)) changed = true;
+                    newElements.Add(paddedType.WithElement(tt));
+                }
+                else
+                {
+                    newElements.Add(paddedType);
+                }
+            }
+            if (changed)
+            {
+                return defaultExpression.WithTypeOperator(defaultExpression.TypeOperator.WithElements(newElements));
             }
         }
         return defaultExpression;
@@ -386,7 +530,11 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitConstrainedTypeParameter(ConstrainedTypeParameter ctp, P p)
     {
-        Visit(ctp.Name, p);
+        var visited = Visit(ctp.Name, p);
+        if (visited is Identifier id && !ReferenceEquals(id, ctp.Name))
+        {
+            return ctp.WithName(id);
+        }
         return ctp;
     }
 
@@ -460,9 +608,30 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitYield(Yield yield, P p)
     {
-        Visit(yield.ReturnOrBreakKeyword, p);
-        if (yield.Expression != null) Visit(yield.Expression, p);
-        return yield;
+        var changed = false;
+
+        Keyword newKeyword = yield.ReturnOrBreakKeyword;
+        var visitedKw = Visit(yield.ReturnOrBreakKeyword, p);
+        if (visitedKw is Keyword kw && !ReferenceEquals(kw, yield.ReturnOrBreakKeyword))
+        {
+            newKeyword = kw;
+            changed = true;
+        }
+
+        Expression? newExpr = yield.Expression;
+        if (yield.Expression != null)
+        {
+            var visited = Visit(yield.Expression, p);
+            if (visited is Expression e && !ReferenceEquals(e, yield.Expression))
+            {
+                newExpr = e;
+                changed = true;
+            }
+        }
+
+        return changed
+            ? yield.WithReturnOrBreakKeyword(newKeyword).WithExpression(newExpr)
+            : yield;
     }
 
     public virtual J VisitNamespaceDeclaration(NamespaceDeclaration ns, P p)
@@ -621,7 +790,11 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitAnnotatedStatement(AnnotatedStatement annotatedStatement, P p)
     {
-        Visit(annotatedStatement.Statement, p);
+        var visited = Visit(annotatedStatement.Statement, p);
+        if (visited is Statement s && !ReferenceEquals(s, annotatedStatement.Statement))
+        {
+            return annotatedStatement.WithStatement(s);
+        }
         return annotatedStatement;
     }
 
@@ -629,34 +802,83 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitAssignmentOperation(AssignmentOperation assignmentOperation, P p)
     {
-        Visit(assignmentOperation.Variable, p);
-        Visit(assignmentOperation.AssignmentValue, p);
+        var visitedVar = Visit(assignmentOperation.Variable, p);
+        var visitedValue = Visit(assignmentOperation.AssignmentValue, p);
+
+        var varChanged = visitedVar is Expression v && !ReferenceEquals(v, assignmentOperation.Variable);
+        var valueChanged = visitedValue is Expression a && !ReferenceEquals(a, assignmentOperation.AssignmentValue);
+
+        if (varChanged || valueChanged)
+        {
+            var result = assignmentOperation;
+            if (varChanged)
+                result = result.WithVariable((Expression)visitedVar!);
+            if (valueChanged)
+                result = result.WithAssignmentValue((Expression)visitedValue!);
+            return result;
+        }
+
         return assignmentOperation;
     }
 
     public virtual J VisitStackAllocExpression(StackAllocExpression stackAllocExpression, P p)
     {
-        Visit(stackAllocExpression.Expression, p);
+        var visited = Visit(stackAllocExpression.Expression, p);
+        if (visited is NewArray na && !ReferenceEquals(na, stackAllocExpression.Expression))
+        {
+            return stackAllocExpression.WithExpression(na);
+        }
         return stackAllocExpression;
     }
 
     public virtual J VisitGotoStatement(GotoStatement gotoStatement, P p)
     {
-        if (gotoStatement.Target != null) Visit(gotoStatement.Target, p);
+        if (gotoStatement.Target != null)
+        {
+            var visited = Visit(gotoStatement.Target, p);
+            if (visited is Expression e && !ReferenceEquals(e, gotoStatement.Target))
+            {
+                return gotoStatement.WithTarget(e);
+            }
+        }
         return gotoStatement;
     }
 
     public virtual J VisitEventDeclaration(EventDeclaration eventDeclaration, P p)
     {
-        Visit(eventDeclaration.TypeExpression, p);
-        Visit(eventDeclaration.Name, p);
-        return eventDeclaration;
+        var changed = false;
+
+        JLeftPadded<TypeTree> newTypeExpr = eventDeclaration.TypeExpressionPadded;
+        var visitedType = Visit(eventDeclaration.TypeExpressionPadded.Element, p);
+        if (visitedType is TypeTree tt && !ReferenceEquals(tt, eventDeclaration.TypeExpressionPadded.Element))
+        {
+            newTypeExpr = eventDeclaration.TypeExpressionPadded.WithElement(tt);
+            changed = true;
+        }
+
+        Identifier newName = eventDeclaration.Name;
+        var visitedName = Visit(eventDeclaration.Name, p);
+        if (visitedName is Identifier id && !ReferenceEquals(id, eventDeclaration.Name))
+        {
+            newName = id;
+            changed = true;
+        }
+
+        return changed
+            ? eventDeclaration.WithTypeExpressionPadded(newTypeExpr).WithName(newName)
+            : eventDeclaration;
     }
 
     public virtual J VisitCsBinary(CsBinary csBinary, P p)
     {
-        Visit(csBinary.Left, p);
-        Visit(csBinary.Right, p);
+        var left = Visit(csBinary.Left, p);
+        var right = Visit(csBinary.Right, p);
+
+        if (left is Expression l && right is Expression r &&
+            (!ReferenceEquals(l, csBinary.Left) || !ReferenceEquals(r, csBinary.Right)))
+        {
+            return csBinary.WithLeft(l).WithRight(r);
+        }
         return csBinary;
     }
 
@@ -664,23 +886,77 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitForEachVariableLoop(ForEachVariableLoop forEachVariableLoop, P p)
     {
-        Visit(forEachVariableLoop.ControlElement, p);
-        Visit(forEachVariableLoop.Body.Element, p);
-        return forEachVariableLoop;
+        var changed = false;
+
+        ForEachVariableLoopControl newControl = forEachVariableLoop.ControlElement;
+        var visitedControl = Visit(forEachVariableLoop.ControlElement, p);
+        if (visitedControl is ForEachVariableLoopControl fc && !ReferenceEquals(fc, forEachVariableLoop.ControlElement))
+        {
+            newControl = fc;
+            changed = true;
+        }
+
+        JRightPadded<Statement> newBody = forEachVariableLoop.Body;
+        var visitedBody = Visit(forEachVariableLoop.Body.Element, p);
+        if (visitedBody is Statement bs && !ReferenceEquals(bs, forEachVariableLoop.Body.Element))
+        {
+            newBody = forEachVariableLoop.Body.WithElement(bs);
+            changed = true;
+        }
+
+        return changed
+            ? forEachVariableLoop.WithControlElement(newControl).WithBody(newBody)
+            : forEachVariableLoop;
     }
 
     public virtual J VisitForEachVariableLoopControl(ForEachVariableLoopControl control, P p)
     {
-        Visit(control.Variable.Element, p);
-        Visit(control.Iterable.Element, p);
-        return control;
+        var changed = false;
+
+        JRightPadded<Expression> newVariable = control.Variable;
+        var visitedVar = Visit(control.Variable.Element, p);
+        if (visitedVar is Expression ve && !ReferenceEquals(ve, control.Variable.Element))
+        {
+            newVariable = control.Variable.WithElement(ve);
+            changed = true;
+        }
+
+        JRightPadded<Expression> newIterable = control.Iterable;
+        var visitedIterable = Visit(control.Iterable.Element, p);
+        if (visitedIterable is Expression ie && !ReferenceEquals(ie, control.Iterable.Element))
+        {
+            newIterable = control.Iterable.WithElement(ie);
+            changed = true;
+        }
+
+        return changed
+            ? control.WithVariable(newVariable).WithIterable(newIterable)
+            : control;
     }
 
     public virtual J VisitUsingStatement(UsingStatement usingStatement, P p)
     {
-        Visit(usingStatement.ExpressionPadded.Element, p);
-        Visit(usingStatement.Statement, p);
-        return usingStatement;
+        var changed = false;
+
+        JLeftPadded<Expression> newExpr = usingStatement.ExpressionPadded;
+        var visitedExpr = Visit(usingStatement.ExpressionPadded.Element, p);
+        if (visitedExpr is Expression e && !ReferenceEquals(e, usingStatement.ExpressionPadded.Element))
+        {
+            newExpr = usingStatement.ExpressionPadded.WithElement(e);
+            changed = true;
+        }
+
+        Statement newStmt = usingStatement.Statement;
+        var visitedStmt = Visit(usingStatement.Statement, p);
+        if (visitedStmt is Statement s && !ReferenceEquals(s, usingStatement.Statement))
+        {
+            newStmt = s;
+            changed = true;
+        }
+
+        return changed
+            ? usingStatement.WithExpressionPadded(newExpr).WithStatement(newStmt)
+            : usingStatement;
     }
 
     public virtual J VisitAllowsConstraintClause(AllowsConstraintClause clause, P p) => clause;
@@ -691,7 +967,11 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitSingleVariableDesignation(SingleVariableDesignation designation, P p)
     {
-        Visit(designation.Name, p);
+        var visited = Visit(designation.Name, p);
+        if (visited is Identifier id && !ReferenceEquals(id, designation.Name))
+        {
+            return designation.WithName(id);
+        }
         return designation;
     }
 
@@ -699,26 +979,59 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitDiscardVariableDesignation(DiscardVariableDesignation designation, P p)
     {
-        Visit(designation.Discard, p);
+        var visited = Visit(designation.Discard, p);
+        if (visited is Identifier id && !ReferenceEquals(id, designation.Discard))
+        {
+            return designation.WithDiscard(id);
+        }
         return designation;
     }
 
     public virtual J VisitCsUnary(CsUnary csUnary, P p)
     {
-        Visit(csUnary.Expression, p);
+        var visited = Visit(csUnary.Expression, p);
+        if (visited is Expression e && !ReferenceEquals(e, csUnary.Expression))
+        {
+            return csUnary.WithExpression(e);
+        }
         return csUnary;
     }
 
     public virtual J VisitTupleElement(TupleElement tupleElement, P p)
     {
-        Visit(tupleElement.ElementType, p);
-        if (tupleElement.Name != null) Visit(tupleElement.Name, p);
-        return tupleElement;
+        var changed = false;
+
+        TypeTree newType = tupleElement.ElementType;
+        var visitedType = Visit(tupleElement.ElementType, p);
+        if (visitedType is TypeTree tt && !ReferenceEquals(tt, tupleElement.ElementType))
+        {
+            newType = tt;
+            changed = true;
+        }
+
+        Identifier? newName = tupleElement.Name;
+        if (tupleElement.Name != null)
+        {
+            var visitedName = Visit(tupleElement.Name, p);
+            if (visitedName is Identifier id && !ReferenceEquals(id, tupleElement.Name))
+            {
+                newName = id;
+                changed = true;
+            }
+        }
+
+        return changed
+            ? tupleElement.WithElementType(newType).WithName(newName)
+            : tupleElement;
     }
 
     public virtual J VisitConstantPattern(ConstantPattern constantPattern, P p)
     {
-        Visit(constantPattern.Value, p);
+        var visited = Visit(constantPattern.Value, p);
+        if (visited is Expression e && !ReferenceEquals(e, constantPattern.Value))
+        {
+            return constantPattern.WithValue(e);
+        }
         return constantPattern;
     }
 
@@ -726,94 +1039,308 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitImplicitElementAccess(ImplicitElementAccess implicitElementAccess, P p)
     {
+        var newArgs = new List<JRightPadded<Expression>>();
+        bool changed = false;
         foreach (var arg in implicitElementAccess.ArgumentList.Elements)
-            Visit(arg.Element, p);
-        return implicitElementAccess;
+        {
+            var visited = Visit(arg.Element, p);
+            if (visited is Expression e)
+            {
+                if (!ReferenceEquals(e, arg.Element)) changed = true;
+                newArgs.Add(arg.WithElement(e));
+            }
+            else
+            {
+                newArgs.Add(arg);
+            }
+        }
+        return changed
+            ? implicitElementAccess.WithArgumentList(implicitElementAccess.ArgumentList.WithElements(newArgs))
+            : implicitElementAccess;
     }
 
     public virtual J VisitSlicePattern(SlicePattern slicePattern, P p) => slicePattern;
 
     public virtual J VisitListPattern(ListPattern listPattern, P p)
     {
-        if (listPattern.Designation != null) Visit(listPattern.Designation, p);
+        if (listPattern.Designation != null)
+        {
+            var visited = Visit(listPattern.Designation, p);
+            if (visited is VariableDesignation v && !ReferenceEquals(v, listPattern.Designation))
+            {
+                return listPattern.WithDesignation(v);
+            }
+        }
         return listPattern;
     }
 
     public virtual J VisitSwitchExpression(SwitchExpression switchExpression, P p)
     {
-        Visit(switchExpression.ExpressionPadded.Element, p);
+        var changed = false;
+
+        JRightPadded<Expression> newExpr = switchExpression.ExpressionPadded;
+        var visitedExpr = Visit(switchExpression.ExpressionPadded.Element, p);
+        if (visitedExpr is Expression e && !ReferenceEquals(e, switchExpression.ExpressionPadded.Element))
+        {
+            newExpr = switchExpression.ExpressionPadded.WithElement(e);
+            changed = true;
+        }
+
+        JContainer<SwitchExpressionArm> newArms = switchExpression.Arms;
+        var armElements = new List<JRightPadded<SwitchExpressionArm>>();
+        bool armsChanged = false;
         foreach (var arm in switchExpression.Arms.Elements)
-            Visit(arm.Element, p);
-        return switchExpression;
+        {
+            var visited = Visit(arm.Element, p);
+            if (visited is SwitchExpressionArm a)
+            {
+                if (!ReferenceEquals(a, arm.Element)) armsChanged = true;
+                armElements.Add(arm.WithElement(a));
+            }
+            else
+            {
+                armElements.Add(arm);
+            }
+        }
+        if (armsChanged)
+        {
+            newArms = switchExpression.Arms.WithElements(armElements);
+            changed = true;
+        }
+
+        return changed
+            ? switchExpression.WithExpressionPadded(newExpr).WithArms(newArms)
+            : switchExpression;
     }
 
     public virtual J VisitSwitchExpressionArm(SwitchExpressionArm arm, P p)
     {
-        Visit(arm.Pattern, p);
-        Visit(arm.ExpressionPadded.Element, p);
-        return arm;
+        var changed = false;
+
+        J newPattern = arm.Pattern;
+        var visitedPattern = Visit(arm.Pattern, p);
+        if (visitedPattern is J pat && !ReferenceEquals(pat, arm.Pattern))
+        {
+            newPattern = pat;
+            changed = true;
+        }
+
+        JLeftPadded<Expression> newExpr = arm.ExpressionPadded;
+        var visitedExpr = Visit(arm.ExpressionPadded.Element, p);
+        if (visitedExpr is Expression e && !ReferenceEquals(e, arm.ExpressionPadded.Element))
+        {
+            newExpr = arm.ExpressionPadded.WithElement(e);
+            changed = true;
+        }
+
+        return changed
+            ? arm.WithPattern(newPattern).WithExpressionPadded(newExpr)
+            : arm;
     }
 
     public virtual J VisitCheckedExpression(CheckedExpression checkedExpression, P p)
     {
-        Visit(checkedExpression.CheckedOrUncheckedKeyword, p);
-        Visit(checkedExpression.ExpressionValue, p);
-        return checkedExpression;
+        var changed = false;
+
+        Keyword newKw = checkedExpression.CheckedOrUncheckedKeyword;
+        var visitedKw = Visit(checkedExpression.CheckedOrUncheckedKeyword, p);
+        if (visitedKw is Keyword kw && !ReferenceEquals(kw, checkedExpression.CheckedOrUncheckedKeyword))
+        {
+            newKw = kw;
+            changed = true;
+        }
+
+        ControlParentheses<Expression> newExpr = checkedExpression.ExpressionValue;
+        var visitedExpr = Visit(checkedExpression.ExpressionValue, p);
+        if (visitedExpr is ControlParentheses<Expression> e && !ReferenceEquals(e, checkedExpression.ExpressionValue))
+        {
+            newExpr = e;
+            changed = true;
+        }
+
+        return changed
+            ? checkedExpression.WithCheckedOrUncheckedKeyword(newKw).WithExpressionValue(newExpr)
+            : checkedExpression;
     }
 
     public virtual J VisitCheckedStatement(CheckedStatement checkedStatement, P p)
     {
-        Visit(checkedStatement.KeywordValue, p);
-        Visit(checkedStatement.Block, p);
-        return checkedStatement;
+        var changed = false;
+
+        Keyword newKw = checkedStatement.KeywordValue;
+        var visitedKw = Visit(checkedStatement.KeywordValue, p);
+        if (visitedKw is Keyword kw && !ReferenceEquals(kw, checkedStatement.KeywordValue))
+        {
+            newKw = kw;
+            changed = true;
+        }
+
+        Block newBlock = checkedStatement.Block;
+        var visitedBlock = Visit(checkedStatement.Block, p);
+        if (visitedBlock is Block b && !ReferenceEquals(b, checkedStatement.Block))
+        {
+            newBlock = b;
+            changed = true;
+        }
+
+        return changed
+            ? checkedStatement.WithKeywordValue(newKw).WithBlock(newBlock)
+            : checkedStatement;
     }
 
     public virtual J VisitRangeExpression(RangeExpression rangeExpression, P p)
     {
-        if (rangeExpression.Start != null) Visit(rangeExpression.Start.Element, p);
-        if (rangeExpression.End != null) Visit(rangeExpression.End, p);
-        return rangeExpression;
+        var changed = false;
+
+        JRightPadded<Expression>? newStart = rangeExpression.Start;
+        if (rangeExpression.Start != null)
+        {
+            var visited = Visit(rangeExpression.Start.Element, p);
+            if (visited is Expression e && !ReferenceEquals(e, rangeExpression.Start.Element))
+            {
+                newStart = rangeExpression.Start.WithElement(e);
+                changed = true;
+            }
+        }
+
+        Expression? newEnd = rangeExpression.End;
+        if (rangeExpression.End != null)
+        {
+            var visited = Visit(rangeExpression.End, p);
+            if (visited is Expression e && !ReferenceEquals(e, rangeExpression.End))
+            {
+                newEnd = e;
+                changed = true;
+            }
+        }
+
+        return changed
+            ? rangeExpression.WithStart(newStart).WithEnd(newEnd)
+            : rangeExpression;
     }
 
     public virtual J VisitIndexerDeclaration(IndexerDeclaration indexerDeclaration, P p)
     {
-        Visit(indexerDeclaration.TypeExpression, p);
-        Visit(indexerDeclaration.Indexer, p);
-        return indexerDeclaration;
+        var changed = false;
+
+        TypeTree newTypeExpr = indexerDeclaration.TypeExpression;
+        var visitedType = Visit(indexerDeclaration.TypeExpression, p);
+        if (visitedType is TypeTree tt && !ReferenceEquals(tt, indexerDeclaration.TypeExpression))
+        {
+            newTypeExpr = tt;
+            changed = true;
+        }
+
+        Expression newIndexer = indexerDeclaration.Indexer;
+        var visitedIndexer = Visit(indexerDeclaration.Indexer, p);
+        if (visitedIndexer is Expression idx && !ReferenceEquals(idx, indexerDeclaration.Indexer))
+        {
+            newIndexer = idx;
+            changed = true;
+        }
+
+        return changed
+            ? indexerDeclaration.WithTypeExpression(newTypeExpr).WithIndexer(newIndexer)
+            : indexerDeclaration;
     }
 
     public virtual J VisitDelegateDeclaration(DelegateDeclaration delegateDeclaration, P p)
     {
-        Visit(delegateDeclaration.ReturnType.Element, p);
-        Visit(delegateDeclaration.IdentifierName, p);
-        return delegateDeclaration;
+        var changed = false;
+
+        JLeftPadded<TypeTree> newReturnType = delegateDeclaration.ReturnType;
+        var visitedReturn = Visit(delegateDeclaration.ReturnType.Element, p);
+        if (visitedReturn is TypeTree tt && !ReferenceEquals(tt, delegateDeclaration.ReturnType.Element))
+        {
+            newReturnType = delegateDeclaration.ReturnType.WithElement(tt);
+            changed = true;
+        }
+
+        Identifier newName = delegateDeclaration.IdentifierName;
+        var visitedName = Visit(delegateDeclaration.IdentifierName, p);
+        if (visitedName is Identifier id && !ReferenceEquals(id, delegateDeclaration.IdentifierName))
+        {
+            newName = id;
+            changed = true;
+        }
+
+        return changed
+            ? delegateDeclaration.WithReturnType(newReturnType).WithIdentifierName(newName)
+            : delegateDeclaration;
     }
 
     public virtual J VisitConversionOperatorDeclaration(ConversionOperatorDeclaration conversion, P p)
     {
-        Visit(conversion.ReturnType.Element, p);
-        if (conversion.Body != null) Visit(conversion.Body, p);
-        return conversion;
+        var changed = false;
+
+        JLeftPadded<TypeTree> newReturnType = conversion.ReturnType;
+        var visitedReturn = Visit(conversion.ReturnType.Element, p);
+        if (visitedReturn is TypeTree tt && !ReferenceEquals(tt, conversion.ReturnType.Element))
+        {
+            newReturnType = conversion.ReturnType.WithElement(tt);
+            changed = true;
+        }
+
+        Block? newBody = conversion.Body;
+        if (conversion.Body != null)
+        {
+            var visitedBody = Visit(conversion.Body, p);
+            if (visitedBody is Block b && !ReferenceEquals(b, conversion.Body))
+            {
+                newBody = b;
+                changed = true;
+            }
+        }
+
+        return changed
+            ? conversion.WithReturnType(newReturnType).WithBody(newBody)
+            : conversion;
     }
 
     public virtual J VisitOperatorDeclaration(OperatorDeclaration operatorDeclaration, P p)
     {
-        Visit(operatorDeclaration.ReturnType, p);
-        Visit(operatorDeclaration.Body, p);
-        return operatorDeclaration;
+        var changed = false;
+
+        TypeTree newReturnType = operatorDeclaration.ReturnType;
+        var visitedReturn = Visit(operatorDeclaration.ReturnType, p);
+        if (visitedReturn is TypeTree tt && !ReferenceEquals(tt, operatorDeclaration.ReturnType))
+        {
+            newReturnType = tt;
+            changed = true;
+        }
+
+        Block newBody = operatorDeclaration.Body;
+        var visitedBody = Visit(operatorDeclaration.Body, p);
+        if (visitedBody is Block b && !ReferenceEquals(b, operatorDeclaration.Body))
+        {
+            newBody = b;
+            changed = true;
+        }
+
+        return changed
+            ? operatorDeclaration.WithReturnType(newReturnType).WithBody(newBody)
+            : operatorDeclaration;
     }
 
     public virtual J VisitEnumDeclaration(EnumDeclaration enumDeclaration, P p) => enumDeclaration;
 
     public virtual J VisitEnumMemberDeclaration(EnumMemberDeclaration enumMember, P p)
     {
-        Visit(enumMember.Name, p);
+        var visited = Visit(enumMember.Name, p);
+        if (visited is Identifier id && !ReferenceEquals(id, enumMember.Name))
+        {
+            return enumMember.WithName(id);
+        }
         return enumMember;
     }
 
     public virtual J VisitAliasQualifiedName(AliasQualifiedName aliasQualifiedName, P p)
     {
-        Visit(aliasQualifiedName.Name, p);
+        var visited = Visit(aliasQualifiedName.Name, p);
+        if (visited is Identifier id && !ReferenceEquals(id, aliasQualifiedName.Name))
+        {
+            return aliasQualifiedName.WithName(id);
+        }
         return aliasQualifiedName;
     }
 
@@ -829,14 +1356,36 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitPointerFieldAccess(PointerFieldAccess pointerFieldAccess, P p)
     {
-        Visit(pointerFieldAccess.Target, p);
-        Visit(pointerFieldAccess.NamePadded.Element, p);
-        return pointerFieldAccess;
+        var changed = false;
+
+        Expression newTarget = pointerFieldAccess.Target;
+        var visitedTarget = Visit(pointerFieldAccess.Target, p);
+        if (visitedTarget is Expression t && !ReferenceEquals(t, pointerFieldAccess.Target))
+        {
+            newTarget = t;
+            changed = true;
+        }
+
+        JLeftPadded<Identifier> newName = pointerFieldAccess.NamePadded;
+        var visitedName = Visit(pointerFieldAccess.NamePadded.Element, p);
+        if (visitedName is Identifier id && !ReferenceEquals(id, pointerFieldAccess.NamePadded.Element))
+        {
+            newName = pointerFieldAccess.NamePadded.WithElement(id);
+            changed = true;
+        }
+
+        return changed
+            ? pointerFieldAccess.WithTarget(newTarget).WithNamePadded(newName)
+            : pointerFieldAccess;
     }
 
     public virtual J VisitRefType(RefType refType, P p)
     {
-        Visit(refType.TypeIdentifier, p);
+        var visited = Visit(refType.TypeIdentifier, p);
+        if (visited is TypeTree tt && !ReferenceEquals(tt, refType.TypeIdentifier))
+        {
+            return refType.WithTypeIdentifier(tt);
+        }
         return refType;
     }
 
@@ -892,15 +1441,44 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitJoinClause(JoinClause joinClause, P p)
     {
-        Visit(joinClause.InExpression.Element, p);
-        Visit(joinClause.LeftExpression.Element, p);
-        Visit(joinClause.RightExpression, p);
-        return joinClause;
+        var changed = false;
+
+        JRightPadded<Expression> newIn = joinClause.InExpression;
+        var visitedIn = Visit(joinClause.InExpression.Element, p);
+        if (visitedIn is Expression ie && !ReferenceEquals(ie, joinClause.InExpression.Element))
+        {
+            newIn = joinClause.InExpression.WithElement(ie);
+            changed = true;
+        }
+
+        JRightPadded<Expression> newLeft = joinClause.LeftExpression;
+        var visitedLeft = Visit(joinClause.LeftExpression.Element, p);
+        if (visitedLeft is Expression le && !ReferenceEquals(le, joinClause.LeftExpression.Element))
+        {
+            newLeft = joinClause.LeftExpression.WithElement(le);
+            changed = true;
+        }
+
+        Expression newRight = joinClause.RightExpression;
+        var visitedRight = Visit(joinClause.RightExpression, p);
+        if (visitedRight is Expression re && !ReferenceEquals(re, joinClause.RightExpression))
+        {
+            newRight = re;
+            changed = true;
+        }
+
+        return changed
+            ? joinClause.WithInExpression(newIn).WithLeftExpression(newLeft).WithRightExpression(newRight)
+            : joinClause;
     }
 
     public virtual J VisitJoinIntoClause(JoinIntoClause joinIntoClause, P p)
     {
-        Visit(joinIntoClause.Identifier, p);
+        var visited = Visit(joinIntoClause.Identifier, p);
+        if (visited is Identifier id && !ReferenceEquals(id, joinIntoClause.Identifier))
+        {
+            return joinIntoClause.WithIdentifier(id);
+        }
         return joinIntoClause;
     }
 
@@ -943,18 +1521,52 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitGroupClause(GroupClause groupClause, P p)
     {
-        Visit(groupClause.GroupExpression.Element, p);
-        Visit(groupClause.Key, p);
-        return groupClause;
+        var changed = false;
+
+        JRightPadded<Expression> newGroupExpr = groupClause.GroupExpression;
+        var visitedGroup = Visit(groupClause.GroupExpression.Element, p);
+        if (visitedGroup is Expression ge && !ReferenceEquals(ge, groupClause.GroupExpression.Element))
+        {
+            newGroupExpr = groupClause.GroupExpression.WithElement(ge);
+            changed = true;
+        }
+
+        Expression newKey = groupClause.Key;
+        var visitedKey = Visit(groupClause.Key, p);
+        if (visitedKey is Expression ke && !ReferenceEquals(ke, groupClause.Key))
+        {
+            newKey = ke;
+            changed = true;
+        }
+
+        return changed
+            ? groupClause.WithGroupExpression(newGroupExpr).WithKey(newKey)
+            : groupClause;
     }
 
     public virtual J VisitQueryContinuation(QueryContinuation queryContinuation, P p)
     {
-        Visit(queryContinuation.Identifier, p);
-        var body = (QueryBody)VisitQueryBody(queryContinuation.Body, p);
-        if (!ReferenceEquals(body, queryContinuation.Body))
-            return queryContinuation.WithBody(body);
-        return queryContinuation;
+        var changed = false;
+
+        Identifier newId = queryContinuation.Identifier;
+        var visitedId = Visit(queryContinuation.Identifier, p);
+        if (visitedId is Identifier id && !ReferenceEquals(id, queryContinuation.Identifier))
+        {
+            newId = id;
+            changed = true;
+        }
+
+        QueryBody newBody = queryContinuation.Body;
+        var visitedBody = (QueryBody)VisitQueryBody(queryContinuation.Body, p);
+        if (!ReferenceEquals(visitedBody, queryContinuation.Body))
+        {
+            newBody = visitedBody;
+            changed = true;
+        }
+
+        return changed
+            ? queryContinuation.WithIdentifier(newId).WithBody(newBody)
+            : queryContinuation;
     }
 
     public virtual J VisitAnonymousObjectCreationExpression(AnonymousObjectCreationExpression anonymousObject, P p)
@@ -964,14 +1576,36 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     public virtual J VisitWithExpression(WithExpression withExpression, P p)
     {
-        Visit(withExpression.Target, p);
-        Visit(withExpression.Initializer, p);
-        return withExpression;
+        var changed = false;
+
+        Expression newTarget = withExpression.Target;
+        var visitedTarget = Visit(withExpression.Target, p);
+        if (visitedTarget is Expression t && !ReferenceEquals(t, withExpression.Target))
+        {
+            newTarget = t;
+            changed = true;
+        }
+
+        JLeftPadded<Expression> newInit = withExpression.InitializerPadded;
+        var visitedInit = Visit(withExpression.InitializerPadded.Element, p);
+        if (visitedInit is Expression ie && !ReferenceEquals(ie, withExpression.InitializerPadded.Element))
+        {
+            newInit = withExpression.InitializerPadded.WithElement(ie);
+            changed = true;
+        }
+
+        return changed
+            ? withExpression.WithTarget(newTarget).WithInitializerPadded(newInit)
+            : withExpression;
     }
 
     public virtual J VisitSpreadExpression(SpreadExpression spreadExpression, P p)
     {
-        Visit(spreadExpression.Expression, p);
+        var visited = Visit(spreadExpression.Expression, p);
+        if (visited is Expression e && !ReferenceEquals(e, spreadExpression.Expression))
+        {
+            return spreadExpression.WithExpression(e);
+        }
         return spreadExpression;
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/Java/JavaVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/JavaVisitor.cs
@@ -85,15 +85,44 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
 
     public virtual J VisitAnnotation(Annotation annotation, P p)
     {
-        Visit(annotation.AnnotationType, p);
+        var changed = false;
+
+        NameTree newAnnotationType = annotation.AnnotationType;
+        var visitedType = Visit(annotation.AnnotationType, p);
+        if (visitedType is NameTree tt && !ReferenceEquals(tt, annotation.AnnotationType))
+        {
+            newAnnotationType = tt;
+            changed = true;
+        }
+
+        JContainer<Expression>? newArguments = annotation.Arguments;
         if (annotation.Arguments != null)
         {
+            var newArgs = new List<JRightPadded<Expression>>();
+            bool argsChanged = false;
             foreach (var paddedArg in annotation.Arguments.Elements)
             {
-                Visit(paddedArg.Element, p);
+                var visited = Visit(paddedArg.Element, p);
+                if (visited is Expression e)
+                {
+                    if (!ReferenceEquals(e, paddedArg.Element)) argsChanged = true;
+                    newArgs.Add(paddedArg.WithElement(e));
+                }
+                else
+                {
+                    newArgs.Add(paddedArg);
+                }
+            }
+            if (argsChanged)
+            {
+                newArguments = annotation.Arguments.WithElements(newArgs);
+                changed = true;
             }
         }
-        return annotation;
+
+        return changed
+            ? annotation.WithAnnotationType(newAnnotationType).WithArguments(newArguments)
+            : annotation;
     }
 
     public virtual J VisitBlock(Block block, P p)
@@ -147,121 +176,351 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
 
     public virtual J VisitEnumValue(EnumValue enumValue, P p)
     {
-        var name = Visit(enumValue.Name, p);
+        var changed = false;
+
+        Identifier newName = enumValue.Name;
+        var visitedName = Visit(enumValue.Name, p);
+        if (visitedName is Identifier id && !ReferenceEquals(id, enumValue.Name))
+        {
+            newName = id;
+            changed = true;
+        }
+
+        JLeftPadded<Expression>? newInitializer = enumValue.Initializer;
         if (enumValue.Initializer != null)
         {
-            var init = Visit(enumValue.Initializer.Element, p);
-            if (init is Expression e && !ReferenceEquals(e, enumValue.Initializer.Element))
+            var visitedInit = Visit(enumValue.Initializer.Element, p);
+            if (visitedInit is Expression e && !ReferenceEquals(e, enumValue.Initializer.Element))
             {
-                return enumValue.WithInitializer(enumValue.Initializer.WithElement(e));
+                newInitializer = enumValue.Initializer.WithElement(e);
+                changed = true;
             }
         }
-        if (name is Identifier id && !ReferenceEquals(id, enumValue.Name))
-        {
-            return enumValue.WithName(id);
-        }
-        return enumValue;
+
+        return changed
+            ? enumValue.WithName(newName).WithInitializer(newInitializer)
+            : enumValue;
     }
 
     public virtual J VisitMethodDeclaration(MethodDeclaration method, P p)
     {
+        var changed = false;
+
+        TypeTree? newReturnType = method.ReturnTypeExpression;
         if (method.ReturnTypeExpression != null)
         {
-            Visit(method.ReturnTypeExpression, p);
-        }
-
-        foreach (var paddedParam in method.Parameters.Elements)
-        {
-            Visit(paddedParam.Element, p);
-        }
-
-        if (method.Body != null)
-        {
-            var body = Visit(method.Body, p);
-            if (body is Block b && !ReferenceEquals(b, method.Body))
+            var visited = Visit(method.ReturnTypeExpression, p);
+            if (visited is TypeTree tt && !ReferenceEquals(tt, method.ReturnTypeExpression))
             {
-                return method.WithBody(b);
+                newReturnType = tt;
+                changed = true;
             }
         }
 
-        return method;
+        JContainer<Statement> newParams = method.Parameters;
+        var paramElements = new List<JRightPadded<Statement>>();
+        bool paramsChanged = false;
+        foreach (var paddedParam in method.Parameters.Elements)
+        {
+            var visited = Visit(paddedParam.Element, p);
+            if (visited is Statement s)
+            {
+                if (!ReferenceEquals(s, paddedParam.Element)) paramsChanged = true;
+                paramElements.Add(paddedParam.WithElement(s));
+            }
+            else
+            {
+                paramElements.Add(paddedParam);
+            }
+        }
+        if (paramsChanged)
+        {
+            newParams = method.Parameters.WithElements(paramElements);
+            changed = true;
+        }
+
+        Block? newBody = method.Body;
+        if (method.Body != null)
+        {
+            var visited = Visit(method.Body, p);
+            if (visited is Block b && !ReferenceEquals(b, method.Body))
+            {
+                newBody = b;
+                changed = true;
+            }
+        }
+
+        return changed
+            ? method.WithReturnTypeExpression(newReturnType).WithParameters(newParams).WithBody(newBody)
+            : method;
     }
 
     public virtual J VisitReturn(Return ret, P p)
     {
         if (ret.Expression != null)
         {
-            Visit(ret.Expression, p);
+            var visited = Visit(ret.Expression, p);
+            if (visited is Expression expr && !ReferenceEquals(expr, ret.Expression))
+            {
+                return ret.WithExpression(expr);
+            }
         }
         return ret;
     }
 
     public virtual J VisitIf(If iff, P p)
     {
-        Visit(iff.Condition.Tree.Element, p);
-        Visit(iff.ThenPart.Element, p);
+        var changed = false;
+
+        var visitedCondition = Visit(iff.Condition.Tree.Element, p);
+        ControlParentheses<Expression> newCondition = iff.Condition;
+        if (visitedCondition is Expression ce && !ReferenceEquals(ce, iff.Condition.Tree.Element))
+        {
+            newCondition = iff.Condition.WithTree(iff.Condition.Tree.WithElement(ce));
+            changed = true;
+        }
+
+        JRightPadded<Statement> newThenPart = iff.ThenPart;
+        var visitedThen = Visit(iff.ThenPart.Element, p);
+        if (visitedThen is Statement ts && !ReferenceEquals(ts, iff.ThenPart.Element))
+        {
+            newThenPart = iff.ThenPart.WithElement(ts);
+            changed = true;
+        }
+
+        If.Else? newElsePart = iff.ElsePart;
         if (iff.ElsePart != null)
         {
-            Visit(iff.ElsePart.Body.Element, p);
+            var visitedElse = Visit(iff.ElsePart.Body.Element, p);
+            if (visitedElse is Statement es && !ReferenceEquals(es, iff.ElsePart.Body.Element))
+            {
+                newElsePart = iff.ElsePart.WithBody(iff.ElsePart.Body.WithElement(es));
+                changed = true;
+            }
         }
-        return iff;
+
+        return changed
+            ? iff.WithCondition(newCondition).WithThenPart(newThenPart).WithElsePart(newElsePart)
+            : iff;
     }
 
     public virtual J VisitWhileLoop(WhileLoop whl, P p)
     {
-        Visit(whl.Condition.Tree.Element, p);
-        Visit(whl.Body.Element, p);
-        return whl;
+        var changed = false;
+
+        ControlParentheses<Expression> newCondition = whl.Condition;
+        var visitedCondition = Visit(whl.Condition.Tree.Element, p);
+        if (visitedCondition is Expression ce && !ReferenceEquals(ce, whl.Condition.Tree.Element))
+        {
+            newCondition = whl.Condition.WithTree(whl.Condition.Tree.WithElement(ce));
+            changed = true;
+        }
+
+        JRightPadded<Statement> newBody = whl.Body;
+        var visitedBody = Visit(whl.Body.Element, p);
+        if (visitedBody is Statement bs && !ReferenceEquals(bs, whl.Body.Element))
+        {
+            newBody = whl.Body.WithElement(bs);
+            changed = true;
+        }
+
+        return changed ? whl.WithCondition(newCondition).WithBody(newBody) : whl;
     }
 
     public virtual J VisitDoWhileLoop(DoWhileLoop dwl, P p)
     {
-        Visit(dwl.Body.Element, p);
-        Visit(dwl.Condition.Element.Tree.Element, p);
-        return dwl;
+        var changed = false;
+
+        JRightPadded<Statement> newBody = dwl.Body;
+        var visitedBody = Visit(dwl.Body.Element, p);
+        if (visitedBody is Statement bs && !ReferenceEquals(bs, dwl.Body.Element))
+        {
+            newBody = dwl.Body.WithElement(bs);
+            changed = true;
+        }
+
+        JLeftPadded<ControlParentheses<Expression>> newCondition = dwl.Condition;
+        var visitedCondition = Visit(dwl.Condition.Element.Tree.Element, p);
+        if (visitedCondition is Expression ce && !ReferenceEquals(ce, dwl.Condition.Element.Tree.Element))
+        {
+            var newCtrlParen = dwl.Condition.Element.WithTree(dwl.Condition.Element.Tree.WithElement(ce));
+            newCondition = dwl.Condition.WithElement(newCtrlParen);
+            changed = true;
+        }
+
+        return changed ? dwl.WithBody(newBody).WithCondition(newCondition) : dwl;
     }
 
     public virtual J VisitForLoop(ForLoop fl, P p)
     {
+        var changed = false;
+
+        var newInit = new List<JRightPadded<Statement>>();
+        bool initChanged = false;
         foreach (var init in fl.LoopControl.Init)
         {
-            Visit(init.Element, p);
+            var visited = Visit(init.Element, p);
+            if (visited is Statement s)
+            {
+                if (!ReferenceEquals(s, init.Element)) initChanged = true;
+                newInit.Add(init.WithElement(s));
+            }
+            else
+            {
+                newInit.Add(init);
+            }
         }
-        Visit(fl.LoopControl.Condition.Element, p);
+        if (initChanged) changed = true;
+
+        JRightPadded<Expression> newControlCondition = fl.LoopControl.Condition;
+        var visitedCondition = Visit(fl.LoopControl.Condition.Element, p);
+        if (visitedCondition is Expression ce && !ReferenceEquals(ce, fl.LoopControl.Condition.Element))
+        {
+            newControlCondition = fl.LoopControl.Condition.WithElement(ce);
+            changed = true;
+        }
+
+        var newUpdate = new List<JRightPadded<Statement>>();
+        bool updateChanged = false;
         foreach (var update in fl.LoopControl.Update)
         {
-            Visit(update.Element, p);
+            var visited = Visit(update.Element, p);
+            if (visited is Statement s)
+            {
+                if (!ReferenceEquals(s, update.Element)) updateChanged = true;
+                newUpdate.Add(update.WithElement(s));
+            }
+            else
+            {
+                newUpdate.Add(update);
+            }
         }
-        Visit(fl.Body.Element, p);
+        if (updateChanged) changed = true;
+
+        JRightPadded<Statement> newBody = fl.Body;
+        var visitedBody = Visit(fl.Body.Element, p);
+        if (visitedBody is Statement bs && !ReferenceEquals(bs, fl.Body.Element))
+        {
+            newBody = fl.Body.WithElement(bs);
+            changed = true;
+        }
+
+        if (changed)
+        {
+            var newControl = fl.LoopControl
+                .WithInit(initChanged ? newInit : fl.LoopControl.Init)
+                .WithCondition(newControlCondition)
+                .WithUpdate(updateChanged ? newUpdate : fl.LoopControl.Update);
+            return fl.WithLoopControl(newControl).WithBody(newBody);
+        }
         return fl;
     }
 
     public virtual J VisitForEachLoop(ForEachLoop fel, P p)
     {
-        Visit(fel.LoopControl.Variable.Element, p);
-        Visit(fel.LoopControl.Iterable.Element, p);
-        Visit(fel.Body.Element, p);
+        var changed = false;
+
+        JRightPadded<VariableDeclarations> newVariable = fel.LoopControl.Variable;
+        var visitedVar = Visit(fel.LoopControl.Variable.Element, p);
+        if (visitedVar is VariableDeclarations vd && !ReferenceEquals(vd, fel.LoopControl.Variable.Element))
+        {
+            newVariable = fel.LoopControl.Variable.WithElement(vd);
+            changed = true;
+        }
+
+        JRightPadded<Expression> newIterable = fel.LoopControl.Iterable;
+        var visitedIterable = Visit(fel.LoopControl.Iterable.Element, p);
+        if (visitedIterable is Expression ie && !ReferenceEquals(ie, fel.LoopControl.Iterable.Element))
+        {
+            newIterable = fel.LoopControl.Iterable.WithElement(ie);
+            changed = true;
+        }
+
+        JRightPadded<Statement> newBody = fel.Body;
+        var visitedBody = Visit(fel.Body.Element, p);
+        if (visitedBody is Statement bs && !ReferenceEquals(bs, fel.Body.Element))
+        {
+            newBody = fel.Body.WithElement(bs);
+            changed = true;
+        }
+
+        if (changed)
+        {
+            var newControl = fel.LoopControl.WithVariable(newVariable).WithIterable(newIterable);
+            return fel.WithLoopControl(newControl).WithBody(newBody);
+        }
         return fel;
     }
 
     public virtual J VisitTry(Try tr, P p)
     {
-        Visit(tr.Body, p);
+        var changed = false;
+
+        Block newBody = tr.Body;
+        var visitedBody = Visit(tr.Body, p);
+        if (visitedBody is Block bb && !ReferenceEquals(bb, tr.Body))
+        {
+            newBody = bb;
+            changed = true;
+        }
+
+        var newCatches = new List<Try.Catch>();
+        bool catchesChanged = false;
         foreach (var c in tr.Catches)
         {
-            Visit(c.Parameter.Tree.Element, p);
-            Visit(c.Body, p);
+            bool catchChanged = false;
+
+            ControlParentheses<VariableDeclarations> newParam = c.Parameter;
+            var visitedParam = Visit(c.Parameter.Tree.Element, p);
+            if (visitedParam is VariableDeclarations pvd && !ReferenceEquals(pvd, c.Parameter.Tree.Element))
+            {
+                newParam = c.Parameter.WithTree(c.Parameter.Tree.WithElement(pvd));
+                catchChanged = true;
+            }
+
+            Block newCatchBody = c.Body;
+            var visitedCatchBody = Visit(c.Body, p);
+            if (visitedCatchBody is Block cb && !ReferenceEquals(cb, c.Body))
+            {
+                newCatchBody = cb;
+                catchChanged = true;
+            }
+
+            if (catchChanged)
+            {
+                catchesChanged = true;
+                newCatches.Add(c.WithParameter(newParam).WithBody(newCatchBody));
+            }
+            else
+            {
+                newCatches.Add(c);
+            }
         }
+        if (catchesChanged) changed = true;
+
+        JLeftPadded<Block>? newFinally = tr.Finally;
         if (tr.Finally != null)
         {
-            Visit(tr.Finally.Element, p);
+            var visitedFinally = Visit(tr.Finally.Element, p);
+            if (visitedFinally is Block fb && !ReferenceEquals(fb, tr.Finally.Element))
+            {
+                newFinally = tr.Finally.WithElement(fb);
+                changed = true;
+            }
         }
-        return tr;
+
+        return changed
+            ? tr.WithBody(newBody).WithCatches(catchesChanged ? newCatches : tr.Catches).WithFinally(newFinally)
+            : tr;
     }
 
     public virtual J VisitThrow(Throw thr, P p)
     {
-        Visit(thr.Exception, p);
+        var visited = Visit(thr.Exception, p);
+        if (visited is Expression e && !ReferenceEquals(e, thr.Exception))
+        {
+            return thr.WithException(e);
+        }
         return thr;
     }
 
@@ -282,19 +541,31 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
 
     public virtual J VisitControlParentheses(ControlParentheses<Expression> cp, P p)
     {
-        Visit(cp.Tree.Element, p);
+        var visited = Visit(cp.Tree.Element, p);
+        if (visited is Expression e && !ReferenceEquals(e, cp.Tree.Element))
+        {
+            return cp.WithTree(cp.Tree.WithElement(e));
+        }
         return cp;
     }
 
     public virtual J VisitControlParentheses(ControlParentheses<TypeTree> cp, P p)
     {
-        Visit(cp.Tree.Element, p);
+        var visited = Visit(cp.Tree.Element, p);
+        if (visited is TypeTree tt && !ReferenceEquals(tt, cp.Tree.Element))
+        {
+            return cp.WithTree(cp.Tree.WithElement(tt));
+        }
         return cp;
     }
 
     public virtual J VisitControlParentheses(ControlParentheses<VariableDeclarations> cp, P p)
     {
-        Visit(cp.Tree.Element, p);
+        var visited = Visit(cp.Tree.Element, p);
+        if (visited is VariableDeclarations vd && !ReferenceEquals(vd, cp.Tree.Element))
+        {
+            return cp.WithTree(cp.Tree.WithElement(vd));
+        }
         return cp;
     }
 
@@ -320,9 +591,27 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
 
     public virtual J VisitMemberReference(MemberReference memberRef, P p)
     {
-        Visit(memberRef.Containing.Element, p);
-        Visit(memberRef.Reference.Element, p);
-        return memberRef;
+        var changed = false;
+
+        JRightPadded<Expression> newContaining = memberRef.Containing;
+        var visitedContaining = Visit(memberRef.Containing.Element, p);
+        if (visitedContaining is Expression ce && !ReferenceEquals(ce, memberRef.Containing.Element))
+        {
+            newContaining = memberRef.Containing.WithElement(ce);
+            changed = true;
+        }
+
+        JLeftPadded<Identifier> newReference = memberRef.Reference;
+        var visitedRef = Visit(memberRef.Reference.Element, p);
+        if (visitedRef is Identifier id && !ReferenceEquals(id, memberRef.Reference.Element))
+        {
+            newReference = memberRef.Reference.WithElement(id);
+            changed = true;
+        }
+
+        return changed
+            ? memberRef.WithContaining(newContaining).WithReference(newReference)
+            : memberRef;
     }
 
     public virtual J VisitBinary(Binary binary, P p)
@@ -412,21 +701,43 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
 
     public virtual J VisitVariableDeclarations(VariableDeclarations varDecl, P p)
     {
+        var changed = false;
+
+        TypeTree? newTypeExpr = varDecl.TypeExpression;
         if (varDecl.TypeExpression != null)
         {
-            Visit(varDecl.TypeExpression, p);
+            var visited = Visit(varDecl.TypeExpression, p);
+            if (visited is TypeTree tt && !ReferenceEquals(tt, varDecl.TypeExpression))
+            {
+                newTypeExpr = tt;
+                changed = true;
+            }
         }
 
+        var newVars = new List<JRightPadded<NamedVariable>>();
+        bool varsChanged = false;
         foreach (var paddedVar in varDecl.Variables)
         {
             var namedVar = paddedVar.Element;
             if (namedVar.Initializer != null)
             {
-                Visit(namedVar.Initializer.Element, p);
+                var visited = Visit(namedVar.Initializer.Element, p);
+                if (visited is Expression expr && !ReferenceEquals(expr, namedVar.Initializer.Element))
+                {
+                    var newInit = namedVar.Initializer.WithElement(expr);
+                    var newNamedVar = namedVar.WithInitializer(newInit);
+                    newVars.Add(paddedVar.WithElement(newNamedVar));
+                    varsChanged = true;
+                    continue;
+                }
             }
+            newVars.Add(paddedVar);
         }
+        if (varsChanged) changed = true;
 
-        return varDecl;
+        return changed
+            ? varDecl.WithTypeExpression(newTypeExpr).WithVariables(varsChanged ? newVars : varDecl.Variables)
+            : varDecl;
     }
 
     public virtual J VisitPrimitive(Primitive primitive, P p)
@@ -436,123 +747,361 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
 
     public virtual J VisitMethodInvocation(MethodInvocation mi, P p)
     {
+        var changed = false;
+
+        JRightPadded<Expression>? newSelect = mi.Select;
         if (mi.Select != null)
         {
-            Visit(mi.Select.Element, p);
-        }
-
-        if (mi.TypeParameters != null)
-        {
-            foreach (var paddedTypeArg in mi.TypeParameters.Elements)
+            var visited = Visit(mi.Select.Element, p);
+            if (visited is Expression sel && !ReferenceEquals(sel, mi.Select.Element))
             {
-                Visit(paddedTypeArg.Element, p);
+                newSelect = mi.Select.WithElement(sel);
+                changed = true;
             }
         }
 
-        foreach (var paddedArg in mi.Arguments.Elements)
+        JContainer<Expression>? newTypeParams = mi.TypeParameters;
+        if (mi.TypeParameters != null)
         {
-            Visit(paddedArg.Element, p);
+            var tpElements = new List<JRightPadded<Expression>>();
+            bool tpChanged = false;
+            foreach (var paddedTypeArg in mi.TypeParameters.Elements)
+            {
+                var visited = Visit(paddedTypeArg.Element, p);
+                if (visited is Expression e)
+                {
+                    if (!ReferenceEquals(e, paddedTypeArg.Element)) tpChanged = true;
+                    tpElements.Add(paddedTypeArg.WithElement(e));
+                }
+                else
+                {
+                    tpElements.Add(paddedTypeArg);
+                }
+            }
+            if (tpChanged)
+            {
+                newTypeParams = mi.TypeParameters.WithElements(tpElements);
+                changed = true;
+            }
         }
 
-        return mi;
+        JContainer<Expression> newArgs = mi.Arguments;
+        var argElements = new List<JRightPadded<Expression>>();
+        bool argsChanged = false;
+        foreach (var paddedArg in mi.Arguments.Elements)
+        {
+            var visited = Visit(paddedArg.Element, p);
+            if (visited is Expression e)
+            {
+                if (!ReferenceEquals(e, paddedArg.Element)) argsChanged = true;
+                argElements.Add(paddedArg.WithElement(e));
+            }
+            else
+            {
+                argElements.Add(paddedArg);
+            }
+        }
+        if (argsChanged)
+        {
+            newArgs = mi.Arguments.WithElements(argElements);
+            changed = true;
+        }
+
+        return changed
+            ? mi.WithSelect(newSelect).WithTypeParameters(newTypeParams).WithArguments(newArgs)
+            : mi;
     }
 
     public virtual J VisitNewClass(NewClass nc, P p)
     {
+        var changed = false;
+
+        JRightPadded<Expression>? newEnclosing = nc.Enclosing;
         if (nc.Enclosing != null)
         {
-            Visit(nc.Enclosing.Element, p);
+            var visited = Visit(nc.Enclosing.Element, p);
+            if (visited is Expression e && !ReferenceEquals(e, nc.Enclosing.Element))
+            {
+                newEnclosing = nc.Enclosing.WithElement(e);
+                changed = true;
+            }
         }
 
+        TypeTree? newClazz = nc.Clazz;
         if (nc.Clazz != null)
         {
-            Visit(nc.Clazz, p);
+            var visited = Visit(nc.Clazz, p);
+            if (visited is TypeTree tt && !ReferenceEquals(tt, nc.Clazz))
+            {
+                newClazz = tt;
+                changed = true;
+            }
         }
 
+        JContainer<Expression> newArgs = nc.Arguments;
+        var argElements = new List<JRightPadded<Expression>>();
+        bool argsChanged = false;
         foreach (var paddedArg in nc.Arguments.Elements)
         {
-            Visit(paddedArg.Element, p);
+            var visited = Visit(paddedArg.Element, p);
+            if (visited is Expression e)
+            {
+                if (!ReferenceEquals(e, paddedArg.Element)) argsChanged = true;
+                argElements.Add(paddedArg.WithElement(e));
+            }
+            else
+            {
+                argElements.Add(paddedArg);
+            }
+        }
+        if (argsChanged)
+        {
+            newArgs = nc.Arguments.WithElements(argElements);
+            changed = true;
         }
 
+        Block? newBody = nc.Body;
         if (nc.Body != null)
         {
-            Visit(nc.Body, p);
+            var visited = Visit(nc.Body, p);
+            if (visited is Block b && !ReferenceEquals(b, nc.Body))
+            {
+                newBody = b;
+                changed = true;
+            }
         }
 
-        return nc;
+        return changed
+            ? nc.WithEnclosing(newEnclosing).WithClazz(newClazz).WithArguments(newArgs).WithBody(newBody)
+            : nc;
     }
 
     public virtual J VisitNewArray(NewArray na, P p)
     {
+        var changed = false;
+
+        TypeTree? newTypeExpr = na.TypeExpression;
         if (na.TypeExpression != null)
         {
-            Visit(na.TypeExpression, p);
-        }
-
-        foreach (var dim in na.Dimensions)
-        {
-            Visit(dim, p);
-        }
-
-        if (na.Initializer != null)
-        {
-            foreach (var paddedElem in na.Initializer.Elements)
+            var visited = Visit(na.TypeExpression, p);
+            if (visited is TypeTree tt && !ReferenceEquals(tt, na.TypeExpression))
             {
-                Visit(paddedElem.Element, p);
+                newTypeExpr = tt;
+                changed = true;
             }
         }
 
-        return na;
+        var newDims = new List<ArrayDimension>();
+        bool dimsChanged = false;
+        foreach (var dim in na.Dimensions)
+        {
+            var visited = Visit(dim, p);
+            if (visited is ArrayDimension d)
+            {
+                if (!ReferenceEquals(d, dim)) dimsChanged = true;
+                newDims.Add(d);
+            }
+            else
+            {
+                newDims.Add(dim);
+            }
+        }
+        if (dimsChanged) changed = true;
+
+        JContainer<Expression>? newInitializer = na.Initializer;
+        if (na.Initializer != null)
+        {
+            var initElements = new List<JRightPadded<Expression>>();
+            bool initChanged = false;
+            foreach (var paddedElem in na.Initializer.Elements)
+            {
+                var visited = Visit(paddedElem.Element, p);
+                if (visited is Expression e)
+                {
+                    if (!ReferenceEquals(e, paddedElem.Element)) initChanged = true;
+                    initElements.Add(paddedElem.WithElement(e));
+                }
+                else
+                {
+                    initElements.Add(paddedElem);
+                }
+            }
+            if (initChanged)
+            {
+                newInitializer = na.Initializer.WithElements(initElements);
+                changed = true;
+            }
+        }
+
+        return changed
+            ? na.WithTypeExpression(newTypeExpr).WithDimensions(dimsChanged ? newDims : na.Dimensions).WithInitializer(newInitializer)
+            : na;
     }
 
     public virtual J VisitLabel(Label label, P p)
     {
-        Visit(label.LabelName.Element, p);
-        Visit(label.Statement, p);
-        return label;
+        var changed = false;
+
+        JRightPadded<Identifier> newLabelName = label.LabelName;
+        var visitedLabel = Visit(label.LabelName.Element, p);
+        if (visitedLabel is Identifier id && !ReferenceEquals(id, label.LabelName.Element))
+        {
+            newLabelName = label.LabelName.WithElement(id);
+            changed = true;
+        }
+
+        Statement newStatement = label.Statement;
+        var visitedStmt = Visit(label.Statement, p);
+        if (visitedStmt is Statement s && !ReferenceEquals(s, label.Statement))
+        {
+            newStatement = s;
+            changed = true;
+        }
+
+        return changed
+            ? label.WithLabelName(newLabelName).WithStatement(newStatement)
+            : label;
     }
 
     public virtual J VisitInstanceOf(InstanceOf instanceOf, P p)
     {
-        Visit(instanceOf.Expression.Element, p);
-        Visit(instanceOf.Clazz, p);
-        if (instanceOf.Pattern != null) Visit(instanceOf.Pattern, p);
-        if (instanceOf.InstanceOfModifier != null) Visit(instanceOf.InstanceOfModifier, p);
-        return instanceOf;
+        var changed = false;
+
+        JRightPadded<Expression> newExpr = instanceOf.Expression;
+        var visitedExpr = Visit(instanceOf.Expression.Element, p);
+        if (visitedExpr is Expression e && !ReferenceEquals(e, instanceOf.Expression.Element))
+        {
+            newExpr = instanceOf.Expression.WithElement(e);
+            changed = true;
+        }
+
+        J newClazz = instanceOf.Clazz;
+        var visitedClazz = Visit(instanceOf.Clazz, p);
+        if (visitedClazz is J vc && !ReferenceEquals(vc, instanceOf.Clazz))
+        {
+            newClazz = vc;
+            changed = true;
+        }
+
+        J? newPattern = instanceOf.Pattern;
+        if (instanceOf.Pattern != null)
+        {
+            var visitedPattern = Visit(instanceOf.Pattern, p);
+            if (visitedPattern is J vp && !ReferenceEquals(vp, instanceOf.Pattern))
+            {
+                newPattern = vp;
+                changed = true;
+            }
+        }
+
+        Modifier? newModifier = instanceOf.InstanceOfModifier;
+        if (instanceOf.InstanceOfModifier != null)
+        {
+            var visitedMod = Visit(instanceOf.InstanceOfModifier, p);
+            if (visitedMod is Modifier vm && !ReferenceEquals(vm, instanceOf.InstanceOfModifier))
+            {
+                newModifier = vm;
+                changed = true;
+            }
+        }
+
+        return changed
+            ? instanceOf.WithExpression(newExpr).WithClazz(newClazz).WithPattern(newPattern).WithInstanceOfModifier(newModifier)
+            : instanceOf;
     }
 
     public virtual J VisitNullableType(NullableType nullableType, P p)
     {
-        Visit(nullableType.TypeTree, p);
+        var visited = Visit(nullableType.TypeTree, p);
+        if (visited is TypeTree tt && !ReferenceEquals(tt, nullableType.TypeTree))
+        {
+            return nullableType.WithTypeTreePadded(nullableType.TypeTreePadded.WithElement(tt));
+        }
         return nullableType;
     }
 
     public virtual J VisitParameterizedType(ParameterizedType pt, P p)
     {
-        Visit(pt.Clazz, p);
+        var changed = false;
+
+        NameTree newClazz = pt.Clazz;
+        var visitedClazz = Visit(pt.Clazz, p);
+        if (visitedClazz is NameTree nt && !ReferenceEquals(nt, pt.Clazz))
+        {
+            newClazz = nt;
+            changed = true;
+        }
+
+        JContainer<Expression>? newTypeParams = pt.TypeParameters;
         if (pt.TypeParameters != null)
         {
+            var tpElements = new List<JRightPadded<Expression>>();
+            bool tpChanged = false;
             foreach (var paddedParam in pt.TypeParameters.Elements)
             {
-                Visit(paddedParam.Element, p);
+                var visited = Visit(paddedParam.Element, p);
+                if (visited is Expression e)
+                {
+                    if (!ReferenceEquals(e, paddedParam.Element)) tpChanged = true;
+                    tpElements.Add(paddedParam.WithElement(e));
+                }
+                else
+                {
+                    tpElements.Add(paddedParam);
+                }
+            }
+            if (tpChanged)
+            {
+                newTypeParams = pt.TypeParameters.WithElements(tpElements);
+                changed = true;
             }
         }
-        return pt;
+
+        return changed
+            ? pt.WithClazz(newClazz).WithTypeParameters(newTypeParams)
+            : pt;
     }
 
     public virtual J VisitArrayType(ArrayType at, P p)
     {
-        Visit(at.ElementType, p);
+        var changed = false;
 
+        TypeTree newElementType = at.ElementType;
+        var visitedElem = Visit(at.ElementType, p);
+        if (visitedElem is TypeTree tt && !ReferenceEquals(tt, at.ElementType))
+        {
+            newElementType = tt;
+            changed = true;
+        }
+
+        IList<Annotation>? newAnnotations = at.Annotations;
         if (at.Annotations != null)
         {
+            var annList = new List<Annotation>();
+            bool annsChanged = false;
             foreach (var ann in at.Annotations)
             {
-                Visit(ann, p);
+                var visited = Visit(ann, p);
+                if (visited is Annotation a)
+                {
+                    if (!ReferenceEquals(a, ann)) annsChanged = true;
+                    annList.Add(a);
+                }
+                else
+                {
+                    annList.Add(ann);
+                }
+            }
+            if (annsChanged)
+            {
+                newAnnotations = annList;
+                changed = true;
             }
         }
 
-        return at;
+        return changed
+            ? at.WithElementType(newElementType).WithAnnotations(newAnnotations)
+            : at;
     }
 
     public virtual J VisitArrayAccess(ArrayAccess arrayAccess, P p)
@@ -764,15 +1313,44 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
 
     public virtual J VisitTypeParameter(TypeParameter typeParameter, P p)
     {
-        Visit(typeParameter.Name, p);
+        var changed = false;
+
+        Expression newName = typeParameter.Name;
+        var visitedName = Visit(typeParameter.Name, p);
+        if (visitedName is Expression ne && !ReferenceEquals(ne, typeParameter.Name))
+        {
+            newName = ne;
+            changed = true;
+        }
+
+        JContainer<TypeTree>? newBounds = typeParameter.Bounds;
         if (typeParameter.Bounds != null)
         {
+            var boundElements = new List<JRightPadded<TypeTree>>();
+            bool boundsChanged = false;
             foreach (var paddedBound in typeParameter.Bounds.Elements)
             {
-                Visit(paddedBound.Element, p);
+                var visited = Visit(paddedBound.Element, p);
+                if (visited is TypeTree tt)
+                {
+                    if (!ReferenceEquals(tt, paddedBound.Element)) boundsChanged = true;
+                    boundElements.Add(paddedBound.WithElement(tt));
+                }
+                else
+                {
+                    boundElements.Add(paddedBound);
+                }
+            }
+            if (boundsChanged)
+            {
+                newBounds = typeParameter.Bounds.WithElements(boundElements);
+                changed = true;
             }
         }
-        return typeParameter;
+
+        return changed
+            ? typeParameter.WithName(newName).WithBounds(newBounds)
+            : typeParameter;
     }
 
     public virtual J VisitPackage(Package pkg, P p)

--- a/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="StreamJsonRpc" Version="2.20.20" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
 using OpenRewrite.Core;
 using OpenRewrite.CSharp;
 using Rewrite.Core;
@@ -38,11 +42,30 @@ public abstract class RewriteTest
         var parser = new CSharpParser();
         var printer = new CSharpPrinter<object>();
 
+        // Resolve metadata references if ReferenceAssemblies is configured
+        ImmutableArray<MetadataReference>? metadataReferences = recipeSpec.ReferenceAssemblies != null
+            ? recipeSpec.ReferenceAssemblies
+                .ResolveAsync(LanguageNames.CSharp, CancellationToken.None)
+                .GetAwaiter()
+                .GetResult()
+            : null;
+
         // 1. Parse all sources and validate round-trip
         var parsed = new List<(SourceSpec Spec, SourceFile Source)>();
         foreach (var spec in specs)
         {
-            var source = parser.Parse(spec.Before);
+            SemanticModel? semanticModel = null;
+            if (metadataReferences != null)
+            {
+                var syntaxTree = CSharpSyntaxTree.ParseText(spec.Before, path: "source.cs");
+                var compilation = CSharpCompilation.Create("TestCompilation")
+                    .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                    .AddReferences(metadataReferences)
+                    .AddSyntaxTrees(syntaxTree);
+                semanticModel = compilation.GetSemanticModel(syntaxTree);
+            }
+
+            var source = parser.Parse(spec.Before, semanticModel: semanticModel);
 
             // Verify round-trip: printed should match input
             var printed = printer.Print(source);
@@ -102,10 +125,45 @@ public record SourceSpec(string Before, string? After = null);
 public class RecipeSpec
 {
     public Recipe? Recipe { get; private set; }
+    public ReferenceAssemblies? ReferenceAssemblies { get; private set; }
 
     public RecipeSpec SetRecipe(Recipe recipe)
     {
         Recipe = recipe;
         return this;
+    }
+
+    public RecipeSpec SetReferenceAssemblies(ReferenceAssemblies referenceAssemblies)
+    {
+        ReferenceAssemblies = referenceAssemblies;
+        return this;
+    }
+}
+
+/// <summary>
+/// Pre-configured reference assemblies for common .NET SDK targets.
+/// </summary>
+public static class Assemblies
+{
+    public static ReferenceAssemblies Net90 => Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90;
+    public static ReferenceAssemblies Net100 => Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net100;
+
+    public static ReferenceAssemblies AspNet90 =>
+        Net90.AddPackage("Microsoft.AspNetCore.App.Ref");
+
+    public static ReferenceAssemblies AspNet100 =>
+        Net100.AddPackage("Microsoft.AspNetCore.App.Ref");
+
+    public static ReferenceAssemblies AddPackage(this ReferenceAssemblies referenceAssemblies, string package)
+    {
+        return referenceAssemblies.AddPackage(package,
+            referenceAssemblies.ReferenceAssemblyPackage?.Version
+            ?? throw new InvalidOperationException("ReferenceAssemblyPackage.Version is null"));
+    }
+
+    public static ReferenceAssemblies AddPackage(this ReferenceAssemblies referenceAssemblies, string package,
+        string version)
+    {
+        return referenceAssemblies.AddPackages([new PackageIdentity(package, version)]);
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/WorkingSetRoundTripTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/WorkingSetRoundTripTests.cs
@@ -48,11 +48,16 @@ public class WorkingSetRoundTripTests
     }
 
     [Trait("Category", "WorkingSet")]
-    [Theory]
-    [MemberData(nameof(AllProjects))]
-    public async Task ParseAndPrintRoundTrip(string displayName, string projectFile, string projectDir)
+    [Fact]
+    public async Task ParseAndPrintRoundTrip()
     {
-        await RunRoundTrip(displayName, projectFile, projectDir);
+        var projects = AllProjects().ToList();
+        if (projects.Count == 0) return; // No WORKING_SET_ROOT configured
+
+        foreach (var data in projects)
+        {
+            await RunRoundTrip((string)data[0], (string)data[1], (string)data[2]);
+        }
     }
 
     #endregion

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -22,6 +22,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
 import org.openrewrite.csharp.tree.Cs;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.marketplace.RecipeMarketplace;
 import org.openrewrite.rpc.RewriteRpc;
 import org.openrewrite.rpc.RewriteRpcProcess;
@@ -180,6 +181,10 @@ public class CSharpRewriteRpc extends RewriteRpc {
 
     @RequiredArgsConstructor
     public static class Builder implements Supplier<CSharpRewriteRpc> {
+        private static final String TOOL_COMMAND = "rewrite-csharp";
+        private static final String NUGET_PACKAGE_ID = "OpenRewrite.CSharp";
+        private static final String REWRITE_SOURCE_PATH_ENV = "REWRITE_SOURCE_PATH";
+
         private RecipeMarketplace marketplace = new RecipeMarketplace();
         private final Map<String, String> environment = new HashMap<>();
         private Path dotnetPath = Paths.get("dotnet");
@@ -207,13 +212,10 @@ public class CSharpRewriteRpc extends RewriteRpc {
         }
 
         /**
-         * Entry point that launches the C# RPC server. When the path has a {@code .csproj}
-         * extension, the server is launched from source via {@code dotnet run --project}.
-         * Otherwise the path is treated as a published executable (DLL) and launched
-         * via {@code dotnet <path>}.
-         *
-         * @param csharpServerEntry Path to either a {@code .csproj} file or a published DLL
-         * @return This builder
+         * Explicit entry point for the C# RPC server, primarily for tests.
+         * When set, the server is launched via {@code dotnet run --project <path>}
+         * (for {@code .csproj}) or {@code dotnet <path>} (for DLLs), bypassing
+         * both {@code REWRITE_SOURCE_PATH} and global tool auto-install.
          */
         public Builder csharpServerEntry(Path csharpServerEntry) {
             this.csharpServerEntry = csharpServerEntry;
@@ -271,26 +273,44 @@ public class CSharpRewriteRpc extends RewriteRpc {
 
         @Override
         public CSharpRewriteRpc get() {
-            Path entry = findCSharpServerEntry();
             Stream<@Nullable String> cmd;
-            if (entry.toString().endsWith(".csproj")) {
-                cmd = Stream.of(
-                        dotnetPath.toString(),
-                        "run",
-                        "--project", entry.toAbsolutePath().normalize().toString(),
-                        "--framework", "net10.0",
-                        log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
-                        traceRpcMessages ? "--trace-rpc-messages" : null
-                );
+
+            if (csharpServerEntry != null) {
+                // Explicit override (used by tests)
+                if (csharpServerEntry.toString().endsWith(".csproj")) {
+                    cmd = buildCsprojCommand(csharpServerEntry);
+                } else {
+                    cmd = Stream.of(
+                            dotnetPath.toString(),
+                            csharpServerEntry.toAbsolutePath().normalize().toString(),
+                            log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
+                            traceRpcMessages ? "--trace-rpc-messages" : null
+                    );
+                }
             } else {
-                cmd = Stream.of(
-                        dotnetPath.toString(),
-                        entry.toAbsolutePath().normalize().toString(),
-                        log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
-                        traceRpcMessages ? "--trace-rpc-messages" : null
-                );
+                // If REWRITE_SOURCE_PATH is set, launch from source via dotnet run
+                String rewriteSourcePath = System.getenv(REWRITE_SOURCE_PATH_ENV);
+                if (rewriteSourcePath != null && !rewriteSourcePath.isEmpty()) {
+                    Path csproj = Paths.get(rewriteSourcePath)
+                            .resolve("rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj");
+                    if (!Files.exists(csproj)) {
+                        throw new IllegalStateException(
+                                REWRITE_SOURCE_PATH_ENV + " is set to " + rewriteSourcePath +
+                                " but " + csproj + " does not exist");
+                    }
+                    cmd = buildCsprojCommand(csproj);
+                } else {
+                    // Run via dotnet tool exec with the pinned version from the build
+                    String version = StringUtils.readFully(
+                            CSharpRewriteRpc.class.getResourceAsStream("/META-INF/rewrite-csharp-version.txt")).trim();
+                    cmd = buildToolExecCommand(version);
+                }
             }
 
+            return startProcess(cmd);
+        }
+
+        private CSharpRewriteRpc startProcess(Stream<@Nullable String> cmd) {
             String[] cmdArr = cmd.filter(Objects::nonNull).toArray(String[]::new);
             RewriteRpcProcess process = new RewriteRpcProcess(cmdArr);
 
@@ -306,7 +326,6 @@ public class CSharpRewriteRpc extends RewriteRpc {
                 env.put("DOTNET_EventPipeOutputPath", profileOutputPath.toAbsolutePath().normalize().toString());
                 env.put("DOTNET_EventPipeOutputStreaming", "1");
                 env.put("DOTNET_EventPipeCircularMB", "256");
-                // CPU sampling + GC events + sampled allocations (low rate) + type loading + runtime counters
                 env.put("DOTNET_EventPipeConfig",
                         "Microsoft-DotNETCore-SampleProfiler:0:5;" +
                         "Microsoft-Windows-DotNETRuntime:2088009:4;" +
@@ -326,51 +345,28 @@ public class CSharpRewriteRpc extends RewriteRpc {
             }
         }
 
-        private Path findCSharpServerEntry() {
-            if (csharpServerEntry != null) {
-                return csharpServerEntry;
-            }
+        private Stream<@Nullable String> buildCsprojCommand(Path csproj) {
+            return Stream.of(
+                    dotnetPath.toString(),
+                    "run",
+                    "--project", csproj.toAbsolutePath().normalize().toString(),
+                    "--framework", "net10.0",
+                    log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
+                    traceRpcMessages ? "--trace-rpc-messages" : null
+            );
+        }
 
-            // Check for globally installed dotnet tool
-            Path toolStore = Paths.get(System.getProperty("user.home"), ".dotnet", "tools", ".store", "openrewrite.csharp");
-            if (Files.isDirectory(toolStore)) {
-                try (Stream<Path> versions = Files.list(toolStore)) {
-                    Optional<Path> dll = versions
-                            .sorted(Comparator.reverseOrder())
-                            .flatMap(versionDir -> {
-                                try {
-                                    return Files.walk(versionDir)
-                                            .filter(p -> p.getFileName().toString().equals("OpenRewrite.dll"));
-                                } catch (IOException e) {
-                                    return Stream.empty();
-                                }
-                            })
-                            .findFirst();
-                    if (dll.isPresent()) {
-                        return dll.get().toAbsolutePath().normalize();
-                    }
-                } catch (IOException ignored) {
-                }
-            }
-
-            // Fall back to development paths relative to working directory
-            Path basePath = workingDirectory != null ? workingDirectory : Paths.get(System.getProperty("user.dir"));
-            Path[] searchPaths = {
-                    basePath.resolve("csharp"),
-                    basePath.resolve("rewrite-csharp/csharp"),
-            };
-
-            for (Path searchPath : searchPaths) {
-                Path csproj = searchPath.resolve("OpenRewrite/OpenRewrite.csproj");
-                if (Files.exists(csproj)) {
-                    return csproj.toAbsolutePath().normalize();
-                }
-            }
-
-            throw new IllegalStateException(
-                    "Could not find C# Rewrite project. Please set csharpServerEntry() on the builder. " +
-                    "Expected to find OpenRewrite.dll in ~/.dotnet/tools/.store/openrewrite.csharp/ " +
-                    "or OpenRewrite/OpenRewrite.csproj in the project directory.");
+        private Stream<@Nullable String> buildToolExecCommand(String version) {
+            return Stream.of(
+                    dotnetPath.toString(),
+                    "tool", "exec",
+                    NUGET_PACKAGE_ID + "@" + version,
+                    "-y",
+                    "--allow-roll-forward",
+                    "--",
+                    log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
+                    traceRpcMessages ? "--trace-rpc-messages" : null
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- Expanded `CSharpVisitor` and `JavaVisitor` with comprehensive visitor method implementations
- Improved RPC server bootstrapping and `CSharpRewriteRpc` message handling
- Updated `RewriteTest` infrastructure and `WorkingSetRoundTripTests`
- Added `.gitignore` and build configuration updates for the C# module

## Test plan
- [ ] Verify C# RPC round-trip tests pass
- [ ] Verify existing C# parser tests are unaffected