### PR TITLE
Also check thread context classloader in `TypeTable.fromClasspath()`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -101,22 +101,27 @@ public class TypeTable implements JavaParserClasspathLoader {
 
     public static @Nullable TypeTable fromClasspath(ExecutionContext ctx, Collection<String> artifactNames) {
         try {
-            ClassLoader classLoader = findCaller().getClassLoader();
-            Vector<URL> combinedResources = new Vector<>();
-            for (Enumeration<URL> e = classLoader.getResources(DEFAULT_RESOURCE_PATH); e.hasMoreElements(); ) {
-                combinedResources.add(e.nextElement());
-            }
-            // TO-BE-REMOVED(2025-10-31) In the future we only want to support the `.gz` extension
-            for (Enumeration<URL> e = classLoader.getResources(DEFAULT_RESOURCE_PATH.replace(".gz", ".zip")); e.hasMoreElements(); ) {
-                combinedResources.add(e.nextElement());
+            ClassLoader callerClassLoader = findCaller().getClassLoader();
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+
+            Set<URL> seen = new LinkedHashSet<>();
+            collectResources(callerClassLoader, DEFAULT_RESOURCE_PATH, seen);
+            if (contextClassLoader != null && contextClassLoader != callerClassLoader) {
+                collectResources(contextClassLoader, DEFAULT_RESOURCE_PATH, seen);
             }
 
-            if (!combinedResources.isEmpty()) {
-                return new TypeTable(ctx, combinedResources.elements(), artifactNames);
+            if (!seen.isEmpty()) {
+                return new TypeTable(ctx, new Vector<>(seen).elements(), artifactNames);
             }
             return null;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void collectResources(ClassLoader classLoader, String resourcePath, Set<URL> target) throws IOException {
+        for (Enumeration<URL> e = classLoader.getResources(resourcePath); e.hasMoreElements(); ) {
+            target.add(e.nextElement());
         }
     }
 

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTest.java
@@ -38,12 +38,15 @@ import javax.tools.ToolProvider;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -830,6 +833,65 @@ class TypeTableTest implements RewriteTest {
             );
         }
 
+    }
+
+    @Nested
+    class ClassloaderResolutionTests {
+
+        /**
+         * Simulates the scenario from <a href="https://github.com/openrewrite/rewrite/issues/6885">#6885</a>:
+         * Recipe JARs are loaded via a custom URLClassLoader (e.g. in Quarkus), so their
+         * classpath.tsv.gz resources are not visible to the caller's classloader.
+         * TypeTable.fromClasspath() should also check the thread context classloader.
+         */
+        @Test
+        void findsResourcesFromThreadContextClassLoader() throws Exception {
+            // Create a simple class, compile it, jar it, and write a classpath.tsv.gz
+            //language=java
+            String source = """
+                package com.example;
+
+                public class SimpleClass {
+                    public static final String VALUE = "hello";
+                }
+                """;
+
+            Path classFile = compileToClassFile(source, "com.example.SimpleClass");
+            Path jarFile = createJarFromClasses("simple.jar", classFile);
+
+            // Create a classpath.tsv.gz in a separate directory that simulates a recipe JAR
+            Path recipeJarDir = tempDir.resolve("recipe-jar");
+            Path metaInfDir = recipeJarDir.resolve("META-INF/rewrite");
+            Files.createDirectories(metaInfDir);
+
+            Path tsvFile = metaInfDir.resolve("classpath.tsv.gz");
+            try (TypeTable.Writer writer = TypeTable.newWriter(Files.newOutputStream(tsvFile))) {
+                writer.jar("com.example", "simple", "1.0").write(jarFile);
+            }
+
+            // Create a URLClassLoader that can see the recipe JAR's resources
+            // Use a parent that does NOT have access to any classpath.tsv.gz (the bootstrap classloader)
+            URLClassLoader isolatedLoader = new URLClassLoader(
+                    new URL[]{recipeJarDir.toUri().toURL()},
+                    ClassLoader.getPlatformClassLoader()
+            );
+
+            // Set the isolated classloader as the TCCL
+            ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(isolatedLoader);
+
+                // TypeTable.fromClasspath should find the resource via TCCL
+                TypeTable typeTable = TypeTable.fromClasspath(ctx, Set.of("simple"));
+                assertThat(typeTable).isNotNull();
+
+                Path loaded = typeTable.load("simple");
+                assertThat(loaded).isNotNull();
+            } finally {
+                Thread.currentThread().setContextClassLoader(originalTccl);
+                isolatedLoader.close();
+            }
+        }
     }
 
     // Helper methods for integration tests


### PR DESCRIPTION
## Summary
- `TypeTable.fromClasspath()` now also searches the thread context classloader (TCCL) in addition to the caller's classloader when looking for `classpath.tsv.gz` resources
- Fixes #6885: when recipe JARs are loaded via a custom `URLClassLoader` (e.g. in Quarkus), the caller's classloader (AppClassLoader) can't see those JARs' resources — the TCCL can
- URLs are collected into a `LinkedHashSet` to deduplicate when both classloaders see the same resources
- Removes the expired `.zip` extension fallback (`TO-BE-REMOVED 2025-10-31`)

## Test plan
- New test `findsResourcesFromThreadContextClassLoader` creates an isolated `URLClassLoader` with a `classpath.tsv.gz`, sets it as TCCL, and verifies `fromClasspath()` finds the resource
- Existing TypeTable tests continue to pass (resources found via caller's classloader as before)