### PR TITLE
JavaScript: Add missing Type properties to some test classes

### DIFF
--- a/rewrite-javascript/rewrite/package.json
+++ b/rewrite-javascript/rewrite/package.json
@@ -53,7 +53,7 @@
     "test": "npm run typecheck && npm run build && bun run testhelper",
     "testhelper": "NODE_OPTIONS='--max-old-space-size=4096 --experimental-vm-modules' jest",
     "build:fixtures": "tsc --build fixtures/tsconfig.json",
-    "ci:test": "bun run testhelper",
+    "ci:test": "npm run typecheck && bun run testhelper",
     "start": "npm run build && node ./dist/rpc/server.js"
   },
   "dependencies": {

--- a/rewrite-javascript/rewrite/test/java/type-signature.test.ts
+++ b/rewrite-javascript/rewrite/test/java/type-signature.test.ts
@@ -22,10 +22,24 @@ describe('Type.signature', () => {
         const classA: Type.ShallowClass = {
             kind: Type.Kind.ShallowClass,
             fullyQualifiedName: "com.example.A",
+            flags: 0,
+            classKind: Type.Class.Kind.Class,
+            typeParameters: [],
+            annotations: [],
+            interfaces: [],
+            members: [],
+            methods: [],
         };
         const classB: Type.ShallowClass = {
             kind: Type.Kind.ShallowClass,
             fullyQualifiedName: "com.example.B",
+            flags: 0,
+            classKind: Type.Class.Kind.Class,
+            typeParameters: [],
+            annotations: [],
+            interfaces: [],
+            members: [],
+            methods: [],
         };
 
         // Shell-cache pattern: create with empty typeParameters first
@@ -55,10 +69,24 @@ describe('Type.signature', () => {
         const classA: Type.ShallowClass = {
             kind: Type.Kind.ShallowClass,
             fullyQualifiedName: "com.example.List",
+            flags: 0,
+            classKind: Type.Class.Kind.Class,
+            typeParameters: [],
+            annotations: [],
+            interfaces: [],
+            members: [],
+            methods: [],
         };
         const classB: Type.ShallowClass = {
             kind: Type.Kind.ShallowClass,
             fullyQualifiedName: "com.example.Map",
+            flags: 0,
+            classKind: Type.Class.Kind.Class,
+            typeParameters: [],
+            annotations: [],
+            interfaces: [],
+            members: [],
+            methods: [],
         };
 
         const inner: Type.Parameterized = {


### PR DESCRIPTION
## What's changed?

- Adding new properties to type attribution in some test classes in JavaScript.
- Also amending the `ci:test` task, so that similar problems are caught earlier.

## What's your motivation?

`npm test` no longer to fail.