### PR TITLE
Filter SNAPSHOT versions from BOM upgrade candidates

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -505,6 +505,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 );
 
                 return metadata.getVersioning().getVersions().stream()
+                        .filter(version -> versionComparator.isValid(currentVersion, version))
                         .filter(version -> versionComparator.compare(null, currentVersion, version) < 0)
                         .sorted(versionComparator)
                         .collect(toList());

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -16,6 +16,10 @@
 package org.openrewrite.maven;
 
 import com.google.common.collect.Lists;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,11 +27,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.Parser;
 import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
 
+import java.nio.file.Path;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -2742,5 +2749,195 @@ class UpgradeDependencyVersionTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void bomUpgradeSkipsSnapshotVersions() throws Exception {
+        try (MockWebServer mockRepo = new MockWebServer()) {
+            mockRepo.setDispatcher(new Dispatcher() {
+                @Override
+                public MockResponse dispatch(RecordedRequest request) {
+                    String path = request.getPath();
+                    if (path == null) {
+                        return new MockResponse().setResponseCode(404);
+                    }
+                    // BOM metadata includes a SNAPSHOT version
+                    if (path.contains("com/example/my-bom/maven-metadata.xml")) {
+                        return new MockResponse().setResponseCode(200).setBody("""
+                          <metadata>
+                            <groupId>com.example</groupId>
+                            <artifactId>my-bom</artifactId>
+                            <versioning>
+                              <versions>
+                                <version>1.0.0</version>
+                                <version>2.0.0-SNAPSHOT</version>
+                                <version>2.0.0</version>
+                              </versions>
+                            </versioning>
+                          </metadata>
+                          """);
+                    }
+                    // BOM 1.0.0 manages my-lib at 1.0.0
+                    if (path.contains("com/example/my-bom/1.0.0/my-bom-1.0.0.pom")) {
+                        return new MockResponse().setResponseCode(200).setBody("""
+                          <project>
+                            <modelVersion>4.0.0</modelVersion>
+                            <groupId>com.example</groupId>
+                            <artifactId>my-bom</artifactId>
+                            <version>1.0.0</version>
+                            <packaging>pom</packaging>
+                            <dependencyManagement>
+                              <dependencies>
+                                <dependency>
+                                  <groupId>com.example</groupId>
+                                  <artifactId>my-lib</artifactId>
+                                  <version>1.0.0</version>
+                                </dependency>
+                              </dependencies>
+                            </dependencyManagement>
+                          </project>
+                          """);
+                    }
+                    // BOM 2.0.0 manages my-lib at 2.0.0
+                    if (path.contains("com/example/my-bom/2.0.0/my-bom-2.0.0.pom")) {
+                        return new MockResponse().setResponseCode(200).setBody("""
+                          <project>
+                            <modelVersion>4.0.0</modelVersion>
+                            <groupId>com.example</groupId>
+                            <artifactId>my-bom</artifactId>
+                            <version>2.0.0</version>
+                            <packaging>pom</packaging>
+                            <dependencyManagement>
+                              <dependencies>
+                                <dependency>
+                                  <groupId>com.example</groupId>
+                                  <artifactId>my-lib</artifactId>
+                                  <version>2.0.0</version>
+                                </dependency>
+                              </dependencies>
+                            </dependencyManagement>
+                          </project>
+                          """);
+                    }
+                    // SNAPSHOT BOM should never be requested — return 404
+                    if (path.contains("2.0.0-SNAPSHOT")) {
+                        return new MockResponse().setResponseCode(404);
+                    }
+                    // Dependency metadata
+                    if (path.contains("com/example/my-lib/maven-metadata.xml")) {
+                        return new MockResponse().setResponseCode(200).setBody("""
+                          <metadata>
+                            <groupId>com.example</groupId>
+                            <artifactId>my-lib</artifactId>
+                            <versioning>
+                              <versions>
+                                <version>1.0.0</version>
+                                <version>2.0.0</version>
+                              </versions>
+                            </versioning>
+                          </metadata>
+                          """);
+                    }
+                    // Dependency POM
+                    if (path.contains("com/example/my-lib/1.0.0/my-lib-1.0.0.pom")) {
+                        return new MockResponse().setResponseCode(200).setBody("""
+                          <project>
+                            <modelVersion>4.0.0</modelVersion>
+                            <groupId>com.example</groupId>
+                            <artifactId>my-lib</artifactId>
+                            <version>1.0.0</version>
+                          </project>
+                          """);
+                    }
+                    if (path.contains("com/example/my-lib/2.0.0/my-lib-2.0.0.pom")) {
+                        return new MockResponse().setResponseCode(200).setBody("""
+                          <project>
+                            <modelVersion>4.0.0</modelVersion>
+                            <groupId>com.example</groupId>
+                            <artifactId>my-lib</artifactId>
+                            <version>2.0.0</version>
+                          </project>
+                          """);
+                    }
+                    return new MockResponse().setResponseCode(404);
+                }
+            });
+            mockRepo.start();
+
+            @SuppressWarnings("ConstantConditions")
+            MavenSettings settings = MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"),
+              //language=xml
+              """
+                <settings>
+                    <mirrors>
+                        <mirror>
+                            <mirrorOf>*</mirrorOf>
+                            <name>mock</name>
+                            <url>http://%s:%d</url>
+                            <id>mock</id>
+                        </mirror>
+                    </mirrors>
+                </settings>
+                """.formatted(mockRepo.getHostName(), mockRepo.getPort())
+            ), new InMemoryExecutionContext());
+
+            rewriteRun(
+              spec -> spec
+                .recipe(new UpgradeDependencyVersion("com.example", "my-lib", "2.x", null, true, null))
+                .executionContext(MavenExecutionContextView.view(new InMemoryExecutionContext())
+                  .setMavenSettings(settings, "mock")),
+              pomXml(
+                """
+                  <project>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>my-app</artifactId>
+                      <version>1</version>
+                      <dependencyManagement>
+                          <dependencies>
+                              <dependency>
+                                  <groupId>com.example</groupId>
+                                  <artifactId>my-bom</artifactId>
+                                  <version>1.0.0</version>
+                                  <type>pom</type>
+                                  <scope>import</scope>
+                              </dependency>
+                          </dependencies>
+                      </dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>com.example</groupId>
+                              <artifactId>my-lib</artifactId>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """,
+                """
+                  <project>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>my-app</artifactId>
+                      <version>1</version>
+                      <dependencyManagement>
+                          <dependencies>
+                              <dependency>
+                                  <groupId>com.example</groupId>
+                                  <artifactId>my-bom</artifactId>
+                                  <version>2.0.0</version>
+                                  <type>pom</type>
+                                  <scope>import</scope>
+                              </dependency>
+                          </dependencies>
+                      </dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>com.example</groupId>
+                              <artifactId>my-lib</artifactId>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """
+              )
+            );
+            mockRepo.shutdown();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Added `isValid()` filter to `getAvailableBomVersions()` to reject SNAPSHOT and other pre-release versions before they are considered as BOM upgrade candidates

## Problem

When `UpgradeDependencyVersion` attempts a BOM upgrade (via `overrideManagedVersion: true`), `getAvailableBomVersions()` only used `compare()` to filter version candidates. Unlike `isValid()`, `compare()` does not reject pre-release versions like SNAPSHOTs. This caused the recipe to attempt downloading SNAPSHOT BOMs, which fails for customers without snapshot repository access.

The failure then short-circuits the BOM upgrade path entirely, falling through to adding an explicit `<version>` tag on the dependency instead — producing incorrect results.

This was observed in the Spring Boot 4.0 migration when `MigrateRestAssured` tried to upgrade `io.rest-assured:rest-assured-bom` and encountered `6.0.0-SNAPSHOT` as a candidate version.

## Solution

Added `.filter(version -> versionComparator.isValid(currentVersion, version))` before the existing `.filter(version -> versionComparator.compare(...) < 0)` in `getAvailableBomVersions()`. This matches the pattern already used in `MavenDependency.findNewerVersion()`.

## Test plan

- [x] New test `bomUpgradeSkipsSnapshotVersions` uses MockWebServer to serve metadata with SNAPSHOT versions and verifies the BOM is upgraded to the release version, skipping the SNAPSHOT
- [x] All existing `UpgradeDependencyVersionTest` tests pass