### PR TITLE
Initialize ScanningRecipe accumulator key eagerly for thread safety

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/ScanningRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ScanningRecipe.java
@@ -35,13 +35,9 @@ import static java.util.Collections.emptyList;
  */
 @SuppressWarnings("ALL")
 public abstract class ScanningRecipe<T> extends Recipe {
-    @Nullable
-    private String recipeAccMessage;
+    private String recipeAccMessage = "org.openrewrite.recipe.acc." + UUID.randomUUID();
 
-    private String getRecipeAccMessage() {
-        if (recipeAccMessage == null) {
-            recipeAccMessage = "org.openrewrite.recipe.acc." + UUID.randomUUID();
-        }
+    String getRecipeAccMessage() {
         return recipeAccMessage;
     }
 


### PR DESCRIPTION
## Problem

`ScanningRecipe.recipeAccMessage` uses lazy initialization that is not thread-safe:

```java
@Nullable
private String recipeAccMessage;

private String getRecipeAccMessage() {
    if (recipeAccMessage == null) {
        recipeAccMessage = "org.openrewrite.recipe.acc." + UUID.randomUUID();
    }
    return recipeAccMessage;
}
```

When recipe instances are shared across concurrent runs, two threads can see `null` simultaneously, generate different UUIDs, and one overwrites the other. The losing thread's accumulator data — stored under the now-orphaned UUID — becomes unreachable.

## Solution

Change to eager initialization at field declaration. The UUID generation cost is negligible and the field is always used, so lazy init provided no benefit. The `clone()` method continues to assign a new UUID as before.