### PR TITLE
Restore classpath.tsv.zip fallback in TypeTable

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -106,8 +106,11 @@ public class TypeTable implements JavaParserClasspathLoader {
 
             Set<URL> seen = new LinkedHashSet<>();
             collectResources(callerClassLoader, DEFAULT_RESOURCE_PATH, seen);
+            // TO-BE-REMOVED(2025-10-31) In the future we only want to support the `.gz` extension
+            collectResources(callerClassLoader, DEFAULT_RESOURCE_PATH.replace(".gz", ".zip"), seen);
             if (contextClassLoader != null && contextClassLoader != callerClassLoader) {
                 collectResources(contextClassLoader, DEFAULT_RESOURCE_PATH, seen);
+                collectResources(contextClassLoader, DEFAULT_RESOURCE_PATH.replace(".gz", ".zip"), seen);
             }
 
             if (!seen.isEmpty()) {


### PR DESCRIPTION
## Summary
- PR #6900 accidentally dropped the `.zip` extension fallback when refactoring `TypeTable.fromClasspath()` to also check the thread context classloader
- Downstream repos like `rewrite-feature-flags` still package their TypeTable data as `classpath.tsv.zip`, causing `Unable to find classpath resource dependencies` test failures (e.g. [this build](https://github.com/openrewrite/rewrite-feature-flags/commit/57e0adc405ecefe752daf2b2f88a956b4be1bd34/checks))
- Restores the `.zip` fallback for both the caller classloader and the new context classloader paths

## Test plan
- [x] `TypeTableTest` passes locally
- [x] `rewrite-feature-flags` `ChangeVariationDefaultTest`, `RemoveBoolVariationTest`, and `MigrateUserToContextTest` all pass locally with this fix (they failed without it)