### PR TITLE
fix: switch npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ on:
   schedule:
     - cron: 0 16 * * *
 
-permissions:
-  contents: read
-  id-token: write
-
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -38,3 +34,13 @@ jobs:
       OPS_GITHUB_ACTIONS_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
       pypi_token: ${{ secrets.PYPI_OPENREWRITE_PUBLISH }}
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+
+  npm-publish:
+    needs: build
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      java_version: |
+        25
+        21
+    secrets:
+      gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,53 @@
+---
+name: npm-publish
+
+on:
+  workflow_call:
+    inputs:
+      java_version:
+        description: Java version for setup-java
+        type: string
+        required: false
+        default: 21
+      releasing:
+        description: Whether this is a release publish (uses tag version and latest npm tag)
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      gradle_enterprise_access_key:
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name != 'pull_request' &&
+      (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          show-progress: false
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.java_version }}
+
+      - uses: gradle/actions/setup-gradle@v5
+        with:
+          develocity-access-key: ${{ secrets.gradle_enterprise_access_key }}
+
+      - name: npm publish
+        run: >
+          ./gradlew ${{ env.GRADLE_SWITCHES }}
+          :rewrite-javascript:npmPublish
+          ${{ inputs.releasing && '-Preleasing' || '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,16 @@ jobs:
       sonatype_token: ${{ secrets.SONATYPE_TOKEN}}
       ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
       ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
-      node_auth_token: ${{ secrets.NPM_TOKEN }}
       pypi_token: ${{ secrets.PYPI_OPENREWRITE_PUBLISH }}
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+
+  npm-publish:
+    needs: release
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      java_version: |
+        25
+        21
+      releasing: true
+    secrets:
+      gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -229,7 +229,12 @@ val npmPublish = tasks.register<NpmTask>("npmPublish") {
 }
 
 tasks.named("publish") {
-    dependsOn(npmPublish)
+    // In CI, npm publishing is handled by a dedicated workflow (npm-publish.yml)
+    // for OIDC trusted publishing. Only include npmPublish in the main publish
+    // task for local development or when a token is explicitly provided.
+    if (System.getenv("CI") == null || project.hasProperty("nodeAuthToken")) {
+        dependsOn(npmPublish)
+    }
 }
 
 extensions.configure<LicenseExtension> {


### PR DESCRIPTION
## Summary
- Extract npm publishing into a dedicated reusable workflow (`npm-publish.yml`) with OIDC trusted publishing support
- Both `ci.yml` (snapshots) and `publish.yml` (releases) call `npm-publish.yml` as a separate job after their main build/release
- Remove expired `NPM_TOKEN` from both workflows
- Skip `npmPublish` from `./gradlew publish` in CI (handled by the dedicated workflow); local dev unchanged
- Add `--provenance --access public` flags for npm OIDC auth

## How it works
```
ci.yml
  job 1: build    → gh-automation/ci-gradle.yml  (Maven, PyPI, NuGet)
  job 2: npm      → ./npm-publish.yml            (npm only, OIDC)

publish.yml
  job 1: release  → gh-automation/publish-gradle.yml  (Maven, PyPI, NuGet)
  job 2: npm      → ./npm-publish.yml                 (npm only, OIDC, -Preleasing)
```

## npm settings change required
- [x] Update the trusted publisher workflow filename from `ci.yml` to `npm-publish.yml` on npmjs.com.

## Test plan
- [x] Update npm trusted publisher to `npm-publish.yml`
- [ ] Verify CI snapshot publish succeeds with OIDC on push to main
- [ ] Verify local `./gradlew publish` still includes npm publishing