### PR TITLE
Fix Python RPC GetObject timeout on Windows

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -82,7 +82,7 @@ def _next_request_id() -> int:
         return _request_id_counter
 
 
-def send_request(method: str, params: dict, timeout_seconds: float = 10.0) -> Any:
+def send_request(method: str, params: dict, timeout_seconds: float = 30.0) -> Any:
     """Send a JSON-RPC request to Java and wait for the response.
 
     This enables bidirectional communication - Python can request
@@ -91,7 +91,7 @@ def send_request(method: str, params: dict, timeout_seconds: float = 10.0) -> An
     Args:
         method: The RPC method name
         params: The request parameters
-        timeout_seconds: Maximum time to wait for response (default 10s)
+        timeout_seconds: Maximum time to wait for response (default 30s)
 
     Returns:
         The result from the RPC response
@@ -1275,18 +1275,38 @@ class _StdinBuffer:
     def _fill(self, deadline: Optional[float] = None) -> bool:
         """Read more data into the internal buffer.
 
-        When *deadline* is set, uses ``select()`` to respect the timeout;
-        otherwise blocks in ``os.read()``.  Returns ``False`` on
-        EOF or timeout.
+        When *deadline* is set, uses ``select()`` to respect the timeout
+        on Unix, or a background-thread read on Windows (where ``select()``
+        does not work on pipes).  Returns ``False`` on EOF or timeout.
         """
         if deadline is not None:
             remaining = deadline - time.time()
             if remaining <= 0:
                 return False
-            readable, _, _ = select.select([self._get_fd()], [], [], remaining)
-            if not readable:
-                return False
-        chunk = os.read(self._get_fd(), self._CHUNK_SIZE)
+            if os.name == 'nt':
+                # Windows: select() doesn't support pipes, use a thread
+                result: list = []
+
+                def _read():
+                    try:
+                        data = os.read(self._get_fd(), self._CHUNK_SIZE)
+                        result.append(data)
+                    except OSError:
+                        result.append(b'')
+
+                t = threading.Thread(target=_read, daemon=True)
+                t.start()
+                t.join(timeout=remaining)
+                if not result:
+                    return False
+                chunk = result[0]
+            else:
+                readable, _, _ = select.select([self._get_fd()], [], [], remaining)
+                if not readable:
+                    return False
+                chunk = os.read(self._get_fd(), self._CHUNK_SIZE)
+        else:
+            chunk = os.read(self._get_fd(), self._CHUNK_SIZE)
         if not chunk:
             return False
         self._buf += chunk


### PR DESCRIPTION
## Summary

- Fix `select.select()` usage in `_StdinBuffer._fill()` which doesn't work on pipes on Windows — use a daemon thread with `join(timeout=...)` instead
- Increase per-batch `send_request` default timeout from 10s to 30s for additional headroom

## Context

On Windows, `select()` only supports sockets, not pipes. The Python RPC server uses `select()` to implement timed reads on stdin (a pipe from the parent Java process). This causes `select()` to return immediately as "not readable", making every bidirectional RPC call fail with:

```
Failed to write patch for tools\faq_report.py: java.lang.RuntimeException:
java.util.concurrent.ExecutionException: io.moderne.jsonrpc.JsonRpcException:
{code=-32603, message='No response received for GetObject request (timeout after 10.0s)'}
```

The specific flow: Java sends `Print` → Python's `handle_print()` sends `GetObject` back to Java → `read_message_with_timeout()` → `_fill(deadline)` → `select.select()` on pipe fd → immediate failure on Windows.

This affects every repo with Python files, since it's a platform-level incompatibility rather than a timing issue.

- Fixes https://github.com/moderneinc/customer-requests/issues/1976