### PR TITLE
Fix NoWhitespaceAfter removing required space after type-use annotation

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/NoWhitespaceAfterTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/NoWhitespaceAfterTest.java
@@ -340,6 +340,35 @@ class NoWhitespaceAfterTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/6917")
+    @Test
+    void typeUseAnnotationOnFieldAccess() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().styles(noWhitespaceAfterStyle(style ->
+            style.withDot(true)))),
+          java(
+            """
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+
+              class Test {
+                  Cache.@Nullable ValueWrapper get(Object key) {
+                      return null;
+                  }
+              }
+
+              class Cache {
+                  class ValueWrapper {}
+              }
+
+              @Target(ElementType.TYPE_USE)
+              @interface Nullable {}
+              """,
+            autoFormatIsIdempotent()
+          )
+        );
+    }
+
     @Test
     void doNotAllowLinebreak() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
@@ -152,7 +152,7 @@ public class NoWhitespaceAfter extends Recipe {
                 if (Boolean.TRUE.equals(noWhitespaceAfterStyle.getAllowLineBreaks()) && f.getName().getPrefix().getWhitespace().contains("\n")) {
                     return f;
                 }
-                if (f.getName().getPrefix().getWhitespace().contains(" ")) {
+                if (f.getName().getPrefix().getWhitespace().contains(" ") && f.getName().getAnnotations().isEmpty()) {
                     f = f.withName(f.getName().withPrefix(
                             f.getName().getPrefix().withWhitespace("")
                     ));


### PR DESCRIPTION
## Summary
- Fix `NoWhitespaceAfter` incorrectly removing the space between a type-use annotation and the annotated type in qualified type expressions (e.g. `Cache.@Nullable ValueWrapper` → `Cache.@NullableValueWrapper`)
- Skip whitespace removal in `visitFieldAccess` when the name identifier has annotations, preserving the required separator space

- Closes #6917

## Test plan
- [x] Added test `typeUseAnnotationOnFieldAccess` covering `Cache.@Nullable ValueWrapper` pattern
- [x] All existing `NoWhitespaceAfterTest` tests pass