### PR TITLE
fix: add setup-node for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -42,6 +42,10 @@ jobs:
           distribution: temurin
           java-version: ${{ inputs.java_version }}
 
+      - uses: actions/setup-node@v4
+        with:
+          registry-url: 'https://registry.npmjs.org'
+
       - uses: gradle/actions/setup-gradle@v5
         with:
           develocity-access-key: ${{ secrets.gradle_enterprise_access_key }}


### PR DESCRIPTION
## Summary
- Add `actions/setup-node@v4` with `registry-url` to `npm-publish.yml`
- This configures `~/.npmrc` so npm can perform the OIDC token exchange for trusted publishing
- Without this step, the Gradle NpmTask's `npm publish --provenance` fails with `ENEEDAUTH` because no registry auth is configured

- Fixes the build failure from #6919: https://github.com/openrewrite/rewrite/actions/runs/22921374981/job/66520345807

## Test plan
- [ ] Verify CI snapshot publish succeeds on merge to main