### PR TITLE
fix: decouple npmPublish from Gradle publish task for OIDC-only npm auth

### DIFF
--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -199,26 +199,11 @@ testing {
     }
 }
 
-// This task creates a `.npmrc` file with the given token, so that the `npm publish` succeeds
-// For local development the user would typically have a `~/.npmrc` file with the token in it
-val setupNpmrc = tasks.register("setupNpmrc") {
-    doLast {
-        if (project.hasProperty("nodeAuthToken")) {
-            val npmrcFile = file("rewrite/.npmrc")
-            npmrcFile.writeText("//registry.npmjs.org/:_authToken=${project.property("nodeAuthToken")}\n")
-        }
-    }
-}
-
-// Implicitly `--tag latest` if not specified
+// npm publishing is handled by a dedicated workflow (npm-publish.yml) using OIDC trusted publishing.
+// This task is invoked directly by that workflow, not wired into the main publish task.
 val npmPublish = tasks.register<NpmTask>("npmPublish") {
     inputs.files(npmPack)
         .withPathSensitivity(PathSensitivity.RELATIVE)
-    // Use setupNpmrc only when a token is explicitly provided (local dev);
-    // in CI, npm trusted publishing (OIDC) handles authentication automatically.
-    if (project.hasProperty("nodeAuthToken")) {
-        dependsOn(setupNpmrc)
-    }
 
     args = provider { listOf("publish", npmPack.get().archiveFile.get().asFile.absolutePath, "--provenance", "--access", "public") }
     if (!project.hasProperty("releasing")) {
@@ -226,15 +211,6 @@ val npmPublish = tasks.register<NpmTask>("npmPublish") {
     }
 
     workingDir.set(file("rewrite"))
-}
-
-tasks.named("publish") {
-    // In CI, npm publishing is handled by a dedicated workflow (npm-publish.yml)
-    // for OIDC trusted publishing. Only include npmPublish in the main publish
-    // task for local development or when a token is explicitly provided.
-    if (System.getenv("CI") == null || project.hasProperty("nodeAuthToken")) {
-        dependsOn(npmPublish)
-    }
 }
 
 extensions.configure<LicenseExtension> {


### PR DESCRIPTION
## Summary
- Remove `setupNpmrc` task, `nodeAuthToken` property checks, and `publish` → `npmPublish` dependency from `rewrite-javascript/build.gradle.kts`
- Follows up on #6919 and #6922 — npm publishing now uses OIDC trusted publishing exclusively via the dedicated `npm-publish.yml` workflow

## Root cause
The external `ci-gradle.yml` workflow passes `ORG_GRADLE_PROJECT_nodeAuthToken: ${{ secrets.node_auth_token }}` to the snapshot publish step. Since `rewrite`'s `ci.yml` never provides a `node_auth_token` secret, Gradle receives the property with an empty string value. `project.hasProperty("nodeAuthToken")` returns `true` for empty strings, which wired `npmPublish` into the main `snapshot publish` task graph where OIDC auth isn't available — causing the `ENEEDAUTH` failure.

## What changed
- Removed `setupNpmrc` task (wrote long-lived tokens to `.npmrc` — no longer needed)
- Removed `nodeAuthToken` property checks from `npmPublish`
- Removed `publish` → `npmPublish` dependency (this was the direct cause of the CI failure)
- `npmPublish` task itself is retained for direct invocation by `npm-publish.yml`

## Test plan
- [ ] Verify CI snapshot publish succeeds on merge to main (no more `ENEEDAUTH`)
- [ ] Verify `npm-publish` job succeeds after `build` completes