### PR TITLE
fix: add workflow_dispatch to npm-publish for manual OIDC testing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,13 @@ on:
     secrets:
       gradle_enterprise_access_key:
         required: false
+  workflow_dispatch:
+    inputs:
+      java_version:
+        description: Java version for setup-java
+        type: string
+        required: false
+        default: 21
 
 permissions:
   contents: read
@@ -48,7 +55,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v5
         with:
-          develocity-access-key: ${{ secrets.gradle_enterprise_access_key }}
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
       - name: npm publish
         run: >


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to `npm-publish.yml` so it can be run manually from the Actions UI
- When manually dispatched, publishes with `--tag next` (snapshot behavior)
- Fix Develocity access key secret reference to uppercase so it resolves for both `workflow_call` and `workflow_dispatch`

## Context
OIDC trusted publishing is returning E404 when npm-publish runs via `workflow_call` from ci.yml. Adding manual dispatch lets us test the OIDC flow with `npm-publish.yml` as the direct top-level workflow, which may produce different OIDC claims that match the npm trusted publisher config.

## Test plan
- [ ] Merge to main, then manually trigger npm-publish from Actions UI
- [ ] Verify OIDC trusted publishing succeeds with `--tag next`