### PR TITLE
fix: replace setup-node with manual .npmrc for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -49,9 +49,8 @@ jobs:
           distribution: temurin
           java-version: ${{ inputs.java_version }}
 
-      - uses: actions/setup-node@v4
-        with:
-          registry-url: 'https://registry.npmjs.org'
+      - name: Configure npm registry for OIDC trusted publishing
+        run: echo "registry=https://registry.npmjs.org/" > ~/.npmrc
 
       - uses: gradle/actions/setup-gradle@v5
         with:


### PR DESCRIPTION
## Summary
- Replace `actions/setup-node` with a manual `~/.npmrc` that only sets the registry URL
- Add `workflow_dispatch` trigger for manual testing

## Root cause
`setup-node` with `registry-url` writes `_authToken=${NODE_AUTH_TOKEN}` to `~/.npmrc`. Since `NODE_AUTH_TOKEN` is never set, npm authenticates with an **empty token** instead of using the OIDC trusted publishing flow. The npm registry returns E404.

We verified via the [Sigstore transparency log](https://search.sigstore.dev/?logIndex=1076936493) that the OIDC claims are correct — the issue is that npm never attempts OIDC authentication because it finds a (empty) `_authToken` in `.npmrc` first.

## What changed
- Replaced `setup-node@v4` with `echo "registry=https://registry.npmjs.org/" > ~/.npmrc` — sets registry URL without the `_authToken` line, so npm uses OIDC for auth
- Added `workflow_dispatch` trigger so this can be tested manually from the Actions UI

## Test plan
- [ ] Merge to main, manually trigger npm-publish from Actions UI
- [ ] Verify npm OIDC trusted publishing succeeds with `--tag next`