### PR TITLE
fix: use system npm for publish to support OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -56,8 +56,13 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
-      - name: npm publish
+      - name: npm pack
         run: >
           ./gradlew ${{ env.GRADLE_SWITCHES }}
-          :rewrite-javascript:npmPublish
+          :rewrite-javascript:npmPack
           ${{ inputs.releasing && '-Preleasing' || '' }}
+
+      - name: npm publish
+        run: |
+          TARBALL=$(ls rewrite-javascript/build/distributions/*.tgz)
+          npm publish "$TARBALL" --provenance --access public ${{ inputs.releasing && ' ' || '--tag next' }}


### PR DESCRIPTION
## Summary
- Split npm publish: Gradle packs the tarball, system npm publishes it
- Restore `setup-node` for OIDC support
- Add `workflow_dispatch` for manual testing

## Root cause
The Gradle `NpmTask` uses its own downloaded npm binary (from `node-gradle-plugin`), not the one installed by `setup-node`. Previous attempts showed:
- **With `setup-node`**: OIDC provenance signs correctly, but registry returns E404 on PUT — Gradle's npm doesn't handle OIDC auth properly
- **Without `setup-node`**: ENEEDAUTH — no auth at all

The system npm installed by `setup-node` is the one that properly supports OIDC trusted publishing.

## What changed
Split the workflow into two steps:
1. `./gradlew :rewrite-javascript:npmPack` — Gradle builds and versions the tarball (where it's needed)
2. `npm publish <tarball> --provenance --access public` — system npm handles publish with OIDC auth

## Test plan
- [ ] Merge to main, manually trigger npm-publish from Actions UI
- [ ] Verify OIDC trusted publishing succeeds with `--tag next`