### PR TITLE
fix: use system npm for publish to support OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -49,8 +49,9 @@ jobs:
           distribution: temurin
           java-version: ${{ inputs.java_version }}
 
-      - name: Configure npm registry for OIDC trusted publishing
-        run: echo "registry=https://registry.npmjs.org/" > ~/.npmrc
+      - uses: actions/setup-node@v4
+        with:
+          registry-url: 'https://registry.npmjs.org'
 
       - uses: gradle/actions/setup-gradle@v5
         with:


### PR DESCRIPTION
## Summary
Restore `setup-node` and use system npm for the publish step instead of Gradle's `NpmTask`.

## Root cause
Previous attempts showed:
- Gradle's npm + `setup-node` → OIDC provenance signs, but registry returns E404 on PUT
- System npm without `setup-node` → ENEEDAUTH (no auth at all)

The Gradle `node-gradle-plugin` downloads its own npm binary that doesn't properly handle OIDC trusted publishing auth. `setup-node` is required to configure the OIDC token exchange.

## What changed
- Restore `actions/setup-node@v4` with `registry-url`
- Split workflow: `./gradlew :rewrite-javascript:npmPack` (Gradle builds the tarball), then `npm publish` directly (system npm handles OIDC auth)

## Test plan
- [ ] Merge to main, manually trigger npm-publish from Actions UI
- [ ] Verify OIDC trusted publishing succeeds with `--tag next`