### PR TITLE
fix: use NPM_TOKEN for npm publish authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,4 @@ jobs:
         21
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,8 @@ on:
     secrets:
       gradle_enterprise_access_key:
         required: false
+      npm_token:
+        required: false
   workflow_dispatch:
     inputs:
       java_version:
@@ -67,3 +69,5 @@ jobs:
         run: |
           TARBALL=$(ls rewrite-javascript/build/distributions/*.tgz)
           npm publish "$TARBALL" --provenance --access public ${{ inputs.releasing && ' ' || '--tag next' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token || secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,3 +37,4 @@ jobs:
       releasing: true
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Pass `NPM_TOKEN` secret for npm publish authentication, keeping `--provenance` for supply chain attestation.

## Context
OIDC trusted publishing on npm returns E404 despite correct OIDC claims (verified via [Sigstore transparency log](https://search.sigstore.dev/?logIndex=1077018850)). Using an explicit npm token for auth while keeping `--provenance` for provenance attestation.

## What changed
- `npm-publish.yml`: Accept `npm_token` secret, set as `NODE_AUTH_TOKEN` env var on publish step
- `ci.yml`: Pass `NPM_TOKEN` secret to npm-publish workflow
- `publish.yml`: Pass `NPM_TOKEN` secret to npm-publish workflow

## Prerequisites
- Add `NPM_TOKEN` as a repository secret (granular access token from npmjs.org with publish permission for `@openrewrite/rewrite`)

## Test plan
- [ ] Add NPM_TOKEN secret to repo
- [ ] Merge to main, manually trigger npm-publish from Actions UI
- [ ] Verify publish succeeds with `--tag next`