### PR TITLE
fix: add repository field to package.json for npm provenance

### DIFF
--- a/rewrite-javascript/rewrite/package.json
+++ b/rewrite-javascript/rewrite/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.0",
   "license": "Moderne Source Available License",
   "description": "OpenRewrite JavaScript.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openrewrite/rewrite",
+    "directory": "rewrite-javascript/rewrite"
+  },
   "homepage": "https://github.com/openrewrite/rewrite",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
Add missing `repository` field to `rewrite-javascript/rewrite/package.json`.

## Root cause
npm provenance (`--provenance`) requires `package.json` to have a `repository.url` that matches the GitHub repo from the OIDC claims. Without it, npm returns:

```
E422 - Error verifying sigstore provenance bundle: Failed to validate
repository information: package.json: "repository.url" is "", expected
to match "https://github.com/openrewrite/rewrite" from provenance
```

## What changed
Added to `package.json`:
```json
"repository": {
  "type": "git",
  "url": "https://github.com/openrewrite/rewrite",
  "directory": "rewrite-javascript/rewrite"
}
```

## Test plan
- [ ] Merge to main, manually trigger npm-publish from Actions UI
- [ ] Verify npm publish succeeds with provenance