### PR TITLE
fix: switch npm publish back to OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,3 @@ jobs:
         21
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,8 +17,6 @@ on:
     secrets:
       gradle_enterprise_access_key:
         required: false
-      npm_token:
-        required: false
   workflow_dispatch:
     inputs:
       java_version:
@@ -69,5 +67,3 @@ jobs:
         run: |
           TARBALL=$(ls rewrite-javascript/build/distributions/*.tgz)
           npm publish "$TARBALL" --provenance --access public ${{ inputs.releasing && ' ' || '--tag next' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token || secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,4 +37,3 @@ jobs:
       releasing: true
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Remove `NPM_TOKEN` secret and use OIDC trusted publishing for npm authentication.

## Context
- The earlier E404 from npm was caused by a missing `repository.url` in `package.json` (fixed in #6929), not by OIDC itself. Now that the repository field is present, OIDC trusted publishing should work without a long-lived npm token.

## What changed
- Remove `npm_token` secret from `npm-publish.yml`, `ci.yml`, and `publish.yml`
- Remove `NODE_AUTH_TOKEN` env var from the publish step
- `setup-node` + `--provenance` + `id-token: write` handles both auth and attestation via OIDC

## Test plan
- [ ] Merge to main, manually trigger npm-publish from Actions UI
- [ ] Verify OIDC trusted publishing succeeds with `--tag next`