### PR TITLE
fix: revert OIDC-only npm auth, restore NPM_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,4 @@ jobs:
         21
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,8 @@ on:
     secrets:
       gradle_enterprise_access_key:
         required: false
+      npm_token:
+        required: false
   workflow_dispatch:
     inputs:
       java_version:
@@ -67,3 +69,5 @@ jobs:
         run: |
           TARBALL=$(ls rewrite-javascript/build/distributions/*.tgz)
           npm publish "$TARBALL" --provenance --access public ${{ inputs.releasing && ' ' || '--tag next' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token || secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,3 +37,4 @@ jobs:
       releasing: true
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Revert #6930 to restore `NPM_TOKEN`-based npm authentication.

OIDC trusted publishing continues to return E404 even with the `repository.url` fix. Reverting to token-based auth which was confirmed working.

## Test plan
- [ ] Verify npm publish succeeds on merge to main