### PR TITLE
Replace DeclarativeRecipe ThreadLocal accumulator with cursor-based lookup

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -230,26 +230,30 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new TreeVisitor<Tree, ExecutionContext>() {
+                // Safe to cache: each getVisitor() call creates a new instance, and each
+                // instance is only used by a single thread (RecipeRunCycle processes files
+                // sequentially). Resolved lazily because getCursor() requires the framework
+                // to set the rootCursor first (via setCursor) before isAcceptable/visit.
                 @Nullable
-                TreeVisitor<?, ExecutionContext> p;
+                TreeVisitor<?, ExecutionContext> resolved;
+
+                private TreeVisitor<?, ExecutionContext> resolved(ExecutionContext ctx) {
+                    if (resolved == null) {
+                        resolved = precondition.resolve(getCursor(), ctx);
+                    }
+                    return resolved;
+                }
 
                 @Override
                 public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-                    return resolve(ctx).isAcceptable(sourceFile, ctx);
+                    return resolved(ctx).isAcceptable(sourceFile, ctx);
                 }
 
                 @Override
                 public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
-                    Tree t = resolve(ctx).visit(tree, ctx);
+                    Tree t = resolved(ctx).visit(tree, ctx);
                     preconditionApplicable = t != tree;
                     return tree;
-                }
-
-                private TreeVisitor<?, ExecutionContext> resolve(ExecutionContext ctx) {
-                    if (p == null) {
-                        p = precondition.resolve(getCursor(), ctx);
-                    }
-                    return p;
                 }
             };
         }


### PR DESCRIPTION
## Problem

- PR #6810 changed `DeclarativeRecipe.accumulator` from a plain field to `ThreadLocal<Accumulator>` to fix concurrent recipe runs overwriting each other's accumulator. However, when a recipe run yields and resumes on a different thread, the ThreadLocal value is lost.

The `orVisitors()` method reads the accumulator from the ThreadLocal to resolve scanning precondition visitors. After a thread switch, `accumulator.get()` returns `null`, causing scanning preconditions to receive null accumulators. This affects any `DeclarativeRecipe` that uses a `ScanningRecipe` as a precondition.

## Solution

The accumulator is already stored on the rootCursor by `ScanningRecipe.getAccumulator()`, which is per-run and survives thread switches. The ThreadLocal was redundant secondary storage.

- Remove `ThreadLocal<Accumulator>` entirely
- Defer precondition resolution to visit time when the rootCursor is available (via `setCursor()` set by `RecipeRunCycle`)
- `orVisitors()` reads the accumulator from the cursor via `getAccumulator(rootCursor, ctx)` instead of ThreadLocal
- Remove `onComplete()` ThreadLocal cleanup and simplify `clone()`