### PR TITLE
Fix npm and NuGet version mismatch across CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       java_version: |
         25
         21
+      npm_version: ${{ needs.build.outputs.npm_version }}
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,6 +14,11 @@ on:
         type: boolean
         required: false
         default: false
+      npm_version:
+        description: Exact npm package version to publish (passed from build/release job)
+        type: string
+        required: false
+        default: ''
     secrets:
       gradle_enterprise_access_key:
         required: false
@@ -64,6 +69,7 @@ jobs:
           ./gradlew ${{ env.GRADLE_SWITCHES }}
           :rewrite-javascript:npmPack
           ${{ inputs.releasing && '-Preleasing' || '' }}
+          ${{ inputs.npm_version && format('-PnpmVersion={0}', inputs.npm_version) || '' }}
 
       - name: npm publish
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,7 @@ jobs:
         25
         21
       releasing: true
+      npm_version: ${{ needs.release.outputs.npm_version }}
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       npm_token: ${{ secrets.NPM_TOKEN }}

--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -121,10 +121,21 @@ tasks.withType<Test> {
 // Generate a NuGet-compatible version
 // Snapshots use pre-release suffix with timestamp: 8.73.0-snapshot.20260110143252
 // Releases use clean version: 8.73.0
-val nugetVersion: String = project.version.toString().replace(
-    "-SNAPSHOT",
-    "-snapshot.${LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))}"
-)
+// Read from version.txt first (written by a prior `build` invocation) to ensure the
+// version published to NuGet matches what's baked into the JAR.
+val nugetVersionTxt = file("src/main/resources/META-INF/rewrite-csharp-version.txt")
+val nugetVersion: String = if (System.getenv("CI") != null) {
+    nugetVersionTxt.takeIf { it.exists() }?.readText()?.trim()?.takeIf { it.isNotEmpty() }
+        ?: project.version.toString().replace(
+            "-SNAPSHOT",
+            "-snapshot.${LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))}"
+        )
+} else {
+    project.version.toString().replace(
+        "-SNAPSHOT",
+        "-snapshot.${LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))}"
+    )
+}
 
 val generateVersionTxt by tasks.registering {
     group = "csharp"

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -55,11 +55,14 @@ extensions.configure<NodeExtension> {
     nodeProjectDir.set(projectDir.resolve("rewrite"))
 }
 
-// Read the version from the version.txt written on disk by a prior build, or generate a fresh
-// timestamped version. This ensures the second Gradle invocation (`snapshot publish`) publishes
-// the same version that the first invocation (`build`) baked into the JAR.
+// Determine the npm package version. Priority:
+// 1. Gradle property `npmVersion` (set by CI workflows to pass the version across jobs)
+// 2. version.txt on disk (written by a prior `build` invocation in the same job)
+// 3. Generate a fresh timestamped version from project.version
 val versionTxt = file("src/main/resources/META-INF/rewrite-javascript-version.txt")
-val datedSnapshotVersion: String = if (System.getenv("CI") != null) {
+val datedSnapshotVersion: String = if (project.hasProperty("npmVersion")) {
+    project.property("npmVersion").toString()
+} else if (System.getenv("CI") != null) {
     versionTxt.takeIf { it.exists() }?.readText()?.trim()?.takeIf { it.isNotEmpty() }
         ?: project.version.toString().replace(
             "SNAPSHOT",


### PR DESCRIPTION
## Summary

- Accept `npm_version` input in `npm-publish.yml` and pass it as `-PnpmVersion` Gradle property
- Add `npmVersion` Gradle property support to `rewrite-javascript/build.gradle.kts` (highest priority override)
- Fix `rewrite-csharp/build.gradle.kts` to read from `version.txt` before generating a fresh timestamp (same fix Python/JS already had from 750bc71067)
- Pass `npm_version` from build/release job outputs in `ci.yml` and `publish.yml`

- **Companion PR:** https://github.com/openrewrite/gh-automation/pull/88

## Context

The npm-publish workflow was decoupled into a separate job in 0947a1433b. Since it does a fresh checkout, it loses the version.txt written during build. For the release of `v8.75.3`, this caused npm to publish `8.76.0-20260311-003608` because Nebula computed the next snapshot version without `-Prelease.useLastTag=true`.

The C# NuGet version also had a latent mismatch bug for snapshots — it was never updated with the version.txt-reading fix from 750bc71067 that Python and JS received.

## Test plan

- [ ] Verify snapshot CI publishes matching versions across Maven, PyPI, npm, NuGet
- [ ] Verify release publish uses the correct tag version for all package registries