### PR TITLE
C#: Fix template substitution for method names and variadic args

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/MatchResult.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/MatchResult.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System.Linq;
 using OpenRewrite.Java;
 
 namespace OpenRewrite.CSharp.Template;
@@ -43,10 +44,18 @@ public sealed class MatchResult
 
     /// <summary>
     /// Get a variadic capture result as a list.
+    /// Handles both IReadOnlyList&lt;T&gt; and IReadOnlyList&lt;object&gt; (from pattern matcher).
     /// </summary>
     public IReadOnlyList<T> GetList<T>(string name) where T : class, J
-        => _captures.TryGetValue(name, out var value) && value is IReadOnlyList<T> list
-            ? list : [];
+    {
+        if (!_captures.TryGetValue(name, out var value))
+            return [];
+        if (value is IReadOnlyList<T> typedList)
+            return typedList;
+        if (value is IReadOnlyList<object> objectList)
+            return objectList.Cast<T>().ToList();
+        return [];
+    }
 
     /// <summary>
     /// Check if a capture with the given name was bound.

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
@@ -236,4 +236,93 @@ internal class SubstitutionVisitor : JavaVisitor<int>
         }
         return base.VisitIdentifier(identifier, p);
     }
+
+    public override J VisitMethodInvocation(MethodInvocation mi, int p)
+    {
+        mi = (MethodInvocation)base.VisitMethodInvocation(mi, p);
+
+        // Substitute placeholder in method name position
+        var namePlaceholder = Placeholder.FromPlaceholder(mi.Name.SimpleName);
+        if (namePlaceholder != null && _values.Has(namePlaceholder))
+        {
+            var captured = _values.Get<Identifier>(namePlaceholder);
+            if (captured != null)
+            {
+                mi = mi.WithName(captured.WithPrefix(mi.Name.Prefix));
+            }
+        }
+
+        // Substitute variadic placeholder in arguments
+        mi = ExpandVariadicArgs(mi);
+
+        return mi;
+    }
+
+    public override J VisitFieldAccess(FieldAccess fieldAccess, int p)
+    {
+        fieldAccess = (FieldAccess)base.VisitFieldAccess(fieldAccess, p);
+
+        // Substitute placeholder in field name position
+        var nameIdent = fieldAccess.Name.Element;
+        var namePlaceholder = Placeholder.FromPlaceholder(nameIdent.SimpleName);
+        if (namePlaceholder != null && _values.Has(namePlaceholder))
+        {
+            var captured = _values.Get<Identifier>(namePlaceholder);
+            if (captured != null)
+            {
+                fieldAccess = fieldAccess.WithName(
+                    fieldAccess.Name.WithElement(captured.WithPrefix(nameIdent.Prefix)));
+            }
+        }
+
+        return fieldAccess;
+    }
+
+    /// <summary>
+    /// If any argument is a placeholder identifier bound to a variadic capture (list),
+    /// expand it into the argument list.
+    /// </summary>
+    private MethodInvocation ExpandVariadicArgs(MethodInvocation mi)
+    {
+        var elements = mi.Arguments.Elements;
+        List<JRightPadded<Expression>>? expanded = null;
+
+        for (int i = 0; i < elements.Count; i++)
+        {
+            var arg = elements[i].Element;
+            if (arg is Identifier ident)
+            {
+                var captureName = Placeholder.FromPlaceholder(ident.SimpleName);
+                if (captureName != null && _values.Has(captureName))
+                {
+                    var capturedList = _values.GetList<Expression>(captureName);
+                    if (expanded == null)
+                    {
+                        expanded = new List<JRightPadded<Expression>>();
+                        for (int k = 0; k < i; k++)
+                            expanded.Add(elements[k]);
+                    }
+                    // Expand captured args (may be empty, removing the placeholder)
+                    for (int j = 0; j < capturedList.Count; j++)
+                    {
+                        var capturedArg = capturedList[j];
+                        // First element inherits the placeholder's prefix
+                        if (j == 0)
+                            capturedArg = (Expression)TreeHelper.SetPrefix(capturedArg, ident.Prefix);
+                        expanded.Add(new JRightPadded<Expression>(
+                            capturedArg, Space.Empty, Markers.Empty));
+                    }
+                    continue;
+                }
+            }
+            expanded?.Add(elements[i]);
+        }
+
+        if (expanded != null)
+        {
+            mi = mi.WithArguments(mi.Arguments.WithElements(expanded));
+        }
+
+        return mi;
+    }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TemplateApplyTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TemplateApplyTests.cs
@@ -181,6 +181,68 @@ public class TemplateApplyTests : RewriteTest
         );
     }
 
+    [Fact]
+    public void SubstitutesMethodNameCapture()
+    {
+        var method = Capture.Of<Identifier>("method");
+        var args = Capture.Of<Expression>("args");
+        RewriteRun(
+            spec => spec.SetRecipe(Replace<MethodInvocation>(
+                $"Console.{method}({args})",
+                $"Trace.{method}({args})")),
+            CSharp(
+                "class C { void M() { Console.Write(42); } }",
+                "class C { void M() { Trace.Write(42); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void SubstitutesVariadicArgs()
+    {
+        var args = Capture.Variadic<Expression>("args");
+        RewriteRun(
+            spec => spec.SetRecipe(Replace<MethodInvocation>(
+                $"Foo({args})",
+                $"Bar({args})")),
+            CSharp(
+                "class C { void M() { Foo(1, 2, 3); } }",
+                "class C { void M() { Bar(1, 2, 3); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void SubstitutesMethodNameAndVariadicArgs()
+    {
+        var method = Capture.Of<Identifier>("method");
+        var args = Capture.Variadic<Expression>("args");
+        RewriteRun(
+            spec => spec.SetRecipe(Replace<MethodInvocation>(
+                $"new Random().{method}({args})",
+                $"Random.Shared.{method}({args})")),
+            CSharp(
+                "class C { void M() { new Random().Next(10); } }",
+                "class C { void M() { Random.Shared.Next(10); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void SubstitutesFieldNameCapture()
+    {
+        var field = Capture.Of<Identifier>("field");
+        RewriteRun(
+            spec => spec.SetRecipe(Replace<FieldAccess>(
+                $"DateTime.{field}",
+                $"DateTimeOffset.{field}")),
+            CSharp(
+                "class C { void M() { var x = DateTime.Now; } }",
+                "class C { void M() { var x = DateTimeOffset.Now; } }"
+            )
+        );
+    }
+
     // ===============================================================
     // Recipe factories
     // ===============================================================


### PR DESCRIPTION
## Problem

`CSharpTemplate.Apply()` outputs placeholder names instead of captured values when captures appear in method-name or variadic-argument positions:

```csharp
var method = Capture.Of<Identifier>("method");
var args = Capture.Variadic<Expression>("args");

var pat = CSharpPattern.Create($"new Random().{method}({args})");
var tmpl = CSharpTemplate.Create($"Random.Shared.{method}({args})");
```

When matching `new Random().Next(10)`, the template produces:
```
Random.Shared.__plh_method__(__plh_args__)
```
instead of:
```
Random.Shared.Next(10)
```

## Summary
- Fix `SubstitutionVisitor` to substitute placeholders in method-name positions (`MethodInvocation.Name`) and field-name positions (`FieldAccess.Name`), which the base visitor never visits
- Fix variadic argument expansion: detect variadic capture placeholders in argument lists and replace them with the captured expression list
- Fix `MatchResult.GetList<T>` to handle `IReadOnlyList<object>` (as stored by the pattern matcher) via `Cast<T>()` instead of failing the type check silently
- Handle empty variadic captures by removing the placeholder argument rather than leaving it in the output
- Use `Cast<T>()` instead of `OfType<T>()` to fail fast on type mismatches

## Test plan
- [x] `SubstitutesMethodNameCapture`: pattern captures method name, template substitutes it into a different target
- [x] `SubstitutesVariadicArgs`: variadic capture of multiple args, template substitutes into different method
- [x] `SubstitutesMethodNameAndVariadicArgs`: combined method name + variadic args (`new Random().Next(10)` → `Random.Shared.Next(10)`)
- [x] `SubstitutesFieldNameCapture`: isolated field-name substitution (`DateTime.Now` → `DateTimeOffset.Now`)
- [x] All 95 existing template tests continue to pass