### PR TITLE
C#: Fix `CSharpPattern` variadic capture: zero args, non-trailing position, and min/max bounds

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
@@ -147,51 +147,90 @@ internal class PatternMatchingComparator
 
     /// <summary>
     /// Compare two lists of (potentially padded) elements with variadic support.
-    /// A variadic capture greedily consumes all remaining candidate elements,
-    /// so it must be the last element in the pattern list.
+    /// Uses recursive backtracking so variadic captures can appear at any position.
     /// </summary>
     private bool MatchPaddedList(IList<object> patternElements, IList<object> candidateElements, Cursor cursor)
     {
-        int pi = 0, ci = 0;
-        while (pi < patternElements.Count)
-        {
-            var patternEl = patternElements[pi];
-            var innerPattern = TreeHelper.UnwrapPadded(patternEl) ?? patternEl;
+        return MatchPaddedListRecursive(patternElements, candidateElements, 0, 0, cursor);
+    }
 
-            // Check if this is a variadic capture placeholder
-            if (innerPattern is Identifier patternId)
+    /// <summary>
+    /// Recursive sequence matcher with backtracking for variadic captures.
+    /// Tries greedy consumption (max to min) and backtracks on failure.
+    /// </summary>
+    private bool MatchPaddedListRecursive(
+        IList<object> patternElements, IList<object> candidateElements,
+        int pi, int ci, Cursor cursor)
+    {
+        // All pattern elements matched; ensure no unconsumed candidates remain
+        if (pi >= patternElements.Count)
+            return ci >= candidateElements.Count;
+
+        var patternEl = patternElements[pi];
+        var innerPattern = TreeHelper.UnwrapPadded(patternEl) ?? patternEl;
+
+        // Check if this is a variadic capture placeholder
+        if (innerPattern is Identifier patternId)
+        {
+            var captureName = Placeholder.FromPlaceholder(patternId.SimpleName);
+            if (captureName != null && _captures.TryGetValue(captureName, out var captureObj)
+                && IsVariadic(captureObj))
             {
-                var captureName = Placeholder.FromPlaceholder(patternId.SimpleName);
-                if (captureName != null && _captures.TryGetValue(captureName, out var captureObj)
-                    && IsVariadic(captureObj))
+                var (min, max) = GetVariadicBounds(captureObj);
+
+                // Count non-variadic patterns remaining after this one
+                var nonVariadicRemaining = 0;
+                for (var i = pi + 1; i < patternElements.Count; i++)
                 {
-                    // Variadic: consume remaining elements (may be zero)
-                    var captured = new List<object>();
-                    while (ci < candidateElements.Count)
+                    var inner = TreeHelper.UnwrapPadded(patternElements[i]) ?? patternElements[i];
+                    if (inner is Identifier id)
                     {
-                        var candidateEl = candidateElements[ci];
+                        var name = Placeholder.FromPlaceholder(id.SimpleName);
+                        if (name != null && _captures.TryGetValue(name, out var cap) && IsVariadic(cap))
+                            continue;
+                    }
+                    nonVariadicRemaining++;
+                }
+
+                var remaining = candidateElements.Count - ci;
+                var maxPossible = Math.Min(remaining - nonVariadicRemaining, max);
+
+                // Greedy: try from max to min
+                for (var consume = maxPossible; consume >= min; consume--)
+                {
+                    var captured = new List<object>();
+                    for (var k = 0; k < consume; k++)
+                    {
+                        var candidateEl = candidateElements[ci + k];
                         var innerCandidate = TreeHelper.UnwrapPadded(candidateEl) ?? candidateEl;
                         captured.Add(innerCandidate);
-                        ci++;
                     }
+
+                    // Save bindings for backtracking
+                    var savedBindings = new Dictionary<string, object>(_bindings);
                     _bindings[captureName] = captured.AsReadOnly();
-                    pi++;
-                    continue;
+
+                    if (MatchPaddedListRecursive(patternElements, candidateElements, pi + 1, ci + consume, cursor))
+                        return true;
+
+                    // Backtrack
+                    _bindings.Clear();
+                    foreach (var kvp in savedBindings)
+                        _bindings[kvp.Key] = kvp.Value;
                 }
+
+                return false;
             }
-
-            // Non-variadic: need a candidate element to match against
-            if (ci >= candidateElements.Count)
-                return false;
-
-            if (!MatchValue(patternEl, candidateElements[ci], cursor))
-                return false;
-            pi++;
-            ci++;
         }
 
-        // All pattern elements matched; ensure no unconsumed candidates remain
-        return ci == candidateElements.Count;
+        // Non-variadic: need a candidate element to match against
+        if (ci >= candidateElements.Count)
+            return false;
+
+        if (!MatchValue(patternEl, candidateElements[ci], cursor))
+            return false;
+
+        return MatchPaddedListRecursive(patternElements, candidateElements, pi + 1, ci + 1, cursor);
     }
 
     /// <summary>
@@ -214,6 +253,16 @@ internal class PatternMatchingComparator
     {
         var prop = captureObj.GetType().GetProperty("IsVariadic");
         return prop != null && (bool)(prop.GetValue(captureObj) ?? false);
+    }
+
+    private static (int min, int max) GetVariadicBounds(object captureObj)
+    {
+        var type = captureObj.GetType();
+        var minProp = type.GetProperty("MinCount");
+        var maxProp = type.GetProperty("MaxCount");
+        var min = minProp?.GetValue(captureObj) as int? ?? 0;
+        var max = maxProp?.GetValue(captureObj) as int? ?? int.MaxValue;
+        return (min, max);
     }
 
     private static bool IsRightPadded(object value)

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/PatternMatchTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/PatternMatchTests.cs
@@ -811,6 +811,46 @@ public class PatternMatchTests : RewriteTest
     }
 
     [Fact]
+    public void VariadicCaptureInNonTrailingPosition()
+    {
+        var args = Capture.Variadic<Expression>("args");
+        var last = Capture.Of<Expression>("last");
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation($"Foo({args}, {last})")),
+            CSharp(
+                "class C { void M() { Foo(1, 2, 3); } }",
+                "class C { void M() { /*~~>*/Foo(1, 2, 3); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void VariadicCaptureWithMinBoundRejectsFewerArgs()
+    {
+        var args = Capture.Variadic<Expression>("args", min: 2);
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation($"Foo({args})")),
+            CSharp(
+                // Only 1 arg — min is 2, should NOT match
+                "class C { void M() { Foo(1); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void VariadicCaptureWithMaxBoundRejectsMoreArgs()
+    {
+        var args = Capture.Variadic<Expression>("args", max: 1);
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation($"Foo({args})")),
+            CSharp(
+                // 3 args — max is 1, should NOT match
+                "class C { void M() { Foo(1, 2, 3); } }"
+            )
+        );
+    }
+
+    [Fact]
     public void ConsistentCaptureBindingMatchesWhenSame()
     {
         var expr = Capture.Of<Expression>("expr");

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TemplateApplyTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TemplateApplyTests.cs
@@ -245,6 +245,22 @@ public class TemplateApplyTests : RewriteTest
     }
 
     [Fact]
+    public void SubstitutesVariadicArgsInNonTrailingPosition()
+    {
+        var args = Capture.Variadic<Expression>("args");
+        var last = Capture.Of<Expression>("last");
+        RewriteRun(
+            spec => spec.SetRecipe(Replace<MethodInvocation>(
+                $"Foo({args}, {last})",
+                $"Bar({last}, {args})")),
+            CSharp(
+                "class C { void M() { Foo(1, 2, 3); } }",
+                "class C { void M() { Bar(3, 1, 2); } }"
+            )
+        );
+    }
+
+    [Fact]
     public void SubstitutesFieldNameCapture()
     {
         var field = Capture.Of<Identifier>("field");


### PR DESCRIPTION
## What's now possible

Previously, `Capture.Variadic` only matched **one or more** arguments and had to be the **last** element in the pattern. These patterns now work:

```csharp
// Match methods with zero arguments (e.g., NextDouble())
var method = Capture.Of<Identifier>("method");
var args = Capture.Variadic<Expression>("args");
var pattern = CSharpPattern.Create($"new Random().{method}({args})");
// ✅ Matches: new Random().NextDouble()   — args binds to []
// ✅ Matches: new Random().Next(10)       — args binds to [10]

// Variadic capture in non-trailing position
var args = Capture.Variadic<Expression>("args");
var last = Capture.Of<Expression>("last");
var pattern = CSharpPattern.Create($"Foo({args}, {last})");
// ✅ Matches: Foo(1, 2, 3)  — args binds to [1, 2], last binds to 3

// Min/max bounds
var args = Capture.Variadic<Expression>("args", min: 2, max: 5);
// ❌ Rejects: Foo(1)         — fewer than min
// ❌ Rejects: Foo(1,2,3,4,5,6) — more than max
```

## Summary

- `Capture.Variadic<Expression>("args")` now correctly matches zero arguments, consistent with `*` (zero or more) semantics
- Variadic captures can appear at any position in the pattern, not just trailing — matching the JS `PatternMatchingComparator` behavior
- `MinCount`/`MaxCount` bounds from `Capture.Variadic` are now respected during matching
- Replaced the greedy-consume-all loop with recursive backtracking that tries consumption amounts from max to min, saving/restoring bindings on failure

## Test plan

- [x] `PatternMatchTests.VariadicCaptureMatchesZeroArguments` — zero args
- [x] `PatternMatchTests.VariadicCaptureInNonTrailingPosition` — variadic followed by non-variadic capture
- [x] `PatternMatchTests.VariadicCaptureWithMinBoundRejectsFewerArgs` — `min: 2` rejects 1 arg
- [x] `PatternMatchTests.VariadicCaptureWithMaxBoundRejectsMoreArgs` — `max: 1` rejects 3 args
- [x] `TemplateApplyTests.SubstitutesMethodNameAndVariadicArgsWithZeroArgs` — match-and-replace with `NextDouble()`
- [x] `TemplateApplyTests.SubstitutesVariadicArgsInNonTrailingPosition` — `Foo(1,2,3)` → `Bar(3,1,2)` with reordered captures
- [x] All 85 pattern/template/capture tests pass with no regressions