### PR TITLE
Fix C# RPC: `RecipeDescriptor` alignment

### DIFF
--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -351,10 +351,8 @@ public class CSharpRewriteRpc extends RewriteRpc {
             return Stream.of(
                     dotnetPath.toString(),
                     "run",
-                    "--no-build",
                     "--project", csproj.toAbsolutePath().normalize().toString(),
                     "--framework", "net10.0",
-                    "--",
                     log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
                     traceRpcMessages ? "--trace-rpc-messages" : null
             );


### PR DESCRIPTION
## Summary
- **RecipeDescriptorDto alignment**: Added missing fields (`instanceName`, `preconditions`, `dataTables`, `maintainers`, `contributors`, `examples`) and fixed null collections that caused NPEs in `RecipeMarketplaceWriter`
- **PrepareRecipeResponse**: Added typed `Precondition` class with `VisitorName` and `VisitorOptions`, plus `EditPreconditions`/`ScanPreconditions` fields
- **Scanning recipe support**: Implemented full `Generate` RPC method with reflection-based dispatch for `ScanningRecipe<T>` (any generic type, not just `object`), accumulator caching across scan/generate/edit phases, and `ExecutionContext` reuse
- **ScanVisitor detection**: Fixed `PrepareRecipe` to use `GetScanningRecipeBase()` reflection instead of `is ScanningRecipe<object>` check
- **RpcSendQueue.ToJavaTypeName**: Changed from `private` to `internal` for use in `Generate` response
- **Semver.max() overflow**: Use `Long.parseLong` instead of `Integer.parseInt` for version segments exceeding `Integer.MAX_VALUE`

## Test plan
- [ ] Run `mod config recipes nuget install OpenRewrite.MigrateCSharp@` with `REWRITE_SOURCE_PATH` set
- [ ] Verify recipes are listed via `mod config recipes list`
- [ ] Verify `Semver.max()` handles version segments > Integer.MAX_VALUE (covered by unit tests)