### PR TITLE
C#: Fix RPC receiver for brand-new trees from Java

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
@@ -195,19 +195,21 @@ public class CSharpReceiver : CSharpVisitor<RpcReceiveQueue>
         q.Receive<object?>(null);
         // Externs: empty list
         q.ReceiveList<JRightPadded<Statement>>([], rp => _delegate.VisitRightPadded(rp, q));
+        // Members may be null when receiving a brand-new tree (ADD via GetUninitializedObject)
+        var existingMembers = cu.Members ?? [];
         // Usings
         var usings = q.ReceiveList(
-            cu.Members.Where(m => m is UsingDirective)
+            existingMembers.Where(m => m is UsingDirective)
                 .Select(m => new JRightPadded<Statement>(m, Space.Empty, Markers.Empty))
                 .ToList(),
             rp => _delegate.VisitRightPadded(rp, q));
         // AttributeLists
         var attrLists = q.ReceiveList(
-            cu.Members.OfType<AttributeList>().ToList(),
+            existingMembers.OfType<AttributeList>().ToList(),
             t => (AttributeList)VisitNonNull(t, q));
         // Members (non-using, non-attributelist)
         var members = q.ReceiveList(
-            cu.Members.Where(m => m is not UsingDirective && m is not AttributeList)
+            existingMembers.Where(m => m is not UsingDirective && m is not AttributeList)
                 .Select(m => new JRightPadded<Statement>(m, Space.Empty, Markers.Empty))
                 .ToList(),
             rp => _delegate.VisitRightPadded(rp, q));
@@ -461,13 +463,15 @@ public class CSharpReceiver : CSharpVisitor<RpcReceiveQueue>
         var name = q.Receive(ns.Name, rp => _delegate.VisitRightPadded(rp, q));
         // Externs
         q.ReceiveList<JRightPadded<Statement>>([], rp => _delegate.VisitRightPadded(rp, q));
+        // Members may be null when receiving a brand-new tree (ADD via GetUninitializedObject)
+        var existingNsMembers = ns.Members ?? [];
         // Usings
         var usings = q.ReceiveList(
-            ns.Members.Where(m => m.Element is UsingDirective).ToList(),
+            existingNsMembers.Where(m => m.Element is UsingDirective).ToList(),
             rp => _delegate.VisitRightPadded(rp, q));
         // Members
         var members = q.ReceiveList(
-            ns.Members.Where(m => m.Element is not UsingDirective).ToList(),
+            existingNsMembers.Where(m => m.Element is not UsingDirective).ToList(),
             rp => _delegate.VisitRightPadded(rp, q));
         var end = q.Receive(ns.End, space => VisitSpace(space, q));
 
@@ -496,12 +500,13 @@ public class CSharpReceiver : CSharpVisitor<RpcReceiveQueue>
     // ---- ConditionalDirective ----
     public override J VisitConditionalDirective(ConditionalDirective cd, RpcReceiveQueue q)
     {
-        // Receive DirectiveLines
-        var count = q.Receive<int>(cd.DirectiveLines.Count);
+        // Receive DirectiveLines (may be null for brand-new trees)
+        var existingDirectiveLines = cd.DirectiveLines ?? [];
+        var count = q.Receive<int>(existingDirectiveLines.Count);
         var directiveLines = new List<DirectiveLine>();
         for (int i = 0; i < count; i++)
         {
-            var existing = i < cd.DirectiveLines.Count ? cd.DirectiveLines[i] : null;
+            var existing = i < existingDirectiveLines.Count ? existingDirectiveLines[i] : null;
             var lineNumber = q.Receive<int>(existing?.LineNumber ?? 0);
             var text = q.Receive<string>(existing?.Text ?? "")!;
             var kind = (PreprocessorDirectiveKind)q.Receive<int>((int)(existing?.Kind ?? 0));

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
@@ -226,6 +226,10 @@ public class RpcReceiveQueue
         if (typeof(T) == typeof(bool) && value is IConvertible bc)
             return (T)(object)bc.ToBoolean(null);
 
+        // Enum values arrive as strings from Java (via StringEnumConverter)
+        if (typeof(T).IsEnum && value is string enumStr)
+            return (T)Enum.Parse(typeof(T), enumStr);
+
         return (T)value;
     }
 
@@ -248,6 +252,9 @@ public class RpcReceiveQueue
             return (T)(object)je.GetInt64();
         if (underlyingType == typeof(double))
             return (T)(object)je.GetDouble();
+
+        if (underlyingType.IsEnum && je.ValueKind == JsonValueKind.String)
+            return (T)Enum.Parse(underlyingType, je.GetString()!);
 
         if (je.ValueKind == JsonValueKind.String)
             return (T)(object)je.GetString()!;
@@ -348,9 +355,7 @@ public class RpcReceiveQueue
 
     private static bool IsTreeType(object obj)
     {
-        var type = obj.GetType();
-        var ns = type.Namespace;
-        return ns != null && (ns.StartsWith("OpenRewrite.Java") || ns.StartsWith("OpenRewrite.CSharp"));
+        return obj is Tree;
     }
 
     /// <summary>
@@ -478,7 +483,8 @@ public class RpcReceiveQueue
 
     private static Type? FindType(string ns, string name)
     {
-        var fullName = $"{ns}.{name}";
+        // Java uses '$' for nested types, .NET uses '+'
+        var fullName = $"{ns}.{name.Replace('$', '+')}";
         // Search in all loaded assemblies
         foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
         {


### PR DESCRIPTION
## Summary

When receiving trees never previously seen by the C# side (ADD state via `GetUninitializedObject`), several receiver bugs surface:

- **Null collection guards**: `Members` and `DirectiveLines` are null on uninitialized objects — added `?? []` guards in `VisitCompilationUnit`, `VisitNamespaceDeclaration`, and `VisitConditionalDirective`
- **Enum deserialization**: Java sends enums as strings via `StringEnumConverter`, but `ExtractValue<T>` and `ExtractFromJsonElement<T>` had no string→enum conversion — added `Enum.Parse` handling
- **`IsTreeType` fix**: Was using namespace prefix heuristic (`ns.StartsWith("OpenRewrite.Java")`) which incorrectly matched enums like `ModifierType` — changed to `obj is Tree`
- **Nested type mapping**: Java uses `$` for nested types (e.g., `J$ClassDeclaration$Kind`) but .NET uses `+` — added `$` → `+` conversion in `FindType`

## Test plan

- [ ] Verify C# RPC server can receive brand-new trees from Java (scanning recipe generate flow)
- [ ] Verify enum fields like `ModifierType` deserialize correctly
- [ ] Verify nested types like `ClassDeclaration.Kind` resolve correctly