### PR TITLE
Use long in Semver.max() for large version segments

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
@@ -115,18 +115,18 @@ public class Semver {
             return version1.compareTo(version2) >= 0 ? version1 : version2;
         }
         try {
-            int maj1 = Integer.parseInt(major1);
-            int maj2 = Integer.parseInt(major2);
+            long maj1 = Long.parseLong(major1);
+            long maj2 = Long.parseLong(major2);
             if (maj1 != maj2) return maj1 > maj2 ? version1 : version2;
 
-            int min1 = Integer.parseInt(minor1);
-            int min2 = Integer.parseInt(minor2);
+            long min1 = Long.parseLong(minor1);
+            long min2 = Long.parseLong(minor2);
             if (min1 != min2) return min1 > min2 ? version1 : version2;
 
             String[] parts1 = version1.split("[.-]");
             String[] parts2 = version2.split("[.-]");
-            int patch1 = parts1.length > 2 && parts1[2].matches("\\d+") ? Integer.parseInt(parts1[2]) : 0;
-            int patch2 = parts2.length > 2 && parts2[2].matches("\\d+") ? Integer.parseInt(parts2[2]) : 0;
+            long patch1 = parts1.length > 2 && parts1[2].matches("\\d+") ? Long.parseLong(parts1[2]) : 0;
+            long patch2 = parts2.length > 2 && parts2[2].matches("\\d+") ? Long.parseLong(parts2[2]) : 0;
             if (patch1 != patch2) return patch1 > patch2 ? version1 : version2;
 
             String label1 = parts1.length > 3 ? parts1[3].toLowerCase() : "";

--- a/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
@@ -94,7 +94,8 @@ class LatestPatchTest {
     @Test
     void overflowingVersionSegment() {
         // Version numbers that exceed Integer.MAX_VALUE should not throw NumberFormatException
-        assertThat(latestPatch.isValid("202302104298", "202302104299")).isFalse();
+        assertThat(latestPatch.isValid("1.202302104298", "1.202302104298")).isTrue();
+        assertThat(latestPatch.isValid("1.202302104298", "1.202302104298.1")).isTrue();
         assertThat(latestPatch.isValid("1.202302104298", "1.202302104299")).isFalse();
     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/semver/SemverTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/SemverTest.java
@@ -79,5 +79,9 @@ class SemverTest {
         assertThat(Semver.max("INVALID-2023.1.0.3", "1.0.2")).isEqualTo("1.0.2");
         assertThat(Semver.max("1.0.2", "INVALID-2023.1.0.3")).isEqualTo("1.0.2");
         assertThat(Semver.max("123456-fix-something-SNAPSHOT", "123456-fix-something-SNAPSHOT")).isEqualTo("123456-fix-something-SNAPSHOT");
+
+        // Version segments exceeding Integer.MAX_VALUE should not throw
+        assertThat(Semver.max("1.202302104298", "1.202302104299")).isEqualTo("1.202302104299");
+        assertThat(Semver.max("202302104298.0.0", "202302104299.0.0")).isEqualTo("202302104299.0.0");
     }
 }


### PR DESCRIPTION
- Follow-up to #6944. Completes the int-to-long migration in the semver package.

`TildeRange`, `CaretRange`, and `LatestRelease.compare()` already use `long`; `Semver.max()` was the last method using `Integer.parseInt`, which would throw `NumberFormatException` for date-based version segments like `202302104298`.