### PR TITLE
Python: Fixing cross-module recipe calls

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -925,6 +925,14 @@ _recipe_phases: Dict[str, str] = {}
 _data_table_output_dir: Optional[str] = None
 
 
+def _install_sub_recipes(recipe, marketplace) -> None:
+    """Ensure sub-recipes from recipe_list() are registered in the marketplace."""
+    for sub_recipe in recipe.recipe_list():
+        if not marketplace.find_recipe(sub_recipe.name):
+            marketplace.install(type(sub_recipe), [])
+            _install_sub_recipes(sub_recipe, marketplace)
+
+
 def handle_prepare_recipe(params: dict) -> dict:
     """Handle a PrepareRecipe RPC request.
 
@@ -974,6 +982,8 @@ def handle_prepare_recipe(params: dict) -> dict:
     # Generate a unique ID for this prepared recipe
     prepared_id = generate_id()
     _prepared_recipes[prepared_id] = recipe
+
+    _install_sub_recipes(recipe, marketplace)
 
     # Build the response
     descriptor = recipe.descriptor()

--- a/rewrite-python/rewrite/tests/test_marketplace.py
+++ b/rewrite-python/rewrite/tests/test_marketplace.py
@@ -23,6 +23,7 @@ from rewrite import (
     categorize,
     get_recipe_category,
     activate,
+    Recipe,
 )
 from rewrite.python.recipes import RemovePass, Cleanup
 
@@ -157,6 +158,48 @@ class TestActivate:
             (c for c in categories if c.descriptor.display_name == "Python"), None
         )
         assert python_cat is not None
+
+
+class _UnregisteredRecipe(Recipe):
+    @property
+    def name(self): return "org.openrewrite.python.test.Unregistered"
+    @property
+    def display_name(self): return "Unregistered"
+    @property
+    def description(self): return "A recipe not registered in the marketplace."
+
+
+class _CrossModuleRecipeList(Recipe):
+    @property
+    def name(self): return "org.openrewrite.python.test.CrossModuleRecipeList"
+    @property
+    def display_name(self): return "Cross-module recipe list"
+    @property
+    def description(self): return "A recipe that delegates to an unregistered sub-recipe."
+    def recipe_list(self):
+        return [_UnregisteredRecipe()]
+
+
+class TestInstallSubRecipes:
+    """Tests for cross-module sub-recipe installation during PrepareRecipe."""
+
+    def test_sub_recipes_installed_on_prepare(self):
+        """Preparing a recipe auto-installs its sub-recipes so they can be prepared later."""
+        import rewrite.rpc.server as server
+
+        # given
+        marketplace = RecipeMarketplace()
+        marketplace.install(_CrossModuleRecipeList, Python)
+        saved = server._marketplace
+        server._marketplace = marketplace
+        try:
+            # when
+            server.handle_prepare_recipe({'id': 'org.openrewrite.python.test.CrossModuleRecipeList'})
+
+            # then
+            server.handle_prepare_recipe({'id': 'org.openrewrite.python.test.Unregistered'})
+        finally:
+            server._marketplace = saved
 
 
 class TestPythonCategory:


### PR DESCRIPTION
## What's changed?

When preparing a recipe, making sure it's subrecipes (from recipeList) are installed too.

## What's your motivation?

Python counterpart of #6894.
