### PR TITLE
AddDependency: tests showing version update inconsistency with test sources

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -229,10 +229,16 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                     for (ResolvedDependency d : dependencies.get(Scope.Compile)) {
                         if (hasAcceptableTransitivity(d, acc) &&
                             groupId.equals(d.getGroupId()) &&
-                            artifactId.equals(d.getArtifactId()) &&
-                            (d.isTransitive() ||
-                                    (d.isDirect() && version.equals(d.getVersion())))
-                        ) {
+                            artifactId.equals(d.getArtifactId())) {
+                            if (d.isTransitive() || (d.isDirect() && version.equals(d.getVersion()))) {
+                                return maven;
+                            }
+                            if (d.isDirect() && (scope == null || Scope.fromName(scope) == Scope.Compile)) {
+                                // Direct compile-scope dependency at a different version — update keeping compile scope
+                                return new AddDependencyVisitor(
+                                        groupId, artifactId, version, versionPattern, null, releasesOnly,
+                                        type, classifier, optional, familyPatternCompiled, metadataFailures).visitNonNull(document, ctx);
+                            }
                             return maven;
                         }
                     }
@@ -243,7 +249,9 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                 if ((resolvedScopeEnum == Scope.Provided || resolvedScopeEnum == Scope.Test) && dependencies.get(resolvedScopeEnum) != null) {
                     for (ResolvedDependency d : dependencies.get(resolvedScopeEnum)) {
                         if (hasAcceptableTransitivity(d, acc) &&
-                                groupId.equals(d.getGroupId()) && artifactId.equals(d.getArtifactId())) {
+                                groupId.equals(d.getGroupId()) && artifactId.equals(d.getArtifactId()) &&
+                                (d.isTransitive() ||
+                                        (d.isDirect() && version.equals(d.getVersion())))) {
                             return maven;
                         }
                     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -2261,6 +2261,82 @@ class AddDependencyTest implements RewriteTest {
         );
     }
 
+    @Test
+    void existingDependencyUpdatedWithMainSources() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:30.0-jre", null)),
+          mavenProject("project",
+            srcMainJava(
+              java("public class A {}")
+            ),
+            pomXml(
+              """
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                            <version>29.0-jre</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              """
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                            <version>30.0-jre</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void existingDependencyNotUpdatedWithTestSourcesOnly() {
+        // BUG: With only test sources present, the resolved scope becomes "test".
+        // The test/provided scope check in AddDependency (lines 243-250) matches on
+        // groupId + artifactId only, WITHOUT checking the version — so it returns early
+        // and the dependency is never updated. The compile scope check (lines 228-239)
+        // DOES include a version check, which is why the update works with srcMainJava.
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:30.0-jre", null)),
+          mavenProject("project",
+            srcTestJava(
+              java("public class A {}")
+            ),
+            pomXml(
+              """
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                            <version>29.0-jre</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+              // No "after" — the dependency is NOT updated (this documents the bug)
+            )
+          )
+        );
+    }
+
     private AddDependency addDependency(@SuppressWarnings("SameParameterValue") String gav) {
         return addDependency(gav, null, null, null);
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -2304,12 +2304,7 @@ class AddDependencyTest implements RewriteTest {
     }
 
     @Test
-    void existingDependencyNotUpdatedWithTestSourcesOnly() {
-        // BUG: With only test sources present, the resolved scope becomes "test".
-        // The test/provided scope check in AddDependency (lines 243-250) matches on
-        // groupId + artifactId only, WITHOUT checking the version — so it returns early
-        // and the dependency is never updated. The compile scope check (lines 228-239)
-        // DOES include a version check, which is why the update works with srcMainJava.
+    void existingDependencyUpdatedWithTestSourcesOnly() {
         rewriteRun(
           spec -> spec.recipe(addDependency("com.google.guava:guava:30.0-jre", null)),
           mavenProject("project",
@@ -2330,8 +2325,21 @@ class AddDependencyTest implements RewriteTest {
                         </dependency>
                     </dependencies>
                 </project>
+                """,
+              """
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                            <version>30.0-jre</version>
+                        </dependency>
+                    </dependencies>
+                </project>
                 """
-              // No "after" — the dependency is NOT updated (this documents the bug)
             )
           )
         );


### PR DESCRIPTION
## Summary

- Fixes #6962

`AddDependency` with `onlyIfUsing=null` did not update an existing dependency's version when only test sources were present. This happened because:

1. The **compile scope check** (lines 228-239) found the dependency at a different version and fell through (correct)
2. The **test/provided scope check** (lines 243-250) then matched on groupId + artifactId **without checking the version**, causing an early return that skipped the update
3. Even if the test/provided check was bypassed, `AddDependencyVisitor` would block the change as a "scope reduction" (compile → test)

### Fix

- The compile scope check now handles version updates directly when the dependency is direct and the recipe scope is unspecified or compile, calling `AddDependencyVisitor` with compile scope
- When the recipe explicitly requests a narrower scope (e.g. runtime), the existing behavior is preserved: the compile-scope dep is considered sufficient
- The test/provided scope check now includes a version comparison, matching the compile scope check behavior, for dependencies exclusively in those scopes

## Test plan

- [x] `existingDependencyUpdatedWithMainSources` — compile scope, version bumps from 29.0-jre → 30.0-jre
- [x] `existingDependencyUpdatedWithTestSourcesOnly` — test scope (only srcTestJava), version now correctly bumps from 29.0-jre → 30.0-jre
- [x] All 49 existing `AddDependencyTest` cases pass, including `addDependencyDoesntAddWhenExistingDependencyWithBroaderScope` (explicit `scope="runtime"` with compile dep — no changes)