### PR TITLE
Add Reset JSON-RPC handler to JS and C# RPC servers

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -952,6 +952,45 @@ public class RewriteRpcServer
     }
 
     /// <summary>
+    /// JSON-RPC handler and public API for resetting all cached state.
+    /// When called via JSON-RPC from the remote process, clears local caches.
+    /// When called directly (e.g., from test infrastructure), also sends Reset
+    /// to the remote process to clear its caches.
+    /// </summary>
+    [JsonRpcMethod("Reset")]
+    public Task<bool> Reset()
+    {
+        ClearLocalState();
+        return Task.FromResult(true);
+    }
+
+    /// <summary>
+    /// Resets all cached state in both the local and remote RPC processes.
+    /// Call between operations that don't share state (e.g., between tests)
+    /// to prevent unbounded memory growth from accumulated objects.
+    /// </summary>
+    [JsonRpcIgnore]
+    public void ResetAll()
+    {
+        // Send reset to remote process (which clears its caches)
+        _jsonRpc!.InvokeWithParameterObjectAsync<bool>("Reset", new { }).GetAwaiter().GetResult();
+
+        // Clear local caches
+        ClearLocalState();
+    }
+
+    private void ClearLocalState()
+    {
+        _localObjects.Clear();
+        _remoteObjects.Clear();
+        _localRefs.Clear();
+        _remoteRefs.Clear();
+        _preparedRecipes.Clear();
+        _recipeAccumulators.Clear();
+        _executionContexts.Clear();
+    }
+
+    /// <summary>
     /// Stores a tree in the local object cache so Java can fetch it via GetObject.
     /// </summary>
     internal void StoreLocalObject(string id, object obj) => _localObjects[id] = obj;

--- a/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
+++ b/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
@@ -106,6 +106,19 @@ export class RewriteRpc {
             }
         )
 
+        this.connection.onRequest(
+            new rpc.RequestType0<boolean, Error>("Reset"),
+            async () => {
+                this.localObjects.clear();
+                this.localObjectIds.clear();
+                this.remoteObjects.clear();
+                this.remoteRefs.clear();
+                this.localRefs.clear();
+                preparedRecipes.clear();
+                return true;
+            }
+        )
+
         RewriteRpc.set(this);
         this.connection.listen();
     }
@@ -311,5 +324,10 @@ class IdentityMap {
         } else {
             return this.primitiveMap.has(key);
         }
+    }
+
+    clear(): void {
+        this.objectMap = new WeakMap<any, string>();
+        this.primitiveMap.clear();
     }
 }


### PR DESCRIPTION
## Summary
- Added `Reset` JSON-RPC handler to the JavaScript RPC server (`rewrite-rpc.ts`) that clears all cached state: `localObjects`, `localObjectIds`, `remoteObjects`, `remoteRefs`, `localRefs`, and `preparedRecipes`
- Added `clear()` method to `IdentityMap` (needed because `WeakMap` has no native `clear()`)
- Added `Reset` / `ResetAll` / `ClearLocalState` to the C# RPC server, matching the same pattern
- Python already had this handler — no changes needed there

## Test plan
- [ ] Verify JS typecheck passes (`npm run typecheck` in `rewrite-javascript/rewrite/`)
- [ ] Run C# RPC tests to confirm reset behavior
- [ ] Confirm Java peer can successfully call Reset on JS and C# RPC servers between test operations