### PR TITLE
C#: Wire auto-format into template engine via RoslynFormatter

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CSharpTemplate.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CSharpTemplate.cs
@@ -114,6 +114,9 @@ public sealed class CSharpTemplate
                 CSharpCoordinates.Replace(cursorValue));
         }
 
+        // Phase 3: auto-format within the enclosing compilation unit
+        tree = TemplateEngine.AutoFormat(tree, cursor);
+
         return tree;
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
@@ -15,6 +15,7 @@
  */
 using System.Collections.Concurrent;
 using OpenRewrite.Core;
+using OpenRewrite.CSharp.Format;
 using OpenRewrite.Java;
 
 namespace OpenRewrite.CSharp.Template;
@@ -190,6 +191,51 @@ internal static class TemplateEngine
         return TreeHelper.SetPrefix(replacement, original.Prefix);
     }
 
+    /// <summary>
+    /// Auto-format the template result in a scratch copy of the enclosing compilation unit.
+    /// Inserts the template result into a local copy of the CU (replacing the original node),
+    /// formats with Roslyn, and extracts the formatted result.
+    /// </summary>
+    internal static J AutoFormat(J tree, Cursor cursor)
+    {
+        var cu = cursor.FirstEnclosing<CompilationUnit>();
+        if (cu == null)
+            return tree;
+
+        // The cursor's value is the original node being replaced
+        if (cursor.Value is not J original)
+            return tree;
+
+        // Assign a fresh ID so FindById targets exactly this instance,
+        // not a stale node from a prior application of the same template
+        tree = TreeHelper.SetId(tree, Guid.NewGuid());
+
+        // Replace the original node with the template result in the CU
+        var replacer = new NodeReplacer(original.Id, tree);
+        replacer.Cursor = new Cursor(null, Cursor.ROOT_VALUE);
+        var modifiedCu = replacer.VisitNonNull(cu, 0) as CompilationUnit;
+        if (modifiedCu == null || ReferenceEquals(modifiedCu, cu))
+            return tree;
+
+        // Format the modified CU, scoped to the new subtree
+        var formattedCu = RoslynFormatter.Format(modifiedCu, targetSubtree: tree, stopAfter: null);
+
+        // If formatting didn't change anything, return as-is
+        if (ReferenceEquals(formattedCu, modifiedCu))
+            return tree;
+
+        // Find the formatted tree node by ID
+        return FindById(formattedCu, tree.Id) ?? tree;
+    }
+
+    private static J? FindById(J root, Guid targetId)
+    {
+        var finder = new IdFinder(targetId);
+        finder.Cursor = new Cursor(null, Cursor.ROOT_VALUE);
+        finder.Visit(root, 0);
+        return finder.Result;
+    }
+
     private static string BuildCacheKey(string code, IReadOnlyList<string> usings,
         IReadOnlyList<string> context)
     {
@@ -207,6 +253,48 @@ internal static class TemplateEngine
             sb.Append(string.Join(",", context));
         }
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Visitor that replaces a node by ID with a replacement node.
+    /// Short-circuits after the replacement is made to avoid visiting remaining subtrees.
+    /// </summary>
+    private class NodeReplacer(Guid targetId, J replacement) : CSharpVisitor<int>
+    {
+        private bool _found;
+
+        protected override J? Accept(J tree, int p)
+        {
+            if (_found)
+                return tree;
+            if (tree.Id == targetId)
+            {
+                _found = true;
+                return replacement;
+            }
+            return base.Accept(tree, p);
+        }
+    }
+
+    /// <summary>
+    /// Visitor that finds a node by ID in a tree.
+    /// Short-circuits after the target is found to avoid visiting remaining subtrees.
+    /// </summary>
+    private class IdFinder(Guid targetId) : CSharpVisitor<int>
+    {
+        internal J? Result { get; private set; }
+
+        protected override J? Accept(J tree, int p)
+        {
+            if (Result != null)
+                return tree;
+            if (tree.Id == targetId)
+            {
+                Result = tree;
+                return tree;
+            }
+            return base.Accept(tree, p);
+        }
     }
 }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TreeHelper.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TreeHelper.cs
@@ -27,6 +27,7 @@ namespace OpenRewrite.CSharp.Template;
 internal static class TreeHelper
 {
     private static readonly ConcurrentDictionary<Type, MethodInfo?> WithPrefixCache = new();
+    private static readonly ConcurrentDictionary<Type, MethodInfo?> WithIdCache = new();
 
     /// <summary>
     /// Property names to always skip when comparing tree nodes structurally.
@@ -56,6 +57,21 @@ internal static class TreeHelper
 
         if (method != null)
             return (J)method.Invoke(node, [prefix])!;
+
+        return node;
+    }
+
+    /// <summary>
+    /// Call WithId on any J node via cached reflection.
+    /// Returns the original node unchanged if the type doesn't have WithId.
+    /// </summary>
+    internal static J SetId(J node, Guid id)
+    {
+        var method = WithIdCache.GetOrAdd(node.GetType(), type =>
+            type.GetMethod("WithId", [typeof(Guid)]));
+
+        if (method != null)
+            return (J)method.Invoke(node, [id])!;
 
         return node;
     }

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TemplateApplyTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TemplateApplyTests.cs
@@ -349,6 +349,43 @@ public class TemplateApplyTests : RewriteTest
     }
 
     // ===============================================================
+    // Auto-formatting
+    // ===============================================================
+
+    [Fact]
+    public void AutoFormatsTemplateResultIndentation()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ReplaceWithIfBlockRecipe()),
+            CSharp(
+                """
+                class C
+                {
+                    void M()
+                    {
+                        Console.Write(42);
+                    }
+                }
+                """,
+                // Auto-format should fix the internal indentation of the if-block
+                // to match the surrounding context (8 spaces for braces, 12 for body)
+                """
+                class C
+                {
+                    void M()
+                    {
+                        if (true)
+                        {
+                            Console.WriteLine(42);
+                        }
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    // ===============================================================
     // Recipe factories
     // ===============================================================
 
@@ -431,6 +468,37 @@ file class RemoveEmptyStatementRecipe : Core.Recipe
             if (Cursor.Parent?.Value is Block)
                 return null!;
             return empty;
+        }
+    }
+}
+
+/// <summary>
+/// Replaces Console.Write(expr) statement with an if-block containing Console.WriteLine(42).
+/// The template produces a single-line if statement that auto-format should expand to multi-line
+/// with correct indentation.
+/// </summary>
+file class ReplaceWithIfBlockRecipe : Core.Recipe
+{
+    public override string DisplayName => "Replace Console.Write with if block";
+    public override string Description => "Wraps Console.Write in an if block.";
+
+    public override JavaVisitor<ExecutionContext> GetVisitor() => new Visitor();
+
+    private class Visitor : CSharpVisitor<ExecutionContext>
+    {
+        public override J VisitExpressionStatement(ExpressionStatement es, ExecutionContext ctx)
+        {
+            es = (ExpressionStatement)base.VisitExpressionStatement(es, ctx);
+            if (es.Expression is MethodInvocation mi &&
+                mi.Select?.Element is Identifier { SimpleName: "Console" } &&
+                mi.Name.SimpleName == "Write")
+            {
+                // Multi-line template with 0-based indentation.
+                // Auto-format should fix internal indentation to match the target context.
+                var tmpl = CSharpTemplate.Create("if (true)\n{\n    Console.WriteLine(42);\n}");
+                return (J)tmpl.Apply(Cursor)!;
+            }
+            return es;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Template results now get Roslyn-formatted in context of their enclosing compilation unit, fixing internal indentation to match the target location
- The approach: temporarily insert the template result into a scratch copy of the CU, format with Roslyn, then extract the formatted subtree by ID
- Added `AutoFormat` method to `TemplateEngine` with short-circuiting `NodeReplacer` and `IdFinder` visitors
- Added `TreeHelper.SetId` to assign fresh GUIDs to template results, avoiding ID collisions when the same cached template is applied multiple times
- Added `ReplaceWithIfBlockRecipe` test verifying multi-line template indentation is corrected to match surrounding context

## Test plan
- [x] `AutoFormatsTemplateResultIndentation` test verifies a single-line `Console.Write(42)` is replaced with a properly indented multi-line `if (true) { Console.WriteLine(42); }` block
- [x] All 1150 existing tests continue to pass
- [x] All existing template apply tests (pattern matching, substitution, variadic args, etc.) unaffected