### PR TITLE
Also check imports in FindAnnotations precondition

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindAnnotationsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindAnnotationsTest.java
@@ -307,6 +307,39 @@ class FindAnnotationsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/moderneinc/customer-requests/issues/1988")
+    @Test
+    void findJUnitTestAnnotation() {
+        rewriteRun(
+          spec -> spec.recipe(new FindAnnotations("@org.junit.jupiter.api.Test", null))
+            .parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api")),
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              class MyTests {
+                  @Test
+                  void shouldWork() {}
+
+                  @Test
+                  void shouldAlsoWork() {}
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              class MyTests {
+                  /*~~>*/@Test
+                  void shouldWork() {}
+
+                  /*~~>*/@Test
+                  void shouldAlsoWork() {}
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void enumArgument() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindAnnotations.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindAnnotations.java
@@ -69,6 +69,17 @@ public class FindAnnotations extends Recipe {
                                 return SearchResult.found(cu);
                             }
                         }
+                        for (J.Import anImport : cu.getImports()) {
+                            JavaType.FullyQualified type;
+                            if (anImport.isStatic()) {
+                                type = TypeUtils.asFullyQualified(anImport.getQualid().getTarget().getType());
+                            } else {
+                                type = TypeUtils.asFullyQualified(anImport.getQualid().getType());
+                            }
+                            if (annotationMatcher.matchesAnnotationOrMetaAnnotation(type)) {
+                                return SearchResult.found(cu);
+                            }
+                        }
                         return tree;
                     }
                 },


### PR DESCRIPTION
## What's changed?

The `FindAnnotations` precondition now also checks imports when determining whether to visit a source file, aligning with how `UsesType` works.

## What's your motivation?

At LVM, `FindTypes` for `org.junit.jupiter.api.Test` finds 66 repos, but `FindAnnotations` for `@org.junit.jupiter.api.Test` only finds 8 repos. This causes the JUnit 6 Upgrade DevCenter card to show incomplete data.

- The root cause: PR #5315 optimized the `FindAnnotations` precondition to only check `cu.getTypesInUse().getTypesInUse()`. However, `TypesInUse` explicitly skips imports (`FindTypesInUse.visitImport` returns immediately). For files where the annotation type is present in imports but not collected into `typesInUse`, the precondition incorrectly skips the file.

`UsesType` (used by `FindTypes`) avoids this by also checking imports as a fallback, which is why `FindTypes` works correctly. This PR applies the same pattern to `FindAnnotations`.

## Anything in particular you'd like reviewers to focus on?

The import checking loop mirrors the pattern from `UsesType.visit()`. The performance impact is minimal since import lists are typically small.

- Fixes moderneinc/customer-requests#1988