### PR TITLE
JS: Fast-path method name check in semantic comparator

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/comparator.ts
+++ b/rewrite-javascript/rewrite/src/javascript/comparator.ts
@@ -2359,6 +2359,16 @@ export class JavaScriptSemanticComparatorVisitor extends JavaScriptComparatorVis
 
         const otherMethod = other as J.MethodInvocation;
 
+        // Fast path: if both have method types with known names, compare canonical method names first.
+        // This catches most mismatches (e.g., jest.fn() vs jest.mock()) before the
+        // more expensive FQ declaring type analysis below.
+        // Skip when either name is the placeholder "unknown" (incomplete type attribution).
+        if (method.methodType && otherMethod.methodType &&
+            method.methodType.name !== otherMethod.methodType.name &&
+            method.methodType.name !== 'unknown' && otherMethod.methodType.name !== 'unknown') {
+            return this.valueMismatch('methodType.name', method.methodType.name, otherMethod.methodType.name);
+        }
+
         // Check if we can skip name checking based on type attribution
         // We can only skip the name check if both have method types AND they represent the SAME method
         // (not just type-compatible methods, but the actual same function with same FQN)

--- a/rewrite-javascript/rewrite/test/javascript/templating/pattern-debug.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/pattern-debug.test.ts
@@ -284,8 +284,8 @@ describe('Pattern Debugging', () => {
         expect(attempt.matched).toBe(false);
         expect(attempt.explanation).toBeDefined();
 
-        // The path should show the property that mismatched with kind information for nested objects
-        expect(attempt.explanation!.path).toEqual(['J$MethodInvocation#name', 'J$Identifier#simpleName']);
+        // The path should show the property that mismatched — caught early via methodType.name
+        expect(attempt.explanation!.path).toEqual(['J$MethodInvocation#methodType', 'JavaType$Method#name']);
 
         // Should be a value mismatch
         expect(attempt.explanation!.reason).toBe('value-mismatch');


### PR DESCRIPTION
## Summary
- Add early `methodType.name` comparison in `JavaScriptSemanticComparatorVisitor.visitMethodInvocation` to bail out before the more expensive FQ declaring type analysis
- When both sides have method types with known names (not `"unknown"`), a single string compare catches most mismatches immediately (e.g., `jest.fn()` vs `jest.mock()`)
- Skips the optimization when either name is the placeholder `"unknown"` (incomplete type attribution)

## Test plan
- [x] All 240 templating tests pass (`npm run testhelper -- test/javascript/templating/`)
- [x] All 117 search and recipe tests pass
- [x] Updated `pattern-debug.test.ts` expectation to reflect that mismatches are now caught at `methodType.name` instead of `name.simpleName`