### PR TITLE
JavaScript: Upgrade diff to v8

### DIFF
--- a/rewrite-javascript/rewrite/package-lock.json
+++ b/rewrite-javascript/rewrite/package-lock.json
@@ -12,7 +12,7 @@
         "@akashrajpurohit/snowflake-id": "^2.0.0",
         "@types/node": "^22.5.4",
         "commander": "^14.0.0",
-        "diff": "^7.0.0",
+        "diff": "^8.0.0",
         "jsonc-parser": "^3.3.1",
         "mutative": "^1.3.0",
         "picomatch": "^4.0.3",
@@ -27,7 +27,7 @@
       },
       "devDependencies": {
         "@types/benchmark": "^2.1.5",
-        "@types/diff": "^5.2.2",
+        "@types/diff": "^8.0.0",
         "@types/picomatch": "^4.0.2",
         "@types/semver": "^7.7.1",
         "@types/tmp": "^0.2.6",
@@ -1031,11 +1031,15 @@
       "license": "MIT"
     },
     "node_modules/@types/diff": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.3.tgz",
-      "integrity": "sha512-K0Oqlrq3kQMaO2RhfrNQX5trmt+XLyom88zS0u84nnIcLvFnRUMRRHmrGny5GSM+kNO9IZLARsdQHDzkhAgmrQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-8.0.0.tgz",
+      "integrity": "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw==",
+      "deprecated": "This is a stub types definition. diff provides its own type definitions, so you do not need this installed.",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "diff": "*"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1260,9 +1264,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"

--- a/rewrite-javascript/rewrite/package.json
+++ b/rewrite-javascript/rewrite/package.json
@@ -65,7 +65,7 @@
     "@akashrajpurohit/snowflake-id": "^2.0.0",
     "@types/node": "^22.5.4",
     "commander": "^14.0.0",
-    "diff": "^7.0.0",
+    "diff": "^8.0.0",
     "jsonc-parser": "^3.3.1",
     "mutative": "^1.3.0",
     "picomatch": "^4.0.3",
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@types/benchmark": "^2.1.5",
-    "@types/diff": "^5.2.2",
+    "@types/diff": "^8.0.0",
     "@types/picomatch": "^4.0.2",
     "@types/semver": "^7.7.1",
     "@types/tmp": "^0.2.6",


### PR DESCRIPTION
## Summary
- Upgrade `diff` dependency from ^7.0.0 to ^8.0.0
- Upgrade `@types/diff` from ^5.2.2 to ^8.0.0 to match
- Only usage is `createTwoFilesPatch` in `src/run.ts`, which has the same API in v8

## Test plan
- [x] `npm run typecheck` passes