### PR TITLE
Fix ChangeDependency isAcceptable to reject PlainText files

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -469,7 +469,8 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                 if (sourceFile instanceof Properties.File) {
                     return sourceFile.getSourcePath().endsWith(GRADLE_PROPERTIES_FILE_NAME);
                 }
-                return sourceFile.getMarkers().findFirst(GradleProject.class).isPresent();
+                return (sourceFile instanceof G.CompilationUnit || sourceFile instanceof K.CompilationUnit)
+                        && sourceFile.getMarkers().findFirst(GradleProject.class).isPresent();
             }
 
             @Override

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.text.PlainTextParser;
 
 import java.nio.file.Path;
@@ -1080,6 +1081,27 @@ class ChangeDependencyTest implements RewriteTest {
         SourceFile sourceFile = PlainTextParser.builder().build().parse("not a gradle file")
                 .findFirst().orElseThrow()
                 .withSourcePath(Path.of("not-a-gradle-file.txt"));
+        assertThat(visitor.isAcceptable(sourceFile, new InMemoryExecutionContext())).isFalse();
+    }
+
+    @Test
+    void isNotAcceptableForPlainTextWithGradleProjectMarker() {
+        ChangeDependency recipe = new ChangeDependency(
+                "org.old", "artifact", "org.new", "artifact", null, null, null
+        );
+        @SuppressWarnings("unchecked")
+        TreeVisitor<?, ExecutionContext> visitor = (TreeVisitor<?, ExecutionContext>) recipe.getVisitor();
+
+        SourceFile sourceFile = PlainTextParser.builder().build().parse("not a gradle file")
+                .findFirst().orElseThrow()
+                .withSourcePath(Path.of("build.gradle"))
+                .withMarkers(new org.openrewrite.marker.Markers(org.openrewrite.Tree.randomId(),
+                        java.util.Collections.singletonList(GradleProject.builder()
+                                .group("com.example")
+                                .name("test")
+                                .version("1.0")
+                                .path(":")
+                                .build())));
         assertThat(visitor.isAcceptable(sourceFile, new InMemoryExecutionContext())).isFalse();
     }
 }


### PR DESCRIPTION
## Summary

- The `isAcceptable()` method in `ChangeDependency` was checking only for `GradleProject` markers but not verifying the file type. This allowed PlainText files (from parser fallback scenarios) with GradleProject markers to pass through to the gradleVisitor, which internally assumes JavaSourceFile and performs unsafe casts, causing ClassCastException (issue #6972).

## Changes

- Tighten `ChangeDependency.isAcceptable()` to verify the file is `G.CompilationUnit` or `K.CompilationUnit` in addition to checking for GradleProject markers
- Add test case `isNotAcceptableForPlainTextWithGradleProjectMarker()` to verify PlainText files with GradleProject markers are correctly rejected

- Fixes #6972