### PR TITLE
C#: Parse attributes on fields, methods, constructors, and event fields

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -1214,6 +1214,13 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
     {
         var prefix = ExtractPrefix(node);
 
+        // Parse attribute lists
+        var attributeLists = new List<AttributeList>();
+        foreach (var attrList in node.AttributeLists)
+        {
+            attributeLists.Add((AttributeList)Visit(attrList)!);
+        }
+
         // Parse modifiers
         var modifiers = new List<Modifier>();
         foreach (var mod in node.Modifiers)
@@ -1339,9 +1346,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (node.ExpressionBody != null)
             methodMarkers = methodMarkers.Add(new ExpressionBodied(Guid.NewGuid()));
 
-        return new MethodDeclaration(
+        var methodDecl = new MethodDeclaration(
             Guid.NewGuid(),
-            prefix,
+            attributeLists.Count > 0 ? Space.Empty : prefix,
             methodMarkers,
             [],
             modifiers,
@@ -1354,11 +1361,31 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             null, // DefaultValue
             _typeMapping?.MethodType(node)
         );
+
+        if (attributeLists.Count > 0)
+        {
+            return new AnnotatedStatement(
+                Guid.NewGuid(),
+                prefix,
+                Markers.Empty,
+                attributeLists,
+                methodDecl
+            );
+        }
+
+        return methodDecl;
     }
 
     public override J VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
     {
         var prefix = ExtractPrefix(node);
+
+        // Parse attribute lists
+        var attributeLists = new List<AttributeList>();
+        foreach (var attrList in node.AttributeLists)
+        {
+            attributeLists.Add((AttributeList)Visit(attrList)!);
+        }
 
         // Parse modifiers
         var modifiers = new List<Modifier>();
@@ -1468,9 +1495,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = node.SemicolonToken.Span.End;
         }
 
-        return new MethodDeclaration(
+        var ctorDecl = new MethodDeclaration(
             Guid.NewGuid(),
-            prefix,
+            attributeLists.Count > 0 ? Space.Empty : prefix,
             methodMarkers,
             [],
             modifiers,
@@ -1483,6 +1510,19 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             defaultValue,
             _typeMapping?.MethodType(node)
         );
+
+        if (attributeLists.Count > 0)
+        {
+            return new AnnotatedStatement(
+                Guid.NewGuid(),
+                prefix,
+                Markers.Empty,
+                attributeLists,
+                ctorDecl
+            );
+        }
+
+        return ctorDecl;
     }
 
     public override J VisitDestructorDeclaration(DestructorDeclarationSyntax node)
@@ -7746,8 +7786,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
     {
         var prefix = ExtractPrefix(node);
 
-        // Parse modifiers — attributes on fields are skipped for now as
-        // LeadingAnnotations takes IList<Modifier> in the C# model
+        // Parse attribute lists
+        var attributeLists = new List<AttributeList>();
+        foreach (var attrList in node.AttributeLists)
+        {
+            attributeLists.Add((AttributeList)Visit(attrList)!);
+        }
+
+        // Parse modifiers
         var modifiers = new List<Modifier>();
         foreach (var mod in node.Modifiers)
         {
@@ -7831,9 +7877,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _pendingSemicolonSpace = ExtractSpaceBefore(node.SemicolonToken);
         _cursor = node.SemicolonToken.Span.End;
 
-        return new VariableDeclarations(
+        var varDecl = new VariableDeclarations(
             Guid.NewGuid(),
-            prefix,
+            attributeLists.Count > 0 ? Space.Empty : prefix,
             Markers.Empty,
             [],
             modifiers,
@@ -7842,11 +7888,31 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             [],
             variables
         );
+
+        if (attributeLists.Count > 0)
+        {
+            return new AnnotatedStatement(
+                Guid.NewGuid(),
+                prefix,
+                Markers.Empty,
+                attributeLists,
+                varDecl
+            );
+        }
+
+        return varDecl;
     }
 
     public override J VisitEventFieldDeclaration(EventFieldDeclarationSyntax node)
     {
         var prefix = ExtractPrefix(node);
+
+        // Parse attribute lists
+        var attributeLists = new List<AttributeList>();
+        foreach (var attrList in node.AttributeLists)
+        {
+            attributeLists.Add((AttributeList)Visit(attrList)!);
+        }
 
         // Parse modifiers — includes the 'event' keyword
         var modifiers = new List<Modifier>();
@@ -7931,9 +7997,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         SkipTo(node.SemicolonToken.SpanStart);
         SkipToken(node.SemicolonToken);
 
-        return new VariableDeclarations(
+        var varDecl = new VariableDeclarations(
             Guid.NewGuid(),
-            prefix,
+            attributeLists.Count > 0 ? Space.Empty : prefix,
             Markers.Empty,
             [],
             modifiers,
@@ -7942,6 +8008,19 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             [],
             variables
         );
+
+        if (attributeLists.Count > 0)
+        {
+            return new AnnotatedStatement(
+                Guid.NewGuid(),
+                prefix,
+                Markers.Empty,
+                attributeLists,
+                varDecl
+            );
+        }
+
+        return varDecl;
     }
 
     public override J VisitLocalFunctionStatement(LocalFunctionStatementSyntax node)

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -97,6 +97,11 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
                 p.Append(';');
                 break;
 
+            // AnnotatedStatement: delegate to inner statement
+            case AnnotatedStatement ann:
+                PrintStatementTerminator(ann.Statement, p);
+                break;
+
             // FieldAccess used as statement (like event accessor declarations)
             case FieldAccess:
                 break;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/AttributeListTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/AttributeListTests.cs
@@ -147,4 +147,129 @@ public class AttributeListTests : RewriteTest
             )
         );
     }
+
+    [Fact]
+    public void AttributeOnField()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Test
+                {
+                    [ThreadStatic]
+                    int _field;
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void AttributeOnMethod()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Test
+                {
+                    [Obsolete]
+                    void M() { }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void MultipleAttributesOnField()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Test
+                {
+                    [ThreadStatic]
+                    [Obsolete("deprecated")]
+                    static int _field;
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void AttributeWithArgumentOnMethod()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Test
+                {
+                    [Obsolete("Use NewMethod instead")]
+                    public void OldMethod() { }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void FieldAttributeIsStructuredAsAnnotation()
+    {
+        var parser = new CSharpParser();
+        var cu = (CompilationUnit)parser.Parse("class Test\n{\n    [ThreadStatic]\n    int _field;\n}");
+        var classDecl = (ClassDeclaration)cu.Members[0].Element;
+        var stmt = classDecl.Body.Statements[0].Element;
+        var annotated = Assert.IsType<AnnotatedStatement>(stmt);
+        Assert.Single(annotated.AttributeLists);
+        var annotation = annotated.AttributeLists[0].Attributes[0].Element;
+        Assert.Equal("ThreadStatic", ((Identifier)annotation.AnnotationType).SimpleName);
+        Assert.IsType<VariableDeclarations>(annotated.Statement);
+    }
+
+    [Fact]
+    public void MethodAttributeIsStructuredAsAnnotation()
+    {
+        var parser = new CSharpParser();
+        var cu = (CompilationUnit)parser.Parse("class Test\n{\n    [Obsolete]\n    void M() { }\n}");
+        var classDecl = (ClassDeclaration)cu.Members[0].Element;
+        var stmt = classDecl.Body.Statements[0].Element;
+        var annotated = Assert.IsType<AnnotatedStatement>(stmt);
+        Assert.Single(annotated.AttributeLists);
+        var annotation = annotated.AttributeLists[0].Attributes[0].Element;
+        Assert.Equal("Obsolete", ((Identifier)annotation.AnnotationType).SimpleName);
+        Assert.IsType<MethodDeclaration>(annotated.Statement);
+    }
+
+    [Fact]
+    public void AttributeOnConstructor()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Test
+                {
+                    [Obsolete]
+                    Test() { }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void AttributeOnEventField()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Test
+                {
+                    [NonSerialized]
+                    event System.EventHandler MyEvent;
+                }
+                """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Attributes on fields, methods, constructors, and event fields inside class bodies are now parsed as proper `Annotation` AST nodes wrapped in `AnnotatedStatement`, instead of being silently absorbed into `Primitive.Prefix` Space fields
- `PrintStatementTerminator` delegates through `AnnotatedStatement` to the inner statement so semicolons are preserved on field and event field declarations
- Adds 8 new tests: round-trip tests for each declaration type plus structural AST tests verifying `AnnotatedStatement` wraps the correct inner node

## Context

Previously, `VisitAnnotation` was never called for member-level attributes, breaking any recipe that inspects field/method attributes via the visitor pattern. Class-level attributes already worked correctly via the `AnnotatedStatement` pattern — this PR extends that same pattern to the four remaining member declaration types.

- Unblocks two skipped tests in [moderneinc/recipes-csharp#9](https://github.com/moderneinc/recipes-csharp/pull/9):
- `FindThreadStaticOnInstanceFieldTest.FindsThreadStaticOnInstanceField`
- `FindThreadStaticOnInstanceFieldTest.NoChangeForThreadStaticOnStaticField`

## Test plan

- [ ] All 17 `AttributeListTests` pass (8 new + 9 existing)
- [ ] Full C# test suite: no new failures (31 pre-existing, same as base)
- [ ] Java-side RPC round-trip tests pass (`gw :rewrite-csharp:test`)
- [ ] Verify downstream `recipes-csharp` tests pass with this parser