### PR TITLE
C#: Fix RPC delta computation and extract RecipeScheduler

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/Core/Recipe.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Recipe.cs
@@ -91,41 +91,25 @@ public abstract class Recipe
         }
         return options;
     }
+}
 
-    public virtual List<Result> Run(List<SourceFile> sources, ExecutionContext ctx)
-    {
-        var visitor = GetVisitor();
-        return EditSources(sources, visitor, ctx);
-    }
-
-    protected static List<Result> EditSources(
-        List<SourceFile> sources,
-        JavaVisitor<ExecutionContext> visitor,
-        ExecutionContext ctx)
-    {
-        var results = new List<Result>();
-        foreach (var source in sources)
-        {
-            var after = visitor.Visit((Tree)source, ctx);
-            if (after == null)
-            {
-                results.Add(new Result(source, null));
-            }
-            else if (after is SourceFile sf && !ReferenceEquals(source, after))
-            {
-                results.Add(new Result(source, sf));
-            }
-        }
-
-        return results;
-    }
+/// <summary>
+/// Non-generic interface for scanning recipes, allowing the scheduler to
+/// manage the scan/generate/edit lifecycle without knowing the accumulator type.
+/// </summary>
+public interface IScanningRecipe
+{
+    object InitialValue(ExecutionContext ctx);
+    JavaVisitor<ExecutionContext> Scanner(object acc);
+    JavaVisitor<ExecutionContext> Editor(object acc);
+    IEnumerable<SourceFile> Generate(object acc, ExecutionContext ctx);
 }
 
 /// <summary>
 /// A recipe that first scans source files to accumulate data, then transforms them.
 /// </summary>
 /// <typeparam name="T">The type of the accumulator for scanning data.</typeparam>
-public abstract class ScanningRecipe<T> : Recipe
+public abstract class ScanningRecipe<T> : Recipe, IScanningRecipe
 {
     public abstract T GetInitialValue(ExecutionContext ctx);
 
@@ -138,35 +122,14 @@ public abstract class ScanningRecipe<T> : Recipe
     public sealed override JavaVisitor<ExecutionContext> GetVisitor()
     {
         throw new InvalidOperationException(
-            "ScanningRecipe.GetVisitor() should not be called directly. Use Run() instead.");
+            "ScanningRecipe.GetVisitor() should not be called directly.");
     }
 
-    public override List<Result> Run(List<SourceFile> sources, ExecutionContext ctx)
-    {
-        var acc = GetInitialValue(ctx);
-
-        // Phase 1: Scan
-        var scanner = GetScanner(acc);
-        foreach (var source in sources)
-        {
-            scanner.Visit((Tree)source, ctx);
-        }
-
-        // Phase 2: Generate
-        var generated = Generate(acc, ctx).ToList();
-
-        // Phase 3: Edit
-        var visitor = GetVisitor(acc);
-        var results = EditSources(sources, visitor, ctx);
-
-        // Add generated files
-        foreach (var gen in generated)
-        {
-            results.Add(new Result(null, gen));
-        }
-
-        return results;
-    }
+    // IScanningRecipe explicit implementation — type-erased bridge for the scheduler
+    object IScanningRecipe.InitialValue(ExecutionContext ctx) => GetInitialValue(ctx)!;
+    JavaVisitor<ExecutionContext> IScanningRecipe.Scanner(object acc) => GetScanner((T)acc);
+    JavaVisitor<ExecutionContext> IScanningRecipe.Editor(object acc) => GetVisitor((T)acc);
+    IEnumerable<SourceFile> IScanningRecipe.Generate(object acc, ExecutionContext ctx) => Generate((T)acc, ctx);
 }
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipeScheduler.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipeScheduler.cs
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Java;
+
+namespace OpenRewrite.Core;
+
+/// <summary>
+/// Runs a recipe (and its sub-recipes) against a set of source files,
+/// collecting before/after results. Handles composite recipes by recursing
+/// through <see cref="Recipe.GetRecipeList"/>.
+/// </summary>
+public static class RecipeScheduler
+{
+    public static List<Result> Run(Recipe recipe, List<SourceFile> sources, ExecutionContext ctx)
+    {
+        var allResults = new Dictionary<Guid, Result>();
+        var currentSources = new List<SourceFile>(sources);
+
+        RunRecipe(recipe, currentSources, allResults, ctx);
+
+        return allResults.Values.ToList();
+    }
+
+    private static void RunRecipe(
+        Recipe recipe,
+        List<SourceFile> currentSources,
+        Dictionary<Guid, Result> allResults,
+        ExecutionContext ctx)
+    {
+        var recipeList = recipe.GetRecipeList();
+        if (recipeList.Count > 0)
+        {
+            foreach (var subRecipe in recipeList)
+            {
+                RunRecipe(subRecipe, currentSources, allResults, ctx);
+            }
+        }
+        else
+        {
+            var results = EditSources(recipe, currentSources, ctx);
+            ApplyResults(results, currentSources, allResults);
+        }
+    }
+
+    private static List<Result> EditSources(
+        Recipe recipe,
+        List<SourceFile> sources,
+        ExecutionContext ctx)
+    {
+        if (recipe is IScanningRecipe scanning)
+        {
+            var acc = scanning.InitialValue(ctx);
+
+            // Phase 1: Scan
+            var scanner = scanning.Scanner(acc);
+            foreach (var source in sources)
+            {
+                scanner.Visit((Tree)source, ctx);
+            }
+
+            // Phase 2: Generate
+            var generated = scanning.Generate(acc, ctx).ToList();
+
+            // Phase 3: Edit
+            var results = VisitAll(scanning.Editor(acc), sources, ctx);
+
+            foreach (var gen in generated)
+            {
+                results.Add(new Result(null, gen));
+            }
+
+            return results;
+        }
+
+        return VisitAll(recipe.GetVisitor(), sources, ctx);
+    }
+
+    private static List<Result> VisitAll(
+        JavaVisitor<ExecutionContext> visitor,
+        List<SourceFile> sources,
+        ExecutionContext ctx)
+    {
+        var results = new List<Result>();
+        foreach (var source in sources)
+        {
+            var after = visitor.Visit((Tree)source, ctx);
+            if (after == null)
+            {
+                results.Add(new Result(source, null));
+            }
+            else if (after is SourceFile sf && !ReferenceEquals(source, after))
+            {
+                results.Add(new Result(source, sf));
+            }
+        }
+
+        return results;
+    }
+
+    private static void ApplyResults(
+        List<Result> results,
+        List<SourceFile> currentSources,
+        Dictionary<Guid, Result> allResults)
+    {
+        foreach (var result in results)
+        {
+            if (result.Before != null)
+            {
+                allResults[result.Before.Id] = result;
+                if (result.After != null)
+                {
+                    for (var i = 0; i < currentSources.Count; i++)
+                    {
+                        if (currentSources[i].Id == result.Before.Id)
+                        {
+                            currentSources[i] = result.After;
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    currentSources.RemoveAll(s => s.Id == result.Before.Id);
+                }
+            }
+            else if (result.After != null)
+            {
+                allResults[result.After.Id] = result;
+                currentSources.Add(result.After);
+            }
+        }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
@@ -138,7 +138,8 @@ public class RpcSendQueue
         var afterVal = Reference.GetValue<object>(after);
         var beforeVal = Reference.GetValue<object>(before);
 
-        if (ReferenceEquals(beforeVal, afterVal))
+        if (ReferenceEquals(beforeVal, afterVal) ||
+            (beforeVal != null && beforeVal.GetType().IsValueType && beforeVal.Equals(afterVal)))
         {
             Put(new RpcObjectData { State = NO_CHANGE });
         }
@@ -211,7 +212,7 @@ public class RpcSendQueue
 
     private Dictionary<object, int> PutListPositions<T>(IList<T> after, IList<T>? before, Func<T, object> id)
     {
-        var beforeIdx = new Dictionary<object, int>(ReferenceEqualityComparer.Instance);
+        var beforeIdx = new Dictionary<object, int>();
         if (before != null)
         {
             for (int i = 0; i < before.Count; i++)

--- a/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
@@ -90,7 +90,7 @@ public abstract class RewriteTest
         if (recipeSpec.Recipe != null)
         {
             var sources = parsed.Select(p => p.Source).ToList();
-            var results = recipeSpec.Recipe.Run(sources, new ExecutionContext());
+            var results = RecipeScheduler.Run(recipeSpec.Recipe, sources, new ExecutionContext());
 
             foreach (var (spec, source) in parsed)
             {

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Recipe/RecipeTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Recipe/RecipeTest.cs
@@ -66,6 +66,18 @@ public class RecipeTest : RewriteTest
     }
 
     [Fact]
+    public void NoOpVisitorPreservesReferenceEquality()
+    {
+        var parser = new CSharpParser();
+        var source = parser.Parse("class C { void M() { var x = 1; } }");
+        var visitor = new CSharpVisitor<Core.ExecutionContext>();
+        var result = visitor.Visit(source, new Core.ExecutionContext());
+        Assert.True(ReferenceEquals(source, result),
+            $"No-op visitor should preserve reference equality. " +
+            $"source type={source.GetType().Name}, result type={result?.GetType().Name}");
+    }
+
+    [Fact]
     public void RecipeDescriptorHasOptions()
     {
         var recipe = new RenameClassRecipe { From = "Foo", To = "Bar" };


### PR DESCRIPTION
## Summary

- **Fix broken RPC delta computation** that caused full tree retransmission on every recipe visit. `PutListPositions` used `ReferenceEqualityComparer` for its ID lookup dictionary — since list element IDs are boxed `Guid`s, lookups always failed and every element was treated as ADD instead of matched for a small delta. Also fixed `Send` to use value equality for value-type fields (Guid, bool, enum) which were always reported as CHANGE due to boxed reference comparison.

- **Extract `RecipeScheduler`** from `Recipe.Run()`, matching the JavaScript SDK pattern. `Recipe` now only defines `GetVisitor()`/`GetRecipeList()`. A separate `RecipeScheduler.Run()` handles composite recipe execution, including recursing through recipe lists and handling `ScanningRecipe`.

Together these caused a 203-recipe composite on Humanizer (756 C# files) to take **50+ minutes** (killed). After the fix: **6 minutes**.

## Test plan
- [x] `NoOpVisitorPreservesReferenceEquality` test added to verify visitor framework preserves structural sharing
- [x] recipes-csharp `./gradlew csharpTest` passes 207/207 (with matching SDK)
- [x] recipes-csharp `./gradlew codeQualityTest` passes 626/632 (4 pre-existing failures)
- [x] Verified delta item counts drop from ~1100 to ~47 per GetObject transfer
- [x] Verified GetObject call count drops from 16K to matching modification count