### PR TITLE
C#: Suppress compiler warnings that break RPC protocol

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
@@ -17,7 +17,9 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <!-- VSTHRD200: RPC method names must match Java-side protocol (no Async suffix) -->
     <!-- VSTHRD002: Synchronous waits needed for RPC interop with Java peer -->
-    <NoWarn>VSTHRD200;VSTHRD002</NoWarn>
+    <!-- VSTHRD103: Synchronous blocks needed for RPC interop -->
+    <!-- CS0114: Intentional method hiding in sender/receiver visitors -->
+    <NoWarn>VSTHRD200;VSTHRD002;VSTHRD103;CS0114</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

When using `REWRITE_SOURCE_PATH`, `dotnet run` compiles the C# project and emits warnings to stdout. The Java side expects JSON-RPC headers on stdout, so any compiler output breaks the protocol — causing `Invalid Request: Expected Content-Length header but received '...warning CS0114...'` errors.

Suppress `CS0114` (intentional method hiding in sender/receiver visitors) and `VSTHRD103` (synchronous blocks for RPC interop) via `NoWarn` in the project file, eliminating all warnings from stdout.

## Test plan
- [x] `dotnet build` produces 0 warnings
- [x] `REWRITE_SOURCE_PATH` recipe runs succeed (were failing with RPC protocol errors)
- [x] MakeClassSealed correctly classifies 30 changes as fix (not search-only)