### PR TITLE
Fix `BatchVisit` over-attributing `RecipesThatMadeChanges` marker

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -467,8 +467,10 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
             if (!originalBefore.getMarkers().findFirst(Generated.class).isPresent()) {
                 recipeRunStats.recordSourceFileChanged(originalBefore, fetched);
             }
-            for (Stack<Recipe> stack : batch.recipeStacks) {
-                fetched = addRecipesThatMadeChanges(stack, fetched);
+            for (int i = 0; i < batch.recipeStacks.size(); i++) {
+                if (response.getResults().get(i).isModified()) {
+                    fetched = addRecipesThatMadeChanges(batch.recipeStacks.get(i), fetched);
+                }
             }
         }
 

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
@@ -34,6 +34,7 @@ import org.openrewrite.internal.RecipeLoader;
 import org.openrewrite.marketplace.*;
 import org.openrewrite.table.TextMatches;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.marker.RecipesThatMadeChanges;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
 
@@ -331,6 +332,42 @@ class RewriteRpcTest implements RewriteTest {
           text(
             "hello",
             "C"
+          )
+        );
+    }
+
+    /**
+     * When a batch contains recipes where only some modify the tree,
+     * only those recipes should appear in the RecipesThatMadeChanges marker.
+     * Previously, all recipes in the batch were attributed regardless of
+     * whether they actually modified the tree.
+     */
+    @Test
+    void batchOnlyAttributesRecipesThatActuallyMadeChanges() {
+        Recipe r1 = client.prepareRecipe("org.openrewrite.text.ChangeText", Map.of("toText", "A"));
+        Recipe r2 = client.prepareRecipe("org.openrewrite.text.Find", Map.of("find", "NOMATCH_PATTERN"));
+        Recipe r3 = client.prepareRecipe("org.openrewrite.text.ChangeText", Map.of("toText", "B"));
+
+        rewriteRun(
+          spec -> spec
+            .recipe(new CompositeRecipe(List.of(r1, r2, r3)))
+            .validateRecipeSerialization(false)
+            .cycles(1).expectedCyclesThatMakeChanges(1),
+          text(
+            "hello",
+            "B",
+            spec -> spec.afterRecipe(result -> {
+                RecipesThatMadeChanges marker = result.getMarkers()
+                  .findFirst(RecipesThatMadeChanges.class)
+                  .orElseThrow(() -> new AssertionError("Expected RecipesThatMadeChanges marker"));
+                List<String> recipeNames = marker.getRecipes().stream()
+                  .map(stack -> stack.get(stack.size() - 1).getName())
+                  .toList();
+                assertThat(recipeNames)
+                  .describedAs("Only recipes that modified the tree should be attributed")
+                  .contains("org.openrewrite.text.ChangeText")
+                  .doesNotContain("org.openrewrite.text.Find");
+            })
           )
         );
     }


### PR DESCRIPTION
## Summary

- `flushBatch` unconditionally added all recipes in a batch to the `RecipesThatMadeChanges` marker when *any* recipe modified the tree. A batch of 10 recipes where only 1 made changes would incorrectly attribute all 10.
- Now only recipes whose `BatchVisitResult.modified` is true get added to the marker.

## Test plan

- [x] Added `batchOnlyAttributesRecipesThatActuallyMadeChanges` test in `RewriteRpcTest` that creates a batch of 3 RPC recipes (ChangeText, Find with no match, ChangeText) and asserts only `ChangeText` appears in the marker
- [x] All existing `RewriteRpcTest` tests pass