### PR TITLE
C#: Add `DataTable`, `DataTableStore`, and `CsvDataTableStore`

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/Core/ColumnAttribute.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/ColumnAttribute.cs
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using JetBrains.Annotations;
+
+namespace OpenRewrite.Core;
+
+/// <summary>
+/// Marks a property as a data table column.
+/// Mirrors Java's <c>@Column</c> annotation.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class ColumnAttribute : Attribute
+{
+    [LanguageInjection("markdown")]
+    public string DisplayName { get; set; } = "";
+
+    [LanguageInjection("markdown")]
+    public string Description { get; set; } = "";
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/ColumnDescriptor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/ColumnDescriptor.cs
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using JetBrains.Annotations;
+
+namespace OpenRewrite.Core;
+
+/// <summary>
+/// Describes a single column in a data table.
+/// Built via reflection from properties annotated with <see cref="ColumnAttribute"/>.
+/// </summary>
+public record ColumnDescriptor(
+    string Name,
+    [property: LanguageInjection("markdown")] string DisplayName,
+    [property: LanguageInjection("markdown")] string Description
+);

--- a/rewrite-csharp/csharp/OpenRewrite/Core/CsvDataTableStore.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/CsvDataTableStore.cs
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Reflection;
+
+namespace OpenRewrite.Core;
+
+/// <summary>
+/// Writes data table rows directly to CSV files (RFC 4180 format).
+/// Each data table is written to a separate CSV file named after the data table.
+/// </summary>
+public class CsvDataTableStore : IDataTableStore
+{
+    private readonly string _outputDir;
+    private bool _acceptRows;
+    private readonly HashSet<string> _initializedTables = [];
+    private readonly Dictionary<string, int> _rowCounts = new();
+    private readonly Dictionary<Type, PropertyInfo[]> _propertyCache = new();
+
+    public CsvDataTableStore(string outputDir)
+    {
+        _outputDir = outputDir;
+        Directory.CreateDirectory(outputDir);
+    }
+
+    public void InsertRow<TRow>(DataTable<TRow> dataTable, ExecutionContext ctx, TRow row) where TRow : notnull
+    {
+        if (!_acceptRows) return;
+
+        var descriptor = dataTable.Descriptor;
+        var tableName = descriptor.Name;
+        var csvPath = Path.Combine(_outputDir, tableName + ".csv");
+
+        if (!_initializedTables.Contains(tableName))
+        {
+            _initializedTables.Add(tableName);
+            _rowCounts[tableName] = 0;
+
+            var headers = descriptor.Columns.Select(c => EscapeCsv(c.DisplayName));
+            File.WriteAllText(csvPath, string.Join(",", headers) + "\n");
+        }
+
+        var properties = GetCachedProperties(typeof(TRow), descriptor);
+        var values = properties.Select(p => EscapeCsv(p.GetValue(row)));
+        File.AppendAllText(csvPath, string.Join(",", values) + "\n");
+        _rowCounts[tableName]++;
+    }
+
+    public void AcceptRows(bool accept) => _acceptRows = accept;
+
+    /// <summary>
+    /// Number of rows written for each data table.
+    /// </summary>
+    public IReadOnlyDictionary<string, int> RowCounts => _rowCounts;
+
+    /// <summary>
+    /// Names of all data tables that have been written to.
+    /// </summary>
+    public IReadOnlyList<string> TableNames => _initializedTables.ToList();
+
+    private PropertyInfo[] GetCachedProperties(Type rowType, DataTableDescriptor descriptor)
+    {
+        if (!_propertyCache.TryGetValue(rowType, out var properties))
+        {
+            properties = descriptor.Columns
+                .Select(c => rowType.GetProperty(c.Name, BindingFlags.Public | BindingFlags.Instance)!)
+                .ToArray();
+            _propertyCache[rowType] = properties;
+        }
+
+        return properties;
+    }
+
+    internal static string EscapeCsv(object? value)
+    {
+        if (value is null) return "\"\"";
+        var s = value.ToString() ?? "";
+        if (s.Contains(',') || s.Contains('"') || s.Contains('\n') || s.Contains('\r'))
+            return "\"" + s.Replace("\"", "\"\"") + "\"";
+        return s;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/DataTable.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/DataTable.cs
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Reflection;
+
+namespace OpenRewrite.Core;
+
+/// <summary>
+/// A data table for collecting structured data during recipe execution.
+/// Recipes create instances of this class and call <see cref="InsertRow"/>
+/// to emit rows that are stored by the configured <see cref="IDataTableStore"/>.
+/// </summary>
+/// <remarks>
+/// Column order is determined by the declaration order of properties on <typeparamref name="TRow"/>
+/// annotated with <see cref="ColumnAttribute"/>. This relies on the current .NET runtime behavior
+/// of <see cref="Type.GetProperties(BindingFlags)"/> returning properties in declaration order,
+/// which matches Python's <c>__dataclass_fields__</c> and JS's decorator registration order.
+/// </remarks>
+public class DataTable<TRow> where TRow : notnull
+{
+    public const string DataTableStoreKey = "org.openrewrite.dataTables.store";
+
+    private readonly DataTableDescriptor _descriptor;
+
+    public DataTable(string name, string displayName, string description)
+    {
+        _descriptor = new DataTableDescriptor(name, displayName, description, BuildColumns());
+    }
+
+    public string Name => _descriptor.Name;
+
+    public DataTableDescriptor Descriptor => _descriptor;
+
+    /// <summary>
+    /// Insert a row into this data table via the store in the execution context.
+    /// If no store exists, an <see cref="InMemoryDataTableStore"/> is created as default.
+    /// </summary>
+    public void InsertRow(ExecutionContext ctx, TRow row)
+    {
+        var store = ctx.ComputeMessageIfAbsent<IDataTableStore>(DataTableStoreKey, _ => new InMemoryDataTableStore());
+        store.InsertRow(this, ctx, row);
+    }
+
+    private static IReadOnlyList<ColumnDescriptor> BuildColumns()
+    {
+        var columns = new List<ColumnDescriptor>();
+        foreach (var prop in typeof(TRow).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var attr = prop.GetCustomAttribute<ColumnAttribute>();
+            if (attr is not null)
+            {
+                columns.Add(new ColumnDescriptor(prop.Name, attr.DisplayName, attr.Description));
+            }
+        }
+
+        return columns;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/DataTableDescriptor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/DataTableDescriptor.cs
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using JetBrains.Annotations;
+
+namespace OpenRewrite.Core;
+
+/// <summary>
+/// Complete metadata description of a data table, including its columns.
+/// </summary>
+public record DataTableDescriptor(
+    string Name,
+    [property: LanguageInjection("markdown")] string DisplayName,
+    [property: LanguageInjection("markdown")] string Description,
+    IReadOnlyList<ColumnDescriptor> Columns
+);

--- a/rewrite-csharp/csharp/OpenRewrite/Core/IDataTableStore.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/IDataTableStore.cs
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace OpenRewrite.Core;
+
+/// <summary>
+/// Interface for storing data table rows emitted during recipe execution.
+/// </summary>
+public interface IDataTableStore
+{
+    /// <summary>
+    /// Insert a row into the specified data table.
+    /// </summary>
+    void InsertRow<TRow>(DataTable<TRow> dataTable, ExecutionContext ctx, TRow row) where TRow : notnull;
+
+    /// <summary>
+    /// Enable or disable row acceptance.
+    /// </summary>
+    void AcceptRows(bool accept);
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/InMemoryDataTableStore.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/InMemoryDataTableStore.cs
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace OpenRewrite.Core;
+
+/// <summary>
+/// Stores data table rows in memory.
+/// </summary>
+public class InMemoryDataTableStore : IDataTableStore
+{
+    private bool _acceptRows;
+    private readonly Dictionary<string, DataTableDescriptor> _dataTables = new();
+    private readonly Dictionary<string, List<object>> _rows = new();
+
+    public void InsertRow<TRow>(DataTable<TRow> dataTable, ExecutionContext ctx, TRow row) where TRow : notnull
+    {
+        if (!_acceptRows) return;
+
+        var name = dataTable.Name;
+        _dataTables[name] = dataTable.Descriptor;
+
+        if (!_rows.TryGetValue(name, out var list))
+        {
+            list = [];
+            _rows[name] = list;
+        }
+
+        list.Add(row);
+    }
+
+    public void AcceptRows(bool accept) => _acceptRows = accept;
+
+    /// <summary>
+    /// All stored rows keyed by data table name.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<object>> Rows =>
+        _rows.ToDictionary(kv => kv.Key, kv => (IReadOnlyList<object>)kv.Value);
+
+    /// <summary>
+    /// Descriptors for all data tables that have rows.
+    /// </summary>
+    public IReadOnlyDictionary<string, DataTableDescriptor> DataTables => _dataTables;
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Core/DataTableTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Core/DataTableTests.cs
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+
+namespace OpenRewrite.Tests.DataTable;
+
+public record TextMatch
+{
+    [Column(DisplayName = "Source Path", Description = "The path of the source file")]
+    public string SourcePath { get; init; } = "";
+
+    [Column(DisplayName = "Line Number", Description = "The line number of the match")]
+    public int LineNumber { get; init; }
+
+    [Column(DisplayName = "Match", Description = "The matched text")]
+    public string Match { get; init; } = "";
+}
+
+public class InMemoryDataTableStoreTests
+{
+    [Fact]
+    public void InsertRowsWhenAccepting()
+    {
+        var store = new InMemoryDataTableStore();
+        var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+            "Matches found by a text search.");
+        var ctx = new Core.ExecutionContext();
+        var row = new TextMatch { SourcePath = "Foo.cs", LineNumber = 42, Match = "hello" };
+
+        store.AcceptRows(true);
+        store.InsertRow(table, ctx, row);
+
+        Assert.Single(store.Rows);
+        Assert.True(store.Rows.ContainsKey("org.openrewrite.table.TextMatches"));
+        Assert.Single(store.Rows["org.openrewrite.table.TextMatches"]);
+        Assert.Equal(row, store.Rows["org.openrewrite.table.TextMatches"][0]);
+    }
+
+    [Fact]
+    public void SuppressesRowsWhenNotAccepting()
+    {
+        var store = new InMemoryDataTableStore();
+        var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+            "Matches found by a text search.");
+        var ctx = new Core.ExecutionContext();
+
+        store.InsertRow(table, ctx, new TextMatch { SourcePath = "Foo.cs", LineNumber = 1, Match = "x" });
+
+        Assert.Empty(store.Rows);
+    }
+
+    [Fact]
+    public void MultipleRowsSameTable()
+    {
+        var store = new InMemoryDataTableStore();
+        var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+            "Matches found by a text search.");
+        var ctx = new Core.ExecutionContext();
+
+        store.AcceptRows(true);
+        store.InsertRow(table, ctx, new TextMatch { SourcePath = "A.cs", LineNumber = 1, Match = "a" });
+        store.InsertRow(table, ctx, new TextMatch { SourcePath = "B.cs", LineNumber = 2, Match = "b" });
+
+        Assert.Equal(2, store.Rows["org.openrewrite.table.TextMatches"].Count);
+    }
+
+    [Fact]
+    public void TracksDataTableDescriptors()
+    {
+        var store = new InMemoryDataTableStore();
+        var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+            "Matches found by a text search.");
+        var ctx = new Core.ExecutionContext();
+
+        store.AcceptRows(true);
+        store.InsertRow(table, ctx, new TextMatch { SourcePath = "A.cs", LineNumber = 1, Match = "a" });
+
+        Assert.Single(store.DataTables);
+        Assert.True(store.DataTables.ContainsKey("org.openrewrite.table.TextMatches"));
+        Assert.Equal("Text Matches", store.DataTables["org.openrewrite.table.TextMatches"].DisplayName);
+    }
+}
+
+public class CsvDataTableStoreTests
+{
+    [Fact]
+    public void WritesHeaderAndDataRows()
+    {
+        var outputDir = Path.Combine(Path.GetTempPath(), "datatable-test-" + Guid.NewGuid());
+        try
+        {
+            var store = new CsvDataTableStore(outputDir);
+            var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+                "Matches found by a text search.");
+            var ctx = new Core.ExecutionContext();
+
+            store.AcceptRows(true);
+            store.InsertRow(table, ctx, new TextMatch { SourcePath = "Foo.cs", LineNumber = 42, Match = "hello" });
+            store.InsertRow(table, ctx, new TextMatch { SourcePath = "Bar.cs", LineNumber = 7, Match = "world" });
+
+            var csvPath = Path.Combine(outputDir, "org.openrewrite.table.TextMatches.csv");
+            Assert.True(File.Exists(csvPath));
+
+            var lines = File.ReadAllLines(csvPath);
+            Assert.Equal(3, lines.Length);
+            Assert.Equal("Source Path,Line Number,Match", lines[0]);
+            Assert.Equal("Foo.cs,42,hello", lines[1]);
+            Assert.Equal("Bar.cs,7,world", lines[2]);
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir)) Directory.Delete(outputDir, true);
+        }
+    }
+
+    [Fact]
+    public void EscapesCsvSpecialCharacters()
+    {
+        var outputDir = Path.Combine(Path.GetTempPath(), "datatable-test-" + Guid.NewGuid());
+        try
+        {
+            var store = new CsvDataTableStore(outputDir);
+            var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+                "Matches found by a text search.");
+            var ctx = new Core.ExecutionContext();
+
+            store.AcceptRows(true);
+            store.InsertRow(table, ctx,
+                new TextMatch { SourcePath = "path,with,commas.cs", LineNumber = 1, Match = "has \"quotes\"" });
+            store.InsertRow(table, ctx,
+                new TextMatch { SourcePath = "normal.cs", LineNumber = 2, Match = "line1\nline2" });
+
+            var csvPath = Path.Combine(outputDir, "org.openrewrite.table.TextMatches.csv");
+            var content = File.ReadAllText(csvPath);
+            // Row with commas and quotes
+            Assert.Contains("\"path,with,commas.cs\",1,\"has \"\"quotes\"\"\"", content);
+            // Row with embedded newline — value is quoted
+            Assert.Contains("normal.cs,2,\"line1\nline2\"", content);
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir)) Directory.Delete(outputDir, true);
+        }
+    }
+
+    [Fact]
+    public void SuppressesRowsWhenNotAccepting()
+    {
+        var outputDir = Path.Combine(Path.GetTempPath(), "datatable-test-" + Guid.NewGuid());
+        try
+        {
+            var store = new CsvDataTableStore(outputDir);
+            var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+                "Matches found by a text search.");
+            var ctx = new Core.ExecutionContext();
+
+            store.InsertRow(table, ctx, new TextMatch { SourcePath = "Foo.cs", LineNumber = 1, Match = "x" });
+
+            var csvPath = Path.Combine(outputDir, "org.openrewrite.table.TextMatches.csv");
+            Assert.False(File.Exists(csvPath));
+            Assert.Empty(store.RowCounts);
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir)) Directory.Delete(outputDir, true);
+        }
+    }
+
+    [Fact]
+    public void ExposesRowCountsAndTableNames()
+    {
+        var outputDir = Path.Combine(Path.GetTempPath(), "datatable-test-" + Guid.NewGuid());
+        try
+        {
+            var store = new CsvDataTableStore(outputDir);
+            var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+                "Matches found by a text search.");
+            var ctx = new Core.ExecutionContext();
+
+            store.AcceptRows(true);
+            store.InsertRow(table, ctx, new TextMatch { SourcePath = "A.cs", LineNumber = 1, Match = "a" });
+            store.InsertRow(table, ctx, new TextMatch { SourcePath = "B.cs", LineNumber = 2, Match = "b" });
+
+            Assert.Single(store.TableNames);
+            Assert.Contains("org.openrewrite.table.TextMatches", store.TableNames);
+            Assert.Equal(2, store.RowCounts["org.openrewrite.table.TextMatches"]);
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir)) Directory.Delete(outputDir, true);
+        }
+    }
+}
+
+public class DataTableTests
+{
+    [Fact]
+    public void InsertRowCreatesDefaultStore()
+    {
+        var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+            "Matches found by a text search.");
+        var ctx = new Core.ExecutionContext();
+
+        table.InsertRow(ctx, new TextMatch { SourcePath = "Foo.cs", LineNumber = 1, Match = "x" });
+
+        var store = ctx.GetMessage<InMemoryDataTableStore>(DataTable<TextMatch>.DataTableStoreKey);
+        Assert.NotNull(store);
+        // Default store does not accept rows until AcceptRows(true) is called
+        Assert.Empty(store.Rows);
+    }
+
+    [Fact]
+    public void InsertRowDelegatesToAcceptingStore()
+    {
+        var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+            "Matches found by a text search.");
+        var ctx = new Core.ExecutionContext();
+
+        var store = new InMemoryDataTableStore();
+        store.AcceptRows(true);
+        ctx.PutMessage(DataTable<TextMatch>.DataTableStoreKey, store);
+
+        table.InsertRow(ctx, new TextMatch { SourcePath = "Foo.cs", LineNumber = 1, Match = "x" });
+
+        Assert.Single(store.Rows);
+        Assert.Equal("Foo.cs", ((TextMatch)store.Rows["org.openrewrite.table.TextMatches"][0]).SourcePath);
+    }
+
+    [Fact]
+    public void InsertRowUsesExistingStore()
+    {
+        var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+            "Matches found by a text search.");
+        var ctx = new Core.ExecutionContext();
+        var store = new InMemoryDataTableStore();
+        store.AcceptRows(true);
+        ctx.PutMessage(DataTable<TextMatch>.DataTableStoreKey, store);
+
+        table.InsertRow(ctx, new TextMatch { SourcePath = "Foo.cs", LineNumber = 1, Match = "x" });
+
+        Assert.Single(store.Rows);
+    }
+
+    [Fact]
+    public void DescriptorReflectsColumnAttributes()
+    {
+        var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+            "Matches found by a text search.");
+
+        var descriptor = table.Descriptor;
+
+        Assert.Equal("org.openrewrite.table.TextMatches", descriptor.Name);
+        Assert.Equal("Text Matches", descriptor.DisplayName);
+        Assert.Equal("Matches found by a text search.", descriptor.Description);
+        Assert.Equal(3, descriptor.Columns.Count);
+        Assert.Equal("SourcePath", descriptor.Columns[0].Name);
+        Assert.Equal("Source Path", descriptor.Columns[0].DisplayName);
+        Assert.Equal("The path of the source file", descriptor.Columns[0].Description);
+    }
+}


### PR DESCRIPTION
## Summary

- Add data table infrastructure to the C# SDK so recipes can emit structured data rows during execution, matching existing Python and JavaScript implementations
- `ColumnAttribute`, `ColumnDescriptor`, `DataTableDescriptor` for column metadata via reflection
- `IDataTableStore` interface with `InMemoryDataTableStore` (in-memory) and `CsvDataTableStore` (RFC 4180 CSV files) implementations
- `DataTable<TRow>` generic class that discovers columns from `[Column]` attributes and delegates row insertion to the store from `ExecutionContext`

## Test plan

- [x] 12 xUnit tests covering `InMemoryDataTableStore`, `CsvDataTableStore`, and `DataTable<TRow>`
- [x] Tests verify row insertion, `AcceptRows` gating, CSV header/data output, RFC 4180 escaping (commas, quotes, newlines), row counts, table name tracking, descriptor metadata tracking, and default store creation
