### PR TITLE
HasSourceSet should match any SourceFile, not just Java files

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasSourceSetTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasSourceSetTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.test.SourceSpecs.text;
 
 class HasSourceSetTest implements RewriteTest {
 
@@ -55,6 +56,47 @@ class HasSourceSetTest implements RewriteTest {
                 /*~~>*/class Test {
                 }
                 """
+            )
+          )
+        );
+    }
+
+    @Test
+    void mainResources() {
+        rewriteRun(
+          spec -> spec.recipe(new HasSourceSet("main")),
+          srcMainResources(
+            text(
+              "app.name=test",
+              "~~>app.name=test",
+              spec -> spec.path("application.properties")
+            )
+          )
+        );
+    }
+
+    @Test
+    void testResourcesNotMatchedByMain() {
+        rewriteRun(
+          spec -> spec.recipe(new HasSourceSet("main")),
+          srcTestResources(
+            text(
+              "app.name=test",
+              spec -> spec.path("application.properties")
+            )
+          )
+        );
+    }
+
+    @Test
+    void testResources() {
+        rewriteRun(
+          spec -> spec.recipe(new HasSourceSet("test")),
+          srcTestResources(
+            text(
+              "app.name=test",
+              "~~>app.name=test",
+              spec -> spec.path("application.properties")
             )
           )
         );

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/HasSourceSet.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/HasSourceSet.java
@@ -19,13 +19,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
-import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.marker.JavaSourceSet;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.marker.SearchResult;
-
-import static java.util.Objects.requireNonNull;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -43,18 +38,18 @@ public class HasSourceSet extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new JavaIsoVisitor<ExecutionContext>() {
+        return new TreeVisitor<Tree, ExecutionContext>() {
             @Override
-            public J visit(@Nullable Tree tree, ExecutionContext ctx) {
-                if (tree instanceof JavaSourceFile) {
-                    JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
-                    if (cu.getMarkers().findFirst(JavaSourceSet.class)
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree instanceof SourceFile) {
+                    SourceFile sf = (SourceFile) tree;
+                    if (sf.getMarkers().findFirst(JavaSourceSet.class)
                             .filter(s -> s.getName().equals(sourceSet))
                             .isPresent()) {
-                        return SearchResult.found(cu);
+                        return SearchResult.found(sf);
                     }
                 }
-                return (J) tree;
+                return tree;
             }
         };
     }


### PR DESCRIPTION
## Summary
- `HasSourceSet` used `JavaIsoVisitor` and only checked `JavaSourceFile` instances, which meant resource files (YAML, properties, XML, etc.) in a source set were never matched
- Changed to a generic `TreeVisitor<Tree, ExecutionContext>` that checks the `JavaSourceSet` marker on any `SourceFile`
- This allows `HasSourceSet` to be used as a `Preconditions.check()` guard for recipes that operate on non-Java files like `SeparateApplicationYamlByProfile`

## Test plan
- [x] Existing `main()` and `test()` tests still pass (Java source files)
- [x] New `mainResources()` test: properties file in `srcMainResources` is matched by `HasSourceSet("main")`
- [x] New `testResourcesNotMatchedByMain()` test: properties file in `srcTestResources` is NOT matched by `HasSourceSet("main")`
- [x] New `testResources()` test: properties file in `srcTestResources` is matched by `HasSourceSet("test")`