### PR TITLE
Use File(URI).toPath() to fix Windows drive letter handling

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -273,7 +273,7 @@ public class MavenPomDownloader {
 
                     if ("file".equals(scheme)) {
                         // A maven repository can be expressed as a URI with a file scheme
-                        Path path = Paths.get(URI.create(baseUri + "maven-metadata-local.xml").getPath());
+                        Path path = new File(URI.create(baseUri + "maven-metadata-local.xml")).toPath();
                         if (Files.exists(path)) {
                             MavenMetadata parsed = MavenMetadata.parse(Files.readAllBytes(path));
                             if (parsed != null) {
@@ -392,7 +392,7 @@ public class MavenPomDownloader {
     }
 
     private MavenMetadata.@Nullable Versioning directoryToVersioning(String uri, GroupArtifactVersion gav) throws MavenDownloadingException {
-        Path dir = Paths.get(URI.create(uri).getPath());
+        Path dir = new File(URI.create(uri)).toPath();
         if (Files.exists(dir)) {
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
                 List<String> versions = new ArrayList<>();

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
@@ -28,6 +28,7 @@ import org.openrewrite.maven.tree.MavenRepository;
 import org.openrewrite.maven.tree.ResolvedDependency;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.SocketTimeoutException;
@@ -107,7 +108,7 @@ public class MavenArtifactDownloader {
             if (uri.startsWith("~")) {
                 bodyStream = Files.newInputStream(Paths.get(System.getProperty("user.home") + uri.substring(1)));
             } else if ("file".equals(URI.create(uri).getScheme())) {
-                bodyStream = Files.newInputStream(Paths.get(URI.create(uri).getPath()));
+                bodyStream = Files.newInputStream(new File(URI.create(uri)).toPath());
             } else {
                 HttpSender.Request.Builder request = applyAuthentication(dependency.getRepository(), httpSender.get(uri));
                 try (HttpSender.Response response = Failsafe.with(retryPolicy).get(() -> httpSender.send(request.build()));


### PR DESCRIPTION
## Problem

v8.75.6 changed `Paths.get(URI.create(...))` to `Paths.get(URI.create(...).getPath())` to fix percent-encoded non-ASCII characters in file URIs. However, `URI.getPath()` on `file:///C:/Users/...` returns `/C:/Users/...` — the leading `/` before the drive letter causes `Paths.get(String)` to fail on Windows.

## Solution

Replace `Paths.get(URI.create(...).getPath())` with `new File(URI.create(...)).toPath()` in all three locations. `new File(URI)` internally calls `URI.getPath()` for percent-decoding and then `fs.fromURIPath()` which strips the leading `/` on Windows drive letters — handling both non-ASCII characters and Windows paths correctly.