### PR TITLE
C#: Add TypeUtils and MethodMatcher

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/Java/MethodMatcher.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/MethodMatcher.cs
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Text.RegularExpressions;
+
+namespace OpenRewrite.Java;
+
+/// <summary>
+/// Matches method invocations and declarations against AspectJ-style method patterns.
+/// C# equivalent of Java's <c>org.openrewrite.java.MethodMatcher</c>.
+///
+/// Pattern syntax:
+/// <code>
+///   DeclaringType MethodName(ArgType1, ArgType2, ..)
+///
+///   Examples:
+///     System.Threading.Tasks.Task Delay(..)          — any overload
+///     System.String *(bool)                          — any method taking a bool
+///     *..* *(..)                                     — any method on any type
+///     System.IO.File WriteAllTextAsync(string, ..)   — first arg is string
+/// </code>
+///
+/// Wildcards:
+/// <list type="bullet">
+///   <item><c>*</c> — matches any single name segment</item>
+///   <item><c>..</c> — in arguments: zero or more arguments of any type</item>
+///   <item><c>*..*</c> — in declaring type: any type in any namespace</item>
+/// </list>
+/// </summary>
+public class MethodMatcher
+{
+    private readonly Regex _declaringTypePattern;
+    private readonly Regex _methodNamePattern;
+    private readonly ArgumentMatcher[] _argMatchers;
+    private readonly bool _matchOverrides;
+    private readonly bool _hasWildcardArgs;
+
+    public MethodMatcher(string methodPattern, bool matchOverrides = false)
+    {
+        _matchOverrides = matchOverrides;
+        var (declaringType, methodName, args) = ParsePattern(methodPattern);
+
+        _declaringTypePattern = GlobToRegex(declaringType);
+        _methodNamePattern = GlobToRegex(methodName);
+
+        if (args == "..")
+        {
+            _argMatchers = [];
+            _hasWildcardArgs = true;
+        }
+        else if (string.IsNullOrEmpty(args))
+        {
+            _argMatchers = [];
+            _hasWildcardArgs = false;
+        }
+        else
+        {
+            var parts = args.Split(',').Select(p => p.Trim()).ToArray();
+            var matchers = new List<ArgumentMatcher>();
+            var hasWild = false;
+            foreach (var part in parts)
+            {
+                if (part == "..")
+                {
+                    hasWild = true;
+                    matchers.Add(new WildcardArgMatcher());
+                }
+                else
+                {
+                    matchers.Add(new TypeArgMatcher(GlobToRegex(part), part));
+                }
+            }
+            _argMatchers = matchers.ToArray();
+            _hasWildcardArgs = hasWild;
+        }
+    }
+
+    /// <summary>
+    /// Match against a <see cref="MethodInvocation"/>.
+    /// </summary>
+    public bool Matches(MethodInvocation mi)
+    {
+        if (mi.MethodType != null)
+            return Matches(mi.MethodType);
+
+        // Fallback: name-only matching when type info is unavailable
+        return _methodNamePattern.IsMatch(mi.Name.SimpleName);
+    }
+
+    /// <summary>
+    /// Match against a <see cref="JavaType.Method"/>.
+    /// </summary>
+    public bool Matches(JavaType.Method methodType)
+    {
+        // Check method name
+        if (!_methodNamePattern.IsMatch(methodType.Name))
+            return false;
+
+        // Check declaring type
+        if (!MatchesDeclaringType(methodType))
+            return false;
+
+        // Check arguments
+        if (!MatchesArguments(methodType))
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Match against a <see cref="MethodDeclaration"/>.
+    /// </summary>
+    public bool Matches(MethodDeclaration md)
+    {
+        if (md.MethodType != null)
+            return Matches(md.MethodType);
+
+        return _methodNamePattern.IsMatch(md.Name.SimpleName);
+    }
+
+    private bool MatchesDeclaringType(JavaType.Method methodType)
+    {
+        var declaring = methodType.DeclaringType;
+        if (declaring == null)
+            return true; // Can't check — allow match
+
+        var fqn = TypeUtils.GetFullyQualifiedName(declaring);
+        if (fqn == null)
+            return true;
+
+        if (_declaringTypePattern.IsMatch(fqn))
+            return true;
+
+        // Check supertypes if matchOverrides is enabled
+        if (_matchOverrides)
+        {
+            var cls = TypeUtils.AsClass(declaring);
+            if (cls != null)
+                return MatchesTypeHierarchy(cls, new HashSet<string>());
+        }
+
+        return false;
+    }
+
+    private bool MatchesTypeHierarchy(JavaType.Class cls, HashSet<string> seen)
+    {
+        if (!seen.Add(cls.FullyQualifiedName))
+            return false;
+
+        if (_declaringTypePattern.IsMatch(cls.FullyQualifiedName))
+            return true;
+
+        var super = TypeUtils.AsClass(cls.Supertype);
+        if (super != null && MatchesTypeHierarchy(super, seen))
+            return true;
+
+        if (cls.Interfaces != null)
+        {
+            foreach (var iface in cls.Interfaces)
+            {
+                var ifaceCls = TypeUtils.AsClass(iface);
+                if (ifaceCls != null && MatchesTypeHierarchy(ifaceCls, seen))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool MatchesArguments(JavaType.Method methodType)
+    {
+        if (_hasWildcardArgs && _argMatchers.Length == 0)
+            return true; // (..) matches anything
+
+        var paramTypes = methodType.ParameterTypes;
+        var paramCount = paramTypes?.Count ?? 0;
+
+        if (!_hasWildcardArgs)
+        {
+            // Exact argument count match required
+            if (_argMatchers.Length != paramCount)
+                return false;
+
+            for (var i = 0; i < _argMatchers.Length; i++)
+            {
+                if (!_argMatchers[i].Matches(paramTypes![i]))
+                    return false;
+            }
+            return true;
+        }
+
+        // Has at least one ".." wildcard — use backtracking
+        return MatchArgsWithWildcard(paramTypes, 0, 0);
+    }
+
+    private bool MatchArgsWithWildcard(IList<JavaType>? paramTypes, int mi, int pi)
+    {
+        var paramCount = paramTypes?.Count ?? 0;
+
+        if (mi >= _argMatchers.Length)
+            return pi >= paramCount;
+
+        if (_argMatchers[mi] is WildcardArgMatcher)
+        {
+            // ".." matches zero or more args — try greedy to lazy
+            for (var consume = paramCount - pi; consume >= 0; consume--)
+            {
+                if (MatchArgsWithWildcard(paramTypes, mi + 1, pi + consume))
+                    return true;
+            }
+            return false;
+        }
+
+        if (pi >= paramCount)
+            return false;
+
+        if (!_argMatchers[mi].Matches(paramTypes![pi]))
+            return false;
+
+        return MatchArgsWithWildcard(paramTypes, mi + 1, pi + 1);
+    }
+
+    private static (string declaringType, string methodName, string args) ParsePattern(string pattern)
+    {
+        // Pattern: "DeclaringType MethodName(args)"
+        var parenStart = pattern.IndexOf('(');
+        var parenEnd = pattern.LastIndexOf(')');
+
+        string args;
+        string beforeArgs;
+        if (parenStart >= 0 && parenEnd > parenStart)
+        {
+            args = pattern[(parenStart + 1)..parenEnd].Trim();
+            beforeArgs = pattern[..parenStart].Trim();
+        }
+        else
+        {
+            args = "..";
+            beforeArgs = pattern.Trim();
+        }
+
+        // Split "DeclaringType MethodName" on last space
+        var lastSpace = beforeArgs.LastIndexOf(' ');
+        if (lastSpace < 0)
+        {
+            // No declaring type — match any type
+            return ("*..*", beforeArgs, args);
+        }
+
+        var declaringType = beforeArgs[..lastSpace].Trim();
+        var methodName = beforeArgs[(lastSpace + 1)..].Trim();
+        return (declaringType, methodName, args);
+    }
+
+    private static Regex GlobToRegex(string glob)
+    {
+        // Convert AspectJ-style glob to regex:
+        // "*..*" → ".*"  (any type in any namespace)
+        // "*"    → "[^.]*" (any single segment)
+        // "Foo"  → "Foo" (exact match)
+        var pattern = Regex.Escape(glob)
+            .Replace(@"\*\.\.\*", ".*")
+            .Replace(@"\.\.", ".+")
+            .Replace(@"\*", "[^.]*");
+
+        return new Regex($"^{pattern}$", RegexOptions.Compiled);
+    }
+
+    // C# keyword aliases to fully-qualified names
+    private static readonly Dictionary<string, string> KeywordToFqn = new(StringComparer.Ordinal)
+    {
+        ["bool"] = "System.Boolean",
+        ["byte"] = "System.Byte",
+        ["sbyte"] = "System.SByte",
+        ["char"] = "System.Char",
+        ["decimal"] = "System.Decimal",
+        ["double"] = "System.Double",
+        ["float"] = "System.Single",
+        ["int"] = "System.Int32",
+        ["uint"] = "System.UInt32",
+        ["long"] = "System.Int64",
+        ["ulong"] = "System.UInt64",
+        ["short"] = "System.Int16",
+        ["ushort"] = "System.UInt16",
+        ["string"] = "System.String",
+        ["object"] = "System.Object",
+    };
+
+    private abstract class ArgumentMatcher
+    {
+        public abstract bool Matches(JavaType paramType);
+    }
+
+    private class TypeArgMatcher : ArgumentMatcher
+    {
+        private readonly Regex _pattern;
+        private readonly Regex? _fqnPattern;
+
+        public TypeArgMatcher(Regex pattern, string originalGlob)
+        {
+            _pattern = pattern;
+            // If the pattern is a C# keyword, also match the fully-qualified name
+            if (KeywordToFqn.TryGetValue(originalGlob, out var fqn))
+                _fqnPattern = GlobToRegex(fqn);
+        }
+
+        public override bool Matches(JavaType paramType)
+        {
+            var fqn = TypeUtils.GetFullyQualifiedName(paramType);
+            if (fqn != null)
+            {
+                if (_pattern.IsMatch(fqn)) return true;
+                if (_fqnPattern != null && _fqnPattern.IsMatch(fqn)) return true;
+            }
+
+            // Also match simple name for primitives/keywords
+            if (paramType is JavaType.Primitive prim)
+            {
+                if (_pattern.IsMatch(prim.Keyword)) return true;
+            }
+
+            return false;
+        }
+    }
+
+    private class WildcardArgMatcher : ArgumentMatcher
+    {
+        public override bool Matches(JavaType paramType) => true;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Java/TypeUtils.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/TypeUtils.cs
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace OpenRewrite.Java;
+
+/// <summary>
+/// Utility methods for working with <see cref="JavaType"/> instances.
+/// C# equivalent of Java's <c>org.openrewrite.java.tree.TypeUtils</c>.
+/// </summary>
+public static class TypeUtils
+{
+    /// <summary>
+    /// Check if a type is a specific fully-qualified class type (exact match, no inheritance).
+    /// </summary>
+    public static bool IsOfClassType(JavaType? type, string fullyQualifiedName)
+    {
+        var fqn = GetFullyQualifiedName(type);
+        return fqn != null && string.Equals(fqn, fullyQualifiedName, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Check if a type is assignable to the target type — i.e., the type IS the target,
+    /// extends it, or implements it. Walks the supertype and interface chains.
+    /// </summary>
+    public static bool IsAssignableTo(JavaType? type, string fullyQualifiedName)
+    {
+        if (type == null) return false;
+
+        var cls = AsClass(type);
+        if (cls == null) return false;
+
+        return IsAssignableToInternal(cls, fullyQualifiedName, new HashSet<string>());
+    }
+
+    /// <summary>
+    /// Check if a type is assignable to any of the given fully-qualified type names.
+    /// </summary>
+    public static bool IsAssignableTo(JavaType? type, IReadOnlyCollection<string> fullyQualifiedNames)
+    {
+        if (type == null) return false;
+
+        var cls = AsClass(type);
+        if (cls == null) return false;
+
+        foreach (var fqn in fullyQualifiedNames)
+        {
+            if (IsAssignableToInternal(cls, fqn, new HashSet<string>()))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Check if a type implements a specific interface (not including the type itself).
+    /// </summary>
+    public static bool Implements(JavaType? type, string interfaceFqn)
+    {
+        var cls = AsClass(type);
+        if (cls == null) return false;
+
+        return ImplementsInternal(cls, interfaceFqn, new HashSet<string>());
+    }
+
+    /// <summary>
+    /// Check if a type inherits from a specific base class (not including the type itself).
+    /// </summary>
+    public static bool InheritsFrom(JavaType? type, string baseClassFqn)
+    {
+        var cls = AsClass(type);
+        if (cls == null) return false;
+
+        var current = AsClass(cls.Supertype);
+        var seen = new HashSet<string>();
+        while (current != null)
+        {
+            if (!seen.Add(current.FullyQualifiedName))
+                break; // Cycle protection
+
+            if (string.Equals(current.FullyQualifiedName, baseClassFqn, StringComparison.Ordinal))
+                return true;
+
+            current = AsClass(current.Supertype);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Check if a type has a method with the given name.
+    /// </summary>
+    public static bool HasMethod(JavaType? type, string methodName)
+    {
+        var cls = AsClass(type);
+        if (cls == null) return false;
+
+        return HasMethodInternal(cls, methodName, new HashSet<string>());
+    }
+
+    /// <summary>
+    /// Check if a type is a string type.
+    /// </summary>
+    public static bool IsString(JavaType? type) =>
+        type is JavaType.Primitive { Kind: JavaType.Primitive.PrimitiveKind.String } ||
+        IsOfClassType(type, "System.String");
+
+    /// <summary>
+    /// Check if a type is System.Object.
+    /// </summary>
+    public static bool IsObject(JavaType? type) =>
+        IsOfClassType(type, "System.Object") || IsOfClassType(type, "object");
+
+    /// <summary>
+    /// Get the fully-qualified name of a type, or null if not resolvable.
+    /// Handles Class, Parameterized, and primitive types.
+    /// </summary>
+    public static string? GetFullyQualifiedName(JavaType? type)
+    {
+        return type switch
+        {
+            JavaType.Class cls => cls.FullyQualifiedName,
+            JavaType.Parameterized p => p.Type != null ? GetFullyQualifiedName(p.Type) : null,
+            JavaType.Primitive prim => prim.Keyword,
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Try to cast a JavaType to JavaType.Class, unwrapping Parameterized if needed.
+    /// </summary>
+    public static JavaType.Class? AsClass(JavaType? type)
+    {
+        return type switch
+        {
+            JavaType.Class cls => cls,
+            JavaType.Parameterized p => p.Type as JavaType.Class,
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Get the type of an expression, handling common node types.
+    /// </summary>
+    public static JavaType? GetType(Expression expr)
+    {
+        return expr switch
+        {
+            MethodInvocation mi => mi.MethodType?.ReturnType,
+            Identifier id => id.Type,
+            FieldAccess fa => fa.Type,
+            Literal lit => lit.Type,
+            _ => TryGetTypeDynamic(expr)
+        };
+    }
+
+    private static bool IsAssignableToInternal(JavaType.Class cls, string fqn, HashSet<string> seen)
+    {
+        if (!seen.Add(cls.FullyQualifiedName))
+            return false; // Cycle protection
+
+        if (string.Equals(cls.FullyQualifiedName, fqn, StringComparison.Ordinal))
+            return true;
+
+        // Check supertype
+        var super = AsClass(cls.Supertype);
+        if (super != null && IsAssignableToInternal(super, fqn, seen))
+            return true;
+
+        // Check interfaces
+        if (cls.Interfaces != null)
+        {
+            foreach (var iface in cls.Interfaces)
+            {
+                var ifaceCls = AsClass(iface);
+                if (ifaceCls != null && IsAssignableToInternal(ifaceCls, fqn, seen))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ImplementsInternal(JavaType.Class cls, string interfaceFqn, HashSet<string> seen)
+    {
+        if (!seen.Add(cls.FullyQualifiedName))
+            return false;
+
+        if (cls.Interfaces != null)
+        {
+            foreach (var iface in cls.Interfaces)
+            {
+                var ifaceCls = AsClass(iface);
+                if (ifaceCls == null) continue;
+
+                if (string.Equals(ifaceCls.FullyQualifiedName, interfaceFqn, StringComparison.Ordinal))
+                    return true;
+
+                // Check super-interfaces
+                if (ImplementsInternal(ifaceCls, interfaceFqn, seen))
+                    return true;
+            }
+        }
+
+        // Also check supertype's interfaces
+        var super = AsClass(cls.Supertype);
+        if (super != null)
+            return ImplementsInternal(super, interfaceFqn, seen);
+
+        return false;
+    }
+
+    private static bool HasMethodInternal(JavaType.Class cls, string methodName, HashSet<string> seen)
+    {
+        if (!seen.Add(cls.FullyQualifiedName))
+            return false;
+
+        if (cls.Methods != null)
+        {
+            foreach (var method in cls.Methods)
+            {
+                if (string.Equals(method.Name, methodName, StringComparison.Ordinal))
+                    return true;
+            }
+        }
+
+        // Check supertype
+        var super = AsClass(cls.Supertype);
+        if (super != null && HasMethodInternal(super, methodName, seen))
+            return true;
+
+        return false;
+    }
+
+    private static JavaType? TryGetTypeDynamic(Expression expr)
+    {
+        try
+        {
+            return ((dynamic)expr).Type as JavaType;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Java/MethodMatcherTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Java/MethodMatcherTests.cs
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Java;
+
+namespace OpenRewrite.Tests.Java;
+
+public class MethodMatcherTests
+{
+    private static JavaType.Class MakeClass(string fqn, JavaType.FullyQualified? supertype = null) =>
+        new() { FullyQualifiedName = fqn, Supertype = supertype };
+
+    private static JavaType.Method MakeMethod(
+        string declaringTypeFqn, string name,
+        JavaType? returnType = null,
+        IList<JavaType>? parameterTypes = null,
+        IList<string>? parameterNames = null)
+    {
+        var declaring = MakeClass(declaringTypeFqn);
+        return new JavaType.Method
+        {
+            Name = name,
+            DeclaringType = declaring,
+            ReturnType = returnType,
+            ParameterTypes = parameterTypes,
+            ParameterNames = parameterNames
+        };
+    }
+
+    // =============================================================
+    // Basic matching
+    // =============================================================
+
+    [Fact]
+    public void MatchesExactMethodSignature()
+    {
+        var mm = new MethodMatcher("System.Threading.Tasks.Task Delay(int)");
+        var method = MakeMethod("System.Threading.Tasks.Task", "Delay",
+            parameterTypes: [JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int)]);
+        Assert.True(mm.Matches(method));
+    }
+
+    [Fact]
+    public void DoesNotMatchWrongMethodName()
+    {
+        var mm = new MethodMatcher("System.Threading.Tasks.Task Delay(int)");
+        var method = MakeMethod("System.Threading.Tasks.Task", "Run",
+            parameterTypes: [JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int)]);
+        Assert.False(mm.Matches(method));
+    }
+
+    [Fact]
+    public void DoesNotMatchWrongDeclaringType()
+    {
+        var mm = new MethodMatcher("System.Threading.Tasks.Task Delay(int)");
+        var method = MakeMethod("System.String", "Delay",
+            parameterTypes: [JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int)]);
+        Assert.False(mm.Matches(method));
+    }
+
+    // =============================================================
+    // Wildcard arguments
+    // =============================================================
+
+    [Fact]
+    public void MatchesWildcardArguments()
+    {
+        var mm = new MethodMatcher("System.Threading.Tasks.Task Delay(..)");
+        var method0 = MakeMethod("System.Threading.Tasks.Task", "Delay");
+        var method1 = MakeMethod("System.Threading.Tasks.Task", "Delay",
+            parameterTypes: [JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int)]);
+        Assert.True(mm.Matches(method0));
+        Assert.True(mm.Matches(method1));
+    }
+
+    [Fact]
+    public void MatchesNoArgs()
+    {
+        var mm = new MethodMatcher("System.String ToString()");
+        var method = MakeMethod("System.String", "ToString");
+        Assert.True(mm.Matches(method));
+    }
+
+    [Fact]
+    public void NoArgsDoesNotMatchMethodWithArgs()
+    {
+        var mm = new MethodMatcher("System.String ToString()");
+        var method = MakeMethod("System.String", "ToString",
+            parameterTypes: [MakeClass("System.IFormatProvider")]);
+        Assert.False(mm.Matches(method));
+    }
+
+    [Fact]
+    public void MatchesTrailingWildcard()
+    {
+        var mm = new MethodMatcher("System.IO.File WriteAllTextAsync(string, ..)");
+        var method = MakeMethod("System.IO.File", "WriteAllTextAsync",
+            parameterTypes: [MakeClass("System.String"), MakeClass("System.String")]);
+        Assert.True(mm.Matches(method));
+    }
+
+    [Fact]
+    public void TrailingWildcardMatchesMinimum()
+    {
+        var mm = new MethodMatcher("System.IO.File WriteAllTextAsync(string, ..)");
+        var method = MakeMethod("System.IO.File", "WriteAllTextAsync",
+            parameterTypes: [MakeClass("System.String")]);
+        Assert.True(mm.Matches(method));
+    }
+
+    // =============================================================
+    // Wildcard type names
+    // =============================================================
+
+    [Fact]
+    public void MatchesWildcardMethodName()
+    {
+        var mm = new MethodMatcher("System.String *(int)");
+        var method = MakeMethod("System.String", "Substring",
+            parameterTypes: [JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int)]);
+        Assert.True(mm.Matches(method));
+    }
+
+    [Fact]
+    public void MatchesWildcardDeclaringType()
+    {
+        var mm = new MethodMatcher("*..* Delay(..)");
+        var method = MakeMethod("System.Threading.Tasks.Task", "Delay");
+        Assert.True(mm.Matches(method));
+    }
+
+    [Fact]
+    public void MatchesPartialWildcardType()
+    {
+        var mm = new MethodMatcher("System.Threading.Tasks.* Delay(..)");
+        var method = MakeMethod("System.Threading.Tasks.Task", "Delay");
+        Assert.True(mm.Matches(method));
+    }
+
+    // =============================================================
+    // matchOverrides
+    // =============================================================
+
+    [Fact]
+    public void MatchesOverride_WhenEnabled()
+    {
+        var baseClass = MakeClass("BaseClass");
+        var derived = MakeClass("DerivedClass", supertype: baseClass);
+        var method = MakeMethod("DerivedClass", "DoWork");
+        method.DeclaringType = derived;
+
+        var mm = new MethodMatcher("BaseClass DoWork(..)", matchOverrides: true);
+        Assert.True(mm.Matches(method));
+    }
+
+    [Fact]
+    public void DoesNotMatchOverride_WhenDisabled()
+    {
+        var baseClass = MakeClass("BaseClass");
+        var derived = MakeClass("DerivedClass", supertype: baseClass);
+        var method = MakeMethod("DerivedClass", "DoWork");
+        method.DeclaringType = derived;
+
+        var mm = new MethodMatcher("BaseClass DoWork(..)");
+        Assert.False(mm.Matches(method));
+    }
+
+    // =============================================================
+    // No declaring type in pattern
+    // =============================================================
+
+    [Fact]
+    public void MatchesWithoutDeclaringType()
+    {
+        var mm = new MethodMatcher("Delay(..)");
+        var method = MakeMethod("System.Threading.Tasks.Task", "Delay");
+        Assert.True(mm.Matches(method));
+    }
+
+    // =============================================================
+    // Multiple argument types
+    // =============================================================
+
+    [Fact]
+    public void MatchesMultipleArgs()
+    {
+        var mm = new MethodMatcher("System.String Equals(string, System.StringComparison)");
+        var method = MakeMethod("System.String", "Equals",
+            parameterTypes: [MakeClass("System.String"), MakeClass("System.StringComparison")]);
+        Assert.True(mm.Matches(method));
+    }
+
+    [Fact]
+    public void DoesNotMatchWrongArgCount()
+    {
+        var mm = new MethodMatcher("System.String Equals(string)");
+        var method = MakeMethod("System.String", "Equals",
+            parameterTypes: [MakeClass("System.String"), MakeClass("System.StringComparison")]);
+        Assert.False(mm.Matches(method));
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Java/TypeUtilsTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Java/TypeUtilsTests.cs
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Java;
+
+namespace OpenRewrite.Tests.Java;
+
+public class TypeUtilsTests
+{
+    private static JavaType.Class MakeClass(
+        string fqn,
+        JavaType.FullyQualified? supertype = null,
+        IList<JavaType.FullyQualified>? interfaces = null,
+        IList<JavaType.Method>? methods = null)
+    {
+        return new JavaType.Class
+        {
+            FullyQualifiedName = fqn,
+            Supertype = supertype,
+            Interfaces = interfaces,
+            Methods = methods
+        };
+    }
+
+    private static JavaType.Method MakeMethod(string name, JavaType.FullyQualified? declaringType = null,
+        JavaType? returnType = null, IList<JavaType>? parameterTypes = null,
+        IList<string>? parameterNames = null)
+    {
+        return new JavaType.Method
+        {
+            Name = name,
+            DeclaringType = declaringType,
+            ReturnType = returnType,
+            ParameterTypes = parameterTypes,
+            ParameterNames = parameterNames
+        };
+    }
+
+    // =============================================================
+    // IsOfClassType
+    // =============================================================
+
+    [Fact]
+    public void IsOfClassType_ExactMatch()
+    {
+        var cls = MakeClass("System.String");
+        Assert.True(TypeUtils.IsOfClassType(cls, "System.String"));
+    }
+
+    [Fact]
+    public void IsOfClassType_NoMatch()
+    {
+        var cls = MakeClass("System.String");
+        Assert.False(TypeUtils.IsOfClassType(cls, "System.Int32"));
+    }
+
+    [Fact]
+    public void IsOfClassType_NullType()
+    {
+        Assert.False(TypeUtils.IsOfClassType(null, "System.String"));
+    }
+
+    // =============================================================
+    // IsAssignableTo
+    // =============================================================
+
+    [Fact]
+    public void IsAssignableTo_SameType()
+    {
+        var cls = MakeClass("System.String");
+        Assert.True(TypeUtils.IsAssignableTo(cls, "System.String"));
+    }
+
+    [Fact]
+    public void IsAssignableTo_Supertype()
+    {
+        var obj = MakeClass("System.Object");
+        var str = MakeClass("System.String", supertype: obj);
+        Assert.True(TypeUtils.IsAssignableTo(str, "System.Object"));
+    }
+
+    [Fact]
+    public void IsAssignableTo_Interface()
+    {
+        var disposable = MakeClass("System.IDisposable");
+        var stream = MakeClass("System.IO.Stream", interfaces: [disposable]);
+        Assert.True(TypeUtils.IsAssignableTo(stream, "System.IDisposable"));
+    }
+
+    [Fact]
+    public void IsAssignableTo_TransitiveSupertype()
+    {
+        var obj = MakeClass("System.Object");
+        var marshalByRef = MakeClass("System.MarshalByRefObject", supertype: obj);
+        var stream = MakeClass("System.IO.Stream", supertype: marshalByRef);
+        Assert.True(TypeUtils.IsAssignableTo(stream, "System.Object"));
+    }
+
+    [Fact]
+    public void IsAssignableTo_NoMatch()
+    {
+        var cls = MakeClass("System.String");
+        Assert.False(TypeUtils.IsAssignableTo(cls, "System.Int32"));
+    }
+
+    [Fact]
+    public void IsAssignableTo_NullType()
+    {
+        Assert.False(TypeUtils.IsAssignableTo(null, "System.String"));
+    }
+
+    [Fact]
+    public void IsAssignableTo_MultipleTargets()
+    {
+        var disposable = MakeClass("System.IDisposable");
+        var stream = MakeClass("System.IO.Stream", interfaces: [disposable]);
+        Assert.True(TypeUtils.IsAssignableTo(stream, ["System.Int32", "System.IDisposable"]));
+        Assert.False(TypeUtils.IsAssignableTo(stream, ["System.Int32", "System.String"]));
+    }
+
+    // =============================================================
+    // InheritsFrom
+    // =============================================================
+
+    [Fact]
+    public void InheritsFrom_DirectParent()
+    {
+        var obj = MakeClass("System.Object");
+        var str = MakeClass("System.String", supertype: obj);
+        Assert.True(TypeUtils.InheritsFrom(str, "System.Object"));
+    }
+
+    [Fact]
+    public void InheritsFrom_DoesNotMatchSelf()
+    {
+        var cls = MakeClass("System.String");
+        Assert.False(TypeUtils.InheritsFrom(cls, "System.String"));
+    }
+
+    // =============================================================
+    // Implements
+    // =============================================================
+
+    [Fact]
+    public void Implements_DirectInterface()
+    {
+        var disposable = MakeClass("System.IDisposable");
+        var cls = MakeClass("MyClass", interfaces: [disposable]);
+        Assert.True(TypeUtils.Implements(cls, "System.IDisposable"));
+    }
+
+    [Fact]
+    public void Implements_DoesNotMatchSelf()
+    {
+        var cls = MakeClass("System.IDisposable");
+        Assert.False(TypeUtils.Implements(cls, "System.IDisposable"));
+    }
+
+    [Fact]
+    public void Implements_InheritedInterface()
+    {
+        var disposable = MakeClass("System.IDisposable");
+        var baseClass = MakeClass("BaseClass", interfaces: [disposable]);
+        var derived = MakeClass("DerivedClass", supertype: baseClass);
+        Assert.True(TypeUtils.Implements(derived, "System.IDisposable"));
+    }
+
+    // =============================================================
+    // HasMethod
+    // =============================================================
+
+    [Fact]
+    public void HasMethod_DirectMethod()
+    {
+        var method = MakeMethod("ConfigureAwait");
+        var cls = MakeClass("System.Threading.Tasks.Task", methods: [method]);
+        Assert.True(TypeUtils.HasMethod(cls, "ConfigureAwait"));
+    }
+
+    [Fact]
+    public void HasMethod_InheritedMethod()
+    {
+        var method = MakeMethod("ToString");
+        var obj = MakeClass("System.Object", methods: [method]);
+        var str = MakeClass("System.String", supertype: obj);
+        Assert.True(TypeUtils.HasMethod(str, "ToString"));
+    }
+
+    [Fact]
+    public void HasMethod_NotFound()
+    {
+        var cls = MakeClass("MyClass");
+        Assert.False(TypeUtils.HasMethod(cls, "NonExistent"));
+    }
+
+    // =============================================================
+    // IsString / IsObject
+    // =============================================================
+
+    [Fact]
+    public void IsString_ClassType()
+    {
+        Assert.True(TypeUtils.IsString(MakeClass("System.String")));
+    }
+
+    [Fact]
+    public void IsString_Primitive()
+    {
+        Assert.True(TypeUtils.IsString(JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.String)));
+    }
+
+    [Fact]
+    public void IsString_NotString()
+    {
+        Assert.False(TypeUtils.IsString(MakeClass("System.Int32")));
+    }
+
+    // =============================================================
+    // GetFullyQualifiedName
+    // =============================================================
+
+    [Fact]
+    public void GetFullyQualifiedName_Class()
+    {
+        Assert.Equal("System.String", TypeUtils.GetFullyQualifiedName(MakeClass("System.String")));
+    }
+
+    [Fact]
+    public void GetFullyQualifiedName_Null()
+    {
+        Assert.Null(TypeUtils.GetFullyQualifiedName(null));
+    }
+
+    // =============================================================
+    // AsClass
+    // =============================================================
+
+    [Fact]
+    public void AsClass_UnwrapsParameterized()
+    {
+        var inner = MakeClass("System.Threading.Tasks.Task");
+        var parameterized = new JavaType.Parameterized { Type = inner };
+        var result = TypeUtils.AsClass(parameterized);
+        Assert.NotNull(result);
+        Assert.Equal("System.Threading.Tasks.Task", result.FullyQualifiedName);
+    }
+
+    [Fact]
+    public void AsClass_NullReturnsNull()
+    {
+        Assert.Null(TypeUtils.AsClass(null));
+    }
+
+    // =============================================================
+    // Cycle protection
+    // =============================================================
+
+    [Fact]
+    public void IsAssignableTo_HandlesCyclicTypeReference()
+    {
+        // Create a cycle: A -> B -> A (via mutable setters)
+        var a = MakeClass("A");
+        var b = MakeClass("B", supertype: a);
+        a.Supertype = b;
+
+        // Should not stack overflow — cycle protection kicks in
+        Assert.False(TypeUtils.IsAssignableTo(a, "System.Object"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TypeUtils` C# implementation for type compatibility checks (assignability, inheritance, generic type handling)
- Add `MethodMatcher` C# implementation for matching method invocations by type pattern and argument types
- Add comprehensive tests for both utilities

## Test plan
- [x] TypeUtilsTests cover assignability, generic types, parameterized types, arrays, and ShallowClass
- [x] MethodMatcherTests cover exact matches, wildcard patterns, subtype matching, constructors, and untyped arguments