### PR TITLE
C#: Handle `Primitive(String)` in `TypeUtils.IsAssignableTo` and `GetFullyQualifiedName`

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/Java/TypeUtils.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/TypeUtils.cs
@@ -38,6 +38,10 @@ public static class TypeUtils
     {
         if (type == null) return false;
 
+        // Primitive(String) is assignable to "System.String" but has no Class representation
+        if (type is JavaType.Primitive { Kind: JavaType.Primitive.PrimitiveKind.String })
+            return string.Equals("System.String", fullyQualifiedName, StringComparison.Ordinal);
+
         var cls = AsClass(type);
         if (cls == null) return false;
 
@@ -50,6 +54,10 @@ public static class TypeUtils
     public static bool IsAssignableTo(JavaType? type, IReadOnlyCollection<string> fullyQualifiedNames)
     {
         if (type == null) return false;
+
+        // Primitive(String) is assignable to "System.String" but has no Class representation
+        if (type is JavaType.Primitive { Kind: JavaType.Primitive.PrimitiveKind.String })
+            return fullyQualifiedNames.Contains("System.String");
 
         var cls = AsClass(type);
         if (cls == null) return false;
@@ -130,6 +138,7 @@ public static class TypeUtils
         {
             JavaType.Class cls => cls.FullyQualifiedName,
             JavaType.Parameterized p => p.Type != null ? GetFullyQualifiedName(p.Type) : null,
+            JavaType.Primitive { Kind: JavaType.Primitive.PrimitiveKind.String } => "System.String",
             JavaType.Primitive prim => prim.Keyword,
             _ => null
         };

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Java/TypeUtilsTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Java/TypeUtilsTests.cs
@@ -116,6 +116,20 @@ public class TypeUtilsTests
     }
 
     [Fact]
+    public void IsAssignableTo_PrimitiveString()
+    {
+        var prim = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.String);
+        Assert.True(TypeUtils.IsAssignableTo(prim, "System.String"));
+    }
+
+    [Fact]
+    public void IsAssignableTo_PrimitiveString_NotAssignableToOther()
+    {
+        var prim = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.String);
+        Assert.False(TypeUtils.IsAssignableTo(prim, "System.Int32"));
+    }
+
+    [Fact]
     public void IsAssignableTo_NullType()
     {
         Assert.False(TypeUtils.IsAssignableTo(null, "System.String"));
@@ -235,6 +249,20 @@ public class TypeUtilsTests
     public void GetFullyQualifiedName_Class()
     {
         Assert.Equal("System.String", TypeUtils.GetFullyQualifiedName(MakeClass("System.String")));
+    }
+
+    [Fact]
+    public void GetFullyQualifiedName_PrimitiveString()
+    {
+        Assert.Equal("System.String",
+            TypeUtils.GetFullyQualifiedName(JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.String)));
+    }
+
+    [Fact]
+    public void GetFullyQualifiedName_PrimitiveInt()
+    {
+        Assert.Equal("int",
+            TypeUtils.GetFullyQualifiedName(JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int)));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

C# maps `string` to `JavaType.Primitive { Kind = PrimitiveKind.String }` in the type system. This causes `TypeUtils` methods that recipe authors rely on to silently fail for string types, since primitives don't carry a fully qualified name. For example, a recipe checking whether a method's return type is `System.String`:

```csharp
// methodType.ReturnType is Primitive(String) when the method returns `string`
if (TypeUtils.IsAssignableTo(methodType.ReturnType, "System.String"))
{
    // This branch was never reached for `string` return types
}
```

This PR adds minimal special-casing so that `Primitive(String)` is treated as `System.String` where it matters:

- **`GetFullyQualifiedName`**: returns `"System.String"` for `Primitive(String)` instead of `"String"` (the keyword)
- **`IsAssignableTo`** (both overloads): recognizes `Primitive(String)` as assignable to `"System.String"`
- **`IsString`**: already handled both representations correctly — no changes needed

## Test plan
- [x] Added `GetFullyQualifiedName_PrimitiveString` — verifies `"System.String"` is returned
- [x] Added `GetFullyQualifiedName_PrimitiveInt` — verifies other primitives still return their keyword
- [x] Added `IsAssignableTo_PrimitiveString` — verifies assignability to `"System.String"`
- [x] Added `IsAssignableTo_PrimitiveString_NotAssignableToOther` — verifies non-assignability to unrelated types
- [x] All 30 TypeUtils tests pass