### PR TITLE
C#: Add null-conditional (`?.`) support to `CSharpPattern`

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
@@ -69,6 +69,10 @@ internal class PatternMatchingComparator
         if (pattern.GetType() != candidate.GetType())
             return false;
 
+        // NullSafe marker must match: ?. and . are structurally different
+        if (HasNullSafe(pattern) != HasNullSafe(candidate))
+            return false;
+
         // Generic property-based comparison: iterate all structural properties
         // and compare them recursively, skipping formatting/identity fields.
         var properties = TreeHelper.GetStructuralProperties(pattern.GetType());
@@ -281,5 +285,10 @@ internal class PatternMatchingComparator
     {
         var type = value.GetType();
         return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(JContainer<>);
+    }
+
+    private static bool HasNullSafe(J node)
+    {
+        return node.Markers.FindFirst<NullSafe>() != null;
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/PatternMatchTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/PatternMatchTests.cs
@@ -762,6 +762,74 @@ public class PatternMatchTests : RewriteTest
     }
 
     // ===============================================================
+    // Null-conditional member access (?.)
+    // ===============================================================
+
+    [Fact]
+    public void MatchesNullConditionalMethodCall()
+    {
+        var obj = Capture.Of<Expression>("obj");
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation($"{obj}?.ToString()")),
+            CSharp(
+                "class C { void M() { string s = null; var x = s?.ToString(); } }",
+                "class C { void M() { string s = null; var x = /*~~>*/s?.ToString(); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void NullConditionalPatternDoesNotMatchRegularDotAccess()
+    {
+        var obj = Capture.Of<Expression>("obj");
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation($"{obj}?.ToString()")),
+            CSharp(
+                // Regular dot access should NOT match a ?. pattern
+                "class C { void M() { var x = \"hello\".ToString(); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void RegularDotPatternDoesNotMatchNullConditionalAccess()
+    {
+        var obj = Capture.Of<Expression>("obj");
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation($"{obj}.ToString()")),
+            CSharp(
+                // ?. access should NOT match a regular . pattern
+                "class C { void M() { string s = null; var x = s?.ToString(); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void MatchesNullConditionalFieldAccess()
+    {
+        var obj = Capture.Of<Expression>("obj");
+        RewriteRun(
+            spec => spec.SetRecipe(FindFieldAccess($"{obj}?.Length")),
+            CSharp(
+                "class C { void M() { string s = null; var x = s?.Length; } }",
+                "class C { void M() { string s = null; var x = /*~~>*/s?.Length; } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void MatchesExactNullConditionalMethodCall()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation("s?.ToString()")),
+            CSharp(
+                "class C { void M() { string s = null; var x = s?.ToString(); } }",
+                "class C { void M() { string s = null; var x = /*~~>*/s?.ToString(); } }"
+            )
+        );
+    }
+
+    // ===============================================================
     // C#-specific: IsPattern (is with pattern variable)
     // ===============================================================
 
@@ -912,6 +980,7 @@ public class PatternMatchTests : RewriteTest
 
     private static Core.Recipe FindMethodInvocation(TemplateStringHandler h) => Search<MethodInvocation>(h);
     private static Core.Recipe FindMethodInvocation(string c) => Search<MethodInvocation>(c);
+    private static Core.Recipe FindFieldAccess(TemplateStringHandler h) => Search<FieldAccess>(h);
     private static Core.Recipe FindFieldAccess(string c) => Search<FieldAccess>(c);
     private static Core.Recipe FindLiteral(string c) => Search<Literal>(c);
     private static Core.Recipe FindBinary(TemplateStringHandler h) => Search<Binary>(h);


### PR DESCRIPTION
## Summary

`CSharpPattern` could not distinguish between regular member access (`.`) and null-conditional member access (`?.`). This meant a pattern like `{obj}?.ToString()` would incorrectly match `x.ToString()`, and `{obj}.ToString()` would incorrectly match `x?.ToString()`. Recipe authors targeting null-conditional expressions had no way to be precise about which access style they wanted to match.

The root cause: `PatternMatchingComparator` skips all `Markers` during structural comparison, but `?.` is represented as a `NullSafe` marker on the `FieldAccess.Name` / `MethodInvocation.Name` identifier — so the two forms were structurally identical to the comparator.

After this change, patterns correctly distinguish the two forms:

```csharp
var obj = Capture.Of<Expression>("obj");

// Matches only x?.ToString(), not x.ToString()
var nullConditional = CSharpPattern.Create($"{obj}?.ToString()");

// Matches only x.ToString(), not x?.ToString()
var regular = CSharpPattern.Create($"{obj}.ToString()");
```

## Changes

- **`PatternMatchingComparator`**: Check `NullSafe` marker presence when comparing nodes. If the pattern node has a `NullSafe` marker, the candidate must too (and vice versa).
- **`PatternMatchTests`**: 5 new tests covering null-conditional method calls, field access, exact matching, and negative cases for both directions (`.` pattern vs `?.` candidate and `?.` pattern vs `.` candidate).

## Test plan

- [x] All 67 `PatternMatchTests` pass (62 existing + 5 new)
- [ ] CI green