### PR TITLE
Make `TreeHelper.SetPrefix` public for recipe authors

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TreeHelper.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TreeHelper.cs
@@ -24,7 +24,7 @@ namespace OpenRewrite.CSharp.Template;
 /// Generic helpers for operating on LST nodes without type-specific switches.
 /// Uses reflection with caching to call WithPrefix and enumerate structural properties.
 /// </summary>
-internal static class TreeHelper
+public static class TreeHelper
 {
     private static readonly ConcurrentDictionary<Type, MethodInfo?> WithPrefixCache = new();
     private static readonly ConcurrentDictionary<Type, MethodInfo?> WithIdCache = new();
@@ -50,7 +50,7 @@ internal static class TreeHelper
     /// Call WithPrefix on any J node via cached reflection.
     /// Returns the original node unchanged if the type doesn't have WithPrefix.
     /// </summary>
-    internal static J SetPrefix(J node, Space prefix)
+    public static J SetPrefix(J node, Space prefix)
     {
         var method = WithPrefixCache.GetOrAdd(node.GetType(), type =>
             type.GetMethod("WithPrefix", [typeof(Space)]));
@@ -65,7 +65,7 @@ internal static class TreeHelper
     /// Call WithId on any J node via cached reflection.
     /// Returns the original node unchanged if the type doesn't have WithId.
     /// </summary>
-    internal static J SetId(J node, Guid id)
+    public static J SetId(J node, Guid id)
     {
         var method = WithIdCache.GetOrAdd(node.GetType(), type =>
             type.GetMethod("WithId", [typeof(Guid)]));


### PR DESCRIPTION
## Summary

Recipe authors frequently need to call `WithPrefix(Space)` on generic `J`/`Expression`/`Statement` nodes where the concrete type isn't known at compile time. Because C# doesn't support covariant return types on interface implementations, adding `J WithPrefix(Space)` to the `J` interface would force callers to cast the return value everywhere. The current workaround is `dynamic` casting:

```csharp
// Before: recipe authors resort to dynamic casts (~60 occurrences across recipes)
var updated = ((dynamic)node).WithPrefix(space);
```

The SDK already solves this internally with `TreeHelper.SetPrefix`, which uses cached reflection — but it's `internal`. This PR makes it `public`:

```csharp
// After: type-safe, cached reflection, no dynamic dispatch
var updated = TreeHelper.SetPrefix(node, space);
```

- Make `TreeHelper` class `public`
- Make `SetPrefix` and `SetId` methods `public`
- All other members remain `internal`

## Test plan

- [x] `gw :rewrite-csharp:assemble` passes
- [ ] Verify existing tests still pass with `public` visibility
- [ ] Downstream: replace `dynamic` casts in recipes-csharp with `TreeHelper.SetPrefix`