### PR TITLE
Add generic `J.SetPrefix<T>` / `J.SetId<T>` static helpers

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
@@ -155,7 +155,7 @@ internal static class TemplateEngine
         if (node is ExpressionStatement es)
             return es.WithExpression((Expression)StripPrefix(es.Expression));
 
-        return TreeHelper.SetPrefix(node, Space.Empty);
+        return J.SetPrefix(node, Space.Empty);
     }
 
     /// <summary>
@@ -188,7 +188,7 @@ internal static class TemplateEngine
     /// </summary>
     private static J PreservePrefix(J replacement, J original)
     {
-        return TreeHelper.SetPrefix(replacement, original.Prefix);
+        return J.SetPrefix(replacement, original.Prefix);
     }
 
     /// <summary>
@@ -208,7 +208,7 @@ internal static class TemplateEngine
 
         // Assign a fresh ID so FindById targets exactly this instance,
         // not a stale node from a prior application of the same template
-        tree = TreeHelper.SetId(tree, Guid.NewGuid());
+        tree = J.SetId(tree, Guid.NewGuid());
 
         // Replace the original node with the template result in the CU
         var replacer = new NodeReplacer(original.Id, tree);
@@ -319,7 +319,7 @@ internal class SubstitutionVisitor : CSharpVisitor<int>
             if (captured != null)
             {
                 // Preserve the placeholder's prefix on the captured node
-                return TreeHelper.SetPrefix(captured, identifier.Prefix);
+                return J.SetPrefix(captured, identifier.Prefix);
             }
         }
         return base.VisitIdentifier(identifier, p);
@@ -396,7 +396,7 @@ internal class SubstitutionVisitor : CSharpVisitor<int>
                         var capturedArg = capturedList[j];
                         // First element inherits the placeholder's prefix
                         if (j == 0)
-                            capturedArg = TreeHelper.SetPrefix(capturedArg, ident.Prefix);
+                            capturedArg = J.SetPrefix(capturedArg, ident.Prefix);
                         expanded.Add(new JRightPadded<Expression>(
                             capturedArg, Space.Empty, Markers.Empty));
                     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TreeHelper.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TreeHelper.cs
@@ -18,17 +18,13 @@ using System.Reflection;
 using OpenRewrite.Core;
 using OpenRewrite.Java;
 
-namespace OpenRewrite.CSharp;
+namespace OpenRewrite.CSharp.Template;
 
 /// <summary>
-/// Generic helpers for operating on LST nodes without type-specific switches.
-/// Uses reflection with caching to call WithPrefix and enumerate structural properties.
+/// Helpers for structural comparison of LST nodes used by the pattern matching engine.
 /// </summary>
-public static class TreeHelper
+internal static class TreeHelper
 {
-    private static readonly ConcurrentDictionary<Type, MethodInfo?> WithPrefixCache = new();
-    private static readonly ConcurrentDictionary<Type, MethodInfo?> WithIdCache = new();
-
     /// <summary>
     /// Property names to always skip when comparing tree nodes structurally.
     /// </summary>
@@ -45,36 +41,6 @@ public static class TreeHelper
     ];
 
     private static readonly ConcurrentDictionary<Type, PropertyInfo[]> StructuralPropertiesCache = new();
-
-    /// <summary>
-    /// Call WithPrefix on any J node via cached reflection, preserving the concrete type.
-    /// Returns the original node unchanged if the type doesn't have WithPrefix.
-    /// </summary>
-    public static T SetPrefix<T>(T node, Space prefix) where T : J
-    {
-        var method = WithPrefixCache.GetOrAdd(node.GetType(), type =>
-            type.GetMethod("WithPrefix", [typeof(Space)]));
-
-        if (method != null)
-            return (T)method.Invoke(node, [prefix])!;
-
-        return node;
-    }
-
-    /// <summary>
-    /// Call WithId on any J node via cached reflection, preserving the concrete type.
-    /// Returns the original node unchanged if the type doesn't have WithId.
-    /// </summary>
-    public static T SetId<T>(T node, Guid id) where T : J
-    {
-        var method = WithIdCache.GetOrAdd(node.GetType(), type =>
-            type.GetMethod("WithId", [typeof(Guid)]));
-
-        if (method != null)
-            return (T)method.Invoke(node, [id])!;
-
-        return node;
-    }
 
     /// <summary>
     /// Get the structural (non-formatting) properties of a J node for comparison.

--- a/rewrite-csharp/csharp/OpenRewrite/Java/J.Helpers.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/J.Helpers.cs
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Collections.Concurrent;
+using System.Reflection;
+using OpenRewrite.Core;
+
+namespace OpenRewrite.Java;
+
+public partial interface J
+{
+    private static readonly ConcurrentDictionary<Type, MethodInfo?> WithPrefixCache = new();
+    private static readonly ConcurrentDictionary<Type, MethodInfo?> WithIdCache = new();
+
+    /// <summary>
+    /// Call WithPrefix on any J node via cached reflection, preserving the concrete type.
+    /// Returns the original node unchanged if the type doesn't have WithPrefix.
+    /// </summary>
+    public static T SetPrefix<T>(T node, Space prefix) where T : J
+    {
+        var method = WithPrefixCache.GetOrAdd(node.GetType(), type =>
+            type.GetMethod("WithPrefix", [typeof(Space)]));
+
+        if (method != null)
+            return (T)method.Invoke(node, [prefix])!;
+
+        return node;
+    }
+
+    /// <summary>
+    /// Call WithId on any J node via cached reflection, preserving the concrete type.
+    /// Returns the original node unchanged if the type doesn't have WithId.
+    /// </summary>
+    public static T SetId<T>(T node, Guid id) where T : J
+    {
+        var method = WithIdCache.GetOrAdd(node.GetType(), type =>
+            type.GetMethod("WithId", [typeof(Guid)]));
+
+        if (method != null)
+            return (T)method.Invoke(node, [id])!;
+
+        return node;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Java/J.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/J.cs
@@ -22,7 +22,7 @@ namespace OpenRewrite.Java;
 /// The base interface for all Java-family LST elements.
 /// C# LST elements extend J where the syntax is isomorphic.
 /// </summary>
-public interface J : Tree
+public partial interface J : Tree
 {
     Space Prefix { get; }
     Markers Markers { get; }


### PR DESCRIPTION
## Summary
- Add `SetPrefix<T>` and `SetId<T>` as static methods on `partial interface J` — generic overloads that preserve the concrete type so callers don't need to cast
- Keep template-specific structural comparison helpers (`GetStructuralProperties`, `IsTreeNode`, `IsPaddedWrapper`, etc.) in `internal static class TreeHelper` under `OpenRewrite.CSharp.Template`

## Motivation

Each concrete LST type defines its own `WithPrefix` method returning the concrete type. However, `WithPrefix` is deliberately not declared on the `J` interface — because C# lacks covariant return types, adding it to `J` would force all implementations to return `J`, losing the concrete type.

This means when you have a node typed as `J`, `Expression`, or `Statement`, you can't call `WithPrefix` at all:

```csharp
Expression expr = ...;
expr.WithPrefix(Space.Empty);  // Compile error — WithPrefix not on Expression
```

`J.SetPrefix<T>` bridges this gap using cached reflection, inferring `T` from the argument:

```csharp
Expression expr = ...;
expr = J.SetPrefix(expr, Space.Empty);  // T inferred as Expression, returns Expression
```

## Test plan
- [x] `dotnet build` passes with 0 warnings/errors
- [x] All 1317 C# tests pass