### PR TITLE
C#: Add `Type` property to `Expression` and `NameTree` interfaces

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -3433,7 +3433,7 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
     public override J VisitTypeWithArguments(TypeWithArguments twa, PrintOutputCapture<P> p)
     {
         BeforeSyntax(twa, p);
-        Visit(twa.Type, p);
+        Visit(twa.TypeExpression, p);
         VisitContainer("(", twa.Arguments, ",", ")", p);
         AfterSyntax(twa, p);
         return twa;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
@@ -3003,15 +3003,15 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         var newMarkers = VisitMarkers(twa.Markers, p);
         if (!ReferenceEquals(newMarkers, twa.Markers)) changed = true;
 
-        var newType = (TypeTree?)Visit(twa.Type, p);
-        if (newType != null && !ReferenceEquals(newType, twa.Type)) changed = true;
+        var newType = (TypeTree?)Visit(twa.TypeExpression, p);
+        if (newType != null && !ReferenceEquals(newType, twa.TypeExpression)) changed = true;
 
         var newArgs = VisitContainer(twa.Arguments, p);
         if (!ReferenceEquals(newArgs, twa.Arguments)) changed = true;
 
         return changed
             ? twa.WithPrefix(newPrefix).WithMarkers(newMarkers)
-                 .WithType(newType ?? twa.Type)
+                 .WithTypeExpression(newType ?? twa.TypeExpression)
                  .WithArguments(newArgs ?? twa.Arguments)
             : twa;
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
@@ -609,6 +609,8 @@ public sealed class NamedExpression(
     public NamedExpression WithExpression(Expression expression) =>
         ReferenceEquals(expression, Expression) ? this : new(Id, Prefix, Markers, Name, expression);
 
+    public JavaType? Type => Expression.Type;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(NamedExpression? other) => other is not null && Id == other.Id;
@@ -659,6 +661,8 @@ public sealed class RefExpression(
     public RefExpression WithExpression(Expression expression) =>
         ReferenceEquals(expression, Expression) ? this : new(Id, Prefix, Markers, Kind, expression);
 
+    public JavaType? Type => Expression.Type;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(RefExpression? other) => other is not null && Id == other.Id;
@@ -696,6 +700,8 @@ public sealed class DeclarationExpression(
         ReferenceEquals(typeExpression, TypeExpression) ? this : new(Id, Prefix, Markers, typeExpression, Variables);
     public DeclarationExpression WithVariables(Expression variables) =>
         ReferenceEquals(variables, Variables) ? this : new(Id, Prefix, Markers, TypeExpression, variables);
+
+    public JavaType? Type => Variables.Type;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -746,6 +752,8 @@ public sealed class CsLambda(
     public CsLambda WithLambdaExpression(Lambda lambdaExpression) =>
         ReferenceEquals(lambdaExpression, LambdaExpression) ? this : new(Id, Prefix, Markers, AttributeLists, Modifiers, ReturnType, lambdaExpression);
 
+    public JavaType? Type => LambdaExpression.Type;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(CsLambda? other) => other is not null && Id == other.Id;
@@ -786,6 +794,8 @@ public sealed class RelationalPattern(
         ReferenceEquals(@operator, Operator) ? this : new(Id, Prefix, Markers, @operator, Value);
     public RelationalPattern WithValue(Expression value) =>
         ReferenceEquals(value, Value) ? this : new(Id, Prefix, Markers, Operator, value);
+
+    JavaType? Expression.Type => null;
 
     public enum Type
     {
@@ -836,6 +846,8 @@ public sealed class IsPattern(
     public IsPattern WithPattern(JLeftPadded<Pattern> pattern) =>
         ReferenceEquals(pattern, Pattern) ? this : new(Id, Prefix, Markers, Expression, pattern);
 
+    public JavaType? Type => JavaType.Primitive.Of(JavaType.PrimitiveKind.Boolean);
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(IsPattern? other) => other is not null && Id == other.Id;
@@ -867,6 +879,8 @@ public sealed class StatementExpression(
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Statement);
     public StatementExpression WithStatement(Statement statement) =>
         ReferenceEquals(statement, Statement) ? this : new(Id, Prefix, Markers, statement);
+
+    public JavaType? Type => null;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -1080,6 +1094,8 @@ public sealed class PropertyPattern(
         ReferenceEquals(subpatterns, Subpatterns) ? this : new(Id, Prefix, Markers, TypeQualifier, subpatterns, Designation);
     public PropertyPattern WithDesignation(Identifier? designation) =>
         ReferenceEquals(designation, Designation) ? this : new(Id, Prefix, Markers, TypeQualifier, Subpatterns, designation);
+
+    public JavaType? Type => TypeQualifier?.Type;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -1690,6 +1706,8 @@ public sealed class InterpolatedString(
     public InterpolatedString WithParts(IList<J> parts) =>
         ReferenceEquals(parts, Parts) ? this : new(Id, Prefix, Markers, Delimiter, EndDelimiter, parts);
 
+    public JavaType? Type => JavaType.Primitive.Of(JavaType.PrimitiveKind.String);
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(InterpolatedString? other) => other is not null && Id == other.Id;
@@ -2006,7 +2024,7 @@ public sealed class NullSafeExpression(
 
     public Expression Expression => ExpressionPadded.Element;
 
-    public JavaType? Type => null;
+    public JavaType? Type => Expression.Type;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -2042,6 +2060,8 @@ public sealed class TupleExpression(
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Arguments);
     public TupleExpression WithArguments(JContainer<Expression> arguments) =>
         ReferenceEquals(arguments, Arguments) ? this : new(Id, Prefix, Markers, arguments);
+
+    public JavaType? Type => null;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -2169,6 +2189,8 @@ public sealed class ArrayRankSpecifier(
     public ArrayRankSpecifier WithSizes(JContainer<Expression> sizes) =>
         ReferenceEquals(sizes, Sizes) ? this : new(Id, Prefix, Markers, sizes);
 
+    public JavaType? Type => null;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(ArrayRankSpecifier? other) => other is not null && Id == other.Id;
@@ -2257,6 +2279,8 @@ public sealed class StackAllocExpression(
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Expression);
     public StackAllocExpression WithExpression(NewArray expression) =>
         ReferenceEquals(expression, Expression) ? this : new(Id, Prefix, Markers, expression);
+
+    public JavaType? Type => Expression.Type;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -2561,6 +2585,8 @@ public sealed class AllowsConstraintClause(
     public AllowsConstraintClause WithExpressions(JContainer<Expression> expressions) =>
         ReferenceEquals(expressions, Expressions) ? this : new(Id, Prefix, Markers, expressions);
 
+    public JavaType? Type => null;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(AllowsConstraintClause? other) => other is not null && Id == other.Id;
@@ -2586,6 +2612,8 @@ public sealed class RefStructConstraint(
         ReferenceEquals(prefix, Prefix) ? this : new(Id, prefix, Markers);
     public RefStructConstraint WithMarkers(Markers markers) =>
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers);
+
+    public JavaType? Type => null;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -2622,6 +2650,9 @@ public sealed class ClassOrStructConstraint(
         nullable == Nullable ? this : new(Id, Prefix, Markers, Kind, nullable);
 
     public enum TypeKind { Class, Struct }
+
+    JavaType? Expression.Type => null;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(ClassOrStructConstraint? other) => other is not null && Id == other.Id;
@@ -2648,6 +2679,8 @@ public sealed class ConstructorConstraint(
     public ConstructorConstraint WithMarkers(Markers markers) =>
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers);
 
+    public JavaType? Type => null;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(ConstructorConstraint? other) => other is not null && Id == other.Id;
@@ -2673,6 +2706,8 @@ public sealed class DefaultConstraint(
         ReferenceEquals(prefix, Prefix) ? this : new(Id, prefix, Markers);
     public DefaultConstraint WithMarkers(Markers markers) =>
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers);
+
+    public JavaType? Type => null;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -2703,6 +2738,8 @@ public sealed class SingleVariableDesignation(
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Name);
     public SingleVariableDesignation WithName(Identifier name) =>
         ReferenceEquals(name, Name) ? this : new(Id, Prefix, Markers, name);
+
+    public JavaType? Type => Name.Type;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -2763,6 +2800,8 @@ public sealed class DiscardVariableDesignation(
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Discard);
     public DiscardVariableDesignation WithDiscard(Identifier discard) =>
         ReferenceEquals(discard, Discard) ? this : new(Id, Prefix, Markers, discard);
+
+    public JavaType? Type => Discard.Type;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -2867,6 +2906,8 @@ public sealed class ImplicitElementAccess(
     public ImplicitElementAccess WithArgumentList(JContainer<Expression> argumentList) =>
         ReferenceEquals(argumentList, ArgumentList) ? this : new(Id, Prefix, Markers, argumentList);
 
+    public JavaType? Type => null;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(ImplicitElementAccess? other) => other is not null && Id == other.Id;
@@ -2894,6 +2935,8 @@ public sealed class ConstantPattern(
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Value);
     public ConstantPattern WithValue(Expression value) =>
         ReferenceEquals(value, Value) ? this : new(Id, Prefix, Markers, value);
+
+    public JavaType? Type => JavaType.Primitive.Of(JavaType.PrimitiveKind.Boolean);
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -2955,6 +2998,8 @@ public sealed class ListPattern(
     public ListPattern WithDesignation(VariableDesignation? designation) =>
         ReferenceEquals(designation, Designation) ? this : new(Id, Prefix, Markers, Patterns, designation);
 
+    public JavaType? Type => null;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(ListPattern? other) => other is not null && Id == other.Id;
@@ -2978,6 +3023,8 @@ public sealed class SlicePattern(
         ReferenceEquals(prefix, Prefix) ? this : new(Id, prefix, Markers);
     public SlicePattern WithMarkers(Markers markers) =>
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers);
+
+    public JavaType? Type => JavaType.Primitive.Of(JavaType.PrimitiveKind.Boolean);
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -3086,6 +3133,8 @@ public sealed class CheckedExpression(
     public CheckedExpression WithExpressionValue(ControlParentheses<Expression> expressionValue) =>
         ReferenceEquals(expressionValue, ExpressionValue) ? this : new(Id, Prefix, Markers, CheckedOrUncheckedKeyword, expressionValue);
 
+    public JavaType? Type => ExpressionValue.Type;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(CheckedExpression? other) => other is not null && Id == other.Id;
@@ -3151,6 +3200,8 @@ public sealed class RangeExpression(
         ReferenceEquals(start, Start) ? this : new(Id, Prefix, Markers, start, End);
     public RangeExpression WithEnd(Expression? end) =>
         ReferenceEquals(end, End) ? this : new(Id, Prefix, Markers, Start, end);
+
+    public JavaType? Type => null;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -3518,6 +3569,8 @@ public sealed class EnumMemberDeclaration(
     public EnumMemberDeclaration WithInitializer(JLeftPadded<Expression>? initializer) =>
         ReferenceEquals(initializer, Initializer) ? this : new(Id, Prefix, Markers, AttributeLists, Name, initializer);
 
+    public JavaType? Type => null;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(EnumMemberDeclaration? other) => other is not null && Id == other.Id;
@@ -3551,6 +3604,8 @@ public sealed class AliasQualifiedName(
         ReferenceEquals(alias, Alias) ? this : new(Id, Prefix, Markers, alias, Name);
     public AliasQualifiedName WithName(Expression name) =>
         ReferenceEquals(name, Name) ? this : new(Id, Prefix, Markers, Alias, name);
+
+    public JavaType? Type => Name.Type;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -3832,27 +3887,28 @@ public sealed class TypeWithArguments(
     Guid id,
     Space prefix,
     Markers markers,
-    TypeTree type,
+    TypeTree typeExpression,
     JContainer<Expression> arguments
 ) : Cs, TypeTree, Expression, IEquatable<TypeWithArguments>
 {
     public Guid Id { get; } = id;
     public Space Prefix { get; } = prefix;
     public Markers Markers { get; } = markers;
-    public TypeTree Type { get; } = type;
+    public TypeTree TypeExpression { get; } = typeExpression;
     public JContainer<Expression> Arguments { get; } = arguments;
-    public JavaType? NodeType => null;
+
+    public JavaType? Type => TypeExpression.Type;
 
     public TypeWithArguments WithId(Guid id) =>
-        id == Id ? this : new(id, Prefix, Markers, Type, Arguments);
+        id == Id ? this : new(id, Prefix, Markers, TypeExpression, Arguments);
     public TypeWithArguments WithPrefix(Space prefix) =>
-        ReferenceEquals(prefix, Prefix) ? this : new(Id, prefix, Markers, Type, Arguments);
+        ReferenceEquals(prefix, Prefix) ? this : new(Id, prefix, Markers, TypeExpression, Arguments);
     public TypeWithArguments WithMarkers(Markers markers) =>
-        ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Type, Arguments);
-    public TypeWithArguments WithType(TypeTree type) =>
-        ReferenceEquals(type, Type) ? this : new(Id, Prefix, Markers, type, Arguments);
+        ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, TypeExpression, Arguments);
+    public TypeWithArguments WithTypeExpression(TypeTree typeExpression) =>
+        ReferenceEquals(typeExpression, TypeExpression) ? this : new(Id, Prefix, Markers, typeExpression, Arguments);
     public TypeWithArguments WithArguments(JContainer<Expression> arguments) =>
-        ReferenceEquals(arguments, Arguments) ? this : new(Id, Prefix, Markers, Type, arguments);
+        ReferenceEquals(arguments, Arguments) ? this : new(Id, Prefix, Markers, TypeExpression, arguments);
 
     Tree Tree.WithId(Guid id) => WithId(id);
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Linq.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Linq.cs
@@ -61,6 +61,8 @@ public sealed class QueryExpression(
     public QueryExpression WithBody(QueryBody body) =>
         ReferenceEquals(body, Body) ? this : new(Id, Prefix, Markers, FromClause, body);
 
+    public JavaType? Type => FromClause.Type;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(QueryExpression? other) => other is not null && Id == other.Id;
@@ -140,6 +142,8 @@ public sealed class FromClause(
         ReferenceEquals(identifierPadded, IdentifierPadded) ? this : new(Id, Prefix, Markers, TypeIdentifier, identifierPadded, Expression);
     public FromClause WithExpression(Expression expression) =>
         ReferenceEquals(expression, Expression) ? this : new(Id, Prefix, Markers, TypeIdentifier, IdentifierPadded, expression);
+
+    public JavaType? Type => Expression.Type;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
@@ -926,9 +926,9 @@ public class CSharpReceiver : CSharpVisitor<RpcReceiveQueue>
 
     public override J VisitTypeWithArguments(TypeWithArguments twa, RpcReceiveQueue q)
     {
-        var type = q.Receive((J)twa.Type, el => (J)VisitNonNull(el, q));
+        var type = q.Receive((J)twa.TypeExpression, el => (J)VisitNonNull(el, q));
         var arguments = q.Receive(twa.Arguments, c => VisitContainer(c, q));
-        return twa.WithId(PvId).WithPrefix(PvPrefix).WithMarkers(PvMarkers).WithType((TypeTree)type!).WithArguments(arguments!);
+        return twa.WithId(PvId).WithPrefix(PvPrefix).WithMarkers(PvMarkers).WithTypeExpression((TypeTree)type!).WithArguments(arguments!);
     }
 
     public override J VisitExplicitInterfaceMember(ExplicitInterfaceMember eim, RpcReceiveQueue q)

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpSender.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpSender.cs
@@ -1005,7 +1005,7 @@ public class CSharpSender : CSharpVisitor<RpcSendQueue>
 
     public override J VisitTypeWithArguments(TypeWithArguments twa, RpcSendQueue q)
     {
-        q.GetAndSend(twa, t => (J)t.Type, el => Visit(el, q));
+        q.GetAndSend(twa, t => (J)t.TypeExpression, el => Visit(el, q));
         q.GetAndSend(twa, t => t.Arguments, c => VisitContainer(c, q));
         return twa;
     }

--- a/rewrite-csharp/csharp/OpenRewrite/Java/J.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/J.cs
@@ -33,6 +33,7 @@ public partial interface J : Tree
 /// </summary>
 public interface Expression : J
 {
+    JavaType? Type { get; }
 }
 
 /// <summary>
@@ -175,7 +176,7 @@ public sealed class Literal(
     object? value,
     string? valueSource,
     IList<Literal.UnicodeEscape>? unicodeEscapes,
-    JavaType.Primitive? type
+    JavaType? type
 ) : J, Expression, IEquatable<Literal>
 {
     public Guid Id { get; } = id;
@@ -184,7 +185,7 @@ public sealed class Literal(
     public object? Value { get; } = value;
     public string? ValueSource { get; } = valueSource;
     public IList<Literal.UnicodeEscape>? UnicodeEscapes { get; } = unicodeEscapes;
-    public JavaType.Primitive? Type { get; } = type;
+    public JavaType? Type { get; } = type;
 
     public Literal WithId(Guid id) =>
         id == Id ? this : new(id, Prefix, Markers, Value, ValueSource, UnicodeEscapes, Type);
@@ -198,7 +199,7 @@ public sealed class Literal(
         string.Equals(valueSource, ValueSource, StringComparison.Ordinal) ? this : new(Id, Prefix, Markers, Value, valueSource, UnicodeEscapes, Type);
     public Literal WithUnicodeEscapes(IList<Literal.UnicodeEscape>? unicodeEscapes) =>
         ReferenceEquals(unicodeEscapes, UnicodeEscapes) ? this : new(Id, Prefix, Markers, Value, ValueSource, unicodeEscapes, Type);
-    public Literal WithType(JavaType.Primitive? type) =>
+    public Literal WithType(JavaType? type) =>
         ReferenceEquals(type, Type) ? this : new(Id, Prefix, Markers, Value, ValueSource, UnicodeEscapes, type);
 
     public record UnicodeEscape(int ValueSourceIndex, string CodePoint);
@@ -400,6 +401,8 @@ public sealed class ControlParentheses<T>(
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Tree);
     public ControlParentheses<T> WithTree(JRightPadded<T> tree) =>
         ReferenceEquals(tree, Tree) ? this : new(Id, Prefix, Markers, tree);
+
+    public JavaType? Type => Tree.Element is Expression expr ? expr.Type : null;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -875,6 +878,8 @@ public sealed class Empty(
         ReferenceEquals(prefix, Prefix) ? this : new(Id, prefix, Markers);
     public Empty WithMarkers(Markers markers) =>
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers);
+
+    public JavaType? Type => null;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -1588,6 +1593,8 @@ public sealed class MethodInvocation(
     public MethodInvocation WithMethodType(JavaType.Method? methodType) =>
         ReferenceEquals(methodType, MethodType) ? this : new(Id, Prefix, Markers, Select, Name, TypeParameters, Arguments, methodType);
 
+    public JavaType? Type => MethodType?.ReturnType;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(MethodInvocation? other) => other is not null && Id == other.Id;
@@ -1742,6 +1749,8 @@ public sealed class TypeCast(
     public TypeCast WithExpression(Expression expression) =>
         ReferenceEquals(expression, Expression) ? this : new(Id, Prefix, Markers, Clazz, expression);
 
+    public JavaType? Type => Clazz.Type;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(TypeCast? other) => other is not null && Id == other.Id;
@@ -1772,6 +1781,8 @@ public sealed class Parentheses<T>(
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Tree);
     public Parentheses<T> WithTree(JRightPadded<T> tree) =>
         ReferenceEquals(tree, Tree) ? this : new(Id, Prefix, Markers, tree);
+
+    public JavaType? Type => Tree.Element is Expression expr ? expr.Type : null;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -1905,6 +1916,8 @@ public sealed class Primitive(
     public Primitive WithKind(JavaType.PrimitiveKind kind) =>
         kind == Kind ? this : new(Id, Prefix, Markers, kind);
 
+    public JavaType? Type => JavaType.Primitive.Of(Kind);
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(Primitive? other) => other is not null && Id == other.Id;
@@ -2011,6 +2024,8 @@ public sealed class Annotation(
     public Annotation WithArguments(JContainer<Expression>? arguments) =>
         ReferenceEquals(arguments, Arguments) ? this : new(Id, Prefix, Markers, AnnotationType, arguments);
 
+    public JavaType? Type => AnnotationType.Type;
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(Annotation? other) => other is not null && Id == other.Id;
@@ -2023,6 +2038,7 @@ public sealed class Annotation(
 /// </summary>
 public interface NameTree : J
 {
+    JavaType? Type { get; }
 }
 
 /// <summary>
@@ -2315,6 +2331,8 @@ public sealed class NewClass(
         ReferenceEquals(body, Body) ? this : new(Id, Prefix, Markers, Enclosing, New, Clazz, Arguments, body, ConstructorType);
     public NewClass WithConstructorType(JavaType.Method? constructorType) =>
         ReferenceEquals(constructorType, ConstructorType) ? this : new(Id, Prefix, Markers, Enclosing, New, Clazz, Arguments, Body, constructorType);
+
+    public JavaType? Type => ConstructorType?.ReturnType;
 
     Tree Tree.WithId(Guid id) => WithId(id);
 


### PR DESCRIPTION
## Summary
- Add `JavaType? Type { get; }` to the `Expression` and `NameTree` interfaces, aligning C# with Java where `Expression.getType()` and `TypedTree.getType()` already exist
- Widen `Literal.Type` from `JavaType.Primitive?` to `JavaType?` to match Java's `@Nullable JavaType type`
- Add computed `Type` properties to all concrete `Expression`/`NameTree`/`TypeTree` implementors (delegating to child fields, returning constants, or returning null as appropriate)
- Rename `TypeWithArguments.Type` (the `TypeTree` child node) to `TypeExpression` to avoid collision with the new `JavaType? Type` property

## Context
Recipe authors working with generic `Expression` references previously had to use `((dynamic)expr).Type` or `TypeUtils.GetType(expr)`. This change lets them use `expr.Type` directly.

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 1317/1317 tests pass