### PR TITLE
C#: Fix `NewClass.Type` returning `void` instead of constructed type

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
@@ -276,7 +276,11 @@ internal class CSharpTypeMapping
         var declaringType = symbol.ContainingType != null
             ? MapType(symbol.ContainingType) as JavaType.FullyQualified
             : null;
-        var returnType = MapType(symbol.ReturnType);
+        // In Roslyn, constructor ReturnType is void, but the Java model expects
+        // the declaring type as the return type for constructors
+        var returnType = symbol.MethodKind == MethodKind.Constructor && symbol.ContainingType != null
+            ? MapType(symbol.ContainingType)
+            : MapType(symbol.ReturnType);
         var parameterNames = symbol.Parameters.Length > 0
             ? symbol.Parameters.Select(p => p.Name).ToList()
             : null;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/NewClassTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/NewClassTests.cs
@@ -13,12 +13,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using OpenRewrite.CSharp;
+using OpenRewrite.Java;
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;
 
 public class NewClassTests : RewriteTest
 {
+    [Fact]
+    public void NewClassHasType()
+    {
+        var source = "class Foo { void Bar() { var x = new Foo(); } }";
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create("Test")
+            .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
+            .AddSyntaxTrees(syntaxTree);
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+
+        var cu = new CSharpParser().Parse(source, semanticModel: semanticModel);
+        NewClass? found = null;
+        new NewClassFinder(nc => found = nc).Visit(cu, 0);
+
+        Assert.NotNull(found);
+        Assert.NotNull(found!.Type);
+        Assert.IsType<JavaType.Class>(found.Type);
+        Assert.Equal("Foo", ((JavaType.Class)found.Type).FullyQualifiedName);
+    }
+
+    private class NewClassFinder(Action<NewClass> callback) : CSharpVisitor<int>
+    {
+        public override J VisitNewClass(NewClass nc, int p)
+        {
+            callback(nc);
+            return base.VisitNewClass(nc, p);
+        }
+    }
+
     [Fact]
     public void SimpleConstructor()
     {


### PR DESCRIPTION
## Summary
- Fix `CSharpTypeMapping.MapMethod` to use `ContainingType` as the return type for constructors instead of Roslyn's `ReturnType` (which is `void` for constructors)
- This aligns with the Java model where a constructor's `MethodType.returnType` is the declaring class
- Add test verifying `NewClass.Type` returns the correct `JavaType.Class`

## Context
- The `Expression.Type` property added in #7002 returns null/void for `NewClass` nodes because Roslyn's `IMethodSymbol.ReturnType` for constructors is `void`. The Java model expects the constructed type instead. This blocks downstream recipes like `ResourceCanBeDisposedAsynchronously` in `recipes-csharp` that need `Expression.Type` on `new` expressions to determine the constructed type.

## Test plan
- [x] New `NewClassHasType` test verifies type attribution on `new Foo()` returns `JavaType.Class("Foo")`
- [x] All 13 existing `NewClassTests` continue to pass