### PR TITLE
JavaScript: reinstantiate `install-recipes.test.ts` tests

### DIFF
--- a/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
@@ -233,8 +233,7 @@ describe("InstallRecipes", () => {
             }, {unsafeCleanup: true});
         }, 60000);
 
-        // Skipped: published @openrewrite/rewrite has vitest runtime dep; fix: https://github.com/openrewrite/rewrite/pull/6957
-        test.skip("installs @openrewrite/recipes-nodejs from npm", async () => {
+        test("installs @openrewrite/recipes-nodejs from npm", async () => {
             await withDir(async (dir) => {
                 // given
                 const installDir = path.join(dir.path, "recipes");
@@ -257,8 +256,7 @@ describe("InstallRecipes", () => {
             }, {unsafeCleanup: true});
         }, 120000);
 
-        // Skipped: published @openrewrite/rewrite has vitest runtime dep; fix: https://github.com/openrewrite/rewrite/pull/6957
-        test.skip("upgrades @openrewrite/recipes-nodejs from 0.36.0 to a later version", async () => {
+        test("upgrades @openrewrite/recipes-nodejs from 0.36.0 to a later version", async () => {
             await withDir(async (dir) => {
                 // given
                 const installDir = path.join(dir.path, "recipes");


### PR DESCRIPTION
## What's changed?

Undo https://github.com/openrewrite/rewrite/pull/6957/changes/d144cc597a83fdd5aa8564bcaee62c21b9d2656e
i.e. re-enable the tests disabled temporarily then.

## What's your motivation?

The underlying reason for the tests to fail have been fixed in #6957 and release train was done since then.