### PR TITLE
C#: Fix `CSharpPrinter` corruption of explicit interface implementations

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/MethodDeclarationTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/MethodDeclarationTests.cs
@@ -118,4 +118,38 @@ public class MethodDeclarationTests : RewriteTest
             )
         );
     }
+
+    [Fact]
+    public void ExplicitInterfaceImplementationVoid()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                interface IFoo { void Bar(); }
+                class Foo : IFoo {
+                    void IFoo.Bar() { }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void ExplicitInterfaceImplementationWithReturnType()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                using System.Collections;
+                public class MyCollection : IEnumerable
+                {
+                    IEnumerator IEnumerable.GetEnumerator()
+                    {
+                        return null;
+                    }
+                }
+                """
+            )
+        );
+    }
 }

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/CSharpRecipeTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/CSharpRecipeTest.java
@@ -446,29 +446,6 @@ class CSharpRecipeTest implements RewriteTest {
     }
 
     @Test
-    void explicitInterfaceImplementationRoundTrip() {
-        rewriteRun(
-                spec -> spec
-                        .parser(CSharpParser.builder())
-                        .typeValidationOptions(TypeValidation.builder()
-                                .allowNonWhitespaceInWhitespace(true)
-                                .build()),
-                csharp(
-                        """
-                        using System.Collections;
-                        public class MyCollection : IEnumerable
-                        {
-                            IEnumerator IEnumerable.GetEnumerator()
-                            {
-                                return null;
-                            }
-                        }
-                        """
-                )
-        );
-    }
-
-    @Test
     void changePackage() {
         rewriteRun(
                 spec -> spec


### PR DESCRIPTION
## Summary

- Fix `CSharpPrinter` printing explicit interface implementations in wrong token order, producing `IEnumerable.IEnumeratorGetEnumerator()` instead of `IEnumerator IEnumerable.GetEnumerator()`
- The root cause was `VisitExplicitInterfaceMember` printing the interface specifier first, then delegating to `VisitMethodDeclaration` which printed the return type again — but in C# source order, the return type precedes the interface qualifier
- Extract method body printing into `PrintMethodDeclarationBody` helper that accepts an optional interface specifier and inserts it between return type and method name

## Test plan

- [x] New C# round-trip tests in `MethodDeclarationTests.cs` for both void and non-void explicit interface implementations
- [x] All 1320 C# tests pass
- [x] All existing Java-side `rewrite-csharp` tests pass