### PR TITLE
Fix CSharpParser handling of preprocessor directives around delegate semicolons

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -1714,6 +1714,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             typeParameters = MergeConstraintClauses(typeParameters, node.ConstraintClauses);
         }
 
+        _pendingSemicolonSpace = ExtractSpaceBefore(node.SemicolonToken);
         _cursor = node.SemicolonToken.Span.End;
 
         return new DelegateDeclaration(Guid.NewGuid(), prefix, Markers.Empty,

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/CSharpSyntaxFragments.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/CSharpSyntaxFragments.cs
@@ -284,6 +284,14 @@ public class CSharpSyntaxFragments
 
         yield return new SourceTestCase("DeclarationParsingTests.TestNestedDelegate", "class a { delegate b c(); }");
 
+        yield return new SourceTestCase("DeclarationParsingTests.TestDelegateWithPreprocessorConstraint", """
+            public delegate TResult Projection<TState, out TResult>(ref TState state)
+            #if NET10_0_OR_GREATER
+                where TState : allows ref struct
+            #endif
+                ;
+            """);
+
         yield return new SourceTestCase("DeclarationParsingTests.TestClassMethod", "class a { b X() { } }");
 
         yield return new SourceTestCase("DeclarationParsingTests.TestClassMethodWithRefReturn", "class a { ref b X() { } }");


### PR DESCRIPTION
## Summary
- `VisitDelegateDeclaration` was the only semicolon-terminated construct that skipped `ExtractSpaceBefore(node.SemicolonToken)`, discarding trivia (including `#endif` ghost comments) between the last parsed element and the `;`
- This caused the printer to emit `#if` without matching `#endif`, corrupting all subsequent output in the file
- The corruption produced ~11,028 false-positive diffs on the StackExchange.Redis repo when running any recipe
- Fix: add `_pendingSemicolonSpace = ExtractSpaceBefore(node.SemicolonToken)` matching the pattern used by every other semicolon-terminated statement handler

## Test plan
- Added round-trip test case `TestDelegateWithPreprocessorConstraint` for a delegate with `#if`/`#endif` around a generic constraint
- All 467 C# dotnet round-trip tests pass
- All Java-side `CSharpRpcTest` tests pass