### PR TITLE
C#: Add documentation comment LST infrastructure

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -2844,7 +2844,12 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
         p.Append(space.Whitespace);
         foreach (var comment in space.Comments)
         {
-            if (comment.Multiline)
+            if (comment is XmlDocComment)
+            {
+                // XmlDocComment text starts after "//" — printer prepends "//"
+                p.Append("//").Append(comment.Text);
+            }
+            else if (comment.Multiline)
             {
                 p.Append("/*").Append(comment.Text).Append("*/");
             }

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
@@ -441,6 +441,7 @@ public class RpcReceiveQueue
         {
             "org.openrewrite.java.tree.Space" => typeof(Space),
             "org.openrewrite.java.tree.TextComment" => typeof(TextComment),
+            "org.openrewrite.csharp.tree.CsDocCommentRawComment" => typeof(XmlDocComment),
             "org.openrewrite.marker.Markers" => typeof(Markers),
             "org.openrewrite.marker.SearchResult" => typeof(SearchResult),
             "org.openrewrite.marker.RecipesThatMadeChanges" => typeof(RecipesThatMadeChanges),

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
@@ -350,6 +350,7 @@ public class RpcSendQueue
                 "Markup" => "org.openrewrite.marker.Markup",
                 "Space" => "org.openrewrite.java.tree.Space",
                 "TextComment" => "org.openrewrite.java.tree.TextComment",
+                "XmlDocComment" => "org.openrewrite.csharp.tree.CsDocCommentRawComment",
                 "Checksum" => "org.openrewrite.Checksum",
                 "FileAttributes" => "org.openrewrite.FileAttributes",
                 _ => null,

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Space.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Space.cs
@@ -185,6 +185,43 @@ public sealed class Space(string whitespace, IList<Comment> comments)
             }
         }
 
+        // Group consecutive /// doc comments into a single XmlDocComment.
+        // After rotation, doc comment lines are TextComment with text starting with "/".
+        if (comments.Count > 0)
+        {
+            var grouped = new List<Comment>();
+            int j = 0;
+            while (j < comments.Count)
+            {
+                var cmt = comments[j];
+                if (cmt is TextComment tc && !tc.Multiline && tc.Text.StartsWith("/"))
+                {
+                    // Start of a doc comment block — group consecutive /// lines.
+                    var sb = new System.Text.StringBuilder();
+                    sb.Append(tc.Text);
+                    string lastSuffix = tc.Suffix;
+                    j++;
+                    while (j < comments.Count &&
+                           comments[j] is TextComment next && !next.Multiline &&
+                           next.Text.StartsWith("/"))
+                    {
+                        sb.Append(lastSuffix);
+                        sb.Append("//");
+                        sb.Append(next.Text);
+                        lastSuffix = next.Suffix;
+                        j++;
+                    }
+                    grouped.Add(new XmlDocComment(sb.ToString(), lastSuffix, true));
+                }
+                else
+                {
+                    grouped.Add(cmt);
+                    j++;
+                }
+            }
+            comments = grouped;
+        }
+
         return comments.Count > 0 ? new Space(ws, comments) : Build(formatting, []);
     }
 
@@ -211,4 +248,12 @@ public abstract class Comment(string text, string suffix, bool multiline)
 /// A single-line or multi-line text comment.
 /// </summary>
 public sealed class TextComment(string text, string suffix, bool multiline)
+    : Comment(text, suffix, multiline);
+
+/// <summary>
+/// An XML documentation comment (///) block.
+/// The Text property contains the raw content after the initial "//",
+/// including continuation "///" prefixes on subsequent lines.
+/// </summary>
+public sealed class XmlDocComment(string text, string suffix, bool multiline)
     : Comment(text, suffix, multiline);

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/CSharpVisitor.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/CSharpVisitor.java
@@ -35,9 +35,44 @@ import java.util.List;
 
 public class CSharpVisitor<P> extends JavaVisitor<P>
 {
+    protected CsDocCommentVisitor<P> csXmlDocVisitor;
+
     @Override
     public boolean isAcceptable(SourceFile sourceFile, P p) {
         return sourceFile instanceof Cs;
+    }
+
+    protected CsDocCommentVisitor<P> getCsDocCommentVisitor() {
+        return new CsDocCommentVisitor<>(this);
+    }
+
+    @Override
+    public Space visitSpace(@Nullable Space space, Space.Location loc, P p) {
+        if (space == Space.EMPTY || space == Space.SINGLE_SPACE || space == null) {
+            return space;
+        } else if (space.getComments().isEmpty()) {
+            return space;
+        }
+        return space.withComments(ListUtils.map(space.getComments(), comment -> {
+            if (comment instanceof CsDocCommentRawComment) {
+                // Convert raw doc comment from RPC into structured tree, then visit
+                CsDocComment.DocComment parsed = CsDocCommentParser.parse((CsDocCommentRawComment) comment);
+                return visitCsDocCommentComment(parsed, p);
+            } else if (comment instanceof CsDocComment.DocComment) {
+                return visitCsDocCommentComment((CsDocComment.DocComment) comment, p);
+            }
+            return comment;
+        }));
+    }
+
+    private Comment visitCsDocCommentComment(CsDocComment.DocComment docComment, P p) {
+        if (csXmlDocVisitor == null) {
+            csXmlDocVisitor = getCsDocCommentVisitor();
+        }
+        Cursor previous = csXmlDocVisitor.getCursor();
+        Comment c = (Comment) csXmlDocVisitor.visit(docComment, p, getCursor());
+        csXmlDocVisitor.setCursor(previous);
+        return c;
     }
 
     public J visitCompilationUnit(Cs.CompilationUnit compilationUnit, P p) {

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/CsDocCommentParser.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/CsDocCommentParser.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp;
+
+import org.openrewrite.Tree;
+import org.openrewrite.csharp.tree.CsDocComment;
+import org.openrewrite.csharp.tree.CsDocCommentRawComment;
+import org.openrewrite.marker.Markers;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Parses raw XML documentation comment text into a structured {@link CsDocComment.DocComment} tree.
+ * <p>
+ * The raw text comes from the C# parser where consecutive {@code ///} lines are grouped
+ * into a single text block. The text starts with {@code /} (since the C# parser strips
+ * the first {@code //}), and continuation lines include their {@code ///} prefixes.
+ */
+public class CsDocCommentParser {
+
+    /**
+     * Parse a raw doc comment into a structured tree.
+     *
+     * @param rawComment the raw comment from the C# parser
+     * @return a structured DocComment tree
+     */
+    public static CsDocComment.DocComment parse(CsDocCommentRawComment rawComment) {
+        String text = rawComment.getText();
+        List<CsDocComment> body = parseContent(text);
+        return new CsDocComment.DocComment(
+                Tree.randomId(),
+                rawComment.getMarkers(),
+                body,
+                rawComment.getSuffix()
+        );
+    }
+
+    /**
+     * Parse the XML content of a documentation comment into a list of CsDocComment nodes.
+     */
+    private static List<CsDocComment> parseContent(String text) {
+        List<CsDocComment> nodes = new ArrayList<>();
+        int pos = 0;
+        int len = text.length();
+
+        while (pos < len) {
+            char c = text.charAt(pos);
+
+            if (c == '<') {
+                // Check for closing tag
+                if (pos + 1 < len && text.charAt(pos + 1) == '/') {
+                    // This is a closing tag — stop parsing content (caller handles it)
+                    break;
+                }
+                // Parse opening or self-closing XML element
+                int tagEnd = findTagEnd(text, pos);
+                if (tagEnd < 0) {
+                    // Malformed — treat rest as text
+                    nodes.add(xmlText(text.substring(pos)));
+                    pos = len;
+                    break;
+                }
+                String tagContent = text.substring(pos + 1, tagEnd);
+                boolean selfClosing = tagContent.endsWith("/");
+                if (selfClosing) {
+                    tagContent = tagContent.substring(0, tagContent.length() - 1);
+                }
+
+                String tagName = extractTagName(tagContent);
+                List<CsDocComment> attributes = parseAttributes(tagContent, tagName.length());
+
+                if (selfClosing) {
+                    nodes.add(new CsDocComment.XmlEmptyElement(
+                            Tree.randomId(), Markers.EMPTY,
+                            tagName, attributes, Collections.emptyList()
+                    ));
+                } else {
+                    // Parse content until matching closing tag
+                    int contentStart = tagEnd + 1;
+                    int closingTagStart = findClosingTag(text, contentStart, tagName);
+
+                    List<CsDocComment> content;
+                    int afterClosingTag;
+                    if (closingTagStart < 0) {
+                        // No closing tag found — treat remaining as content
+                        content = parseContent(text.substring(contentStart));
+                        afterClosingTag = len;
+                    } else {
+                        String innerText = text.substring(contentStart, closingTagStart);
+                        content = parseContent(innerText);
+                        // Skip past </tagName>
+                        afterClosingTag = text.indexOf('>', closingTagStart) + 1;
+                        if (afterClosingTag == 0) afterClosingTag = len;
+                    }
+
+                    nodes.add(new CsDocComment.XmlElement(
+                            Tree.randomId(), Markers.EMPTY,
+                            tagName, attributes,
+                            Collections.emptyList(), // spaceBeforeClose
+                            content,
+                            Collections.emptyList()  // closingTagSpaceBeforeClose
+                    ));
+                    pos = afterClosingTag;
+                    continue;
+                }
+                pos = tagEnd + 1;
+            } else if (c == '\n' || c == '\r') {
+                // Parse line break with margin
+                int lineBreakEnd = pos;
+                StringBuilder margin = new StringBuilder();
+                margin.append(c);
+                lineBreakEnd++;
+                if (c == '\r' && lineBreakEnd < len && text.charAt(lineBreakEnd) == '\n') {
+                    margin.append('\n');
+                    lineBreakEnd++;
+                }
+                // Consume whitespace and /// prefix
+                while (lineBreakEnd < len && (text.charAt(lineBreakEnd) == ' ' || text.charAt(lineBreakEnd) == '\t')) {
+                    margin.append(text.charAt(lineBreakEnd));
+                    lineBreakEnd++;
+                }
+                // Check for /// prefix (stored as "///" in the raw text from grouped comments)
+                if (lineBreakEnd + 2 < len &&
+                    text.charAt(lineBreakEnd) == '/' &&
+                    text.charAt(lineBreakEnd + 1) == '/' &&
+                    text.charAt(lineBreakEnd + 2) == '/') {
+                    margin.append("///");
+                    lineBreakEnd += 3;
+                }
+                nodes.add(new CsDocComment.LineBreak(Tree.randomId(), margin.toString(), Markers.EMPTY));
+                pos = lineBreakEnd;
+            } else {
+                // Parse text content until next tag or line break
+                int textEnd = pos;
+                while (textEnd < len && text.charAt(textEnd) != '<' &&
+                       text.charAt(textEnd) != '\n' && text.charAt(textEnd) != '\r') {
+                    // Also stop at </ (closing tag of parent)
+                    textEnd++;
+                }
+                if (textEnd > pos) {
+                    nodes.add(xmlText(text.substring(pos, textEnd)));
+                }
+                pos = textEnd;
+            }
+        }
+        return nodes;
+    }
+
+    private static CsDocComment.XmlText xmlText(String text) {
+        return new CsDocComment.XmlText(Tree.randomId(), Markers.EMPTY, text);
+    }
+
+    /**
+     * Find the position of '>' that closes the opening tag starting at pos.
+     * Handles quoted attribute values.
+     */
+    private static int findTagEnd(String text, int pos) {
+        boolean inQuote = false;
+        char quoteChar = 0;
+        for (int i = pos + 1; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (inQuote) {
+                if (c == quoteChar) inQuote = false;
+            } else if (c == '"' || c == '\'') {
+                inQuote = true;
+                quoteChar = c;
+            } else if (c == '>') {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Extract the tag name from tag content (everything after '<' and before '>').
+     */
+    private static String extractTagName(String tagContent) {
+        int end = 0;
+        while (end < tagContent.length() && !Character.isWhitespace(tagContent.charAt(end))) {
+            end++;
+        }
+        return tagContent.substring(0, end);
+    }
+
+    /**
+     * Parse attributes from tag content starting after the tag name.
+     */
+    private static List<CsDocComment> parseAttributes(String tagContent, int offset) {
+        List<CsDocComment> attrs = new ArrayList<>();
+        int pos = offset;
+        int len = tagContent.length();
+
+        while (pos < len) {
+            // Skip whitespace
+            int wsStart = pos;
+            while (pos < len && Character.isWhitespace(tagContent.charAt(pos))) {
+                pos++;
+            }
+            if (pos >= len) break;
+
+            String leadingSpace = tagContent.substring(wsStart, pos);
+
+            // Parse attribute name
+            int nameStart = pos;
+            while (pos < len && tagContent.charAt(pos) != '=' &&
+                   !Character.isWhitespace(tagContent.charAt(pos)) &&
+                   tagContent.charAt(pos) != '/' && tagContent.charAt(pos) != '>') {
+                pos++;
+            }
+            if (pos == nameStart) break;
+            String attrName = tagContent.substring(nameStart, pos);
+
+            // Skip whitespace before =
+            while (pos < len && Character.isWhitespace(tagContent.charAt(pos))) {
+                pos++;
+            }
+
+            if (pos >= len || tagContent.charAt(pos) != '=') {
+                // Attribute without value
+                CsDocComment.XmlText spaceText = xmlText(leadingSpace);
+                attrs.add(spaceText);
+                attrs.add(new CsDocComment.XmlAttribute(
+                        Tree.randomId(), Markers.EMPTY,
+                        attrName, null, null
+                ));
+                continue;
+            }
+            pos++; // skip '='
+
+            // Skip whitespace after =
+            while (pos < len && Character.isWhitespace(tagContent.charAt(pos))) {
+                pos++;
+            }
+
+            // Parse quoted value
+            String value = "";
+            if (pos < len && (tagContent.charAt(pos) == '"' || tagContent.charAt(pos) == '\'')) {
+                char q = tagContent.charAt(pos);
+                int valueStart = pos;
+                pos++; // skip opening quote
+                while (pos < len && tagContent.charAt(pos) != q) {
+                    pos++;
+                }
+                if (pos < len) pos++; // skip closing quote
+                value = tagContent.substring(valueStart, pos);
+            }
+
+            // Create the appropriate attribute type
+            CsDocComment.XmlText spaceText = xmlText(leadingSpace);
+            List<CsDocComment> valueList = Collections.singletonList(xmlText(value));
+
+            if ("cref".equals(attrName)) {
+                attrs.add(spaceText);
+                attrs.add(new CsDocComment.XmlCrefAttribute(
+                        Tree.randomId(), Markers.EMPTY,
+                        null, valueList, null // reference resolved later
+                ));
+            } else if ("name".equals(attrName)) {
+                attrs.add(spaceText);
+                attrs.add(new CsDocComment.XmlNameAttribute(
+                        Tree.randomId(), Markers.EMPTY,
+                        null, valueList, null // paramName resolved later
+                ));
+            } else {
+                attrs.add(spaceText);
+                attrs.add(new CsDocComment.XmlAttribute(
+                        Tree.randomId(), Markers.EMPTY,
+                        attrName, null, valueList
+                ));
+            }
+        }
+        return attrs;
+    }
+
+    /**
+     * Find the start of the closing tag {@code </tagName>} for the given tag name.
+     * Handles nested elements with the same tag name.
+     */
+    private static int findClosingTag(String text, int start, String tagName) {
+        int depth = 1;
+        int pos = start;
+        int len = text.length();
+
+        while (pos < len) {
+            int nextTag = text.indexOf('<', pos);
+            if (nextTag < 0) return -1;
+
+            if (nextTag + 1 < len && text.charAt(nextTag + 1) == '/') {
+                // Closing tag
+                int nameStart = nextTag + 2;
+                int nameEnd = nameStart;
+                while (nameEnd < len && text.charAt(nameEnd) != '>' &&
+                       !Character.isWhitespace(text.charAt(nameEnd))) {
+                    nameEnd++;
+                }
+                String closingName = text.substring(nameStart, nameEnd);
+                if (closingName.equals(tagName)) {
+                    depth--;
+                    if (depth == 0) {
+                        return nextTag;
+                    }
+                }
+                pos = text.indexOf('>', nextTag);
+                if (pos < 0) return -1;
+                pos++;
+            } else {
+                // Opening or self-closing tag
+                int tagEnd = findTagEnd(text, nextTag);
+                if (tagEnd < 0) return -1;
+                String content = text.substring(nextTag + 1, tagEnd);
+                boolean selfClosing = content.endsWith("/");
+                String name = extractTagName(selfClosing ? content.substring(0, content.length() - 1) : content);
+                if (!selfClosing && name.equals(tagName)) {
+                    depth++;
+                }
+                pos = tagEnd + 1;
+            }
+        }
+        return -1;
+    }
+}

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/CsDocCommentPrinter.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/CsDocCommentPrinter.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.csharp.tree.CsDocComment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+public class CsDocCommentPrinter<P> extends CsDocCommentVisitor<PrintOutputCapture<P>> {
+    public CsDocCommentPrinter() {
+        super(new CsDocCommentCSharpPrinter<>());
+    }
+
+    @Override
+    public CsDocComment visitDocComment(CsDocComment.DocComment docComment, PrintOutputCapture<P> p) {
+        beforeSyntax(docComment, p, MARKER_WRAPPER);
+        p.append("///");
+        visit(docComment.getBody(), p);
+        afterSyntax(docComment, p);
+        return docComment;
+    }
+
+    @Override
+    public CsDocComment visitXmlElement(CsDocComment.XmlElement element, PrintOutputCapture<P> p) {
+        beforeSyntax(element, p);
+        // Opening tag
+        p.append('<').append(element.getName());
+        visit(element.getAttributes(), p);
+        visit(element.getSpaceBeforeClose(), p);
+        p.append('>');
+        // Content
+        visit(element.getContent(), p);
+        // Closing tag
+        p.append("</").append(element.getName());
+        visit(element.getClosingTagSpaceBeforeClose(), p);
+        p.append('>');
+        afterSyntax(element, p);
+        return element;
+    }
+
+    @Override
+    public CsDocComment visitXmlEmptyElement(CsDocComment.XmlEmptyElement element, PrintOutputCapture<P> p) {
+        beforeSyntax(element, p);
+        p.append('<').append(element.getName());
+        visit(element.getAttributes(), p);
+        visit(element.getSpaceBeforeSlashClose(), p);
+        p.append("/>");
+        afterSyntax(element, p);
+        return element;
+    }
+
+    @Override
+    public CsDocComment visitXmlText(CsDocComment.XmlText text, PrintOutputCapture<P> p) {
+        beforeSyntax(text, p);
+        p.append(text.getText());
+        afterSyntax(text, p);
+        return text;
+    }
+
+    @Override
+    public CsDocComment visitXmlAttribute(CsDocComment.XmlAttribute attribute, PrintOutputCapture<P> p) {
+        beforeSyntax(attribute, p);
+        p.append(attribute.getName());
+        if (attribute.getSpaceBeforeEquals() != null && !attribute.getSpaceBeforeEquals().isEmpty()) {
+            visit(attribute.getSpaceBeforeEquals(), p);
+            if (attribute.getValue() != null) {
+                p.append('=');
+                visit(attribute.getValue(), p);
+            }
+        }
+        afterSyntax(attribute, p);
+        return attribute;
+    }
+
+    @Override
+    public CsDocComment visitXmlCrefAttribute(CsDocComment.XmlCrefAttribute attribute, PrintOutputCapture<P> p) {
+        beforeSyntax(attribute, p);
+        p.append("cref");
+        if (attribute.getSpaceBeforeEquals() != null && !attribute.getSpaceBeforeEquals().isEmpty()) {
+            visit(attribute.getSpaceBeforeEquals(), p);
+            if (attribute.getValue() != null) {
+                p.append('=');
+                visit(attribute.getValue(), p);
+            }
+        }
+        afterSyntax(attribute, p);
+        return attribute;
+    }
+
+    @Override
+    public CsDocComment visitXmlNameAttribute(CsDocComment.XmlNameAttribute attribute, PrintOutputCapture<P> p) {
+        beforeSyntax(attribute, p);
+        p.append("name");
+        if (attribute.getSpaceBeforeEquals() != null && !attribute.getSpaceBeforeEquals().isEmpty()) {
+            visit(attribute.getSpaceBeforeEquals(), p);
+            if (attribute.getValue() != null) {
+                p.append('=');
+                visit(attribute.getValue(), p);
+            }
+        }
+        afterSyntax(attribute, p);
+        return attribute;
+    }
+
+    @Override
+    public CsDocComment visitLineBreak(CsDocComment.LineBreak lineBreak, PrintOutputCapture<P> p) {
+        beforeSyntax(lineBreak, p, MARKER_WRAPPER);
+        p.append(lineBreak.getMargin());
+        afterSyntax(lineBreak, p);
+        return lineBreak;
+    }
+
+    public void visit(@Nullable List<? extends CsDocComment> nodes, PrintOutputCapture<P> p) {
+        if (nodes != null) {
+            for (CsDocComment node : nodes) {
+                visit(node, p);
+            }
+        }
+    }
+
+    private static final UnaryOperator<String> MARKER_WRAPPER =
+            out -> "~~" + out + (out.isEmpty() ? "" : "~~") + ">";
+
+    private static final UnaryOperator<String> CSHARP_MARKER_WRAPPER =
+            out -> "/*~~" + out + (out.isEmpty() ? "" : "~~") + ">*/";
+
+    private void beforeSyntax(CsDocComment j, PrintOutputCapture<P> p) {
+        beforeSyntax(j, p, MARKER_WRAPPER);
+    }
+
+    private void beforeSyntax(CsDocComment j, PrintOutputCapture<P> p, UnaryOperator<String> commentWrapper) {
+        beforeSyntax(j.getMarkers(), p, commentWrapper);
+    }
+
+    private void beforeSyntax(Markers markers, PrintOutputCapture<P> p, UnaryOperator<String> commentWrapper) {
+        visitMarkers(markers, p);
+        for (Marker marker : markers.getMarkers()) {
+            p.append(p.getMarkerPrinter().beforeSyntax(marker, new Cursor(getCursor(), marker), commentWrapper));
+        }
+    }
+
+    private void afterSyntax(CsDocComment j, PrintOutputCapture<P> p) {
+        afterSyntax(j.getMarkers(), p);
+    }
+
+    private void afterSyntax(Markers markers, PrintOutputCapture<P> p) {
+        for (Marker marker : markers.getMarkers()) {
+            p.append(p.getMarkerPrinter().afterSyntax(marker, new Cursor(getCursor(), marker), MARKER_WRAPPER));
+        }
+    }
+
+    /**
+     * Inner printer for handling embedded C# (J) references within cref attributes.
+     */
+    static class CsDocCommentCSharpPrinter<P> extends CSharpVisitor<PrintOutputCapture<P>> {
+        @Override
+        public J visitIdentifier(J.Identifier ident, PrintOutputCapture<P> p) {
+            beforeSyntax(ident, p);
+            p.append(ident.getSimpleName());
+            afterSyntax(ident, p);
+            return ident;
+        }
+
+        @Override
+        public J visitFieldAccess(J.FieldAccess fieldAccess, PrintOutputCapture<P> p) {
+            beforeSyntax(fieldAccess, p);
+            visit(fieldAccess.getTarget(), p);
+            p.append('.');
+            visit(fieldAccess.getName(), p);
+            afterSyntax(fieldAccess, p);
+            return fieldAccess;
+        }
+
+        private void beforeSyntax(J j, PrintOutputCapture<P> p) {
+            for (Marker marker : j.getMarkers().getMarkers()) {
+                p.append(p.getMarkerPrinter().beforePrefix(marker, new Cursor(getCursor(), marker), CSHARP_MARKER_WRAPPER));
+            }
+            p.append(j.getPrefix().getWhitespace());
+            visitMarkers(j.getMarkers(), p);
+            for (Marker marker : j.getMarkers().getMarkers()) {
+                p.append(p.getMarkerPrinter().beforeSyntax(marker, new Cursor(getCursor(), marker), CSHARP_MARKER_WRAPPER));
+            }
+        }
+
+        private void afterSyntax(J j, PrintOutputCapture<P> p) {
+            for (Marker marker : j.getMarkers().getMarkers()) {
+                p.append(p.getMarkerPrinter().afterSyntax(marker, new Cursor(getCursor(), marker), CSHARP_MARKER_WRAPPER));
+            }
+        }
+    }
+}

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/CsDocCommentVisitor.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/CsDocCommentVisitor.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.csharp.tree.CsDocComment;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.tree.J;
+
+public class CsDocCommentVisitor<P> extends TreeVisitor<CsDocComment, P> {
+    /**
+     * Don't use directly. Use {@link #csharpVisitorVisit(Tree, Object)} instead.
+     */
+    private final CSharpVisitor<P> csharpVisitor;
+
+    public CsDocCommentVisitor(CSharpVisitor<P> csharpVisitor) {
+        this.csharpVisitor = csharpVisitor;
+    }
+
+    protected @Nullable J csharpVisitorVisit(@Nullable Tree tree, P p) {
+        Cursor previous = csharpVisitor.getCursor();
+        J j = csharpVisitor.visit(tree, p, getCursor());
+        csharpVisitor.setCursor(previous);
+        return j;
+    }
+
+    public CsDocComment visitDocComment(CsDocComment.DocComment docComment, P p) {
+        CsDocComment.DocComment d = docComment;
+        d = d.withMarkers(visitMarkers(d.getMarkers(), p));
+        return d.withBody(ListUtils.map(d.getBody(), b -> visit(b, p)));
+    }
+
+    public CsDocComment visitXmlElement(CsDocComment.XmlElement element, P p) {
+        CsDocComment.XmlElement e = element;
+        e = e.withMarkers(visitMarkers(e.getMarkers(), p));
+        e = e.withAttributes(ListUtils.map(e.getAttributes(), attr -> visit(attr, p)));
+        e = e.withSpaceBeforeClose(ListUtils.map(e.getSpaceBeforeClose(), s -> visit(s, p)));
+        e = e.withContent(ListUtils.map(e.getContent(), c -> visit(c, p)));
+        return e.withClosingTagSpaceBeforeClose(ListUtils.map(e.getClosingTagSpaceBeforeClose(), s -> visit(s, p)));
+    }
+
+    public CsDocComment visitXmlEmptyElement(CsDocComment.XmlEmptyElement element, P p) {
+        CsDocComment.XmlEmptyElement e = element;
+        e = e.withMarkers(visitMarkers(e.getMarkers(), p));
+        e = e.withAttributes(ListUtils.map(e.getAttributes(), attr -> visit(attr, p)));
+        return e.withSpaceBeforeSlashClose(ListUtils.map(e.getSpaceBeforeSlashClose(), s -> visit(s, p)));
+    }
+
+    public CsDocComment visitXmlText(CsDocComment.XmlText text, P p) {
+        CsDocComment.XmlText t = text;
+        return t.withMarkers(visitMarkers(t.getMarkers(), p));
+    }
+
+    public CsDocComment visitXmlAttribute(CsDocComment.XmlAttribute attribute, P p) {
+        CsDocComment.XmlAttribute a = attribute;
+        a = a.withMarkers(visitMarkers(a.getMarkers(), p));
+        a = a.withSpaceBeforeEquals(ListUtils.map(a.getSpaceBeforeEquals(), s -> visit(s, p)));
+        return a.withValue(ListUtils.map(a.getValue(), v -> visit(v, p)));
+    }
+
+    public CsDocComment visitXmlCrefAttribute(CsDocComment.XmlCrefAttribute attribute, P p) {
+        CsDocComment.XmlCrefAttribute a = attribute;
+        a = a.withMarkers(visitMarkers(a.getMarkers(), p));
+        a = a.withSpaceBeforeEquals(ListUtils.map(a.getSpaceBeforeEquals(), s -> visit(s, p)));
+        a = a.withValue(ListUtils.map(a.getValue(), v -> visit(v, p)));
+        return a.withReference(csharpVisitorVisit(a.getReference(), p));
+    }
+
+    public CsDocComment visitXmlNameAttribute(CsDocComment.XmlNameAttribute attribute, P p) {
+        CsDocComment.XmlNameAttribute a = attribute;
+        a = a.withMarkers(visitMarkers(a.getMarkers(), p));
+        a = a.withSpaceBeforeEquals(ListUtils.map(a.getSpaceBeforeEquals(), s -> visit(s, p)));
+        a = a.withValue(ListUtils.map(a.getValue(), v -> visit(v, p)));
+        return a.withParamName(csharpVisitorVisit(a.getParamName(), p));
+    }
+
+    public CsDocComment visitLineBreak(CsDocComment.LineBreak lineBreak, P p) {
+        CsDocComment.LineBreak l = lineBreak;
+        return l.withMarkers(visitMarkers(l.getMarkers(), p));
+    }
+}

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/tree/CsDocComment.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/tree/CsDocComment.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.tree;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import lombok.With;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.csharp.CsDocCommentPrinter;
+import org.openrewrite.csharp.CsDocCommentVisitor;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface CsDocComment extends Tree {
+    @SuppressWarnings("unchecked")
+    @Override
+    default <R extends Tree, P> R accept(TreeVisitor<R, P> v, P p) {
+        return (R) acceptCsDocComment((CsDocCommentVisitor<P>) v, p);
+    }
+
+    @Override
+    default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
+        return v instanceof CsDocCommentVisitor;
+    }
+
+    default <P> @Nullable CsDocComment acceptCsDocComment(CsDocCommentVisitor<P> v, P p) {
+        return v.defaultValue(this, p);
+    }
+
+    @Override
+    default <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+        return new CsDocCommentPrinter<>();
+    }
+
+    /**
+     * The root of a C# XML documentation comment. Implements {@link Comment} so it can be
+     * stored in {@link org.openrewrite.java.tree.Space#getComments()}.
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    class DocComment implements CsDocComment, Comment {
+        @With
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        @With
+        Markers markers;
+
+        @With
+        List<CsDocComment> body;
+
+        String suffix;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public DocComment withSuffix(String suffix) {
+            if (!suffix.equals(this.suffix)) {
+                return new DocComment(id, markers, body, suffix);
+            }
+            return this;
+        }
+
+        @Override
+        public boolean isMultiline() {
+            return true;
+        }
+
+        @Override
+        public <P> CsDocComment acceptCsDocComment(CsDocCommentVisitor<P> v, P p) {
+            return v.visitDocComment(this, p);
+        }
+
+        @Override
+        public <P> void printComment(Cursor cursor, PrintOutputCapture<P> print) {
+            new CsDocCommentPrinter<P>().visit(this, print, cursor);
+        }
+    }
+
+    /**
+     * An XML element with opening and closing tags: {@code <tag attr="val">content</tag>}.
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class XmlElement implements CsDocComment {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Markers markers;
+        String name;
+        List<CsDocComment> attributes;
+        List<CsDocComment> spaceBeforeClose;
+        List<CsDocComment> content;
+        List<CsDocComment> closingTagSpaceBeforeClose;
+
+        @Override
+        public <P> CsDocComment acceptCsDocComment(CsDocCommentVisitor<P> v, P p) {
+            return v.visitXmlElement(this, p);
+        }
+    }
+
+    /**
+     * A self-closing XML element: {@code <tag attr="val"/>}.
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class XmlEmptyElement implements CsDocComment {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Markers markers;
+        String name;
+        List<CsDocComment> attributes;
+        List<CsDocComment> spaceBeforeSlashClose;
+
+        @Override
+        public <P> CsDocComment acceptCsDocComment(CsDocCommentVisitor<P> v, P p) {
+            return v.visitXmlEmptyElement(this, p);
+        }
+    }
+
+    /**
+     * Plain text content within an XML documentation comment.
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class XmlText implements CsDocComment {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Markers markers;
+        String text;
+
+        @Override
+        public <P> CsDocComment acceptCsDocComment(CsDocCommentVisitor<P> v, P p) {
+            return v.visitXmlText(this, p);
+        }
+    }
+
+    /**
+     * A generic XML attribute: {@code attr="value"}.
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class XmlAttribute implements CsDocComment {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Markers markers;
+        String name;
+
+        @Nullable
+        List<CsDocComment> spaceBeforeEquals;
+
+        @Nullable
+        List<CsDocComment> value;
+
+        @Override
+        public <P> CsDocComment acceptCsDocComment(CsDocCommentVisitor<P> v, P p) {
+            return v.visitXmlAttribute(this, p);
+        }
+    }
+
+    /**
+     * A {@code cref} attribute referencing a type or member: {@code cref="System.String"}.
+     * Contains a type-attributed {@link J} reference for recipe support.
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class XmlCrefAttribute implements CsDocComment {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Markers markers;
+
+        @Nullable
+        List<CsDocComment> spaceBeforeEquals;
+
+        @Nullable
+        List<CsDocComment> value;
+
+        @Nullable
+        J reference;
+
+        @Override
+        public <P> CsDocComment acceptCsDocComment(CsDocCommentVisitor<P> v, P p) {
+            return v.visitXmlCrefAttribute(this, p);
+        }
+    }
+
+    /**
+     * A {@code name} attribute binding to a parameter or type parameter: {@code name="paramName"}.
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class XmlNameAttribute implements CsDocComment {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Markers markers;
+
+        @Nullable
+        List<CsDocComment> spaceBeforeEquals;
+
+        @Nullable
+        List<CsDocComment> value;
+
+        @Nullable
+        J paramName;
+
+        @Override
+        public <P> CsDocComment acceptCsDocComment(CsDocCommentVisitor<P> v, P p) {
+            return v.visitXmlNameAttribute(this, p);
+        }
+    }
+
+    /**
+     * A line break within a documentation comment, including the margin (e.g., {@code "\n/// "}).
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    class LineBreak implements CsDocComment {
+        @EqualsAndHashCode.Include
+        @With
+        UUID id;
+
+        String margin;
+        Markers markers;
+
+        @Override
+        public <P> CsDocComment acceptCsDocComment(CsDocCommentVisitor<P> v, P p) {
+            return v.visitLineBreak(this, p);
+        }
+
+        public LineBreak withMargin(String margin) {
+            if (margin.equals(this.margin)) {
+                return this;
+            }
+            return new LineBreak(this.id, margin, this.markers);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public LineBreak withMarkers(Markers markers) {
+            if (markers == this.markers) {
+                return this;
+            }
+            return new LineBreak(id, margin, markers);
+        }
+    }
+}

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/tree/CsDocCommentRawComment.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/tree/CsDocCommentRawComment.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.tree;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.Cursor;
+import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.marker.Markers;
+
+/**
+ * A raw XML documentation comment received from the C# parser via RPC.
+ * Contains the raw text of the doc comment block (with continuation {@code ///} prefixes).
+ * <p>
+ * This is a transient representation: {@link org.openrewrite.csharp.CSharpVisitor#visitSpace}
+ * converts these into structured {@link CsDocComment.DocComment} trees for visitor/recipe support.
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+@With
+public class CsDocCommentRawComment implements Comment {
+    String text;
+    String suffix;
+    Markers markers;
+
+    public CsDocCommentRawComment(String text, String suffix) {
+        this.text = text;
+        this.suffix = suffix;
+        this.markers = Markers.EMPTY;
+    }
+
+    public CsDocCommentRawComment(String text, String suffix, Markers markers) {
+        this.text = text;
+        this.suffix = suffix;
+        this.markers = markers;
+    }
+
+    @Override
+    public boolean isMultiline() {
+        return true;
+    }
+
+    @Override
+    public <P> void printComment(Cursor cursor, PrintOutputCapture<P> p) {
+        p.append("//");
+        p.append(text);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a structured LST for C# XML documentation comments (`///`) following the same architectural pattern as Java's Javadoc support
- `CsDocComment` interface with 8 node types (vs Javadoc's ~31) using a generic XML model since C# doc comments are XML-native
- `CsDocCommentVisitor` with bidirectional `CSharpVisitor` bridge for `cref` type references
- `CsDocCommentPrinter` and `CsDocCommentParser` for round-trip fidelity
- C# side groups consecutive `///` lines into a single `XmlDocComment` in `FormatWithComments`
- RPC type mappings between C# `XmlDocComment` and Java `CsDocCommentRawComment`

### Why not reuse Javadoc?

Javadoc models `@param name desc` positional syntax with ~31 tag-specific types. C# doc comments are XML (`<param name="x">desc</param>`) — fundamentally different structure. The **architectural pattern** is identical (separate tree hierarchy, DocComment implementing Comment, visitor with language visitor bridge via `visitSpace()`), but the node types are XML-centric.

### Architecture

```
CsDocComment (interface extends Tree)
├── DocComment        — root; implements Comment for Space.comments attachment
├── XmlElement        — <tag>content</tag>
├── XmlEmptyElement   — <tag/>
├── XmlText           — plain text
├── XmlAttribute      — generic attribute
├── XmlCrefAttribute  — cref="Type" with J reference for type attribution
├── XmlNameAttribute  — name="param" with identifier
└── LineBreak         — line break with "/// " margin
```

## Test plan

- [ ] Round-trip tests: parse C# with doc comments, print, verify identical output
- [ ] Visitor traversal tests for all node types
- [ ] Verify `cref` references get type attribution
- [ ] Edge cases: empty doc comments, nested XML, self-closing tags, multi-line content
- [ ] Run existing C# test suite for no regressions