### PR TITLE
C#: Add JUnit XML reporting for xUnit tests

### DIFF
--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -1,5 +1,7 @@
 @file:Suppress("UnstableApiUsage")
 
+import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports
+import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect
 import com.hierynomus.gradle.license.tasks.LicenseCheck
 import com.hierynomus.gradle.license.tasks.LicenseFormat
 import nl.javadude.gradle.plugins.license.LicenseExtension
@@ -71,18 +73,26 @@ val csharpBuild by tasks.registering(Exec::class) {
     }
 }
 
+val junitXmlFile = csharpDir.resolve("build/test-results/xunit/junit.xml")
+
 val csharpTest by tasks.registering(Exec::class) {
     group = "csharp"
     description = "Run C# xunit tests"
     dependsOn(csharpBuild)
 
     workingDir = csharpDir
-    commandLine(findDotnet(), "test", "--no-build", "--verbosity", "normal")
+    commandLine(
+        findDotnet(), "test", "--no-build", "--verbosity", "normal",
+        "--logger", "junit;LogFilePath=${junitXmlFile.absolutePath}"
+    )
+    outputs.files(junitXmlFile)
 
     doFirst {
         logger.lifecycle("Running C# tests in ${csharpDir}")
     }
 }
+
+ImportJUnitXmlReports.register(tasks, csharpTest, JUnitXmlDialect.GENERIC)
 
 tasks.named("check") {
     dependsOn(csharpTest)

--- a/rewrite-csharp/csharp/.gitignore
+++ b/rewrite-csharp/csharp/.gitignore
@@ -20,6 +20,7 @@ packages/
 
 # Test results
 TestResults/
+build/
 *.trx
 
 # OS generated

--- a/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="JunitXml.TestLogger" Version="4.0.254" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Adds `JunitXml.TestLogger` NuGet package to produce JUnit XML output from `dotnet test`
- Wires up Develocity's `ImportJUnitXmlReports` so C# test results appear in build scans
- Matches the pattern already used by `rewrite-javascript` for Vitest results

## Test plan
- [ ] CI build succeeds and C# test results appear in the Develocity build scan