### PR TITLE
JavaScript: When failing to install a recipe, let the user know which recipe

### DIFF
--- a/rewrite-javascript/rewrite/src/marketplace.ts
+++ b/rewrite-javascript/rewrite/src/marketplace.ts
@@ -87,7 +87,9 @@ export namespace RecipeMarketplace {
                         const recipeInst = new recipe({});
                         this.recipes.set(await recipeInst.descriptor(), recipe);
                     } catch (e) {
-                        throw new Error(`Failed to install recipe '${recipe.name}'. Ensure the constructor can be called without any arguments.`, {cause: e});
+                        const err = new Error(`Failed to install recipe '${recipe.name}'. Ensure the constructor can be called without any arguments.`);
+                        (err as any).cause = e;
+                        throw err;
                     }
                 } else {
                     this.recipes.set(recipe, undefined);


### PR DESCRIPTION
## What's changed?

Amending the error message for failures of JavaScript RPC installing recipes.

## What's your motivation?

When running a recipe from a derived project, I can get this error message:
```
Caused by io.moderne.jsonrpc.JsonRpcException: {code=-32603, message='Request PrepareRecipe failed with message: Failed to install recipe. Ensure the constructor can be called without any arguments.'}
```
And it's hard to learn what's wrong.
