### PR TITLE
Python: Default `pipPackagesPath` to a temp directory location

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -368,7 +368,8 @@ public class PythonRewriteRpc extends RewriteRpc {
         // Default to looking for a venv python, falling back to system python
         private Path pythonPath = findDefaultPythonPath();
         private @Nullable Path log;
-        private @Nullable Path pipPackagesPath;
+        private @Nullable Path pipPackagesPath = Paths.get(
+                System.getProperty("java.io.tmpdir"), "openrewrite-python-packages");
         private @Nullable Path recipeInstallDir;
 
         private static Path findDefaultPythonPath() {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
