### PR TITLE
C#: Fix `CSharpParser` round-trip for `default (T)` spacing

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -3535,7 +3535,6 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.Keyword.Span.End;
 
         // Parse parentheses and type: (T)
-        SkipTo(node.OpenParenToken.SpanStart);
         var beforeParen = ExtractSpaceBefore(node.OpenParenToken);
         _cursor = node.OpenParenToken.Span.End;
 

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/DefaultExpressionTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/DefaultExpressionTests.cs
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Test;
+
+namespace OpenRewrite.Tests.Tree;
+
+public class DefaultExpressionTests : RewriteTest
+{
+    [Fact]
+    public void DefaultExpressionNoSpace()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Foo {
+                    void Bar() {
+                        var x = default(int);
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void DefaultExpressionWithSpace()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Foo {
+                    void Bar() {
+                        var x = default (int);
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void DefaultLiteral()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Foo {
+                    void Bar() {
+                        int x = default;
+                    }
+                }
+                """
+            )
+        );
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/NewClassTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/NewClassTests.cs
@@ -238,6 +238,36 @@ public class NewClassTests : RewriteTest
     }
 
     [Fact]
+    public void ImplicitNewNoSpace()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                using System.Collections.Generic;
+                class Foo {
+                    List<int> x = new();
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void ImplicitNewWithSpace()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                using System.Collections.Generic;
+                class Foo {
+                    List<int> x = new ();
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
     public void QualifiedConstructor()
     {
         RewriteRun(


### PR DESCRIPTION
## Summary

- Fix `VisitDefaultExpression` dropping the space between `default` and `(` during parse — `SkipTo(node.OpenParenToken.SpanStart)` advanced the cursor past the whitespace before `ExtractSpaceBefore` could capture it
- Add round-trip tests for `default(int)`, `default (int)` (with space), `default` literal, and implicit `new()` / `new ()` expressions

## Test plan

- [x] `DefaultExpressionTests.DefaultExpressionWithSpace` — previously failed, now passes
- [x] `DefaultExpressionTests.DefaultExpressionNoSpace` — regression check
- [x] `DefaultExpressionTests.DefaultLiteral` — regression check
- [x] `NewClassTests.ImplicitNewWithSpace` — confirms `new ()` already works
- [x] `NewClassTests.ImplicitNewNoSpace` — regression check
- [x] All 1109 Tree tests pass