### PR TITLE
C#: Fix RPC reentrancy deadlock and enable cross-ecosystem recipe resolution

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -115,8 +115,25 @@ public class RewriteRpc {
      *                    marketplace allows the remote peer to discover what recipes
      *                    the host process has available for its use in composite recipes.
      */
+    /**
+     * Mutable resolver list so it can be updated after construction
+     * (e.g. when the RPC process is started eagerly before all resolvers are built).
+     */
+    private final List<RecipeBundleResolver> resolvers = new ArrayList<>();
+
+    /**
+     * Replace the resolver list. Useful when the RPC process is started before all
+     * resolvers are built (e.g. the NuGet resolver starts the C# RPC during
+     * buildResolvers, but Maven resolvers are added to the list afterward).
+     */
+    public void setResolvers(List<RecipeBundleResolver> resolvers) {
+        this.resolvers.clear();
+        this.resolvers.addAll(resolvers);
+    }
+
     public RewriteRpc(JsonRpc jsonRpc, RecipeMarketplace marketplace, List<RecipeBundleResolver> resolvers) {
         this.jsonRpc = jsonRpc;
+        this.resolvers.addAll(resolvers);
 
         jsonRpc.rpc("Visit", new Visit.Handler(localObjects, preparedRecipes,
                 this::getObject, this::getCursor));
@@ -129,7 +146,7 @@ public class RewriteRpc {
         jsonRpc.rpc("GetMarketplace", new JsonRpcMethod<Void>() {
             @Override
             protected Object handle(Void noParams) {
-                return GetMarketplaceResponse.fromMarketplace(marketplace, resolvers);
+                return GetMarketplaceResponse.fromMarketplace(marketplace, RewriteRpc.this.resolvers);
             }
         });
         jsonRpc.rpc("TraceGetObject", new JsonRpcMethod<TraceGetObject>() {
@@ -162,7 +179,7 @@ public class RewriteRpc {
         jsonRpc.rpc("PrepareRecipe", new PrepareRecipe.Handler(preparedRecipes, (id, opts) -> {
             RecipeListing listing = marketplace.findRecipe(id);
             if (listing != null) {
-                return listing.prepare(resolvers, opts);
+                return listing.prepare(RewriteRpc.this.resolvers, opts);
             }
             // Fall back to loading by class name if not found in marketplace
             return new RecipeLoader(null).load(id, opts);

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -82,6 +82,7 @@ public class RewriteRpcServer
     public void Connect(JsonRpc jsonRpc)
     {
         _jsonRpc = jsonRpc;
+        jsonRpc.SynchronizationContext = null;
         jsonRpc.AddLocalRpcTarget(this);
         jsonRpc.StartListening();
     }
@@ -1398,6 +1399,10 @@ public class RewriteRpcServer
         var server = new RewriteRpcServer(marketplace);
         server._jsonRpc = jsonRpc;
         _current = server;
+        // Allow concurrent request dispatch so reentrant callbacks don't deadlock.
+        // Without this, the default NonConcurrentSynchronizationContext serializes
+        // dispatch, blocking incoming GetObject requests while BatchVisit is in progress.
+        jsonRpc.SynchronizationContext = null;
         jsonRpc.AddLocalRpcTarget(server);
         jsonRpc.StartListening();
 

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -369,6 +369,9 @@ public class CSharpRewriteRpc extends RewriteRpc {
                     NUGET_PACKAGE_ID + "@" + version,
                     "-y",
                     "--allow-roll-forward",
+                    // Suppress NuGet informational messages (e.g. "Skipping NuGet package
+                    // signature verification") that would corrupt the RPC stdout channel.
+                    "-v", "q",
                     "--",
                     log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
                     traceRpcMessages ? "--trace-rpc-messages" : null


### PR DESCRIPTION
## Summary

- **Fix reentrancy deadlock** in C# RPC server by setting `SynchronizationContext = null` on StreamJsonRpc. The default `NonConcurrentSynchronizationContext` (since v2.6) serializes dispatch, which deadlocks when `BatchVisit` → `Visit` callback → `GetObject` creates a 3-way reentrant call chain.
- **Add `RewriteRpc.setResolvers()`** so resolvers can be injected after the RPC process starts. The NuGet resolver eagerly starts the C# RPC during `buildResolvers()`, before Maven resolvers are added. Without this, the `PrepareRecipe` handler has no resolvers and fails with "No available resolver for 'maven' ecosystem" when C# recipes use HasType/HasMethod preconditions.
- **Add `-v q`** to `dotnet tool exec` to suppress "Skipping NuGet package signature verification" from corrupting the RPC stdout channel.

## Test plan

- [x] Ran `UpgradeToDotNet10` (176 sub-recipes) on winsw — completed in 27s with real changes (was deadlocking indefinitely before)
- [x] Ran CodeQuality recipe on 22-repo working set — completed in ~1m
- [ ] CI tests pass