### PR TITLE
UpdateGradleWrapper: handle TaskContainer-based Wrapper DSL patterns

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -475,6 +475,26 @@ public class UpdateGradleWrapper extends ScanningRecipe<UpdateGradleWrapper.Grad
                     m.getArguments().size() == 1 && m.getArguments().get(0) instanceof J.Lambda) {
                 return true;
             }
+            // Pattern: tasks.wrapper { ... } (property-style access on TaskContainer)
+            if ("wrapper".equals(m.getSimpleName()) && m.getSelect() instanceof J.Identifier &&
+                    "tasks".equals(((J.Identifier) m.getSelect()).getSimpleName())) {
+                return true;
+            }
+            // Pattern: tasks.withType(Wrapper) { ... } or tasks.withType<Wrapper> { ... }
+            if ("withType".equals(m.getSimpleName()) && m.getSelect() instanceof J.Identifier &&
+                    "tasks".equals(((J.Identifier) m.getSelect()).getSimpleName())) {
+                List<Expression> args = m.getArguments();
+                // Groovy: tasks.withType(Wrapper) { ... }
+                if (!args.isEmpty() && args.get(0) instanceof J.Identifier &&
+                        "Wrapper".equals(((J.Identifier) args.get(0)).getSimpleName())) {
+                    return true;
+                }
+                // Kotlin: tasks.withType<Wrapper> { ... } (type param, single lambda arg)
+                if (m.getTypeParameters() != null && !m.getTypeParameters().isEmpty()) {
+                    return m.getTypeParameters().stream()
+                            .anyMatch(tp -> tp instanceof J.Identifier && "Wrapper".equals(((J.Identifier) tp).getSimpleName()));
+                }
+            }
             return false;
         }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -1301,6 +1301,178 @@ class UpdateGradleWrapperTest implements RewriteTest {
         );
     }
 
+    @Test
+    void updateWrapperVersionViaTasksPropertyAccessInGroovyDSL() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateGradleWrapper("7.4.2", "bin", null, null, null))
+            .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4"))),
+          properties(
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://downloads.gradle.org/distributions/gradle-7.4-all.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              """,
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://downloads.gradle.org/distributions/gradle-7.4.2-bin.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
+              """,
+            spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
+          ),
+          buildGradle(
+            """
+              tasks.wrapper {
+                  gradleVersion = '7.4'
+                  distributionType = Wrapper.DistributionType.ALL
+              }
+              """,
+            """
+              tasks.wrapper {
+                  gradleVersion = '7.4.2'
+                  distributionType = Wrapper.DistributionType.BIN
+              }
+              """
+          ),
+          gradlew,
+          gradlewBat,
+          gradleWrapperJarQuark
+        );
+    }
+
+    @Test
+    void updateWrapperVersionViaTasksPropertyAccessInKotlinDSL() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateGradleWrapper("7.4.2", "bin", null, null, null))
+            .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4"))),
+          properties(
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://downloads.gradle.org/distributions/gradle-7.4-all.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              """,
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://downloads.gradle.org/distributions/gradle-7.4.2-bin.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
+              """,
+            spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
+          ),
+          buildGradleKts(
+            """
+              tasks.wrapper {
+                  gradleVersion = "7.4"
+                  distributionType = Wrapper.DistributionType.ALL
+              }
+              """,
+            """
+              tasks.wrapper {
+                  gradleVersion = "7.4.2"
+                  distributionType = Wrapper.DistributionType.BIN
+              }
+              """
+          ),
+          gradlew,
+          gradlewBat,
+          gradleWrapperJarQuark
+        );
+    }
+
+    @Test
+    void updateWrapperVersionViaTasksWithTypeInGroovyDSL() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateGradleWrapper("7.4.2", "bin", null, null, null))
+            .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4"))),
+          properties(
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://downloads.gradle.org/distributions/gradle-7.4-all.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              """,
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://downloads.gradle.org/distributions/gradle-7.4.2-bin.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
+              """,
+            spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
+          ),
+          buildGradle(
+            """
+              tasks.withType(Wrapper) {
+                  gradleVersion = '7.4'
+                  distributionType = Wrapper.DistributionType.ALL
+              }
+              """,
+            """
+              tasks.withType(Wrapper) {
+                  gradleVersion = '7.4.2'
+                  distributionType = Wrapper.DistributionType.BIN
+              }
+              """
+          ),
+          gradlew,
+          gradlewBat,
+          gradleWrapperJarQuark
+        );
+    }
+
+    @Test
+    void updateWrapperVersionViaTasksWithTypeInKotlinDSL() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateGradleWrapper("7.4.2", "bin", null, null, null))
+            .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4"))),
+          properties(
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://downloads.gradle.org/distributions/gradle-7.4-all.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              """,
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://downloads.gradle.org/distributions/gradle-7.4.2-bin.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
+              """,
+            spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
+          ),
+          buildGradleKts(
+            """
+              tasks.withType<Wrapper> {
+                  gradleVersion = "7.4"
+                  distributionType = Wrapper.DistributionType.ALL
+              }
+              """,
+            """
+              tasks.withType<Wrapper> {
+                  gradleVersion = "7.4.2"
+                  distributionType = Wrapper.DistributionType.BIN
+              }
+              """
+          ),
+          gradlew,
+          gradlewBat,
+          gradleWrapperJarQuark
+        );
+    }
+
     private <S extends SourceFile> S result(RecipeRun run, Class<S> clazz, String endsWith) {
         return run.getChangeset().getAllResults().stream()
           .map(Result::getAfter)


### PR DESCRIPTION
## Summary
- Add support for `tasks.wrapper { ... }` (property-style access on TaskContainer) in both Groovy and Kotlin DSL
- Add support for `tasks.withType(Wrapper) { ... }` (Groovy) and `tasks.withType<Wrapper> { ... }` (Kotlin)
- Previously only `tasks.named('wrapper') { ... }` and `wrapper { ... }` were recognized