### PR TITLE
Fix multi-repo RPC deadlock via stderr redirect and dedicated GetObject pool

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -31,6 +31,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.jspecify.annotations.Nullable;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -46,6 +47,9 @@ import static org.openrewrite.internal.StringUtils.readFully;
  * A client for spawning and communicating with a subprocess that implements Rewrite RPC.
  */
 public class RewriteRpcProcess extends Thread {
+    private static final File DEV_NULL = new File(
+            System.getProperty("os.name").startsWith("Windows") ? "NUL" : "/dev/null");
+
     private final String[] command;
 
     @Setter
@@ -63,7 +67,8 @@ public class RewriteRpcProcess extends Thread {
 
     private final Map<String, String> environment = new LinkedHashMap<>();
 
-    private final StringBuffer accumulatedStderr = new StringBuffer();
+    @Setter
+    private @Nullable Path stderrRedirect;
 
     public RewriteRpcProcess(String... command) {
         this.command = command;
@@ -88,6 +93,11 @@ public class RewriteRpcProcess extends Thread {
             if (workingDirectory != null) {
                 pb.directory(workingDirectory.toFile());
             }
+            if (stderrRedirect != null) {
+                pb.redirectError(ProcessBuilder.Redirect.appendTo(stderrRedirect.toFile()));
+            } else {
+                pb.redirectError(ProcessBuilder.Redirect.to(DEV_NULL));
+            }
             process = pb.start();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -99,31 +109,8 @@ public class RewriteRpcProcess extends Thread {
             return null;
         }
 
-        // Accumulate any available stderr
-        try {
-            InputStream errorStream = process.getErrorStream();
-            int available = errorStream.available();
-            if (available > 0) {
-                byte[] buffer = new byte[available];
-                int read = errorStream.read(buffer);
-                if (read > 0) {
-                    accumulatedStderr.append(new String(buffer, 0, read));
-                }
-            }
-        } catch (IOException | UnsupportedOperationException e) {
-            // Ignore errors reading stderr
-        }
-
         if (!process.isAlive()) {
             int exitCode = process.exitValue();
-
-            // Read any remaining stderr
-            try {
-                InputStream errorStream = process.getErrorStream();
-                accumulatedStderr.append(readFully(errorStream));
-            } catch (UnsupportedOperationException e) {
-                // Ignore errors reading final stderr
-            }
 
             // Read any remaining stdout
             String stdOutput = "";
@@ -135,12 +122,11 @@ public class RewriteRpcProcess extends Thread {
             }
 
             String message = "RPC process shut down early with exit code " + exitCode;
-            String errorOutput = accumulatedStderr.toString();
             if (!stdOutput.isEmpty()) {
                 message += "\nStandard output:\n  " + stdOutput.replace("\n", "\n  ");
             }
-            if (!errorOutput.isEmpty()) {
-                message += "\nError output:\n  " + errorOutput.replace("\n", "\n  ");
+            if (stderrRedirect != null) {
+                message += "\nSee stderr log: " + stderrRedirect;
             }
             return new IllegalStateException(message.trim());
         }

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/GetObject.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/GetObject.java
@@ -44,7 +44,13 @@ public class GetObject implements RpcRequest {
 
     @RequiredArgsConstructor
     public static class Handler extends JsonRpcMethod<GetObject> {
-        private static final ExecutorService forkJoin = ForkJoinPool.commonPool();
+        // Dedicated pool for tree traversal so GetObject producers can't be starved
+        // by unrelated tasks (e.g. repo-level fork-join work) occupying the commonPool.
+        private static final ExecutorService TREE_TRAVERSAL_POOL = Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r, "rpc-get-object-traversal");
+            t.setDaemon(true);
+            return t;
+        });
 
         private final AtomicInteger batchSize;
         private final Map<String, Object> remoteObjects;
@@ -77,7 +83,7 @@ public class GetObject implements RpcRequest {
                 Object before = remoteObjects.get(id);
 
                 RpcSendQueue sendQueue = new RpcSendQueue(batchSize.get(), batch::put, localRefs, request.getSourceFileType(), traceGetObject.get());
-                forkJoin.submit(() -> {
+                TREE_TRAVERSAL_POOL.submit(() -> {
                     try {
                         sendQueue.send(after, before, null);
 

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -323,6 +323,7 @@ public class CSharpRewriteRpc extends RewriteRpc {
             if (workingDirectory != null) {
                 process.setWorkingDirectory(workingDirectory);
             }
+            process.setStderrRedirect(log);
 
             process.environment().putAll(environment);
 

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -382,6 +382,7 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
             if (workingDirectory != null) {
                 process.setWorkingDirectory(workingDirectory);
             }
+            process.setStderrRedirect(log);
 
             process.environment().putAll(environment);
             // caller-provided options, if any, are taking precedence over the options baked above

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -581,6 +581,7 @@ public class PythonRewriteRpc extends RewriteRpc {
             if (workingDirectory != null) {
                 process.setWorkingDirectory(workingDirectory);
             }
+            process.setStderrRedirect(log);
 
             process.environment().putAll(environment);
 


### PR DESCRIPTION
## Summary

- **Redirect subprocess stderr** at the OS level via `ProcessBuilder.redirectError()` to prevent pipe-buffer deadlock on macOS (64KB kernel buffer). When a log path is configured, stderr goes to that file; otherwise it goes to `/dev/null`.
- **Use a dedicated thread pool** for `GetObject` tree traversal instead of `ForkJoinPool.commonPool()`, which gets saturated by repo-level fork-join tasks and starves GetObject producers.
- **Wire `stderrRedirect`** through C#, JavaScript, and Python RPC builders.

These two deadlocks were independent — the stderr issue blocked the subprocess from writing RPC responses, while the pool starvation prevented Java from servicing `GetObject` callbacks during `BatchVisit`.

## Test plan

- [x] Ran `mod run` with `UpgradeToDotNet10` on 11 C# repos in parallel — completed in 6m 25s with no deadlock
- [x] Previously deadlocked after 1-2 repos with the serializing semaphore, and immediately with parallel execution