### PR TITLE
Improve local NuGet development workflow

### DIFF
--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -147,12 +147,17 @@ tasks.withType<Test> {
 // ============================================
 
 // Generate a NuGet-compatible version
-// Snapshots use pre-release suffix with UTC timestamp: 8.73.0-snapshot.20260110143252
+// CI builds use timestamped pre-release: 8.73.0-snapshot.20260110143252
+// Local builds use stable suffix that sorts higher: 8.73.0-zlocal
 // Releases use clean version: 8.73.0
-val nugetVersion: String = project.version.toString().replace(
-    "-SNAPSHOT",
-    "-snapshot.${Instant.now().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))}"
-)
+val nugetVersion: String = if (System.getenv("CI") != null) {
+    project.version.toString().replace(
+        "-SNAPSHOT",
+        "-snapshot.${Instant.now().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))}"
+    )
+} else {
+    project.version.toString().replace("-SNAPSHOT", "-zlocal")
+}
 
 val generateVersionTxt by tasks.registering {
     group = "csharp"
@@ -281,10 +286,19 @@ val csharpPublishLocal by tasks.registering {
                 }
             }
 
-        // Create a temp project and add packages to populate the NuGet cache
+        // Create a temp project with PackageDownload entries and restore to populate the NuGet cache
         val tempDir = temporaryDir
         tempDir.deleteRecursively()
         tempDir.mkdirs()
+
+        val packageDownloads = csharpDir.resolve("dist").listFiles()
+            ?.filter { it.name.endsWith(".nupkg") }
+            ?.joinToString("\n") { nupkg ->
+                val nameWithoutExt = nupkg.name.removeSuffix(".nupkg")
+                val packageId = nameWithoutExt.removeSuffix(".$nugetVersion")
+                logger.lifecycle("Installing $packageId@$nugetVersion into NuGet cache from $distDir")
+                """    <PackageDownload Include="$packageId" Version="[$nugetVersion]" />"""
+            } ?: ""
 
         val tempCsproj = tempDir.resolve("Temp.csproj")
         tempCsproj.writeText("""
@@ -292,27 +306,20 @@ val csharpPublishLocal by tasks.registering {
               <PropertyGroup>
                 <TargetFramework>net10.0</TargetFramework>
               </PropertyGroup>
+              <ItemGroup>
+            $packageDownloads
+              </ItemGroup>
             </Project>
         """.trimIndent())
 
-        csharpDir.resolve("dist").listFiles()
-            ?.filter { it.name.endsWith(".nupkg") }
-            ?.forEach { nupkg ->
-                val nameWithoutExt = nupkg.name.removeSuffix(".nupkg")
-                val packageId = nameWithoutExt.removeSuffix(".$nugetVersion")
-
-                logger.lifecycle("Installing $packageId@$nugetVersion into NuGet cache from $distDir")
-                // Tool packages (DotnetTool type) fail restore with NU1212 but still get
-                // installed into the NuGet cache, which is all we need for dotnet tool exec.
-                val addOutput = run(
-                    dotnet, "add", "package", packageId,
-                    "--version", nugetVersion,
-                    "--source", distDir,
-                    dir = tempDir,
-                    ignoreExitCode = true
-                )
-                logger.lifecycle(addOutput)
-            }
+        val restoreOutput = run(
+            dotnet, "restore",
+            "--source", distDir,
+            "--force",
+            dir = tempDir,
+            ignoreExitCode = true
+        )
+        logger.lifecycle(restoreOutput)
 
     }
 }

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -363,12 +363,21 @@ public class CSharpRewriteRpc extends RewriteRpc {
         }
 
         private Stream<@Nullable String> buildToolExecCommand(String version) {
+            // When the tool package exists in the NuGet global cache (e.g. from pTML),
+            // add it as a source so dotnet tool exec can resolve it without remote feeds
+            Path globalCachePath = Paths.get(System.getProperty("user.home"),
+                    ".nuget", "packages", NUGET_PACKAGE_ID.toLowerCase(), version);
+            String addSource = Files.isDirectory(globalCachePath) ? globalCachePath.toString() : null;
+
             return Stream.of(
                     dotnetPath.toString(),
                     "tool", "exec",
                     NUGET_PACKAGE_ID + "@" + version,
                     "-y",
                     "--allow-roll-forward",
+                    addSource != null ? "--add-source" : null,
+                    addSource,
+                    "--ignore-failed-sources",
                     // Suppress NuGet informational messages (e.g. "Skipping NuGet package
                     // signature verification") that would corrupt the RPC stdout channel.
                     "-v", "q",


### PR DESCRIPTION
## Summary
- Use stable `zlocal` pre-release suffix for local builds instead of UTC timestamps, so downstream projects don't need re-registration between iterations (CI still uses timestamped versions)
- Use `PackageDownload` + `dotnet restore` instead of `dotnet add package` to populate NuGet global cache (cleaner, no NU1212 workarounds)
- Add `--add-source` pointing to NuGet global cache in `dotnet tool exec` so locally-published tool packages resolve without remote feeds or `REWRITE_SOURCE_PATH`
- Add `--ignore-failed-sources` to `dotnet tool exec` for resilience

## Test plan
- [x] Verified `pTML` produces `8.76.0-zlocal` packages and installs them into NuGet global cache via PackageDownload
- [x] Verified `mod build` resolves `OpenRewrite.CSharp.Tool@8.76.0-zlocal` from global cache without `REWRITE_SOURCE_PATH`
- [x] Verified CI path still generates timestamped versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)