### PR TITLE
Skip RPC for Java-delegate recipes in cross-language composites

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -121,6 +121,8 @@ public class RewriteRpc {
      */
     private final List<RecipeBundleResolver> resolvers = new ArrayList<>();
 
+    private final RecipeMarketplace marketplace;
+
     /**
      * Replace the resolver list. Useful when the RPC process is started before all
      * resolvers are built (e.g. the NuGet resolver starts the C# RPC during
@@ -133,6 +135,7 @@ public class RewriteRpc {
 
     public RewriteRpc(JsonRpc jsonRpc, RecipeMarketplace marketplace, List<RecipeBundleResolver> resolvers) {
         this.jsonRpc = jsonRpc;
+        this.marketplace = marketplace;
         this.resolvers.addAll(resolvers);
 
         jsonRpc.rpc("Visit", new Visit.Handler(localObjects, preparedRecipes,
@@ -330,12 +333,23 @@ public class RewriteRpc {
         return remoteLanguages;
     }
 
-    public RpcRecipe prepareRecipe(String id) {
+    public Recipe prepareRecipe(String id) {
         return prepareRecipe(id, emptyMap());
     }
 
-    public RpcRecipe prepareRecipe(String id, Map<String, Object> options) {
+    public Recipe prepareRecipe(String id, Map<String, Object> options) {
         PrepareRecipeResponse r = send("PrepareRecipe", new PrepareRecipe(id, options), PrepareRecipeResponse.class);
+
+        if (r.getDelegatesTo() != null) {
+            PrepareRecipeResponse.DelegatesTo d = r.getDelegatesTo();
+            RecipeListing listing = marketplace.findRecipe(d.getRecipeName());
+            if (listing == null) {
+                throw new IllegalStateException(
+                        "Remote declared delegatesTo " + d.getRecipeName() +
+                        " but no recipe found in marketplace.");
+            }
+            return listing.prepare(resolvers, d.getOptions());
+        }
 
         // FIXME do this validation on the server side instead
         for (OptionDescriptor option : r.getDescriptor().getOptions()) {

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipe.java
@@ -55,7 +55,8 @@ public class PrepareRecipe implements RpcRequest {
                     // of the edit visitor in this Java RPC process. Same for the scan precondition visitor below.
                     emptyList(),
                     recipe instanceof ScanningRecipe ? "scan:" + instanceId : null,
-                    emptyList()
+                    emptyList(),
+                    null
             );
         }
     }

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipeResponse.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipeResponse.java
@@ -39,6 +39,20 @@ public class PrepareRecipeResponse {
 
     List<Precondition> scanPreconditions;
 
+    /**
+     * When non-null, the remote declares that this recipe delegates entirely
+     * to a Java recipe. The host should load the recipe locally via the
+     * marketplace instead of wrapping it in an RpcRecipe.
+     */
+    @Nullable
+    DelegatesTo delegatesTo;
+
+    @Value
+    public static class DelegatesTo {
+        String recipeName;
+        Map<String, Object> options;
+    }
+
     @Value
     public static class Precondition {
         String visitorName;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -25,6 +25,7 @@ using Newtonsoft.Json.Serialization;
 using OpenRewrite.Core;
 using OpenRewrite.Core.Rpc;
 using OpenRewrite.Java;
+using OpenRewrite.Java.Search;
 using Serilog;
 using StreamJsonRpc;
 using static OpenRewrite.Core.Rpc.RpcObjectData.ObjectState;
@@ -1109,13 +1110,66 @@ public class RewriteRpcServer
         var id = Guid.NewGuid().ToString();
         _preparedRecipes[id] = recipe;
 
-        return Task.FromResult(new PrepareRecipeResponse
+        var response = new PrepareRecipeResponse
         {
             Id = id,
             Descriptor = RecipeDescriptorDto.FromDescriptor(recipe.GetDescriptor()),
             EditVisitor = $"edit:{id}",
             ScanVisitor = GetScanningRecipeBase(recipe.GetType()) != null ? $"scan:{id}" : null
-        });
+        };
+
+        if (recipe is IDelegatesTo del)
+        {
+            response.DelegatesTo = new DelegatesTo
+            {
+                RecipeName = del.JavaRecipeName,
+                Options = del.Options
+            };
+        }
+        else
+        {
+            OptimizePreconditions(recipe, response);
+        }
+
+        return Task.FromResult(response);
+    }
+
+    /// <summary>
+    /// Inspects a recipe's visitor to extract preconditions that Java can evaluate
+    /// before sending files via RPC. Also adds a FindTreesOfType precondition based
+    /// on the visitor type so Java only sends compatible files.
+    /// </summary>
+    private void OptimizePreconditions(Recipe recipe, PrepareRecipeResponse response)
+    {
+        try
+        {
+            var visitor = recipe.GetVisitor();
+
+            var innerVisitor = visitor;
+            if (visitor is Check check && check.Precondition is RpcVisitor rpcPrecondition)
+            {
+                response.EditPreconditions.Add(new Precondition
+                {
+                    VisitorName = rpcPrecondition.VisitorName,
+                    VisitorOptions = new()
+                });
+                innerVisitor = check.Visitor;
+            }
+
+            // Add tree type precondition so Java only sends files this visitor can handle
+            if (innerVisitor is CSharpVisitor<ExecutionContext>)
+            {
+                response.EditPreconditions.Add(new Precondition
+                {
+                    VisitorName = "org.openrewrite.rpc.internal.FindTreesOfType",
+                    VisitorOptions = new() { ["type"] = "org.openrewrite.csharp.tree.Cs" }
+                });
+            }
+        }
+        catch
+        {
+            // Some recipes may fail during GetVisitor() — skip precondition detection
+        }
     }
 
     private static Recipe InstantiateWithOptions(Type recipeType, Dictionary<string, object?> options)
@@ -1772,6 +1826,13 @@ public class PrepareRecipeResponse
     public List<Precondition> EditPreconditions { get; set; } = [];
     public string? ScanVisitor { get; set; }
     public List<Precondition> ScanPreconditions { get; set; } = [];
+    public DelegatesTo? DelegatesTo { get; set; }
+}
+
+public class DelegatesTo
+{
+    public string RecipeName { get; set; } = "";
+    public Dictionary<string, object?> Options { get; set; } = new();
 }
 
 public class Precondition

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Recipe.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Recipe.cs
@@ -94,6 +94,25 @@ public abstract class Recipe
 }
 
 /// <summary>
+/// Marker interface for recipes that delegate entirely to a Java recipe.
+/// When a recipe implements this interface, the Java host loads the recipe
+/// locally instead of wrapping it in an RpcRecipe, eliminating per-file
+/// RPC round trips.
+/// </summary>
+public interface IDelegatesTo
+{
+    /// <summary>
+    /// The fully-qualified Java recipe name, e.g. "org.openrewrite.java.ChangeType".
+    /// </summary>
+    string JavaRecipeName { get; }
+
+    /// <summary>
+    /// Options to configure the Java recipe, keyed by option name.
+    /// </summary>
+    Dictionary<string, object?> Options { get; }
+}
+
+/// <summary>
 /// Non-generic interface for scanning recipes, allowing the scheduler to
 /// manage the scan/generate/edit lifecycle without knowing the accumulator type.
 /// </summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcVisitor.cs
@@ -28,6 +28,8 @@ public class RpcVisitor : JavaVisitor<ExecutionContext>
     private readonly RewriteRpcServer _rpc;
     private readonly string _visitorName;
 
+    public string VisitorName => _visitorName;
+
     public RpcVisitor(RewriteRpcServer rpc, string visitorName)
     {
         _rpc = rpc;

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Search/Check.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Search/Check.cs
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Java.Search;
+
+/// <summary>
+/// A visitor wrapper that runs a precondition check before the actual visitor.
+/// If the precondition modifies the tree (indicating a match), the inner visitor runs.
+/// Otherwise the tree is returned unchanged.
+/// </summary>
+public class Check : JavaVisitor<ExecutionContext>
+{
+    public JavaVisitor<ExecutionContext> Precondition { get; }
+    public JavaVisitor<ExecutionContext> Visitor { get; }
+
+    internal Check(JavaVisitor<ExecutionContext> precondition, JavaVisitor<ExecutionContext> visitor)
+    {
+        Precondition = precondition;
+        Visitor = visitor;
+    }
+
+    public override J? PreVisit(J tree, ExecutionContext ctx)
+    {
+        StopAfterPreVisit();
+        var result = Precondition.Visit(tree, ctx);
+        if (result != tree)
+        {
+            return (J?)Visitor.Visit(tree, ctx);
+        }
+        return tree;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Search/Preconditions.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Search/Preconditions.cs
@@ -27,6 +27,17 @@ namespace OpenRewrite.Java.Search;
 public static class Preconditions
 {
     /// <summary>
+    /// Wraps a visitor with a precondition check. The inner visitor only runs
+    /// on files where the precondition matches.
+    /// </summary>
+    public static JavaVisitor<ExecutionContext> Check(
+        JavaVisitor<ExecutionContext> precondition,
+        JavaVisitor<ExecutionContext> visitor)
+    {
+        return new Check(precondition, visitor);
+    }
+
+    /// <summary>
     /// Creates a UsesType precondition. If connected to Java via RPC, delegates to
     /// Java's org.openrewrite.java.search.HasType. Otherwise falls back to local implementation.
     /// </summary>
@@ -39,7 +50,7 @@ public static class Preconditions
                 "org.openrewrite.java.search.HasType",
                 new Dictionary<string, object?>
                 {
-                    ["fullyQualifiedType"] = fullyQualifiedTypeName,
+                    ["fullyQualifiedTypeName"] = fullyQualifiedTypeName,
                     ["checkAssignability"] = false
                 }
             );

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/rpc/XmlRpcBridgeTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/rpc/XmlRpcBridgeTest.java
@@ -86,7 +86,7 @@ class XmlRpcBridgeTest {
      * Applies a C#-side recipe to an XML document and returns the modified result.
      */
     private Xml.Document visitOnCSharp(Xml.Document doc, String recipeName, Map<String, Object> options) {
-        RpcRecipe recipe = rpc.prepareRecipe(recipeName, options);
+        RpcRecipe recipe = (RpcRecipe) rpc.prepareRecipe(recipeName, options);
         InMemoryExecutionContext ctx = new InMemoryExecutionContext();
         Tree result = rpc.visit(doc, recipe.getEditVisitor(), ctx);
         assertThat(result).isNotNull().isInstanceOf(Xml.Document.class);

--- a/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
@@ -60,7 +60,7 @@ export class PrepareRecipe {
 
                     await this.installSubRecipes(recipe, marketplace);
 
-                    const result = {
+                    const result: PrepareRecipeResponse = {
                         id: id,
                         descriptor: await recipe.descriptor(),
                         editVisitor: `edit:${id}`,
@@ -68,6 +68,13 @@ export class PrepareRecipe {
                         scanVisitor: recipe instanceof ScanningRecipe ? `scan:${id}` : undefined,
                         scanPreconditions: scanPreconditions
                     };
+
+                    if ('javaRecipeName' in recipe) {
+                        result.delegatesTo = {
+                            recipeName: (recipe as any).javaRecipeName,
+                            options: (recipe as any).delegatesToOptions ?? {}
+                        };
+                    }
 
                     return result;
                 }
@@ -161,6 +168,11 @@ export class PrepareRecipe {
     }
 }
 
+export interface DelegatesTo {
+    recipeName: string
+    options: Record<string, any>
+}
+
 export interface PrepareRecipeResponse {
     id: string
     descriptor: RecipeDescriptor
@@ -168,6 +180,7 @@ export interface PrepareRecipeResponse {
     editPreconditions: Precondition[]
     scanVisitor?: string
     scanPreconditions: Precondition[]
+    delegatesTo?: DelegatesTo
 }
 
 export interface Precondition {

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1001,6 +1001,13 @@ def handle_prepare_recipe(params: dict) -> dict:
         'scanPreconditions': _get_preconditions(recipe, 'scan') if is_scanning else [],
     }
 
+    # If the recipe declares delegation to a Java recipe, include it in the response
+    if hasattr(recipe, 'java_recipe_name'):
+        response['delegatesTo'] = {
+            'recipeName': recipe.java_recipe_name,
+            'options': getattr(recipe, 'delegates_to_options', {}),
+        }
+
     logger.debug(f"PrepareRecipe response: {response}")
     return response
 


### PR DESCRIPTION
## Summary

- C# migration recipes (UpgradeToDotNet5-10) contain sub-recipes like ChangeType, ChangeMethodName, and DeleteMethodArgument that delegate entirely to Java. Each delegate recipe per source file triggered 5+ RPC round trips — unnecessary since these Java recipes are on the classpath and `Cs.CompilationUnit implements JavaSourceFile`.
- Add `DelegatesTo` field to `PrepareRecipeResponse` so the remote peer can declare delegation. Java loads the recipe locally via the marketplace instead of wrapping in `RpcRecipe`.
- Add `Check` class and `Preconditions.Check()` to C# SDK. The PrepareRecipe handler inspects visitors and extracts preconditions (including `FindTreesOfType` for `CSharpVisitor`) so Java skips RPC for non-matching files.
- Fix option name typo in `Preconditions.UsesType` (`fullyQualifiedType` → `fullyQualifiedTypeName`).

## Test plan

- [x] `UpgradeToDotNet10` on shadowsocks-windows (150 files): 22s
- [x] `UpgradeToDotNet10` on 22 repos (8,046 files): 1m 25s wall clock (down from 6+ min)
- [x] RecipeRunStats confirms ChangeType/ChangeMethodName/DeleteMethodArgument run as Java-local recipes
- [ ] Run existing C# integration tests
- [ ] Run JS/Python integration tests to verify backward compatibility (old peers ignore `delegatesTo`)