### PR TITLE
C#: Add `ParentTree` property and `PathToRoot()` to `Cursor`

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -488,7 +488,7 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
         BeforeSyntax(na, p);
 
         // Don't print "new" when inside a stackalloc expression
-        if (Cursor.GetParentTreeCursor().Value is not StackAllocExpression)
+        if (Cursor.ParentTree.Value is not StackAllocExpression)
         {
             p.Append("new");
         }
@@ -1847,7 +1847,7 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
     {
         // Determine brace count from parent InterpolatedString delimiter (e.g., $$""" → 2 braces)
         int braceCount = 1;
-        var parentCursor = Cursor.GetParentTreeCursor();
+        var parentCursor = Cursor.ParentTree;
         if (parentCursor.Value is InterpolatedString istr)
         {
             int dollarCount = 0;

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Cursor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Cursor.cs
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System.Collections.Generic;
+
 namespace OpenRewrite.Core;
 
 /// <summary>
@@ -117,10 +119,20 @@ public class Cursor
     }
 
     /// <summary>
-    /// Return the first parent pointing to a Tree element, skipping padding.
+    /// The first parent pointing to a Tree element, skipping padding.
     /// </summary>
-    public Cursor GetParentTreeCursor()
+    public Cursor ParentTree => DropParentUntil(it => it is Tree || Equals(it, ROOT_VALUE));
+
+    /// <summary>
+    /// Enumerates all ancestor cursors from the immediate parent to the root.
+    /// </summary>
+    public IEnumerable<Cursor> PathToRoot()
     {
-        return DropParentUntil(it => it is Tree || Equals(it, ROOT_VALUE));
+        var cursor = _parent;
+        while (cursor != null)
+        {
+            yield return cursor;
+            cursor = cursor._parent;
+        }
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TemplateApplyTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TemplateApplyTests.cs
@@ -465,7 +465,7 @@ file class RemoveEmptyStatementRecipe : Core.Recipe
     {
         public override J VisitEmpty(Empty empty, ExecutionContext ctx)
         {
-            if (Cursor.GetParentTreeCursor().Value is Block)
+            if (Cursor.ParentTree.Value is Block)
                 return null!;
             return empty;
         }


### PR DESCRIPTION
## Summary

- Replace `GetParentTreeCursor()` with a `ParentTree` property for idiomatic C# cursor walking
- Add `PathToRoot()` returning `IEnumerable<Cursor>` to enable LINQ-style ancestor queries
- Update all existing call sites in `CSharpPrinter` and tests

## Examples

### ParentTree — concise parent access skipping padding

```csharp
// Before (verbose):
if (Cursor.GetParentTreeCursor().Value is MethodDeclaration)

// After (concise):
if (Cursor.ParentTree.Value is MethodDeclaration)
```

### PathToRoot — LINQ-style ancestor queries

Find an enclosing `Try.Catch` but stop at method boundaries:
```csharp
// Before (manual while loop):
var cursor = Cursor;
while (cursor.Parent != null)
{
    cursor = cursor.Parent;
    if (cursor.Value is Try.Catch catchClause)
    {
        // ... handle catch
        break;
    }
    if (cursor.Value is MethodDeclaration)
        break;
}

// After (LINQ):
var catchClause = Cursor.PathToRoot()
    .TakeWhile(c => c.Value is not MethodDeclaration)
    .FirstOrDefault(c => c.Value is Try.Catch);
```

Check if inside an async method:
```csharp
// Before:
private static bool IsInsideAsyncMethod(Cursor cursor)
{
    var c = cursor;
    while (c != null)
    {
        if (c.Value is MethodDeclaration md)
            return md.Modifiers.Any(m => m.Type == "Async");
        c = c.Parent;
    }
    return false;
}

// After:
bool isAsync = Cursor.PathToRoot()
    .Select(c => c.Value)
    .OfType<MethodDeclaration>()
    .FirstOrDefault()
    ?.Modifiers.Any(m => m.Type == "Async") ?? false;
```

## Test plan
- [x] All existing `rewrite-csharp` tests pass
- [ ] Migrate `recipes-csharp` call sites from `GetParentTreeCursor()` to `ParentTree`