### PR TITLE
Simplify csharpPublishLocal to use local feed

### DIFF
--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -236,91 +236,36 @@ val csharpPublish by tasks.registering(Exec::class) {
 // Usage: ./gradlew :rewrite-csharp:csharpPublishLocal
 val csharpPublishLocal by tasks.registering {
     group = "csharp"
-    description = "Pack and install C# NuGet packages into local NuGet cache"
+    description = "Pack and publish C# NuGet packages to local feed"
 
     dependsOn(csharpPack)
 
     doLast {
+        val localFeed = file("${System.getProperty("user.home")}/.nuget/local-feed")
+        localFeed.mkdirs()
+
+        // Clear stale version from NuGet global packages cache so restore re-evaluates
         val dotnet = findDotnet()
-        val distDir = csharpDir.resolve("dist").absolutePath
-
-        fun run(vararg args: String, dir: File? = null, ignoreExitCode: Boolean = false): String {
-            val pb = ProcessBuilder(*args)
-                .redirectErrorStream(true)
-            if (dir != null) pb.directory(dir)
-            val proc = pb.start()
-            val output = proc.inputStream.bufferedReader().readText()
-            val exitCode = proc.waitFor()
-            if (exitCode != 0 && !ignoreExitCode) {
-                throw GradleException("Command failed (exit $exitCode): ${args.joinToString(" ")}\n$output")
-            }
-            return output
-        }
-
-        // Find NuGet global-packages cache path
-        val localsOutput = run(dotnet, "nuget", "locals", "global-packages", "--list")
+        val localsOutput = ProcessBuilder(dotnet, "nuget", "locals", "global-packages", "--list")
+            .redirectErrorStream(true).start().let { it.inputStream.bufferedReader().readText().also { _ -> it.waitFor() } }
         val cachePath = localsOutput.trim().substringAfter("global-packages: ")
 
-        // Clear stale entries from all NuGet caches for each package
         csharpDir.resolve("dist").listFiles()
             ?.filter { it.name.endsWith(".nupkg") }
             ?.forEach { nupkg ->
-                // Extract package ID and version from filename (e.g. OpenRewrite.CSharp.8.76.0-snapshot.20260311.nupkg)
                 val nameWithoutExt = nupkg.name.removeSuffix(".nupkg")
-                // NuGet package filenames are PackageId.Version.nupkg
-                // Find the version part by matching the nugetVersion suffix
                 val packageId = nameWithoutExt.removeSuffix(".$nugetVersion")
 
-                // Clear the specific version from global packages cache
+                // Clear cached version so consumers pick up the fresh package
                 val packageCacheDir = file("$cachePath/${packageId.lowercase()}/$nugetVersion")
                 if (packageCacheDir.exists()) {
                     logger.lifecycle("Clearing cached: ${packageCacheDir.absolutePath}")
                     packageCacheDir.deleteRecursively()
                 }
 
-                // Clear any globally installed tool versions (used by `dotnet tool install -g`)
-                val toolStoreDir = file("${System.getProperty("user.home")}/.dotnet/tools/.store/${packageId.lowercase()}")
-                if (toolStoreDir.exists()) {
-                    logger.lifecycle("Clearing tool store: ${toolStoreDir.absolutePath}")
-                    toolStoreDir.deleteRecursively()
-                }
+                nupkg.copyTo(localFeed.resolve(nupkg.name), overwrite = true)
+                logger.lifecycle("Published $packageId@$nugetVersion to ${localFeed.absolutePath}")
             }
-
-        // Create a temp project with PackageDownload entries and restore to populate the NuGet cache
-        val tempDir = temporaryDir
-        tempDir.deleteRecursively()
-        tempDir.mkdirs()
-
-        val packageDownloads = csharpDir.resolve("dist").listFiles()
-            ?.filter { it.name.endsWith(".nupkg") }
-            ?.joinToString("\n") { nupkg ->
-                val nameWithoutExt = nupkg.name.removeSuffix(".nupkg")
-                val packageId = nameWithoutExt.removeSuffix(".$nugetVersion")
-                logger.lifecycle("Installing $packageId@$nugetVersion into NuGet cache from $distDir")
-                """    <PackageDownload Include="$packageId" Version="[$nugetVersion]" />"""
-            } ?: ""
-
-        val tempCsproj = tempDir.resolve("Temp.csproj")
-        tempCsproj.writeText("""
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-                <TargetFramework>net10.0</TargetFramework>
-              </PropertyGroup>
-              <ItemGroup>
-            $packageDownloads
-              </ItemGroup>
-            </Project>
-        """.trimIndent())
-
-        val restoreOutput = run(
-            dotnet, "restore",
-            "--source", distDir,
-            "--force",
-            dir = tempDir,
-            ignoreExitCode = true
-        )
-        logger.lifecycle(restoreOutput)
-
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace the temp-project + `dotnet restore` approach in `csharpPublishLocal` with a simple copy of `.nupkg` files to `~/.nuget/local-feed/`
- NuGet populates its global packages cache automatically when consumers restore, so the manual cache population was unnecessary
- Still clears the stale cached version so consumers pick up fresh packages on rebuild

## Test plan
- [x] Ran `csharpPublishLocal`, confirmed packages appear in `~/.nuget/local-feed/`
- [x] Ran `dotnet restore` in recipes-csharp, confirmed it resolves `8.76.0-zlocal` from the local feed