### PR TITLE
Gradle 9.4.1 entry in gradle wrapper versions CSV

### DIFF
--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-wrapper/versions.csv
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-wrapper/versions.csv
@@ -1,4 +1,5 @@
 version,gradlew,gradlewBat
+9.4.1,e5083bb6,9af86e4b
 9.4.0,e5083bb6,9af86e4b
 9.4.0-milestone-4,e5083bb6,9af86e4b
 9.4.0-milestone-3,e5083bb6,9af86e4b


### PR DESCRIPTION
## What's changed?

Adding an entry for Gradle 9.4.1 to gradle versions CSV manually.

## What's your motivation?

Tests fail:
```
UpdateGradleWrapperTest > defaultsToLatestRelease() FAILED
        Caused by:
        java.lang.NullPointerException: Cannot invoke "org.openrewrite.gradle.internal.GradleWrapperScriptLoader$Version.getGradlewChecksum()" because "this.resolved" is null
            at org.openrewrite.gradle.internal.GradleWrapperScriptLoader$Nearest.gradlew(GradleWrapperScriptLoader.java:69)
```