### PR TITLE
C#: Fix null-coalescing pattern that prevents node deletion in visitors

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
@@ -159,7 +159,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithPrefix(VisitSpace(usingDirective.Prefix, p))
             .WithMarkers(VisitMarkers(usingDirective.Markers, p))
             .WithAlias(VisitRightPadded(usingDirective.Alias, p))
-            .WithNamespaceOrType(Visit(usingDirective.NamespaceOrType, p) as TypeTree ?? usingDirective.NamespaceOrType);
+            .WithNamespaceOrType((TypeTree)Visit(usingDirective.NamespaceOrType, p)!);
     }
 
     public virtual J VisitPropertyDeclaration(PropertyDeclaration prop, P p)
@@ -169,10 +169,10 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithPrefix(VisitSpace(prop.Prefix, p))
             .WithMarkers(VisitMarkers(prop.Markers, p))
             .WithAttributeLists(ListUtils.Map(prop.AttributeLists, al => Visit(al, p) as AttributeList))
-            .WithTypeExpression(Visit(prop.TypeExpression, p) as TypeTree ?? prop.TypeExpression)
+            .WithTypeExpression((TypeTree)Visit(prop.TypeExpression, p)!)
             .WithInterfaceSpecifier(VisitRightPadded(prop.InterfaceSpecifier, p))
-            .WithName(Visit(prop.Name, p) as Identifier ?? prop.Name)
-            .WithAccessors(prop.Accessors != null ? Visit(prop.Accessors, p) as Block ?? prop.Accessors : null)
+            .WithName((Identifier)Visit(prop.Name, p)!)
+            .WithAccessors((Block?)Visit(prop.Accessors, p))
             .WithExpressionBody(VisitLeftPadded(prop.ExpressionBody, p))
             .WithInitializer(VisitLeftPadded(prop.Initializer, p));
     }
@@ -184,7 +184,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithPrefix(VisitSpace(accessor.Prefix, p))
             .WithMarkers(VisitMarkers(accessor.Markers, p))
             .WithAttributeLists(ListUtils.Map(accessor.AttributeLists, al => Visit(al, p) as AttributeList))
-            .WithBody(accessor.Body != null ? Visit(accessor.Body, p) as Block ?? accessor.Body : null)
+            .WithBody((Block?)Visit(accessor.Body, p))
             .WithExpressionBody(VisitLeftPadded(accessor.ExpressionBody, p));
     }
 
@@ -204,8 +204,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return ne
             .WithPrefix(VisitSpace(ne.Prefix, p))
             .WithMarkers(VisitMarkers(ne.Markers, p))
-            .WithName(VisitRightPadded(ne.Name, p) ?? ne.Name)
-            .WithExpression(Visit(ne.Expression, p) as Expression ?? ne.Expression);
+            .WithName(VisitRightPadded(ne.Name, p)!)
+            .WithExpression((Expression)Visit(ne.Expression, p)!);
     }
 
     public virtual J VisitRefExpression(RefExpression re, P p)
@@ -214,7 +214,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return re
             .WithPrefix(VisitSpace(re.Prefix, p))
             .WithMarkers(VisitMarkers(re.Markers, p))
-            .WithExpression(Visit(re.Expression, p) as Expression ?? re.Expression);
+            .WithExpression((Expression)Visit(re.Expression, p)!);
     }
 
     public virtual J VisitDeclarationExpression(DeclarationExpression de, P p)
@@ -223,8 +223,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return de
             .WithPrefix(VisitSpace(de.Prefix, p))
             .WithMarkers(VisitMarkers(de.Markers, p))
-            .WithTypeExpression(de.TypeExpression != null ? Visit(de.TypeExpression, p) as TypeTree ?? de.TypeExpression : null)
-            .WithVariables(Visit(de.Variables, p) as Expression ?? de.Variables);
+            .WithTypeExpression((TypeTree?)Visit(de.TypeExpression, p))
+            .WithVariables((Expression)Visit(de.Variables, p)!);
     }
 
     public virtual J VisitIsPattern(IsPattern isPattern, P p)
@@ -233,8 +233,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return isPattern
             .WithPrefix(VisitSpace(isPattern.Prefix, p))
             .WithMarkers(VisitMarkers(isPattern.Markers, p))
-            .WithExpression(Visit(isPattern.Expression, p) as Expression ?? isPattern.Expression)
-            .WithPattern(VisitLeftPadded(isPattern.Pattern, p) ?? isPattern.Pattern);
+            .WithExpression((Expression)Visit(isPattern.Expression, p)!)
+            .WithPattern(VisitLeftPadded(isPattern.Pattern, p)!);
     }
 
     public virtual J VisitStatementExpression(StatementExpression se, P p)
@@ -244,7 +244,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return se
             .WithPrefix(VisitSpace(se.Prefix, p))
             .WithMarkers(VisitMarkers(se.Markers, p))
-            .WithStatement(Visit(se.Statement, p) as Statement ?? se.Statement);
+            .WithStatement((Statement)Visit(se.Statement, p)!);
     }
 
     public virtual J VisitSizeOf(SizeOf sizeOf, P p)
@@ -253,7 +253,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return sizeOf
             .WithPrefix(VisitSpace(sizeOf.Prefix, p))
             .WithMarkers(VisitMarkers(sizeOf.Markers, p))
-            .WithExpression(Visit(sizeOf.Expression, p) as Expression ?? sizeOf.Expression)
+            .WithExpression((Expression)Visit(sizeOf.Expression, p)!)
             .WithType((JavaType?)VisitType(sizeOf.Type, p));
     }
 
@@ -263,7 +263,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return unsafeStatement
             .WithPrefix(VisitSpace(unsafeStatement.Prefix, p))
             .WithMarkers(VisitMarkers(unsafeStatement.Markers, p))
-            .WithBlock(Visit(unsafeStatement.Block, p) as Block ?? unsafeStatement.Block);
+            .WithBlock((Block)Visit(unsafeStatement.Block, p)!);
     }
 
     public virtual J VisitPointerType(PointerType pointerType, P p)
@@ -272,7 +272,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return pointerType
             .WithPrefix(VisitSpace(pointerType.Prefix, p))
             .WithMarkers(VisitMarkers(pointerType.Markers, p))
-            .WithElementType(VisitRightPadded(pointerType.ElementType, p) ?? pointerType.ElementType);
+            .WithElementType(VisitRightPadded(pointerType.ElementType, p)!);
     }
 
     public virtual J VisitFixedStatement(FixedStatement fixedStatement, P p)
@@ -281,8 +281,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return fixedStatement
             .WithPrefix(VisitSpace(fixedStatement.Prefix, p))
             .WithMarkers(VisitMarkers(fixedStatement.Markers, p))
-            .WithDeclarations(Visit(fixedStatement.Declarations, p) as ControlParentheses<VariableDeclarations> ?? fixedStatement.Declarations)
-            .WithBlock(Visit(fixedStatement.Block, p) as Block ?? fixedStatement.Block);
+            .WithDeclarations((ControlParentheses<VariableDeclarations>)Visit(fixedStatement.Declarations, p)!)
+            .WithBlock((Block)Visit(fixedStatement.Block, p)!);
     }
 
     public virtual J VisitExternAlias(ExternAlias externAlias, P p)
@@ -300,7 +300,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return initializerExpression
             .WithPrefix(VisitSpace(initializerExpression.Prefix, p))
             .WithMarkers(VisitMarkers(initializerExpression.Markers, p))
-            .WithExpressions(VisitContainer(initializerExpression.Expressions, p) ?? initializerExpression.Expressions);
+            .WithExpressions(VisitContainer(initializerExpression.Expressions, p)!);
     }
 
     public virtual J VisitNullSafeExpression(NullSafeExpression nullSafeExpression, P p)
@@ -309,7 +309,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return nullSafeExpression
             .WithPrefix(VisitSpace(nullSafeExpression.Prefix, p))
             .WithMarkers(VisitMarkers(nullSafeExpression.Markers, p))
-            .WithExpressionPadded(VisitRightPadded(nullSafeExpression.ExpressionPadded, p) ?? nullSafeExpression.ExpressionPadded);
+            .WithExpressionPadded(VisitRightPadded(nullSafeExpression.ExpressionPadded, p)!);
     }
 
     public virtual J VisitDefaultExpression(DefaultExpression defaultExpression, P p)
@@ -329,8 +329,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithPrefix(VisitSpace(csLambda.Prefix, p))
             .WithMarkers(VisitMarkers(csLambda.Markers, p))
             .WithAttributeLists(ListUtils.Map(csLambda.AttributeLists, al => Visit(al, p) as AttributeList))
-            .WithReturnType(csLambda.ReturnType != null ? Visit(csLambda.ReturnType, p) as TypeTree ?? csLambda.ReturnType : null)
-            .WithLambdaExpression(VisitLambda(csLambda.LambdaExpression, p) as Lambda ?? csLambda.LambdaExpression);
+            .WithReturnType((TypeTree?)Visit(csLambda.ReturnType, p))
+            .WithLambdaExpression((Lambda)VisitLambda(csLambda.LambdaExpression, p)!);
     }
 
     public virtual J VisitRelationalPattern(RelationalPattern rp, P p)
@@ -339,7 +339,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return rp
             .WithPrefix(VisitSpace(rp.Prefix, p))
             .WithMarkers(VisitMarkers(rp.Markers, p))
-            .WithValue(Visit(rp.Value, p) as Expression ?? rp.Value);
+            .WithValue((Expression)Visit(rp.Value, p)!);
     }
 
     public virtual J VisitPropertyPattern(PropertyPattern pp, P p)
@@ -348,9 +348,9 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return pp
             .WithPrefix(VisitSpace(pp.Prefix, p))
             .WithMarkers(VisitMarkers(pp.Markers, p))
-            .WithTypeQualifier(pp.TypeQualifier != null ? Visit(pp.TypeQualifier, p) as TypeTree ?? pp.TypeQualifier : null)
+            .WithTypeQualifier((TypeTree?)Visit(pp.TypeQualifier, p))
             .WithSubpatterns(VisitContainer(pp.Subpatterns, p)!)
-            .WithDesignation(pp.Designation != null ? Visit(pp.Designation, p) as Identifier ?? pp.Designation : null);
+            .WithDesignation((Identifier?)Visit(pp.Designation, p));
     }
 
     public virtual J VisitConstrainedTypeParameter(ConstrainedTypeParameter ctp, P p)
@@ -359,7 +359,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithPrefix(VisitSpace(ctp.Prefix, p))
             .WithMarkers(VisitMarkers(ctp.Markers, p))
             .WithAttributeLists(ListUtils.Map(ctp.AttributeLists, al => Visit(al, p) as AttributeList))
-            .WithName(Visit(ctp.Name, p) as Identifier ?? ctp.Name)
+            .WithName((Identifier)Visit(ctp.Name, p)!)
             .WithWhereConstraint(VisitLeftPadded(ctp.WhereConstraint, p))
             .WithConstraints(VisitContainer(ctp.Constraints, p))
             .WithType((JavaType?)VisitType(ctp.Type, p));
@@ -380,7 +380,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return interp
             .WithPrefix(VisitSpace(interp.Prefix, p))
             .WithMarkers(VisitMarkers(interp.Markers, p))
-            .WithExpression(Visit(interp.Expression, p) as Expression ?? interp.Expression)
+            .WithExpression((Expression)Visit(interp.Expression, p)!)
             .WithAlignment(VisitLeftPadded(interp.Alignment, p))
             .WithFormat(VisitLeftPadded(interp.Format, p))
             .WithAfter(VisitSpace(interp.After, p));
@@ -393,7 +393,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return ae
             .WithPrefix(VisitSpace(ae.Prefix, p))
             .WithMarkers(VisitMarkers(ae.Markers, p))
-            .WithExpression(Visit(ae.Expression, p) as Expression ?? ae.Expression)
+            .WithExpression((Expression)Visit(ae.Expression, p)!)
             .WithType((JavaType?)VisitType(ae.Type, p));
     }
 
@@ -403,8 +403,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return yield
             .WithPrefix(VisitSpace(yield.Prefix, p))
             .WithMarkers(VisitMarkers(yield.Markers, p))
-            .WithReturnOrBreakKeyword(Visit(yield.ReturnOrBreakKeyword, p) as Keyword ?? yield.ReturnOrBreakKeyword)
-            .WithExpression(yield.Expression != null ? Visit(yield.Expression, p) as Expression ?? yield.Expression : null);
+            .WithReturnOrBreakKeyword((Keyword)Visit(yield.ReturnOrBreakKeyword, p)!)
+            .WithExpression((Expression?)Visit(yield.Expression, p));
     }
 
     public virtual J VisitNamespaceDeclaration(NamespaceDeclaration ns, P p)
@@ -413,7 +413,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return ns
             .WithPrefix(VisitSpace(ns.Prefix, p))
             .WithMarkers(VisitMarkers(ns.Markers, p))
-            .WithName(VisitRightPadded(ns.Name, p) ?? ns.Name)
+            .WithName(VisitRightPadded(ns.Name, p)!)
             .WithMembers(ListUtils.Map(ns.Members, m => VisitRightPadded(m, p)))
             .WithEnd(VisitSpace(ns.End, p));
     }
@@ -424,7 +424,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return tupleType
             .WithPrefix(VisitSpace(tupleType.Prefix, p))
             .WithMarkers(VisitMarkers(tupleType.Markers, p))
-            .WithElements(VisitContainer(tupleType.Elements, p) ?? tupleType.Elements)
+            .WithElements(VisitContainer(tupleType.Elements, p)!)
             .WithType((JavaType?)VisitType(tupleType.Type, p));
     }
 
@@ -434,7 +434,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return tupleExpr
             .WithPrefix(VisitSpace(tupleExpr.Prefix, p))
             .WithMarkers(VisitMarkers(tupleExpr.Markers, p))
-            .WithArguments(VisitContainer(tupleExpr.Arguments, p) ?? tupleExpr.Arguments);
+            .WithArguments(VisitContainer(tupleExpr.Arguments, p)!);
     }
 
     public virtual J VisitConditionalDirective(ConditionalDirective conditionalDirective, P p)
@@ -493,7 +493,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return defineDirective
             .WithPrefix(VisitSpace(defineDirective.Prefix, p))
             .WithMarkers(VisitMarkers(defineDirective.Markers, p))
-            .WithSymbol(Visit(defineDirective.Symbol, p) as Identifier ?? defineDirective.Symbol);
+            .WithSymbol((Identifier)Visit(defineDirective.Symbol, p)!);
     }
 
     public virtual J VisitUndefDirective(UndefDirective undefDirective, P p)
@@ -502,7 +502,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return undefDirective
             .WithPrefix(VisitSpace(undefDirective.Prefix, p))
             .WithMarkers(VisitMarkers(undefDirective.Markers, p))
-            .WithSymbol(Visit(undefDirective.Symbol, p) as Identifier ?? undefDirective.Symbol);
+            .WithSymbol((Identifier)Visit(undefDirective.Symbol, p)!);
     }
 
     public virtual J VisitErrorDirective(ErrorDirective errorDirective, P p)
@@ -527,8 +527,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return lineDirective
             .WithPrefix(VisitSpace(lineDirective.Prefix, p))
             .WithMarkers(VisitMarkers(lineDirective.Markers, p))
-            .WithLine(lineDirective.Line != null ? Visit(lineDirective.Line, p) as Expression ?? lineDirective.Line : null)
-            .WithFile(lineDirective.File != null ? Visit(lineDirective.File, p) as Expression ?? lineDirective.File : null);
+            .WithLine((Expression?)Visit(lineDirective.Line, p))
+            .WithFile((Expression?)Visit(lineDirective.File, p));
     }
 
     // ---- New types ----
@@ -545,7 +545,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return nameColon
             .WithPrefix(VisitSpace(nameColon.Prefix, p))
             .WithMarkers(VisitMarkers(nameColon.Markers, p))
-            .WithName(VisitRightPadded(nameColon.Name, p) ?? nameColon.Name);
+            .WithName(VisitRightPadded(nameColon.Name, p)!);
     }
 
     public virtual J VisitAnnotatedStatement(AnnotatedStatement annotatedStatement, P p)
@@ -555,7 +555,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithPrefix(VisitSpace(annotatedStatement.Prefix, p))
             .WithMarkers(VisitMarkers(annotatedStatement.Markers, p))
             .WithAttributeLists(ListUtils.Map(annotatedStatement.AttributeLists, al => Visit(al, p) as AttributeList))
-            .WithStatement(Visit(annotatedStatement.Statement, p) as Statement ?? annotatedStatement.Statement);
+            .WithStatement((Statement)Visit(annotatedStatement.Statement, p)!);
     }
 
     public virtual J VisitArrayRankSpecifier(ArrayRankSpecifier arrayRankSpecifier, P p)
@@ -564,7 +564,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return arrayRankSpecifier
             .WithPrefix(VisitSpace(arrayRankSpecifier.Prefix, p))
             .WithMarkers(VisitMarkers(arrayRankSpecifier.Markers, p))
-            .WithSizes(VisitContainer(arrayRankSpecifier.Sizes, p) ?? arrayRankSpecifier.Sizes);
+            .WithSizes(VisitContainer(arrayRankSpecifier.Sizes, p)!);
     }
 
     public virtual J VisitAssignmentOperation(AssignmentOperation assignmentOperation, P p)
@@ -574,8 +574,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return assignmentOperation
             .WithPrefix(VisitSpace(assignmentOperation.Prefix, p))
             .WithMarkers(VisitMarkers(assignmentOperation.Markers, p))
-            .WithVariable(Visit(assignmentOperation.Variable, p) as Expression ?? assignmentOperation.Variable)
-            .WithAssignmentValue(Visit(assignmentOperation.AssignmentValue, p) as Expression ?? assignmentOperation.AssignmentValue)
+            .WithVariable((Expression)Visit(assignmentOperation.Variable, p)!)
+            .WithAssignmentValue((Expression)Visit(assignmentOperation.AssignmentValue, p)!)
             .WithType((JavaType?)VisitType(assignmentOperation.Type, p));
     }
 
@@ -585,7 +585,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return stackAllocExpression
             .WithPrefix(VisitSpace(stackAllocExpression.Prefix, p))
             .WithMarkers(VisitMarkers(stackAllocExpression.Markers, p))
-            .WithExpression(Visit(stackAllocExpression.Expression, p) as NewArray ?? stackAllocExpression.Expression);
+            .WithExpression((NewArray)Visit(stackAllocExpression.Expression, p)!);
     }
 
     public virtual J VisitGotoStatement(GotoStatement gotoStatement, P p)
@@ -594,8 +594,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return gotoStatement
             .WithPrefix(VisitSpace(gotoStatement.Prefix, p))
             .WithMarkers(VisitMarkers(gotoStatement.Markers, p))
-            .WithCaseOrDefaultKeyword(gotoStatement.CaseOrDefaultKeyword != null ? Visit(gotoStatement.CaseOrDefaultKeyword, p) as Keyword ?? gotoStatement.CaseOrDefaultKeyword : null)
-            .WithTarget(gotoStatement.Target != null ? Visit(gotoStatement.Target, p) as Expression ?? gotoStatement.Target : null);
+            .WithCaseOrDefaultKeyword((Keyword?)Visit(gotoStatement.CaseOrDefaultKeyword, p))
+            .WithTarget((Expression?)Visit(gotoStatement.Target, p));
     }
 
     public virtual J VisitEventDeclaration(EventDeclaration eventDeclaration, P p)
@@ -606,7 +606,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithMarkers(VisitMarkers(eventDeclaration.Markers, p))
             .WithAttributeLists(ListUtils.Map(eventDeclaration.AttributeLists, al => Visit(al, p) as AttributeList))
             .WithTypeExpressionPadded(VisitLeftPadded(eventDeclaration.TypeExpressionPadded, p)!)
-            .WithName(Visit(eventDeclaration.Name, p) as Identifier ?? eventDeclaration.Name)
+            .WithName((Identifier)Visit(eventDeclaration.Name, p)!)
             .WithInterfaceSpecifier(VisitRightPadded(eventDeclaration.InterfaceSpecifier, p))
             .WithAccessors(VisitContainer(eventDeclaration.Accessors, p));
     }
@@ -617,8 +617,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return csBinary
             .WithPrefix(VisitSpace(csBinary.Prefix, p))
             .WithMarkers(VisitMarkers(csBinary.Markers, p))
-            .WithLeft(Visit(csBinary.Left, p) as Expression ?? csBinary.Left)
-            .WithRight(Visit(csBinary.Right, p) as Expression ?? csBinary.Right)
+            .WithLeft((Expression)Visit(csBinary.Left, p)!)
+            .WithRight((Expression)Visit(csBinary.Right, p)!)
             .WithType((JavaType?)VisitType(csBinary.Type, p));
     }
 
@@ -638,8 +638,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return forEachVariableLoop
             .WithPrefix(VisitSpace(forEachVariableLoop.Prefix, p))
             .WithMarkers(VisitMarkers(forEachVariableLoop.Markers, p))
-            .WithControlElement(Visit(forEachVariableLoop.ControlElement, p) as ForEachVariableLoopControl ?? forEachVariableLoop.ControlElement)
-            .WithBody(VisitRightPadded(forEachVariableLoop.Body, p) ?? forEachVariableLoop.Body);
+            .WithControlElement((ForEachVariableLoopControl)Visit(forEachVariableLoop.ControlElement, p)!)
+            .WithBody(VisitRightPadded(forEachVariableLoop.Body, p)!);
     }
 
     public virtual J VisitForEachVariableLoopControl(ForEachVariableLoopControl control, P p)
@@ -647,8 +647,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return control
             .WithPrefix(VisitSpace(control.Prefix, p))
             .WithMarkers(VisitMarkers(control.Markers, p))
-            .WithVariable(VisitRightPadded(control.Variable, p) ?? control.Variable)
-            .WithIterable(VisitRightPadded(control.Iterable, p) ?? control.Iterable);
+            .WithVariable(VisitRightPadded(control.Variable, p)!)
+            .WithIterable(VisitRightPadded(control.Iterable, p)!);
     }
 
     public virtual J VisitUsingStatement(UsingStatement usingStatement, P p)
@@ -658,7 +658,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithPrefix(VisitSpace(usingStatement.Prefix, p))
             .WithMarkers(VisitMarkers(usingStatement.Markers, p))
             .WithExpressionPadded(VisitLeftPadded(usingStatement.ExpressionPadded, p)!)
-            .WithStatement(Visit(usingStatement.Statement, p) as Statement ?? usingStatement.Statement);
+            .WithStatement((Statement)Visit(usingStatement.Statement, p)!);
     }
 
     public virtual J VisitAllowsConstraintClause(AllowsConstraintClause clause, P p)
@@ -667,7 +667,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return clause
             .WithPrefix(VisitSpace(clause.Prefix, p))
             .WithMarkers(VisitMarkers(clause.Markers, p))
-            .WithExpressions(VisitContainer(clause.Expressions, p) ?? clause.Expressions);
+            .WithExpressions(VisitContainer(clause.Expressions, p)!);
     }
 
     public virtual J VisitRefStructConstraint(RefStructConstraint constraint, P p)
@@ -708,7 +708,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return designation
             .WithPrefix(VisitSpace(designation.Prefix, p))
             .WithMarkers(VisitMarkers(designation.Markers, p))
-            .WithName(Visit(designation.Name, p) as Identifier ?? designation.Name);
+            .WithName((Identifier)Visit(designation.Name, p)!);
     }
 
     public virtual J VisitParenthesizedVariableDesignation(ParenthesizedVariableDesignation designation, P p)
@@ -717,7 +717,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return designation
             .WithPrefix(VisitSpace(designation.Prefix, p))
             .WithMarkers(VisitMarkers(designation.Markers, p))
-            .WithVariables(VisitContainer(designation.Variables, p) ?? designation.Variables)
+            .WithVariables(VisitContainer(designation.Variables, p)!)
             .WithType((JavaType?)VisitType(designation.Type, p));
     }
 
@@ -727,7 +727,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return designation
             .WithPrefix(VisitSpace(designation.Prefix, p))
             .WithMarkers(VisitMarkers(designation.Markers, p))
-            .WithDiscard(Visit(designation.Discard, p) as Identifier ?? designation.Discard);
+            .WithDiscard((Identifier)Visit(designation.Discard, p)!);
     }
 
     public virtual J VisitCsUnary(CsUnary csUnary, P p)
@@ -737,7 +737,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return csUnary
             .WithPrefix(VisitSpace(csUnary.Prefix, p))
             .WithMarkers(VisitMarkers(csUnary.Markers, p))
-            .WithExpression(Visit(csUnary.Expression, p) as Expression ?? csUnary.Expression)
+            .WithExpression((Expression)Visit(csUnary.Expression, p)!)
             .WithType((JavaType?)VisitType(csUnary.Type, p));
     }
 
@@ -746,8 +746,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return tupleElement
             .WithPrefix(VisitSpace(tupleElement.Prefix, p))
             .WithMarkers(VisitMarkers(tupleElement.Markers, p))
-            .WithElementType(Visit(tupleElement.ElementType, p) as TypeTree ?? tupleElement.ElementType)
-            .WithName(tupleElement.Name != null ? Visit(tupleElement.Name, p) as Identifier ?? tupleElement.Name : null);
+            .WithElementType((TypeTree)Visit(tupleElement.ElementType, p)!)
+            .WithName((Identifier?)Visit(tupleElement.Name, p));
     }
 
     public virtual J VisitConstantPattern(ConstantPattern constantPattern, P p)
@@ -756,7 +756,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return constantPattern
             .WithPrefix(VisitSpace(constantPattern.Prefix, p))
             .WithMarkers(VisitMarkers(constantPattern.Markers, p))
-            .WithValue(Visit(constantPattern.Value, p) as Expression ?? constantPattern.Value);
+            .WithValue((Expression)Visit(constantPattern.Value, p)!);
     }
 
     public virtual J VisitDiscardPattern(DiscardPattern discardPattern, P p)
@@ -774,7 +774,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return implicitElementAccess
             .WithPrefix(VisitSpace(implicitElementAccess.Prefix, p))
             .WithMarkers(VisitMarkers(implicitElementAccess.Markers, p))
-            .WithArgumentList(VisitContainer(implicitElementAccess.ArgumentList, p) ?? implicitElementAccess.ArgumentList);
+            .WithArgumentList(VisitContainer(implicitElementAccess.ArgumentList, p)!);
     }
 
     public virtual J VisitSlicePattern(SlicePattern slicePattern, P p)
@@ -791,8 +791,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return listPattern
             .WithPrefix(VisitSpace(listPattern.Prefix, p))
             .WithMarkers(VisitMarkers(listPattern.Markers, p))
-            .WithPatterns(VisitContainer(listPattern.Patterns, p) ?? listPattern.Patterns)
-            .WithDesignation(listPattern.Designation != null ? Visit(listPattern.Designation, p) as VariableDesignation ?? listPattern.Designation : null);
+            .WithPatterns(VisitContainer(listPattern.Patterns, p)!)
+            .WithDesignation((VariableDesignation?)Visit(listPattern.Designation, p));
     }
 
     public virtual J VisitSwitchExpression(SwitchExpression switchExpression, P p)
@@ -801,8 +801,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return switchExpression
             .WithPrefix(VisitSpace(switchExpression.Prefix, p))
             .WithMarkers(VisitMarkers(switchExpression.Markers, p))
-            .WithExpressionPadded(VisitRightPadded(switchExpression.ExpressionPadded, p) ?? switchExpression.ExpressionPadded)
-            .WithArms(VisitContainer(switchExpression.Arms, p) ?? switchExpression.Arms);
+            .WithExpressionPadded(VisitRightPadded(switchExpression.ExpressionPadded, p)!)
+            .WithArms(VisitContainer(switchExpression.Arms, p)!);
     }
 
     public virtual J VisitSwitchExpressionArm(SwitchExpressionArm arm, P p)
@@ -810,7 +810,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return arm
             .WithPrefix(VisitSpace(arm.Prefix, p))
             .WithMarkers(VisitMarkers(arm.Markers, p))
-            .WithPattern(Visit(arm.Pattern, p) as J ?? arm.Pattern)
+            .WithPattern((J)Visit(arm.Pattern, p)!)
             .WithWhenExpression(VisitLeftPadded(arm.WhenExpression, p))
             .WithExpressionPadded(VisitLeftPadded(arm.ExpressionPadded, p)!);
     }
@@ -821,8 +821,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return checkedExpression
             .WithPrefix(VisitSpace(checkedExpression.Prefix, p))
             .WithMarkers(VisitMarkers(checkedExpression.Markers, p))
-            .WithCheckedOrUncheckedKeyword(Visit(checkedExpression.CheckedOrUncheckedKeyword, p) as Keyword ?? checkedExpression.CheckedOrUncheckedKeyword)
-            .WithExpressionValue(Visit(checkedExpression.ExpressionValue, p) as ControlParentheses<Expression> ?? checkedExpression.ExpressionValue);
+            .WithCheckedOrUncheckedKeyword((Keyword)Visit(checkedExpression.CheckedOrUncheckedKeyword, p)!)
+            .WithExpressionValue((ControlParentheses<Expression>)Visit(checkedExpression.ExpressionValue, p)!);
     }
 
     public virtual J VisitCheckedStatement(CheckedStatement checkedStatement, P p)
@@ -831,8 +831,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return checkedStatement
             .WithPrefix(VisitSpace(checkedStatement.Prefix, p))
             .WithMarkers(VisitMarkers(checkedStatement.Markers, p))
-            .WithKeywordValue(Visit(checkedStatement.KeywordValue, p) as Keyword ?? checkedStatement.KeywordValue)
-            .WithBlock(Visit(checkedStatement.Block, p) as Block ?? checkedStatement.Block);
+            .WithKeywordValue((Keyword)Visit(checkedStatement.KeywordValue, p)!)
+            .WithBlock((Block)Visit(checkedStatement.Block, p)!);
     }
 
     public virtual J VisitRangeExpression(RangeExpression rangeExpression, P p)
@@ -842,7 +842,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithPrefix(VisitSpace(rangeExpression.Prefix, p))
             .WithMarkers(VisitMarkers(rangeExpression.Markers, p))
             .WithStart(VisitRightPadded(rangeExpression.Start, p))
-            .WithEnd(rangeExpression.End != null ? Visit(rangeExpression.End, p) as Expression ?? rangeExpression.End : null);
+            .WithEnd((Expression?)Visit(rangeExpression.End, p));
     }
 
     public virtual J VisitIndexerDeclaration(IndexerDeclaration indexerDeclaration, P p)
@@ -851,12 +851,12 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return indexerDeclaration
             .WithPrefix(VisitSpace(indexerDeclaration.Prefix, p))
             .WithMarkers(VisitMarkers(indexerDeclaration.Markers, p))
-            .WithTypeExpression(Visit(indexerDeclaration.TypeExpression, p) as TypeTree ?? indexerDeclaration.TypeExpression)
+            .WithTypeExpression((TypeTree)Visit(indexerDeclaration.TypeExpression, p)!)
             .WithExplicitInterfaceSpecifier(VisitRightPadded(indexerDeclaration.ExplicitInterfaceSpecifier, p))
-            .WithIndexer(Visit(indexerDeclaration.Indexer, p) as Expression ?? indexerDeclaration.Indexer)
-            .WithParameters(VisitContainer(indexerDeclaration.Parameters, p) ?? indexerDeclaration.Parameters)
+            .WithIndexer((Expression)Visit(indexerDeclaration.Indexer, p)!)
+            .WithParameters(VisitContainer(indexerDeclaration.Parameters, p)!)
             .WithExpressionBody(VisitLeftPadded(indexerDeclaration.ExpressionBody, p))
-            .WithAccessors(indexerDeclaration.Accessors != null ? Visit(indexerDeclaration.Accessors, p) as Block ?? indexerDeclaration.Accessors : null);
+            .WithAccessors((Block?)Visit(indexerDeclaration.Accessors, p));
     }
 
     public virtual J VisitDelegateDeclaration(DelegateDeclaration delegateDeclaration, P p)
@@ -867,9 +867,9 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithMarkers(VisitMarkers(delegateDeclaration.Markers, p))
             .WithAttributes(ListUtils.Map(delegateDeclaration.Attributes, al => Visit(al, p) as AttributeList))
             .WithReturnType(VisitLeftPadded(delegateDeclaration.ReturnType, p)!)
-            .WithIdentifierName(Visit(delegateDeclaration.IdentifierName, p) as Identifier ?? delegateDeclaration.IdentifierName)
+            .WithIdentifierName((Identifier)Visit(delegateDeclaration.IdentifierName, p)!)
             .WithTypeParameters(VisitContainer(delegateDeclaration.TypeParameters, p))
-            .WithParameters(VisitContainer(delegateDeclaration.Parameters, p) ?? delegateDeclaration.Parameters);
+            .WithParameters(VisitContainer(delegateDeclaration.Parameters, p)!);
     }
 
     public virtual J VisitConversionOperatorDeclaration(ConversionOperatorDeclaration conversion, P p)
@@ -880,9 +880,9 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithMarkers(VisitMarkers(conversion.Markers, p))
             .WithInterfaceSpecifier(VisitRightPadded(conversion.InterfaceSpecifier, p))
             .WithReturnType(VisitLeftPadded(conversion.ReturnType, p)!)
-            .WithParameters(VisitContainer(conversion.Parameters, p) ?? conversion.Parameters)
+            .WithParameters(VisitContainer(conversion.Parameters, p)!)
             .WithExpressionBody(VisitLeftPadded(conversion.ExpressionBody, p))
-            .WithBody(conversion.Body != null ? Visit(conversion.Body, p) as Block ?? conversion.Body : null);
+            .WithBody((Block?)Visit(conversion.Body, p));
     }
 
     public virtual J VisitOperatorDeclaration(OperatorDeclaration operatorDeclaration, P p)
@@ -893,11 +893,11 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithMarkers(VisitMarkers(operatorDeclaration.Markers, p))
             .WithAttributeLists(ListUtils.Map(operatorDeclaration.AttributeLists, al => Visit(al, p) as AttributeList))
             .WithExplicitInterfaceSpecifier(VisitRightPadded(operatorDeclaration.ExplicitInterfaceSpecifier, p))
-            .WithOperatorKeyword(Visit(operatorDeclaration.OperatorKeyword, p) as Keyword ?? operatorDeclaration.OperatorKeyword)
-            .WithCheckedKeyword(operatorDeclaration.CheckedKeyword != null ? Visit(operatorDeclaration.CheckedKeyword, p) as Keyword ?? operatorDeclaration.CheckedKeyword : null)
-            .WithReturnType(Visit(operatorDeclaration.ReturnType, p) as TypeTree ?? operatorDeclaration.ReturnType)
-            .WithParameters(VisitContainer(operatorDeclaration.Parameters, p) ?? operatorDeclaration.Parameters)
-            .WithBody(Visit(operatorDeclaration.Body, p) as Block ?? operatorDeclaration.Body)
+            .WithOperatorKeyword((Keyword)Visit(operatorDeclaration.OperatorKeyword, p)!)
+            .WithCheckedKeyword((Keyword?)Visit(operatorDeclaration.CheckedKeyword, p))
+            .WithReturnType((TypeTree)Visit(operatorDeclaration.ReturnType, p)!)
+            .WithParameters(VisitContainer(operatorDeclaration.Parameters, p)!)
+            .WithBody((Block)Visit(operatorDeclaration.Body, p)!)
             .WithMethodType((JavaType.Method?)VisitType(operatorDeclaration.MethodType, p));
     }
 
@@ -922,7 +922,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithPrefix(VisitSpace(enumMember.Prefix, p))
             .WithMarkers(VisitMarkers(enumMember.Markers, p))
             .WithAttributeLists(ListUtils.Map(enumMember.AttributeLists, al => Visit(al, p) as AttributeList))
-            .WithName(Visit(enumMember.Name, p) as Identifier ?? enumMember.Name)
+            .WithName((Identifier)Visit(enumMember.Name, p)!)
             .WithInitializer(VisitLeftPadded(enumMember.Initializer, p));
     }
 
@@ -932,8 +932,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return aliasQualifiedName
             .WithPrefix(VisitSpace(aliasQualifiedName.Prefix, p))
             .WithMarkers(VisitMarkers(aliasQualifiedName.Markers, p))
-            .WithAlias(VisitRightPadded(aliasQualifiedName.Alias, p) ?? aliasQualifiedName.Alias)
-            .WithName(Visit(aliasQualifiedName.Name, p) as Expression ?? aliasQualifiedName.Name);
+            .WithAlias(VisitRightPadded(aliasQualifiedName.Alias, p)!)
+            .WithName((Expression)Visit(aliasQualifiedName.Name, p)!);
     }
 
     public virtual J VisitPointerDereference(PointerDereference pointerDereference, P p)
@@ -942,7 +942,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return pointerDereference
             .WithPrefix(VisitSpace(pointerDereference.Prefix, p))
             .WithMarkers(VisitMarkers(pointerDereference.Markers, p))
-            .WithExpression(Visit(pointerDereference.Expression, p) as Expression ?? pointerDereference.Expression)
+            .WithExpression((Expression)Visit(pointerDereference.Expression, p)!)
             .WithType((JavaType?)VisitType(pointerDereference.Type, p));
     }
 
@@ -953,7 +953,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return pointerFieldAccess
             .WithPrefix(VisitSpace(pointerFieldAccess.Prefix, p))
             .WithMarkers(VisitMarkers(pointerFieldAccess.Markers, p))
-            .WithTarget(Visit(pointerFieldAccess.Target, p) as Expression ?? pointerFieldAccess.Target)
+            .WithTarget((Expression)Visit(pointerFieldAccess.Target, p)!)
             .WithNamePadded(VisitLeftPadded(pointerFieldAccess.NamePadded, p)!)
             .WithType((JavaType?)VisitType(pointerFieldAccess.Type, p));
     }
@@ -964,7 +964,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return refType
             .WithPrefix(VisitSpace(refType.Prefix, p))
             .WithMarkers(VisitMarkers(refType.Markers, p))
-            .WithTypeIdentifier(Visit(refType.TypeIdentifier, p) as TypeTree ?? refType.TypeIdentifier)
+            .WithTypeIdentifier((TypeTree)Visit(refType.TypeIdentifier, p)!)
             .WithType((JavaType?)VisitType(refType.Type, p));
     }
 
@@ -976,8 +976,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return queryExpression
             .WithPrefix(VisitSpace(queryExpression.Prefix, p))
             .WithMarkers(VisitMarkers(queryExpression.Markers, p))
-            .WithFromClause(Visit(queryExpression.FromClause, p) as FromClause ?? queryExpression.FromClause)
-            .WithBody(Visit(queryExpression.Body, p) as QueryBody ?? queryExpression.Body);
+            .WithFromClause((FromClause)Visit(queryExpression.FromClause, p)!)
+            .WithBody((QueryBody)Visit(queryExpression.Body, p)!);
     }
 
     public virtual J VisitQueryBody(QueryBody queryBody, P p)
@@ -986,7 +986,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithPrefix(VisitSpace(queryBody.Prefix, p))
             .WithMarkers(VisitMarkers(queryBody.Markers, p))
             .WithClauses(ListUtils.Map(queryBody.Clauses, c => (QueryClause?)Visit(c, p)))
-            .WithSelectOrGroup(queryBody.SelectOrGroup != null ? Visit(queryBody.SelectOrGroup, p) as SelectOrGroupClause ?? queryBody.SelectOrGroup : null)
+            .WithSelectOrGroup((SelectOrGroupClause?)Visit(queryBody.SelectOrGroup, p))
             .WithContinuation(queryBody.Continuation != null ? (QueryContinuation)VisitQueryContinuation(queryBody.Continuation, p) : null);
     }
 
@@ -996,9 +996,9 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return fromClause
             .WithPrefix(VisitSpace(fromClause.Prefix, p))
             .WithMarkers(VisitMarkers(fromClause.Markers, p))
-            .WithTypeIdentifier(fromClause.TypeIdentifier != null ? Visit(fromClause.TypeIdentifier, p) as TypeTree ?? fromClause.TypeIdentifier : null)
-            .WithIdentifierPadded(VisitRightPadded(fromClause.IdentifierPadded, p) ?? fromClause.IdentifierPadded)
-            .WithExpression(Visit(fromClause.Expression, p) as Expression ?? fromClause.Expression);
+            .WithTypeIdentifier((TypeTree?)Visit(fromClause.TypeIdentifier, p))
+            .WithIdentifierPadded(VisitRightPadded(fromClause.IdentifierPadded, p)!)
+            .WithExpression((Expression)Visit(fromClause.Expression, p)!);
     }
 
     public virtual J VisitLetClause(LetClause letClause, P p)
@@ -1006,8 +1006,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return letClause
             .WithPrefix(VisitSpace(letClause.Prefix, p))
             .WithMarkers(VisitMarkers(letClause.Markers, p))
-            .WithIdentifierPadded(VisitRightPadded(letClause.IdentifierPadded, p) ?? letClause.IdentifierPadded)
-            .WithExpression(Visit(letClause.Expression, p) as Expression ?? letClause.Expression);
+            .WithIdentifierPadded(VisitRightPadded(letClause.IdentifierPadded, p)!)
+            .WithExpression((Expression)Visit(letClause.Expression, p)!);
     }
 
     public virtual J VisitJoinClause(JoinClause joinClause, P p)
@@ -1015,10 +1015,10 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return joinClause
             .WithPrefix(VisitSpace(joinClause.Prefix, p))
             .WithMarkers(VisitMarkers(joinClause.Markers, p))
-            .WithIdentifierPadded(VisitRightPadded(joinClause.IdentifierPadded, p) ?? joinClause.IdentifierPadded)
-            .WithInExpression(VisitRightPadded(joinClause.InExpression, p) ?? joinClause.InExpression)
-            .WithLeftExpression(VisitRightPadded(joinClause.LeftExpression, p) ?? joinClause.LeftExpression)
-            .WithRightExpression(Visit(joinClause.RightExpression, p) as Expression ?? joinClause.RightExpression)
+            .WithIdentifierPadded(VisitRightPadded(joinClause.IdentifierPadded, p)!)
+            .WithInExpression(VisitRightPadded(joinClause.InExpression, p)!)
+            .WithLeftExpression(VisitRightPadded(joinClause.LeftExpression, p)!)
+            .WithRightExpression((Expression)Visit(joinClause.RightExpression, p)!)
             .WithInto(VisitLeftPadded(joinClause.Into, p));
     }
 
@@ -1027,7 +1027,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return joinIntoClause
             .WithPrefix(VisitSpace(joinIntoClause.Prefix, p))
             .WithMarkers(VisitMarkers(joinIntoClause.Markers, p))
-            .WithIdentifier(Visit(joinIntoClause.Identifier, p) as Identifier ?? joinIntoClause.Identifier);
+            .WithIdentifier((Identifier)Visit(joinIntoClause.Identifier, p)!);
     }
 
     public virtual J VisitWhereClause(WhereClause whereClause, P p)
@@ -1035,7 +1035,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return whereClause
             .WithPrefix(VisitSpace(whereClause.Prefix, p))
             .WithMarkers(VisitMarkers(whereClause.Markers, p))
-            .WithCondition(Visit(whereClause.Condition, p) as Expression ?? whereClause.Condition);
+            .WithCondition((Expression)Visit(whereClause.Condition, p)!);
     }
 
     public virtual J VisitOrderByClause(OrderByClause orderByClause, P p)
@@ -1051,7 +1051,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return ordering
             .WithPrefix(VisitSpace(ordering.Prefix, p))
             .WithMarkers(VisitMarkers(ordering.Markers, p))
-            .WithExpressionPadded(VisitRightPadded(ordering.ExpressionPadded, p) ?? ordering.ExpressionPadded);
+            .WithExpressionPadded(VisitRightPadded(ordering.ExpressionPadded, p)!);
     }
 
     public virtual J VisitSelectClause(SelectClause selectClause, P p)
@@ -1059,7 +1059,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return selectClause
             .WithPrefix(VisitSpace(selectClause.Prefix, p))
             .WithMarkers(VisitMarkers(selectClause.Markers, p))
-            .WithExpression(Visit(selectClause.Expression, p) as Expression ?? selectClause.Expression);
+            .WithExpression((Expression)Visit(selectClause.Expression, p)!);
     }
 
     public virtual J VisitGroupClause(GroupClause groupClause, P p)
@@ -1067,8 +1067,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return groupClause
             .WithPrefix(VisitSpace(groupClause.Prefix, p))
             .WithMarkers(VisitMarkers(groupClause.Markers, p))
-            .WithGroupExpression(VisitRightPadded(groupClause.GroupExpression, p) ?? groupClause.GroupExpression)
-            .WithKey(Visit(groupClause.Key, p) as Expression ?? groupClause.Key);
+            .WithGroupExpression(VisitRightPadded(groupClause.GroupExpression, p)!)
+            .WithKey((Expression)Visit(groupClause.Key, p)!);
     }
 
     public virtual J VisitQueryContinuation(QueryContinuation queryContinuation, P p)
@@ -1076,7 +1076,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return queryContinuation
             .WithPrefix(VisitSpace(queryContinuation.Prefix, p))
             .WithMarkers(VisitMarkers(queryContinuation.Markers, p))
-            .WithIdentifier(Visit(queryContinuation.Identifier, p) as Identifier ?? queryContinuation.Identifier)
+            .WithIdentifier((Identifier)Visit(queryContinuation.Identifier, p)!)
             .WithBody((QueryBody)VisitQueryBody(queryContinuation.Body, p));
     }
 
@@ -1086,7 +1086,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return anonymousObject
             .WithPrefix(VisitSpace(anonymousObject.Prefix, p))
             .WithMarkers(VisitMarkers(anonymousObject.Markers, p))
-            .WithInitializers(VisitContainer(anonymousObject.Initializers, p) ?? anonymousObject.Initializers)
+            .WithInitializers(VisitContainer(anonymousObject.Initializers, p)!)
             .WithType((JavaType?)VisitType(anonymousObject.Type, p));
     }
 
@@ -1096,7 +1096,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return withExpression
             .WithPrefix(VisitSpace(withExpression.Prefix, p))
             .WithMarkers(VisitMarkers(withExpression.Markers, p))
-            .WithTarget(Visit(withExpression.Target, p) as Expression ?? withExpression.Target)
+            .WithTarget((Expression)Visit(withExpression.Target, p)!)
             .WithInitializerPadded(VisitLeftPadded(withExpression.InitializerPadded, p)!)
             .WithType((JavaType?)VisitType(withExpression.Type, p));
     }
@@ -1107,7 +1107,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return spreadExpression
             .WithPrefix(VisitSpace(spreadExpression.Prefix, p))
             .WithMarkers(VisitMarkers(spreadExpression.Markers, p))
-            .WithExpression(Visit(spreadExpression.Expression, p) as Expression ?? spreadExpression.Expression)
+            .WithExpression((Expression)Visit(spreadExpression.Expression, p)!)
             .WithType((JavaType?)VisitType(spreadExpression.Type, p));
     }
 
@@ -1118,7 +1118,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithPrefix(VisitSpace(functionPointerType.Prefix, p))
             .WithMarkers(VisitMarkers(functionPointerType.Markers, p))
             .WithUnmanagedCallingConventionTypes(VisitContainer(functionPointerType.UnmanagedCallingConventionTypes, p))
-            .WithParameterTypes(VisitContainer(functionPointerType.ParameterTypes, p) ?? functionPointerType.ParameterTypes)
+            .WithParameterTypes(VisitContainer(functionPointerType.ParameterTypes, p)!)
             .WithType((JavaType?)VisitType(functionPointerType.Type, p));
     }
 
@@ -1128,8 +1128,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return twa
             .WithPrefix(VisitSpace(twa.Prefix, p))
             .WithMarkers(VisitMarkers(twa.Markers, p))
-            .WithTypeExpression(Visit(twa.TypeExpression, p) as TypeTree ?? twa.TypeExpression)
-            .WithArguments(VisitContainer(twa.Arguments, p) ?? twa.Arguments);
+            .WithTypeExpression((TypeTree)Visit(twa.TypeExpression, p)!)
+            .WithArguments(VisitContainer(twa.Arguments, p)!);
     }
 
     public virtual J VisitExceptionFilteredTry(ExceptionFilteredTry eft, P p)
@@ -1139,7 +1139,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         eft = eft
             .WithPrefix(VisitSpace(eft.Prefix, p))
             .WithMarkers(VisitMarkers(eft.Markers, p))
-            .WithTry(Visit(eft.Try, p) as Try ?? eft.Try);
+            .WithTry((Try)Visit(eft.Try, p)!);
 
         // Keep manual loop for CatchFilters since the list element type is nullable (JLeftPadded<...>?)
         var newFilters = new List<JLeftPadded<ControlParentheses<Expression>>?>(eft.CatchFilters.Count);
@@ -1167,8 +1167,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         return eim
             .WithPrefix(VisitSpace(eim.Prefix, p))
             .WithMarkers(VisitMarkers(eim.Markers, p))
-            .WithInterfaceSpecifier(VisitRightPadded(eim.InterfaceSpecifier, p) ?? eim.InterfaceSpecifier)
-            .WithMethodDeclaration(Visit(eim.MethodDeclaration, p) as MethodDeclaration ?? eim.MethodDeclaration);
+            .WithInterfaceSpecifier(VisitRightPadded(eim.InterfaceSpecifier, p)!)
+            .WithMethodDeclaration((MethodDeclaration)Visit(eim.MethodDeclaration, p)!);
     }
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Java/JavaVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/JavaVisitor.cs
@@ -221,7 +221,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithAnnotationType(Visit(node.AnnotationType, p) as NameTree ?? node.AnnotationType)
+            .WithAnnotationType((NameTree)Visit(node.AnnotationType, p)!)
             .WithArguments(VisitContainer(node.Arguments, p));
     }
 
@@ -255,13 +255,13 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithMarkers(VisitMarkers(node.Markers, p))
             .WithLeadingAnnotations(ListUtils.Map(node.LeadingAnnotations, ann => Visit(ann, p) as Annotation))
             .WithClassKind(node.ClassKind.WithAnnotations(newKindAnnotations))
-            .WithName(Visit(node.Name, p) as Identifier ?? node.Name)
+            .WithName((Identifier)Visit(node.Name, p)!)
             .WithTypeParameters(VisitContainer(node.TypeParameters, p))
             .WithPrimaryConstructor(VisitContainer(node.PrimaryConstructor, p))
             .WithExtends(VisitLeftPadded(node.Extends, p))
             .WithImplements(VisitContainer(node.Implements, p))
             .WithPermits(VisitContainer(node.Permits, p))
-            .WithBody(Visit(node.Body, p) as Block ?? node.Body)
+            .WithBody((Block)Visit(node.Body, p)!)
             .WithType((JavaType.FullyQualified?)VisitType(node.Type, p));
     }
 
@@ -288,8 +288,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithPrefix(VisitSpace(enumValue.Prefix, p))
             .WithMarkers(VisitMarkers(enumValue.Markers, p))
             .WithAnnotations(ListUtils.Map(enumValue.Annotations, ann => Visit(ann, p) as Annotation))
-            .WithName(Visit(enumValue.Name, p) as Identifier ?? enumValue.Name)
-            .WithInitializer(enumValue.Initializer != null ? Visit(enumValue.Initializer, p) as NewClass ?? enumValue.Initializer : null);
+            .WithName((Identifier)Visit(enumValue.Name, p)!)
+            .WithInitializer((NewClass?)Visit(enumValue.Initializer, p));
     }
 
     // -----------------------------------------------------------------------
@@ -305,11 +305,11 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithMarkers(VisitMarkers(node.Markers, p))
             .WithLeadingAnnotations(ListUtils.Map(node.LeadingAnnotations, ann => Visit(ann, p) as Annotation))
             .WithTypeParameters(VisitContainer(node.TypeParameters, p))
-            .WithReturnTypeExpression(node.ReturnTypeExpression != null ? Visit(node.ReturnTypeExpression, p) as TypeTree ?? node.ReturnTypeExpression : null)
-            .WithName(Visit(node.Name, p) as Identifier ?? node.Name)
+            .WithReturnTypeExpression((TypeTree?)Visit(node.ReturnTypeExpression, p))
+            .WithName((Identifier)Visit(node.Name, p)!)
             .WithParameters(VisitContainer(node.Parameters, p)!)
             .WithThrows(VisitContainer(node.Throws, p))
-            .WithBody(node.Body != null ? Visit(node.Body, p) as Block ?? node.Body : null)
+            .WithBody((Block?)Visit(node.Body, p))
             .WithDefaultValue(VisitLeftPadded(node.DefaultValue, p))
             .WithMethodType((JavaType.Method?)VisitType(node.MethodType, p));
     }
@@ -325,7 +325,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithExpression(node.Expression != null ? Visit(node.Expression, p) as Expression ?? node.Expression : null);
+            .WithExpression((Expression?)Visit(node.Expression, p));
     }
 
     // -----------------------------------------------------------------------
@@ -339,9 +339,9 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithCondition(Visit(node.Condition, p) as ControlParentheses<Expression> ?? node.Condition)
-            .WithThenPart(VisitRightPadded(node.ThenPart, p) ?? node.ThenPart)
-            .WithElsePart(node.ElsePart != null ? Visit(node.ElsePart, p) as If.Else ?? node.ElsePart : null);
+            .WithCondition((ControlParentheses<Expression>)Visit(node.Condition, p)!)
+            .WithThenPart(VisitRightPadded(node.ThenPart, p)!)
+            .WithElsePart((If.Else?)Visit(node.ElsePart, p));
     }
 
     // -----------------------------------------------------------------------
@@ -352,7 +352,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return @else
             .WithPrefix(VisitSpace(@else.Prefix, p))
             .WithMarkers(VisitMarkers(@else.Markers, p))
-            .WithBody(VisitRightPadded(@else.Body, p) ?? @else.Body);
+            .WithBody(VisitRightPadded(@else.Body, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -366,8 +366,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithCondition(Visit(node.Condition, p) as ControlParentheses<Expression> ?? node.Condition)
-            .WithBody(VisitRightPadded(node.Body, p) ?? node.Body);
+            .WithCondition((ControlParentheses<Expression>)Visit(node.Condition, p)!)
+            .WithBody(VisitRightPadded(node.Body, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -381,8 +381,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithBody(VisitRightPadded(node.Body, p) ?? node.Body)
-            .WithCondition(VisitLeftPadded(node.Condition, p) ?? node.Condition);
+            .WithBody(VisitRightPadded(node.Body, p)!)
+            .WithCondition(VisitLeftPadded(node.Condition, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -396,8 +396,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithLoopControl(Visit(node.LoopControl, p) as ForLoop.Control ?? node.LoopControl)
-            .WithBody(VisitRightPadded(node.Body, p) ?? node.Body);
+            .WithLoopControl((ForLoop.Control)Visit(node.LoopControl, p)!)
+            .WithBody(VisitRightPadded(node.Body, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -409,7 +409,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithPrefix(VisitSpace(control.Prefix, p))
             .WithMarkers(VisitMarkers(control.Markers, p))
             .WithInit(ListUtils.Map(control.Init, init => VisitRightPadded(init, p)))
-            .WithCondition(VisitRightPadded(control.Condition, p) ?? control.Condition)
+            .WithCondition(VisitRightPadded(control.Condition, p)!)
             .WithUpdate(ListUtils.Map(control.Update, update => VisitRightPadded(update, p)));
     }
 
@@ -424,8 +424,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithLoopControl(Visit(node.LoopControl, p) as ForEachLoop.Control ?? node.LoopControl)
-            .WithBody(VisitRightPadded(node.Body, p) ?? node.Body);
+            .WithLoopControl((ForEachLoop.Control)Visit(node.LoopControl, p)!)
+            .WithBody(VisitRightPadded(node.Body, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -436,8 +436,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return control
             .WithPrefix(VisitSpace(control.Prefix, p))
             .WithMarkers(VisitMarkers(control.Markers, p))
-            .WithVariable(VisitRightPadded(control.Variable, p) ?? control.Variable)
-            .WithIterable(VisitRightPadded(control.Iterable, p) ?? control.Iterable);
+            .WithVariable(VisitRightPadded(control.Variable, p)!)
+            .WithIterable(VisitRightPadded(control.Iterable, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -452,7 +452,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
             .WithResources(VisitContainer(node.Resources, p))
-            .WithBody(Visit(node.Body, p) as Block ?? node.Body)
+            .WithBody((Block)Visit(node.Body, p)!)
             .WithCatches(ListUtils.Map(node.Catches, c => Visit(c, p) as Try.Catch))
             .WithFinally(VisitLeftPadded(node.Finally, p));
     }
@@ -465,8 +465,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return cat
             .WithPrefix(VisitSpace(cat.Prefix, p))
             .WithMarkers(VisitMarkers(cat.Markers, p))
-            .WithParameter(Visit(cat.Parameter, p) as ControlParentheses<VariableDeclarations> ?? cat.Parameter)
-            .WithBody(Visit(cat.Body, p) as Block ?? cat.Body);
+            .WithParameter((ControlParentheses<VariableDeclarations>)Visit(cat.Parameter, p)!)
+            .WithBody((Block)Visit(cat.Body, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -480,7 +480,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithException(Visit(node.Exception, p) as Expression ?? node.Exception);
+            .WithException((Expression)Visit(node.Exception, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -494,7 +494,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithLabel(node.Label != null ? Visit(node.Label, p) as Identifier ?? node.Label : null);
+            .WithLabel((Identifier?)Visit(node.Label, p));
     }
 
     // -----------------------------------------------------------------------
@@ -508,7 +508,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithLabel(node.Label != null ? Visit(node.Label, p) as Identifier ?? node.Label : null);
+            .WithLabel((Identifier?)Visit(node.Label, p));
     }
 
     // -----------------------------------------------------------------------
@@ -538,7 +538,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithTree(VisitRightPadded(node.Tree, p) ?? node.Tree);
+            .WithTree(VisitRightPadded(node.Tree, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -552,7 +552,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithTree(VisitRightPadded(node.Tree, p) ?? node.Tree);
+            .WithTree(VisitRightPadded(node.Tree, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -566,7 +566,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithTree(VisitRightPadded(node.Tree, p) ?? node.Tree);
+            .WithTree(VisitRightPadded(node.Tree, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -612,8 +612,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithTarget(Visit(node.Target, p) as Expression ?? node.Target)
-            .WithName(VisitLeftPadded(node.Name, p) ?? node.Name)
+            .WithTarget((Expression)Visit(node.Target, p)!)
+            .WithName(VisitLeftPadded(node.Name, p)!)
             .WithType(VisitType(node.Type, p));
     }
 
@@ -628,9 +628,9 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithContaining(VisitRightPadded(node.Containing, p) ?? node.Containing)
+            .WithContaining(VisitRightPadded(node.Containing, p)!)
             .WithTypeParameters(VisitContainer(node.TypeParameters, p))
-            .WithReference(VisitLeftPadded(node.Reference, p) ?? node.Reference)
+            .WithReference(VisitLeftPadded(node.Reference, p)!)
             .WithType(VisitType(node.Type, p))
             .WithMethodType((JavaType.Method?)VisitType(node.MethodType, p))
             .WithVariableType((JavaType.Variable?)VisitType(node.VariableType, p));
@@ -647,9 +647,9 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithLeft(Visit(node.Left, p) as Expression ?? node.Left)
-            .WithOperator(VisitLeftPadded(node.Operator, p) ?? node.Operator)
-            .WithRight(Visit(node.Right, p) as Expression ?? node.Right)
+            .WithLeft((Expression)Visit(node.Left, p)!)
+            .WithOperator(VisitLeftPadded(node.Operator, p)!)
+            .WithRight((Expression)Visit(node.Right, p)!)
             .WithType(VisitType(node.Type, p));
     }
 
@@ -667,9 +667,9 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithCondition(Visit(node.Condition, p) as Expression ?? node.Condition)
-            .WithTruePart(VisitLeftPadded(node.TruePart, p) ?? node.TruePart)
-            .WithFalsePart(VisitLeftPadded(node.FalsePart, p) ?? node.FalsePart)
+            .WithCondition((Expression)Visit(node.Condition, p)!)
+            .WithTruePart(VisitLeftPadded(node.TruePart, p)!)
+            .WithFalsePart(VisitLeftPadded(node.FalsePart, p)!)
             .WithType(VisitType(node.Type, p));
     }
 
@@ -687,8 +687,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithVariable(Visit(node.Variable, p) as Expression ?? node.Variable)
-            .WithAssignmentValue(VisitLeftPadded(node.AssignmentValue, p) ?? node.AssignmentValue)
+            .WithVariable((Expression)Visit(node.Variable, p)!)
+            .WithAssignmentValue(VisitLeftPadded(node.AssignmentValue, p)!)
             .WithType(VisitType(node.Type, p));
     }
 
@@ -706,8 +706,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithVariable(Visit(node.Variable, p) as Expression ?? node.Variable)
-            .WithAssignmentValue(Visit(node.AssignmentValue, p) as Expression ?? node.AssignmentValue)
+            .WithVariable((Expression)Visit(node.Variable, p)!)
+            .WithAssignmentValue((Expression)Visit(node.AssignmentValue, p)!)
             .WithType(VisitType(node.Type, p));
     }
 
@@ -725,7 +725,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithExpression(Visit(node.Expression, p) as Expression ?? node.Expression)
+            .WithExpression((Expression)Visit(node.Expression, p)!)
             .WithType(VisitType(node.Type, p));
     }
 
@@ -740,7 +740,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithTree(VisitRightPadded(node.Tree, p) ?? node.Tree);
+            .WithTree(VisitRightPadded(node.Tree, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -754,7 +754,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         // ExpressionStatement delegates Prefix/Markers to its inner Expression,
         // so they are visited when the Expression itself is visited.
         return node
-            .WithExpression(Visit(node.Expression, p) as Expression ?? node.Expression);
+            .WithExpression((Expression)Visit(node.Expression, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -769,7 +769,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
             .WithLeadingAnnotations(ListUtils.Map(node.LeadingAnnotations, ann => Visit(ann, p) as Annotation))
-            .WithTypeExpression(node.TypeExpression != null ? Visit(node.TypeExpression, p) as TypeTree ?? node.TypeExpression : null)
+            .WithTypeExpression((TypeTree?)Visit(node.TypeExpression, p))
             .WithVarargs(node.Varargs != null ? VisitSpace(node.Varargs, p) : null)
             .WithVariables(ListUtils.Map(node.Variables, v => VisitRightPadded(v, p)));
     }
@@ -782,7 +782,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return namedVariable
             .WithPrefix(VisitSpace(namedVariable.Prefix, p))
             .WithMarkers(VisitMarkers(namedVariable.Markers, p))
-            .WithName(Visit(namedVariable.Name, p) as Identifier ?? namedVariable.Name)
+            .WithName((Identifier)Visit(namedVariable.Name, p)!)
             .WithInitializer(VisitLeftPadded(namedVariable.Initializer, p))
             .WithType(VisitType(namedVariable.Type, p));
     }
@@ -816,7 +816,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithMarkers(VisitMarkers(node.Markers, p))
             .WithSelect(VisitRightPadded(node.Select, p))
             .WithTypeParameters(VisitContainer(node.TypeParameters, p))
-            .WithName(Visit(node.Name, p) as Identifier ?? node.Name)
+            .WithName((Identifier)Visit(node.Name, p)!)
             .WithArguments(VisitContainer(node.Arguments, p)!)
             .WithMethodType((JavaType.Method?)VisitType(node.MethodType, p));
     }
@@ -837,9 +837,9 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithMarkers(VisitMarkers(node.Markers, p))
             .WithNew(VisitSpace(node.New, p))
             .WithEnclosing(VisitRightPadded(node.Enclosing, p))
-            .WithClazz(node.Clazz != null ? Visit(node.Clazz, p) as J ?? node.Clazz : null)
+            .WithClazz((J?)Visit(node.Clazz, p))
             .WithArguments(VisitContainer(node.Arguments, p)!)
-            .WithBody(node.Body != null ? Visit(node.Body, p) as Block ?? node.Body : null)
+            .WithBody((Block?)Visit(node.Body, p))
             .WithConstructorType((JavaType.Method?)VisitType(node.ConstructorType, p));
     }
 
@@ -854,7 +854,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithTypeExpression(node.TypeExpression != null ? Visit(node.TypeExpression, p) as TypeTree ?? node.TypeExpression : null)
+            .WithTypeExpression((TypeTree?)Visit(node.TypeExpression, p))
             .WithDimensions(ListUtils.Map(node.Dimensions, dim => Visit(dim, p) as ArrayDimension))
             .WithInitializer(VisitContainer(node.Initializer, p))
             .WithType(VisitType(node.Type, p));
@@ -871,9 +871,9 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithExpression(VisitRightPadded(node.Expression, p) ?? node.Expression)
-            .WithClazz(Visit(node.Clazz, p) as J ?? node.Clazz)
-            .WithPattern(node.Pattern != null ? Visit(node.Pattern, p) as J ?? node.Pattern : null)
+            .WithExpression(VisitRightPadded(node.Expression, p)!)
+            .WithClazz((J)Visit(node.Clazz, p)!)
+            .WithPattern((J?)Visit(node.Pattern, p))
             .WithType(VisitType(node.Type, p));
     }
 
@@ -889,7 +889,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
             .WithAnnotations(ListUtils.Map(node.Annotations, ann => Visit(ann, p) as Annotation))
-            .WithTypeTreePadded(VisitRightPadded(node.TypeTreePadded, p) ?? node.TypeTreePadded)
+            .WithTypeTreePadded(VisitRightPadded(node.TypeTreePadded, p)!)
             .WithType(VisitType(node.Type, p));
     }
 
@@ -904,7 +904,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithClazz(Visit(node.Clazz, p) as NameTree ?? node.Clazz)
+            .WithClazz((NameTree)Visit(node.Clazz, p)!)
             .WithTypeParameters(VisitContainer(node.TypeParameters, p))
             .WithType(VisitType(node.Type, p));
     }
@@ -920,7 +920,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithElementType(Visit(node.ElementType, p) as TypeTree ?? node.ElementType)
+            .WithElementType((TypeTree)Visit(node.ElementType, p)!)
             .WithAnnotations(node.Annotations != null ? ListUtils.Map(node.Annotations, ann => Visit(ann, p) as Annotation) : null)
             .WithType(VisitType(node.Type, p));
     }
@@ -936,8 +936,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithIndexed(Visit(node.Indexed, p) as Expression ?? node.Indexed)
-            .WithDimension(Visit(node.Dimension, p) as ArrayDimension ?? node.Dimension)
+            .WithIndexed((Expression)Visit(node.Indexed, p)!)
+            .WithDimension((ArrayDimension)Visit(node.Dimension, p)!)
             .WithType(VisitType(node.Type, p));
     }
 
@@ -949,7 +949,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return dimension
             .WithPrefix(VisitSpace(dimension.Prefix, p))
             .WithMarkers(VisitMarkers(dimension.Markers, p))
-            .WithIndex(VisitRightPadded(dimension.Index, p) ?? dimension.Index);
+            .WithIndex(VisitRightPadded(dimension.Index, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -966,9 +966,9 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithParams(Visit(node.Params, p) as Lambda.Parameters ?? node.Params)
+            .WithParams((Lambda.Parameters)Visit(node.Params, p)!)
             .WithArrow(VisitSpace(node.Arrow, p))
-            .WithBody(Visit(node.Body, p) as J ?? node.Body)
+            .WithBody((J)Visit(node.Body, p)!)
             .WithType(VisitType(node.Type, p));
     }
 
@@ -994,8 +994,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithSelector(Visit(node.Selector, p) as ControlParentheses<Expression> ?? node.Selector)
-            .WithCases(Visit(node.Cases, p) as Block ?? node.Cases);
+            .WithSelector((ControlParentheses<Expression>)Visit(node.Selector, p)!)
+            .WithCases((Block)Visit(node.Cases, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -1009,8 +1009,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithSelector(Visit(node.Selector, p) as ControlParentheses<Expression> ?? node.Selector)
-            .WithCases(Visit(node.Cases, p) as Block ?? node.Cases);
+            .WithSelector((ControlParentheses<Expression>)Visit(node.Selector, p)!)
+            .WithCases((Block)Visit(node.Cases, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -1025,7 +1025,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
             .WithCaseLabels(VisitContainer(node.CaseLabels, p)!)
-            .WithGuard(node.Guard != null ? Visit(node.Guard, p) as Expression ?? node.Guard : null)
+            .WithGuard((Expression?)Visit(node.Guard, p))
             .WithBody(VisitRightPadded(node.Body, p))
             .WithStatements(VisitContainer(node.Statements, p)!);
     }
@@ -1041,7 +1041,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithDeconstructor(Visit(node.Deconstructor, p) as Expression ?? node.Deconstructor)
+            .WithDeconstructor((Expression)Visit(node.Deconstructor, p)!)
             .WithNested(VisitContainer(node.Nested, p)!)
             .WithType(VisitType(node.Type, p));
     }
@@ -1057,8 +1057,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithLabelName(VisitRightPadded(node.LabelName, p) ?? node.LabelName)
-            .WithStatement(Visit(node.Statement, p) as Statement ?? node.Statement);
+            .WithLabelName(VisitRightPadded(node.LabelName, p)!)
+            .WithStatement((Statement)Visit(node.Statement, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -1072,8 +1072,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithLock(Visit(node.Lock, p) as ControlParentheses<Expression> ?? node.Lock)
-            .WithBody(Visit(node.Body, p) as Block ?? node.Body);
+            .WithLock((ControlParentheses<Expression>)Visit(node.Lock, p)!)
+            .WithBody((Block)Visit(node.Body, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -1087,8 +1087,8 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithClazz(Visit(node.Clazz, p) as ControlParentheses<TypeTree> ?? node.Clazz)
-            .WithExpression(Visit(node.Expression, p) as Expression ?? node.Expression);
+            .WithClazz((ControlParentheses<TypeTree>)Visit(node.Clazz, p)!)
+            .WithExpression((Expression)Visit(node.Expression, p)!);
     }
 
     // -----------------------------------------------------------------------
@@ -1100,7 +1100,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithPrefix(VisitSpace(typeParameter.Prefix, p))
             .WithMarkers(VisitMarkers(typeParameter.Markers, p))
             .WithAnnotations(ListUtils.Map(typeParameter.Annotations, ann => Visit(ann, p) as Annotation))
-            .WithName(Visit(typeParameter.Name, p) as Expression ?? typeParameter.Name)
+            .WithName((Expression)Visit(typeParameter.Name, p)!)
             .WithBounds(VisitContainer(typeParameter.Bounds, p));
     }
 
@@ -1115,7 +1115,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return node
             .WithPrefix(VisitSpace(node.Prefix, p))
             .WithMarkers(VisitMarkers(node.Markers, p))
-            .WithExpression(Visit(node.Expression, p) as Expression ?? node.Expression)
+            .WithExpression((Expression)Visit(node.Expression, p)!)
             .WithAnnotations(ListUtils.Map(node.Annotations, ann => Visit(ann, p) as Annotation));
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Recipe/NullCoalescingVisitorTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Recipe/NullCoalescingVisitorTest.cs
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp;
+using OpenRewrite.Java;
+using OpenRewrite.Test;
+
+namespace OpenRewrite.Tests.Recipe;
+
+/// <summary>
+/// Tests that returning null from a child visit method propagates correctly
+/// instead of being silently swallowed by the ?? (null-coalescing) operator.
+/// </summary>
+public class NullCoalescingVisitorTest : RewriteTest
+{
+    /// <summary>
+    /// Verifies that when VisitBlock returns null for a class body,
+    /// the parent VisitClassDeclaration reflects the null child
+    /// rather than silently restoring the original via ??.
+    /// </summary>
+    [Fact]
+    public void NullReturnFromChildVisitIsNotSwallowedByNullCoalescing()
+    {
+        var parser = new CSharpParser();
+        var source = parser.Parse("class C { }");
+
+        var visitor = new NullifyBlockVisitor();
+        var result = visitor.Visit(source, new Core.ExecutionContext());
+
+        // When VisitBlock returns null, the parent should NOT silently restore
+        // the original. The tree should be modified (different reference).
+        Assert.False(ReferenceEquals(source, result),
+            "When VisitBlock returns null for the class body, " +
+            "VisitClassDeclaration should not silently restore the original via ??. " +
+            "The tree should reflect the null child.");
+    }
+
+    /// <summary>
+    /// Verifies that returning null from VisitMethodInvocation within an
+    /// ExpressionStatement properly propagates, allowing the containing
+    /// statement to be affected.
+    /// </summary>
+    [Fact]
+    public void NullReturnFromExpressionStatementChildPropagates()
+    {
+        var parser = new CSharpParser();
+        var source = parser.Parse(
+            """
+            class C {
+                void M() {
+                    System.Console.WriteLine();
+                }
+            }
+            """);
+
+        var visitor = new NullifyMethodInvocationVisitor();
+        var result = visitor.Visit(source, new Core.ExecutionContext());
+
+        // The visitor returned null for the MethodInvocation inside the
+        // ExpressionStatement. The tree should change.
+        Assert.False(ReferenceEquals(source, result),
+            "When VisitMethodInvocation returns null, the containing " +
+            "ExpressionStatement should not silently restore the original.");
+    }
+
+    private class NullifyBlockVisitor : CSharpVisitor<Core.ExecutionContext>
+    {
+        public override J VisitBlock(Block block, Core.ExecutionContext ctx)
+        {
+            return null!;
+        }
+    }
+
+    private class NullifyMethodInvocationVisitor : CSharpVisitor<Core.ExecutionContext>
+    {
+        public override J VisitMethodInvocation(MethodInvocation mi, Core.ExecutionContext ctx)
+        {
+            return null!;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replace `Visit(x.Child, p) as Type ?? x.Child` with direct casts (`(Type)Visit(...)!` or `(Type?)Visit(...)`) across ~140 call sites in `CSharpVisitor.cs` and `JavaVisitor.cs`
- The `?? original` fallback silently swallowed null returns from child visit methods, making it impossible to delete nodes by returning null from a visitor
- Add tests verifying null returns from child visits propagate correctly

## Test plan

- [x] All 1375 existing C# tests pass
- [x] New `NullCoalescingVisitorTest` confirms null propagation works (failed before fix, passes after)