### PR TITLE
C#: Fix `TrailingComma` markers on array initializers

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -6209,17 +6209,30 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 }
 
                 Space afterSpace;
-                if (i < initializer.Expressions.Count - 1)
+                var elemMarkers = Markers.Empty;
+                var isLast = i == initializer.Expressions.Count - 1;
+                if (!isLast && i < initializer.Expressions.SeparatorCount)
                 {
+                    // Non-last element with comma separator
                     afterSpace = ExtractSpaceBefore(initializer.Expressions.GetSeparator(i));
                     _cursor = initializer.Expressions.GetSeparator(i).Span.End;
                 }
+                else if (isLast && i < initializer.Expressions.SeparatorCount)
+                {
+                    // Last element with trailing comma
+                    var sep = initializer.Expressions.GetSeparator(i);
+                    afterSpace = ExtractSpaceBefore(sep);
+                    _cursor = sep.Span.End;
+                    var suffix = ExtractSpaceBefore(initializer.CloseBraceToken);
+                    elemMarkers = elemMarkers.Add(new TrailingComma(Guid.NewGuid(), suffix));
+                }
                 else
                 {
+                    // Last element without trailing comma
                     afterSpace = ExtractSpaceBefore(initializer.CloseBraceToken);
                 }
 
-                elements.Add(new JRightPadded<Expression>(elementExpr, afterSpace, Markers.Empty));
+                elements.Add(new JRightPadded<Expression>(elementExpr, afterSpace, elemMarkers));
             }
         }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -549,16 +549,7 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
             }
             else
             {
-                for (int i = 0; i < elements.Count; i++)
-                {
-                    var elem = elements[i];
-                    Visit(elem.Element, p);
-                    VisitSpace(elem.After, p);
-                    if (i < elements.Count - 1)
-                    {
-                        p.Append(',');
-                    }
-                }
+                VisitRightPadded(elements, ",", p);
             }
 
             p.Append('}');

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/ArrayTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/ArrayTests.cs
@@ -217,4 +217,36 @@ public class ArrayTests : RewriteTest
             )
         );
     }
+
+    [Fact]
+    public void ArrayInitializerWithTrailingComma()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Foo {
+                    void Bar() {
+                        int[] arr = new int[] { 1, 2, 3, };
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void ImplicitArrayWithTrailingComma()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Foo {
+                    void Bar() {
+                        var arr = new[] { 1, 2, 3, };
+                    }
+                }
+                """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Fix `ParseArrayInitializer` to detect trailing commas in array initializers (e.g., `new int[] { 1, 2, 3, }`), matching the pattern used by other initializer parsers
- Fix `VisitNewArray` printer to use `VisitRightPadded(elements, ",", p)` instead of a manual loop that skipped `VisitMarkers`, causing `TrailingComma` markers to be silently dropped

## Test plan

- [x] Added `ArrayInitializerWithTrailingComma` round-trip test
- [x] Added `ImplicitArrayWithTrailingComma` round-trip test
- [x] All 15 array tests pass
- [x] Full C# test suite (1379 tests) passes with no regressions