### PR TITLE
C#: Add typed captures to template engine

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Capture.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Capture.cs
@@ -31,16 +31,19 @@ public sealed class Capture<T> where T : J
     public bool IsVariadic { get; }
     public int? MinCount { get; }
     public int? MaxCount { get; }
+    public string? Type { get; }
     public Func<T, Cursor, bool>? Constraint { get; }
 
     internal Capture(string name, bool variadic = false,
         int? minCount = null, int? maxCount = null,
+        string? type = null,
         Func<T, Cursor, bool>? constraint = null)
     {
         Name = name;
         IsVariadic = variadic;
         MinCount = minCount;
         MaxCount = maxCount;
+        Type = type;
         Constraint = constraint;
     }
 
@@ -61,9 +64,12 @@ public static class Capture
 
     /// <summary>
     /// Create a capture that matches a single AST node of type <typeparamref name="T"/>.
+    /// When <paramref name="type"/> is specified, the template engine generates a typed
+    /// variable declaration in the scaffold preamble, giving the placeholder proper type
+    /// attribution from the parser.
     /// </summary>
-    public static Capture<T> Of<T>(string? name = null) where T : J
-        => new(name ?? $"_capture_{Interlocked.Increment(ref _counter)}");
+    public static Capture<T> Of<T>(string? name = null, string? type = null) where T : J
+        => new(name ?? $"_capture_{Interlocked.Increment(ref _counter)}", type: type);
 
     /// <summary>
     /// Create a variadic capture that matches zero or more elements.

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
@@ -37,19 +37,20 @@ internal static class TemplateEngine
     internal static J Parse(string code, IReadOnlyDictionary<string, object> captures,
         IReadOnlyList<string> usings, IReadOnlyList<string> context)
     {
-        var cacheKey = BuildCacheKey(code, usings, context);
+        var cacheKey = BuildCacheKey(code, captures, usings, context);
         if (GlobalCache.TryGetValue(cacheKey, out var cached))
             return cached;
 
-        var result = ParseInternal(code, usings, context);
+        var result = ParseInternal(code, captures, usings, context);
         GlobalCache.TryAdd(cacheKey, result);
         return result;
     }
 
-    private static J ParseInternal(string code, IReadOnlyList<string> usings,
-        IReadOnlyList<string> context)
+    private static J ParseInternal(string code, IReadOnlyDictionary<string, object> captures,
+        IReadOnlyList<string> usings, IReadOnlyList<string> context)
     {
-        var scaffold = BuildScaffold(code, usings, context);
+        var preamble = BuildTypePreamble(captures);
+        var scaffold = BuildScaffold(code, preamble, usings, context);
         var parser = new CSharpParser();
         var cu = parser.Parse(scaffold, "__template__.cs");
 
@@ -57,11 +58,32 @@ internal static class TemplateEngine
     }
 
     /// <summary>
-    /// Build a parseable C# source from the template code.
-    /// Wraps the template code in: usings + class __T__ { void __M__() { code; } }
+    /// Build typed field declarations for captures that have a Type.
+    /// These are emitted as class fields on the scaffold class so they are in scope
+    /// inside the method body. This avoids mixing preamble statements with the template
+    /// code, so <see cref="ExtractTemplateNode"/> doesn't need to skip anything.
     /// </summary>
-    private static string BuildScaffold(string code, IReadOnlyList<string> usings,
-        IReadOnlyList<string> context)
+    private static List<string> BuildTypePreamble(IReadOnlyDictionary<string, object> captures)
+    {
+        var preamble = new List<string>();
+        foreach (var kvp in captures)
+        {
+            var captureType = kvp.Value.GetType().GetProperty("Type")?.GetValue(kvp.Value) as string;
+            if (!string.IsNullOrEmpty(captureType))
+            {
+                preamble.Add($"{captureType} {Placeholder.ToPlaceholder(kvp.Key)};");
+            }
+        }
+        return preamble;
+    }
+
+    /// <summary>
+    /// Build a parseable C# source from the template code.
+    /// Typed capture declarations are emitted as class fields (before the method),
+    /// so the method body contains only the template code.
+    /// </summary>
+    private static string BuildScaffold(string code, IReadOnlyList<string> preamble,
+        IReadOnlyList<string> usings, IReadOnlyList<string> context)
     {
         var sb = new System.Text.StringBuilder();
 
@@ -79,6 +101,14 @@ internal static class TemplateEngine
         }
 
         sb.AppendLine("class __T__ {");
+
+        // Typed capture declarations as class fields — in scope inside the method
+        foreach (var decl in preamble)
+        {
+            sb.Append("    ");
+            sb.AppendLine(decl);
+        }
+
         sb.AppendLine("    void __M__() {");
         sb.Append("        ");
         sb.Append(code);
@@ -236,12 +266,24 @@ internal static class TemplateEngine
         return finder.Result;
     }
 
-    private static string BuildCacheKey(string code, IReadOnlyList<string> usings,
-        IReadOnlyList<string> context)
+    private static string BuildCacheKey(string code, IReadOnlyDictionary<string, object> captures,
+        IReadOnlyList<string> usings, IReadOnlyList<string> context)
     {
         var sb = new System.Text.StringBuilder();
         sb.Append("code:");
         sb.Append(code);
+
+        // Include capture types in cache key so typed and untyped patterns
+        // with the same code don't collide
+        foreach (var kvp in captures.OrderBy(c => c.Key))
+        {
+            var captureType = kvp.Value.GetType().GetProperty("Type")?.GetValue(kvp.Value) as string;
+            if (!string.IsNullOrEmpty(captureType))
+            {
+                sb.Append($"|type:{kvp.Key}={captureType}");
+            }
+        }
+
         if (usings.Count > 0)
         {
             sb.Append("|usings:");

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TypedCaptureTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TypedCaptureTests.cs
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp;
+using OpenRewrite.CSharp.Template;
+using OpenRewrite.Java;
+using OpenRewrite.Test;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Tests.Template;
+
+public class TypedCaptureTests : RewriteTest
+{
+    [Fact]
+    public void TypedCaptureStoresType()
+    {
+        var s = Capture.Of<Expression>("s", type: "string");
+        Assert.Equal("string", s.Type);
+    }
+
+    [Fact]
+    public void UntypedCaptureHasNullType()
+    {
+        var s = Capture.Of<Expression>("s");
+        Assert.Null(s.Type);
+    }
+
+    [Fact]
+    public void TypedCaptureProducesCorrectPlaceholder()
+    {
+        var s = Capture.Of<Expression>("s", type: "string");
+        Assert.Equal("__plh_s__", s.ToString());
+    }
+
+    [Fact]
+    public void TypedCaptureEnablesMemberAccess()
+    {
+        // With a typed capture, `{s}.Length` should parse correctly because
+        // the parser knows __plh_s__ is a string and .Length is a valid member
+        var s = Capture.Of<Expression>("s", type: "string");
+        var pat = CSharpPattern.Create($"{s}.Length");
+        var tree = pat.GetTree();
+        Assert.IsType<FieldAccess>(tree);
+    }
+
+    [Fact]
+    public void TypedCaptureEnablesMethodCall()
+    {
+        // With a typed capture, `{s}.ToUpper()` should parse correctly
+        var s = Capture.Of<Expression>("s", type: "string");
+        var pat = CSharpPattern.Create($"{s}.ToUpper()");
+        var tree = pat.GetTree();
+        Assert.IsType<MethodInvocation>(tree);
+    }
+
+    [Fact]
+    public void TypedCapturePatternMatchesMemberAccess()
+    {
+        var s = Capture.Of<Expression>("s", type: "string");
+        RewriteRun(
+            spec => spec.SetRecipe(FindExpression($"{s}.Length")),
+            CSharp(
+                "class C { void M() { string x = \"hello\"; var n = x.Length; } }",
+                "class C { void M() { string x = \"hello\"; var n = /*~~>*/x.Length; } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void TypedCapturePatternMatchesMethodCall()
+    {
+        var s = Capture.Of<Expression>("s", type: "string");
+        RewriteRun(
+            spec => spec.SetRecipe(FindExpression($"{s}.ToUpper()")),
+            CSharp(
+                "class C { void M() { string x = \"hello\"; var y = x.ToUpper(); } }",
+                "class C { void M() { string x = \"hello\"; var y = /*~~>*/x.ToUpper(); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void TypedCaptureWorksAlongsideUntypedCapture()
+    {
+        var s = Capture.Of<Expression>("s", type: "string");
+        var n = Capture.Of<Expression>("n");
+        RewriteRun(
+            spec => spec.SetRecipe(FindExpression($"{s}.Substring({n})")),
+            CSharp(
+                "class C { void M() { string x = \"hello\"; var y = x.Substring(1); } }",
+                "class C { void M() { string x = \"hello\"; var y = /*~~>*/x.Substring(1); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void TypedCaptureWithIntType()
+    {
+        var n = Capture.Of<Expression>("n", type: "int");
+        var pat = CSharpPattern.Create($"{n}.ToString()");
+        var tree = pat.GetTree();
+        Assert.IsType<MethodInvocation>(tree);
+    }
+
+    [Fact]
+    public void MultipleTypedCaptures()
+    {
+        var s = Capture.Of<Expression>("s", type: "string");
+        var n = Capture.Of<Expression>("n", type: "int");
+        var pat = CSharpPattern.Create($"{s}.Substring({n})");
+        var tree = pat.GetTree();
+        Assert.IsType<MethodInvocation>(tree);
+    }
+
+    // ===============================================================
+    // Recipe factory
+    // ===============================================================
+
+    private static Core.Recipe FindExpression(TemplateStringHandler handler)
+        => new TypedPatternSearchRecipe(CSharpPattern.Create(handler));
+
+    private static Core.Recipe FindExpression(string code)
+        => new TypedPatternSearchRecipe(CSharpPattern.Create(code));
+}
+
+file class TypedPatternSearchRecipe(CSharpPattern pat) : Core.Recipe
+{
+    public override string DisplayName => "Find expression";
+    public override string Description => "Searches for expressions matching the pattern.";
+
+    public override JavaVisitor<ExecutionContext> GetVisitor() => new SearchVisitor(pat);
+
+    private class SearchVisitor(CSharpPattern pat) : CSharpVisitor<ExecutionContext>
+    {
+        public override J? PreVisit(J tree, ExecutionContext ctx)
+        {
+            if (tree is Expression e)
+            {
+                return pat.Find(e, Cursor);
+            }
+            return tree;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add optional `type` parameter to `Capture.Of<T>()` so captures can declare a C# type (e.g., `"string"`, `"int"`)
- When a typed capture is used, the template engine emits a typed class field in the scaffold, giving the placeholder proper type attribution from the parser
- Enables patterns like `{s}.Length` and `{s}.ToUpper()` to parse and resolve correctly when `s` is typed as `string`

## How it works

The scaffold for `Capture.Of<Expression>("s", type: "string")` used in `$"{s}.Length"` becomes:

```csharp
class __T__ {
    string __plh_s__;       // class field — in scope inside __M__()
    void __M__() {
        __plh_s__.Length;    // only template code in method body
    }
}
```

Typed declarations are emitted as **class fields** rather than local variables, so the method body contains only the template code and `ExtractTemplateNode` needs no changes.

## Test plan

- [x] `TypedCaptureStoresType` / `UntypedCaptureHasNullType` — property storage
- [x] `TypedCaptureEnablesMemberAccess` — `{s}.Length` parses as `FieldAccess`
- [x] `TypedCaptureEnablesMethodCall` — `{s}.ToUpper()` parses as `MethodInvocation`
- [x] `TypedCapturePatternMatchesMemberAccess` / `TypedCapturePatternMatchesMethodCall` — end-to-end pattern matching with `RewriteRun`
- [x] `TypedCaptureWorksAlongsideUntypedCapture` — mixed typed/untyped captures
- [x] `TypedCaptureWithIntType` / `MultipleTypedCaptures` — multiple types
- [x] All 124 existing template tests pass (no regressions)