### PR TITLE
C#: Commutative `==` / `!=` and `== null` ↔ `is null` in pattern matching

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
@@ -65,9 +65,9 @@ internal class PatternMatchingComparator
             }
         }
 
-        // Different node types don't match
+        // Different node types — check for cross-type equivalences before failing
         if (pattern.GetType() != candidate.GetType())
-            return false;
+            return MatchCrossType(pattern, candidate, cursor);
 
         // NullSafe marker must match: ?. and . are structurally different
         if (TreeHelper.HasNullSafe(pattern) != TreeHelper.HasNullSafe(candidate))
@@ -75,6 +75,28 @@ internal class PatternMatchingComparator
 
         // Generic property-based comparison: iterate all structural properties
         // and compare them recursively, skipping formatting/identity fields.
+        if (pattern is Binary patBin && candidate is Binary candBin)
+        {
+            // Save bindings so we can backtrack if direct match fails
+            var savedBindings = new Dictionary<string, object>(_bindings);
+            if (MatchProperties(pattern, candidate, cursor))
+                return true;
+
+            // Restore bindings and try commuted (swapped) operands for == and !=
+            _bindings.Clear();
+            foreach (var kvp in savedBindings)
+                _bindings[kvp.Key] = kvp.Value;
+            return MatchCommutedBinary(patBin, candBin, cursor);
+        }
+
+        return MatchProperties(pattern, candidate, cursor);
+    }
+
+    /// <summary>
+    /// Compare all structural properties of two same-type nodes.
+    /// </summary>
+    private bool MatchProperties(J pattern, J candidate, Cursor cursor)
+    {
         var properties = TreeHelper.GetStructuralProperties(pattern.GetType());
         foreach (var prop in properties)
         {
@@ -84,9 +106,96 @@ internal class PatternMatchingComparator
             if (!MatchValue(patternValue, candidateValue, cursor))
                 return false;
         }
-
         return true;
     }
+
+    /// <summary>
+    /// For Binary == and != where one side is a literal, try matching with
+    /// left and right swapped (commutative match).
+    /// </summary>
+    private bool MatchCommutedBinary(Binary pattern, Binary candidate, Cursor cursor)
+    {
+        var op = pattern.Operator.Element;
+        if (op != Binary.OperatorType.Equal && op != Binary.OperatorType.NotEqual)
+            return false;
+
+        if (!HasLiteral(pattern) && !HasLiteral(candidate))
+            return false;
+
+        // Operator must still match
+        if (!MatchPaddedElement(pattern.Operator, candidate.Operator, cursor))
+            return false;
+
+        // Try swapped: pattern.Left ↔ candidate.Right, pattern.Right ↔ candidate.Left
+        return MatchNode(pattern.Left, candidate.Right, cursor)
+            && MatchNode(pattern.Right, candidate.Left, cursor);
+    }
+
+    /// <summary>
+    /// Handle cross-type equivalences (e.g. <c>== null</c> ↔ <c>is null</c>).
+    /// Called when pattern and candidate have different node types.
+    /// </summary>
+    private bool MatchCrossType(J pattern, J candidate, Cursor cursor)
+    {
+        // Binary(expr == null) pattern ↔ IsPattern(expr is null) candidate
+        if (pattern is Binary patBin && candidate is IsPattern candIsP)
+            return MatchBinaryPatternToIsNullCandidate(patBin, candIsP, cursor);
+        // IsPattern(expr is null) pattern ↔ Binary(expr == null) candidate
+        if (pattern is IsPattern patIsP && candidate is Binary candBin)
+            return MatchIsNullPatternToBinaryCandidate(patIsP, candBin, cursor);
+
+        return false;
+    }
+
+    /// <summary>
+    /// Pattern is <c>expr == null</c> (Binary), candidate is <c>expr is null</c> (IsPattern).
+    /// Also handles commuted pattern <c>null == expr</c>.
+    /// </summary>
+    private bool MatchBinaryPatternToIsNullCandidate(Binary patternBinary, IsPattern candidateIsPattern, Cursor cursor)
+    {
+        if (patternBinary.Operator.Element != Binary.OperatorType.Equal)
+            return false;
+
+        if (candidateIsPattern.Pattern.Element is not ConstantPattern cp || !IsNullLiteral(cp.Value))
+            return false;
+
+        // pattern: {s} == null → match {s} against candidate's expression
+        if (IsNullLiteral(patternBinary.Right))
+            return MatchNode(patternBinary.Left, candidateIsPattern.Expression, cursor);
+        // pattern: null == {s} → match {s} against candidate's expression
+        if (IsNullLiteral(patternBinary.Left))
+            return MatchNode(patternBinary.Right, candidateIsPattern.Expression, cursor);
+
+        return false;
+    }
+
+    /// <summary>
+    /// Pattern is <c>expr is null</c> (IsPattern), candidate is <c>expr == null</c> (Binary).
+    /// Also handles commuted candidate <c>null == expr</c>.
+    /// </summary>
+    private bool MatchIsNullPatternToBinaryCandidate(IsPattern patternIsPattern, Binary candidateBinary, Cursor cursor)
+    {
+        if (candidateBinary.Operator.Element != Binary.OperatorType.Equal)
+            return false;
+
+        if (patternIsPattern.Pattern.Element is not ConstantPattern cp || !IsNullLiteral(cp.Value))
+            return false;
+
+        // candidate: expr == null → match pattern's expression against candidate's left
+        if (IsNullLiteral(candidateBinary.Right))
+            return MatchNode(patternIsPattern.Expression, candidateBinary.Left, cursor);
+        // candidate: null == expr → match pattern's expression against candidate's right
+        if (IsNullLiteral(candidateBinary.Left))
+            return MatchNode(patternIsPattern.Expression, candidateBinary.Right, cursor);
+
+        return false;
+    }
+
+    private static bool IsNullLiteral(J node) =>
+        node is Literal { Type: JavaType.Primitive { Kind: JavaType.PrimitiveKind.Null } };
+
+    private static bool HasLiteral(Binary binary) =>
+        binary.Left is Literal || binary.Right is Literal;
 
     /// <summary>
     /// Compare two property values, dispatching based on their type.

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/PatternMatchTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/PatternMatchTests.cs
@@ -1022,6 +1022,173 @@ public class PatternMatchTests : RewriteTest
     }
 
     // ===============================================================
+    // Commutative == and != with literals
+    // ===============================================================
+
+    [Fact]
+    public void CommutedEqualWithNullLiteral()
+    {
+        var s = Capture.Of<Expression>("s");
+        RewriteRun(
+            spec => spec.SetRecipe(FindBinary($"{s} == null")),
+            CSharp(
+                "class C { void M(object s) { var x = null == s; } }",
+                "class C { void M(object s) { var x = /*~~>*/null == s; } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void CommutedEqualWithIntLiteral()
+    {
+        var s = Capture.Of<Expression>("s");
+        RewriteRun(
+            spec => spec.SetRecipe(FindBinary($"{s} == 0")),
+            CSharp(
+                "class C { void M(int s) { var x = 0 == s; } }",
+                "class C { void M(int s) { var x = /*~~>*/0 == s; } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void CommutedNotEqualWithNullLiteral()
+    {
+        var s = Capture.Of<Expression>("s");
+        RewriteRun(
+            spec => spec.SetRecipe(FindBinary($"{s} != null")),
+            CSharp(
+                "class C { void M(object s) { var x = null != s; } }",
+                "class C { void M(object s) { var x = /*~~>*/null != s; } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void NonCommutedEqualStillMatches()
+    {
+        var s = Capture.Of<Expression>("s");
+        RewriteRun(
+            spec => spec.SetRecipe(FindBinary($"{s} == null")),
+            CSharp(
+                "class C { void M(object s) { var x = s == null; } }",
+                "class C { void M(object s) { var x = /*~~>*/s == null; } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void CommutedDoesNotApplyToNonEqualityOperators()
+    {
+        var s = Capture.Of<Expression>("s");
+        RewriteRun(
+            spec => spec.SetRecipe(FindBinary($"{s} + 1")),
+            CSharp(
+                // 1 + s should NOT match {s} + 1 since + is not == or !=
+                "class C { void M(int s) { var x = 1 + s; } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void CommutedDoesNotApplyWithoutLiteral()
+    {
+        var a = Capture.Of<Expression>("a");
+        var b = Capture.Of<Expression>("b");
+        RewriteRun(
+            spec => spec.SetRecipe(FindBinary($"{a} == {b}")),
+            CSharp(
+                // Both sides are captures, not literals — commuted match should NOT fire
+                // because both orderings would match anyway via normal matching
+                "class C { void M(int x, int y) { var z = x == y; } }",
+                "class C { void M(int x, int y) { var z = /*~~>*/x == y; } }"
+            )
+        );
+    }
+
+    // ===============================================================
+    // == null ↔ is null equivalence
+    // ===============================================================
+
+    [Fact]
+    public void BinaryEqNullMatchesIsNull()
+    {
+        var s = Capture.Of<Expression>("s");
+        RewriteRun(
+            spec => spec.SetRecipe(FindNullCheck($"{s} == null")),
+            CSharp(
+                "class C { void M(object s) { var x = s is null; } }",
+                "class C { void M(object s) { var x = /*~~>*/s is null; } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void IsNullMatchesBinaryEqNull()
+    {
+        var s = Capture.Of<Expression>("s");
+        RewriteRun(
+            spec => spec.SetRecipe(FindNullCheck($"{s} is null")),
+            CSharp(
+                "class C { void M(object s) { var x = s == null; } }",
+                "class C { void M(object s) { var x = /*~~>*/s == null; } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void CommutedBinaryEqNullMatchesIsNull()
+    {
+        var s = Capture.Of<Expression>("s");
+        RewriteRun(
+            spec => spec.SetRecipe(FindNullCheck($"{s} == null")),
+            CSharp(
+                // null == s written as is null
+                "class C { void M(object s) { var x = s is null; } }",
+                "class C { void M(object s) { var x = /*~~>*/s is null; } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void BinaryNotEqualNullDoesNotMatchIsNull()
+    {
+        var s = Capture.Of<Expression>("s");
+        RewriteRun(
+            spec => spec.SetRecipe(FindNullCheck($"{s} != null")),
+            CSharp(
+                // != null should NOT match is null (different semantics)
+                "class C { void M(object s) { var x = s is null; } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void IsNullDoesNotMatchNonNullBinaryEq()
+    {
+        var s = Capture.Of<Expression>("s");
+        RewriteRun(
+            spec => spec.SetRecipe(FindNullCheck($"{s} is null")),
+            CSharp(
+                // s == 0 should NOT match is null
+                "class C { void M(int s) { var x = s == 0; } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void ExactIsNullStillMatches()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(FindIsPattern("s is null")),
+            CSharp(
+                "class C { void M(object s) { var x = s is null; } }",
+                "class C { void M(object s) { var x = /*~~>*/s is null; } }"
+            )
+        );
+    }
+
+    // ===============================================================
     // Recipe factories
     // ===============================================================
 
@@ -1065,6 +1232,15 @@ public class PatternMatchTests : RewriteTest
     private static Core.Recipe FindIsPattern(string c) => Search<IsPattern>(c);
     private static Core.Recipe FindCsBinary(string c) => Search<CsBinary>(c);
     private static Core.Recipe FindCsBinary(TemplateStringHandler h) => Search<CsBinary>(h);
+
+    /// <summary>
+    /// Search for a Binary or IsPattern null-check, matching across both node types.
+    /// </summary>
+    private static Core.Recipe FindNullCheck(TemplateStringHandler h) =>
+        new NullCheckSearchRecipe(CSharpPattern.Create(h));
+
+    private static Core.Recipe FindNullCheck(string c) =>
+        new NullCheckSearchRecipe(CSharpPattern.Create(c));
 }
 
 /// <summary>
@@ -1085,6 +1261,30 @@ file class PatternSearchRecipe<T>(CSharpPattern pat) : Core.Recipe where T : J
             if (tree is T t)
             {
                 return pat.Find(t, Cursor);
+            }
+            return tree;
+        }
+    }
+}
+
+/// <summary>
+/// Search recipe that visits both Binary and IsPattern nodes to support
+/// cross-type null-check equivalence (== null ↔ is null).
+/// </summary>
+file class NullCheckSearchRecipe(CSharpPattern pat) : Core.Recipe
+{
+    public override string DisplayName => "Find null check";
+    public override string Description => "Searches for null checks matching the pattern (== null or is null).";
+
+    public override JavaVisitor<ExecutionContext> GetVisitor() => new SearchVisitor(pat);
+
+    private class SearchVisitor(CSharpPattern pat) : CSharpVisitor<ExecutionContext>
+    {
+        public override J? PreVisit(J tree, ExecutionContext ctx)
+        {
+            if (tree is Binary or IsPattern)
+            {
+                return pat.Find(tree, Cursor);
             }
             return tree;
         }


### PR DESCRIPTION
## Summary
- Extend `PatternMatchingComparator` to try commuted (swapped) operands for `==` and `!=` when one side is a literal, so `{s} == null` also matches `null == s`
- Treat `== null` and `is null` as equivalent patterns across `Binary` and `IsPattern` node types, in both directions
- Add 12 new tests covering commutative matching, cross-type null-check equivalence, and negative cases

## Test plan
- [x] All 83 `PatternMatchTests` pass (71 existing + 12 new)
- [x] Commuted matching only applies to `==` and `!=`, not other operators
- [x] Cross-type equivalence only applies when the literal is `null` and operator is `==`
- [x] Existing tests remain green (no regressions)