### PR TITLE
C#: Restore NuGet global cache population during pTML

### DIFF
--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -252,7 +252,7 @@ val csharpPublish by tasks.registering(Exec::class) {
 // Usage: ./gradlew :rewrite-csharp:csharpPublishLocal
 val csharpPublishLocal by tasks.registering {
     group = "csharp"
-    description = "Pack and publish C# NuGet packages to local feed"
+    description = "Pack and install C# NuGet packages into local NuGet cache"
 
     dependsOn(csharpPack)
 
@@ -260,19 +260,34 @@ val csharpPublishLocal by tasks.registering {
         val localFeed = file("${System.getProperty("user.home")}/.nuget/local-feed")
         localFeed.mkdirs()
 
-        // Clear stale version from NuGet global packages cache so restore re-evaluates
         val dotnet = findDotnet()
-        val localsOutput = ProcessBuilder(dotnet, "nuget", "locals", "global-packages", "--list")
-            .redirectErrorStream(true).start().let { it.inputStream.bufferedReader().readText().also { _ -> it.waitFor() } }
+        val distDir = csharpDir.resolve("dist").absolutePath
+
+        fun run(vararg args: String, dir: File? = null, ignoreExitCode: Boolean = false): String {
+            val pb = ProcessBuilder(*args)
+                .redirectErrorStream(true)
+            if (dir != null) pb.directory(dir)
+            val proc = pb.start()
+            val output = proc.inputStream.bufferedReader().readText()
+            val exitCode = proc.waitFor()
+            if (exitCode != 0 && !ignoreExitCode) {
+                throw GradleException("Command failed (exit $exitCode): ${args.joinToString(" ")}\n$output")
+            }
+            return output
+        }
+
+        // Find NuGet global-packages cache path
+        val localsOutput = run(dotnet, "nuget", "locals", "global-packages", "--list")
         val cachePath = localsOutput.trim().substringAfter("global-packages: ")
 
+        // Clear stale entries from NuGet caches for each package
         csharpDir.resolve("dist").listFiles()
             ?.filter { it.name.endsWith(".nupkg") }
             ?.forEach { nupkg ->
                 val nameWithoutExt = nupkg.name.removeSuffix(".nupkg")
                 val packageId = nameWithoutExt.removeSuffix(".$nugetVersion")
 
-                // Clear cached version so consumers pick up the fresh package
+                // Clear the specific version from global packages cache
                 val packageCacheDir = file("$cachePath/${packageId.lowercase()}/$nugetVersion")
                 if (packageCacheDir.exists()) {
                     logger.lifecycle("Clearing cached: ${packageCacheDir.absolutePath}")
@@ -282,6 +297,41 @@ val csharpPublishLocal by tasks.registering {
                 nupkg.copyTo(localFeed.resolve(nupkg.name), overwrite = true)
                 logger.lifecycle("Published $packageId@$nugetVersion to ${localFeed.absolutePath}")
             }
+
+        // Create a temp project with PackageDownload entries and restore to populate the NuGet cache
+        val tempDir = temporaryDir
+        tempDir.deleteRecursively()
+        tempDir.mkdirs()
+
+        val packageDownloads = csharpDir.resolve("dist").listFiles()
+            ?.filter { it.name.endsWith(".nupkg") }
+            ?.joinToString("\n") { nupkg ->
+                val nameWithoutExt = nupkg.name.removeSuffix(".nupkg")
+                val packageId = nameWithoutExt.removeSuffix(".$nugetVersion")
+                logger.lifecycle("Installing $packageId@$nugetVersion into NuGet cache from $distDir")
+                """    <PackageDownload Include="$packageId" Version="[$nugetVersion]" />"""
+            } ?: ""
+
+        val tempCsproj = tempDir.resolve("Temp.csproj")
+        tempCsproj.writeText("""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+            $packageDownloads
+              </ItemGroup>
+            </Project>
+        """.trimIndent())
+
+        val restoreOutput = run(
+            dotnet, "restore",
+            "--source", distDir,
+            "--force",
+            dir = tempDir,
+            ignoreExitCode = true
+        )
+        logger.lifecycle(restoreOutput)
     }
 }
 


### PR DESCRIPTION
## Summary
- Restores the temp-project + `dotnet restore` approach for populating the NuGet global packages cache (`~/.nuget/packages/`) during `publishToMavenLocal`
- This was removed in #7041, which broke `dotnet tool exec` resolution from the global cache (used by `CSharpRewriteRpc.buildToolExecCommand`)
- Without this, packages only land in `~/.nuget/local-feed/` but the Java RPC layer checks the global cache path

## Test plan
- [x] Ran `./gradlew :rewrite-csharp:publishToMavenLocal` locally
- [x] Verified `OpenRewrite.CSharp/8.76.0-zlocal` and `OpenRewrite.CSharp.Tool/8.76.0-zlocal` appear in `~/.nuget/packages/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)