### PR TITLE
Store ExecutionContext in localObjects for onComplete() retrieval

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -1522,7 +1522,10 @@ public class RewriteRpcServer
 
         var ctx = new ExecutionContext();
         if (pId != null)
+        {
             _executionContexts[pId] = ctx;
+            _localObjects[pId] = ctx;
+        }
         return ctx;
     }
 

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1055,6 +1055,7 @@ def handle_visit(params: dict) -> dict:
             ctx.put_message(DATA_TABLE_STORE, store)
         if p_id:
             _execution_contexts[p_id] = ctx
+            local_objects[p_id] = ctx
 
     # Always fetch the tree from Java to ensure we have the latest version.
     # Java may have modified the tree (e.g., via a Java-side recipe) since our last sync.
@@ -1122,6 +1123,7 @@ def handle_batch_visit(params: dict) -> dict:
             ctx.put_message(DATA_TABLE_STORE, store)
         if p_id:
             _execution_contexts[p_id] = ctx
+            local_objects[p_id] = ctx
 
     # Fetch tree once from Java
     tree = get_object_from_java(tree_id, source_file_type)
@@ -1299,6 +1301,7 @@ def handle_generate(params: dict) -> dict:
             ctx.put_message(DATA_TABLE_STORE, store)
         if p_id:
             _execution_contexts[p_id] = ctx
+            local_objects[p_id] = ctx
 
     # Only scanning recipes can generate files
     from rewrite.recipe import ScanningRecipe


### PR DESCRIPTION
## Summary
- C# and Python RPC servers stored the ExecutionContext in a separate `_executionContexts` dict but not in `localObjects`
- When Java's `RpcRecipe.onComplete()` called `getObject()` with the EC's snowflake ID, the GetObject handler returned DELETE (82 spurious DELETE log entries per recipe run)
- Fix: also store in `localObjects` when creating the EC, matching the invariant that `localObjects` contains everything GetObject may be asked for
- JavaScript already handles this correctly via `getObject(request.p)` which stores in `localObjects` automatically — follow-up #7064 tracks aligning C#/Python to this pattern

## Test plan
- [x] C# recipe run produces zero `GetObject not found, returning DELETE` entries (was 82)
- [x] `onComplete()` successfully retrieves ExecutionContext with data tables
- [x] Full 22-repo working set passes with UpgradeToDotNet9