### PR TITLE
Fix ConcurrentModificationException in DeclarativeRecipe

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -66,13 +66,13 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
     private final List<Recipe> uninitializedRecipes = new ArrayList<>();
 
     @Setter
-    private List<Recipe> recipeList = new ArrayList<>();
+    private volatile List<Recipe> recipeList = Collections.emptyList();
 
     private final List<Recipe> uninitializedPreconditions = new ArrayList<>();
 
     @Getter
     @Setter
-    private List<Recipe> preconditions = new ArrayList<>();
+    private volatile List<Recipe> preconditions = Collections.emptyList();
 
     public void addPrecondition(Recipe recipe) {
         uninitializedPreconditions.add(recipe);
@@ -94,8 +94,8 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
         Map<String, Recipe> recipeMap = new HashMap<>();
         availableRecipes.forEach(r -> recipeMap.putIfAbsent(r.getName(), r));
         Set<String> initializingRecipes = new HashSet<>();
-        initialize(uninitializedRecipes, recipeList, recipeMap::get, initializingRecipes);
-        initialize(uninitializedPreconditions, preconditions, recipeMap::get, initializingRecipes);
+        recipeList = initialize(uninitializedRecipes, recipeMap::get, initializingRecipes);
+        preconditions = initialize(uninitializedPreconditions, recipeMap::get, initializingRecipes);
     }
 
     @Deprecated
@@ -106,8 +106,8 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
 
     public void initialize(Function<String, @Nullable Recipe> availableRecipes) {
         Set<String> initializingRecipes = new HashSet<>();
-        initialize(uninitializedRecipes, recipeList, availableRecipes, initializingRecipes);
-        initialize(uninitializedPreconditions, preconditions, availableRecipes, initializingRecipes);
+        recipeList = initialize(uninitializedRecipes, availableRecipes, initializingRecipes);
+        preconditions = initialize(uninitializedPreconditions, availableRecipes, initializingRecipes);
     }
 
     @Deprecated
@@ -116,8 +116,8 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
         this.initialize(availableRecipes);
     }
 
-    private void initialize(List<Recipe> uninitialized, List<Recipe> initialized, Function<String, @Nullable Recipe> availableRecipes, Set<String> initializingRecipes) {
-        initialized.clear();
+    private List<Recipe> initialize(List<Recipe> uninitialized, Function<String, @Nullable Recipe> availableRecipes, Set<String> initializingRecipes) {
+        List<Recipe> result = new ArrayList<>();
         for (int i = 0; i < uninitialized.size(); i++) {
             Recipe recipe = uninitialized.get(i);
             if (recipe instanceof LazyLoadedRecipe) {
@@ -127,7 +127,7 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
                     if (subRecipe instanceof DeclarativeRecipe) {
                         initializeDeclarativeRecipe((DeclarativeRecipe) subRecipe, recipeFqn, availableRecipes, initializingRecipes);
                     }
-                    initialized.add(subRecipe);
+                    result.add(subRecipe);
                 } else {
                     initValidation = initValidation.and(
                             invalid(name + ".recipeList" +
@@ -140,9 +140,10 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
                 if (recipe instanceof DeclarativeRecipe) {
                     initializeDeclarativeRecipe((DeclarativeRecipe) recipe, recipe.getName(), availableRecipes, initializingRecipes);
                 }
-                initialized.add(recipe);
+                result.add(recipe);
             }
         }
+        return Collections.unmodifiableList(result);
     }
 
     private void initializeDeclarativeRecipe(DeclarativeRecipe declarativeRecipe, String recipeIdentifier,
@@ -155,8 +156,8 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
                     "Recipe '" + recipeIdentifier + "' creates a cycle: " + cycle);
         } else {
             initializingRecipes.add(recipeName);
-            declarativeRecipe.initialize(declarativeRecipe.uninitializedRecipes, declarativeRecipe.recipeList, availableRecipes, initializingRecipes);
-            declarativeRecipe.initialize(declarativeRecipe.uninitializedPreconditions, declarativeRecipe.preconditions, availableRecipes, initializingRecipes);
+            declarativeRecipe.recipeList = initialize(declarativeRecipe.uninitializedRecipes, availableRecipes, initializingRecipes);
+            declarativeRecipe.preconditions = initialize(declarativeRecipe.uninitializedPreconditions, availableRecipes, initializingRecipes);
             initializingRecipes.remove(recipeName);
         }
     }

--- a/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
@@ -38,6 +38,10 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.emptyList;
@@ -365,6 +369,90 @@ class DeclarativeRecipeTest implements RewriteTest {
         dr.addUninitialized(new Find("sam", null, null, null, null, null, null, null));
         dr.initialize(List.of());
         assertThat(dr.getDataTableDescriptors()).anyMatch(it -> "org.openrewrite.table.TextMatches".equals(it.getName()));
+    }
+
+    @Test
+    void getDataTableDescriptorsThreadSafe() throws Exception {
+        DeclarativeRecipe dr = new DeclarativeRecipe("org.openrewrite.ConcurrentTest", "concurrent test",
+          "test", emptySet(), null, URI.create("dummy"), true, emptyList());
+        dr.addUninitialized(new Find("sam", null, null, null, null, null, null, null));
+        dr.initialize(List.of());
+
+        int threadCount = 10;
+        int iterations = 100;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadIdx = i;
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    for (int j = 0; j < iterations; j++) {
+                        if (threadIdx % 2 == 0) {
+                            // Reader threads: iterate via getDataTableDescriptors and getDescriptor
+                            dr.getDataTableDescriptors();
+                            dr.getDescriptor();
+                        } else {
+                            // Writer threads: re-initialize to modify recipeList concurrently
+                            dr.addUninitialized(new Find("sam", null, null, null, null, null, null, null));
+                            dr.initialize(List.of());
+                        }
+                    }
+                } catch (Throwable t) {
+                    errors.add(t);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        doneLatch.await();
+        executor.shutdown();
+
+        assertThat(errors).as("Concurrent access to getDataTableDescriptors/getDescriptor should not throw").isEmpty();
+    }
+
+    @Test
+    void concurrentInitializeDoesNotDuplicateRecipes() throws Exception {
+        DeclarativeRecipe dr = new DeclarativeRecipe("org.openrewrite.ConcurrentInitTest", "concurrent init test",
+          "test", emptySet(), null, URI.create("dummy"), true, emptyList());
+        dr.addUninitialized(new Find("sam", null, null, null, null, null, null, null));
+        dr.addUninitialized(new ChangeText("hello"));
+        dr.initialize(List.of());
+
+        int expectedSize = dr.getRecipeList().size();
+
+        int threadCount = 20;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    for (int j = 0; j < 50; j++) {
+                        dr.initialize(List.of());
+                    }
+                } catch (Throwable t) {
+                    errors.add(t);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        doneLatch.await();
+        executor.shutdown();
+
+        assertThat(errors).as("Concurrent initialize() should not throw").isEmpty();
+        assertThat(dr.getRecipeList()).as("Concurrent initialize() should not duplicate recipes").hasSize(expectedSize);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `DeclarativeRecipe.recipeList` and `preconditions` are mutable `ArrayList` fields that are populated during `initialize()` (via `clear()` + `add()`) and concurrently iterated by `getDataTableDescriptors()`, `createRecipeDescriptor()`, and `getRecipeList()`
- Under concurrent access from virtual threads calling `describe()`/`getDescriptor()` on the same recipe instance, this causes `ConcurrentModificationException`
- Fix: make both fields `volatile` and assign immutable list snapshots from `initialize()`. Readers always see a complete, immutable list — no CME possible, and no risk of duplicate entries from interleaved `initialize()` calls

## Why not align with `Recipe.getRecipeList()` (fresh list per call)?
The base `Recipe.getRecipeList()` builds a new list every call via `buildRecipeList()` — inherently thread-safe, no shared state. We considered making `DeclarativeRecipe` follow this pattern, but it isn't feasible: `DeclarativeRecipe` resolves `LazyLoadedRecipe` references by name during `initialize()`, which requires the `availableRecipes` context that is only available at startup. The recipe list is data-driven (YAML), not code-driven, so it must be built once and cached. The volatile + immutable swap gives the same thread-safety guarantees while preserving this lifecycle.

## Changes
- `recipeList` and `preconditions` declared as `volatile`, initialized to `Collections.emptyList()`
- `initialize(List, List, Function, Set)` refactored to `initialize(List, Function, Set)` — builds a new `ArrayList` internally, returns `Collections.unmodifiableList(result)`
- Callers assign the returned list directly: `recipeList = initialize(...)`
- No changes needed to iteration sites — they now iterate immutable snapshots

## Test plan
- [x] Added `getDataTableDescriptorsThreadSafe` — concurrent reader/writer threads that reproduces the CME
- [x] Added `concurrentInitializeDoesNotDuplicateRecipes` — concurrent `initialize()` calls don't produce duplicate entries
- [x] Verified both tests fail without the fix, pass with it
- [x] All existing `DeclarativeRecipeTest` tests pass