### PR TITLE
Add `constantValue` to `JavaType.Variable` for compile-time constants

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
@@ -313,6 +313,17 @@ internal class CSharpTypeMapping
 
         var variable = new JavaType.Variable(name, owner, type, null);
         _typeCache[symbol] = variable;
+
+        if (symbol is IFieldSymbol { HasConstantValue: true } field)
+        {
+            var val = field.ConstantValue;
+            if (val is string or bool or char or byte or sbyte or short or ushort
+                or int or uint or long or ulong or float or double or decimal)
+            {
+                variable.ConstantValue = val;
+            }
+        }
+
         return variable;
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/Java/JavaType.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/JavaType.cs
@@ -282,6 +282,7 @@ public abstract class JavaType
         public JavaType? Owner { get; set; }
         public JavaType? Type { get; set; }
         public IList<FullyQualified>? Annotations { get; set; }
+        public object? ConstantValue { get; set; }
 
         public Variable() { }
 

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaReceiver.cs
@@ -806,6 +806,7 @@ public class JavaReceiver : JavaVisitor<RpcReceiveQueue>
                 variable.Type = q.Receive(variable.Type, t => VisitType(t, q)!);
                 variable.Annotations = (IList<JavaType.FullyQualified>?)q.ReceiveList(variable.Annotations,
                     t => (JavaType.FullyQualified)VisitType(t, q)!);
+                variable.ConstantValue = q.Receive<object?>(variable.ConstantValue);
                 break;
         }
 

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaSender.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaSender.cs
@@ -790,6 +790,7 @@ public class JavaSender : JavaVisitor<RpcSendQueue>
                     t => VisitType(GetValueNonNull<JavaType>(t), q));
                 q.GetAndSendListAsRef(variable, v => v.Annotations,
                     t => TypeSignature(t), t => VisitType(t, q));
+                q.GetAndSend(variable, v => v.ConstantValue);
                 break;
         }
 

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
@@ -427,7 +427,8 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
                 null,
                 symbol.flags_field,
                 symbol.name.toString(),
-                null, null, null);
+                null, null, null,
+                ((Symbol.VarSymbol) symbol).getConstValue());
 
         typeCache.put(signature, variable);
 

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
@@ -427,7 +427,8 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
                 null,
                 symbol.flags_field,
                 symbol.name.toString(),
-                null, null, null);
+                null, null, null,
+                ((Symbol.VarSymbol) symbol).getConstValue());
 
         typeCache.put(signature, variable);
 

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
@@ -418,7 +418,8 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
                 null,
                 symbol.flags_field,
                 symbol.name.toString(),
-                null, null, null);
+                null, null, null,
+                ((Symbol.VarSymbol) symbol).getConstValue());
 
         typeCache.put(signature, variable);
 
@@ -437,7 +438,8 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
             assert resolvedOwner != null;
         }
 
-        return variable.unsafeSet(resolvedOwner, type(symbol.type), listAnnotations(symbol));
+        variable.unsafeSet(resolvedOwner, type(symbol.type), listAnnotations(symbol));
+        return variable;
     }
 
     /**

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25TypeMapping.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25TypeMapping.java
@@ -417,7 +417,8 @@ class ReloadableJava25TypeMapping implements JavaTypeMapping<Tree> {
                 null,
                 symbol.flags_field,
                 symbol.name.toString(),
-                null, null, null);
+                null, null, null,
+                ((Symbol.VarSymbol) symbol).getConstValue());
 
         typeCache.put(signature, variable);
 
@@ -436,7 +437,8 @@ class ReloadableJava25TypeMapping implements JavaTypeMapping<Tree> {
             assert resolvedOwner != null;
         }
 
-        return variable.unsafeSet(resolvedOwner, type(symbol.type), listAnnotations(symbol));
+        variable.unsafeSet(resolvedOwner, type(symbol.type), listAnnotations(symbol));
+        return variable;
     }
 
     /**

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
@@ -419,7 +419,8 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
                 null,
                 symbol.flags_field,
                 symbol.name.toString(),
-                null, null, null);
+                null, null, null,
+                ((Symbol.VarSymbol) symbol).getConstValue());
 
         typeCache.put(signature, variable);
 

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaParserTypeMappingTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaParserTypeMappingTest.java
@@ -397,4 +397,75 @@ class JavaParserTypeMappingTest implements JavaTypeMappingTest, RewriteTest {
           )
         );
     }
+
+    @Test
+    void constantValueFromClasspath() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  int x = Integer.MAX_VALUE;
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> new JavaVisitor<>() {
+                @Override
+                public J visitIdentifier(J.Identifier ident, Object o) {
+                    if ("MAX_VALUE".equals(ident.getSimpleName())) {
+                        assertThat(ident.getFieldType()).isNotNull();
+                        assertThat(ident.getFieldType().getConstantValue()).isEqualTo(Integer.MAX_VALUE);
+                    }
+                    return ident;
+                }
+            }.visit(cu, 0))
+          )
+        );
+    }
+
+    @Test
+    void constantValueOnStaticFinalFields() {
+        rewriteRun(
+          java(
+            """
+              class Constants {
+                  static final int INT_CONST = 42;
+                  static final long LONG_CONST = 100L;
+                  static final String STRING_CONST = "hello";
+                  static final boolean BOOL_CONST = true;
+                  static final double DOUBLE_CONST = 3.14;
+                  static final Object NOT_CONST = new Object();
+                  int instanceField = 1;
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                JavaType.Class type = (JavaType.Class) cu.getClasses().get(0).getType();
+                assertThat(type).isNotNull();
+                for (JavaType.Variable member : type.getMembers()) {
+                    switch (member.getName()) {
+                        case "INT_CONST":
+                            assertThat(member.getConstantValue()).isEqualTo(42);
+                            break;
+                        case "LONG_CONST":
+                            assertThat(member.getConstantValue()).isEqualTo(100L);
+                            break;
+                        case "STRING_CONST":
+                            assertThat(member.getConstantValue()).isEqualTo("hello");
+                            break;
+                        case "BOOL_CONST":
+                            assertThat(member.getConstantValue()).isEqualTo(true);
+                            break;
+                        case "DOUBLE_CONST":
+                            assertThat(member.getConstantValue()).isEqualTo(3.14);
+                            break;
+                        case "NOT_CONST":
+                            assertThat(member.getConstantValue()).isNull();
+                            break;
+                        case "instanceField":
+                            assertThat(member.getConstantValue()).isNull();
+                            break;
+                    }
+                }
+            })
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
@@ -279,11 +279,28 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
             return existing;
         }
 
+        Object constantValue = null;
+        if (java.lang.reflect.Modifier.isStatic(field.getModifiers()) &&
+                java.lang.reflect.Modifier.isFinal(field.getModifiers())) {
+            try {
+                Object val = field.get(null);
+                if (val instanceof String || val instanceof Boolean ||
+                        val instanceof Character || val instanceof Byte ||
+                        val instanceof Short || val instanceof Integer ||
+                        val instanceof Long || val instanceof Float ||
+                        val instanceof Double) {
+                    constantValue = val;
+                }
+            } catch (Exception ignored) {
+            }
+        }
+
         JavaType.Variable mappedVariable = new JavaType.Variable(
                 null,
                 field.getModifiers(),
                 field.getName(),
-                null, null, null
+                null, null, null,
+                constantValue
         );
         typeCache.put(signature, mappedVariable);
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaTypeReceiver.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaTypeReceiver.java
@@ -147,6 +147,7 @@ public class JavaTypeReceiver extends JavaTypeVisitor<RpcReceiveQueue> {
         JavaType owner = q.receive(variable.getOwner(), v -> visit(v, q));
         JavaType type = q.receive(variable.getType(), v -> visit(v, q));
         List<JavaType.FullyQualified> annotations = q.receiveList(variable.getAnnotations(), v -> (JavaType.FullyQualified) visit(v, q));
-        return variable.unsafeSet(name, owner, type, arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY));
+        Object constantValue = q.receive(variable.getConstantValue());
+        return variable.unsafeSet(name, owner, type, arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY), constantValue);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaTypeSender.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaTypeSender.java
@@ -127,6 +127,7 @@ public class JavaTypeSender extends JavaTypeVisitor<RpcSendQueue> {
         q.getAndSend(variable, v -> asRef(v.getOwner()), t -> visit(Reference.<JavaType>getValueNonNull(t), q));
         q.getAndSend(variable, v -> asRef(v.getType()), t -> visit(Reference.<JavaType>getValueNonNull(t), q));
         q.getAndSendListAsRef(variable, JavaType.Variable::getAnnotations, sig::signature, t -> visit(t, q));
+        q.getAndSend(variable, JavaType.Variable::getConstantValue);
         return variable;
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -1682,26 +1682,34 @@ public interface JavaType {
         @NonFinal
         FullyQualified @Nullable [] annotations;
 
+        @Getter
+        @With
+        @NonFinal
+        @Nullable
+        Object constantValue;
+
         public Variable(@Nullable Integer managedReference, long flagsBitMap, String name, @Nullable JavaType owner,
                         @Nullable JavaType type, @Nullable List<FullyQualified> annotations) {
-            this(
-                    managedReference,
-                    flagsBitMap,
-                    name,
-                    owner,
-                    type,
-                    arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY)
-            );
+            this(managedReference, flagsBitMap, name, owner, type,
+                    arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY), null);
+        }
+
+        public Variable(@Nullable Integer managedReference, long flagsBitMap, String name, @Nullable JavaType owner,
+                        @Nullable JavaType type, @Nullable List<FullyQualified> annotations,
+                        @Nullable Object constantValue) {
+            this(managedReference, flagsBitMap, name, owner, type,
+                    arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY), constantValue);
         }
 
         Variable(@Nullable Integer managedReference, long flagsBitMap, String name, @Nullable JavaType owner,
-                 @Nullable JavaType type, FullyQualified @Nullable [] annotations) {
+                 @Nullable JavaType type, FullyQualified @Nullable [] annotations, @Nullable Object constantValue) {
             this.managedReference = managedReference;
             this.flagsBitMap = flagsBitMap & Flag.VALID_FLAGS;
             this.name = name;
             this.owner = owner;
             this.type = unknownIfNull(type);
             this.annotations = nullIfEmpty(annotations);
+            this.constantValue = constantValue;
         }
 
         @JsonCreator
@@ -1721,7 +1729,7 @@ public interface JavaType {
             if (Arrays.equals(annotationsArray, this.annotations)) {
                 return this;
             }
-            return new Variable(this.managedReference, this.flagsBitMap, this.name, this.owner, this.type, annotationsArray);
+            return new Variable(this.managedReference, this.flagsBitMap, this.name, this.owner, this.type, annotationsArray, this.constantValue);
         }
 
         public boolean hasFlags(Flag... test) {
@@ -1743,11 +1751,12 @@ public interface JavaType {
         }
 
         public Variable unsafeSet(String name, JavaType owner, @Nullable JavaType type,
-                                  FullyQualified @Nullable [] annotations) {
+                                  FullyQualified @Nullable [] annotations, @Nullable Object constantValue) {
             this.name = name;
             this.owner = owner;
             this.type = unknownIfNull(type);
             this.annotations = annotations;
+            this.constantValue = constantValue;
             return this;
         }
 

--- a/rewrite-javascript/rewrite/package-lock.json
+++ b/rewrite-javascript/rewrite/package-lock.json
@@ -1053,7 +1053,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
       "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1456,7 +1455,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1691,7 +1689,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -1870,7 +1867,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/rewrite-javascript/rewrite/src/java/rpc.ts
+++ b/rewrite-javascript/rewrite/src/java/rpc.ts
@@ -47,6 +47,7 @@ class TypeSender extends TypeVisitor<RpcSendQueue> {
         await q.getAndSend(variable, v => v.owner ? asRef(v.owner) : undefined, owner => this.visit(owner, q));
         await q.getAndSend(variable, v => asRef(v.type), t => this.visit(t, q));
         await q.getAndSendList(variable, v => (v.annotations || []).map(v2 => asRef(v2)), t => Type.signature(t), a => this.visit(a, q));
+        await q.getAndSend(variable, v => v.constantValue);
         return variable;
     }
 
@@ -168,6 +169,7 @@ class TypeReceiver extends TypeVisitor<RpcReceiveQueue> {
         variable.owner = await q.receive(variable.owner, owner => this.visit(owner, q));
         variable.type = await q.receive(variable.type, t => this.visit(t, q));
         variable.annotations = await q.receiveList(variable.annotations, a => this.visit(a, q)) || [];
+        variable.constantValue = await q.receive(variable.constantValue);
         return variable;
     }
 

--- a/rewrite-javascript/rewrite/src/java/type.ts
+++ b/rewrite-javascript/rewrite/src/java/type.ts
@@ -111,6 +111,7 @@ export namespace Type {
         owner?: Type;
         type: Type;
         annotations: Type.Annotation[];
+        constantValue?: string | number | boolean;
 
         toJSON?(): string;
     }

--- a/rewrite-python/rewrite/src/rewrite/java/support_types.py
+++ b/rewrite-python/rewrite/src/rewrite/java/support_types.py
@@ -359,6 +359,7 @@ class JavaType(ABC):
         _owner: Optional[JavaType] = field(default=None)
         _type: Optional[JavaType] = field(default=None)
         _annotations: Optional[List[JavaType.FullyQualified]] = field(default=None)
+        _constant_value: Optional[object] = field(default=None)
 
         @property
         def flags_bit_map(self) -> int:
@@ -379,6 +380,10 @@ class JavaType(ABC):
         @property
         def annotations(self) -> Optional[List[JavaType.FullyQualified]]:
             return self._annotations
+
+        @property
+        def constant_value(self) -> Optional[object]:
+            return self._constant_value
 
     @dataclass
     class Array:

--- a/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
@@ -1064,11 +1064,13 @@ class PythonRpcReceiver:
                                lambda t: self._receive_type(t, q))
             annotations = q.receive_list(getattr(java_type, '_annotations', None) or [],
                                           lambda t: self._receive_type(t, q))
+            constant_value = q.receive(getattr(java_type, '_constant_value', None))
             var = JT.Variable()
             var._name = name  # ty: ignore[invalid-assignment]  # RPC deserialization
             var._owner = owner
             var._type = type_
             var._annotations = annotations
+            var._constant_value = constant_value
             return var
 
         elif isinstance(java_type, JT.GenericTypeVariable):

--- a/rewrite-python/rewrite/src/rewrite/rpc/python_sender.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_sender.py
@@ -890,11 +890,12 @@ class PythonRpcSender:
             q.get_and_send_list_as_ref(java_type, lambda x: x._annotations or [], self._type_signature, lambda t: self._visit_type(t, q))
 
         elif isinstance(java_type, JT.Variable):
-            # Variable: name, owner, type, annotations (no flags over RPC)
+            # Variable: name, owner, type, annotations, constantValue (no flags over RPC)
             q.get_and_send(java_type, lambda x: x._name)
             q.get_and_send_as_ref(java_type, lambda x: x._owner, lambda t: self._visit_type(t, q))
             q.get_and_send_as_ref(java_type, lambda x: x._type, lambda t: self._visit_type(t, q))
             q.get_and_send_list_as_ref(java_type, lambda x: x._annotations or [], self._type_signature, lambda t: self._visit_type(t, q))
+            q.get_and_send(java_type, lambda x: x._constant_value)
 
         elif isinstance(java_type, JT.GenericTypeVariable):
             # GenericTypeVariable: name, variance, bounds


### PR DESCRIPTION
## Summary

- Adds a `@Nullable Object constantValue` field to `JavaType.Variable` to store compile-time constant values (primitives and `String`)
- Populates the value from `VarSymbol.getConstValue()` in all Java parser variants (8, 11, 17, 21, 25)
- Populates from `Field.get(null)` in the reflection type mapping path
- Populates from Roslyn's `IFieldSymbol.ConstantValue` in the C# type mapping
- Updates RPC sender/receiver across all languages (Java, Python, TypeScript, C#)
- Passes `null` for Groovy and Kotlin type mappings (no constant extraction yet)

## Motivation

This enriches the type model to enable future constant propagation in recipes like `SemanticallyEqual`, where comparing `Constants.TIMEOUT` (with value `30`) against a literal `30` should be recognized as semantically equal.

## Scope

Only JVM `ConstantValue`-eligible types: `boolean`, `byte`, `short`, `char`, `int`, `long`, `float`, `double`, and `String`. Does not cover enum constants, class literals, or non-compile-time-constant expressions.

## Test plan

- [ ] `constantValueOnStaticFinalFields` — verifies constant values from source parsing (int, long, String, boolean, double) and null for non-constants
- [ ] `constantValueFromClasspath` — verifies `Integer.MAX_VALUE` is resolved via the TypeTable/classpath path
- [ ] Full `rewrite-java-17` test suite passes with no regressions
- [ ] Cross-language RPC tests (Python, JS, C#) should be validated in CI