### PR TITLE
C#: Allow `Capture` objects as `MatchResult` keys

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Capture.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Capture.cs
@@ -33,13 +33,22 @@ internal enum CaptureKind
 }
 
 /// <summary>
+/// Non-generic interface for captures, providing access to the capture name
+/// without requiring knowledge of the captured type.
+/// </summary>
+public interface ICapture
+{
+    string Name { get; }
+}
+
+/// <summary>
 /// A named placeholder for pattern matching and template substitution.
 /// When used in an interpolated string passed to <see cref="CSharpTemplate.Create"/>
 /// or <see cref="CSharpPattern.Create"/>, the <see cref="TemplateStringHandler"/>
 /// intercepts it and registers the capture automatically.
 /// </summary>
 /// <typeparam name="T">The type of AST node this capture matches.</typeparam>
-public sealed class Capture<T> where T : J
+public sealed class Capture<T> : ICapture where T : J
 {
     public string Name { get; }
     public bool IsVariadic { get; }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/MatchResult.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/MatchResult.cs
@@ -53,6 +53,31 @@ public sealed class MatchResult
     }
 
     /// <summary>
+    /// Create a <see cref="MatchResult"/> from <see cref="ICapture"/> keys.
+    /// This allows using unnamed captures (with auto-generated names) as keys,
+    /// avoiding the need to manually synchronize string names between template
+    /// creation and value binding.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var left = Capture.Expression();
+    /// var right = Capture.Expression();
+    /// var template = CSharpTemplate.Expression($"{left} &amp;&amp; {right}");
+    /// var values = MatchResult.Of((left, outerCond), (right, innerCond));
+    /// var result = template.Apply(cursor, values: values);
+    /// </code>
+    /// </example>
+    public static MatchResult Of(params (ICapture capture, J value)[] captures)
+    {
+        var dict = new Dictionary<string, object>(captures.Length);
+        foreach (var (capture, value) in captures)
+        {
+            dict[capture.Name] = value;
+        }
+        return new MatchResult(dict);
+    }
+
+    /// <summary>
     /// Get a captured value by name.
     /// </summary>
     public T? Get<T>(string name) where T : class, J
@@ -62,6 +87,13 @@ public sealed class MatchResult
     /// Get a captured value by its <see cref="Capture{T}"/> object.
     /// </summary>
     public T? Get<T>(Capture<T> capture) where T : class, J
+        => Get<T>(capture.Name);
+
+    /// <summary>
+    /// Get a captured value by its <see cref="ICapture"/> object.
+    /// Useful when the capture's type parameter doesn't match the desired return type.
+    /// </summary>
+    public T? Get<T>(ICapture capture) where T : class, J
         => Get<T>(capture.Name);
 
     /// <summary>
@@ -83,6 +115,11 @@ public sealed class MatchResult
     /// Check if a capture with the given name was bound.
     /// </summary>
     public bool Has(string name) => _captures.ContainsKey(name);
+
+    /// <summary>
+    /// Check if a capture was bound.
+    /// </summary>
+    public bool Has(ICapture capture) => _captures.ContainsKey(capture.Name);
 
     internal Dictionary<string, object> AsDict() => _captures;
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/ScaffoldStrategyTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/ScaffoldStrategyTests.cs
@@ -236,6 +236,22 @@ public class ScaffoldStrategyTests
         Assert.Equal(42, lit!.Value);
     }
 
+    [Fact]
+    public void MatchResultOfWithUnnamedCaptures()
+    {
+        var x = Capture.Expression();
+        var y = Capture.Expression();
+        var lit1 = new Literal(Guid.NewGuid(), Space.Empty, Markers.Empty, 1, "1", null, null);
+        var lit2 = new Literal(Guid.NewGuid(), Space.Empty, Markers.Empty, 2, "2", null, null);
+
+        var values = MatchResult.Of((x, lit1), (y, lit2));
+
+        Assert.True(values.Has(x));
+        Assert.True(values.Has(y));
+        Assert.Equal(1, values.Get<Literal>(x)!.Value);
+        Assert.Equal(2, values.Get<Literal>(y)!.Value);
+    }
+
     // === Cache isolation ===
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add `ICapture` interface with a `Name` property, implemented by `Capture<T>`
- Add `MatchResult.Of(params (ICapture, J)[])` overload so capture objects can be used as keys instead of strings
- Add `Get<T>(ICapture)` and `Has(ICapture)` overloads for retrieval
- This enables working with unnamed captures (auto-generated names) without manually keeping string keys in sync between template creation and value binding

### Before

```csharp
var left = Capture.Expression("left");
var right = Capture.Expression("right");
var template = CSharpTemplate.Expression($"{left} && {right}");
// ...
var combined = SetPrefix((Expression)template.Apply(
    Cursor, values: MatchResult.Of(
        ("left", (J)outerCond),
        ("right", (J)innerCond)))!, Space.Empty);
```

### After

```csharp
var left = Capture.Expression();
var right = Capture.Expression();
var template = CSharpTemplate.Expression($"{left} && {right}");
// ...
var combined = SetPrefix((Expression)template.Apply(
    Cursor, values: MatchResult.Of(
        (left, (J)outerCond),
        (right, (J)innerCond)))!, Space.Empty);
```

No more stringly-typed keys to keep in sync between template creation and value binding.

## Test plan
- [x] Existing `MatchResultOfCreatesManualBindings` test still passes (string-based API unchanged)
- [x] New `MatchResultOfWithUnnamedCaptures` test verifies capture-keyed API with auto-named captures