### PR TITLE
C#: Add extension method flag to type model

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
@@ -351,6 +351,8 @@ internal class CSharpTypeMapping
         if (symbol.IsStatic) flags |= 8;     // Flag.Static
         if (symbol.IsAbstract) flags |= 1024; // Flag.Abstract
         if (symbol.IsSealed) flags |= 16;     // Flag.Final (sealed ~ final)
+        // C#-specific: mark extension methods (bit 20, not used by Java Flag enum)
+        if (symbol is IMethodSymbol { IsExtensionMethod: true }) flags |= 1L << 20;
         return flags;
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -1296,6 +1296,10 @@ public interface JavaType {
     @Getter
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     class Method implements JavaType {
+        // C#-specific: marks extension methods (bit 20, not used by Java Flag enum)
+        private static final long EXTENSION_METHOD_FLAG = 1L << 20;
+        private static final long VALID_METHOD_FLAGS = Flag.VALID_FLAGS | EXTENSION_METHOD_FLAG;
+
         @With
         @Nullable
         @NonFinal
@@ -1387,7 +1391,7 @@ public interface JavaType {
                       FullyQualified @Nullable [] annotations, @Nullable List<String> defaultValue,
                       String @Nullable [] declaredFormalTypeNames) {
             this.managedReference = managedReference;
-            this.flagsBitMap = flagsBitMap & Flag.VALID_FLAGS;
+            this.flagsBitMap = flagsBitMap & VALID_METHOD_FLAGS;
             this.declaringType = unknownIfNull(declaringType);
             this.name = name;
             this.returnType = unknownIfNull(returnType);
@@ -1634,6 +1638,13 @@ public interface JavaType {
 
         public Method withFlags(Set<Flag> flags) {
             return withFlagsBitMap(Flag.flagsToBitMap(flags));
+        }
+
+        /**
+         * @return {@code true} if this method is a C# extension method.
+         */
+        public boolean isExtensionMethod() {
+            return (flagsBitMap & EXTENSION_METHOD_FLAG) != 0;
         }
 
         @Override


### PR DESCRIPTION
## Summary
- Sets bit 20 in `CSharpTypeMapping.MapFlags` when `IMethodSymbol.IsExtensionMethod` is true (bit 20 is unused by both the JVM spec and Java's `Flag` enum)
- Widens `JavaType.Method`'s constructor flag mask to preserve bit 20 across RPC round-trips
- Adds `JavaType.Method.isExtensionMethod()` so recipes can detect C# extension methods without knowing the raw bit position

## Test plan
- [ ] Existing tests pass (no behavior change for Java — bit 20 was previously unused)
- [ ] Consumer tests in `recipes-csharp` on branch `noble-lemur` (`CallExtensionMethodAsInstanceTest`) should pass once this is published