### PR TITLE
C#: Fix parsing of nullable type constraints

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -7443,8 +7443,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         {
             case TypeConstraintSyntax typeConstraint:
             {
-                // TypeTree types (Identifier, ParameterizedType, etc.) implement Expression
-                return (Expression)Visit(typeConstraint.Type)!;
+                // Use VisitType instead of Visit to handle types like NullableTypeSyntax
+                // that don't have a dedicated Roslyn visitor override
+                return (Expression)VisitType(typeConstraint.Type)!;
             }
 
             case ClassOrStructConstraintSyntax classOrStruct:

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/ClassDeclarationTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/ClassDeclarationTests.cs
@@ -1561,4 +1561,48 @@ public class ClassDeclarationTests : RewriteTest
             )
         );
     }
+
+    [Fact]
+    public void ConstraintNullableInterfaceType()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                interface IComparable<T> { }
+                class Foo<T> where T : IComparable<T>? { }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void ConstraintNullableInterfaceTypeOnMethod()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                using System;
+                class Foo
+                {
+                    void Bar<T>(T input, T rangeFrom, T rangeTo) where T : IComparable<T>?
+                    {
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void ConstraintStructAndNullableInterface()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                using System;
+                class Foo<T> where T : struct, IComparable<T>? { }
+                """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Fix `NullReferenceException` when parsing nullable type constraints like `where T : IComparable<T>?`
- `ParseConstraintExpression` used `Visit()` (Roslyn's visitor dispatch) which returned null for `NullableTypeSyntax` since there's no dedicated override — switched to `VisitType()` which handles it
- Discovered via build failure on [ardalis/GuardClauses](https://github.com/ardalis/GuardClauses) where `NullOrOutOfRangeInternal<T>` has `where T : IComparable<T>?`

## Test plan

- [x] Added 3 xUnit parser round-trip tests for nullable type constraints (class-level, method-level, combined with `struct`)
- [x] All 130 `ClassDeclarationTests` pass
- [x] All 21 constraint-specific tests pass