### PR TITLE
C#: Add `JavaType.ShallowClass` to match Java-side type hierarchy

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/Java/JavaType.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/JavaType.cs
@@ -135,6 +135,52 @@ public abstract class JavaType
     }
 
     /// <summary>
+    /// A lightweight class type that only carries the fully qualified name, kind, flags,
+    /// and owning class. All other fields (type parameters, supertype, annotations,
+    /// interfaces, members, methods) are discarded.
+    /// Matches Java's JavaType.ShallowClass.
+    /// </summary>
+    public class ShallowClass : Class
+    {
+        public ShallowClass() { }
+
+        public ShallowClass(long flagsBitMap, FullyQualifiedKind classKind, string fullyQualifiedName,
+            FullyQualified? owningClass)
+            : base(flagsBitMap, classKind, fullyQualifiedName, null, null, owningClass, null, null, null, null)
+        {
+        }
+
+        public static ShallowClass Build(string fullyQualifiedName)
+        {
+            ShallowClass? owningClass = null;
+
+            int firstClassNameIndex = 0;
+            int lastDelimiter = 0;
+            char prev = ' ';
+            for (int i = 0; i < fullyQualifiedName.Length; i++)
+            {
+                char c = fullyQualifiedName[i];
+                if (firstClassNameIndex == 0 && (prev == '.' || prev == '$') && char.IsUpper(c))
+                {
+                    firstClassNameIndex = i;
+                }
+                else if (c == '.' || c == '$')
+                {
+                    lastDelimiter = i;
+                }
+                prev = c;
+            }
+
+            if (lastDelimiter > firstClassNameIndex)
+            {
+                owningClass = Build(fullyQualifiedName[..lastDelimiter]);
+            }
+
+            return new ShallowClass(1, FullyQualifiedKind.Class, fullyQualifiedName, owningClass);
+        }
+    }
+
+    /// <summary>
     /// A generic type instantiation (e.g., List&lt;int&gt;).
     /// </summary>
     public class Parameterized : FullyQualified


### PR DESCRIPTION
## Summary
- Adds `JavaType.ShallowClass` to the C# type model, extending `JavaType.Class` to match the Java-side `JavaType.ShallowClass`
- Includes the `Build(string fullyQualifiedName)` static factory that parses the FQN to determine the owning class, mirroring the Java implementation
- No sender/receiver changes needed — the existing `JavaType.Class` RPC handling covers `ShallowClass` via subclass matching, and the type name convention mapping already resolves `JavaType$ShallowClass` correctly

## Test plan
- [x] `dotnet build` succeeds
- [ ] Verify RPC round-trip with Java-side `ShallowClass` instances