### PR TITLE
C#: Preserve UTF-8 BOM flag in parser for correct patch generation

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -26,9 +26,12 @@ namespace OpenRewrite.CSharp;
 /// </summary>
 public class CSharpParser
 {
+    private bool _charsetBomMarked;
+
     public CompilationUnit Parse(string source, string sourcePath = "source.cs",
-        SemanticModel? semanticModel = null)
+        SemanticModel? semanticModel = null, bool charsetBomMarked = false)
     {
+        _charsetBomMarked = charsetBomMarked;
         var symbols = PreprocessorSourceTransformer.ExtractSymbols(source);
         if (symbols.Count == 0)
             return ParseSingle(source, sourcePath, semanticModel);
@@ -44,9 +47,10 @@ public class CSharpParser
     /// define DEBUG, the #else branch would be lost.
     /// </summary>
     public CompilationUnit ParseWithConfigurations(string source, string sourcePath,
-        SemanticModel? semanticModel, List<HashSet<string>> configSymbolSets)
+        SemanticModel? semanticModel, List<HashSet<string>> configSymbolSets,
+        bool charsetBomMarked = false)
     {
-        return Parse(source, sourcePath, semanticModel);
+        return Parse(source, sourcePath, semanticModel, charsetBomMarked);
     }
 
     private CompilationUnit ParseMultiWithSymbolSets(string source, string sourcePath,
@@ -123,7 +127,7 @@ public class CSharpParser
             Markers.Empty,
             primaryCu.SourcePath,
             "UTF-8",
-            false,
+            _charsetBomMarked,
             null,
             null,
             new List<JRightPadded<Statement>> { new(directive, Space.Empty, Markers.Empty) },
@@ -136,7 +140,7 @@ public class CSharpParser
         if (semanticModel != null)
         {
             var root = semanticModel.SyntaxTree.GetCompilationUnitRoot();
-            var visitor = new CSharpParserVisitor(source, semanticModel);
+            var visitor = new CSharpParserVisitor(source, semanticModel, _charsetBomMarked);
             var cu = visitor.VisitCompilationUnit(root);
             // Override source path since the semantic model's tree has the absolute path
             // from MSBuildWorkspace, but we want the relative path
@@ -148,7 +152,7 @@ public class CSharpParser
         {
             var syntaxTree = CSharpSyntaxTree.ParseText(source, path: sourcePath);
             var root = syntaxTree.GetCompilationUnitRoot();
-            var visitor = new CSharpParserVisitor(source);
+            var visitor = new CSharpParserVisitor(source, charsetBomMarked: _charsetBomMarked);
             return visitor.VisitCompilationUnit(root);
         }
     }
@@ -216,7 +220,7 @@ public class CSharpParser
             Markers.Empty,
             primaryCu.SourcePath,
             "UTF-8",
-            false,
+            _charsetBomMarked,
             null,
             null,
             new List<JRightPadded<Statement>> { new(directive, Space.Empty, Markers.Empty) },
@@ -234,6 +238,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
     private int _cursor;
     private readonly SemanticModel? _semanticModel;
     private readonly CSharpTypeMapping? _typeMapping;
+    private readonly bool _charsetBomMarked;
     private readonly Dictionary<string, Space> _spaceCache = new();
 
     /// <summary>
@@ -242,12 +247,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
     /// </summary>
     private Space _pendingSemicolonSpace = Space.Empty;
 
-    public CSharpParserVisitor(string source, SemanticModel? semanticModel = null)
+    public CSharpParserVisitor(string source, SemanticModel? semanticModel = null,
+        bool charsetBomMarked = false)
     {
         _source = source;
         _cursor = 0;
         _semanticModel = semanticModel;
         _typeMapping = semanticModel != null ? new CSharpTypeMapping(semanticModel) : null;
+        _charsetBomMarked = charsetBomMarked;
     }
 
     /// <summary>
@@ -381,7 +388,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             Markers.Empty,
             node.SyntaxTree.FilePath ?? "source.cs",
             "UTF-8",
-            false,
+            _charsetBomMarked,
             null,
             null,
             members,

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -277,6 +277,10 @@ public class SolutionParser
             // Normalize path separators to forward slashes for cross-platform consistency
             relativePath = relativePath.Replace('\\', '/');
 
+            // Detect UTF-8 BOM — Roslyn's SourceText.ToString() strips the BOM character,
+            // so we check the raw file bytes to preserve the flag for patch fidelity.
+            var charsetBomMarked = HasUtf8Bom(doc.FilePath!);
+
             var fileSw = Stopwatch.StartNew();
             try
             {
@@ -291,11 +295,12 @@ public class SolutionParser
                 CompilationUnit cu;
                 if (configSymbolSets.Count > 1)
                 {
-                    cu = _parser.ParseWithConfigurations(source, relativePath, semanticModel, configSymbolSets);
+                    cu = _parser.ParseWithConfigurations(source, relativePath, semanticModel, configSymbolSets,
+                        charsetBomMarked);
                 }
                 else
                 {
-                    cu = _parser.Parse(source, relativePath, semanticModel);
+                    cu = _parser.Parse(source, relativePath, semanticModel, charsetBomMarked);
                 }
 
                 if (requirePrintEqualsInput)
@@ -334,6 +339,24 @@ public class SolutionParser
         Log.Debug("ParseProject: {ProjectName} completed {ResultCount} files in {ElapsedSec}s",
             projectName, results.Count, projectSw.Elapsed.TotalSeconds.ToString("F1"));
         return results;
+    }
+
+    /// <summary>
+    /// Checks whether a file starts with a UTF-8 BOM (byte order mark: EF BB BF).
+    /// </summary>
+    private static bool HasUtf8Bom(string filePath)
+    {
+        try
+        {
+            using var stream = File.OpenRead(filePath);
+            Span<byte> buf = stackalloc byte[3];
+            return stream.Read(buf) == 3
+                   && buf[0] == 0xEF && buf[1] == 0xBB && buf[2] == 0xBF;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/SolutionParserTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/SolutionParserTests.cs
@@ -41,6 +41,14 @@ public class SolutionParserTests : IDisposable
         return fullPath;
     }
 
+    private string WriteFileWithBom(string relativePath, string content)
+    {
+        var fullPath = Path.Combine(_tempDir, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, content, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+        return fullPath;
+    }
+
     [Fact]
     public async Task ParseSimpleClass()
     {
@@ -113,6 +121,37 @@ public class SolutionParserTests : IDisposable
             Path.Combine(_tempDir, "Directives.csproj"), _tempDir);
 
         Assert.Single(results);
+    }
+
+    [Fact]
+    public async Task ParseFileWithBomPreservesCharsetBomMarked()
+    {
+        WriteFile("Bom.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+        WriteFileWithBom("WithBom.cs", "namespace Test { class WithBom { } }\n");
+        WriteFile("NoBom.cs", "namespace Test { class NoBom { } }\n");
+
+        var parser = new SolutionParser();
+        var solution = await parser.LoadAsync(Path.Combine(_tempDir, "Bom.csproj"));
+        var results = parser.ParseProject(solution,
+            Path.Combine(_tempDir, "Bom.csproj"), _tempDir);
+
+        Assert.Equal(2, results.Count);
+
+        var withBom = results.OfType<CompilationUnit>()
+            .Single(cu => cu.SourcePath.Contains("WithBom"));
+        var noBom = results.OfType<CompilationUnit>()
+            .Single(cu => cu.SourcePath.Contains("NoBom"));
+
+        Assert.True(withBom.CharsetBomMarked,
+            "File written with UTF-8 BOM should have CharsetBomMarked=true");
+        Assert.False(noBom.CharsetBomMarked,
+            "File written without BOM should have CharsetBomMarked=false");
     }
 
     [Fact]

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/WorkingSetRoundTripTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/WorkingSetRoundTripTests.cs
@@ -608,4 +608,40 @@ public class WorkingSetRoundTripTests
         s.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
 
     #endregion
+
+    #region BOM (Byte Order Mark) handling
+
+    [Fact]
+    public void CharsetBomMarked_SetFromParser()
+    {
+        var source = "class C { }\n";
+
+        var parser = new CSharpParser();
+        var cuWithBom = parser.Parse(source, "Test.cs", charsetBomMarked: true);
+        var cuWithoutBom = parser.Parse(source, "Test.cs", charsetBomMarked: false);
+
+        Assert.True(cuWithBom.CharsetBomMarked,
+            "Parser should propagate charsetBomMarked=true to CompilationUnit");
+        Assert.False(cuWithoutBom.CharsetBomMarked,
+            "Parser should propagate charsetBomMarked=false to CompilationUnit");
+
+        // Both should print identically (BOM is not part of the printed source)
+        var printer = new CSharpPrinter<int>();
+        Assert.Equal(source, printer.Print(cuWithBom));
+        Assert.Equal(source, printer.Print(cuWithoutBom));
+    }
+
+    [Fact]
+    public void CharsetBomMarked_PreservedWithPreprocessorDirectives()
+    {
+        var source = "#if DEBUG\nclass C { }\n#else\nclass C { }\n#endif\n";
+
+        var parser = new CSharpParser();
+        var cu = parser.Parse(source, "Test.cs", charsetBomMarked: true);
+
+        Assert.True(cu.CharsetBomMarked,
+            "charsetBomMarked should be preserved through preprocessor directive parsing");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
The C# parser hardcoded `charsetBomMarked = false` on all CompilationUnit instances. Roslyn's SourceText.ToString() strips the BOM character, so the parser had no way to detect it. This caused patches to omit the BOM from "before" content, leading to PatchApplyException ("hunk does not apply") when applied to files that have a BOM on disk.

The fix detects BOM by reading the first 3 bytes of each source file in SolutionParser and propagates the flag through CSharpParser and CSharpParserVisitor to the CompilationUnit constructor.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
