### PR TITLE
Fix FindEmptyMethods false positives for bodyless declarations

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindEmptyMethodsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindEmptyMethodsTest.java
@@ -174,6 +174,19 @@ class FindEmptyMethodsTest implements RewriteTest {
     }
 
     @Test
+    void annotationInterfaceMethods() {
+        rewriteRun(
+          java(
+            """
+              public @interface Requirement {
+                  String[] value();
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void interfaceMethods() {
         rewriteRun(
           java(

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindEmptyMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindEmptyMethods.java
@@ -24,7 +24,6 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.SearchResult;
@@ -80,21 +79,13 @@ public class FindEmptyMethods extends Recipe {
             }
 
             private boolean hasEmptyBody(J.MethodDeclaration method) {
-                return method.getBody() == null || method.getBody().getStatements().isEmpty() && method.getBody().getEnd().getComments().isEmpty();
+                return method.getBody() != null && method.getBody().getStatements().isEmpty() && method.getBody().getEnd().getComments().isEmpty();
             }
 
             private boolean isEmptyMethod(J.MethodDeclaration method) {
-                return !method.isConstructor() && !isInterfaceMethod(method) &&
+                return !method.isConstructor() &&
                        (matchOverrides == null || !matchOverrides && !TypeUtils.isOverride(method.getMethodType()) || matchOverrides) &&
                        hasEmptyBody(method);
-            }
-
-            private boolean isInterfaceMethod(J.MethodDeclaration method) {
-                //noinspection ConstantConditions
-                return method.getMethodType() != null &&
-                       method.getMethodType().getDeclaringType() != null &&
-                       method.getMethodType().getDeclaringType().getKind() == JavaType.FullyQualified.Kind.Interface &&
-                       !method.hasModifier(J.Modifier.Type.Default);
             }
 
             private boolean hasEmptySinglePublicNoArgsConstructor(List<Statement> classStatements) {


### PR DESCRIPTION
## Summary
- Fixes #7030 — `FindEmptyMethods` was flagging annotation interface element declarations (e.g. `String[] value()` in `@interface`) as empty methods
- Root cause: `hasEmptyBody()` treated `body == null` (bodyless by design) the same as an empty block `{}`
- Changed to require a non-null body, and removed the now-redundant `isInterfaceMethod()` check
- Added test for annotation interface methods

## Test plan
- [x] Existing `FindEmptyMethodsTest` tests pass
- [x] New `annotationInterfaceMethods` test verifies `@interface` elements are not flagged