### PR TITLE
ChangeType: visit annotations on package declarations

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -413,6 +413,26 @@ class ChangeTypeTest implements RewriteTest {
     }
 
     @Test
+    void fullyQualifiedAnnotationOnPackageDeclaration() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("a.b.c.A1", "a.b.d.A2", true)),
+          java("package a.b.c;\npublic @interface A1 {}"),
+          java("package a.b.d;\npublic @interface A2 {}"),
+          java(
+            """
+              @a.b.c.A1 package foo;
+              """,
+            """
+              @A2 package foo;
+
+              import a.b.d.A2;
+              """,
+            spec -> spec.path("foo/package-info.java")
+          )
+        );
+    }
+
+    @Test
     void array2() {
         rewriteRun(
           spec -> spec.recipe(new ChangeType("com.acme.product.Pojo", "com.acme.product.v2.Pojo", true)),

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -693,7 +693,7 @@ public class ChangeType extends Recipe {
                 }
             }
             //noinspection ConstantConditions
-            return pkg;
+            return super.visitPackage(pkg, ctx);
         }
 
         @Override


### PR DESCRIPTION
## Summary
- Call `super.visitPackage(pkg, ctx)` instead of returning `pkg` directly in `JavaChangeTypeVisitor.visitPackage()`, ensuring annotations on package declarations are properly visited during type changes
- Add test for `ChangeType` with a fully-qualified annotation on a package declaration in `package-info.java`

- Closes https://github.com/openrewrite/rewrite-migrate-java/issues/1018