### PR TITLE
Add support for Kotlin multi-dollar interpolation string

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -3132,7 +3132,16 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
     }
 
     private static String getString(KtStringTemplateExpression expression, StringBuilder valueSb) {
-        PsiElement openQuote = expression.getFirstChild();
+        PsiElement openQuote;
+        String prefix;
+        if (expression.getInterpolationPrefix() == null) {
+            openQuote = expression.getFirstChild();
+            prefix = "";
+        } else {
+            openQuote = expression.getFirstChild().getNextSibling();
+            prefix = expression.getInterpolationPrefix().getInterpolationPrefix();
+        }
+
         PsiElement closingQuota = expression.getLastChild();
         if (openQuote == null || closingQuota == null ||
             openQuote.getNode().getElementType() != KtTokens.OPEN_QUOTE ||
@@ -3140,7 +3149,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
             throw new UnsupportedOperationException("This should never happen");
         }
 
-        return openQuote.getText() + valueSb + closingQuota.getText();
+        return prefix + openQuote.getText() + valueSb + closingQuota.getText();
     }
 
     @Override

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinParserTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinParserTest.java
@@ -63,4 +63,15 @@ class KotlinParserTest implements RewriteTest {
         );
     }
 
+    @Test
+    void multiDollarStringInterpolation() {
+        rewriteRun(
+          kotlin(
+            """
+              val x = $$"$something"
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?
Add support for Kotlin [multi-dollar](https://kotlinlang.org/docs/strings.html#multi-dollar-string-interpolation) interpolation String.

## What's your motivation?
- fixes https://github.com/openrewrite/rewrite/issues/7089

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
