### PR TITLE
Remove productive usage of DataTable#withInstanceName

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/FindParseFailures.java
+++ b/rewrite-core/src/main/java/org/openrewrite/FindParseFailures.java
@@ -58,8 +58,7 @@ public class FindParseFailures extends Recipe {
     @Nullable
     String createdAfter;
 
-    transient ParseFailures failures = new ParseFailures(this)
-            .withInstanceName(this::dataTableInstanceName);
+    transient ParseFailures failures = new ParseFailures(this);
 
     private String dataTableInstanceName() {
         return parserType != null ? "Parse failures for " + parserType : "Parse failures";

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
@@ -51,8 +51,7 @@ public class FindDeprecatedMethods extends Recipe {
     @Nullable
     Boolean ignoreDeprecatedScopes;
 
-    transient MethodCalls deprecatedMethodCalls = new MethodCalls(this)
-            .withInstanceName(this::dataTableInstanceName);
+    transient MethodCalls deprecatedMethodCalls = new MethodCalls(this);
 
     private String dataTableInstanceName() {
         return methodPattern != null ? "Deprecated method calls matching `" + methodPattern + "`" : "Deprecated method calls";

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDistinctMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDistinctMethods.java
@@ -55,8 +55,7 @@ public class FindDistinctMethods extends ScanningRecipe<Map<String, UUID>> {
     @Nullable
     Boolean matchOverrides;
 
-    transient MethodCalls methodCalls = new MethodCalls(this)
-            .withInstanceName(this::dataTableInstanceName);
+    transient MethodCalls methodCalls = new MethodCalls(this);
 
     private String dataTableInstanceName() {
         return methodPattern != null ? "Distinct method calls matching `" + methodPattern + "`" : "Distinct method calls";

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
@@ -56,8 +56,7 @@ public class FindMethods extends Recipe {
     @Nullable
     Boolean matchOverrides;
 
-    transient MethodCalls methodCalls = new MethodCalls(this)
-            .withInstanceName(this::dataTableInstanceName);
+    transient MethodCalls methodCalls = new MethodCalls(this);
 
     private String dataTableInstanceName() {
         return "Method calls matching `" + methodPattern + "`";

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
@@ -49,8 +49,7 @@ public class FindTypes extends Recipe {
     @Nullable
     Boolean checkAssignability;
 
-    transient TypeUses typeUses = new TypeUses(this)
-            .withInstanceName(this::dataTableInstanceName);
+    transient TypeUses typeUses = new TypeUses(this);
 
     private String dataTableInstanceName() {
         return "Type uses of `" + fullyQualifiedTypeName + "`";


### PR DESCRIPTION
Rollback usage of `DataTable#withInstanceName` as identified by https://app.moderne.io/results/6rWorWXXP.

**Refactoring of data table helper initialization:**

* [`FindParseFailures.java`](diffhunk://#diff-92fbd997e56b1eff774097179a0ee375627d7d6554812a14dda469428661cf6eL61-R61): The `ParseFailures` instance is now created without the `.withInstanceName` call.
* [`FindDeprecatedMethods.java`](diffhunk://#diff-e2dc9e7e6d07f635b24d5d5b7bfc6155fe62da2c12461b7fe51035f2aaca9cc9L54-R54): The `MethodCalls` instance is now created without the `.withInstanceName` call.
* [`FindDistinctMethods.java`](diffhunk://#diff-77cddef4acd31b594bb7fa642b6d9e1ce48299a39ff29e6b493a131f5b0b4cc1L58-R58): The `MethodCalls` instance is now created without the `.withInstanceName` call.
* [`FindMethods.java`](diffhunk://#diff-5311fa88b0a3464c07815702d1c08f9289bfc77125b6d4bf949b757fd80b2a32L59-R59): The `MethodCalls` instance is now created without the `.withInstanceName` call.
* [`FindTypes.java`](diffhunk://#diff-a6585a724018ee5ee9a0fd138b58c10eacf1e17eca9918817018fbd71af58b0bL52-R52): The `TypeUses` instance is now created without the `.withInstanceName` call.