### PR TITLE
Don't append display name suffix to data table file keys

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/CsvDataTableStore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/CsvDataTableStore.java
@@ -242,11 +242,19 @@ public class CsvDataTableStore implements DataTableStore, AutoCloseable {
      */
     public static String fileKey(DataTable<?> dataTable) {
         String group = dataTable.getGroup();
-        String suffix = group != null ? group : dataTable.getInstanceName();
-        if (suffix.equals(dataTable.getName())) {
+        if (group != null) {
+            if (group.equals(dataTable.getName())) {
+                return dataTable.getName();
+            }
+            return dataTable.getName() + "--" + sanitize(group);
+        }
+        // Only add a suffix when the instance name was explicitly customized
+        // (i.e. differs from the default display name)
+        String instanceName = dataTable.getInstanceName();
+        if (instanceName.equals(dataTable.getDisplayName())) {
             return dataTable.getName();
         }
-        return dataTable.getName() + "--" + sanitize(suffix);
+        return dataTable.getName() + "--" + sanitize(instanceName);
     }
 
     /**

--- a/rewrite-core/src/test/java/org/openrewrite/DataTableStoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/DataTableStoreTest.java
@@ -247,6 +247,31 @@ class DataTableStoreTest {
     }
 
     // =========================================================================
+    // CsvDataTableStore.fileKey
+    // =========================================================================
+
+    @Test
+    void fileKeyNoSuffixWhenInstanceNameNotCustomized() {
+        TestTable table = new TestTable(Recipe.noop());
+        assertThat(CsvDataTableStore.fileKey(table)).isEqualTo(TestTable.class.getName());
+    }
+
+    @Test
+    void fileKeySuffixWhenInstanceNameCustomized() {
+        TestTable table = new TestTable(Recipe.noop())
+                .withInstanceName(() -> "custom instance");
+        String key = CsvDataTableStore.fileKey(table);
+        assertThat(key).startsWith(TestTable.class.getName() + "--");
+    }
+
+    @Test
+    void fileKeySuffixFromGroup() {
+        TestTable table = new TestTable(Recipe.noop()).withGroup("my-group");
+        String key = CsvDataTableStore.fileKey(table);
+        assertThat(key).startsWith(TestTable.class.getName() + "--");
+    }
+
+    // =========================================================================
     // CsvDataTableStore.sanitize
     // =========================================================================
 


### PR DESCRIPTION
## Summary

- `CsvDataTableStore.fileKey()` was always appending a sanitized suffix from the data table's display name (e.g. `RecipeRunStats--recipe-performance-c5de`), even when no custom instance name was set and no disambiguation was needed.
- Now only adds a suffix when the instance name was explicitly customized via `withInstanceName()`, or when a group is set. Plain data tables get a clean key like `org.openrewrite.table.RecipeRunStats`.

## Test plan

- [x] Added `fileKeyNoSuffixWhenInstanceNameNotCustomized` — verifies bare name when no customization
- [x] Added `fileKeySuffixWhenInstanceNameCustomized` — verifies suffix present with `withInstanceName()`
- [x] Added `fileKeySuffixFromGroup` — verifies suffix present with `withGroup()`
- [x] All existing `DataTableStoreTest` tests pass