### PR TITLE
C#: Fix indentation of flattened multi-statement template blocks

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/RewriteRule.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/RewriteRule.cs
@@ -248,23 +248,30 @@ public static class RewriteRule
         new RecipeRuleAdapter(recipe, ctx);
 
     /// <summary>
-    /// Creates a visitor that splices the statements of <paramref name="block"/> into its
-    /// parent block. Use when a multi-statement <see cref="CSharpTemplate.Statement"/> produces
-    /// a <see cref="Block"/> that should replace a single statement — the flattener runs as an
-    /// after-visitor and inlines the block's statements into the enclosing block.
+    /// Creates a visitor that splices statements from any <see cref="Block"/> marked with
+    /// <see cref="SyntheticBlockContainer"/> into its parent block. Register once via
+    /// <see cref="TreeVisitor{T,P}.DoAfterVisit"/> — a single instance handles all
+    /// synthetic blocks produced during the visit.
     /// </summary>
     /// <example>
     /// <code>
     /// var result = rule.TryOn(Cursor, ret);
-    /// if (result is Block block)
+    /// if (result is Block block &amp;&amp; block.Markers.FindFirst&lt;SyntheticBlockContainer&gt;() != null)
     /// {
-    ///     DoAfterVisit(RewriteRule.CreateBlockFlattener&lt;ExecutionContext&gt;(block));
+    ///     MaybeDoAfterVisit(RewriteRule.CreateBlockFlattener&lt;ExecutionContext&gt;());
     ///     return block;
     /// }
     /// return result ?? ret;
     /// </code>
     /// </example>
-    public static CSharpVisitor<P> CreateBlockFlattener<P>(Block block) => new BlockFlattener<P>(block);
+    public static CSharpVisitor<P> CreateBlockFlattener<P>() => new BlockFlattener<P>();
+
+    /// <summary>
+    /// Overload accepting a block for backwards compatibility. The block parameter is ignored;
+    /// the flattener identifies targets by the <see cref="SyntheticBlockContainer"/> marker.
+    /// </summary>
+    [Obsolete("Use the parameterless overload. The block parameter is no longer needed.")]
+    public static CSharpVisitor<P> CreateBlockFlattener<P>(Block block) => new BlockFlattener<P>();
 
     // ===============================================================
     // Implementation
@@ -352,8 +359,11 @@ public static class RewriteRule
         }
     }
 
-    private sealed class BlockFlattener<P>(Block target) : CSharpVisitor<P>
+    private sealed class BlockFlattener<P> : CSharpVisitor<P>, IEquatable<BlockFlattener<P>>
     {
+        public bool Equals(BlockFlattener<P>? other) => other is not null;
+        public override bool Equals(object? obj) => obj is BlockFlattener<P>;
+        public override int GetHashCode() => typeof(BlockFlattener<P>).GetHashCode();
         public override J VisitBlock(Block block, P ctx)
         {
             block = (Block)base.VisitBlock(block, ctx);
@@ -365,7 +375,7 @@ public static class RewriteRule
             foreach (var stmt in statements)
             {
                 if (stmt.Element is Block inner &&
-                    (ReferenceEquals(inner, target) || inner.Id == target.Id))
+                    inner.Markers.FindFirst<SyntheticBlockContainer>() != null)
                 {
                     // Splice inner block's statements into the parent.
                     // An empty inner block is intentionally dropped — flattening a block
@@ -375,7 +385,11 @@ public static class RewriteRule
                     {
                         var s = innerStmts[i];
                         if (i == 0)
-                            s = s.WithElement(J.SetPrefix(s.Element, stmt.Element.Prefix));
+                        {
+                            // Transfer the original statement's prefix (comments, blank lines)
+                            // to the first spliced statement.
+                            s = s.WithElement(SetStatementPrefix(s.Element, stmt.Element.Prefix));
+                        }
                         newStatements.Add(s);
                     }
                     changed = true;
@@ -387,6 +401,17 @@ public static class RewriteRule
             }
 
             return changed ? block.WithStatements(newStatements) : block;
+        }
+
+        /// <summary>
+        /// Sets the prefix on a statement, handling <see cref="ExpressionStatement"/> which
+        /// delegates its prefix to its inner expression and has no <c>WithPrefix</c> method.
+        /// </summary>
+        private static Statement SetStatementPrefix(Statement stmt, Space prefix)
+        {
+            if (stmt is ExpressionStatement es)
+                return es.WithExpression(J.SetPrefix(es.Expression, prefix));
+            return (Statement)J.SetPrefix(stmt, prefix);
         }
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
@@ -21,6 +21,18 @@ using OpenRewrite.Java;
 namespace OpenRewrite.CSharp.Template;
 
 /// <summary>
+/// Marker placed on a <see cref="Block"/> that is a synthetic container for multiple statements
+/// produced by a multi-statement template, rather than a real block in the source code.
+/// Used by <see cref="TemplateEngine.AutoFormat"/> to format each statement at the parent level,
+/// and by <see cref="RewriteRule.CreateBlockFlattener{P}"/> to identify blocks to splice.
+/// </summary>
+public sealed class SyntheticBlockContainer : Marker
+{
+    public static readonly SyntheticBlockContainer Instance = new();
+    public Guid Id { get; } = Guid.NewGuid();
+}
+
+/// <summary>
 /// Controls how template code is wrapped in a scaffold and how the target node is extracted.
 /// </summary>
 internal enum ScaffoldKind
@@ -296,7 +308,8 @@ internal static class TemplateEngine
         }
 
         // Multiple statements: return them as a Block
-        return methodDecl.Body;
+        return methodDecl.Body.WithMarkers(
+            methodDecl.Body.Markers.Add(SyntheticBlockContainer.Instance));
     }
 
     /// <summary>
@@ -316,7 +329,8 @@ internal static class TemplateEngine
         if (statements.Count == 1)
             return StripPrefix(statements[0].Element);
 
-        return methodDecl.Body;
+        return methodDecl.Body.WithMarkers(
+            methodDecl.Body.Markers.Add(SyntheticBlockContainer.Instance));
     }
 
     /// <summary>
@@ -516,6 +530,17 @@ internal static class TemplateEngine
         if (original == null)
             return tree;
 
+        // Synthetic block containers hold multiple statements that will be spliced
+        // into the parent block. Format each statement individually at the parent level
+        // so Roslyn sees them as direct siblings, not block-internal children.
+        if (tree is Block blk && blk.Markers.FindFirst<SyntheticBlockContainer>() != null)
+            return AutoFormatSyntheticBlock(blk, cu, original);
+
+        return AutoFormatSingle(tree, cu, original);
+    }
+
+    private static J AutoFormatSingle(J tree, CompilationUnit cu, J original)
+    {
         // Save the prefix set by ApplyCoordinates — the formatter may override it
         var preservedPrefix = tree.Prefix;
 
@@ -528,6 +553,26 @@ internal static class TemplateEngine
         // Restore the coordinate-set prefix. The formatter handles internal whitespace;
         // the prefix (indentation/newlines before the node) comes from the original tree.
         return J.SetPrefix(formatted, preservedPrefix);
+    }
+
+    /// <summary>
+    /// Format each statement in a synthetic block individually, splicing each one
+    /// into the original node's position so Roslyn formats it at the parent level.
+    /// </summary>
+    private static Block AutoFormatSyntheticBlock(Block blk, CompilationUnit cu, J original)
+    {
+        var preservedBlockPrefix = blk.Prefix;
+        var formattedStmts = new List<JRightPadded<Statement>>(blk.Statements.Count);
+
+        foreach (var s in blk.Statements)
+        {
+            var stmt = (J)s.Element;
+            stmt = J.SetId(stmt, Guid.NewGuid());
+            var formatted = RoslynFormatter.FormatSubtree(cu, original.Id, stmt, stopAfter: null);
+            formattedStmts.Add(s.WithElement((Statement)formatted));
+        }
+
+        return blk.WithStatements(formattedStmts).WithPrefix(preservedBlockPrefix);
     }
 
     private static string BuildCacheKey(string code, IReadOnlyList<string> preamble,

--- a/rewrite-csharp/csharp/OpenRewrite/Core/TreeVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/TreeVisitor.cs
@@ -130,6 +130,19 @@ public class TreeVisitor<T, P> : ITreeVisitor<P> where T : class, Tree
         _afterVisit.Add(visitor);
     }
 
+    protected IReadOnlyList<TreeVisitor<T, P>> GetAfterVisit() =>
+        _afterVisit ?? (IReadOnlyList<TreeVisitor<T, P>>)[];
+
+    /// <summary>
+    /// Register an after-visitor only if an equal instance is not already registered.
+    /// Requires the visitor to implement proper equality (e.g., <see cref="IEquatable{T}"/>).
+    /// </summary>
+    protected void MaybeDoAfterVisit(TreeVisitor<T, P> visitor)
+    {
+        if (_afterVisit == null || !_afterVisit.Contains(visitor))
+            DoAfterVisit(visitor);
+    }
+
     public static TreeVisitor<T, P> Noop() => new NoopVisitor();
 
     private class NoopVisitor : TreeVisitor<T, P>

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/RewriteRuleTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/RewriteRuleTests.cs
@@ -348,8 +348,8 @@ public class RewriteRuleTests : RewriteTest
                 {
                     int M()
                     {
-                            Console.WriteLine(42);
-                            return 42;
+                        Console.WriteLine(42);
+                        return 42;
                     }
                 }
                 """
@@ -583,9 +583,10 @@ class LogBeforeReturnRecipe : Core.Recipe
         {
             ret = (Return)base.VisitReturn(ret, ctx);
             var result = rule.TryOn(Cursor, ret);
-            if (result is Block block)
+            if (result is Block { Markers: var m } block &&
+                m.FindFirst<SyntheticBlockContainer>() != null)
             {
-                DoAfterVisit(RewriteRule.CreateBlockFlattener<ExecutionContext>(block));
+                MaybeDoAfterVisit(RewriteRule.CreateBlockFlattener<ExecutionContext>());
                 return block;
             }
             return result ?? ret;


### PR DESCRIPTION
## Motivation

When `CSharpTemplate.Statement()` produces a `Block` with multiple statements (e.g., expanding `return 42;` into `Console.WriteLine(42); return 42;`), the auto-formatter formats them relative to the block's nesting context — one indent level too deep. After `BlockFlattener` splices those statements into the parent block, the extra indentation remains.

## Examples

Before (incorrect):
```csharp
class C
{
    int M()
    {
            Console.WriteLine(42);  // extra indent
            return 42;              // extra indent
    }
}
```

After (correct):
```csharp
class C
{
    int M()
    {
        Console.WriteLine(42);
        return 42;
    }
}
```

## Summary

- Introduce `SyntheticBlockContainer` marker to flag blocks that are temporary multi-statement containers, not real blocks in source
- `AutoFormat` detects the marker and formats each statement individually at the parent level, so Roslyn assigns correct indentation from the start
- `BlockFlattener` identifies targets by marker instead of by ID, so a single instance handles all synthetic blocks in one pass
- Add `MaybeDoAfterVisit` on `TreeVisitor` to prevent duplicate after-visitor registration (mirrors the Java `getAfterVisit().contains()` pattern)
- Add `GetAfterVisit()` to expose registered after-visitors for inspection

## Test plan

- [x] Updated `FlattenBlockSplicesStatementsIntoParent` expected output to require correct indentation
- [x] All 192 template tests pass
- [x] All 12 RewriteRule tests pass