### PR TITLE
C#: Add non-capturing support to pattern matching captures

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Capture.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Capture.cs
@@ -39,6 +39,7 @@ internal enum CaptureKind
 public interface ICapture
 {
     string Name { get; }
+    bool IsCapturing { get; }
 }
 
 /// <summary>
@@ -51,6 +52,7 @@ public interface ICapture
 public sealed class Capture<T> : ICapture where T : J
 {
     public string Name { get; }
+    public bool IsCapturing { get; }
     public bool IsVariadic { get; }
     public int? MinCount { get; }
     public int? MaxCount { get; }
@@ -62,9 +64,11 @@ public sealed class Capture<T> : ICapture where T : J
         int? minCount = null, int? maxCount = null,
         string? type = null,
         CaptureKind kind = CaptureKind.Expression,
-        Func<T, Cursor, bool>? constraint = null)
+        Func<T, Cursor, bool>? constraint = null,
+        bool capturing = true)
     {
         Name = name;
+        IsCapturing = capturing;
         IsVariadic = variadic;
         MinCount = minCount;
         MaxCount = maxCount;
@@ -98,49 +102,69 @@ public static class Capture
     /// <see cref="Name"/>) when the capture position is known. Use <c>Of</c> as a generic
     /// fallback for AST node types that don't have a dedicated factory.
     /// </para>
+    /// <para>
+    /// When <paramref name="capturing"/> is <c>false</c>, the placeholder matches
+    /// structurally but the matched value is not stored in the result bindings.
+    /// Useful for "don't care" positions in patterns.
+    /// </para>
     /// </summary>
-    public static Capture<T> Of<T>(string? name = null, string? type = null) where T : J
-        => new(name ?? $"_capture_{Interlocked.Increment(ref _counter)}", type: type);
+    public static Capture<T> Of<T>(string? name = null, string? type = null,
+        bool capturing = true) where T : J
+        => new(name ?? AutoName(capturing), type: type, capturing: capturing);
 
     /// <summary>
     /// Create a capture for an expression-position node.
     /// When <paramref name="type"/> is specified, the template engine generates a typed
     /// field declaration in the scaffold preamble for type attribution.
     /// </summary>
-    public static Capture<Expression> Expression(string? name = null, string? type = null)
-        => new(name ?? $"_capture_{Interlocked.Increment(ref _counter)}",
-            type: type, kind: CaptureKind.Expression);
+    public static Capture<Expression> Expression(string? name = null, string? type = null,
+        Func<Expression, Cursor, bool>? constraint = null,
+        bool capturing = true)
+        => new(name ?? AutoName(capturing),
+            type: type, kind: CaptureKind.Expression,
+            constraint: constraint, capturing: capturing);
 
     /// <summary>
     /// Create a variadic capture that matches zero or more elements.
     /// Useful for matching argument lists, statement sequences, etc.
     /// </summary>
     public static Capture<T> Variadic<T>(string? name = null,
-        int? min = null, int? max = null) where T : J
-        => new(name ?? $"_capture_{Interlocked.Increment(ref _counter)}",
-            variadic: true, minCount: min, maxCount: max);
+        int? min = null, int? max = null,
+        Func<T, Cursor, bool>? constraint = null,
+        bool capturing = true) where T : J
+        => new(name ?? AutoName(capturing),
+            variadic: true, minCount: min, maxCount: max,
+            constraint: constraint, capturing: capturing);
 
     /// <summary>
     /// Create a capture for a type-position node (e.g., base type, generic argument, variable type).
     /// The template engine will use an appropriate scaffold strategy so Roslyn parses
     /// the placeholder in a type context.
     /// </summary>
-    public static Capture<NameTree> Type(string? name = null)
-        => new(name ?? $"_capture_{Interlocked.Increment(ref _counter)}",
-            kind: CaptureKind.Type);
+    public static Capture<NameTree> Type(string? name = null,
+        bool capturing = true)
+        => new(name ?? AutoName(capturing),
+            kind: CaptureKind.Type, capturing: capturing);
 
     /// <summary>
     /// Create a capture for a name/identifier-position node.
     /// No preamble declaration is needed; the placeholder is substituted directly.
     /// </summary>
-    public static Capture<Identifier> Name(string? name = null)
-        => new(name ?? $"_capture_{Interlocked.Increment(ref _counter)}",
-            kind: CaptureKind.Name);
+    public static Capture<Identifier> Name(string? name = null,
+        bool capturing = true)
+        => new(name ?? AutoName(capturing),
+            kind: CaptureKind.Name, capturing: capturing);
 
     /// <summary>
     /// Create a capture with a constraint predicate that must be satisfied for matching.
     /// </summary>
     public static Capture<T> WithConstraint<T>(string name,
-        Func<T, Cursor, bool> constraint) where T : J
-        => new(name, constraint: constraint);
+        Func<T, Cursor, bool> constraint,
+        bool capturing = true) where T : J
+        => new(name, constraint: constraint, capturing: capturing);
+
+    private static string AutoName(bool capturing) =>
+        capturing
+            ? $"_capture_{Interlocked.Increment(ref _counter)}"
+            : $"_anon_{Interlocked.Increment(ref _counter)}";
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
@@ -43,7 +43,21 @@ internal class PatternMatchingComparator
     public Dictionary<string, object>? Match(J pattern, J candidate, Cursor cursor)
     {
         _bindings.Clear();
-        return MatchNode(pattern, candidate, cursor) ? new Dictionary<string, object>(_bindings) : null;
+        if (!MatchNode(pattern, candidate, cursor))
+            return null;
+
+        // Filter out non-capturing bindings before returning.
+        // Non-capturing captures are stored during matching (for consistency checking
+        // when the same placeholder appears in multiple positions) but should not
+        // be visible to the caller.
+        var result = new Dictionary<string, object>(_bindings.Count);
+        foreach (var kvp in _bindings)
+        {
+            if (_captures.TryGetValue(kvp.Key, out var captureObj) && !IsCapturing(captureObj))
+                continue;
+            result[kvp.Key] = kvp.Value;
+        }
+        return result;
     }
 
     private bool MatchNode(J pattern, J candidate, Cursor cursor)
@@ -52,9 +66,15 @@ internal class PatternMatchingComparator
         if (pattern is Identifier patternId)
         {
             var captureName = Placeholder.FromPlaceholder(patternId.SimpleName);
-            if (captureName != null && _captures.ContainsKey(captureName))
+            if (captureName != null && _captures.TryGetValue(captureName, out var captureObj))
             {
-                // This is a capture placeholder — bind the candidate
+                // Evaluate constraint if present
+                if (!EvaluateConstraint(captureObj, candidate, cursor))
+                    return false;
+
+                // This is a capture placeholder — bind the candidate.
+                // Always store (even for non-capturing) so consistency checking works
+                // when the same placeholder appears in multiple positions.
                 if (_bindings.TryGetValue(captureName, out var existing))
                 {
                     // Already bound — check consistency
@@ -406,12 +426,22 @@ internal class PatternMatchingComparator
                 for (var consume = maxPossible; consume >= min; consume--)
                 {
                     var captured = new List<object>();
+                    var constraintFailed = false;
                     for (var k = 0; k < consume; k++)
                     {
                         var candidateEl = candidateElements[ci + k];
                         var innerCandidate = TreeHelper.UnwrapPadded(candidateEl) ?? candidateEl;
+                        // Evaluate per-element constraint if present
+                        if (innerCandidate is J candidateJ
+                            && !EvaluateConstraint(captureObj, candidateJ, cursor))
+                        {
+                            constraintFailed = true;
+                            break;
+                        }
                         captured.Add(innerCandidate);
                     }
+                    if (constraintFailed)
+                        continue;
 
                     // Save bindings for backtracking
                     var savedBindings = new Dictionary<string, object>(_bindings);
@@ -454,6 +484,34 @@ internal class PatternMatchingComparator
                 return false;
         }
         return true;
+    }
+
+    private static bool IsCapturing(object captureObj)
+    {
+        var prop = captureObj.GetType().GetProperty("IsCapturing");
+        return prop == null || (bool)(prop.GetValue(captureObj) ?? true);
+    }
+
+    /// <summary>
+    /// Evaluate a capture's constraint predicate against the candidate node.
+    /// Uses reflection to invoke the generic Func&lt;T, Cursor, bool&gt; constraint.
+    /// Returns true if no constraint is set or if the constraint passes.
+    /// </summary>
+    private static bool EvaluateConstraint(object captureObj, J candidate, Cursor cursor)
+    {
+        var prop = captureObj.GetType().GetProperty("Constraint");
+        if (prop?.GetValue(captureObj) is not Delegate constraint)
+            return true;
+        try
+        {
+            var result = constraint.DynamicInvoke(candidate, cursor);
+            return result is true;
+        }
+        catch
+        {
+            // Type mismatch (candidate doesn't match T) — constraint fails
+            return false;
+        }
     }
 
     private static bool IsVariadic(object captureObj)

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/PatternMatchTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/PatternMatchTests.cs
@@ -1408,6 +1408,212 @@ public class PatternMatchTests : RewriteTest
     }
 
     // ===============================================================
+    // Non-capturing captures
+    // ===============================================================
+
+    [Fact]
+    public void NonCapturingMatchesStructurallyButDoesNotBind()
+    {
+        var ignored = Capture.Expression(capturing: false);
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation($"Console.WriteLine({ignored})")),
+            CSharp(
+                "class C { void M() { Console.WriteLine(42); } }",
+                "class C { void M() { /*~~>*/Console.WriteLine(42); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void NonCapturingDoesNotAppearInBindings()
+    {
+        var ignored = Capture.Expression(capturing: false);
+        var pat = CSharpPattern.Expression($"Console.WriteLine({ignored})");
+        var tree = TemplateEngine.Parse(
+            "Console.WriteLine(42)", new Dictionary<string, object>(),
+            [], [], new Dictionary<string, string>(), ScaffoldKind.Expression);
+        var result = pat.Match(tree, new Cursor(null!, tree));
+        Assert.NotNull(result);
+        Assert.False(result!.Has(ignored));
+    }
+
+    [Fact]
+    public void NonCapturingWithConstraintStillEvaluatesConstraint()
+    {
+        // Constraint requires the literal value to be the integer 42
+        var constrained = Capture.Expression(
+            constraint: (expr, _) => expr is Literal { Value: 42 },
+            capturing: false);
+        var pat = CSharpPattern.Expression($"Console.WriteLine({constrained})");
+        var tree = TemplateEngine.Parse(
+            "Console.WriteLine(42)", new Dictionary<string, object>(),
+            [], [], new Dictionary<string, string>(), ScaffoldKind.Expression);
+
+        // Should match: constraint passes
+        var result = pat.Match(tree, new Cursor(null!, tree));
+        Assert.NotNull(result);
+        Assert.False(result!.Has(constrained));
+    }
+
+    [Fact]
+    public void NonCapturingWithFailingConstraintDoesNotMatch()
+    {
+        // Constraint requires value > 100 — will fail for 42
+        var constrained = Capture.Expression(
+            constraint: (expr, _) => expr is Literal { Value: int v } && v > 100,
+            capturing: false);
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation($"Console.WriteLine({constrained})")),
+            CSharp(
+                "class C { void M() { Console.WriteLine(42); } }"
+                // No after = no match expected
+            )
+        );
+    }
+
+    [Fact]
+    public void MixedCapturingAndNonCapturing()
+    {
+        var important = Capture.Expression("important");
+        var ignored = Capture.Expression(capturing: false);
+        var pat = CSharpPattern.Expression($"Math.Max({ignored}, {important})");
+        var tree = TemplateEngine.Parse(
+            "Math.Max(1, 2)", new Dictionary<string, object>(),
+            [], [], new Dictionary<string, string>(), ScaffoldKind.Expression);
+        var result = pat.Match(tree, new Cursor(null!, tree));
+
+        Assert.NotNull(result);
+        // The capturing one should be bound
+        Assert.True(result!.Has(important));
+        Assert.NotNull(result.Get<Literal>("important"));
+        // The non-capturing one should NOT be bound
+        Assert.False(result.Has(ignored));
+    }
+
+    [Fact]
+    public void NonCapturingVariadicMatchesMultipleArgs()
+    {
+        var ignored = Capture.Variadic<Expression>(capturing: false);
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation($"Foo({ignored})")),
+            CSharp(
+                "class C { void Foo(int a, int b, int c) {} void M() { Foo(1, 2, 3); } }",
+                "class C { void Foo(int a, int b, int c) {} void M() { /*~~>*/Foo(1, 2, 3); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void NonCapturingVariadicDoesNotAppearInBindings()
+    {
+        var ignored = Capture.Variadic<Expression>(capturing: false);
+        var pat = CSharpPattern.Expression($"Foo({ignored})");
+        var tree = TemplateEngine.Parse(
+            "Foo(1, 2, 3)", new Dictionary<string, object>(),
+            [], [], new Dictionary<string, string>(), ScaffoldKind.Expression);
+        var result = pat.Match(tree, new Cursor(null!, tree));
+        Assert.NotNull(result);
+        Assert.False(result!.Has(ignored));
+    }
+
+    [Fact]
+    public void CaptureFirstArgIgnoreRest()
+    {
+        var first = Capture.Expression("first");
+        var rest = Capture.Variadic<Expression>(capturing: false);
+        var pat = CSharpPattern.Expression($"Foo({first}, {rest})");
+        var tree = TemplateEngine.Parse(
+            "Foo(1, 2, 3)", new Dictionary<string, object>(),
+            [], [], new Dictionary<string, string>(), ScaffoldKind.Expression);
+        var result = pat.Match(tree, new Cursor(null!, tree));
+
+        Assert.NotNull(result);
+        Assert.True(result!.Has(first));
+        Assert.NotNull(result.Get<Literal>("first"));
+        Assert.False(result.Has(rest));
+    }
+
+    [Fact]
+    public void ConsistentNonCapturingBindingBothMatch()
+    {
+        // Same named non-capturing capture used twice — both positions must match structurally
+        var same = Capture.Of<Expression>("same", capturing: false);
+        var pat = CSharpPattern.Expression($"Math.Max({same}, {same})");
+        var tree = TemplateEngine.Parse(
+            "Math.Max(1, 1)", new Dictionary<string, object>(),
+            [], [], new Dictionary<string, string>(), ScaffoldKind.Expression);
+        var result = pat.Match(tree, new Cursor(null!, tree));
+
+        Assert.NotNull(result);
+        Assert.False(result!.Has(same)); // non-capturing: not in bindings
+    }
+
+    [Fact]
+    public void ConsistentNonCapturingBindingFailsWhenDifferent()
+    {
+        // Same named non-capturing capture — values differ, should fail
+        var same = Capture.Of<Expression>("same", capturing: false);
+        var pat = CSharpPattern.Expression($"Math.Max({same}, {same})");
+        var tree = TemplateEngine.Parse(
+            "Math.Max(1, 2)", new Dictionary<string, object>(),
+            [], [], new Dictionary<string, string>(), ScaffoldKind.Expression);
+        var result = pat.Match(tree, new Cursor(null!, tree));
+
+        Assert.Null(result); // inconsistent — match fails
+    }
+
+    // ===============================================================
+    // Captures with constraints
+    // ===============================================================
+
+    [Fact]
+    public void CapturingWithConstraintEvaluatesConstraint()
+    {
+        var expr = Capture.WithConstraint<Literal>("lit",
+            (lit, _) => lit.Value is 42);
+        var pat = CSharpPattern.Expression($"Console.WriteLine({expr})");
+        var tree = TemplateEngine.Parse(
+            "Console.WriteLine(42)", new Dictionary<string, object>(),
+            [], [], new Dictionary<string, string>(), ScaffoldKind.Expression);
+        var result = pat.Match(tree, new Cursor(null!, tree));
+
+        Assert.NotNull(result);
+        Assert.True(result!.Has(expr));
+        Assert.NotNull(result.Get<Literal>(expr));
+    }
+
+    [Fact]
+    public void CapturingWithConstraintRejectsOnConstraintFailure()
+    {
+        var expr = Capture.WithConstraint<Literal>("lit",
+            (lit, _) => lit.Value is int v && v > 100);
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation($"Console.WriteLine({expr})")),
+            CSharp(
+                "class C { void M() { Console.WriteLine(42); } }"
+                // No after = no match expected
+            )
+        );
+    }
+
+    [Fact]
+    public void NonCapturingVariadicWithConstraintRejectsOnFailure()
+    {
+        // All elements must be integer literals
+        var args = Capture.Variadic<Literal>(
+            constraint: (lit, _) => lit.Value is int,
+            capturing: false);
+        var pat = CSharpPattern.Expression($"Foo({args})");
+
+        // "hello" is not an int literal — should fail
+        var tree = TemplateEngine.Parse(
+            "Foo(1, \"hello\", 3)", new Dictionary<string, object>(),
+            [], [], new Dictionary<string, string>(), ScaffoldKind.Expression);
+        var result = pat.Match(tree, new Cursor(null!, tree));
+        Assert.Null(result);
+    }
+
+    // ===============================================================
     // Recipe factories
     // ===============================================================
 


### PR DESCRIPTION
## Motivation

The JS/TS pattern matching engine has `any()` — a non-capturing placeholder that matches structurally but doesn't store the result in bindings. This is useful for "don't care" positions in patterns where you need structural matching but don't need to extract the value. The C# template engine lacked this capability.

## Examples

```csharp
// Non-capturing: matches any expression but doesn't bind
var ignored = Capture.Expression(capturing: false);
var pat = CSharpPattern.Expression($"Console.WriteLine({ignored})");

// Mix capturing and non-capturing
var important = Capture.Expression("val");
var ignored = Capture.Expression(capturing: false);
var pat = CSharpPattern.Expression($"Math.Max({ignored}, {important})");
// result.Has(important) == true, result.Has(ignored) == false

// Non-capturing variadic: match any number of args without binding
var rest = Capture.Variadic<Expression>(capturing: false);
var first = Capture.Expression("first");
var pat = CSharpPattern.Expression($"Foo({first}, {rest})");

// Non-capturing with constraint: structural validation without binding
var constrained = Capture.Expression(
    constraint: (expr, _) => expr is Literal { Value: 42 },
    capturing: false);

// Named non-capturing for consistency checking
var same = Capture.Of<Expression>("same", capturing: false);
var pat = CSharpPattern.Expression($"Math.Max({same}, {same})");
// Matches Math.Max(1, 1) but NOT Math.Max(1, 2)
```

## Summary

- Add `capturing` parameter (default `true`) to all `Capture` factory methods (`Of`, `Expression`, `Variadic`, `Type`, `Name`, `WithConstraint`)
- Add constraint evaluation in `PatternMatchingComparator` for both single-node and variadic captures
- Filter non-capturing entries from `MatchResult` after matching (while still using them internally for consistency checking)

## Test plan

- [x] Non-capturing matches structurally but doesn't appear in `MatchResult`
- [x] Non-capturing with passing constraint matches, with failing constraint rejects
- [x] Mixed capturing and non-capturing in same pattern — only capturing appears in result
- [x] Non-capturing variadic matches multiple args without binding
- [x] Named non-capturing enforces consistency (same value in both positions)
- [x] Capturing captures with constraints evaluate correctly
- [x] Non-capturing variadic with per-element constraint rejects on failure
- [x] All 106 PatternMatchTests pass (93 existing + 13 new)