### PR TITLE
C#: Support variadic captures in attribute pattern matching and templates

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
@@ -317,9 +317,14 @@ internal class PatternMatchingComparator
         // Both null
         if (patternValue == null && candidateValue == null)
             return true;
-        // One null
+        // One null — but a pattern container with only zero-min variadic captures
+        // can match a null candidate (e.g., pattern `Fact({args})` vs `[Fact]` with no parens)
         if (patternValue == null || candidateValue == null)
+        {
+            if (patternValue != null && candidateValue == null && TreeHelper.IsContainer(patternValue))
+                return MatchContainerAgainstNull(patternValue, cursor);
             return false;
+        }
 
         // J tree nodes — recursive structural match
         if (patternValue is J pj && candidateValue is J cj)
@@ -367,6 +372,39 @@ internal class PatternMatchingComparator
             return patternElements == null && candidateElements == null;
 
         return MatchPaddedList(patternElements, candidateElements, cursor);
+    }
+
+    /// <summary>
+    /// Match a pattern container against a null candidate. Succeeds only when every
+    /// element in the container is a variadic capture placeholder with min == 0,
+    /// binding each to an empty list.
+    /// </summary>
+    private bool MatchContainerAgainstNull(object patternContainer, Cursor cursor)
+    {
+        var patternElements = TreeHelper.GetContainerElements(patternContainer);
+        if (patternElements == null || patternElements.Count == 0)
+            return true;
+
+        foreach (var el in patternElements)
+        {
+            var inner = TreeHelper.UnwrapPadded(el) ?? el;
+            if (inner is Identifier id)
+            {
+                var captureName = Placeholder.FromPlaceholder(id.SimpleName);
+                if (captureName != null && _captures.TryGetValue(captureName, out var captureObj)
+                    && IsVariadic(captureObj))
+                {
+                    var (min, _) = GetVariadicBounds(captureObj);
+                    if (min == 0)
+                    {
+                        _bindings[captureName] = new List<object>().AsReadOnly();
+                        continue;
+                    }
+                }
+            }
+            return false;
+        }
+        return true;
     }
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
@@ -642,6 +642,13 @@ internal class SubstitutionVisitor : CSharpVisitor<int>
         return base.VisitIdentifier(identifier, p);
     }
 
+    public override J VisitAnnotation(Annotation annotation, int p)
+    {
+        annotation = (Annotation)base.VisitAnnotation(annotation, p);
+        annotation = ExpandVariadicAnnotationArgs(annotation);
+        return annotation;
+    }
+
     public override J VisitMethodInvocation(MethodInvocation mi, int p)
     {
         mi = (MethodInvocation)base.VisitMethodInvocation(mi, p);
@@ -729,5 +736,63 @@ internal class SubstitutionVisitor : CSharpVisitor<int>
         }
 
         return mi;
+    }
+
+    /// <summary>
+    /// If any argument in an Annotation is a placeholder identifier bound to a variadic capture,
+    /// expand it into the argument list. When all arguments expand to empty, remove the
+    /// Arguments container entirely (producing an attribute with no parentheses).
+    /// </summary>
+    private Annotation ExpandVariadicAnnotationArgs(Annotation annotation)
+    {
+        if (annotation.Arguments == null)
+            return annotation;
+
+        var elements = annotation.Arguments.Elements;
+        List<JRightPadded<Expression>>? expanded = null;
+
+        for (int i = 0; i < elements.Count; i++)
+        {
+            var arg = elements[i].Element;
+            if (arg is Identifier ident)
+            {
+                var captureName = Placeholder.FromPlaceholder(ident.SimpleName);
+                if (captureName != null && _values.Has(captureName))
+                {
+                    var capturedList = _values.GetList<Expression>(captureName);
+                    if (expanded == null)
+                    {
+                        expanded = new List<JRightPadded<Expression>>();
+                        for (int k = 0; k < i; k++)
+                            expanded.Add(elements[k]);
+                    }
+                    for (int j = 0; j < capturedList.Count; j++)
+                    {
+                        var capturedArg = capturedList[j];
+                        if (j == 0)
+                            capturedArg = J.SetPrefix(capturedArg, ident.Prefix);
+                        expanded.Add(new JRightPadded<Expression>(
+                            capturedArg, Space.Empty, Markers.Empty));
+                    }
+                    continue;
+                }
+            }
+            expanded?.Add(elements[i]);
+        }
+
+        if (expanded != null)
+        {
+            if (expanded.Count == 0)
+            {
+                // All variadic captures were empty — remove parentheses entirely
+                annotation = annotation.WithArguments(null);
+            }
+            else
+            {
+                annotation = annotation.WithArguments(annotation.Arguments.WithElements(expanded));
+            }
+        }
+
+        return annotation;
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/PatternMatchTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/PatternMatchTests.cs
@@ -971,6 +971,44 @@ public class PatternMatchTests : RewriteTest
         );
     }
 
+    // ===============================================================
+    // Variadic captures in attribute arguments
+    // ===============================================================
+
+    [Fact]
+    public void VariadicAttributeCaptureMatchesNoParens()
+    {
+        var args = Capture.Expression("args", variadic: new());
+        RewriteRun(
+            spec => spec.SetRecipe(FindAnnotation($"Fact({args})")),
+            CSharp(
+                """
+                class C { [Fact] void M() {} }
+                """,
+                """
+                class C { [/*~~>*/Fact] void M() {} }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void VariadicAttributeCaptureMatchesWithArguments()
+    {
+        var args = Capture.Expression("args", variadic: new());
+        RewriteRun(
+            spec => spec.SetRecipe(FindAnnotation($"Fact({args})")),
+            CSharp(
+                """
+                class C { [Fact(DisplayName = "test")] void M() {} }
+                """,
+                """
+                class C { [/*~~>*/Fact(DisplayName = "test")] void M() {} }
+                """
+            )
+        );
+    }
+
     [Fact]
     public void ConsistentCaptureBindingMatchesWhenSame()
     {
@@ -1641,6 +1679,9 @@ public class PatternMatchTests : RewriteTest
     private static Core.Recipe FindIsPattern(string c) => Search<IsPattern>(c);
     private static Core.Recipe FindCsBinary(string c) => Search<CsBinary>(c);
     private static Core.Recipe FindCsBinary(TemplateStringHandler h) => Search<CsBinary>(h);
+
+    private static Core.Recipe FindAnnotation(TemplateStringHandler h) =>
+        new PatternSearchRecipe<Annotation>(CSharpPattern.Attribute(h));
 
     /// <summary>
     /// Search for a Binary or IsPattern null-check, matching across both node types.

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TemplateApplyTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TemplateApplyTests.cs
@@ -260,6 +260,76 @@ public class TemplateApplyTests : RewriteTest
         );
     }
 
+    // ===============================================================
+    // Attribute variadic captures
+    // ===============================================================
+
+    [Fact]
+    public void SubstitutesVariadicArgsInAttribute()
+    {
+        var args = Capture.Expression("args", variadic: new());
+        RewriteRun(
+            spec => spec.SetRecipe(ReplaceAnnotation(
+                $"Fact({args})",
+                $"Test({args})")),
+            CSharp(
+                """
+                class C { [Fact(DisplayName = "test")] void M() {} }
+                """,
+                """
+                class C { [Test(DisplayName = "test")] void M() {} }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void SubstitutesEmptyVariadicArgsInAttribute()
+    {
+        var args = Capture.Expression("args", variadic: new());
+        RewriteRun(
+            spec => spec.SetRecipe(ReplaceAnnotation(
+                $"Fact({args})",
+                $"Test({args})")),
+            CSharp(
+                """
+                class C { [Fact] void M() {} }
+                """,
+                """
+                class C { [Test] void M() {} }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void AttributeRenameViaRewriteRule()
+    {
+        var args = Capture.Expression("args", variadic: new());
+        var rule = RewriteRule.Rewrite(
+            CSharpPattern.Attribute($"Fact({args})"),
+            CSharpTemplate.Attribute($"Test({args})"));
+        RewriteRun(
+            spec => spec.SetRecipe(new RewriteRuleRecipe(rule)),
+            CSharp(
+                """
+                class C
+                {
+                    [Fact] void M1() {}
+                    [Fact(DisplayName = "test")] void M2() {}
+                }
+                """,
+                """
+                class C
+                {
+                    [Test] void M1() {}
+                    [Test(DisplayName = "test")] void M2() {}
+                }
+                """
+            )
+        );
+    }
+
     [Fact]
     public void SubstitutesFieldNameCapture()
     {
@@ -462,6 +532,9 @@ public class TemplateApplyTests : RewriteTest
     // Recipe factories
     // ===============================================================
 
+    private static Core.Recipe ReplaceAnnotation(TemplateStringHandler pattern, TemplateStringHandler template) =>
+        new PatternReplaceRecipe<Annotation>(CSharpPattern.Attribute(pattern), CSharpTemplate.Attribute(template));
+
 #pragma warning disable CS0618
     private static Core.Recipe Replace<T>(TemplateStringHandler pattern, TemplateStringHandler template)
         where T : J =>
@@ -652,4 +725,12 @@ file class UseRethrowRecipe : Core.Recipe
             return throwStmt;
         }
     }
+}
+
+file class RewriteRuleRecipe(IRewriteRule rule) : Core.Recipe
+{
+    public override string DisplayName => "RewriteRule";
+    public override string Description => "Applies a RewriteRule via ToVisitor().";
+
+    public override JavaVisitor<ExecutionContext> GetVisitor() => rule.ToVisitor();
 }


### PR DESCRIPTION
## Motivation

Attribute rename recipes (e.g., `[Fact]` → `[Test]`) should be expressible declaratively with `RewriteRule` + variadic captures, but two bugs prevented this. A variadic capture like `Fact({args})` failed to match `[Fact]` (no parentheses), and when it did match `[Fact(DisplayName = "test")]`, the template produced `[Test(__plh_args__)]` instead of substituting the captured arguments.

## Examples

After this fix, attribute rename recipes can be written as:

```csharp
var args = Capture.Expression("args", variadic: new());
var rule = RewriteRule.Rewrite(
    CSharpPattern.Attribute($"Fact({args})"),
    CSharpTemplate.Attribute($"Test({args})"));
return rule.ToVisitor();
```

This handles both `[Fact]` → `[Test]` and `[Fact(DisplayName = "test")]` → `[Test(DisplayName = "test")]`.

## Summary

- **Pattern matching**: When a pattern container contains only zero-min variadic captures and the candidate has null arguments (no parentheses), bind the variadics to empty lists and match successfully
- **Template substitution**: Add `VisitAnnotation` override in `SubstitutionVisitor` with variadic expansion for `Annotation.Arguments`; when all variadics expand to empty, remove the `Arguments` container entirely (no parentheses in output)

## Test plan

- [x] `VariadicAttributeCaptureMatchesNoParens` — `[Fact]` matches `Fact({args})` with args bound to empty list
- [x] `VariadicAttributeCaptureMatchesWithArguments` — `[Fact(DisplayName = "test")]` matches with args bound
- [x] `SubstitutesVariadicArgsInAttribute` — template produces `[Test(DisplayName = "test")]` when args has values
- [x] `SubstitutesEmptyVariadicArgsInAttribute` — template produces `[Test]` when args is empty
- [x] `AttributeRenameViaRewriteRule` — full round-trip via `RewriteRule.Rewrite()` + `ToVisitor()`
- [x] All 1660 existing C# tests pass