### PR TITLE
C#: Add `Find()` annotator overload and `ToFindVisitor()` to `CSharpPattern`

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CSharpPattern.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CSharpPattern.cs
@@ -200,6 +200,67 @@ public sealed class CSharpPattern
     /// </summary>
     public T Find<T>(T tree, Cursor cursor, string? description = null) where T : J
     {
-        return Match(tree, cursor) != null ? SearchResult.Found(tree, description) : tree;
+        return Find(tree, cursor, (T t, Cursor _, MatchResult _) => SearchResult.Found(t, description));
+    }
+
+    /// <summary>
+    /// If this pattern matches the given tree node, call <paramref name="annotator"/> with
+    /// the matched node, cursor, and match result, returning the annotated node.
+    /// If the pattern does not match, returns the node unchanged.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// return pat.Find(mi, Cursor, (node, _, _) => Markup.CreateWarn(node, "Avoid this API"));
+    /// </code>
+    /// </example>
+    public T Find<T>(T tree, Cursor cursor, Func<T, Cursor, MatchResult, T> annotator) where T : J
+    {
+        var match = Match(tree, cursor);
+        return match != null ? annotator(tree, cursor, match) : tree;
+    }
+
+    /// <summary>
+    /// Create a <see cref="CSharpVisitor{ExecutionContext}"/> that visits every node and
+    /// adds a <see cref="SearchResult"/> marker to matches. The pattern's fast-reject in
+    /// <see cref="Match"/> ensures only nodes whose type matches the pattern root are fully
+    /// compared, so iterating over all nodes is cheap.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// public override JavaVisitor&lt;ExecutionContext&gt; GetVisitor() =>
+    ///     CSharpPattern.Expression("Console.WriteLine(\"hello\")")
+    ///         .ToFindVisitor("found it");
+    /// </code>
+    /// </example>
+    public CSharpVisitor<Core.ExecutionContext> ToFindVisitor(string? description = null)
+    {
+        return ToFindVisitor((node, _, _) => SearchResult.Found(node, description));
+    }
+
+    /// <summary>
+    /// Create a <see cref="CSharpVisitor{ExecutionContext}"/> that visits every node and
+    /// calls <paramref name="annotator"/> on matches. Use this to produce visitors that mark
+    /// matches with custom markers (e.g. <see cref="Markup.CreateWarn{T}"/>).
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// public override JavaVisitor&lt;ExecutionContext&gt; GetVisitor() =>
+    ///     CSharpPattern.Expression($"new BinaryFormatter({args})")
+    ///         .ToFindVisitor((node, _, _) => Markup.CreateWarn(node, "BinaryFormatter is obsolete"));
+    /// </code>
+    /// </example>
+    public CSharpVisitor<Core.ExecutionContext> ToFindVisitor(Func<J, Cursor, MatchResult, J> annotator)
+    {
+        return new FindVisitor(this, annotator);
+    }
+
+    private sealed class FindVisitor(CSharpPattern pattern, Func<J, Cursor, MatchResult, J> annotator)
+        : CSharpVisitor<Core.ExecutionContext>
+    {
+        public override J? PostVisit(J tree, Core.ExecutionContext ctx)
+        {
+            var match = pattern.Match(tree, Cursor);
+            return match != null ? annotator(tree, Cursor, match) : tree;
+        }
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/AnnotateTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/AnnotateTests.cs
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp;
+using OpenRewrite.CSharp.Template;
+using OpenRewrite.Java;
+using OpenRewrite.Test;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Tests.Template;
+
+public class AnnotateTests : RewriteTest
+{
+    [Fact]
+    public void DefaultAnnotatorAddsSearchResult()
+    {
+        var pat = CSharpPattern.Expression("Console.WriteLine(\"hello\")");
+        RewriteRun(
+            spec => spec.SetRecipe(new AnnotateRecipe<MethodInvocation>(pat)),
+            CSharp(
+                "class C { void M() { Console.WriteLine(\"hello\"); } }",
+                "class C { void M() { /*~~>*/Console.WriteLine(\"hello\"); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void DefaultAnnotatorWithDescription()
+    {
+        var pat = CSharpPattern.Expression("Console.WriteLine(\"hello\")");
+        RewriteRun(
+            spec => spec.SetRecipe(new AnnotateRecipe<MethodInvocation>(
+                pat, description: "found it")),
+            CSharp(
+                "class C { void M() { Console.WriteLine(\"hello\"); } }",
+                "class C { void M() { /*~~(found it)~~>*/Console.WriteLine(\"hello\"); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void CustomAnnotatorWithMarkupWarn()
+    {
+        var pat = CSharpPattern.Expression("Console.WriteLine(\"hello\")");
+        RewriteRun(
+            spec => spec.SetRecipe(new AnnotateRecipe<MethodInvocation>(
+                pat, annotator: (node, _, _) => Markup.CreateWarn(node, "Avoid Console.WriteLine"))),
+            CSharp(
+                "class C { void M() { Console.WriteLine(\"hello\"); } }",
+                "class C { void M() { /*~~(Avoid Console.WriteLine)~~>*/Console.WriteLine(\"hello\"); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void CustomAnnotatorReceivesMatchResult()
+    {
+        var expr = Capture.Of<Expression>("expr");
+        var pat = CSharpPattern.Expression($"Console.WriteLine({expr})");
+        RewriteRun(
+            spec => spec.SetRecipe(new AnnotateRecipe<MethodInvocation>(
+                pat, annotator: (node, _, match) =>
+                    Markup.CreateWarn(node, $"Found arg: {match.Get(expr)!.GetType().Name}"))),
+            CSharp(
+                "class C { void M() { Console.WriteLine(42); } }",
+                "class C { void M() { /*~~(Found arg: Literal)~~>*/Console.WriteLine(42); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void NoMatchReturnsNodeUnchanged()
+    {
+        var pat = CSharpPattern.Expression("Console.Write(\"hello\")");
+        RewriteRun(
+            spec => spec.SetRecipe(new AnnotateRecipe<MethodInvocation>(
+                pat, annotator: (node, _, _) => Markup.CreateWarn(node, "should not appear"))),
+            CSharp(
+                "class C { void M() { Console.WriteLine(\"hello\"); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void FindDelegatesToAnnotate()
+    {
+        // Verifies that Find() produces the same result as Annotate() with the default annotator
+        var pat = CSharpPattern.Expression("Console.WriteLine(\"hello\")");
+        RewriteRun(
+            spec => spec.SetRecipe(new FindVsAnnotateRecipe(pat)),
+            CSharp(
+                "class C { void M() { Console.WriteLine(\"hello\"); } }",
+                "class C { void M() { /*~~>*/Console.WriteLine(\"hello\"); } }"
+            )
+        );
+    }
+
+    // ===============================================================
+    // ToFindVisitor
+    // ===============================================================
+
+    [Fact]
+    public void ToFindVisitorDefaultSearchResult()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ToFindVisitorRecipe(
+                CSharpPattern.Expression("Console.WriteLine(\"hello\")")
+                    .ToFindVisitor())),
+            CSharp(
+                "class C { void M() { Console.WriteLine(\"hello\"); } }",
+                "class C { void M() { /*~~>*/Console.WriteLine(\"hello\"); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void ToFindVisitorWithDescription()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ToFindVisitorRecipe(
+                CSharpPattern.Expression("Console.WriteLine(\"hello\")")
+                    .ToFindVisitor("found it"))),
+            CSharp(
+                "class C { void M() { Console.WriteLine(\"hello\"); } }",
+                "class C { void M() { /*~~(found it)~~>*/Console.WriteLine(\"hello\"); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void ToFindVisitorWithCustomAnnotator()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ToFindVisitorRecipe(
+                CSharpPattern.Expression("Console.WriteLine(\"hello\")")
+                    .ToFindVisitor((node, _, _) => Markup.CreateWarn(node, "Avoid Console.WriteLine")))),
+            CSharp(
+                "class C { void M() { Console.WriteLine(\"hello\"); } }",
+                "class C { void M() { /*~~(Avoid Console.WriteLine)~~>*/Console.WriteLine(\"hello\"); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void ToFindVisitorAnnotatorReceivesMatchResult()
+    {
+        var expr = Capture.Of<Expression>("expr");
+        RewriteRun(
+            spec => spec.SetRecipe(new ToFindVisitorRecipe(
+                CSharpPattern.Expression($"Console.WriteLine({expr})")
+                    .ToFindVisitor((node, _, match) =>
+                        Markup.CreateWarn(node, $"Found arg: {match.Get(expr)!.GetType().Name}")))),
+            CSharp(
+                "class C { void M() { Console.WriteLine(42); } }",
+                "class C { void M() { /*~~(Found arg: Literal)~~>*/Console.WriteLine(42); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void ToFindVisitorNoMatchLeavesUnchanged()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ToFindVisitorRecipe(
+                CSharpPattern.Expression("Console.Write(\"hello\")")
+                    .ToFindVisitor((node, _, _) => Markup.CreateWarn(node, "should not appear")))),
+            CSharp(
+                "class C { void M() { Console.WriteLine(\"hello\"); } }"
+            )
+        );
+    }
+}
+
+/// <summary>
+/// Test recipe that uses <see cref="CSharpPattern.Find{T}"/> with a configurable annotator.
+/// </summary>
+file class AnnotateRecipe<T>(
+    CSharpPattern pat,
+    Func<T, Cursor, MatchResult, T>? annotator = null,
+    string? description = null) : Core.Recipe where T : J
+{
+    public override string DisplayName => "Annotate test";
+    public override string Description => "Test recipe for Annotate.";
+
+    public override JavaVisitor<ExecutionContext> GetVisitor() => new Visitor(pat, annotator, description);
+
+    private class Visitor(
+        CSharpPattern pat,
+        Func<T, Cursor, MatchResult, T>? annotator,
+        string? description) : CSharpVisitor<ExecutionContext>
+    {
+        public override J? PreVisit(J tree, ExecutionContext ctx)
+        {
+            if (tree is T t)
+            {
+                return annotator != null
+                    ? pat.Find(t, Cursor, annotator)
+                    : pat.Find(t, Cursor, description);
+            }
+            return tree;
+        }
+    }
+}
+
+/// <summary>
+/// Test recipe that verifies Find() and Annotate() with SearchResult produce equivalent results.
+/// Uses Find() — the point is that Find() should still work after being refactored to use Annotate().
+/// </summary>
+file class FindVsAnnotateRecipe(CSharpPattern pat) : Core.Recipe
+{
+    public override string DisplayName => "Find vs Annotate";
+    public override string Description => "Verifies Find delegates to Annotate.";
+
+    public override JavaVisitor<ExecutionContext> GetVisitor() => new Visitor(pat);
+
+    private class Visitor(CSharpPattern pat) : CSharpVisitor<ExecutionContext>
+    {
+        public override J? PreVisit(J tree, ExecutionContext ctx)
+        {
+            if (tree is MethodInvocation mi)
+            {
+                return pat.Find(mi, Cursor);
+            }
+            return tree;
+        }
+    }
+}
+
+/// <summary>
+/// Thin recipe wrapper around a pre-built visitor from <see cref="CSharpPattern.ToFindVisitor"/>.
+/// </summary>
+file class ToFindVisitorRecipe(CSharpVisitor<ExecutionContext> visitor) : Core.Recipe
+{
+    public override string DisplayName => "ToFindVisitor test";
+    public override string Description => "Test recipe wrapping ToFindVisitor.";
+
+    public override JavaVisitor<ExecutionContext> GetVisitor() => visitor;
+}


### PR DESCRIPTION
## Motivation

There are 230+ search-only recipes in `recipes-csharp` (`Find*` recipes) that all follow the same boilerplate: a custom `CSharpVisitor` subclass that calls `CSharpPattern.Match()` then `Markup.CreateWarn()`. Currently `CSharpPattern.Find()` only supports `SearchResult` markers, so these recipes can't use it and must implement the full visitor manually.

This PR adds a `Find()` overload that accepts a custom annotator callback, and a `ToFindVisitor()` convenience method that creates a complete visitor from a pattern. Together, these let the 230 recipes collapse from a full visitor class to a one-liner:

## Examples

```csharp
// Before: full visitor class needed
public override JavaVisitor<ExecutionContext> GetVisitor() => new Visitor();
private class Visitor : CSharpVisitor<ExecutionContext>
{
    public override J VisitMethodInvocation(MethodInvocation mi, ExecutionContext ctx)
    {
        mi = (MethodInvocation)base.VisitMethodInvocation(mi, ctx);
        if (pat.Match(mi, Cursor) is { })
            return Markup.CreateWarn(mi, "BinaryFormatter is obsolete");
        return mi;
    }
}

// After: one-liner with ToFindVisitor()
public override JavaVisitor<ExecutionContext> GetVisitor() =>
    CSharpPattern.Expression($"new BinaryFormatter({args})")
        .ToFindVisitor((node, _, _) => Markup.CreateWarn(node, "BinaryFormatter is obsolete"));

// Or use Find() directly in a custom visitor
return pat.Find(mi, Cursor, (node, _, match) =>
    Markup.CreateWarn(node, $"Found arg: {match.Get(expr)!.GetType().Name}"));
```

## Summary

- Add `Find<T>(T, Cursor, Func<T, Cursor, MatchResult, T>)` overload — the generic annotator primitive; existing `Find()` with `string? description` delegates to it
- Add `ToFindVisitor(string?)` — creates a visitor that adds `SearchResult` markers to matches
- Add `ToFindVisitor(Func<J, Cursor, MatchResult, J>)` — creates a visitor with a custom annotator (e.g. `Markup.CreateWarn`)
- The annotator callback receives `(node, cursor, matchResult)`, consistent with `RewriteConfig.PostMatch`

## Test plan

- [x] 6 tests for `Find()` overloads: default SearchResult, with description, custom `Markup.CreateWarn`, annotator receiving `MatchResult` with captures, no-match unchanged, Find delegates to annotator
- [x] 5 tests for `ToFindVisitor()`: default SearchResult, with description, custom annotator, annotator with captures, no-match unchanged
- [x] All 104 existing `PatternMatchTests` pass (regression)