### PR TITLE
C#: Enforce typed capture constraints at pattern matching time

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Capture.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Capture.cs
@@ -113,11 +113,44 @@ public sealed class Capture<T> : ICapture where T : J
     /// <inheritdoc />
     public bool EvaluateConstraint(object candidate, CaptureConstraintContext context)
     {
+        // When the capture declares a type constraint and the candidate has type
+        // attribution, verify the candidate's semantic type is assignable to it.
+        // If the candidate has no type info (expr.Type == null), skip the check —
+        // type attribution may be unavailable when reference assemblies aren't provided.
+        if (Type != null && candidate is Expression { Type: not null } expr
+            && !TypeUtils.IsAssignableTo(expr.Type, ResolveCSharpAlias(Type)))
+            return false;
+
         if (Constraint == null) return true;
         // The `is T` check acts as an implicit type guard: if the candidate is not
         // assignable to T, the constraint fails without invoking the delegate.
         return candidate is T typed && Constraint(typed, context);
     }
+
+    /// <summary>
+    /// Resolve C# keyword aliases (e.g. <c>string</c>, <c>int</c>) to their
+    /// fully-qualified .NET type names for use with <see cref="TypeUtils.IsAssignableTo"/>.
+    /// Returns the input unchanged if it is not a keyword alias.
+    /// </summary>
+    private static string ResolveCSharpAlias(string type) => type switch
+    {
+        "bool" => "System.Boolean",
+        "byte" => "System.Byte",
+        "sbyte" => "System.SByte",
+        "char" => "System.Char",
+        "decimal" => "System.Decimal",
+        "double" => "System.Double",
+        "float" => "System.Single",
+        "int" => "System.Int32",
+        "uint" => "System.UInt32",
+        "long" => "System.Int64",
+        "ulong" => "System.UInt64",
+        "short" => "System.Int16",
+        "ushort" => "System.UInt16",
+        "string" => "System.String",
+        "object" => "System.Object",
+        _ => type
+    };
 
     /// <inheritdoc />
     public bool EvaluateVariadicConstraint(IReadOnlyList<object> captured, CaptureConstraintContext context)

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TypedCaptureTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TypedCaptureTests.cs
@@ -125,8 +125,48 @@ public class TypedCaptureTests : RewriteTest
         Assert.IsType<MethodInvocation>(tree);
     }
 
+    [Fact]
+    public void TypedCaptureRejectsIncompatibleType()
+    {
+        var target = Capture.Expression("target", type: "System.IO.BinaryReader");
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation($"{target}.ReadString()", ["System.IO"]))
+                .SetReferenceAssemblies(Assemblies.Net90),
+            CSharp(
+                // MyReader.ReadString() should NOT match — MyReader is not BinaryReader
+                """
+                class MyReader
+                {
+                    public string ReadString() => "hello";
+                }
+                class Test
+                {
+                    void M(MyReader reader)
+                    {
+                        var text = reader.ReadString();
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void TypedCaptureMatchesCompatibleType()
+    {
+        var target = Capture.Expression("target", type: "System.IO.BinaryReader");
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation($"{target}.ReadString()", ["System.IO"]))
+                .SetReferenceAssemblies(Assemblies.Net90),
+            CSharp(
+                "using System.IO; class Test { void M(BinaryReader r) { r.ReadString(); } }",
+                "using System.IO; class Test { void M(BinaryReader r) { /*~~>*/r.ReadString(); } }"
+            )
+        );
+    }
+
     // ===============================================================
-    // Recipe factory
+    // Recipe factories
     // ===============================================================
 
     private static Core.Recipe FindExpression(TemplateStringHandler handler)
@@ -134,6 +174,9 @@ public class TypedCaptureTests : RewriteTest
 
     private static Core.Recipe FindExpression(string code)
         => new TypedPatternSearchRecipe(CSharpPattern.Expression(code));
+
+    private static Core.Recipe FindMethodInvocation(TemplateStringHandler handler, IReadOnlyList<string> usings)
+        => new MethodInvocationSearchRecipe(CSharpPattern.Expression(handler, usings: usings));
 }
 
 file class TypedPatternSearchRecipe(CSharpPattern pat) : Core.Recipe
@@ -150,6 +193,26 @@ file class TypedPatternSearchRecipe(CSharpPattern pat) : Core.Recipe
             if (tree is Expression e)
             {
                 return pat.Find(e, Cursor);
+            }
+            return tree;
+        }
+    }
+}
+
+file class MethodInvocationSearchRecipe(CSharpPattern pat) : Core.Recipe
+{
+    public override string DisplayName => "Find method invocation";
+    public override string Description => "Searches for method invocations matching the pattern.";
+
+    public override JavaVisitor<ExecutionContext> GetVisitor() => new SearchVisitor(pat);
+
+    private class SearchVisitor(CSharpPattern pat) : CSharpVisitor<ExecutionContext>
+    {
+        public override J? PreVisit(J tree, ExecutionContext ctx)
+        {
+            if (tree is MethodInvocation m)
+            {
+                return pat.Find(m, Cursor);
             }
             return tree;
         }


### PR DESCRIPTION
## Motivation

When a capture is declared with `type:`, the type was only used during pattern *parsing* (the scaffold generates a typed preamble so member access resolves), but was **not** used during pattern *matching*. This meant `Capture.Expression("target", type: "System.IO.BinaryReader")` in a pattern `{target}.ReadString()` would match ANY `x.ReadString()` call regardless of whether `x` is actually a `BinaryReader`.

## Examples

```csharp
// Typed capture now rejects incompatible types at match time
var target = Capture.Expression("target", type: "System.IO.BinaryReader");
var pat = CSharpPattern.Expression($"{target}.ReadString()", usings: ["System.IO"]);

// ✅ Matches — r is a BinaryReader
// BinaryReader r = ...; r.ReadString();

// ❌ No longer matches — reader is MyReader, not BinaryReader
// MyReader reader = ...; reader.ReadString();
```

## Summary

- `Capture<T>.EvaluateConstraint` now checks `TypeUtils.IsAssignableTo(expr.Type, captureType)` when the capture has a `Type` constraint and the candidate has type attribution
- Added `ResolveCSharpAlias` to map C# keyword aliases (`string`, `int`, etc.) to FQNs (`System.String`, `System.Int32`) since `TypeUtils.IsAssignableTo` operates on fully-qualified names
- When the candidate has no type attribution (no reference assemblies), the check is skipped gracefully

## Test plan

- [x] New test `TypedCaptureRejectsIncompatibleType` — verifies `MyReader.ReadString()` does NOT match when capture requires `BinaryReader`
- [x] New test `TypedCaptureMatchesCompatibleType` — verifies `BinaryReader.ReadString()` still matches
- [x] All 12 `TypedCaptureTests` pass (including existing tests with keyword aliases like `type: "string"`)
- [x] All 106 `PatternMatchTests` pass with no regressions