### PR TITLE
Gradle: fix GradleJavaTemplateTest

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleJavaTemplateTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleJavaTemplateTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.gradle;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
@@ -29,7 +28,6 @@ import static org.openrewrite.test.RewriteTest.toRecipe;
 
 class GradleJavaTemplateTest implements RewriteTest {
 
-    @Disabled("work in progress")
     @Test
     void useJavaTemplateInBuildGradle() {
         Recipe addDependency = toRecipe(() -> new JavaIsoVisitor<>() {
@@ -37,9 +35,8 @@ class GradleJavaTemplateTest implements RewriteTest {
             public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
                 if (block.getStatements().isEmpty()) {
                     return JavaTemplate.builder("implementation(\"com.google.guava:guava:latest.release\")")
-                      .contextSensitive()
                       .build()
-                      .apply(getCursor(), block.getCoordinates().replace());
+                      .apply(getCursor(), block.getCoordinates().lastStatement());
                 }
                 return super.visitBlock(block, ctx);
             }


### PR DESCRIPTION
## What's changed?

Re-enable one of the test cases - in `GradleJavaTemplateTest`.

## What's your motivation?

- The test passes (with slight modification).
- I see no reason to keep it disabled.
- The works is certainly not in progress ;) since 2023
