### PR TITLE
C#: Fix typed capture constraints for generic interfaces and primitives

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Capture.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Capture.cs
@@ -117,9 +117,16 @@ public sealed class Capture<T> : ICapture where T : J
         // attribution, verify the candidate's semantic type is assignable to it.
         // If the candidate has no type info (expr.Type == null), skip the check —
         // type attribution may be unavailable when reference assemblies aren't provided.
-        if (Type != null && candidate is Expression { Type: not null } expr
-            && !TypeUtils.IsAssignableTo(expr.Type, ResolveCSharpAlias(Type)))
-            return false;
+        if (Type != null && candidate is Expression { Type: not null } expr)
+        {
+            // Prefer the Roslyn-resolved type from the pattern scaffold when available.
+            // This handles generics (IDictionary<object, object> resolves to its FQN)
+            // and primitives (int resolves to System.Int32) correctly without string parsing.
+            var matched = context.PatternType != null
+                ? TypeUtils.IsAssignableTo(expr.Type, context.PatternType)
+                : TypeUtils.IsAssignableTo(expr.Type, ResolveCSharpAlias(Type));
+            if (!matched) return false;
+        }
 
         if (Constraint == null) return true;
         // The `is T` check acts as an implicit type guard: if the candidate is not

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CaptureConstraintContext.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CaptureConstraintContext.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 using OpenRewrite.Core;
+using OpenRewrite.Java;
 
 namespace OpenRewrite.CSharp.Template;
 
@@ -26,7 +27,11 @@ namespace OpenRewrite.CSharp.Template;
 /// <param name="Captures">Read-only snapshot of captures already bound at the point this
 /// constraint is evaluated. Enables dependent constraints where one capture's validity
 /// depends on another's value.</param>
+/// <param name="PatternType">The Roslyn-resolved <see cref="JavaType"/> of the pattern
+/// placeholder, when available. Used by typed captures to compare against the candidate's
+/// type using the fully-resolved type from the scaffold rather than the raw type string.</param>
 public sealed record CaptureConstraintContext(
     Cursor Cursor,
-    IReadOnlyDictionary<string, object> Captures
+    IReadOnlyDictionary<string, object> Captures,
+    JavaType? PatternType = null
 );

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
@@ -60,8 +60,9 @@ internal class PatternMatchingComparator
                     // Already bound — check consistency
                     return MatchValue(existing, candidate, cursor);
                 }
-                // Evaluate constraint before binding
-                if (!EvaluateConstraint(_captures[captureName], candidate, cursor))
+                // Evaluate constraint before binding — pass the pattern placeholder's
+                // resolved type so typed captures can compare JavaType-to-JavaType
+                if (!EvaluateConstraint(_captures[captureName], candidate, cursor, patternId.Type))
                     return false;
                 _bindings[captureName] = candidate;
                 return true;
@@ -559,11 +560,11 @@ internal class PatternMatchingComparator
     private static bool IsStatic(JavaType.Variable variable) =>
         (variable.FlagsBitMap & FlagStatic) != 0;
 
-    private CaptureConstraintContext BuildConstraintContext(Cursor cursor) =>
-        new(cursor, new Dictionary<string, object>(_bindings));
+    private CaptureConstraintContext BuildConstraintContext(Cursor cursor, JavaType? patternType = null) =>
+        new(cursor, new Dictionary<string, object>(_bindings), patternType);
 
-    private bool EvaluateConstraint(object captureObj, object candidate, Cursor cursor) =>
-        captureObj is not ICapture capture || capture.EvaluateConstraint(candidate, BuildConstraintContext(cursor));
+    private bool EvaluateConstraint(object captureObj, object candidate, Cursor cursor, JavaType? patternType = null) =>
+        captureObj is not ICapture capture || capture.EvaluateConstraint(candidate, BuildConstraintContext(cursor, patternType));
 
     private bool EvaluateVariadicConstraint(object captureObj, IReadOnlyList<object> captured, Cursor cursor) =>
         captureObj is not ICapture capture || capture.EvaluateVariadicConstraint(captured, BuildConstraintContext(cursor));

--- a/rewrite-csharp/csharp/OpenRewrite/Java/TypeUtils.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/TypeUtils.cs
@@ -38,14 +38,40 @@ public static class TypeUtils
     {
         if (type == null) return false;
 
-        // Primitive(String) is assignable to "System.String" but has no Class representation
-        if (type is JavaType.Primitive { Kind: JavaType.Primitive.PrimitiveKind.String })
-            return string.Equals("System.String", fullyQualifiedName, StringComparison.Ordinal);
+        // Primitives (int, bool, string, etc.) have no Class representation —
+        // map to their .NET FQN and compare directly
+        if (type is JavaType.Primitive prim)
+        {
+            var primFqn = PrimitiveToFqn(prim.Kind);
+            return primFqn != null && string.Equals(primFqn, fullyQualifiedName, StringComparison.Ordinal);
+        }
 
         var cls = AsClass(type);
         if (cls == null) return false;
 
         return IsAssignableToInternal(cls, fullyQualifiedName, new HashSet<string>());
+    }
+
+    /// <summary>
+    /// Check if a type is assignable to the target type, where the target is specified
+    /// as a <see cref="JavaType"/> rather than a string FQN. This is the preferred overload
+    /// when the target type comes from a parsed AST (e.g., a typed capture's scaffold).
+    /// For parameterized targets like <c>IDictionary&lt;object, object&gt;</c>, the generic
+    /// type arguments are ignored — only the base type definition is checked.
+    /// </summary>
+    public static bool IsAssignableTo(JavaType? type, JavaType? targetType)
+    {
+        if (type == null || targetType == null) return false;
+
+        // Both primitives: same kind means match
+        if (type is JavaType.Primitive candPrim && targetType is JavaType.Primitive targetPrim)
+            return candPrim.Kind == targetPrim.Kind;
+
+        // Extract the base FQN from the target, stripping generic type parameters
+        var targetFqn = GetFullyQualifiedName(targetType);
+        if (targetFqn == null) return false;
+
+        return IsAssignableTo(type, targetFqn);
     }
 
     /// <summary>
@@ -55,9 +81,12 @@ public static class TypeUtils
     {
         if (type == null) return false;
 
-        // Primitive(String) is assignable to "System.String" but has no Class representation
-        if (type is JavaType.Primitive { Kind: JavaType.Primitive.PrimitiveKind.String })
-            return fullyQualifiedNames.Contains("System.String");
+        // Primitives have no Class representation — map to FQN and check
+        if (type is JavaType.Primitive prim)
+        {
+            var primFqn = PrimitiveToFqn(prim.Kind);
+            return primFqn != null && fullyQualifiedNames.Contains(primFqn);
+        }
 
         var cls = AsClass(type);
         if (cls == null) return false;
@@ -250,6 +279,24 @@ public static class TypeUtils
 
         return false;
     }
+
+    /// <summary>
+    /// Map a <see cref="JavaType.PrimitiveKind"/> to its .NET fully-qualified type name.
+    /// Returns null for non-value primitives (Null, None, Void).
+    /// </summary>
+    private static string? PrimitiveToFqn(JavaType.PrimitiveKind kind) => kind switch
+    {
+        JavaType.PrimitiveKind.Boolean => "System.Boolean",
+        JavaType.PrimitiveKind.Byte => "System.Byte",
+        JavaType.PrimitiveKind.Char => "System.Char",
+        JavaType.PrimitiveKind.Double => "System.Double",
+        JavaType.PrimitiveKind.Float => "System.Single",
+        JavaType.PrimitiveKind.Int => "System.Int32",
+        JavaType.PrimitiveKind.Long => "System.Int64",
+        JavaType.PrimitiveKind.Short => "System.Int16",
+        JavaType.PrimitiveKind.String => "System.String",
+        _ => null
+    };
 
     private static JavaType? TryGetTypeDynamic(Expression expr)
     {

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Java/TypeUtilsTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Java/TypeUtilsTests.cs
@@ -292,6 +292,87 @@ public class TypeUtilsTests
     }
 
     // =============================================================
+    // IsAssignableTo — primitives beyond String
+    // =============================================================
+
+    [Fact]
+    public void IsAssignableTo_PrimitiveInt()
+    {
+        var prim = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int);
+        Assert.True(TypeUtils.IsAssignableTo(prim, "System.Int32"));
+    }
+
+    [Fact]
+    public void IsAssignableTo_PrimitiveBool()
+    {
+        var prim = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Boolean);
+        Assert.True(TypeUtils.IsAssignableTo(prim, "System.Boolean"));
+    }
+
+    [Fact]
+    public void IsAssignableTo_PrimitiveDouble()
+    {
+        var prim = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Double);
+        Assert.True(TypeUtils.IsAssignableTo(prim, "System.Double"));
+    }
+
+    [Fact]
+    public void IsAssignableTo_PrimitiveInt_NotAssignableToOther()
+    {
+        var prim = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int);
+        Assert.False(TypeUtils.IsAssignableTo(prim, "System.String"));
+    }
+
+    // =============================================================
+    // IsAssignableTo — JavaType target overload
+    // =============================================================
+
+    [Fact]
+    public void IsAssignableTo_JavaType_SamePrimitive()
+    {
+        var candidateType = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int);
+        var targetType = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int);
+        Assert.True(TypeUtils.IsAssignableTo(candidateType, targetType));
+    }
+
+    [Fact]
+    public void IsAssignableTo_JavaType_DifferentPrimitive()
+    {
+        var candidateType = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int);
+        var targetType = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.String);
+        Assert.False(TypeUtils.IsAssignableTo(candidateType, targetType));
+    }
+
+    [Fact]
+    public void IsAssignableTo_JavaType_ClassTarget()
+    {
+        var iface = MakeClass("System.IDisposable");
+        var candidate = MakeClass("MyClass", interfaces: [iface]);
+        var target = MakeClass("System.IDisposable");
+        Assert.True(TypeUtils.IsAssignableTo(candidate, target));
+    }
+
+    [Fact]
+    public void IsAssignableTo_JavaType_ParameterizedTarget()
+    {
+        // Target is Parameterized(IDictionary) — should compare by base FQN
+        var idict = MakeClass("System.Collections.Generic.IDictionary");
+        var dict = MakeClass("System.Collections.Generic.Dictionary", interfaces: [idict]);
+        var target = new JavaType.Parameterized
+        {
+            Type = MakeClass("System.Collections.Generic.IDictionary")
+        };
+        Assert.True(TypeUtils.IsAssignableTo(dict, target));
+    }
+
+    [Fact]
+    public void IsAssignableTo_JavaType_NullTarget()
+    {
+        var cls = MakeClass("System.String");
+        Assert.False(TypeUtils.IsAssignableTo(cls, (JavaType?)null));
+    }
+
+    // =============================================================
     // Cycle protection
     // =============================================================
 

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TypedCaptureTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TypedCaptureTests.cs
@@ -165,6 +165,84 @@ public class TypedCaptureTests : RewriteTest
         );
     }
 
+    [Fact]
+    public void TypedCaptureMatchesGenericInterfaceImplementation()
+    {
+        var dict = Capture.Expression("dict", type: "IDictionary<object, object>");
+        var key = Capture.Expression("key");
+        var pat = CSharpPattern.Expression($"{dict}.Keys.Contains({key})",
+            usings: ["System.Collections.Generic"]);
+
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation(pat))
+                .SetReferenceAssemblies(Assemblies.Net90),
+            CSharp(
+                """
+                using System.Collections.Generic;
+                class Test
+                {
+                    void M()
+                    {
+                        var dict = new Dictionary<string, int>();
+                        bool has = dict.Keys.Contains("key");
+                    }
+                }
+                """,
+                """
+                using System.Collections.Generic;
+                class Test
+                {
+                    void M()
+                    {
+                        var dict = new Dictionary<string, int>();
+                        bool has = /*~~>*/dict.Keys.Contains("key");
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void TypedCaptureMatchesPrimitiveInt()
+    {
+        var expr = Capture.Expression("expr");
+        var idx = Capture.Expression("idx", type: "int");
+        var pat = CSharpPattern.Expression($"{expr}.ElementAt({idx})",
+            usings: ["System.Linq"]);
+
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation(pat))
+                .SetReferenceAssemblies(Assemblies.Net90),
+            CSharp(
+                """
+                using System.Linq;
+                using System.Collections.Generic;
+                class Test
+                {
+                    void M()
+                    {
+                        var list = new List<string>();
+                        var item = list.ElementAt(0);
+                    }
+                }
+                """,
+                """
+                using System.Linq;
+                using System.Collections.Generic;
+                class Test
+                {
+                    void M()
+                    {
+                        var list = new List<string>();
+                        var item = /*~~>*/list.ElementAt(0);
+                    }
+                }
+                """
+            )
+        );
+    }
+
     // ===============================================================
     // Recipe factories
     // ===============================================================
@@ -177,6 +255,9 @@ public class TypedCaptureTests : RewriteTest
 
     private static Core.Recipe FindMethodInvocation(TemplateStringHandler handler, IReadOnlyList<string> usings)
         => new MethodInvocationSearchRecipe(CSharpPattern.Expression(handler, usings: usings));
+
+    private static Core.Recipe FindMethodInvocation(CSharpPattern pat)
+        => new MethodInvocationSearchRecipe(pat);
 }
 
 file class TypedPatternSearchRecipe(CSharpPattern pat) : Core.Recipe


### PR DESCRIPTION
## Motivation

- The runtime typed capture constraint introduced in #7117 fails for two cases:

1. **Generic interface types** — `Capture.Expression(type: "IDictionary<object, object>")` rejects `Dictionary<string, int>` because the raw type string (with generic args) is compared literally against FQNs in the type hierarchy, which never include generic arguments.
2. **Primitive types** — `Capture.Expression(type: "int")` rejects `int` candidates because `TypeUtils.IsAssignableTo` only handled `Primitive(String)`, not other primitive kinds.

## Summary

- Use the Roslyn-resolved `JavaType` from the pattern scaffold's placeholder for type comparison instead of the raw type string. This lets Roslyn handle namespace resolution and generic type stripping naturally — `IDictionary<object, object> __plh_dict__` resolves to `Parameterized(Class("System.Collections.Generic.IDictionary"))`, and `AsClass` extracts the base FQN for hierarchy comparison.
- Generalize `TypeUtils.IsAssignableTo` to handle all `PrimitiveKind` values (not just `String`) via a `PrimitiveKind`-to-.NET-FQN mapping.
- Add `TypeUtils.IsAssignableTo(JavaType?, JavaType?)` overload for type-to-type comparison.
- Pass the resolved pattern type through `CaptureConstraintContext.PatternType` from `PatternMatchingComparator` to `Capture.EvaluateConstraint`.

## Test plan

- Added unit tests for `TypeUtils`: primitive int/bool/double assignability, `JavaType`-to-`JavaType` overload (same/different primitives, class target, parameterized target, null)
- Added integration tests: `TypedCaptureMatchesGenericInterfaceImplementation` (`IDictionary<object, object>` matches `Dictionary<string, int>`) and `TypedCaptureMatchesPrimitiveInt` (`int` matches literal `0`)
- All 1684 existing tests continue to pass