### PR TITLE
Fix JavaTemplate statement replacement regression for non-J.Block parent cursors

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -435,8 +435,11 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                     }
                     return m;
                 }
+                Object parentValue = getCursor().getParentTreeCursor().getValue();
                 if (loc == STATEMENT_PREFIX && isScope(method) &&
-                    !(getCursor().getParentTreeCursor().getValue() instanceof J.Block)) {
+                    (parentValue instanceof J.Return ||
+                     parentValue instanceof J.Assignment ||
+                     parentValue instanceof J.AssignmentOperation)) {
                     // Method invocation is used as an expression (e.g., inside return, assignment),
                     // not as a standalone statement in a block. Parse as expression replacement.
                     return autoFormat(unsubstitute(templateParser.parseExpression(
@@ -452,8 +455,11 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             @Override
             public J visitNewClass(J.NewClass newClass, Integer p) {
                 if (isScope(newClass)) {
+                    Object parentValue = getCursor().getParentTreeCursor().getValue();
                     if (loc == STATEMENT_PREFIX &&
-                        !(getCursor().getParentTreeCursor().getValue() instanceof J.Block)) {
+                        (parentValue instanceof J.Return ||
+                         parentValue instanceof J.Assignment ||
+                         parentValue instanceof J.AssignmentOperation)) {
                         return autoFormat(unsubstitute(templateParser.parseExpression(
                                         getCursor(),
                                         substitutedTemplate,


### PR DESCRIPTION
## Summary

- Fixes a regression introduced by #7096 where `JavaTemplate.apply()` with `coordinates.replace()` throws `IndexOutOfBoundsException` when the cursor's parent tree is not a `J.Block` and the template produces a statement (not an expression)
- The negative check `!(parent instanceof J.Block)` over-matched, routing statement templates to `parseExpression()` which returns an empty list
- Replaced with a positive check for the specific expression-wrapping contexts (`J.Return`, `J.Assignment`, `J.AssignmentOperation`) that #7096 intended to handle

## Test plan

- [x] Existing `JavaTemplateTest8Test` tests from #7096 still pass (expression replacement inside return statements)
- [x] All `*JavaTemplate*` tests pass