### PR TITLE
C#: Support open generic type parameters in typed captures

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Capture.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Capture.cs
@@ -42,6 +42,7 @@ public interface ICapture
     bool IsVariadic { get; }
     int? MinCount { get; }
     int? MaxCount { get; }
+    IReadOnlyList<string>? TypeParameters { get; }
 
     /// <summary>
     /// Evaluate the single-node constraint (if any) against a candidate.
@@ -81,12 +82,14 @@ public sealed class Capture<T> : ICapture where T : J
     public int? MinCount => Variadic?.Min;
     public int? MaxCount => Variadic?.Max;
     public string? Type { get; }
+    public IReadOnlyList<string>? TypeParameters { get; }
     internal CaptureKind Kind { get; }
     public Func<T, CaptureConstraintContext, bool>? Constraint { get; }
     public VariadicOptions<T>? Variadic { get; }
 
     internal Capture(string name,
         string? type = null,
+        IReadOnlyList<string>? typeParameters = null,
         CaptureKind kind = CaptureKind.Expression,
         Func<T, CaptureConstraintContext, bool>? constraint = null,
         VariadicOptions<T>? variadic = null)
@@ -98,6 +101,7 @@ public sealed class Capture<T> : ICapture where T : J
 
         Name = name;
         Type = type;
+        TypeParameters = typeParameters;
         Kind = kind;
         Constraint = constraint;
         Variadic = variadic;
@@ -120,7 +124,7 @@ public sealed class Capture<T> : ICapture where T : J
         if (Type != null && candidate is Expression { Type: not null } expr)
         {
             // Prefer the Roslyn-resolved type from the pattern scaffold when available.
-            // This handles generics (IDictionary<object, object> resolves to its FQN)
+            // This handles generics (IDictionary<TKey, TValue> with GenericTypeVariable entries)
             // and primitives (int resolves to System.Int32) correctly without string parsing.
             var matched = context.PatternType != null
                 ? TypeUtils.IsAssignableTo(expr.Type, context.PatternType)
@@ -188,21 +192,29 @@ public static class Capture
     /// </para>
     /// </summary>
     public static Capture<T> Of<T>(string? name = null, string? type = null,
+        IReadOnlyList<string>? typeParameters = null,
         Func<T, CaptureConstraintContext, bool>? constraint = null,
         VariadicOptions<T>? variadic = null) where T : J
         => new(name ?? $"_capture_{Interlocked.Increment(ref _counter)}",
-            type: type, constraint: constraint, variadic: variadic);
+            type: type, typeParameters: typeParameters,
+            constraint: constraint, variadic: variadic);
 
     /// <summary>
     /// Create a capture for an expression-position node.
     /// When <paramref name="type"/> is specified, the template engine generates a typed
     /// field declaration in the scaffold preamble for type attribution.
+    /// When <paramref name="typeParameters"/> is specified, the listed names are treated
+    /// as generic type parameters on the scaffold class, allowing the capture to match
+    /// any instantiation of the generic type. Each entry is either a bare name (unbounded)
+    /// or <c>"Name : Bound1, Bound2"</c> (with constraints), following C# where-clause syntax.
     /// </summary>
     public static Capture<Expression> Expression(string? name = null, string? type = null,
+        IReadOnlyList<string>? typeParameters = null,
         Func<Expression, CaptureConstraintContext, bool>? constraint = null,
         VariadicOptions<Expression>? variadic = null)
         => new(name ?? $"_capture_{Interlocked.Increment(ref _counter)}",
-            type: type, kind: CaptureKind.Expression, constraint: constraint,
+            type: type, typeParameters: typeParameters,
+            kind: CaptureKind.Expression, constraint: constraint,
             variadic: variadic);
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
@@ -83,7 +83,7 @@ internal static class TemplateEngine
         IReadOnlyDictionary<string, string> dependencies, ScaffoldKind? scaffoldKind)
     {
         // Compute preamble first — it affects the scaffold shape and must be part of the cache key
-        var preamble = BuildTypePreamble(captures);
+        var preamble = BuildScaffoldPreamble(captures);
         var cacheKey = BuildCacheKey(code, preamble, usings, context, dependencies, scaffoldKind);
         if (GlobalCache.TryGetValue(cacheKey, out var cached))
             return cached;
@@ -93,7 +93,7 @@ internal static class TemplateEngine
         return result;
     }
 
-    private static J ParseInternal(string code, IReadOnlyList<string> preamble,
+    private static J ParseInternal(string code, ScaffoldPreamble preamble,
         IReadOnlyList<string> usings, IReadOnlyList<string> context,
         IReadOnlyDictionary<string, string> dependencies, ScaffoldKind? scaffoldKind)
     {
@@ -128,24 +128,73 @@ internal static class TemplateEngine
     }
 
     /// <summary>
-    /// Build typed field declarations for captures that have a Type.
-    /// These are emitted as class fields on the scaffold class so they are in scope
-    /// inside the method body. This avoids mixing preamble statements with the template
-    /// code, so <see cref="ExtractTemplateNode"/> doesn't need to skip anything.
-    /// Dispatches on <see cref="CaptureKind"/> to generate the right scaffold form.
+    /// Collects field declarations, type parameters, and where clauses from captures
+    /// for scaffold generation.
     /// </summary>
-    private static List<string> BuildTypePreamble(IReadOnlyDictionary<string, object> captures)
+    private sealed record ScaffoldPreamble(
+        IReadOnlyList<string> Fields,
+        IReadOnlyList<string> TypeParameterNames,
+        IReadOnlyList<string> WhereClauses);
+
+    /// <summary>
+    /// Build the scaffold preamble from captures: field declarations for expression captures,
+    /// type parameter names and where clauses from captures with <see cref="ICapture.TypeParameters"/>.
+    /// </summary>
+    private static ScaffoldPreamble BuildScaffoldPreamble(IReadOnlyDictionary<string, object> captures)
     {
         const System.Reflection.BindingFlags bindingFlags =
             System.Reflection.BindingFlags.Instance |
             System.Reflection.BindingFlags.Public |
             System.Reflection.BindingFlags.NonPublic;
 
-        var preamble = new List<string>();
+        var fields = new List<string>();
+        var typeParamNames = new List<string>();
+        var whereClauses = new List<string>();
+        // Track bounds per type parameter name for conflict detection
+        var typeParamBounds = new Dictionary<string, string?>();
+
         foreach (var kvp in captures)
         {
             var kind = kvp.Value.GetType().GetProperty("Kind", bindingFlags)?.GetValue(kvp.Value);
             var placeholder = Placeholder.ToPlaceholder(kvp.Key);
+
+            // Collect type parameters from captures that declare them
+            if (kvp.Value is ICapture { TypeParameters: { } typeParams })
+            {
+                foreach (var tp in typeParams)
+                {
+                    // Each entry is either "TName" (unbounded) or "TName : Bound1, Bound2"
+                    var colonIdx = tp.IndexOf(':');
+                    string name;
+                    string? bounds;
+                    if (colonIdx >= 0)
+                    {
+                        name = tp[..colonIdx].Trim();
+                        bounds = tp[(colonIdx + 1)..].Trim();
+                    }
+                    else
+                    {
+                        name = tp.Trim();
+                        bounds = null;
+                    }
+
+                    if (typeParamBounds.TryGetValue(name, out var existingBounds))
+                    {
+                        // Same name already declared — check for conflicts
+                        if (!string.Equals(existingBounds, bounds, StringComparison.Ordinal))
+                            throw new InvalidOperationException(
+                                $"Conflicting bounds for type parameter '{name}': " +
+                                $"'{existingBounds ?? "(none)"}' vs '{bounds ?? "(none)"}'");
+                    }
+                    else
+                    {
+                        typeParamBounds[name] = bounds;
+                        typeParamNames.Add(name);
+                        if (bounds != null)
+                            whereClauses.Add($"where {name} : {bounds}");
+                    }
+                }
+            }
 
             if (kind is CaptureKind captureKind)
             {
@@ -156,7 +205,7 @@ internal static class TemplateEngine
                         // Always emit a field declaration for expression captures so Roslyn
                         // knows the placeholder is a variable, not a type. Without this,
                         // `__plh_x__ * __plh_y__` is misparsed as a pointer declaration.
-                        preamble.Add($"{(string.IsNullOrEmpty(captureType) ? "object" : captureType)} {placeholder};");
+                        fields.Add($"{(string.IsNullOrEmpty(captureType) ? "object" : captureType)} {placeholder};");
                         break;
                     case CaptureKind.Type:
                         // TODO: emit scaffold that places placeholder in a type position
@@ -172,18 +221,18 @@ internal static class TemplateEngine
                 var captureType = kvp.Value.GetType().GetProperty("Type")?.GetValue(kvp.Value) as string;
                 if (!string.IsNullOrEmpty(captureType))
                 {
-                    preamble.Add($"{captureType} {placeholder};");
+                    fields.Add($"{captureType} {placeholder};");
                 }
             }
         }
-        return preamble;
+        return new ScaffoldPreamble(fields, typeParamNames, whereClauses);
     }
 
     /// <summary>
     /// Build a parseable C# source from the template code.
     /// The scaffold shape is controlled by <paramref name="scaffoldKind"/>.
     /// </summary>
-    private static string BuildScaffold(string code, IReadOnlyList<string> preamble,
+    private static string BuildScaffold(string code, ScaffoldPreamble preamble,
         IReadOnlyList<string> usings, IReadOnlyList<string> context, ScaffoldKind? scaffoldKind)
     {
         var sb = new System.Text.StringBuilder();
@@ -201,10 +250,23 @@ internal static class TemplateEngine
             sb.AppendLine(c);
         }
 
-        sb.AppendLine("class __T__ {");
+        // Emit class declaration with type parameters if any captures declare them
+        sb.Append("class __T__");
+        if (preamble.TypeParameterNames.Count > 0)
+        {
+            sb.Append('<');
+            sb.Append(string.Join(", ", preamble.TypeParameterNames));
+            sb.Append('>');
+        }
+        if (preamble.WhereClauses.Count > 0)
+        {
+            sb.Append(' ');
+            sb.Append(string.Join(" ", preamble.WhereClauses));
+        }
+        sb.AppendLine(" {");
 
         // Typed capture declarations as class fields — in scope for all scaffold kinds
-        foreach (var decl in preamble)
+        foreach (var decl in preamble.Fields)
         {
             sb.Append("    ");
             sb.AppendLine(decl);
@@ -575,7 +637,7 @@ internal static class TemplateEngine
         return blk.WithStatements(formattedStmts).WithPrefix(preservedBlockPrefix);
     }
 
-    private static string BuildCacheKey(string code, IReadOnlyList<string> preamble,
+    private static string BuildCacheKey(string code, ScaffoldPreamble preamble,
         IReadOnlyList<string> usings, IReadOnlyList<string> context,
         IReadOnlyDictionary<string, string> dependencies, ScaffoldKind? scaffoldKind = null)
     {
@@ -589,10 +651,22 @@ internal static class TemplateEngine
         sb.Append("code:");
         sb.Append(code);
 
-        if (preamble.Count > 0)
+        if (preamble.Fields.Count > 0)
         {
             sb.Append("|preamble:");
-            sb.Append(string.Join(",", preamble));
+            sb.Append(string.Join(",", preamble.Fields));
+        }
+
+        if (preamble.TypeParameterNames.Count > 0)
+        {
+            sb.Append("|typeParams:");
+            sb.Append(string.Join(",", preamble.TypeParameterNames));
+        }
+
+        if (preamble.WhereClauses.Count > 0)
+        {
+            sb.Append("|where:");
+            sb.Append(string.Join(",", preamble.WhereClauses));
         }
 
         if (usings.Count > 0)

--- a/rewrite-csharp/csharp/OpenRewrite/Java/TypeUtils.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/TypeUtils.cs
@@ -56,8 +56,13 @@ public static class TypeUtils
     /// Check if a type is assignable to the target type, where the target is specified
     /// as a <see cref="JavaType"/> rather than a string FQN. This is the preferred overload
     /// when the target type comes from a parsed AST (e.g., a typed capture's scaffold).
-    /// For parameterized targets like <c>IDictionary&lt;object, object&gt;</c>, the generic
-    /// type arguments are ignored — only the base type definition is checked.
+    /// <para>
+    /// When the target is a <see cref="JavaType.Parameterized"/> type with
+    /// <see cref="JavaType.GenericTypeVariable"/> type parameters, those positions are treated
+    /// as wildcards: any concrete type argument satisfies an unbounded type variable, and
+    /// bounded type variables check that the candidate's type argument satisfies the bound.
+    /// Concrete type parameters require an exact FQN match.
+    /// </para>
     /// </summary>
     public static bool IsAssignableTo(JavaType? type, JavaType? targetType)
     {
@@ -67,7 +72,14 @@ public static class TypeUtils
         if (type is JavaType.Primitive candPrim && targetType is JavaType.Primitive targetPrim)
             return candPrim.Kind == targetPrim.Kind;
 
-        // Extract the base FQN from the target, stripping generic type parameters
+        // When target is parameterized with type parameters, do parameter-aware matching.
+        // This handles both open generics (with GenericTypeVariable wildcards) and concrete
+        // generics (where all type args must match exactly).
+        if (targetType is JavaType.Parameterized targetParam
+            && targetParam.TypeParameters is { Count: > 0 })
+            return IsAssignableToParameterized(type, targetParam);
+
+        // Fall back to raw FQN comparison
         var targetFqn = GetFullyQualifiedName(targetType);
         if (targetFqn == null) return false;
 
@@ -82,9 +94,9 @@ public static class TypeUtils
         if (type == null) return false;
 
         // Primitives have no Class representation — map to FQN and check
-        if (type is JavaType.Primitive prim)
+        if (type is JavaType.Primitive prim2)
         {
-            var primFqn = PrimitiveToFqn(prim.Kind);
+            var primFqn = PrimitiveToFqn(prim2.Kind);
             return primFqn != null && fullyQualifiedNames.Contains(primFqn);
         }
 
@@ -281,20 +293,211 @@ public static class TypeUtils
     }
 
     /// <summary>
-    /// Map a <see cref="JavaType.PrimitiveKind"/> to its .NET fully-qualified type name.
+    /// Check if <paramref name="type"/> is assignable to a parameterized target type.
+    /// Walks the candidate's supertype/interface chain looking for a
+    /// <see cref="JavaType.Parameterized"/> whose raw type matches, then compares type
+    /// arguments position-by-position.
+    /// </summary>
+    private static bool IsAssignableToParameterized(JavaType type, JavaType.Parameterized target)
+    {
+        var targetFqn = GetFullyQualifiedName(target.Type);
+        if (targetFqn == null) return false;
+
+        // Collect all parameterized types in the candidate's hierarchy that match the target FQN
+        var matching = new List<JavaType.Parameterized>();
+        CollectParameterizedMatches(type, targetFqn, matching, new HashSet<string>());
+
+        // Check if any matching parameterized type satisfies the type argument constraints
+        foreach (var match in matching)
+        {
+            if (TypeParametersMatch(match.TypeParameters, target.TypeParameters))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Recursively collect <see cref="JavaType.Parameterized"/> types in the hierarchy
+    /// of <paramref name="type"/> whose raw FQN matches <paramref name="targetFqn"/>.
+    /// When walking from a <see cref="JavaType.Parameterized"/> type, resolves
+    /// <see cref="JavaType.GenericTypeVariable"/> entries in supertypes/interfaces by
+    /// substituting the actual type arguments (mirroring Java's <c>maybeResolveParameters</c>).
+    /// </summary>
+    private static void CollectParameterizedMatches(JavaType? type, string targetFqn,
+        List<JavaType.Parameterized> results, HashSet<string> seen)
+    {
+        if (type == null) return;
+
+        if (type is JavaType.Parameterized param)
+        {
+            var rawFqn = GetFullyQualifiedName(param.Type);
+            if (rawFqn != null)
+            {
+                if (string.Equals(rawFqn, targetFqn, StringComparison.Ordinal))
+                    results.Add(param);
+
+                // Continue walking the underlying class's hierarchy, resolving
+                // type parameters in supertypes/interfaces using the actual type args
+                if (param.Type is JavaType.Class cls && seen.Add(cls.FullyQualifiedName))
+                {
+                    var resolved = MaybeResolveParameters(param, cls.Supertype as JavaType.FullyQualified);
+                    CollectParameterizedMatches(resolved ?? cls.Supertype, targetFqn, results, seen);
+                    if (cls.Interfaces != null)
+                    {
+                        foreach (var iface in cls.Interfaces)
+                        {
+                            resolved = MaybeResolveParameters(param, iface);
+                            CollectParameterizedMatches(resolved ?? iface, targetFqn, results, seen);
+                        }
+                    }
+                }
+            }
+        }
+        else if (type is JavaType.Class cls)
+        {
+            if (!seen.Add(cls.FullyQualifiedName)) return;
+
+            CollectParameterizedMatches(cls.Supertype, targetFqn, results, seen);
+            if (cls.Interfaces != null)
+            {
+                foreach (var iface in cls.Interfaces)
+                    CollectParameterizedMatches(iface, targetFqn, results, seen);
+            }
+        }
+    }
+
+    /// <summary>
+    /// When a <see cref="JavaType.Parameterized"/> type (e.g., <c>Dictionary&lt;string, int&gt;</c>)
+    /// has a supertype or interface that is also parameterized (e.g., <c>IDictionary&lt;TKey, TValue&gt;</c>),
+    /// resolve the target's type parameters by substituting the source's actual type arguments
+    /// for the formal type parameters.
+    /// <para>
+    /// Mirrors Java's <c>TypeUtils.maybeResolveParameters</c>.
+    /// </para>
+    /// </summary>
+    private static JavaType.Parameterized? MaybeResolveParameters(
+        JavaType.Parameterized source, JavaType.FullyQualified? target)
+    {
+        if (target is not JavaType.Parameterized targetParam)
+            return null;
+
+        var sourceClass = source.Type as JavaType.Class;
+        if (sourceClass?.TypeParameters == null || source.TypeParameters == null)
+            return null;
+
+        if (sourceClass.TypeParameters.Count != source.TypeParameters.Count)
+            return null;
+
+        // Build substitution map: formal type param → actual type arg
+        var map = new Dictionary<string, JavaType>();
+        for (int i = 0; i < sourceClass.TypeParameters.Count; i++)
+        {
+            if (sourceClass.TypeParameters[i] is JavaType.GenericTypeVariable gtv)
+                map[gtv.Name] = source.TypeParameters[i];
+        }
+
+        if (map.Count == 0 || targetParam.TypeParameters == null)
+            return null;
+
+        // Apply substitution to the target's type parameters
+        var resolved = new List<JavaType>(targetParam.TypeParameters.Count);
+        bool changed = false;
+        foreach (var tp in targetParam.TypeParameters)
+        {
+            var sub = SubstituteTypeParam(tp, map);
+            resolved.Add(sub);
+            if (!ReferenceEquals(sub, tp)) changed = true;
+        }
+
+        return changed ? new JavaType.Parameterized(targetParam.Type, resolved) : targetParam;
+    }
+
+    /// <summary>
+    /// Replace a <see cref="JavaType.GenericTypeVariable"/> with its substitution
+    /// from the map. For <see cref="JavaType.Parameterized"/> types, recursively
+    /// substitute type parameters.
+    /// </summary>
+    private static JavaType SubstituteTypeParam(JavaType type, Dictionary<string, JavaType> map)
+    {
+        if (type is JavaType.GenericTypeVariable gtv && map.TryGetValue(gtv.Name, out var replacement))
+            return replacement;
+
+        if (type is JavaType.Parameterized param && param.TypeParameters != null)
+        {
+            var substituted = new List<JavaType>(param.TypeParameters.Count);
+            bool changed = false;
+            foreach (var tp in param.TypeParameters)
+            {
+                var sub = SubstituteTypeParam(tp, map);
+                substituted.Add(sub);
+                if (!ReferenceEquals(sub, tp)) changed = true;
+            }
+            if (changed)
+                return new JavaType.Parameterized(param.Type, substituted);
+        }
+
+        return type;
+    }
+
+    /// <summary>
+    /// Compare type parameter lists position-by-position. A <see cref="JavaType.GenericTypeVariable"/>
+    /// in the target acts as a wildcard (any concrete type matches). If the variable has bounds,
+    /// the candidate's type argument must be assignable to all bounds.
+    /// Concrete type parameters require exact FQN match.
+    /// </summary>
+    private static bool TypeParametersMatch(IList<JavaType>? candidateParams, IList<JavaType>? targetParams)
+    {
+        if (targetParams == null || targetParams.Count == 0) return true;
+        if (candidateParams == null || candidateParams.Count != targetParams.Count) return false;
+
+        for (int i = 0; i < targetParams.Count; i++)
+        {
+            var targetParam = targetParams[i];
+            var candidateParam = candidateParams[i];
+
+            if (targetParam is JavaType.GenericTypeVariable gtv)
+            {
+                // Unbounded type variable — any type matches
+                if (gtv.Bounds == null || gtv.Bounds.Count == 0)
+                    continue;
+
+                // Bounded — candidate must be assignable to all bounds
+                foreach (var bound in gtv.Bounds)
+                {
+                    var boundFqn = GetFullyQualifiedName(bound);
+                    if (boundFqn != null && !IsAssignableTo(candidateParam, boundFqn))
+                        return false;
+                }
+            }
+            else
+            {
+                // Concrete type parameter — require exact FQN match
+                var targetFqn = GetFullyQualifiedName(targetParam);
+                var candidateFqn = GetFullyQualifiedName(candidateParam);
+                if (targetFqn == null || candidateFqn == null ||
+                    !string.Equals(targetFqn, candidateFqn, StringComparison.Ordinal))
+                    return false;
+            }
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Map a <see cref="JavaType.Primitive.PrimitiveKind"/> to its .NET fully-qualified type name.
     /// Returns null for non-value primitives (Null, None, Void).
     /// </summary>
-    private static string? PrimitiveToFqn(JavaType.PrimitiveKind kind) => kind switch
+    private static string? PrimitiveToFqn(JavaType.Primitive.PrimitiveKind kind) => kind switch
     {
-        JavaType.PrimitiveKind.Boolean => "System.Boolean",
-        JavaType.PrimitiveKind.Byte => "System.Byte",
-        JavaType.PrimitiveKind.Char => "System.Char",
-        JavaType.PrimitiveKind.Double => "System.Double",
-        JavaType.PrimitiveKind.Float => "System.Single",
-        JavaType.PrimitiveKind.Int => "System.Int32",
-        JavaType.PrimitiveKind.Long => "System.Int64",
-        JavaType.PrimitiveKind.Short => "System.Int16",
-        JavaType.PrimitiveKind.String => "System.String",
+        JavaType.Primitive.PrimitiveKind.Boolean => "System.Boolean",
+        JavaType.Primitive.PrimitiveKind.Byte => "System.Byte",
+        JavaType.Primitive.PrimitiveKind.Char => "System.Char",
+        JavaType.Primitive.PrimitiveKind.Double => "System.Double",
+        JavaType.Primitive.PrimitiveKind.Float => "System.Single",
+        JavaType.Primitive.PrimitiveKind.Int => "System.Int32",
+        JavaType.Primitive.PrimitiveKind.Long => "System.Int64",
+        JavaType.Primitive.PrimitiveKind.Short => "System.Int16",
+        JavaType.Primitive.PrimitiveKind.String => "System.String",
         _ => null
     };
 

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/CSharpTypeMappingTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/CSharpTypeMappingTests.cs
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using OpenRewrite.CSharp;
+using OpenRewrite.Java;
+using OpenRewrite.Test;
+
+namespace OpenRewrite.Tests.CSharp;
+
+/// <summary>
+/// Tests that the C# parser's type mapping correctly handles generic types,
+/// especially how parameterized interfaces store type arguments.
+/// </summary>
+public class CSharpTypeMappingTests : RewriteTest
+{
+    /// <summary>
+    /// Parse source code with reference assemblies and return the CompilationUnit.
+    /// </summary>
+    private static CompilationUnit ParseWithSemanticModel(string code)
+    {
+        var refs = Assemblies.Net90.ResolveAsync(LanguageNames.CSharp, CancellationToken.None)
+            .GetAwaiter().GetResult();
+        var syntaxTree = CSharpSyntaxTree.ParseText(code, path: "source.cs");
+        var compilation = CSharpCompilation.Create("TestCompilation")
+            .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddReferences(refs)
+            .AddSyntaxTrees(syntaxTree);
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+
+        var parser = new CSharpParser();
+        return parser.Parse(code, semanticModel: semanticModel);
+    }
+
+    /// <summary>
+    /// Find the first variable declaration in a compilation unit by variable name.
+    /// </summary>
+    private static VariableDeclarations? FindVariableDeclaration(CompilationUnit cu, string varName)
+    {
+        var finder = new VarFinder(varName);
+        finder.Cursor = new Core.Cursor(null, Core.Cursor.ROOT_VALUE);
+        finder.Visit(cu, 0);
+        return finder.Found;
+    }
+
+    private class VarFinder(string name) : CSharpVisitor<int>
+    {
+        public VariableDeclarations? Found { get; private set; }
+
+        public override J? VisitVariableDeclarations(VariableDeclarations multiVariable, int p)
+        {
+            if (multiVariable.Variables.Any(v => v.Element.Name.SimpleName == name))
+                Found = multiVariable;
+            return base.VisitVariableDeclarations(multiVariable, p);
+        }
+    }
+
+    [Fact]
+    public void GenericClassField_HasParameterizedTypeWithGenericTypeVariables()
+    {
+        // A class with type parameters and a field whose type references them.
+        // The field's type should be Parameterized with GenericTypeVariable entries.
+        var cu = ParseWithSemanticModel("""
+            using System.Collections.Generic;
+            class Foo<TKey, TValue>
+            {
+                IDictionary<TKey, TValue> dict;
+            }
+            """);
+
+        var varDecl = FindVariableDeclaration(cu, "dict");
+        Assert.NotNull(varDecl);
+
+        // The declared type should be Parameterized(IDictionary, [GTV(TKey), GTV(TValue)])
+        var declType = varDecl!.TypeExpression?.Type;
+        Assert.NotNull(declType);
+        var paramType = Assert.IsType<JavaType.Parameterized>(declType);
+
+        Assert.NotNull(paramType.Type);
+        Assert.Contains("IDictionary", TypeUtils.GetFullyQualifiedName(paramType.Type));
+
+        Assert.NotNull(paramType.TypeParameters);
+        Assert.Equal(2, paramType.TypeParameters!.Count);
+
+        var tp0 = Assert.IsType<JavaType.GenericTypeVariable>(paramType.TypeParameters[0]);
+        Assert.Equal("TKey", tp0.Name);
+
+        var tp1 = Assert.IsType<JavaType.GenericTypeVariable>(paramType.TypeParameters[1]);
+        Assert.Equal("TValue", tp1.Name);
+    }
+
+    [Fact]
+    public void ConcreteGenericVariable_HasParameterizedTypeWithConcreteArgs()
+    {
+        // A local variable with a concrete generic type.
+        var cu = ParseWithSemanticModel("""
+            using System.Collections.Generic;
+            class Test
+            {
+                void M()
+                {
+                    Dictionary<string, int> dict = new Dictionary<string, int>();
+                }
+            }
+            """);
+
+        var varDecl = FindVariableDeclaration(cu, "dict");
+        Assert.NotNull(varDecl);
+
+        var declType = varDecl!.TypeExpression?.Type;
+        Assert.NotNull(declType);
+        var paramType = Assert.IsType<JavaType.Parameterized>(declType);
+
+        Assert.Contains("Dictionary", TypeUtils.GetFullyQualifiedName(paramType.Type));
+
+        // Type args should be concrete: String, Int32
+        Assert.NotNull(paramType.TypeParameters);
+        Assert.Equal(2, paramType.TypeParameters!.Count);
+
+        // string is mapped as Primitive(String) or Class(System.String)
+        var tp0Fqn = TypeUtils.GetFullyQualifiedName(paramType.TypeParameters[0]);
+        Assert.NotNull(tp0Fqn);
+        Assert.Contains("String", tp0Fqn);
+
+        // int is mapped as Primitive(Int) or Class(System.Int32)
+        var tp1 = paramType.TypeParameters[1];
+        Assert.True(
+            tp1 is JavaType.Primitive { Kind: JavaType.Primitive.PrimitiveKind.Int } ||
+            TypeUtils.GetFullyQualifiedName(tp1)?.Contains("Int32") == true,
+            $"Expected int type but got: {tp1.GetType().Name}");
+    }
+
+    [Fact]
+    public void ConcreteGenericVariable_InterfacesHaveUnsubstitutedTypeParams()
+    {
+        // Verify that the underlying Class for Dictionary stores interfaces
+        // with unsubstituted type parameters (GenericTypeVariable), not
+        // concrete types. This is the expected behavior — TypeUtils must
+        // resolve these at comparison time.
+        var cu = ParseWithSemanticModel("""
+            using System.Collections.Generic;
+            class Test
+            {
+                void M()
+                {
+                    Dictionary<string, int> dict = new Dictionary<string, int>();
+                }
+            }
+            """);
+
+        var varDecl = FindVariableDeclaration(cu, "dict");
+        Assert.NotNull(varDecl);
+
+        var paramType = Assert.IsType<JavaType.Parameterized>(varDecl!.TypeExpression?.Type);
+        var dictClass = TypeUtils.AsClass(paramType);
+        Assert.NotNull(dictClass);
+
+        // Dictionary should implement IDictionary (among other interfaces)
+        Assert.NotNull(dictClass!.Interfaces);
+        var idict = dictClass.Interfaces!
+            .Select(TypeUtils.AsClass)
+            .FirstOrDefault(c => c?.FullyQualifiedName.Contains("IDictionary") == true);
+        Assert.NotNull(idict);
+
+        // Find the Parameterized form of the IDictionary interface
+        var idictParam = dictClass.Interfaces!
+            .OfType<JavaType.Parameterized>()
+            .FirstOrDefault(p => TypeUtils.GetFullyQualifiedName(p.Type)?.Contains("IDictionary") == true);
+
+        // The interface should be parameterized with GenericTypeVariables
+        // (TKey, TValue from the Dictionary definition), NOT concrete types
+        if (idictParam != null && idictParam.TypeParameters != null)
+        {
+            // At least one type param should be a GenericTypeVariable
+            // (confirming these are unsubstituted from the original definition)
+            var hasGtv = idictParam.TypeParameters.Any(tp => tp is JavaType.GenericTypeVariable);
+            Assert.True(hasGtv,
+                "Expected IDictionary interface to have GenericTypeVariable type params " +
+                "(unsubstituted from Dictionary's original definition), but found: " +
+                string.Join(", ", idictParam.TypeParameters.Select(tp => tp.GetType().Name)));
+        }
+    }
+
+    [Fact]
+    public void DictionaryClass_HasFormalTypeParameters()
+    {
+        // Verify that the underlying Class for Dictionary has formal type parameters
+        // (needed for building substitution maps during type comparison).
+        var cu = ParseWithSemanticModel("""
+            using System.Collections.Generic;
+            class Test
+            {
+                void M()
+                {
+                    Dictionary<string, int> dict = new Dictionary<string, int>();
+                }
+            }
+            """);
+
+        var varDecl = FindVariableDeclaration(cu, "dict");
+        Assert.NotNull(varDecl);
+
+        var paramType = Assert.IsType<JavaType.Parameterized>(varDecl!.TypeExpression?.Type);
+        var dictClass = TypeUtils.AsClass(paramType);
+        Assert.NotNull(dictClass);
+
+        // The Class should have TypeParameters listing formal type params
+        Assert.NotNull(dictClass!.TypeParameters);
+        Assert.Equal(2, dictClass.TypeParameters!.Count);
+
+        var formal0 = Assert.IsType<JavaType.GenericTypeVariable>(dictClass.TypeParameters[0]);
+        Assert.Equal("TKey", formal0.Name);
+
+        var formal1 = Assert.IsType<JavaType.GenericTypeVariable>(dictClass.TypeParameters[1]);
+        Assert.Equal("TValue", formal1.Name);
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Java/TypeUtilsTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Java/TypeUtilsTests.cs
@@ -330,17 +330,17 @@ public class TypeUtilsTests
     [Fact]
     public void IsAssignableTo_JavaType_SamePrimitive()
     {
-        var candidateType = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int);
-        var targetType = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int);
-        Assert.True(TypeUtils.IsAssignableTo(candidateType, targetType));
+        var from = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int);
+        var to = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int);
+        Assert.True(TypeUtils.IsAssignableTo(from, to));
     }
 
     [Fact]
     public void IsAssignableTo_JavaType_DifferentPrimitive()
     {
-        var candidateType = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int);
-        var targetType = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.String);
-        Assert.False(TypeUtils.IsAssignableTo(candidateType, targetType));
+        var from = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.Int);
+        var to = JavaType.Primitive.Of(JavaType.Primitive.PrimitiveKind.String);
+        Assert.False(TypeUtils.IsAssignableTo(from, to));
     }
 
     [Fact]
@@ -353,9 +353,9 @@ public class TypeUtilsTests
     }
 
     [Fact]
-    public void IsAssignableTo_JavaType_ParameterizedTarget()
+    public void IsAssignableTo_JavaType_ParameterizedTarget_RawFqnMatch()
     {
-        // Target is Parameterized(IDictionary) — should compare by base FQN
+        // Target is Parameterized(IDictionary) with no type params — should match by base FQN
         var idict = MakeClass("System.Collections.Generic.IDictionary");
         var dict = MakeClass("System.Collections.Generic.Dictionary", interfaces: [idict]);
         var target = new JavaType.Parameterized
@@ -370,6 +370,156 @@ public class TypeUtilsTests
     {
         var cls = MakeClass("System.String");
         Assert.False(TypeUtils.IsAssignableTo(cls, (JavaType?)null));
+    }
+
+    // =============================================================
+    // IsAssignableTo — GenericTypeVariable (open generic matching)
+    // =============================================================
+
+    [Fact]
+    public void IsAssignableTo_GenericTypeVariable_UnboundedMatchesAny()
+    {
+        // Target: IDictionary<TKey, TValue> (both unbounded GenericTypeVariables)
+        var idictClass = MakeClass("System.Collections.Generic.IDictionary");
+        var target = new JavaType.Parameterized(
+            idictClass,
+            [
+                new JavaType.GenericTypeVariable("TKey", JavaType.GenericTypeVariable.VarianceKind.Invariant, null),
+                new JavaType.GenericTypeVariable("TValue", JavaType.GenericTypeVariable.VarianceKind.Invariant, null)
+            ]);
+
+        // Candidate: Dictionary<string, int> implementing IDictionary<string, int>
+        var idictStringInt = new JavaType.Parameterized(
+            MakeClass("System.Collections.Generic.IDictionary"),
+            [MakeClass("System.String"), MakeClass("System.Int32")]);
+        var dictClass = MakeClass("System.Collections.Generic.Dictionary",
+            interfaces: [idictStringInt]);
+        var candidate = new JavaType.Parameterized(
+            dictClass,
+            [MakeClass("System.String"), MakeClass("System.Int32")]);
+
+        Assert.True(TypeUtils.IsAssignableTo(candidate, target));
+    }
+
+    [Fact]
+    public void IsAssignableTo_PartialGeneric_FixedFirstParam()
+    {
+        // Target: IDictionary<string, TValue> — first param fixed, second open
+        var idictClass = MakeClass("System.Collections.Generic.IDictionary");
+        var target = new JavaType.Parameterized(
+            idictClass,
+            [
+                MakeClass("System.String"),
+                new JavaType.GenericTypeVariable("TValue", JavaType.GenericTypeVariable.VarianceKind.Invariant, null)
+            ]);
+
+        // Candidate: Dictionary<string, int> implementing IDictionary<string, int> — should match
+        var idictStringInt = new JavaType.Parameterized(
+            MakeClass("System.Collections.Generic.IDictionary"),
+            [MakeClass("System.String"), MakeClass("System.Int32")]);
+        var dictClass = MakeClass("System.Collections.Generic.Dictionary",
+            interfaces: [idictStringInt]);
+        var candidate = new JavaType.Parameterized(
+            dictClass,
+            [MakeClass("System.String"), MakeClass("System.Int32")]);
+
+        Assert.True(TypeUtils.IsAssignableTo(candidate, target));
+    }
+
+    [Fact]
+    public void IsAssignableTo_PartialGeneric_FixedParamMismatch()
+    {
+        // Target: IDictionary<string, TValue> — first param must be string
+        var idictClass = MakeClass("System.Collections.Generic.IDictionary");
+        var target = new JavaType.Parameterized(
+            idictClass,
+            [
+                MakeClass("System.String"),
+                new JavaType.GenericTypeVariable("TValue", JavaType.GenericTypeVariable.VarianceKind.Invariant, null)
+            ]);
+
+        // Candidate: Dictionary<int, string> implementing IDictionary<int, string> — should NOT match
+        var idictIntString = new JavaType.Parameterized(
+            MakeClass("System.Collections.Generic.IDictionary"),
+            [MakeClass("System.Int32"), MakeClass("System.String")]);
+        var dictClass = MakeClass("System.Collections.Generic.Dictionary",
+            interfaces: [idictIntString]);
+        var candidate = new JavaType.Parameterized(
+            dictClass,
+            [MakeClass("System.Int32"), MakeClass("System.String")]);
+
+        Assert.False(TypeUtils.IsAssignableTo(candidate, target));
+    }
+
+    [Fact]
+    public void IsAssignableTo_GenericTypeVariable_WithBound()
+    {
+        // Target: IEnumerable<T> where T : IComparable
+        var ienumClass = MakeClass("System.Collections.Generic.IEnumerable");
+        var icomparable = MakeClass("System.IComparable");
+        var target = new JavaType.Parameterized(
+            ienumClass,
+            [new JavaType.GenericTypeVariable("T", JavaType.GenericTypeVariable.VarianceKind.Invariant,
+                [icomparable])]);
+
+        // Candidate: List<string> implementing IEnumerable<string>
+        // string implements IComparable → should match
+        var stringClass = MakeClass("System.String", interfaces: [MakeClass("System.IComparable")]);
+        var ienumString = new JavaType.Parameterized(
+            MakeClass("System.Collections.Generic.IEnumerable"),
+            [stringClass]);
+        var listClass = MakeClass("System.Collections.Generic.List",
+            interfaces: [ienumString]);
+        var candidate = new JavaType.Parameterized(listClass, [stringClass]);
+
+        Assert.True(TypeUtils.IsAssignableTo(candidate, target));
+    }
+
+    [Fact]
+    public void IsAssignableTo_GenericTypeVariable_BoundNotSatisfied()
+    {
+        // Target: IEnumerable<T> where T : IComparable
+        var ienumClass = MakeClass("System.Collections.Generic.IEnumerable");
+        var icomparable = MakeClass("System.IComparable");
+        var target = new JavaType.Parameterized(
+            ienumClass,
+            [new JavaType.GenericTypeVariable("T", JavaType.GenericTypeVariable.VarianceKind.Invariant,
+                [icomparable])]);
+
+        // Candidate: List<object> implementing IEnumerable<object>
+        // object does NOT implement IComparable → should NOT match
+        var objectClass = MakeClass("System.Object");
+        var ienumObject = new JavaType.Parameterized(
+            MakeClass("System.Collections.Generic.IEnumerable"),
+            [objectClass]);
+        var listClass = MakeClass("System.Collections.Generic.List",
+            interfaces: [ienumObject]);
+        var candidate = new JavaType.Parameterized(listClass, [objectClass]);
+
+        Assert.False(TypeUtils.IsAssignableTo(candidate, target));
+    }
+
+    [Fact]
+    public void IsAssignableTo_ConcreteGeneric_StillRequiresExactTypeArgs()
+    {
+        // Target: IDictionary<string, string> — NO GenericTypeVariables, all concrete
+        var idictClass = MakeClass("System.Collections.Generic.IDictionary");
+        var target = new JavaType.Parameterized(
+            idictClass,
+            [MakeClass("System.String"), MakeClass("System.String")]);
+
+        // Candidate: Dictionary<string, int> implementing IDictionary<string, int>
+        // Type args don't match → should NOT match
+        var idictStringInt = new JavaType.Parameterized(
+            MakeClass("System.Collections.Generic.IDictionary"),
+            [MakeClass("System.String"), MakeClass("System.Int32")]);
+        var dictClass = MakeClass("System.Collections.Generic.Dictionary",
+            interfaces: [idictStringInt]);
+        var candidate = new JavaType.Parameterized(
+            dictClass,
+            [MakeClass("System.String"), MakeClass("System.Int32")]);
+
+        Assert.False(TypeUtils.IsAssignableTo(candidate, target));
     }
 
     // =============================================================

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TypedCaptureTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TypedCaptureTests.cs
@@ -168,7 +168,9 @@ public class TypedCaptureTests : RewriteTest
     [Fact]
     public void TypedCaptureMatchesGenericInterfaceImplementation()
     {
-        var dict = Capture.Expression("dict", type: "IDictionary<object, object>");
+        var dict = Capture.Expression("dict",
+            type: "IDictionary<TKey, TValue>",
+            typeParameters: ["TKey", "TValue"]);
         var key = Capture.Expression("key");
         var pat = CSharpPattern.Expression($"{dict}.Keys.Contains({key})",
             usings: ["System.Collections.Generic"]);
@@ -244,6 +246,200 @@ public class TypedCaptureTests : RewriteTest
     }
 
     // ===============================================================
+    // Open generic captures
+    // ===============================================================
+
+    [Fact]
+    public void OpenGenericCapture_MatchesAnyDictionary()
+    {
+        var dict = Capture.Expression("dict",
+            type: "IDictionary<TKey, TValue>",
+            typeParameters: ["TKey", "TValue"]);
+        var pat = CSharpPattern.Expression($"{dict}.Count",
+            usings: ["System.Collections.Generic"]);
+
+        RewriteRun(
+            spec => spec.SetRecipe(FindExpression(pat))
+                .SetReferenceAssemblies(Assemblies.Net90),
+            CSharp(
+                """
+                using System.Collections.Generic;
+                class Test
+                {
+                    void M()
+                    {
+                        var d = new Dictionary<string, int>();
+                        var n = d.Count;
+                    }
+                }
+                """,
+                """
+                using System.Collections.Generic;
+                class Test
+                {
+                    void M()
+                    {
+                        var d = new Dictionary<string, int>();
+                        var n = /*~~>*/d.Count;
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void OpenGenericCapture_PartialFixedFirstParam()
+    {
+        var dict = Capture.Expression("dict",
+            type: "IDictionary<string, TValue>",
+            typeParameters: ["TValue"]);
+        var pat = CSharpPattern.Expression($"{dict}.Count",
+            usings: ["System.Collections.Generic"]);
+
+        RewriteRun(
+            spec => spec.SetRecipe(FindExpression(pat))
+                .SetReferenceAssemblies(Assemblies.Net90),
+            CSharp(
+                // Dictionary<string, int> — first param is string → should match
+                """
+                using System.Collections.Generic;
+                class Test
+                {
+                    void M()
+                    {
+                        var d = new Dictionary<string, int>();
+                        var n = d.Count;
+                    }
+                }
+                """,
+                """
+                using System.Collections.Generic;
+                class Test
+                {
+                    void M()
+                    {
+                        var d = new Dictionary<string, int>();
+                        var n = /*~~>*/d.Count;
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void OpenGenericCapture_PartialFixedFirstParam_Rejects()
+    {
+        var dict = Capture.Expression("dict",
+            type: "IDictionary<string, TValue>",
+            typeParameters: ["TValue"]);
+        var pat = CSharpPattern.Expression($"{dict}.Count",
+            usings: ["System.Collections.Generic"]);
+
+        RewriteRun(
+            spec => spec.SetRecipe(FindExpression(pat))
+                .SetReferenceAssemblies(Assemblies.Net90),
+            CSharp(
+                // Dictionary<int, string> — first param is int, not string → no match
+                """
+                using System.Collections.Generic;
+                class Test
+                {
+                    void M()
+                    {
+                        var d = new Dictionary<int, string>();
+                        var n = d.Count;
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void OpenGenericCapture_WithBound()
+    {
+        var list = Capture.Expression("list",
+            type: "IEnumerable<T>",
+            typeParameters: ["T : IComparable"]);
+        var pat = CSharpPattern.Expression($"{list}.Count()",
+            usings: ["System.Collections.Generic", "System.Linq"]);
+
+        RewriteRun(
+            spec => spec.SetRecipe(FindExpression(pat))
+                .SetReferenceAssemblies(Assemblies.Net90),
+            CSharp(
+                // List<string> — string implements IComparable → should match
+                """
+                using System.Collections.Generic;
+                using System.Linq;
+                class Test
+                {
+                    void M()
+                    {
+                        var list = new List<string>();
+                        var n = list.Count();
+                    }
+                }
+                """,
+                """
+                using System.Collections.Generic;
+                using System.Linq;
+                class Test
+                {
+                    void M()
+                    {
+                        var list = new List<string>();
+                        var n = /*~~>*/list.Count();
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void OpenGenericCapture_StoresTypeParameters()
+    {
+        var cap = Capture.Expression("x",
+            type: "IDictionary<TKey, TValue>",
+            typeParameters: ["TKey", "TValue"]);
+        Assert.NotNull(cap.TypeParameters);
+        Assert.Equal(2, cap.TypeParameters!.Count);
+        Assert.Equal("TKey", cap.TypeParameters[0]);
+        Assert.Equal("TValue", cap.TypeParameters[1]);
+    }
+
+    [Fact]
+    public void ConcreteGenericCapture_StillMatchesExact()
+    {
+        // No typeParameters → concrete generic, should only match exact type args
+        var dict = Capture.Expression("dict", type: "Dictionary<string, string>");
+        var pat = CSharpPattern.Expression($"{dict}.Count",
+            usings: ["System.Collections.Generic"]);
+
+        RewriteRun(
+            spec => spec.SetRecipe(FindExpression(pat))
+                .SetReferenceAssemblies(Assemblies.Net90),
+            CSharp(
+                // Dictionary<string, int> — type args don't match → no match
+                """
+                using System.Collections.Generic;
+                class Test
+                {
+                    void M()
+                    {
+                        var d = new Dictionary<string, int>();
+                        var n = d.Count;
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    // ===============================================================
     // Recipe factories
     // ===============================================================
 
@@ -252,6 +448,9 @@ public class TypedCaptureTests : RewriteTest
 
     private static Core.Recipe FindExpression(string code)
         => new TypedPatternSearchRecipe(CSharpPattern.Expression(code));
+
+    private static Core.Recipe FindExpression(CSharpPattern pat)
+        => new TypedPatternSearchRecipe(pat);
 
     private static Core.Recipe FindMethodInvocation(TemplateStringHandler handler, IReadOnlyList<string> usings)
         => new MethodInvocationSearchRecipe(CSharpPattern.Expression(handler, usings: usings));


### PR DESCRIPTION
## Motivation

When a typed capture needs to match any instantiation of a generic type (e.g., any `IDictionary<K,V>`), recipe authors previously had to either remove the `type:` entirely (losing semantic matching) or pick a specific instantiation that only matches one concrete type.

This adds a `typeParameters` parameter to captures that allows expressing "any instantiation of this generic type", with optional bounds:

## Examples

```csharp
// Match any IDictionary<K,V>
var dict = Capture.Expression(type: "IDictionary<TKey, TValue>",
    typeParameters: ["TKey", "TValue"]);

// Partial: first param fixed, second open
var dict = Capture.Expression(type: "IDictionary<string, TValue>",
    typeParameters: ["TValue"]);

// With bounds
var list = Capture.Expression(type: "IEnumerable<T>",
    typeParameters: ["T : IComparable"]);
```

## Summary

- Add `typeParameters` to `Capture` and `ICapture` — each entry is either a bare name (unbounded) or `"Name : Bound1, Bound2"` (with constraints in C# `where`-clause syntax)
- Scaffold generation emits type parameters on the scaffold class (`class __T__<TKey, TValue> where TKey : IComparable { ... }`), so Roslyn produces proper `GenericTypeVariable`-based type attribution
- Extend `TypeUtils.IsAssignableTo(JavaType, JavaType)` with generic-aware matching: walks the candidate's type hierarchy, resolves unsubstituted type parameters via `MaybeResolveParameters` (mirroring Java's approach), and compares type args position-by-position treating `GenericTypeVariable` as wildcards
- Concrete parameterized types (no `typeParameters` declared) now require exact type argument match, fixing a previous bug where `IDictionary<object, object>` would incorrectly match `Dictionary<string, int>`

## Test plan

- [x] `TypeUtils` unit tests: unbounded GTV matches any type, partial open generic with fixed param, fixed param mismatch rejected, bounded GTV checks bounds, concrete generic requires exact match
- [x] Parser type mapping tests: confirm generic class fields get `GenericTypeVariable` entries, concrete generic variables get concrete type args, interfaces store unsubstituted type params, `Class.TypeParameters` has formal params
- [x] Integration tests: open generic `IDictionary<TKey, TValue>` matches `Dictionary<string, int>`, partial open `IDictionary<string, TValue>` matches/rejects correctly, bounded captures work, concrete generics still require exact match
- [x] Full test suite (1700 tests) passes