### PR TITLE
Add FindAndReplace regex test for Gradle Artifactory URL replacement

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/text/FindAndReplaceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/text/FindAndReplaceTest.java
@@ -137,6 +137,37 @@ class FindAndReplaceTest implements RewriteTest {
     }
 
     @Test
+    void regexWithSlashDelimiters() {
+        rewriteRun(
+          spec -> spec.recipe(new FindAndReplace(
+            "url\\s+\"(\\$\\{?ARTIFACTORY_URL\\}?\\/(libs-release|plugins-release))\"",
+            "url \"\\${ARTIFACTORY_URL}/plugins-release\"\n" +
+              "        credentials(HttpHeaderCredentials) { name = \"Authorization\" value = \"Bearer \" + System.getenv('ARTIFACTORY_ACCESS_TOKEN') }\n" +
+              "        authentication { header(HttpHeaderAuthentication) }",
+            true, null, null, null, "**/*.gradle", null)),
+          text(
+            """
+              repositories {
+                  maven {
+                      url "$ARTIFACTORY_URL/plugins-release"
+                  }
+              }
+              """,
+            """
+              repositories {
+                  maven {
+                      url "${ARTIFACTORY_URL}/plugins-release"
+                      credentials(HttpHeaderCredentials) { name = "Authorization" value = "Bearer " + System.getenv('ARTIFACTORY_ACCESS_TOKEN') }
+                      authentication { header(HttpHeaderAuthentication) }
+                  }
+              }
+              """,
+            spec -> spec.path("build.gradle")
+          )
+        );
+    }
+
+    @Test
     void successiveReplacement() {
         rewriteRun(
           spec -> spec.recipes(


### PR DESCRIPTION
## Background / problem

A customer reported that `FindAndReplace` with `regex=true` returned zero results when using a regex pattern to match and replace Artifactory repository URLs in Gradle build files. The pattern worked in external regex testers but not in `FindAndReplace`.

The root cause was two user-facing pitfalls:

1. The customer wrapped their regex in JavaScript-style `/pattern/` delimiters, which `Pattern.compile` treats as literal `/` characters, preventing any match.
2. The replacement string contained `${ARTIFACTORY_URL}`, which Java's `Matcher.replaceAll` interprets as a named capturing group reference rather than a literal string. The `$` needs to be escaped as `\$` in regex mode.

Neither of these failure modes had test coverage.

## Solution

Added a test exercising `FindAndReplace` with `regex=true` against a realistic Gradle build file scenario: matching Artifactory repository URLs with capture groups, using escaped dollar signs in the replacement string, and filtering by `**/*.gradle` file pattern.

## Test plan

- [x] `./gradlew :rewrite-core:test --tests "org.openrewrite.text.FindAndReplaceTest.regexWithSlashDelimiters"` passes