### PR TITLE
C#: Replace RewriteRule/IRewriteRule with Rewriter class

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CSharpPattern.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CSharpPattern.cs
@@ -151,6 +151,12 @@ public sealed class CSharpPattern
     }
 
     /// <summary>
+    /// Create a <see cref="Rewriter"/> that rewrites nodes matching this pattern
+    /// to the given template.
+    /// </summary>
+    public Rewriter RewriteTo(CSharpTemplate template) => new Rewriter(this, template);
+
+    /// <summary>
     /// Get the parsed pattern tree (cached after first parse).
     /// </summary>
     public J GetTree()

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Rewriter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/Rewriter.cs
@@ -20,73 +20,66 @@ using ExecutionContext = OpenRewrite.Core.ExecutionContext;
 namespace OpenRewrite.CSharp.Template;
 
 /// <summary>
-/// A declarative rewrite rule that pairs structural pattern matching with template application.
-/// Create rules with <see cref="RewriteRule.Rewrite(CSharpPattern, CSharpTemplate)"/>.
+/// A declarative rewriter that pairs structural pattern matching with template application.
+/// Create instances via <see cref="CSharpPattern.RewriteTo"/>.
 /// </summary>
 /// <example>
 /// <code>
 /// var expr = Capture.Expression("expr");
-/// var rule = RewriteRule.Rewrite(
-///     CSharpPattern.Expression($"Console.Write({expr})"),
-///     CSharpTemplate.Expression($"Console.WriteLine({expr})"));
+/// var rewriter = CSharpPattern.Expression($"Console.Write({expr})")
+///     .RewriteTo(CSharpTemplate.Expression($"Console.WriteLine({expr})"));
 ///
 /// // In a visitor method:
-/// return rule.TryOn(Cursor, node) ?? node;
+/// return rewriter.TryOn(Cursor, node) ?? node;
 /// </code>
 /// </example>
-public interface IRewriteRule
+public sealed class Rewriter
 {
-    /// <summary>
-    /// Try to apply this rule to the given node. Returns the transformed node if the
-    /// rule's pattern matches, or <c>null</c> if the rule does not apply.
-    /// The typical calling convention is <c>rule.TryOn(Cursor, node) ?? node</c>.
-    /// </summary>
-    J? TryOn(Cursor cursor, J node);
+    private readonly CSharpPattern _before;
+    private readonly CSharpTemplate _after;
+
+    internal Rewriter(CSharpPattern before, CSharpTemplate after)
+    {
+        _before = before;
+        _after = after;
+    }
 
     /// <summary>
-    /// Create a <see cref="CSharpVisitor{ExecutionContext}"/> that applies this rule to every
+    /// Try to apply this rewriter to the given node. Returns the transformed node if the
+    /// pattern matches, or <c>null</c> if the rewriter does not apply.
+    /// The typical calling convention is <c>rewriter.TryOn(Cursor, node) ?? node</c>.
+    /// </summary>
+    public J? TryOn(Cursor cursor, J node)
+    {
+        var match = _before.Match(node, cursor);
+        if (match == null) return null;
+        return _after.Apply(cursor, values: match);
+    }
+
+    /// <summary>
+    /// Create a <see cref="CSharpVisitor{ExecutionContext}"/> that applies this rewriter to every
     /// visited node via <see cref="TreeVisitor{T,P}.PostVisit"/>. The pattern's fast-reject
     /// in <see cref="CSharpPattern.Match"/> ensures only nodes whose type matches the pattern
     /// root are fully compared, so iterating over all nodes is cheap.
     /// <para>
     /// This is a convenience method for the common case where a recipe only matches a pattern
-    /// and applies a template. For more complex scenarios — such as combining multiple rules,
-    /// cursor-based filtering, or using <see cref="RewriteRule.CreateBlockFlattener{P}"/> —
+    /// and applies a template. For more complex scenarios — such as combining multiple rewriters,
+    /// cursor-based filtering, or using <see cref="CreateBlockFlattener{P}"/> —
     /// create a custom visitor and call <see cref="TryOn"/> directly.
     /// </para>
     /// </summary>
     /// <example>
     /// <code>
-    /// public override ITreeVisitor&lt;ExecutionContext&gt; GetVisitor()
+    /// public override JavaVisitor&lt;ExecutionContext&gt; GetVisitor()
     /// {
     ///     var x = Capture.Expression("x");
-    ///     return RewriteRule.Rewrite(
-    ///             CSharpPattern.Expression($"Console.Write({x})"),
-    ///             CSharpTemplate.Expression($"Console.WriteLine({x})"))
+    ///     return CSharpPattern.Expression($"Console.Write({x})")
+    ///         .RewriteTo(CSharpTemplate.Expression($"Console.WriteLine({x})"))
     ///         .ToVisitor();
     /// }
     /// </code>
     /// </example>
-    CSharpVisitor<ExecutionContext> ToVisitor() => new RewriteRule.RewriteRuleVisitor(this);
-}
-
-/// <summary>
-/// Factory methods for creating <see cref="IRewriteRule"/> instances.
-/// </summary>
-public static class RewriteRule
-{
-    /// <summary>
-    /// Create a rewrite rule from a <see cref="CSharpPattern"/> and <see cref="CSharpTemplate"/>.
-    /// <para>
-    /// When using typed captures with <c>typeParameters</c>, the pattern's <c>usings</c> must
-    /// include the namespaces needed for the capture type to resolve (e.g.,
-    /// <c>"System.Collections.Generic"</c> for <c>IDictionary&lt;TKey, TValue&gt;</c>).
-    /// Without proper usings, the scaffold has no semantic model and type constraints
-    /// fall back to string matching, which cannot handle generic types.
-    /// </para>
-    /// </summary>
-    public static IRewriteRule Rewrite(CSharpPattern before, CSharpTemplate after) =>
-        new RewriteRuleImpl(before, after);
+    public CSharpVisitor<ExecutionContext> ToVisitor() => new RewriterVisitor(this);
 
     /// <summary>
     /// Creates a visitor that splices statements from any <see cref="Block"/> marked with
@@ -96,10 +89,10 @@ public static class RewriteRule
     /// </summary>
     /// <example>
     /// <code>
-    /// var result = rule.TryOn(Cursor, ret);
+    /// var result = rewriter.TryOn(Cursor, ret);
     /// if (result is Block block &amp;&amp; block.Markers.FindFirst&lt;SyntheticBlockContainer&gt;() != null)
     /// {
-    ///     MaybeDoAfterVisit(RewriteRule.CreateBlockFlattener&lt;ExecutionContext&gt;());
+    ///     MaybeDoAfterVisit(Rewriter.CreateBlockFlattener&lt;ExecutionContext&gt;());
     ///     return block;
     /// }
     /// return result ?? ret;
@@ -118,21 +111,11 @@ public static class RewriteRule
     // Implementation
     // ===============================================================
 
-    private sealed class RewriteRuleImpl(CSharpPattern before, CSharpTemplate after) : IRewriteRule
-    {
-        public J? TryOn(Cursor cursor, J node)
-        {
-            var match = before.Match(node, cursor);
-            if (match == null) return null;
-            return after.Apply(cursor, values: match);
-        }
-    }
-
-    internal sealed class RewriteRuleVisitor(IRewriteRule rule) : CSharpVisitor<ExecutionContext>
+    internal sealed class RewriterVisitor(Rewriter rewriter) : CSharpVisitor<ExecutionContext>
     {
         public override J? PostVisit(J tree, ExecutionContext ctx)
         {
-            return rule.TryOn(Cursor, tree) ?? tree;
+            return rewriter.TryOn(Cursor, tree) ?? tree;
         }
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
@@ -24,7 +24,7 @@ namespace OpenRewrite.CSharp.Template;
 /// Marker placed on a <see cref="Block"/> that is a synthetic container for multiple statements
 /// produced by a multi-statement template, rather than a real block in the source code.
 /// Used by <see cref="TemplateEngine.AutoFormat"/> to format each statement at the parent level,
-/// and by <see cref="RewriteRule.CreateBlockFlattener{P}"/> to identify blocks to splice.
+/// and by <see cref="Rewriter.CreateBlockFlattener{P}"/> to identify blocks to splice.
 /// </summary>
 public sealed class SyntheticBlockContainer : Marker
 {

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/RewriterTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/RewriterTests.cs
@@ -22,7 +22,7 @@ using ExecutionContext = OpenRewrite.Core.ExecutionContext;
 
 namespace OpenRewrite.Tests.Template;
 
-public class RewriteRuleTests : RewriteTest
+public class RewriterTests : RewriteTest
 {
     [Fact]
     public void SimpleBeforeAfterReplacement()
@@ -559,19 +559,18 @@ class SwapBinaryOperandsRecipe : Core.Recipe
     {
         var left = Capture.Expression("left");
         var right = Capture.Expression("right");
-        var rule = RewriteRule.Rewrite(
-            CSharpPattern.Expression($"{left} + {right}"),
-            CSharpTemplate.Expression($"{right} + {left}"));
+        var rewriter = CSharpPattern.Expression($"{left} + {right}")
+            .RewriteTo(CSharpTemplate.Expression($"{right} + {left}"));
 
-        return new Visitor(rule);
+        return new Visitor(rewriter);
     }
 
-    private class Visitor(IRewriteRule rule) : CSharpVisitor<ExecutionContext>
+    private class Visitor(Rewriter rewriter) : CSharpVisitor<ExecutionContext>
     {
         public override J VisitBinary(Binary binary, ExecutionContext ctx)
         {
             binary = (Binary)base.VisitBinary(binary, ctx);
-            return rule.TryOn(Cursor, binary) ?? binary;
+            return rewriter.TryOn(Cursor, binary) ?? binary;
         }
     }
 }
@@ -608,24 +607,22 @@ class NormalizeConsoleOutputRecipe : Core.Recipe
 class MigrateAndRedirectRecipe : Core.Recipe
 {
     public override string DisplayName => "Migrate and redirect";
-    public override string Description => "Chains two rules: Write→WriteLine, then WriteLine→Error.WriteLine.";
+    public override string Description => "Chains two rewriters: Write→WriteLine, then WriteLine→Error.WriteLine.";
 
     public override ITreeVisitor<ExecutionContext> GetVisitor()
     {
         var expr1 = Capture.Expression("expr");
-        var migrateRule = RewriteRule.Rewrite(
-            CSharpPattern.Expression($"Console.Write({expr1})"),
-            CSharpTemplate.Expression($"Console.WriteLine({expr1})"));
+        var migrate = CSharpPattern.Expression($"Console.Write({expr1})")
+            .RewriteTo(CSharpTemplate.Expression($"Console.WriteLine({expr1})"));
 
         var expr2 = Capture.Expression("expr");
-        var redirectRule = RewriteRule.Rewrite(
-            CSharpPattern.Expression($"Console.WriteLine({expr2})"),
-            CSharpTemplate.Expression($"Console.Error.WriteLine({expr2})"));
+        var redirect = CSharpPattern.Expression($"Console.WriteLine({expr2})")
+            .RewriteTo(CSharpTemplate.Expression($"Console.Error.WriteLine({expr2})"));
 
-        return new Visitor(migrateRule, redirectRule);
+        return new Visitor(migrate, redirect);
     }
 
-    private class Visitor(IRewriteRule migrate, IRewriteRule redirect)
+    private class Visitor(Rewriter migrate, Rewriter redirect)
         : CSharpVisitor<ExecutionContext>
     {
         public override J VisitMethodInvocation(MethodInvocation mi, ExecutionContext ctx)
@@ -642,24 +639,22 @@ class MigrateAndRedirectRecipe : Core.Recipe
 class MigrateWithFallbackRecipe : Core.Recipe
 {
     public override string DisplayName => "Migrate with fallback";
-    public override string Description => "Tries primary then fallback rule.";
+    public override string Description => "Tries primary then fallback rewriter.";
 
     public override ITreeVisitor<ExecutionContext> GetVisitor()
     {
         var expr1 = Capture.Expression("expr");
-        var primaryRule = RewriteRule.Rewrite(
-            CSharpPattern.Expression($"Console.Write({expr1})"),
-            CSharpTemplate.Expression($"Console.WriteLine({expr1})"));
+        var primary = CSharpPattern.Expression($"Console.Write({expr1})")
+            .RewriteTo(CSharpTemplate.Expression($"Console.WriteLine({expr1})"));
 
         var expr2 = Capture.Expression("expr");
-        var fallbackRule = RewriteRule.Rewrite(
-            CSharpPattern.Expression($"Console.Error.Write({expr2})"),
-            CSharpTemplate.Expression($"Console.Error.WriteLine({expr2})"));
+        var fallback = CSharpPattern.Expression($"Console.Error.Write({expr2})")
+            .RewriteTo(CSharpTemplate.Expression($"Console.Error.WriteLine({expr2})"));
 
-        return new Visitor(primaryRule, fallbackRule);
+        return new Visitor(primary, fallback);
     }
 
-    private class Visitor(IRewriteRule primary, IRewriteRule fallback)
+    private class Visitor(Rewriter primary, Rewriter fallback)
         : CSharpVisitor<ExecutionContext>
     {
         public override J VisitMethodInvocation(MethodInvocation mi, ExecutionContext ctx)
@@ -679,21 +674,20 @@ class PreMatchFilteredRecipe : Core.Recipe
     public override ITreeVisitor<ExecutionContext> GetVisitor()
     {
         var expr = Capture.Expression("expr");
-        var rule = RewriteRule.Rewrite(
-            CSharpPattern.Expression($"Console.Write({expr})"),
-            CSharpTemplate.Expression($"Console.WriteLine({expr})"));
+        var rewriter = CSharpPattern.Expression($"Console.Write({expr})")
+            .RewriteTo(CSharpTemplate.Expression($"Console.WriteLine({expr})"));
 
-        return new Visitor(rule);
+        return new Visitor(rewriter);
     }
 
-    private class Visitor(IRewriteRule rule) : CSharpVisitor<ExecutionContext>
+    private class Visitor(Rewriter rewriter) : CSharpVisitor<ExecutionContext>
     {
         public override J VisitMethodInvocation(MethodInvocation mi, ExecutionContext ctx)
         {
             mi = (MethodInvocation)base.VisitMethodInvocation(mi, ctx);
             if (Cursor.FirstEnclosing<MethodDeclaration>()?.Name.SimpleName != "Target")
                 return mi;
-            return (MethodInvocation)(rule.TryOn(Cursor, mi) ?? mi);
+            return (MethodInvocation)(rewriter.TryOn(Cursor, mi) ?? mi);
         }
     }
 }
@@ -708,19 +702,18 @@ class CaptureConstraintFilteredRecipe : Core.Recipe
         var left = Capture.Expression("left");
         var right = Capture.Expression("right",
             constraint: (node, _) => node is Literal { ValueSource: "0" });
-        var rule = RewriteRule.Rewrite(
-            CSharpPattern.Expression($"{left} + {right}"),
-            CSharpTemplate.Expression($"{left}"));
+        var rewriter = CSharpPattern.Expression($"{left} + {right}")
+            .RewriteTo(CSharpTemplate.Expression($"{left}"));
 
-        return new Visitor(rule);
+        return new Visitor(rewriter);
     }
 
-    private class Visitor(IRewriteRule rule) : CSharpVisitor<ExecutionContext>
+    private class Visitor(Rewriter rewriter) : CSharpVisitor<ExecutionContext>
     {
         public override J VisitBinary(Binary binary, ExecutionContext ctx)
         {
             binary = (Binary)base.VisitBinary(binary, ctx);
-            return rule.TryOn(Cursor, binary) ?? binary;
+            return rewriter.TryOn(Cursor, binary) ?? binary;
         }
     }
 }
@@ -733,26 +726,25 @@ class CaptureFlowRecipe : Core.Recipe
     public override ITreeVisitor<ExecutionContext> GetVisitor()
     {
         var expr = Capture.Expression("expr");
-        var rule = RewriteRule.Rewrite(
-            CSharpPattern.Expression($"Console.Write({expr})"),
-            CSharpTemplate.Expression($"Console.WriteLine({expr})"));
+        var rewriter = CSharpPattern.Expression($"Console.Write({expr})")
+            .RewriteTo(CSharpTemplate.Expression($"Console.WriteLine({expr})"));
 
-        return new Visitor(rule);
+        return new Visitor(rewriter);
     }
 
-    private class Visitor(IRewriteRule rule) : CSharpVisitor<ExecutionContext>
+    private class Visitor(Rewriter rewriter) : CSharpVisitor<ExecutionContext>
     {
         public override J VisitMethodInvocation(MethodInvocation mi, ExecutionContext ctx)
         {
             mi = (MethodInvocation)base.VisitMethodInvocation(mi, ctx);
-            return (MethodInvocation)(rule.TryOn(Cursor, mi) ?? mi);
+            return (MethodInvocation)(rewriter.TryOn(Cursor, mi) ?? mi);
         }
     }
 }
 
 /// <summary>
 /// Expands "return expr" into "Console.WriteLine(expr); return expr;" — two statements.
-/// Exercises multi-statement templates and RewriteRule.CreateBlockFlattener.
+/// Exercises multi-statement templates and Rewriter.CreateBlockFlattener.
 /// </summary>
 class LogBeforeReturnRecipe : Core.Recipe
 {
@@ -762,24 +754,22 @@ class LogBeforeReturnRecipe : Core.Recipe
     public override ITreeVisitor<ExecutionContext> GetVisitor()
     {
         var expr = Capture.Expression("expr");
-        var pat = CSharpPattern.Statement($"return {expr}");
-        var tmpl = CSharpTemplate.Statement($"Console.WriteLine({expr});\nreturn {expr};");
+        var rewriter = CSharpPattern.Statement($"return {expr}")
+            .RewriteTo(CSharpTemplate.Statement($"Console.WriteLine({expr});\nreturn {expr};"));
 
-        var rule = RewriteRule.Rewrite(pat, tmpl);
-
-        return new Visitor(rule);
+        return new Visitor(rewriter);
     }
 
-    private class Visitor(IRewriteRule rule) : CSharpVisitor<ExecutionContext>
+    private class Visitor(Rewriter rewriter) : CSharpVisitor<ExecutionContext>
     {
         public override J VisitReturn(Return ret, ExecutionContext ctx)
         {
             ret = (Return)base.VisitReturn(ret, ctx);
-            var result = rule.TryOn(Cursor, ret);
+            var result = rewriter.TryOn(Cursor, ret);
             if (result is Block { Markers: var m } block &&
                 m.FindFirst<SyntheticBlockContainer>() != null)
             {
-                MaybeDoAfterVisit(RewriteRule.CreateBlockFlattener<ExecutionContext>());
+                MaybeDoAfterVisit(Rewriter.CreateBlockFlattener<ExecutionContext>());
                 return block;
             }
             return result ?? ret;
@@ -796,9 +786,8 @@ class ToVisitorBinaryRecipe : Core.Recipe
     {
         var left = Capture.Expression("left");
         var right = Capture.Expression("right");
-        return RewriteRule.Rewrite(
-                CSharpPattern.Expression($"{left} + {right}"),
-                CSharpTemplate.Expression($"{right} + {left}"))
+        return CSharpPattern.Expression($"{left} + {right}")
+            .RewriteTo(CSharpTemplate.Expression($"{right} + {left}"))
             .ToVisitor();
     }
 }
@@ -811,9 +800,8 @@ class ToVisitorMethodInvocationRecipe : Core.Recipe
     public override ITreeVisitor<ExecutionContext> GetVisitor()
     {
         var expr = Capture.Expression("expr");
-        return RewriteRule.Rewrite(
-                CSharpPattern.Expression($"Console.Write({expr})"),
-                CSharpTemplate.Expression($"Console.WriteLine({expr})"))
+        return CSharpPattern.Expression($"Console.Write({expr})")
+            .RewriteTo(CSharpTemplate.Expression($"Console.WriteLine({expr})"))
             .ToVisitor();
     }
 }
@@ -827,10 +815,9 @@ class UseContainsKeyRecipe : Core.Recipe
     {
         var dict = Capture.Expression(type: "IDictionary<TKey, TValue>", typeParameters: ["TKey", "TValue"]);
         var key = Capture.Expression();
-        return RewriteRule.Rewrite(
-                CSharpPattern.Expression($"{dict}.Keys.Contains({key})",
-                    usings: ["System.Collections.Generic"]),
-                CSharpTemplate.Expression($"{dict}.ContainsKey({key})"))
+        return CSharpPattern.Expression($"{dict}.Keys.Contains({key})",
+                usings: ["System.Collections.Generic"])
+            .RewriteTo(CSharpTemplate.Expression($"{dict}.ContainsKey({key})"))
             .ToVisitor();
     }
 }
@@ -844,10 +831,9 @@ class UseElementAtRecipe : Core.Recipe
     {
         var expr = Capture.Expression("expr", type: "IEnumerable<T>", typeParameters: ["T"]);
         var idx = Capture.Expression("idx", type: "int");
-        return RewriteRule.Rewrite(
-                CSharpPattern.Expression($"{expr}.ElementAt({idx})",
-                    usings: ["System.Collections.Generic", "System.Linq"]),
-                CSharpTemplate.Expression($"{expr}[{idx}]"))
+        return CSharpPattern.Expression($"{expr}.ElementAt({idx})",
+                usings: ["System.Collections.Generic", "System.Linq"])
+            .RewriteTo(CSharpTemplate.Expression($"{expr}[{idx}]"))
             .ToVisitor();
     }
 }
@@ -860,17 +846,15 @@ class FallbackWithManualVisitorRecipe : Core.Recipe
     public override ITreeVisitor<ExecutionContext> GetVisitor()
     {
         var x = Capture.Expression("x");
-        var isNull = RewriteRule.Rewrite(
-            CSharpPattern.Expression($"{x} == null"),
-            CSharpTemplate.Expression($"{x} is null"));
-        var isNotNull = RewriteRule.Rewrite(
-            CSharpPattern.Expression($"{x} != null"),
-            CSharpTemplate.Expression($"{x} is not null"));
+        var isNull = CSharpPattern.Expression($"{x} == null")
+            .RewriteTo(CSharpTemplate.Expression($"{x} is null"));
+        var isNotNull = CSharpPattern.Expression($"{x} != null")
+            .RewriteTo(CSharpTemplate.Expression($"{x} is not null"));
 
         return new Visitor(isNull, isNotNull);
     }
 
-    private class Visitor(IRewriteRule isNull, IRewriteRule isNotNull)
+    private class Visitor(Rewriter isNull, Rewriter isNotNull)
         : CSharpVisitor<ExecutionContext>
     {
         public override J VisitBinary(Binary binary, ExecutionContext ctx)

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TemplateApplyTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/TemplateApplyTests.cs
@@ -306,11 +306,10 @@ public class TemplateApplyTests : RewriteTest
     public void AttributeRenameViaRewriteRule()
     {
         var args = Capture.Expression("args", variadic: new());
-        var rule = RewriteRule.Rewrite(
-            CSharpPattern.Attribute($"Fact({args})"),
-            CSharpTemplate.Attribute($"Test({args})"));
+        var rewriter = CSharpPattern.Attribute($"Fact({args})")
+            .RewriteTo(CSharpTemplate.Attribute($"Test({args})"));
         RewriteRun(
-            spec => spec.SetRecipe(new RewriteRuleRecipe(rule)),
+            spec => spec.SetRecipe(new RewriterRecipe(rewriter)),
             CSharp(
                 """
                 class C
@@ -727,10 +726,10 @@ file class UseRethrowRecipe : Core.Recipe
     }
 }
 
-file class RewriteRuleRecipe(IRewriteRule rule) : Core.Recipe
+file class RewriterRecipe(Rewriter rewriter) : Core.Recipe
 {
-    public override string DisplayName => "RewriteRule";
-    public override string Description => "Applies a RewriteRule via ToVisitor().";
+    public override string DisplayName => "Rewriter";
+    public override string Description => "Applies a Rewriter via ToVisitor().";
 
-    public override JavaVisitor<ExecutionContext> GetVisitor() => rule.ToVisitor();
+    public override JavaVisitor<ExecutionContext> GetVisitor() => rewriter.ToVisitor();
 }


### PR DESCRIPTION
## Motivation

Feedback from the team is that "RewriteRule" introduces vocabulary ("rule") that's at odds with the existing pattern/template/visitor/recipe terminology. The API should build naturally on `CSharpPattern` and `CSharpTemplate` without introducing new top-level concepts.

## Examples

```csharp
// Simple — no visitor class needed:
var expr = Capture.Expression();
return CSharpPattern.Expression($"Console.Write({expr})")
    .RewriteTo(CSharpTemplate.Expression($"Console.WriteLine({expr})"))
    .ToVisitor();

// In a custom visitor with TryOn:
var rewriter = CSharpPattern.Expression($"{x} == null")
    .RewriteTo(CSharpTemplate.Expression($"{x} is null"));
return rewriter.TryOn(Cursor, binary) ?? binary;
```

## Summary

- Add `CSharpPattern.RewriteTo(CSharpTemplate)` returning a new `Rewriter` class
- `Rewriter` has `TryOn()`, `ToVisitor()`, and static `CreateBlockFlattener<P>()` — same implementation as the old `RewriteRuleImpl`/`RewriteRuleVisitor`
- Remove `IRewriteRule` interface and `RewriteRule` static factory class
- Rename `RewriteRuleTests.cs` → `RewriterTests.cs` and update all recipe implementations

## Test plan

- [x] All 18 RewriterTests pass
- [x] TemplateApplyTests.AttributeRenameViaRewriteRule passes
- [x] `dotnet build` succeeds with no errors