### PR TITLE
Add visitArrayAccess to JavaPrinter for marker rendering

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -190,6 +190,15 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
     }
 
     @Override
+    public J visitArrayAccess(ArrayAccess arrayAccess, PrintOutputCapture<P> p) {
+        beforeSyntax(arrayAccess, Space.Location.ARRAY_ACCESS_PREFIX, p);
+        visit(arrayAccess.getIndexed(), p);
+        visit(arrayAccess.getDimension(), p);
+        afterSyntax(arrayAccess, p);
+        return arrayAccess;
+    }
+
+    @Override
     public J visitArrayDimension(ArrayDimension arrayDimension, PrintOutputCapture<P> p) {
         beforeSyntax(arrayDimension, Space.Location.DIMENSION_PREFIX, p);
         p.append('[');


### PR DESCRIPTION
## Summary
- `JavaPrinter` was missing a `visitArrayAccess` override, which meant `SearchResult` markers on `J.ArrayAccess` nodes were never rendered during printing
- Every other J node type had an explicit override that called `beforeSyntax`/`afterSyntax` (which renders markers), but `ArrayAccess` fell through to the base `JavaVisitor.visitArrayAccess` which doesn't call `beforeSyntax`
- This prevented taint analysis recipes from marking array access expressions as sinks (e.g., `items[taintedIdx]`)