### PR TITLE
Continue refinements of `AddSettingsPluginRepository`

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepository.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepository.java
@@ -138,12 +138,31 @@ public class AddSettingsPluginRepository extends Recipe {
                 if (mapped != statements) {
                     return mapped;
                 }
-                // No existing pluginManagement found — insert a new block
+                // No existing pluginManagement found — insert after any leading imports
                 Statement pluginManagementStatement = pluginManagement instanceof J.Block ?
                         ((J.Block) pluginManagement).getStatements().get(0) :
                         (J.MethodInvocation) pluginManagement;
-                List<Statement> result = ListUtils.concat(pluginManagementStatement, statements);
-                return ListUtils.map(result, (i, s) -> i == 1 ? s.withPrefix(Space.format("\n\n")) : s);
+
+                int insertIdx = 0;
+                for (int i = 0; i < statements.size(); i++) {
+                    if (statements.get(i) instanceof J.Import) {
+                        insertIdx = i + 1;
+                    } else {
+                        break;
+                    }
+                }
+
+                if (insertIdx == 0) {
+                    List<Statement> result = ListUtils.concat(pluginManagementStatement, statements);
+                    return ListUtils.map(result, (i, s) -> i == 1 ? s.withPrefix(Space.format("\n\n")) : s);
+                } else {
+                    List<Statement> result = ListUtils.insert(statements, pluginManagementStatement.withPrefix(Space.format("\n\n")), insertIdx);
+                    if (insertIdx < result.size() - 1) {
+                        int nextIdx = insertIdx + 1;
+                        result = ListUtils.map(result, (i, s) -> i == nextIdx ? s.withPrefix(Space.format("\n\n")) : s);
+                    }
+                    return result;
+                }
             }
 
             private J.@Nullable MethodInvocation unwrapMethodCall(Statement statement, String methodName) {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepositoryTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepositoryTest.java
@@ -505,35 +505,6 @@ class AddSettingsPluginRepositoryTest implements RewriteTest {
     }
 
     @Test
-    void addToExistingPluginManagementNotFirstStatement() {
-        rewriteRun(
-          spec -> spec.recipe(new AddSettingsPluginRepository("gradlePluginPortal", null))
-            .expectedCyclesThatMakeChanges(1).cycles(3),
-          settingsGradle(
-            """
-              rootProject.name = "demo"
-
-              pluginManagement {
-                  repositories {
-                      mavenLocal()
-                  }
-              }
-              """,
-            """
-              rootProject.name = "demo"
-
-              pluginManagement {
-                  repositories {
-                      mavenLocal()
-                      gradlePluginPortal()
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
     void addToExistingPluginManagementNotFirstStatementKts() {
         rewriteRun(
           spec -> spec.recipe(new AddSettingsPluginRepository("gradlePluginPortal", null))
@@ -563,10 +534,10 @@ class AddSettingsPluginRepositoryTest implements RewriteTest {
     }
 
     @Test
-    void skipWhenExistsPluginManagementNotFirstStatement() {
+    void skipWhenExistsPluginManagementNotFirstStatementKts() {
         rewriteRun(
           spec -> spec.recipe(new AddSettingsPluginRepository("gradlePluginPortal", null)),
-          settingsGradle(
+          settingsGradleKts(
             """
               rootProject.name = "demo"
 
@@ -581,18 +552,33 @@ class AddSettingsPluginRepositoryTest implements RewriteTest {
     }
 
     @Test
-    void skipWhenExistsPluginManagementNotFirstStatementKts() {
+    void noPluginManagementBlockWithBuildCacheKts() {
         rewriteRun(
-          spec -> spec.recipe(new AddSettingsPluginRepository("gradlePluginPortal", null)),
+          spec -> spec.recipe(new AddSettingsPluginRepository("mavenCentral", null)),
           settingsGradleKts(
             """
-              rootProject.name = "demo"
-
-              pluginManagement {
-                  repositories {
-                      gradlePluginPortal()
+              buildCache {
+                  local {
+                      isEnabled = false
                   }
               }
+
+              rootProject.name = "demo"
+              """,
+            """
+              pluginManagement {
+                  repositories {
+                      mavenCentral()
+                  }
+              }
+
+              buildCache {
+                  local {
+                      isEnabled = false
+                  }
+              }
+
+              rootProject.name = "demo"
               """
           )
         );


### PR DESCRIPTION
## What's changed?
- Fixes the AddSettingsPluginRepository recipe to correctly handle pluginManagement block placement in Gradle settings files, and corrects invalid test examples introduced in #7105.

- Insertion of new pluginManagement blocks now skips past any leading import statements before inserting at position 0
- Removed Groovy DSL tests that placed rootProject.name before pluginManagement (invalid in Groovy — "The pluginManagement {} block must appear before any other statements in the script")
- Retained Kotlin DSL "not first statement" tests with rootProject.name before pluginManagement (valid in Kotlin DSL)
- Added noPluginManagementBlockWithBuildCacheKts test covering the customer-reported scenario where buildCache exists and pluginManagement must be inserted before it

## What's your motivation?

- PR #7105 fixed duplicate pluginManagement detection but introduced test cases with invalid Gradle scripts and didn't account for the different ordering rules between Groovy and Kotlin DSL.

Verified with Gradle 9.3.1:
- Groovy DSL: pluginManagement must be the absolute first statement (only imports may precede it). buildscript, buildCache, rootProject.name — all fail if placed before it.
- Kotlin DSL: pluginManagement can appear after most blocks (buildCache, rootProject.name, include()), but buildscript cannot appear before it.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files