### PR TITLE
C#: Replace `CSharpPattern.ToFindVisitor()` with static `CSharpPattern.Find()`

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CSharpPattern.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CSharpPattern.cs
@@ -219,6 +219,10 @@ public sealed class CSharpPattern
         return match != null ? annotator(tree, cursor, match) : tree;
     }
 
+    // ===============================================================
+    // Find — declarative pattern→annotator visitor factory
+    // ===============================================================
+
     /// <summary>
     /// Create a <see cref="CSharpVisitor{ExecutionContext}"/> that visits every node and
     /// adds a <see cref="SearchResult"/> marker to matches. The pattern's fast-reject in
@@ -228,14 +232,14 @@ public sealed class CSharpPattern
     /// <example>
     /// <code>
     /// public override JavaVisitor&lt;ExecutionContext&gt; GetVisitor() =>
-    ///     CSharpPattern.Expression("Console.WriteLine(\"hello\")")
-    ///         .ToFindVisitor("found it");
+    ///     CSharpPattern.Find(
+    ///         CSharpPattern.Expression("Console.WriteLine(\"hello\")"),
+    ///         "found it");
     /// </code>
     /// </example>
-    public CSharpVisitor<Core.ExecutionContext> ToFindVisitor(string? description = null)
-    {
-        return ToFindVisitor((node, _, _) => SearchResult.Found(node, description));
-    }
+    public static CSharpVisitor<Core.ExecutionContext> Find(
+        CSharpPattern pattern, string? description = null) =>
+        new FindVisitor([pattern], (node, _, _) => SearchResult.Found(node, description));
 
     /// <summary>
     /// Create a <see cref="CSharpVisitor{ExecutionContext}"/> that visits every node and
@@ -245,22 +249,54 @@ public sealed class CSharpPattern
     /// <example>
     /// <code>
     /// public override JavaVisitor&lt;ExecutionContext&gt; GetVisitor() =>
-    ///     CSharpPattern.Expression($"new BinaryFormatter({args})")
-    ///         .ToFindVisitor((node, _, _) => Markup.CreateWarn(node, "BinaryFormatter is obsolete"));
+    ///     CSharpPattern.Find(
+    ///         CSharpPattern.Expression($"new BinaryFormatter({args})"),
+    ///         (node, _, _) => Markup.CreateWarn(node, "BinaryFormatter is obsolete"));
     /// </code>
     /// </example>
-    public CSharpVisitor<Core.ExecutionContext> ToFindVisitor(Func<J, Cursor, MatchResult, J> annotator)
-    {
-        return new FindVisitor(this, annotator);
-    }
+    public static CSharpVisitor<Core.ExecutionContext> Find(
+        CSharpPattern pattern, Func<J, Cursor, MatchResult, J> annotator) =>
+        new FindVisitor([pattern], annotator);
 
-    private sealed class FindVisitor(CSharpPattern pattern, Func<J, Cursor, MatchResult, J> annotator)
+    /// <summary>
+    /// Create a <see cref="CSharpVisitor{ExecutionContext}"/> that tries multiple patterns
+    /// and adds a <see cref="SearchResult"/> marker on the first match.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var x = Capture.Expression();
+    /// return CSharpPattern.Find(
+    ///     [
+    ///         CSharpPattern.Expression($"{x} == double.NaN"),
+    ///         CSharpPattern.Expression($"{x} != double.NaN"),
+    ///     ],
+    ///     "Use IsNaN() instead");
+    /// </code>
+    /// </example>
+    public static CSharpVisitor<Core.ExecutionContext> Find(
+        CSharpPattern[] patterns, string? description = null) =>
+        new FindVisitor(patterns, (node, _, _) => SearchResult.Found(node, description));
+
+    /// <summary>
+    /// Create a <see cref="CSharpVisitor{ExecutionContext}"/> that tries multiple patterns
+    /// and calls <paramref name="annotator"/> on the first match.
+    /// </summary>
+    public static CSharpVisitor<Core.ExecutionContext> Find(
+        CSharpPattern[] patterns, Func<J, Cursor, MatchResult, J> annotator) =>
+        new FindVisitor(patterns, annotator);
+
+    private sealed class FindVisitor(CSharpPattern[] patterns, Func<J, Cursor, MatchResult, J> annotator)
         : CSharpVisitor<Core.ExecutionContext>
     {
         public override J? PostVisit(J tree, Core.ExecutionContext ctx)
         {
-            var match = pattern.Match(tree, Cursor);
-            return match != null ? annotator(tree, Cursor, match) : tree;
+            foreach (var pattern in patterns)
+            {
+                var match = pattern.Match(tree, Cursor);
+                if (match != null)
+                    return annotator(tree, Cursor, match);
+            }
+            return tree;
         }
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/AnnotateTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/AnnotateTests.cs
@@ -109,16 +109,16 @@ public class AnnotateTests : RewriteTest
     }
 
     // ===============================================================
-    // ToFindVisitor
+    // CSharpPattern.Find (static factory)
     // ===============================================================
 
     [Fact]
-    public void ToFindVisitorDefaultSearchResult()
+    public void FindDefaultSearchResult()
     {
         RewriteRun(
-            spec => spec.SetRecipe(new ToFindVisitorRecipe(
-                CSharpPattern.Expression("Console.WriteLine(\"hello\")")
-                    .ToFindVisitor())),
+            spec => spec.SetRecipe(new FindVisitorRecipe(
+                CSharpPattern.Find(
+                    CSharpPattern.Expression("Console.WriteLine(\"hello\")")))),
             CSharp(
                 "class C { void M() { Console.WriteLine(\"hello\"); } }",
                 "class C { void M() { /*~~>*/Console.WriteLine(\"hello\"); } }"
@@ -127,12 +127,13 @@ public class AnnotateTests : RewriteTest
     }
 
     [Fact]
-    public void ToFindVisitorWithDescription()
+    public void FindWithDescription()
     {
         RewriteRun(
-            spec => spec.SetRecipe(new ToFindVisitorRecipe(
-                CSharpPattern.Expression("Console.WriteLine(\"hello\")")
-                    .ToFindVisitor("found it"))),
+            spec => spec.SetRecipe(new FindVisitorRecipe(
+                CSharpPattern.Find(
+                    CSharpPattern.Expression("Console.WriteLine(\"hello\")"),
+                    "found it"))),
             CSharp(
                 "class C { void M() { Console.WriteLine(\"hello\"); } }",
                 "class C { void M() { /*~~(found it)~~>*/Console.WriteLine(\"hello\"); } }"
@@ -141,12 +142,13 @@ public class AnnotateTests : RewriteTest
     }
 
     [Fact]
-    public void ToFindVisitorWithCustomAnnotator()
+    public void FindWithCustomAnnotator()
     {
         RewriteRun(
-            spec => spec.SetRecipe(new ToFindVisitorRecipe(
-                CSharpPattern.Expression("Console.WriteLine(\"hello\")")
-                    .ToFindVisitor((node, _, _) => Markup.CreateWarn(node, "Avoid Console.WriteLine")))),
+            spec => spec.SetRecipe(new FindVisitorRecipe(
+                CSharpPattern.Find(
+                    CSharpPattern.Expression("Console.WriteLine(\"hello\")"),
+                    (node, _, _) => Markup.CreateWarn(node, "Avoid Console.WriteLine")))),
             CSharp(
                 "class C { void M() { Console.WriteLine(\"hello\"); } }",
                 "class C { void M() { /*~~(Avoid Console.WriteLine)~~>*/Console.WriteLine(\"hello\"); } }"
@@ -155,13 +157,14 @@ public class AnnotateTests : RewriteTest
     }
 
     [Fact]
-    public void ToFindVisitorAnnotatorReceivesMatchResult()
+    public void FindAnnotatorReceivesMatchResult()
     {
         var expr = Capture.Of<Expression>("expr");
         RewriteRun(
-            spec => spec.SetRecipe(new ToFindVisitorRecipe(
-                CSharpPattern.Expression($"Console.WriteLine({expr})")
-                    .ToFindVisitor((node, _, match) =>
+            spec => spec.SetRecipe(new FindVisitorRecipe(
+                CSharpPattern.Find(
+                    CSharpPattern.Expression($"Console.WriteLine({expr})"),
+                    (node, _, match) =>
                         Markup.CreateWarn(node, $"Found arg: {match.Get(expr)!.GetType().Name}")))),
             CSharp(
                 "class C { void M() { Console.WriteLine(42); } }",
@@ -171,12 +174,71 @@ public class AnnotateTests : RewriteTest
     }
 
     [Fact]
-    public void ToFindVisitorNoMatchLeavesUnchanged()
+    public void FindNoMatchLeavesUnchanged()
     {
         RewriteRun(
-            spec => spec.SetRecipe(new ToFindVisitorRecipe(
-                CSharpPattern.Expression("Console.Write(\"hello\")")
-                    .ToFindVisitor((node, _, _) => Markup.CreateWarn(node, "should not appear")))),
+            spec => spec.SetRecipe(new FindVisitorRecipe(
+                CSharpPattern.Find(
+                    CSharpPattern.Expression("Console.Write(\"hello\")"),
+                    (node, _, _) => Markup.CreateWarn(node, "should not appear")))),
+            CSharp(
+                "class C { void M() { Console.WriteLine(\"hello\"); } }"
+            )
+        );
+    }
+
+    // ===============================================================
+    // CSharpPattern.Find with multiple patterns
+    // ===============================================================
+
+    [Fact]
+    public void FindMultiplePatternsMatchesFirst()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new FindVisitorRecipe(
+                CSharpPattern.Find(
+                    [
+                        CSharpPattern.Expression("Console.WriteLine(\"hello\")"),
+                        CSharpPattern.Expression("Console.WriteLine(\"world\")"),
+                    ],
+                    "found it"))),
+            CSharp(
+                "class C { void M() { Console.WriteLine(\"hello\"); Console.WriteLine(\"world\"); } }",
+                "class C { void M() { /*~~(found it)~~>*/Console.WriteLine(\"hello\"); /*~~(found it)~~>*/Console.WriteLine(\"world\"); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void FindMultiplePatternsWithCustomAnnotator()
+    {
+        var x = Capture.Of<Expression>("x");
+        RewriteRun(
+            spec => spec.SetRecipe(new FindVisitorRecipe(
+                CSharpPattern.Find(
+                    [
+                        CSharpPattern.Expression($"{x} == double.NaN"),
+                        CSharpPattern.Expression($"{x} != double.NaN"),
+                    ],
+                    (node, _, _) => Markup.CreateWarn(node, "Use IsNaN() instead")))),
+            CSharp(
+                "class C { bool M(double d) { return d == double.NaN; } }",
+                "class C { bool M(double d) { return /*~~(Use IsNaN() instead)~~>*/d == double.NaN; } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void FindMultiplePatternsNoMatchLeavesUnchanged()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new FindVisitorRecipe(
+                CSharpPattern.Find(
+                    [
+                        CSharpPattern.Expression("Console.Write(\"hello\")"),
+                        CSharpPattern.Expression("Console.Write(\"world\")"),
+                    ],
+                    "should not appear"))),
             CSharp(
                 "class C { void M() { Console.WriteLine(\"hello\"); } }"
             )
@@ -240,12 +302,12 @@ file class FindVsAnnotateRecipe(CSharpPattern pat) : Core.Recipe
 }
 
 /// <summary>
-/// Thin recipe wrapper around a pre-built visitor from <see cref="CSharpPattern.ToFindVisitor"/>.
+/// Thin recipe wrapper around a pre-built visitor from <see cref="CSharpPattern.Find(CSharpPattern, string?)"/>.
 /// </summary>
-file class ToFindVisitorRecipe(CSharpVisitor<ExecutionContext> visitor) : Core.Recipe
+file class FindVisitorRecipe(CSharpVisitor<ExecutionContext> visitor) : Core.Recipe
 {
-    public override string DisplayName => "ToFindVisitor test";
-    public override string Description => "Test recipe wrapping ToFindVisitor.";
+    public override string DisplayName => "Find visitor test";
+    public override string Description => "Test recipe wrapping CSharpPattern.Find.";
 
     public override JavaVisitor<ExecutionContext> GetVisitor() => visitor;
 }


### PR DESCRIPTION
## Motivation

`CSharpPattern.ToFindVisitor()` is an instance method that creates a visitor from a single pattern. This doesn't mirror the `CSharpTemplate.Rewrite()` API which is a static factory, and it doesn't support multiple patterns — forcing recipes to manually loop over pattern arrays.

## Examples

```csharp
// Single pattern (before):
return CSharpPattern.Expression($"new BinaryFormatter({args})")
    .ToFindVisitor((node, _, _) => Markup.CreateWarn(node, "obsolete"));

// Single pattern (after):
return CSharpPattern.Find(
    CSharpPattern.Expression($"new BinaryFormatter({args})"),
    (node, _, _) => Markup.CreateWarn(node, "obsolete"));

// Multiple patterns (new capability):
return CSharpPattern.Find(
    [
        CSharpPattern.Expression($"{x} == double.NaN"),
        CSharpPattern.Expression($"{x} != double.NaN"),
    ],
    (node, _, _) => Markup.CreateWarn(node, "Use IsNaN() instead"));
```

## Summary

- Replace `ToFindVisitor(string?)` and `ToFindVisitor(Func<...>)` instance methods with four static `Find()` overloads on `CSharpPattern`
- Add multi-pattern overloads (`CSharpPattern[]`) with first-match-wins semantics, matching `RewriteVisitor`
- Instance `Find<T>()` methods for use inside custom visitors are unchanged

## Test plan

- [x] Existing `ToFindVisitor` tests migrated to `CSharpPattern.Find()` — all pass
- [x] New multi-pattern tests: `FindMultiplePatternsMatchesFirst`, `FindMultiplePatternsWithCustomAnnotator`, `FindMultiplePatternsNoMatchLeavesUnchanged`
- [x] `TemplateRecipeTests` still pass (use instance `Find<T>`, unaffected)
- [x] 14/14 AnnotateTests pass, 8/8 TemplateRecipeTests pass