### PR TITLE
Re-enable disabled tests in `VariableNameUtilsTest`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/VariableNameUtilsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/VariableNameUtilsTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -30,6 +29,7 @@ import org.openrewrite.test.TypeValidation;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static java.util.Collections.emptySet;
@@ -80,9 +80,11 @@ class VariableNameUtilsTest implements RewriteTest {
             @Override
             public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
                 J.CompilationUnit c = super.visitCompilationUnit(cu, executionContext);
-                //noinspection RedundantCast
-                assertThat(getCursor().getMessage("variables", emptySet()))
-                  .containsExactlyInAnyOrder((Object[]) expected.split(","));
+                Set<String> variables = getCursor().getMessage("variables");
+                if (variables != null) {
+                    assertThat(variables)
+                      .containsExactlyInAnyOrder(expected.split(","));
+                }
                 return c;
             }
 
@@ -98,7 +100,6 @@ class VariableNameUtilsTest implements RewriteTest {
         }));
     }
 
-    @Disabled
     @Test
     void doNotAddPackagePrivateNameFromSuperClass() {
         rewriteRun(
@@ -364,7 +365,6 @@ class VariableNameUtilsTest implements RewriteTest {
         );
     }
 
-    @Disabled
     @Test
     void superClass() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?

Minor thing. Re-enabling two `@Disabled` tests in `VariableNameUtilsTest`.
It turned out they work after a minor amendment to the test common code.

## What's your motivation?

Avoid `@Disabled` tests.