### PR TITLE
Validate types in newly generated sources

### DIFF
--- a/rewrite-test/build.gradle.kts
+++ b/rewrite-test/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation("org.slf4j:slf4j-api:1.7.36")
     implementation("org.slf4j:slf4j-nop:1.7.36")
 
+    testImplementation(project(":rewrite-java"))
     testImplementation(project(":rewrite-groovy"))
+    testRuntimeOnly(project(":rewrite-java-21"))
     testRuntimeOnly("org.antlr:antlr4-runtime:4.13.2")
 }

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -470,6 +470,7 @@ public interface RewriteTest extends SourceSpecs {
                                 sourceSpec.after.apply(actual) :
                                 trimIndentPreserveCRLF(sourceSpec.after.apply(actual));
                         assertThat(actual).as("Unexpected result in \"" + result.getAfter().getSourcePath() + "\"").isEqualTo(expected);
+                        sourceSpec.validateSource.accept(result.getAfter(), TypeValidation.after(testMethodSpec, testClassSpec));
                         continue nextSourceSpec;
                     }
                 }
@@ -496,6 +497,7 @@ public interface RewriteTest extends SourceSpecs {
                         expectedNewResults.add(result);
                         //noinspection unchecked
                         ((Consumer<SourceFile>) sourceSpec.afterRecipe).accept(result.getAfter());
+                        sourceSpec.validateSource.accept(result.getAfter(), TypeValidation.after(testMethodSpec, testClassSpec));
                         if (sourceSpec.sourcePath != null) {
                             assertThat(result.getAfter().getSourcePath())
                                     .isEqualTo(sourceSpec.dir.resolve(sourceSpec.sourcePath));

--- a/rewrite-test/src/test/java/org/openrewrite/test/internal/RewriteTestTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/test/internal/RewriteTestTest.java
@@ -24,6 +24,8 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.*;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpecs;
 import org.openrewrite.test.TypeValidation;
@@ -34,14 +36,15 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.SourceSpecs.text;
 
-@SuppressWarnings("UnnecessarySemicolon")
 class RewriteTestTest implements RewriteTest {
 
     @Test
@@ -144,6 +147,22 @@ class RewriteTestTest implements RewriteTest {
           spec -> spec.recipe(new ScannerEdit()),
           text("foo")
         ));
+    }
+
+    @Test
+    void typeValidationAppliedToNewSourceFiles() {
+        assertThrows(AssertionError.class, () ->
+          rewriteRun(
+            spec -> spec.recipe(new GeneratesCompilationUnitMissingTypes()),
+            java(null, """
+              public class A {
+                  void foo() {
+                  }
+              }
+              """,
+              s -> s.path("A.java"))
+          )
+        );
     }
 
     @Test
@@ -415,6 +434,38 @@ class GeneratesExistingFile extends ScanningRecipe<AtomicBoolean> {
 class RecipeWithNoOptions extends Recipe {
     String displayName = "Recipe with no options";
     String description = "Has no configurable options at all.";
+}
+
+@EqualsAndHashCode(callSuper = false)
+@NullMarked
+@Value
+class GeneratesCompilationUnitMissingTypes extends ScanningRecipe<AtomicBoolean> {
+
+    String displayName = "Generates a compilation unit missing type information";
+
+    String description = "A recipe that generates a J.CompilationUnit with class and method declarations that have null types.";
+
+    @Override
+    public AtomicBoolean getInitialValue(ExecutionContext ctx) {
+        return new AtomicBoolean(false);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(AtomicBoolean acc) {
+        return TreeVisitor.noop();
+    }
+
+    @Override
+    public Collection<? extends SourceFile> generate(AtomicBoolean acc, ExecutionContext ctx) {
+        return JavaParser.fromJavaVersion().build()
+          .parse("public class A {\n    void foo() {\n    }\n}\n")
+          .map(cu -> (J.CompilationUnit) cu)
+          .map(cu -> cu.withClasses(cu.getClasses().stream()
+            .map(c -> c.withType(null))
+            .collect(Collectors.toList())))
+          .map(cu -> (SourceFile) cu.withSourcePath(Path.of("A.java")))
+          .collect(Collectors.toList());
+    }
 }
 
 @EqualsAndHashCode(callSuper = false)


### PR DESCRIPTION
I noticed that we don't actually validate types when a recipe creates new files. This fixes that. 