### PR TITLE
Fix prepareRecipe failing for cross-ecosystem delegatesTo recipes

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -344,12 +344,12 @@ public class RewriteRpc {
         if (r.getDelegatesTo() != null) {
             PrepareRecipeResponse.DelegatesTo d = r.getDelegatesTo();
             RecipeListing listing = marketplace.findRecipe(d.getRecipeName());
-            if (listing == null) {
-                throw new IllegalStateException(
-                        "Remote declared delegatesTo " + d.getRecipeName() +
-                        " but no recipe found in marketplace.");
+            if (listing != null) {
+                return listing.prepare(resolvers, d.getOptions());
             }
-            return listing.prepare(resolvers, d.getOptions());
+            // Delegate recipe not available locally (e.g. cross-ecosystem delegation).
+            // Fall through to wrap in an RpcRecipe so the descriptor is still accessible
+            // and the remote can handle execution via its own delegation mechanism.
         }
 
         // FIXME do this validation on the server side instead


### PR DESCRIPTION
## Motivation

When using `CSharpRewriteRpc` (or any non-Java RPC) to call `prepareRecipe` for recipes that delegate to recipes in another ecosystem (e.g. a C# recipe delegating to `org.openrewrite.java.ChangeMethodName`), the call fails with:

```
Remote declared delegatesTo org.openrewrite.java.ChangeMethodName but no recipe found in marketplace.
```

This happens because the delegate target isn't loaded in the local marketplace. This blocks the [rewrite-recipe-markdown-generator](https://github.com/moderneinc/rewrite-recipe-markdown-generator) from generating docs for these recipes — 8 recipes are silently skipped.

## Summary

- When `delegatesTo` can't be resolved locally, fall through to wrap the recipe in an `RpcRecipe` instead of throwing
- The remote server still has the recipe instance cached with a valid `editVisitor`, so it can handle execution via RPC
- The `RecipeDescriptor` is already in the response, so callers that only need metadata (like the markdown generator) get what they need
- The `delegatesTo` mechanism is an optimization to avoid RPC round-trips; falling back to RPC is a correct degradation

## Test plan

- [x] `rewrite-core` compiles and all tests pass
- [x] Verified the remote always provides a valid `editVisitor` even when `delegatesTo` is set (C#, Python, JS servers all set `editVisitor = "edit:{id}"` alongside `delegatesTo`)

- Closes #7142