### PR TITLE
Fix template matching for member references with literal receivers

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateMatchTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateMatchTest.java
@@ -1148,4 +1148,53 @@ class JavaTemplateMatchTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-templating/issues/183")
+    @Test
+    void matchMemberReferenceWithLiteralReceiver() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              final JavaTemplate before = JavaTemplate
+                .builder("#{collection:any(java.util.Collection)}.stream().anyMatch(#{value:any(java.lang.Object)}::equals)")
+                .build();
+              final JavaTemplate after = JavaTemplate
+                .builder("#{collection:any(java.util.Collection)}.contains(#{value:any(java.lang.Object)})")
+                .build();
+
+              @Override
+              public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
+                  JavaTemplate.Matcher matcher = before.matcher(getCursor());
+                  if (matcher.find()) {
+                      return after.apply(getCursor(), mi.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1));
+                  }
+                  return mi;
+              }
+          })),
+          java(
+            """
+              import java.util.Collection;
+              import java.util.List;
+
+              class Test {
+                  void test(List<String> list, String value) {
+                      boolean a = list.stream().anyMatch(value::equals);
+                      boolean b = list.stream().anyMatch("string"::equals);
+                  }
+              }
+              """,
+            """
+              import java.util.Collection;
+              import java.util.List;
+
+              class Test {
+                  void test(List<String> list, String value) {
+                      boolean a = list.contains(value);
+                      boolean b = list.contains("string");
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplateSemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplateSemanticallyEqual.java
@@ -201,6 +201,27 @@ class JavaTemplateSemanticallyEqual extends SemanticallyEqual {
         }
 
         @Override
+        public J.MemberReference visitMemberReference(J.MemberReference memberRef, J j) {
+            if (isEqual.get() && j instanceof J.MemberReference) {
+                J.MemberReference compareTo = (J.MemberReference) j;
+                // When the template's containing expression is a template parameter placeholder,
+                // always visit it to match against the actual containing expression.
+                // The base class only visits containing when it's a J.Identifier or J.FieldAccess
+                // with a fieldType, which misses literals and other expression types.
+                if (memberRef.getContaining() instanceof J.Empty &&
+                    isTemplateParameterPlaceholder((J.Empty) memberRef.getContaining())) {
+                    if (!memberRef.getReference().getSimpleName().equals(compareTo.getReference().getSimpleName())) {
+                        isEqual.set(false);
+                        return memberRef;
+                    }
+                    visit(memberRef.getContaining(), compareTo.getContaining());
+                    return memberRef;
+                }
+            }
+            return super.visitMemberReference(memberRef, j);
+        }
+
+        @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation template, J j) {
             if (!isEqual.get()) {
                 return template;


### PR DESCRIPTION
## Motivation

- Refaster templates crash with an `IndexOutOfBoundsException` when a method reference's receiver is a string literal (e.g., `"string"::equals`). The template matcher only captures 1 parameter instead of 2, and `matcher.parameter(1)` throws. This was reported in https://github.com/openrewrite/rewrite-templating/issues/183.

## Summary

- The root cause is in `SemanticallyEqual.visitMemberReference`, which only visits the `containing` expression of a `J.MemberReference` when it's a `J.Identifier` or `J.FieldAccess` with a non-null `fieldType`. When the actual containing is a literal (like `"string"`), neither condition matches and the template parameter placeholder is never visited, so the parameter is never captured.
- Override `visitMemberReference` in `JavaTemplateSemanticallyEqualVisitor` to always visit the `containing` expression when it's a template parameter placeholder (`J.Empty` with `TemplateParameter` marker).

## Test plan

- Added `matchMemberReferenceWithLiteralReceiver` test that reproduces the exact scenario from the issue: a Refaster-style template matching `collection.stream().anyMatch(value::equals)` against both variable (`value::equals`) and literal (`"string"::equals`) receivers
- Verified all existing `JavaTemplateMatchTest`, `JavaTemplateSemanticallyEqualVarargsTest`, and `SemanticallyEqualTest` tests still pass