### PR TITLE
C#: Deduplicate TargetFrameworks list after replacement

### DIFF
--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/ChangeDotNetTargetFramework.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/ChangeDotNetTargetFramework.java
@@ -22,6 +22,9 @@ import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.XmlIsoVisitor;
 import org.openrewrite.xml.tree.Xml;
 
+import java.util.LinkedHashSet;
+import java.util.StringJoiner;
+
 /**
  * Changes the target framework in .csproj files.
  * Handles both single-TFM ({@code <TargetFramework>}) and
@@ -69,24 +72,24 @@ public class ChangeDotNetTargetFramework extends Recipe {
                             }
                         } else if ("TargetFrameworks".equals(name)) {
                             String value = t.getValue().orElse("");
-                            // Replace within semicolon-delimited list
+                            // Replace within semicolon-delimited list, deduplicating
                             String[] frameworks = value.split(";");
                             boolean changed = false;
-                            StringBuilder sb = new StringBuilder();
-                            for (int i = 0; i < frameworks.length; i++) {
-                                String fw = frameworks[i].trim();
+                            LinkedHashSet<String> seen = new LinkedHashSet<>();
+                            for (String framework : frameworks) {
+                                String fw = framework.trim();
                                 if (oldTargetFramework.equals(fw)) {
-                                    sb.append(newTargetFramework);
                                     changed = true;
-                                } else {
-                                    sb.append(fw);
+                                    fw = newTargetFramework;
                                 }
-                                if (i < frameworks.length - 1) {
-                                    sb.append(';');
-                                }
+                                seen.add(fw);
                             }
                             if (changed) {
-                                doAfterVisit(new ChangeTagValueVisitor<>(t, sb.toString()));
+                                StringJoiner sj = new StringJoiner(";");
+                                for (String fw : seen) {
+                                    sj.add(fw);
+                                }
+                                doAfterVisit(new ChangeTagValueVisitor<>(t, sj.toString()));
                             }
                         }
                         return t;

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/ChangeDotNetTargetFrameworkTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/ChangeDotNetTargetFrameworkTest.java
@@ -151,6 +151,29 @@ class ChangeDotNetTargetFrameworkTest implements RewriteTest {
     }
 
     @Test
+    void deduplicatesMultiTfmAfterReplacement() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDotNetTargetFramework("netstandard2.0", "net6.0")),
+          csproj(
+            """
+              <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                  <TargetFrameworks>net40;netstandard2.0;net6.0</TargetFrameworks>
+                </PropertyGroup>
+              </Project>
+              """,
+            """
+              <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                  <TargetFrameworks>net40;net6.0</TargetFrameworks>
+                </PropertyGroup>
+              </Project>
+              """
+          )
+        );
+    }
+
+    @Test
     void noChangeWhenTfmNotPresent() {
         rewriteRun(
           csproj(


### PR DESCRIPTION
## Motivation

When a `.csproj` has multiple TFMs that independently map to the same target through chained upgrade recipes (e.g. `UpgradeToDotNet10`), `ChangeDotNetTargetFramework` produces duplicates in the `<TargetFrameworks>` list. For example, `net40;netstandard2.0;net6.0` becomes `net40;net10.0;net10.0` instead of `net40;net10.0`.

## Summary

- Replace `StringBuilder`-based loop with a `LinkedHashSet` to collect frameworks after replacement, preserving order while deduplicating
- Add test case where two TFMs converge to the same target

## Test plan

- [x] New test `deduplicatesMultiTfmAfterReplacement` verifies `net40;netstandard2.0;net6.0` → `net40;net6.0` when replacing `netstandard2.0` with `net6.0`
- [x] All existing `ChangeDotNetTargetFrameworkTest` tests pass