### PR TITLE
C#: Add `CSharpTypeUtils.isNullableType` utility method

### DIFF
--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/tree/CSharpTypeUtils.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/tree/CSharpTypeUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.tree;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+
+public class CSharpTypeUtils {
+
+    /**
+     * Check if a type is {@code System.Nullable<T>} (i.e., a nullable value type like {@code int?}).
+     *
+     * @param type the type to check
+     * @return {@code true} if the type is {@code Nullable<T>}
+     */
+    public static boolean isNullableType(@Nullable JavaType type) {
+        JavaType.Parameterized parameterized = TypeUtils.asParameterized(type);
+        return parameterized != null &&
+               TypeUtils.isOfClassType(parameterized.getType(), "System.Nullable");
+    }
+}

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/tree/CSharpTypeUtilsTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/tree/CSharpTypeUtilsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CSharpTypeUtilsTest {
+
+    @Test
+    void nullableValueType() {
+        JavaType.Class intType = JavaType.ShallowClass.build("System.Int32");
+        JavaType.Parameterized nullableInt = new JavaType.Parameterized(
+                null,
+                JavaType.ShallowClass.build("System.Nullable"),
+                List.of(intType)
+        );
+        assertThat(CSharpTypeUtils.isNullableType(nullableInt)).isTrue();
+    }
+
+    @Test
+    void nonNullableParameterizedType() {
+        JavaType.Class stringType = JavaType.ShallowClass.build("System.String");
+        JavaType.Parameterized listOfString = new JavaType.Parameterized(
+                null,
+                JavaType.ShallowClass.build("System.Collections.Generic.List"),
+                List.of(stringType)
+        );
+        assertThat(CSharpTypeUtils.isNullableType(listOfString)).isFalse();
+    }
+
+    @Test
+    void plainClassType() {
+        JavaType.Class stringType = JavaType.ShallowClass.build("System.String");
+        assertThat(CSharpTypeUtils.isNullableType(stringType)).isFalse();
+    }
+
+    @Test
+    void primitiveType() {
+        assertThat(CSharpTypeUtils.isNullableType(JavaType.Primitive.Int)).isFalse();
+    }
+
+    @Test
+    void nullType() {
+        assertThat(CSharpTypeUtils.isNullableType(null)).isFalse();
+    }
+}


### PR DESCRIPTION
## Motivation

In `recipes-csharp`, the ThrowIf* recipes need to check whether a parameter's type is `Nullable<T>` (e.g. `int?`) to avoid invalid transformations — `Nullable<T>` doesn't satisfy `IComparable<T>` and lifted comparison operators have different semantics. This check is generally useful for C# recipes, so it belongs in the SDK rather than as a local helper.

## Examples

```java
// Check if a type is Nullable<T>
CSharpTypeUtils.isNullableType(identifier.getType()) // true for int?, bool?, etc.
```

## Summary

- Add `CSharpTypeUtils` class in `rewrite-csharp` at `org.openrewrite.csharp.tree`
- `isNullableType(@Nullable JavaType)` returns `true` when the type is `System.Nullable<T>`
- Delegates to existing `TypeUtils.asParameterized()` and `TypeUtils.isOfClassType()` for consistency
- Takes `JavaType` (not `Identifier`) for broader applicability

## Test plan

- [x] Unit tests for `Nullable<Int32>` → true
- [x] Unit tests for non-nullable parameterized type (`List<String>`) → false
- [x] Unit tests for plain class type → false
- [x] Unit tests for primitive type → false
- [x] Unit tests for null input → false