### PR TITLE
Fix template replacement for method invocations inside type casts

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.Cursor;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.NameTree;
 import org.openrewrite.marker.SearchResult;
@@ -96,6 +97,82 @@ class JavaTemplateTest8Test implements RewriteTest {
               class Test {
                   CharSequence test(String s) {
                       return new StringBuilder(s);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7153")
+    @Test
+    void replaceMethodInvocationInsideTypeCast() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              final JavaTemplate t = JavaTemplate.builder("String.valueOf(#{any(String)})")
+                .build();
+
+              @Override
+              public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  method = super.visitMethodInvocation(method, ctx);
+                  if (method.getSimpleName().equals("toString")) {
+                      return t.apply(getCursor(), method.getCoordinates().replace(),
+                        method.getSelect());
+                  }
+                  return method;
+              }
+          })),
+          java(
+            """
+              class Test {
+                  Object test(String s) {
+                      return (Object) s.toString();
+                  }
+              }
+              """,
+            """
+              class Test {
+                  Object test(String s) {
+                      return (Object) String.valueOf(s);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7153")
+    @Test
+    void replaceNewClassInsideTypeCast() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              final JavaTemplate t = JavaTemplate.builder("new StringBuilder(#{any(String)})")
+                .build();
+
+              @Override
+              public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
+                  newClass = super.visitNewClass(newClass, ctx);
+                  if (newClass.getClazz() != null &&
+                      newClass.getClazz().toString().equals("StringBuffer") &&
+                      newClass.getArguments().size() == 1) {
+                      return t.apply(getCursor(), newClass.getCoordinates().replace(),
+                        newClass.getArguments().get(0));
+                  }
+                  return newClass;
+              }
+          })),
+          java(
+            """
+              class Test {
+                  Object test(String s) {
+                      return (CharSequence) new StringBuffer(s);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  Object test(String s) {
+                      return (CharSequence) new StringBuilder(s);
                   }
               }
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -439,8 +439,9 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                 if (loc == STATEMENT_PREFIX && isScope(method) &&
                     (parentValue instanceof J.Return ||
                      parentValue instanceof J.Assignment ||
-                     parentValue instanceof J.AssignmentOperation)) {
-                    // Method invocation is used as an expression (e.g., inside return, assignment),
+                     parentValue instanceof J.AssignmentOperation ||
+                     parentValue instanceof J.TypeCast)) {
+                    // Method invocation is used as an expression (e.g., inside return, assignment, type cast),
                     // not as a standalone statement in a block. Parse as expression replacement.
                     return autoFormat(unsubstitute(templateParser.parseExpression(
                                     getCursor(),
@@ -459,7 +460,8 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                     if (loc == STATEMENT_PREFIX &&
                         (parentValue instanceof J.Return ||
                          parentValue instanceof J.Assignment ||
-                         parentValue instanceof J.AssignmentOperation)) {
+                         parentValue instanceof J.AssignmentOperation ||
+                         parentValue instanceof J.TypeCast)) {
                         return autoFormat(unsubstitute(templateParser.parseExpression(
                                         getCursor(),
                                         substitutedTemplate,


### PR DESCRIPTION
- Closes https://github.com/openrewrite/rewrite/issues/7153

When a `JavaTemplate` replaces a `J.MethodInvocation` or `J.NewClass` that is wrapped in a `J.TypeCast` (e.g., `(J.Block) visitor.visitBlock(...)`), the template engine incorrectly tried to parse the replacement as a block statement instead of an expression, producing 0 statements and throwing `IllegalArgumentException`. Added `J.TypeCast` to the parent type allowlist in both `visitMethodInvocation` and `visitNewClass` so the template is parsed as an expression in that context. Includes regression tests for both cases.