### PR TITLE
Fix contextSensitive() JavaTemplate for lambda arguments

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -1523,4 +1523,107 @@ class JavaTemplateTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2074")
+    @Test
+    void contextSensitiveTemplateInsideLambdaInAnonymousClass() {
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(1).cycles(1)
+            .recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                final MethodMatcher matcher = new MethodMatcher("Test oldMethod(..)");
+
+                @Override
+                public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
+                    if (matcher.matches(mi)) {
+                        return JavaTemplate.builder("newMethod()")
+                          .contextSensitive()
+                          .build()
+                          .apply(getCursor(), mi.getCoordinates().replace());
+                    }
+                    return mi;
+                }
+            })),
+          java(
+            """
+              import java.util.ArrayList;
+              import java.util.List;
+              import java.util.function.UnaryOperator;
+
+              abstract class Test {
+                  abstract Test withBody(Test body);
+                  abstract Test getBody();
+                  abstract List<String> getStatements();
+                  abstract Test withStatements(List<String> stmts);
+
+                  interface Visitor {
+                      Test visit(Test cd);
+                  }
+
+                  Visitor getVisitor() {
+                      return new Visitor() {
+                          @Override
+                          public Test visit(Test test) {
+                              Test cd = test;
+                              return cd.withBody(cd.getBody().withStatements(map(cd.getBody().getStatements(), st -> {
+                                  return oldMethod(st);
+                              })));
+                          }
+                      };
+                  }
+
+                  static <T> List<T> map(List<T> list, UnaryOperator<T> fn) {
+                      List<T> result = new ArrayList<>();
+                      for (T t : list) {
+                          result.add(fn.apply(t));
+                      }
+                      return result;
+                  }
+
+                  String oldMethod(String s) { return s; }
+                  String newMethod() { return ""; }
+              }
+              """,
+            """
+              import java.util.ArrayList;
+              import java.util.List;
+              import java.util.function.UnaryOperator;
+
+              abstract class Test {
+                  abstract Test withBody(Test body);
+                  abstract Test getBody();
+                  abstract List<String> getStatements();
+                  abstract Test withStatements(List<String> stmts);
+
+                  interface Visitor {
+                      Test visit(Test cd);
+                  }
+
+                  Visitor getVisitor() {
+                      return new Visitor() {
+                          @Override
+                          public Test visit(Test test) {
+                              Test cd = test;
+                              return cd.withBody(cd.getBody().withStatements(map(cd.getBody().getStatements(), st -> {
+                                  return newMethod();
+                              })));
+                          }
+                      };
+                  }
+
+                  static <T> List<T> map(List<T> list, UnaryOperator<T> fn) {
+                      List<T> result = new ArrayList<>();
+                      for (T t : list) {
+                          result.add(fn.apply(t));
+                      }
+                      return result;
+                  }
+
+                  String oldMethod(String s) { return s; }
+                  String newMethod() { return ""; }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -485,12 +485,19 @@ public class BlockStatementTemplateGenerator {
             J.MethodInvocation m = (J.MethodInvocation) j;
             J firstEnclosing = cursor.getParentOrThrow().firstEnclosing(J.class);
             if (m.getArguments().stream().anyMatch(arg -> referToSameElement(prior, arg))) {
-                before.insert(0, "__M__.any(");
-                if (firstEnclosing instanceof J.Block || firstEnclosing instanceof J.Case ||
-                    firstEnclosing instanceof J.If || firstEnclosing instanceof J.If.Else) {
-                    after.append(");");
+                if (prior instanceof J.Lambda || prior instanceof J.MemberReference) {
+                    // Lambdas and method references require a functional interface target type for
+                    // type inference, so they cannot be wrapped in __M__.any(Object). Instead,
+                    // reconstruct the method call to provide the compiler with the necessary context.
+                    methodInvocationWithLambdaArg(m, prior, before, after, cursor, firstEnclosing);
                 } else {
-                    after.append(")");
+                    before.insert(0, "__M__.any(");
+                    if (firstEnclosing instanceof J.Block || firstEnclosing instanceof J.Case ||
+                        firstEnclosing instanceof J.If || firstEnclosing instanceof J.If.Else) {
+                        after.append(");");
+                    } else {
+                        after.append(")");
+                    }
                 }
             } else if (m.getTypeParameters() != null && m.getTypeParameters().stream().anyMatch(tp -> referToSameElement(prior, tp))) {
                 before.insert(0, "__M__.anyT<");
@@ -618,6 +625,52 @@ public class BlockStatementTemplateGenerator {
         }
     }
 
+    private void methodInvocationWithLambdaArg(J.MethodInvocation m, J prior,
+                                                StringBuilder before, StringBuilder after,
+                                                Cursor cursor, J firstEnclosing) {
+        StringBuilder methodBefore = new StringBuilder();
+        StringBuilder methodAfter = new StringBuilder();
+
+        JavaType.Method mt = m.getMethodType();
+        if (m.getSelect() != null && mt != null) {
+            String fqn = mt.getDeclaringType().getFullyQualifiedName();
+            if (mt.hasFlags(Flag.Static)) {
+                methodBefore.append(fqn);
+            } else {
+                methodBefore.append("((").append(fqn).append(") null)");
+            }
+            methodBefore.append(".");
+        }
+
+        methodBefore.append(m.getSimpleName()).append("(");
+
+        boolean priorFound = false;
+        List<Expression> args = m.getArguments();
+        for (int i = 0; i < args.size(); i++) {
+            Expression arg = args.get(i);
+            if (!priorFound) {
+                if (referToSameElement(prior, arg)) {
+                    priorFound = true;
+                    continue;
+                }
+                methodBefore.append(valueOfType(arg.getType()));
+                methodBefore.append(", ");
+            } else {
+                methodAfter.append(", ");
+                methodAfter.append(valueOfType(arg.getType()));
+            }
+        }
+        methodAfter.append(")");
+
+        if (firstEnclosing instanceof J.Block || firstEnclosing instanceof J.Case ||
+            firstEnclosing instanceof J.If || firstEnclosing instanceof J.If.Else) {
+            methodAfter.append(";");
+        }
+
+        before.insert(0, methodBefore);
+        after.append(methodAfter);
+    }
+
     private void insertControlWithBlock(J body, StringBuilder before, StringBuilder after, Runnable insertion) {
         if (!(body instanceof J.Block)) {
             before.insert(0, "{");
@@ -687,14 +740,18 @@ public class BlockStatementTemplateGenerator {
             throw new IllegalStateException("Unable to template inside a J.NewClass instance having a null clazz and constructor type.");
         }
 
-        // Build stub arguments to make it parseable
+        // Build stub arguments to make it parseable.
+        // For interface implementations, skip arguments since interfaces have no constructors.
         StringBuilder stubArgs = new StringBuilder("(");
         List<Expression> arguments = nc.getArguments();
-        for (int i = 0; i < arguments.size(); i++) {
-            if (i > 0) {
-                stubArgs.append(", ");
+        boolean hasRealArguments = arguments.stream().anyMatch(arg -> !(arg instanceof J.Empty));
+        if (hasRealArguments) {
+            for (int i = 0; i < arguments.size(); i++) {
+                if (i > 0) {
+                    stubArgs.append(", ");
+                }
+                stubArgs.append(valueOfType(arguments.get(i).getType()));
             }
-            stubArgs.append(valueOfType(arguments.get(i).getType()));
         }
         stubArgs.append(")");
 


### PR DESCRIPTION
## Summary
- Fix `contextSensitive()` `JavaTemplate` failing with `IndexOutOfBoundsException` when applied inside lambda expressions that are arguments to method invocations
- When a lambda/method-reference was a method argument, `contextTemplate()` wrapped it with `__M__.any(lambda)`, but lambdas can't convert to `Object`, causing the generated stub to fail compilation and `listTemplatedTrees()` to return an empty list
- Instead of `__M__.any()`, reconstruct the actual method call with default values for non-lambda arguments, preserving the functional interface target type for lambda type inference
- Also fix anonymous class stub generation for interface implementations incorrectly generating constructor arguments (e.g. `new Visitor(null)` → `new Visitor()`)

## Test plan
- [x] Added `contextSensitiveTemplateInsideLambdaInAnonymousClass` test with deeply nested cursor path: ClassDeclaration → MethodDeclaration → anonymous NewClass → MethodDeclaration → MethodInvocation → Lambda → Return → MethodInvocation (target)
- [x] All `JavaTemplateTest*` tests pass
- [x] Full `rewrite-java-test` suite passes
- [x] Full `rewrite-java` suite passes

- Fixes https://github.com/moderneinc/customer-requests/issues/2074