### PR TITLE
FindManagedDependency: resolve version for BOM imports

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindManagedDependency.java
@@ -21,13 +21,16 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.maven.tree.ResolvedManagedDependency;
+import org.openrewrite.maven.tree.Scope;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 @EqualsAndHashCode(callSuper = false)
@@ -70,7 +73,7 @@ public class FindManagedDependency extends Recipe {
             @Override
             public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
                 if (isManagedDependencyTag(groupId, artifactId) &&
-                    versionIsValid(version, versionPattern, () -> findManagedDependency(tag, null))) {
+                    versionIsValid(version, versionPattern, tag, this::findManagedDependency, this::getResolutionResult)) {
                     ds.add(tag);
                 }
                 return super.visitTag(tag, ctx);
@@ -95,7 +98,7 @@ public class FindManagedDependency extends Recipe {
             @Override
             public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
                 if (isManagedDependencyTag(groupId, artifactId) &&
-                    versionIsValid(version, versionPattern, () -> findManagedDependency(tag, null))) {
+                    versionIsValid(version, versionPattern, tag, this::findManagedDependency, this::getResolutionResult)) {
                     return SearchResult.found(tag);
                 }
                 return super.visitTag(tag, ctx);
@@ -103,20 +106,28 @@ public class FindManagedDependency extends Recipe {
         };
     }
 
-    private static boolean versionIsValid(@Nullable String desiredVersion, @Nullable String versionPattern,
-                                          Supplier<@Nullable ResolvedManagedDependency> resolvedDependencySupplier) {
+    private static boolean versionIsValid(@Nullable String desiredVersion, @Nullable String versionPattern, Xml.Tag tag,
+                                          BiFunction<Xml.Tag, @Nullable Scope, @Nullable ResolvedManagedDependency> findManagedDependency,
+                                          Supplier<MavenResolutionResult> getResolutionResult) {
         if (desiredVersion == null) {
             return true;
         }
-        ResolvedManagedDependency resolvedDependency = resolvedDependencySupplier.get();
-        if (resolvedDependency == null) {
-            // shouldn't happen, but if it does, fail the condition
+
+        ResolvedManagedDependency resolved = findManagedDependency.apply(tag, null);
+        String actualVersion;
+        if (resolved != null) {
+            actualVersion = resolved.getVersion();
+        } else {
+            actualVersion = tag.getChildValue("version")
+                    .map(v -> getResolutionResult.get().getPom().getValue(v))
+                    .orElse(null);
+        }
+        if (actualVersion == null) {
             return false;
         }
-        String actualVersion = resolvedDependency.getVersion();
+
         Validated<VersionComparator> validate = Semver.validate(desiredVersion, versionPattern);
-        return actualVersion != null &&
-                validate.isValid() &&
+        return validate.isValid() &&
                 validate.getValue() != null &&
                 validate.getValue().isValid(actualVersion, actualVersion);
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindManagedDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindManagedDependencyTest.java
@@ -18,7 +18,9 @@ package org.openrewrite.maven.search;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpec;
 
+import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class FindManagedDependencyTest implements RewriteTest {
@@ -271,6 +273,130 @@ class FindManagedDependencyTest implements RewriteTest {
           </dependencyManagement>
         </project>
         """
+          )
+        );
+    }
+
+    @Test
+    void versionFromProjectParentVersion() {
+        rewriteRun(spec -> spec.recipe(new FindManagedDependency("jakarta.activation", "jakarta.activation-api", "1.0.0", null)),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>parent</artifactId>
+                <version>1.0.0</version>
+                <packaging>pom</packaging>
+              </project>
+              """,
+            SourceSpec::skip
+          ),
+          mavenProject("child",
+            pomXml(
+              """
+                <project>
+                  <parent>
+                    <groupId>org.sample</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0.0</version>
+                  </parent>
+                  <artifactId>child</artifactId>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>jakarta.activation</groupId>
+                        <artifactId>jakarta.activation-api</artifactId>
+                        <version>${project.parent.version}</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """,
+              """
+                <project>
+                  <parent>
+                    <groupId>org.sample</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0.0</version>
+                  </parent>
+                  <artifactId>child</artifactId>
+                  <dependencyManagement>
+                    <dependencies>
+                      <!--~~>--><dependency>
+                        <groupId>jakarta.activation</groupId>
+                        <artifactId>jakarta.activation-api</artifactId>
+                        <version>${project.parent.version}</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void bomImportVersionFromProjectParentVersion() {
+        rewriteRun(spec -> spec.recipe(new FindManagedDependency("org.junit", "junit-bom", "5.12.2", null)),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>parent</artifactId>
+                <version>5.12.2</version>
+                <packaging>pom</packaging>
+              </project>
+              """,
+            SourceSpec::skip
+          ),
+          mavenProject("child",
+            pomXml(
+              """
+                <project>
+                  <parent>
+                    <groupId>org.sample</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>5.12.2</version>
+                  </parent>
+                  <artifactId>child</artifactId>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.junit</groupId>
+                        <artifactId>junit-bom</artifactId>
+                        <version>${project.parent.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """,
+              """
+                <project>
+                  <parent>
+                    <groupId>org.sample</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>5.12.2</version>
+                  </parent>
+                  <artifactId>child</artifactId>
+                  <dependencyManagement>
+                    <dependencies>
+                      <!--~~>--><dependency>
+                        <groupId>org.junit</groupId>
+                        <artifactId>junit-bom</artifactId>
+                        <version>${project.parent.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """
+            )
           )
         );
     }


### PR DESCRIPTION
## Summary
- `FindManagedDependency` failed to match BOM imports (`<type>pom</type><scope>import</scope>`) when a version selector was specified, because `findManagedDependency()` returns `null` for BOM entries (only their transitive managed dependencies are stored as `ResolvedManagedDependency`)
- Added fallback in `versionIsValid()` to resolve the version directly from the tag's `<version>` child via `ResolvedPom.getValue()` when `findManagedDependency()` returns `null`
- This handles `${project.parent.version}` and other property expressions in BOM import versions

- Fixes moderneinc/customer-requests#2076

## Test plan
- [x] `versionFromProjectParentVersion` — regular managed dep with `${project.parent.version}`, version selector matches
- [x] `bomImportVersionFromProjectParentVersion` — BOM import with `${project.parent.version}`, version selector matches
- [x] All existing `FindManagedDependencyTest` tests continue to pass