### PR TITLE
Treat missing POMs for non-classpath dependencies as warnings

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -1182,7 +1182,13 @@ public class ResolvedPom {
                         }
                     }
                 } catch (MavenDownloadingException e) {
-                    exceptions = MavenDownloadingExceptions.append(exceptions, e.setRoot(dd.getRootDependent().getGav()));
+                    String type = dd.getDependency().getType();
+                    if (type != null && !"jar".equals(type) && !"ejb".equals(type)) {
+                        // Non-classpath artifacts may lack a POM; skip like Maven does
+                        ctx.getOnError().accept(e);
+                    } else {
+                        exceptions = MavenDownloadingExceptions.append(exceptions, e.setRoot(dd.getRootDependent().getGav()));
+                    }
                 }
             }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
@@ -342,6 +342,46 @@ class MavenDependencyFailuresTest implements RewriteTest {
         );
     }
 
+    @Test
+    void unresolvableTgzDependencyShouldNotFailBuild() {
+        rewriteRun(
+          spec -> spec.executionContext(new InMemoryExecutionContext())
+            .typeValidationOptions(TypeValidation.builder()
+              .dependencyModel(false)
+              .build()),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.example.mongo.osx</groupId>
+                    <artifactId>mongodb-osx-ssl-x86_64</artifactId>
+                    <version>3.6.23</version>
+                    <type>tgz</type>
+                    <scope>test</scope>
+                  </dependency>
+                  <dependency>
+                    <groupId>com.example.mongo.linux</groupId>
+                    <artifactId>mongodb-linux-x86_64</artifactId>
+                    <version>3.6.23</version>
+                    <type>tgz</type>
+                    <scope>test</scope>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            spec -> spec.afterRecipe(after -> {
+                // tgz dependencies that can't be downloaded should NOT cause a parse failure
+                Optional<ParseExceptionResult> maybeParseException = after.getMarkers().findFirst(ParseExceptionResult.class);
+                assertThat(maybeParseException).isEmpty();
+            })
+          )
+        );
+    }
+
     private Recipe updateModel() {
         return toRecipe(() -> new MavenIsoVisitor<>() {
             @Override


### PR DESCRIPTION
## Summary
- When a dependency's POM cannot be downloaded, Maven itself only logs a warning (`The POM for ... is missing, no dependency information available`) and continues the build. Our dependency resolution was treating this as a fatal `MavenDownloadingExceptions`, causing the entire LST build to fail.
- For non-classpath artifact types (e.g. `tgz`, `zip`), we now skip the dependency on download failure instead of failing, matching Maven's behavior.

## References
- Fixes https://github.com/moderneinc/customer-requests/issues/2095
- Maven warning behavior: https://www.orangeandbronze.com/blogs/2013/04/maven-and-archiva-no-dependency-information-available-missing-pom/
- Maven Artifact Resolver misconceptions: https://maven.apache.org/resolver/common-misconceptions.html

## Test plan
- [x] Added `unresolvableTgzDependencyShouldNotFailBuild` test that verifies tgz dependencies with unreachable POMs don't produce a `ParseExceptionResult`
- [x] Existing `siblingDependencyWithTgzPackagingAndSnapshot` test still passes (tgz deps with available POMs still resolve)
- [x] Full `rewrite-maven` test suite passes