### PR TITLE
Write data table headers using column descriptor names not display names

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/CsvDataTableStore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/CsvDataTableStore.java
@@ -149,7 +149,7 @@ public class CsvDataTableStore implements DataTableStore, AutoCloseable {
         List<String> headers = new ArrayList<>();
         headers.addAll(prefixColumns.keySet());
         for (ColumnDescriptor col : descriptor.getColumns()) {
-            headers.add(col.getDisplayName());
+            headers.add(col.getName());
         }
         headers.addAll(suffixColumns.keySet());
 


### PR DESCRIPTION

## What's changed?
`CsvDataTableStore#createBucketWriter` was  building data table headers using `ColumnDescriptor.displayName` not `ColumnDescriptor.name` which regresses previous behaviour. 

## What's your motivation?
Data tables written by Moderne's CLI were using a mix of data table names and displayNames.

## Anything in particular you'd like reviewers to focus on?
No.

## Anyone you would like to review specifically?
@jkschneider 

## Have you considered any alternatives or workarounds?
No.

## Any additional context
No.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
