### PR TITLE
C#: Fix `CSharpTemplate.Rewrite` whitespace artifact on sibling methods

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/RoslynFormatter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/RoslynFormatter.cs
@@ -216,16 +216,21 @@ public static class RoslynFormatter
         if (nodeIds.Count == 0)
             return cu;
 
-        // 1. Ensure minimum spacing so printed output is parseable
-        cu = (CompilationUnit)(new MinimumViableSpacingVisitor().Visit(cu, 0) ?? cu);
+        // 1. Ensure minimum spacing so printed output is parseable.
+        // MVS may introduce spacing artifacts on nodes outside the target subtrees
+        // (e.g., adding space to a ParameterizedType whose prefix is empty but whose
+        // inner Clazz already carries the space). Use the MVS result only for
+        // printing/Roslyn formatting, and reconcile back against the original CU.
+        var originalCu = cu;
+        var mvsCu = (CompilationUnit)(new MinimumViableSpacingVisitor().Visit(cu, 0) ?? cu);
 
         // 2. Print to string, tracking positions of all target nodes
         var trackingPrinter = new MultiPositionTrackingPrinter(nodeIds);
-        var source = trackingPrinter.Print(cu);
+        var source = trackingPrinter.Print(mvsCu);
         var spans = trackingPrinter.GetTrackedSpans();
 
         if (spans.Count == 0)
-            return cu;
+            return originalCu;
 
         // 3. Detect style
         var style = FormatStyle.DetectStyle(source);
@@ -235,7 +240,7 @@ public static class RoslynFormatter
 
         // 5. If formatting didn't change anything, return original
         if (string.Equals(source, formattedSource, StringComparison.Ordinal))
-            return cu;
+            return originalCu;
 
         // 6. Parse formatted string back to LST
         var parser = new CSharpParser();
@@ -246,17 +251,18 @@ public static class RoslynFormatter
         }
         catch (Exception)
         {
-            return cu;
+            return originalCu;
         }
 
-        // 7. Reconcile whitespace only within the target subtrees
+        // 7. Reconcile whitespace only within the target subtrees.
+        // Reconcile against the original CU so MVS artifacts outside targets are discarded.
         var reconciler = new WhitespaceReconciler();
-        var result = reconciler.Reconcile(cu, formattedCu, nodeIds);
+        var result = reconciler.Reconcile(originalCu, formattedCu, nodeIds);
 
         if (!reconciler.IsCompatible)
-            return cu;
+            return originalCu;
 
-        cu = result as CompilationUnit ?? cu;
+        cu = result as CompilationUnit ?? originalCu;
 
         // 8. Restore preserved prefixes
         if (preservedPrefixes.Count > 0)

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/RewriteRuleTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/RewriteRuleTests.cs
@@ -723,6 +723,46 @@ public class RewriteRuleTests : RewriteTest
             )
         );
     }
+
+    [Fact]
+    public void AttributeRewriteDoesNotAffectSiblingMethodWhitespace()
+    {
+        // Replacing [Foo] with [Bar] on one method should not introduce
+        // extra whitespace on the return type of an unrelated sibling method
+        RewriteRun(
+            spec => spec.SetRecipe(new RenameAttributeRecipe()),
+            CSharp(
+                """
+                using System.Collections.Generic;
+
+                public class MyTests
+                {
+                    [Foo]
+                    public void SimpleTest() { }
+
+                    public static IEnumerable<object[]> TestData()
+                    {
+                        yield return new object[] { 3, "foo" };
+                    }
+                }
+                """,
+                """
+                using System.Collections.Generic;
+
+                public class MyTests
+                {
+                    [Bar]
+                    public void SimpleTest() { }
+
+                    public static IEnumerable<object[]> TestData()
+                    {
+                        yield return new object[] { 3, "foo" };
+                    }
+                }
+                """
+            )
+        );
+    }
 }
 
 // ===============================================================


### PR DESCRIPTION
## Motivation

When `CSharpTemplate.Rewrite` (with `CSharpPattern.Attribute` + `CSharpTemplate.Attribute`) replaces an attribute on one method in a class, it introduces an extra space on the return type of an unrelated sibling method that was not modified. For example, replacing `[Fact]` with `[Test]` on `SimpleTest()` causes `TestData()` to print as `public static  IEnumerable<object[]>` (double space before `IEnumerable`).

## Summary

- `FormatSpans` ran `MinimumViableSpacingVisitor` (MVS) on the entire compilation unit and returned the MVS-modified CU even when Roslyn formatting made no changes. MVS added a space to a `ParameterizedType`'s outer prefix (which was empty because the parser placed the space on the inner `Clazz` prefix), creating a double space on unrelated sibling methods.
- Preserve the original CU before MVS and use the MVS result only for printing/Roslyn formatting. All return paths and the whitespace reconciliation step now reference the original CU, so MVS artifacts outside target subtrees are never leaked into the result.

## Test plan

- [x] New test `AttributeRewriteDoesNotAffectSiblingMethodWhitespace` reproduces the exact bug scenario and passes with the fix
- [x] Test fails without the fix (double space on sibling method return type)
- [x] All 24 `RewriteRuleTests` pass
- [x] All 247 Template tests pass
- [x] All 21 AutoFormat tests pass
- [x] Full C# test suite (1744 tests) passes