### PR TITLE
Yaml: handle dashes on its own lines better

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/IndentsVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/IndentsVisitor.java
@@ -82,8 +82,15 @@ public class IndentsVisitor<P> extends YamlIsoVisitor<P> {
 
                 getCursor().getParentOrThrow().putMessage("sequenceEntryIndent", indent);
                 // the +1 is for the '-' character
-                getCursor().getParentOrThrow().putMessage("lastIndent",
-                        indent + firstIndent(((Yaml.Sequence.Entry) y).getBlock()).length() + 1);
+                String fi = firstIndent(((Yaml.Sequence.Entry) y).getBlock());
+                int contentIndent;
+                if (StringUtils.hasLineBreak(fi)) {
+                    // When the dash is on its own line, content is indented by indentSize from the dash
+                    contentIndent = indent + style.getIndentSize();
+                } else {
+                    contentIndent = indent + fi.length() + 1;
+                }
+                getCursor().getParentOrThrow().putMessage("lastIndent", contentIndent);
             } else if (y instanceof Yaml.Mapping.Entry) {
                 y = y.withPrefix(indentTo(y.getPrefix(), indent + style.getIndentSize()));
                 getCursor().putMessage("lastIndent", indent + style.getIndentSize());

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyKeyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyKeyTest.java
@@ -766,6 +766,45 @@ class ChangePropertyKeyTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/4802")
+    @Test
+    void changePropertyKeyWithSequenceContainingDashOnOwnLine() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyKey("app.rhino", "rhino", null, null, null)),
+          yaml(
+            """
+              app:
+                rhino:
+                  config:
+                    props:
+                      - prop: 'name1'
+                        config[0]:
+                          prop1: 1
+                          prop2: 2
+                      -
+                        prop: 'name2'
+                        config[0]:
+                          prop1: 3
+                          prop2: 4
+              """,
+            """
+              rhino:
+                config:
+                  props:
+                    - prop: 'name1'
+                      config[0]:
+                        prop1: 1
+                        prop2: 2
+                    -
+                      prop: 'name2'
+                      config[0]:
+                        prop1: 3
+                        prop2: 4
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/2881")
     @Test
     void embedIndentedPropertyIntoExisting() {


### PR DESCRIPTION
## What's changed?

Change how Yaml autoformat (used by recipes) handles the case of a Yaml sequence with dash being the only thing in a line and subsequent entries in next lines.

## What's your motivation?

- Solves #4802