### PR TITLE
Fix context-sensitive template crash for anonymous class args in assignments

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
@@ -180,6 +180,83 @@ class JavaTemplateTest8Test implements RewriteTest {
         );
     }
 
+    @Test
+    void replaceContextSensitiveMethodInvocationInsideAssignment() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  method = super.visitMethodInvocation(method, ctx);
+                  if (method.getSimpleName().equals("visitClassDeclaration") &&
+                      method.getSelect() != null &&
+                      !(method.getSelect() instanceof J.Identifier &&
+                        "super".equals(((J.Identifier) method.getSelect()).getSimpleName()))) {
+                      return JavaTemplate.builder("#{any()}.visit(#{any()}, #{any()}, getCursor().getParentTreeCursor())")
+                        .contextSensitive()
+                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                        .build()
+                        .apply(getCursor(), method.getCoordinates().replace(),
+                          method.getSelect(), method.getArguments().get(0), method.getArguments().get(1));
+                  }
+                  return method;
+              }
+          })),
+          java(
+            """
+              import org.openrewrite.*;
+              import org.openrewrite.java.JavaIsoVisitor;
+              import org.openrewrite.java.JavaVisitor;
+              import org.openrewrite.java.tree.J;
+
+              class MyRecipe extends Recipe {
+                  @Override
+                  public String getDisplayName() { return ""; }
+                  @Override
+                  public String getDescription() { return ""; }
+
+                  @Override
+                  public TreeVisitor<?, ExecutionContext> getVisitor() {
+                      return Preconditions.check(new JavaIsoVisitor<ExecutionContext>() {}, new JavaIsoVisitor<ExecutionContext>() {
+                          @Override
+                          public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                              J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+                              cd = new JavaVisitor<ExecutionContext>() {}.visitClassDeclaration(cd, ctx);
+                              return cd;
+                          }
+                      });
+                  }
+              }
+              """,
+            """
+              import org.openrewrite.*;
+              import org.openrewrite.java.JavaIsoVisitor;
+              import org.openrewrite.java.JavaVisitor;
+              import org.openrewrite.java.tree.J;
+
+              class MyRecipe extends Recipe {
+                  @Override
+                  public String getDisplayName() { return ""; }
+                  @Override
+                  public String getDescription() { return ""; }
+
+                  @Override
+                  public TreeVisitor<?, ExecutionContext> getVisitor() {
+                      return Preconditions.check(new JavaIsoVisitor<ExecutionContext>() {}, new JavaIsoVisitor<ExecutionContext>() {
+                          @Override
+                          public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                              J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+                              cd = new JavaVisitor<ExecutionContext>() {
+                              }.visit(cd, ctx, getCursor().getParentTreeCursor());
+                              return cd;
+                          }
+                      });
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @DocumentExample
     @Test
     void parameterizedMatch() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -132,6 +132,17 @@ public class BlockStatementTemplateGenerator {
             @Override
             public <T> JLeftPadded<T> visitLeftPadded(@Nullable JLeftPadded<T> left, JLeftPadded.Location loc,
                                                       Integer integer) {
+                if (left != null && blockEnclosingTemplateComment == null) {
+                    for (Comment comment : left.getBefore().getComments()) {
+                        if (comment instanceof TextComment && ((TextComment) comment).getText().equals(TEMPLATE_COMMENT)) {
+                            // The __TEMPLATE__ comment is in the JLeftPadded padding (e.g., between '=' and
+                            // the RHS expression in an assignment). Set the enclosing block so the element
+                            // inside this padding will be collected by the visit() method.
+                            blockEnclosingTemplateComment = getCursor().firstEnclosing(J.Block.class);
+                            break;
+                        }
+                    }
+                }
                 left = super.visitLeftPadded(left, loc, integer);
                 if (left != null) {
                     for (Comment comment : left.getBefore().getComments()) {
@@ -376,7 +387,9 @@ public class BlockStatementTemplateGenerator {
             if (n.getBody() != null && referToSameElement(prior, n.getBody())) {
                 // prior is the body of this anonymous class - already handled by J.Block case
                 // just need to close the anonymous class properly
-                after.append(";");
+                if (!(next(cursor).getValue() instanceof MethodCall)) {
+                    after.append(";");
+                }
             } else if (n.getArguments().stream().anyMatch(arg -> referToSameElement(prior, arg))) {
                 StringBuilder beforeSegments = new StringBuilder();
                 StringBuilder afterSegments = new StringBuilder();


### PR DESCRIPTION
## Summary
- Fixes `IndexOutOfBoundsException` in `JavaTemplateParser.parseExpression()` when a context-sensitive template replaces a method invocation inside an assignment, where the containing anonymous class is an argument to another method call (e.g., `Preconditions.check()`)
- The stub generator produced invalid Java (`__M__.any(new Foo(){...};)` — semicolon inside method argument) causing the parser to drop `/*__TEMPLATE__*/` comment markers during error recovery
- Conditionally omit the semicolon after anonymous class body when the parent is a `MethodCall`, consistent with the existing pattern used elsewhere in the same method
- Also detect `__TEMPLATE__` comment in `JLeftPadded.before` padding for assignment-context templates where the comment lands in the padding space rather than on a tree node prefix

## Test plan
- [x] Added `replaceContextSensitiveMethodInvocationInsideAssignment` test reproducing the exact crash scenario
- [x] All existing `JavaTemplateTest*` tests pass
- [x] Full `rewrite-java-test` and `rewrite-java` test suites pass