### PR TITLE
C#: Fix `AutoFormat` corrupting whitespace outside target subtree

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/RoslynFormatter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/RoslynFormatter.cs
@@ -45,8 +45,13 @@ public static class RoslynFormatter
     /// </summary>
     public static CompilationUnit Format(CompilationUnit cu, J? targetSubtree, J? stopAfter)
     {
-        // 1. Ensure minimum spacing so printed output is parseable
-        cu = (CompilationUnit)(new MinimumViableSpacingVisitor().Visit(cu, 0) ?? cu);
+        // 1. Ensure minimum spacing so printed output is parseable.
+        // MVS may introduce spacing artifacts on nodes outside the target subtree
+        // (e.g., adding space to a ParameterizedType whose prefix is empty but whose
+        // inner Clazz already carries the space). Use the MVS result only for
+        // printing/Roslyn formatting, and reconcile back against the original CU.
+        var originalCu = cu;
+        var mvsCu = (CompilationUnit)(new MinimumViableSpacingVisitor().Visit(cu, 0) ?? cu);
 
         // 2. Print to string, tracking the position of the target subtree if provided
         string source;
@@ -55,7 +60,7 @@ public static class RoslynFormatter
         if (targetSubtree != null)
         {
             var trackingPrinter = new PositionTrackingPrinter(targetSubtree.Id);
-            source = trackingPrinter.Print(cu);
+            source = trackingPrinter.Print(mvsCu);
             var (start, end) = trackingPrinter.GetTrackedSpan();
             if (start >= 0 && end > start)
             {
@@ -65,7 +70,7 @@ public static class RoslynFormatter
         else
         {
             var printer = new CSharpPrinter<int>();
-            source = printer.Print(cu);
+            source = printer.Print(mvsCu);
         }
 
         // 3. Detect style
@@ -76,7 +81,7 @@ public static class RoslynFormatter
 
         // 5. If formatting didn't change anything, return original
         if (string.Equals(source, formattedSource, StringComparison.Ordinal))
-            return cu;
+            return originalCu;
 
         // 6. Parse formatted string back to LST (no type attribution)
         var parser = new CSharpParser();
@@ -88,17 +93,18 @@ public static class RoslynFormatter
         catch (Exception)
         {
             // If parsing fails (shouldn't happen with Roslyn), return original
-            return cu;
+            return originalCu;
         }
 
-        // 7. Reconcile whitespace
+        // 7. Reconcile whitespace against the original CU so MVS artifacts
+        // outside the target subtree are discarded.
         var reconciler = new WhitespaceReconciler();
-        var result = reconciler.Reconcile(cu, formattedCu, targetSubtree, stopAfter);
+        var result = reconciler.Reconcile(originalCu, formattedCu, targetSubtree, stopAfter);
 
         if (!reconciler.IsCompatible)
-            return cu;
+            return originalCu;
 
-        return result as CompilationUnit ?? cu;
+        return result as CompilationUnit ?? originalCu;
     }
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Format/AutoFormatTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Format/AutoFormatTests.cs
@@ -554,6 +554,50 @@ public class AutoFormatTests
         Assert.Equal(block.Id, result.Id);
     }
 
+    [Fact]
+    public void FormatSubtreeDoesNotCorruptUnrelatedWhitespace()
+    {
+        // Reproducer for autoformat corrupting whitespace in base type lists
+        // and async modifiers when a method body subtree is formatted.
+        const string source =
+            "using System;\n" +
+            "using System.Threading.Tasks;\n" +
+            "\n" +
+            "public class TestObj : IComparable<TestObj?>, IEquatable<TestObj?>\n" +
+            "{\n" +
+            "    public int CompareTo(TestObj? other) => 0;\n" +
+            "    public bool Equals(TestObj? other) => false;\n" +
+            "\n" +
+            "    public async Task<int> RunAsync()\n" +
+            "    {\n" +
+            "        return await Task.FromResult(0);\n" +
+            "    }\n" +
+            "}\n";
+
+        var cu = _parser.Parse(source);
+        var originalPrinted = _printer.Print(cu);
+        Assert.Equal(source, originalPrinted);
+
+        // Find the first method body (simulating a localized change via FormatSubtree)
+        var classDecl = cu.Members[0].Element as ClassDeclaration;
+        Assert.NotNull(classDecl);
+        var method = classDecl.Body.Statements[0].Element as MethodDeclaration;
+        Assert.NotNull(method);
+        var body = method.Body!;
+
+        // 1. Test FormatSubtree path (used by template application):
+        //    Splice the unmodified body back and format — should be a no-op
+        var subtreeResult = RoslynFormatter.FormatSubtree(cu, body.Id, body, stopAfter: null);
+        Assert.Equal(body.Id, subtreeResult.Id);
+
+        // 2. Test Format path with a target subtree
+        var formattedCu = RoslynFormatter.Format(cu, targetSubtree: method, stopAfter: null);
+        var result = _printer.Print(formattedCu);
+
+        // Since the body is unmodified, the output should be character-identical to input
+        Assert.Equal(source, result);
+    }
+
     private class ForLoopFinder(Action<ForLoop> onFound) : CSharpVisitor<int>
     {
         public override J VisitForLoop(ForLoop forLoop, int p)


### PR DESCRIPTION
## Motivation

When `CSharpTemplate.Rewrite()` or `AutoFormatVisitor` formats a specific subtree (e.g., replacing `[Fact]` with `[Test]`), the `RoslynFormatter.Format()` method corrupts whitespace in unrelated parts of the file. For example:

- **Base type lists**: `IComparable<TestObj?>, IEquatable<TestObj?>` → `IComparable<TestObj?> ,  IEquatable<TestObj?>`
- **Async modifiers**: `async Task<RunSummary>` → `async  Task<RunSummary>`

This happens because `MinimumViableSpacingVisitor` (MVS) adds spacing artifacts to ensure parseable output, and when reconciling whitespace back, those artifacts leak into nodes outside the formatting target.

## Summary

- **Root cause**: `Format()` overwrote `cu` with the MVS result, so whitespace reconciliation used the MVS-modified tree as the "original" — leaking MVS artifacts into non-target nodes
- **Fix**: Save `originalCu` before MVS, use `mvsCu` only for printing/Roslyn formatting, reconcile against `originalCu`. This matches the pattern already used in `FormatSpans()`
- Changed file: `RoslynFormatter.cs` — the `Format(cu, targetSubtree, stopAfter)` overload

## Test plan

- [x] Added `FormatSubtreeDoesNotCorruptUnrelatedWhitespace` test with base type lists (nullable generics) and async methods
- [x] Test exercises both `FormatSubtree` and `Format` code paths
- [x] Asserts full character-level equality (not just substring checks)
- [x] All 20 AutoFormatTests pass
- [x] All 50 format-related tests pass