### PR TITLE
C#: Exclude git-ignored files from SolutionParser results

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -261,6 +261,15 @@ public class SolutionParser
         var userDocs = project.Documents
             .Where(d => d.FilePath != null && IsUserSource(d, project))
             .ToList();
+
+        // Filter out git-ignored files when inside a git repository
+        var ignoredPaths = GetGitIgnoredPaths(rootDir, userDocs.Select(d => d.FilePath!));
+        if (ignoredPaths.Count > 0)
+        {
+            var before = userDocs.Count;
+            userDocs = userDocs.Where(d => !ignoredPaths.Contains(d.FilePath!)).ToList();
+            Log.Debug("ParseProject: excluded {ExcludedCount} git-ignored files", before - userDocs.Count);
+        }
         Log.Debug("ParseProject: {ProjectName} has {UserDocCount} user source files (of {TotalDocCount} total)",
             projectName, userDocs.Count, project.Documents.Count());
 
@@ -391,6 +400,77 @@ public class SolutionParser
         }
 
         return symbolSets;
+    }
+
+    /// <summary>
+    /// Returns the set of file paths (from <paramref name="candidatePaths"/>) that are
+    /// git-ignored according to the repository rooted at or above <paramref name="rootDir"/>.
+    /// Returns an empty set when git is not available or <paramref name="rootDir"/> is not
+    /// inside a git repository.
+    /// </summary>
+    private static HashSet<string> GetGitIgnoredPaths(string rootDir, IEnumerable<string> candidatePaths)
+    {
+        var ignored = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var paths = candidatePaths.ToList();
+        if (paths.Count == 0) return ignored;
+
+        try
+        {
+            // Check if rootDir is inside a git repo
+            var checkPsi = new ProcessStartInfo("git", "rev-parse --git-dir")
+            {
+                WorkingDirectory = rootDir,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var checkProcess = Process.Start(checkPsi);
+            if (checkProcess == null) return ignored;
+            checkProcess.WaitForExit(5_000);
+            if (checkProcess.ExitCode != 0) return ignored;
+
+            // Use git check-ignore --stdin to batch-check all candidate paths
+            var psi = new ProcessStartInfo("git", "check-ignore --stdin")
+            {
+                WorkingDirectory = rootDir,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var process = Process.Start(psi);
+            if (process == null) return ignored;
+
+            // Write all paths to stdin, one per line
+            foreach (var path in paths)
+                process.StandardInput.WriteLine(path);
+            process.StandardInput.Close();
+
+            // Read ignored paths from stdout
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit(10_000);
+
+            foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var trimmed = line.TrimEnd('\r');
+                if (!string.IsNullOrEmpty(trimmed))
+                {
+                    // git check-ignore outputs paths relative to the working directory;
+                    // resolve them to full paths for comparison
+                    var fullPath = Path.GetFullPath(trimmed, rootDir);
+                    ignored.Add(fullPath);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("GetGitIgnoredPaths: failed ({ExType}: {ExMessage}), skipping filter",
+                ex.GetType().Name, ex.Message);
+        }
+
+        return ignored;
     }
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/SolutionParserTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/SolutionParserTests.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System.Diagnostics;
 using OpenRewrite.CSharp;
 
 namespace OpenRewrite.Tests;
@@ -152,6 +153,82 @@ public class SolutionParserTests : IDisposable
             "File written with UTF-8 BOM should have CharsetBomMarked=true");
         Assert.False(noBom.CharsetBomMarked,
             "File written without BOM should have CharsetBomMarked=false");
+    }
+
+    [Fact]
+    public async Task GitIgnoredFilesAreExcluded()
+    {
+        // Initialize a git repo with a .gitignore that excludes **/[Pp]ackages/*
+        RunGit("init");
+        WriteFile(".gitignore", "**/[Pp]ackages/*\n");
+
+        // Create a project that includes a source file under .nuget/packages/
+        // (simulating NuGet source packages like xunit.assert.source)
+        WriteFile("Test.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <Compile Include=".nuget/packages/SomePackage/Source.cs" />
+              </ItemGroup>
+            </Project>
+            """);
+        WriteFile("App.cs", "class App { }\n");
+        WriteFile(".nuget/packages/SomePackage/Source.cs", "class Source { }\n");
+
+        var parser = new SolutionParser();
+        var solution = await parser.LoadAsync(Path.Combine(_tempDir, "Test.csproj"));
+        var results = parser.ParseProject(solution,
+            Path.Combine(_tempDir, "Test.csproj"), _tempDir);
+
+        // Only App.cs should be parsed; the file under packages/ should be excluded
+        Assert.Single(results);
+        var cu = Assert.IsType<CompilationUnit>(results[0]);
+        Assert.Contains("App.cs", cu.SourcePath);
+    }
+
+    [Fact]
+    public async Task NonGitRepoDoesNotFilter()
+    {
+        // No git init — should parse all files including those that would match gitignore patterns
+        WriteFile("Test.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <Compile Include=".nuget/packages/SomePackage/Source.cs" />
+              </ItemGroup>
+            </Project>
+            """);
+        WriteFile("App.cs", "class App { }\n");
+        WriteFile(".nuget/packages/SomePackage/Source.cs", "class Source { }\n");
+
+        var parser = new SolutionParser();
+        var solution = await parser.LoadAsync(Path.Combine(_tempDir, "Test.csproj"));
+        var results = parser.ParseProject(solution,
+            Path.Combine(_tempDir, "Test.csproj"), _tempDir);
+
+        // Both files should be parsed since there's no git repo
+        Assert.Equal(2, results.Count);
+    }
+
+    private void RunGit(string args)
+    {
+        var psi = new ProcessStartInfo("git", args)
+        {
+            WorkingDirectory = _tempDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        using var process = Process.Start(psi)!;
+        process.WaitForExit(10_000);
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"git {args} failed: {process.StandardError.ReadToEnd()}");
     }
 
     [Fact]


### PR DESCRIPTION
## Motivation

`SolutionParser` includes all files that MSBuildWorkspace discovers via `.csproj` references, but some of those files live in directories that are git-ignored (e.g., `.nuget/packages/` matching `**/[Pp]ackages/*`). NuGet source packages like `xunit.assert.source` get parsed as user code, inflating results with third-party sources.

## Summary

- Add `GetGitIgnoredPaths()` to `SolutionParser` that batch-checks candidate file paths via `git check-ignore --stdin`
- Filter out ignored files in `ParseProject` before parsing
- Gracefully skips filtering when git is unavailable or the directory is not a git repo

## Test plan

- [x] `GitIgnoredFilesAreExcluded` — inits a temp git repo with `.gitignore`, verifies files under `packages/` are excluded
- [x] `NonGitRepoDoesNotFilter` — verifies no filtering when not in a git repo (all files parsed)
- [x] All existing `SolutionParserTests` continue to pass (7/7)