### PR TITLE
C#: Preserve `MinimumViableSpacing` fixes when Roslyn formatting is a no-op

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/RoslynFormatter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/RoslynFormatter.cs
@@ -79,9 +79,21 @@ public static class RoslynFormatter
         // 4. Format with Roslyn (scoped to the target span when available)
         var formattedSource = FormatWithRoslyn(source, style, formatSpan);
 
-        // 5. If formatting didn't change anything, return original
+        // 5. If Roslyn formatting didn't change anything, reconcile MVS changes
+        // (if any) within the target subtree and return. MVS changes like added
+        // spaces between modifiers and types must not be discarded.
         if (string.Equals(source, formattedSource, StringComparison.Ordinal))
-            return originalCu;
+        {
+            if (ReferenceEquals(mvsCu, originalCu))
+                return originalCu;
+
+            // MVS made changes — reconcile them within the target subtree
+            var mvsReconciler = new WhitespaceReconciler();
+            var mvsResult = mvsReconciler.Reconcile(originalCu, mvsCu, targetSubtree, stopAfter);
+            if (!mvsReconciler.IsCompatible)
+                return originalCu;
+            return mvsResult as CompilationUnit ?? originalCu;
+        }
 
         // 6. Parse formatted string back to LST (no type attribution)
         var parser = new CSharpParser();
@@ -244,9 +256,31 @@ public static class RoslynFormatter
         // 4. Format with Roslyn, scoped to all target spans
         var formattedSource = FormatWithRoslyn(source, style, spans);
 
-        // 5. If formatting didn't change anything, return original
+        // 5. If Roslyn formatting didn't change anything, reconcile MVS changes
+        // (if any) within the target subtrees and return. MVS changes like added
+        // spaces between modifiers and types must not be discarded.
         if (string.Equals(source, formattedSource, StringComparison.Ordinal))
-            return originalCu;
+        {
+            if (ReferenceEquals(mvsCu, originalCu))
+                return originalCu;
+
+            // MVS made changes — reconcile them within the target subtrees
+            var mvsReconciler = new WhitespaceReconciler();
+            var mvsResult = mvsReconciler.Reconcile(originalCu, mvsCu, nodeIds);
+            if (!mvsReconciler.IsCompatible)
+                return originalCu;
+            cu = mvsResult as CompilationUnit ?? originalCu;
+
+            // Restore preserved prefixes
+            if (preservedPrefixes.Count > 0)
+            {
+                var restorer = new PrefixRestorer(preservedPrefixes);
+                restorer.Cursor = new Cursor(null, Cursor.ROOT_VALUE);
+                cu = (CompilationUnit)(restorer.Visit(cu, 0) ?? cu);
+            }
+
+            return cu;
+        }
 
         // 6. Parse formatted string back to LST
         var parser = new CSharpParser();

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Format/AutoFormatTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Format/AutoFormatTests.cs
@@ -598,6 +598,82 @@ public class AutoFormatTests
         Assert.Equal(source, result);
     }
 
+    /// <summary>
+    /// Simulates what the MakeFieldReadOnly recipe does: adds a readonly modifier
+    /// to a field and calls MaybeAutoFormat. Verifies the output has proper spacing
+    /// between the modifier and the type name.
+    /// </summary>
+    [Fact]
+    public void AutoFormatAfterAddingReadonlyModifierToGenericField()
+    {
+        const string source = """
+            class Foo
+            {
+                List<int> _elements = new List<int>();
+            }
+            """;
+
+        var cu = _parser.Parse(source);
+
+        var visitor = new AddReadonlyModifierVisitor();
+        visitor.Cursor = new Cursor(null, Cursor.ROOT_VALUE);
+        var result = visitor.Visit(cu, 0)!;
+
+        var printed = _printer.Print(result);
+
+        // The readonly keyword must be separated from the type name
+        Assert.DoesNotContain("readonlyList", printed);
+        Assert.Contains("readonly List<int>", printed);
+    }
+
+    [Fact]
+    public void AutoFormatAfterAddingReadonlyModifierToSimpleField()
+    {
+        const string source = """
+            class Foo
+            {
+                int _x;
+            }
+            """;
+
+        var cu = _parser.Parse(source);
+
+        var visitor = new AddReadonlyModifierVisitor();
+        visitor.Cursor = new Cursor(null, Cursor.ROOT_VALUE);
+        var result = visitor.Visit(cu, 0)!;
+
+        var printed = _printer.Print(result);
+
+        Assert.DoesNotContain("readonlyint", printed);
+        Assert.Contains("readonly int", printed);
+    }
+
+    /// <summary>
+    /// Visitor that adds a readonly modifier to fields and calls AutoFormat,
+    /// simulating MakeFieldReadOnly recipe behavior.
+    /// </summary>
+    private class AddReadonlyModifierVisitor : CSharpVisitor<int>
+    {
+        public override J VisitVariableDeclarations(VariableDeclarations varDecl, int p)
+        {
+            var v = (VariableDeclarations)base.VisitVariableDeclarations(varDecl, p);
+
+            if (Cursor.FirstEnclosing<ClassDeclaration>() == null)
+                return v;
+
+            if (v.Modifiers.Any(m => m.Type == Modifier.ModifierType.Readonly))
+                return v;
+
+            var newModifiers = new List<Modifier>(v.Modifiers);
+            newModifiers.Add(new Modifier(
+                Guid.NewGuid(), Space.SingleSpace, Markers.Empty,
+                Modifier.ModifierType.Readonly, new List<Annotation>()));
+            var after = v.WithModifiers(newModifiers);
+
+            return MaybeAutoFormat(v, after, p, Cursor);
+        }
+    }
+
     private class ForLoopFinder(Action<ForLoop> onFound) : CSharpVisitor<int>
     {
         public override J VisitForLoop(ForLoop forLoop, int p)

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Format/MinimumViableSpacingTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Format/MinimumViableSpacingTests.cs
@@ -81,6 +81,59 @@ public class MinimumViableSpacingTests
         Assert.DoesNotContain("int_x", result);
     }
 
+    /// <summary>
+    /// Simulates what MakeFieldReadOnly does: adds a readonly modifier to a field
+    /// that previously had none. The type expression has an empty prefix because
+    /// the indentation lives on the VariableDeclarations prefix.
+    /// </summary>
+    [Fact]
+    public void AddedModifierToFieldWithGenericType()
+    {
+        var cu = _parser.Parse("""
+            class Foo
+            {
+                List<int> _elements = new List<int>();
+            }
+            """);
+
+        // Add a readonly modifier to the field, simulating what a recipe does
+        var addModifier = new AddReadonlyModifierVisitor();
+        addModifier.Cursor = new Cursor(null, Cursor.ROOT_VALUE);
+        cu = (CompilationUnit)(addModifier.Visit(cu, 0) ?? cu);
+
+        // Run MVS to ensure spacing
+        var restored = new MinimumViableSpacingVisitor().Visit(cu, 0) as CompilationUnit ?? cu;
+        var result = _printer.Print(restored);
+
+        // The readonly keyword must be separated from the type name
+        Assert.DoesNotContain("readonlyList", result);
+        Assert.Contains("readonly List", result);
+    }
+
+    /// <summary>
+    /// Same as above but with a simple (non-generic) type.
+    /// </summary>
+    [Fact]
+    public void AddedModifierToFieldWithSimpleType()
+    {
+        var cu = _parser.Parse("""
+            class Foo
+            {
+                int _x;
+            }
+            """);
+
+        var addModifier = new AddReadonlyModifierVisitor();
+        addModifier.Cursor = new Cursor(null, Cursor.ROOT_VALUE);
+        cu = (CompilationUnit)(addModifier.Visit(cu, 0) ?? cu);
+
+        var restored = new MinimumViableSpacingVisitor().Visit(cu, 0) as CompilationUnit ?? cu;
+        var result = _printer.Print(restored);
+
+        Assert.DoesNotContain("readonlyint", result);
+        Assert.Contains("readonly int", result);
+    }
+
     [Fact]
     public void ReturnWithExpression()
     {
@@ -295,6 +348,32 @@ public class MinimumViableSpacingTests
         public override Space VisitSpace(Space space, int p)
         {
             return Space.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Visitor that adds a readonly modifier to field declarations,
+    /// simulating what the MakeFieldReadOnly recipe does.
+    /// </summary>
+    private class AddReadonlyModifierVisitor : CSharpVisitor<int>
+    {
+        public override J VisitVariableDeclarations(VariableDeclarations varDecl, int p)
+        {
+            var v = (VariableDeclarations)base.VisitVariableDeclarations(varDecl, p);
+
+            // Only add to fields (inside a class body)
+            if (Cursor.FirstEnclosing<ClassDeclaration>() == null)
+                return v;
+
+            // Don't add if already has readonly
+            if (v.Modifiers.Any(m => m.Type == Modifier.ModifierType.Readonly))
+                return v;
+
+            var newModifiers = new List<Modifier>(v.Modifiers);
+            newModifiers.Add(new Modifier(
+                Guid.NewGuid(), Space.SingleSpace, Markers.Empty,
+                Modifier.ModifierType.Readonly, new List<Annotation>()));
+            return v.WithModifiers(newModifiers);
         }
     }
 }


### PR DESCRIPTION
## Motivation

The `MakeFieldReadOnly` recipe in `recipes-csharp` produces `readonlyList<T>` instead of `readonly List<T>` when adding the `readonly` modifier to fields. The `readonly` keyword is missing a trailing space before the type name.

The root cause is in `RoslynFormatter`: when `MinimumViableSpacingVisitor` (MVS) correctly adds a space between the modifier and the type expression, but Roslyn formatting makes no *additional* changes, the formatter short-circuits at `source == formattedSource` and returns the original CU — discarding the MVS fix.

The flow was:
1. MVS adds space to type expression prefix → `mvsCu` (correct: `readonly List<int>`)
2. Print `mvsCu` → correct output
3. Roslyn formats → no change (already correct)
4. `source == formattedSource` → returns `originalCu` (no space!) → `readonlyList<int>`

## Summary

- When Roslyn is a no-op but MVS made changes, reconcile the MVS changes within the target subtrees instead of discarding them
- Fixed in both `Format()` (single subtree) and `FormatSpans()` (multi-target batch)
- Added integration tests simulating MakeFieldReadOnly recipe behavior (adding modifier + `MaybeAutoFormat`)
- Added MVS unit tests confirming the visitor correctly handles added modifiers

## Test plan

- [x] New `AutoFormatAfterAddingReadonlyModifierToGenericField` — adds `readonly` to `List<int>` field via visitor + `MaybeAutoFormat`, verifies `readonly List<int>` output
- [x] New `AutoFormatAfterAddingReadonlyModifierToSimpleField` — same for `int` field
- [x] New MVS unit tests (`AddedModifierToFieldWithGenericType`, `AddedModifierToFieldWithSimpleType`)
- [x] Full C# test suite (1771 tests pass)