### PR TITLE
C#: Fix Stack empty crash in CSharpPrinter.VisitConditionalDirective

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -2962,7 +2962,10 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
             if (branchTrailingNewlines[0][d])
                 p.Append('\n');
 
-            // Update the active branch stack
+            // Update the active branch stack.
+            // Guard against empty stack: recipe visitors can remove nodes whose
+            // prefix carried ghost comments, causing directiveOrder to be missing
+            // the matching #if for an #elif/#else/#endif.
             switch (directive.Kind)
             {
                 case PreprocessorDirectiveKind.If:
@@ -2970,16 +2973,16 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
                     break;
                 case PreprocessorDirectiveKind.Elif:
                 case PreprocessorDirectiveKind.Else:
-                    stack.Pop();
+                    if (stack.Count > 0) stack.Pop();
                     stack.Push(directive.ActiveBranchIndex);
                     break;
                 case PreprocessorDirectiveKind.Endif:
-                    stack.Pop();
+                    if (stack.Count > 0) stack.Pop();
                     break;
             }
 
             // Emit next section from the active branch
-            int activeBranch = stack.Peek();
+            int activeBranch = stack.Count > 0 ? stack.Peek() : 0;
             // Fall back to primary branch when no branch activates this directive
             if (activeBranch < 0) activeBranch = 0;
             int sectionIndex = d + 1;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/WorkingSetRoundTripTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/WorkingSetRoundTripTests.cs
@@ -16,6 +16,7 @@
 using Microsoft.CodeAnalysis;
 using OpenRewrite.Core;
 using OpenRewrite.CSharp;
+using OpenRewrite.Java;
 
 namespace OpenRewrite.Tests;
 
@@ -410,6 +411,57 @@ public class WorkingSetRoundTripTests
         }
 
         Assert.Equal(source, printed);
+    }
+
+    [Fact]
+    public void PrintDoesNotCrashWhenRecipeRemovesNodeWithGhostComments()
+    {
+        // Reproduction of Stack empty crash in VisitConditionalDirective.
+        // When a recipe removes a using whose prefix contains ghost comments (e.g.,
+        // #if A / using X; / #endif — removing 'using X;' loses the #if ghost comment
+        // but the #endif ghost comment survives on the next node), the printer's
+        // internal stack becomes unbalanced.
+        var source =
+            "using System;\r\n" +
+            "\r\n" +
+            "#if XUNIT_NULLABLE\r\n" +
+            "using System.Diagnostics.CodeAnalysis;\r\n" +
+            "#endif\r\n" +
+            "\r\n" +
+            "class C\r\n" +
+            "{\r\n" +
+            "}";
+
+        var parser = new CSharpParser();
+        var cu = parser.Parse(source, "Test.cs");
+
+        // Find the ConditionalDirective
+        var cd = cu.Members[0].Element as ConditionalDirective;
+        Assert.NotNull(cd);
+
+        // Simulate a recipe removing "using System.Diagnostics.CodeAnalysis;" from branch 0.
+        // That using's prefix carries the ghost comment for #if (DIRECTIVE:0).
+        // The #endif ghost comment (DIRECTIVE:1) is on the next node (ClassDeclaration prefix).
+        // This creates an unbalanced stack: Endif without matching If.
+        var branch0 = cd.Branches[0].Element;
+        Assert.Equal(2, branch0.Usings.Count);
+
+        // Keep only the first using (System), drop the conditional one (CodeAnalysis)
+        var modifiedUsings = new List<JRightPadded<Statement>> { branch0.Usings[0] };
+        var modifiedBranch = branch0.WithUsings(modifiedUsings);
+
+        var modifiedBranches = new List<JRightPadded<CompilationUnit>>(cd.Branches);
+        modifiedBranches[0] = cd.Branches[0].WithElement(modifiedBranch);
+        var modifiedCd = cd.WithBranches(modifiedBranches);
+
+        var modifiedCu = cu.WithMembers([
+            new JRightPadded<Statement>(modifiedCd, Space.Empty, Markers.Empty)
+        ]);
+
+        // Before the fix, this would throw: System.InvalidOperationException: Stack empty.
+        var printer = new CSharpPrinter<int>();
+        var exception = Record.Exception(() => printer.Print(modifiedCu));
+        Assert.Null(exception);
     }
 
     #endregion


### PR DESCRIPTION
## Motivation

`CSharpPrinter.VisitConditionalDirective` throws `System.InvalidOperationException: Stack empty.` when printing a `ConditionalDirective` whose branch CU has been modified by a recipe visitor. Found while running the `CodeQuality` composite recipe against `xunit/samples.xunit` via the Moderne CLI — 1 file out of hundreds triggered this crash (`AssertHelper.cs` from `xunit.assert.source`).

The printer uses ghost comments (`//DIRECTIVE:N`) embedded in branch CU whitespace to reconstruct directive boundaries during printing. It tracks the active branch with a stack that is pushed on `#if` and popped on `#elif`/`#else`/`#endif`. When a recipe removes a node whose prefix carries a ghost comment (e.g., removing a conditional `using` wrapped in `#if`/`#endif`), the `#if` ghost comment is lost but the `#endif` ghost comment survives on the next node. This causes more pops than pushes, emptying the stack, and `stack.Peek()` crashes.

## Summary

- Guard `Pop()` calls in the `Elif`/`Else`/`Endif` cases against empty stack (`stack.Count > 0`)
- Guard `Peek()` after the switch to fall back to primary branch (index 0) when the stack is empty
- Add test that reproduces the exact crash: parse a file with `#if`/`#endif` around a using, remove the using from a branch CU (simulating a recipe), and verify printing doesn't throw

## Test plan

- [x] New test `PrintDoesNotCrashWhenRecipeRemovesNodeWithGhostComments` reproduces `Stack empty` without the fix, passes with it
- [x] All 1767 C# xUnit tests pass
- [x] Existing preprocessor round-trip tests unchanged