### PR TITLE
AutoFormat support removal of extraneous newlines in more circumstances

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/format/MergeSpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/MergeSpacesVisitor.java
@@ -73,11 +73,6 @@ public class MergeSpacesVisitor extends JavaVisitor<Object> {
             return space;
         }
         Space newSpace = (Space) ctx;
-        if (evaluate(() -> wrappingAndBracesStyle.getKeepWhenFormatting().getLineBreaks(), true) && space.getWhitespace().contains("\n")) {
-            if (newSpace.getWhitespace().contains("\n")) {
-                newSpace = newSpace.withWhitespace(space.getWhitespace().substring(0, space.getWhitespace().lastIndexOf("\n") + 1) + newSpace.getWhitespace().substring(newSpace.getWhitespace().lastIndexOf("\n") + 1));
-            }
-        }
         if (space == null) {
             return newSpace;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
@@ -794,11 +794,11 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
 
     private Space minimizedSkipComments(Space space, String whitespace) {
         if (space.getComments().isEmpty()) {
+            //Reduce to single new line
             if (evaluate(() -> wrappingAndBracesStyle.getKeepWhenFormatting().getLineBreaks(), true) && StringUtils.hasLineBreak(space.getWhitespace())) {
-                return space;
+                return space.withWhitespace(space.getWhitespace().substring(space.getWhitespace().lastIndexOf('\n')));
             }
             if (StringUtils.hasLineBreak(whitespace)) {
-                //Reduce to single new line
                 return space.withWhitespace(whitespace.substring(whitespace.lastIndexOf('\n')));
             }
             return space.withWhitespace(whitespace);

--- a/rewrite-java/src/test/java/org/openrewrite/java/format/AutoFormatTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/format/AutoFormatTest.java
@@ -128,6 +128,55 @@ class AutoFormatTest implements RewriteTest {
     }
 
     @Test
+    void extraNewlinesInVariableInitializer() {
+        rewriteRun(
+          java(
+            """
+              public class Test {
+                  int a =
+
+                    1;
+              }
+              """,
+            """
+              public class Test {
+                  int a = 1;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void extraNewlinesInVariableInitializerKeepLineBreaks() {
+        rewriteRun(
+          spec -> spec.recipe(new AutoFormat(null))
+            .parser(JavaParser.fromJavaVersion()
+              .styles(singletonList(
+                new NamedStyles(
+                  Tree.randomId(), "test", "Test", "A test.", emptySet(),
+                  List.of(IntelliJ.wrappingAndBraces())
+                )))
+            ),
+          java(
+            """
+              public class Test {
+                  int a =
+
+                    1;
+              }
+              """,
+            """
+              public class Test {
+                  int a =
+                          1;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void annotatedMethod() {
         rewriteRun(
           java(


### PR DESCRIPTION
I noticed that autoformat wasn't fixing extraneous newlines in variable declarations today. 
Here's a proposed fix, @Jenson3210 let me know if you're aware of any reasons this would be problematic that aren't covered by the current tests.