### PR TITLE
C#: Fix MinimumViableSpacing fix lost during WhitespaceReconciler

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/WhitespaceReconciler.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/WhitespaceReconciler.cs
@@ -94,11 +94,27 @@ public class WhitespaceReconciler
     {
         if (!_compatible) return original;
 
-        // Handle null
+        // Handle null: if one is null and the other isn't, check whether it's a
+        // structural type (J, padded wrapper, list) where a mismatch is fatal.
+        // For primitive/string properties (e.g., Modifier.Keyword), null vs non-null
+        // is not a structural divergence — just keep the original value.
         if (original == null || formatted == null)
         {
-            if (!ReferenceEquals(original, formatted) && (original != null || formatted != null))
+            if (ReferenceEquals(original, formatted))
+                return original;
+
+            // A null mismatch on a structural type is a real incompatibility
+            var nonNull = original ?? formatted;
+            if (nonNull is J || nonNull is Space || nonNull is Markers ||
+                nonNull is IList ||
+                IsGenericOf(nonNull, typeof(JRightPadded<>)) ||
+                IsGenericOf(nonNull, typeof(JLeftPadded<>)) ||
+                IsGenericOf(nonNull, typeof(JContainer<>)))
+            {
                 return StructureMismatch(original);
+            }
+
+            // For primitive types (string, enum, etc.), keep the original
             return original;
         }
 

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Format/MinimumViableSpacingTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Format/MinimumViableSpacingTests.cs
@@ -111,6 +111,37 @@ public class MinimumViableSpacingTests
     }
 
     /// <summary>
+    /// Same scenario as AddedModifierToFieldWithGenericType but going through the full
+    /// RoslynFormatter.Format() pipeline, which involves MVS → print → Roslyn → reconcile.
+    /// This is the actual code path used by MaybeAutoFormat in recipes.
+    /// </summary>
+    [Fact]
+    public void AddedModifierToFieldWithGenericTypeThroughRoslynFormatter()
+    {
+        var cu = _parser.Parse("""
+            using System.Collections.Generic;
+            class Stack<T>
+            {
+                List<T> elements = new List<T>();
+                public int Count => elements.Count;
+            }
+            """);
+
+        // Add a readonly modifier to the field, simulating what MakeFieldReadOnly does
+        var addModifier = new AddReadonlyModifierVisitor();
+        addModifier.Cursor = new Cursor(null, Cursor.ROOT_VALUE);
+        cu = (CompilationUnit)(addModifier.Visit(cu, 0) ?? cu);
+
+        // Run through the full formatting pipeline (same as MaybeAutoFormat)
+        var formatted = RoslynFormatter.Format(cu);
+        var result = _printer.Print(formatted);
+
+        // The readonly keyword must be separated from the type name
+        Assert.DoesNotContain("readonlyList", result);
+        Assert.Contains("readonly List", result);
+    }
+
+    /// <summary>
     /// Same as above but with a simple (non-generic) type.
     /// </summary>
     [Fact]
@@ -340,6 +371,61 @@ public class MinimumViableSpacingTests
     }
 
     /// <summary>
+    /// Reproduces the exact MakeFieldReadOnly pattern: a visitor that adds a modifier
+    /// in VisitVariableDeclarations, then calls MaybeAutoFormat at the CU level.
+    /// This is the actual code path that was producing "readonlyList&lt;T&gt;".
+    /// </summary>
+    [Fact]
+    public void AddedModifierWithMaybeAutoFormatAtCuLevel()
+    {
+        var cu = _parser.Parse("""
+            using System.Collections.Generic;
+            class Stack<T>
+            {
+                List<T> elements = new List<T>();
+                public int Count => elements.Count;
+            }
+            """);
+
+        // Use a visitor that adds readonly and calls MaybeAutoFormat at CU level
+        var visitor = new AddReadonlyWithAutoFormatVisitor();
+        visitor.Cursor = new Cursor(null, Cursor.ROOT_VALUE);
+        var result = visitor.Visit(cu, 0) as CompilationUnit ?? cu;
+        var printed = _printer.Print(result);
+
+        // The readonly keyword must be separated from the type name
+        Assert.DoesNotContain("readonlyList", printed);
+        Assert.Contains("readonly List", printed);
+    }
+
+    /// <summary>
+    /// Same as above but using RecipeScheduler.Run() — the exact path that
+    /// recipes-csharp uses. This matches how MakeFieldReadOnly actually executes.
+    /// </summary>
+    [Fact]
+    public void AddedModifierWithMaybeAutoFormatViaRecipeScheduler()
+    {
+        var cu = _parser.Parse("""
+            using System.Collections.Generic;
+            class Stack<T>
+            {
+                List<T> elements = new List<T>();
+                public int Count => elements.Count;
+            }
+            """);
+
+        var recipe = new AddReadonlyRecipe();
+        var results = RecipeScheduler.Run(recipe, [cu], new OpenRewrite.Core.ExecutionContext());
+
+        Assert.Single(results);
+        Assert.NotNull(results[0].After);
+        var printed = _printer.Print(results[0].After!);
+
+        Assert.DoesNotContain("readonlyList", printed);
+        Assert.Contains("readonly List", printed);
+    }
+
+    /// <summary>
     /// Visitor that strips all whitespace from the tree, simulating a recipe
     /// that builds nodes with Space.Empty everywhere.
     /// </summary>
@@ -373,6 +459,58 @@ public class MinimumViableSpacingTests
             newModifiers.Add(new Modifier(
                 Guid.NewGuid(), Space.SingleSpace, Markers.Empty,
                 Modifier.ModifierType.Readonly, new List<Annotation>()));
+            return v.WithModifiers(newModifiers);
+        }
+    }
+
+    /// <summary>
+    /// ScanningRecipe that adds readonly to fields, matching MakeFieldReadOnly's
+    /// structure for use with RecipeScheduler.Run().
+    /// </summary>
+    private class AddReadonlyRecipe : ScanningRecipe<int>
+    {
+        public override string DisplayName => "Test";
+        public override string Description => "Test";
+        public override int GetInitialValue(OpenRewrite.Core.ExecutionContext ctx) => 0;
+        public override ITreeVisitor<OpenRewrite.Core.ExecutionContext> GetScanner(int acc) => ITreeVisitor<OpenRewrite.Core.ExecutionContext>.Noop();
+        public override ITreeVisitor<OpenRewrite.Core.ExecutionContext> GetVisitor(int acc) => new AddReadonlyWithAutoFormatVisitor<OpenRewrite.Core.ExecutionContext>();
+    }
+
+    /// <summary>
+    /// Visitor that adds a readonly modifier in VisitVariableDeclarations and
+    /// calls MaybeAutoFormat at the CompilationUnit level — the exact pattern
+    /// used by MakeFieldReadOnly.
+    /// </summary>
+    private class AddReadonlyWithAutoFormatVisitor : AddReadonlyWithAutoFormatVisitor<int>;
+
+    private class AddReadonlyWithAutoFormatVisitor<P> : CSharpVisitor<P>
+    {
+        public override J VisitCompilationUnit(CompilationUnit cu, P p)
+        {
+            var before = cu;
+            cu = (CompilationUnit)base.VisitCompilationUnit(cu, p);
+            return MaybeAutoFormat(before, cu, p, Cursor);
+        }
+
+        public override J VisitVariableDeclarations(VariableDeclarations varDecl, P p)
+        {
+            var v = (VariableDeclarations)base.VisitVariableDeclarations(varDecl, p);
+
+            if (Cursor.FirstEnclosing<ClassDeclaration>() == null)
+                return v;
+
+            if (v.Modifiers.Any(m => m.Type == Modifier.ModifierType.Readonly))
+                return v;
+
+            // Skip properties (has accessors)
+            if (Cursor.FirstEnclosing<PropertyDeclaration>() != null)
+                return v;
+
+            // Test with keyword string but using Add
+            var newModifiers = new List<Modifier>(v.Modifiers);
+            newModifiers.Add(new Modifier(
+                Guid.NewGuid(), Space.SingleSpace, Markers.Empty,
+                Modifier.ModifierType.Readonly, new List<Annotation>(), "readonly"));
             return v.WithModifiers(newModifiers);
         }
     }


### PR DESCRIPTION
## Motivation

When a C# recipe adds a modifier (e.g., `readonly`) to a field and calls `MaybeAutoFormat`, the `MinimumViableSpacingVisitor` correctly adds a space between the modifier and the type expression. However, the `WhitespaceReconciler` was discarding this fix because it treated a null/non-null mismatch on `Modifier.Keyword` as a structural incompatibility.

The recipe creates a `Modifier` with `keyword="readonly"`, but the C# parser produces modifiers with `keyword=null` (it only sets keywords for `LanguageExtension` modifiers). When reconciling the MVS-fixed tree against the Roslyn-formatted re-parsed tree, the reconciler saw this mismatch on the `Keyword` property and aborted, returning the original unformatted tree — producing `readonlyList<T>` instead of `readonly List<T>`.

## Summary

- Fix `WhitespaceReconciler.VisitProperty()` to only treat null/non-null mismatches as structural errors for structural types (J, Space, Markers, lists, padded wrappers). For primitive types (strings, enums), keep the original value without aborting.
- Add tests reproducing the exact `MakeFieldReadOnly` pattern: a visitor that adds a modifier with a keyword string and calls `MaybeAutoFormat` at the CU level, both directly and via `RecipeScheduler.Run()`.

## Test plan

- [x] New test `AddedModifierWithMaybeAutoFormatAtCuLevel` verifies spacing with MaybeAutoFormat directly
- [x] New test `AddedModifierWithMaybeAutoFormatViaRecipeScheduler` verifies via RecipeScheduler
- [x] New test `AddedModifierToFieldWithGenericTypeThroughRoslynFormatter` verifies RoslynFormatter integration
- [x] All 1775 existing C# tests pass
- [x] All 26 MinimumViableSpacing tests pass