### PR TITLE
C#: Fix numeric literal type attribution to reflect suffix

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -4622,7 +4622,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         // Skip past the literal token
         _cursor = node.Token.Span.End;
 
-        var type = GetPrimitiveType(node.Kind());
+        var type = node.Kind() == SyntaxKind.NumericLiteralExpression
+            ? _typeMapping?.Type(node) ?? GetPrimitiveType(node.Kind())
+            : GetPrimitiveType(node.Kind());
 
         return new Literal(
             Guid.NewGuid(),

--- a/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using OpenRewrite.Core;
 using OpenRewrite.CSharp;
+using OpenRewrite.Java;
 using Rewrite.Core;
 using ExecutionContext = OpenRewrite.Core.ExecutionContext;
 
@@ -131,6 +132,46 @@ public abstract class RewriteTest
     protected static SourceSpec CSharp(string before, string? after = null)
     {
         return new SourceSpec(before, after);
+    }
+
+    /// <summary>
+    /// Parses C# source with a semantic model, returning the CompilationUnit.
+    /// </summary>
+    protected static CSharp.CompilationUnit Parse(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, path: "source.cs");
+        var compilation = CSharpCompilation.Create("TestCompilation")
+            .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddReferences(ResolveAssemblies(Assemblies.Net90))
+            .AddSyntaxTrees(syntaxTree);
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+        return new CSharpParser().Parse(source, semanticModel: semanticModel);
+    }
+
+    /// <summary>
+    /// Finds the first node of type TNode in the tree using a depth-first walk.
+    /// </summary>
+    protected static TNode? FindFirst<TNode>(Tree tree) where TNode : J
+    {
+        var finder = new FirstFinder<TNode>();
+        finder.Visit(tree, 0);
+        return finder.Found;
+    }
+
+    private class FirstFinder<TNode> : CSharpVisitor<int> where TNode : J
+    {
+        public TNode? Found { get; private set; }
+
+        public override J? Visit(Tree? tree, int p)
+        {
+            if (Found != null) return tree as J;
+            if (tree is TNode match)
+            {
+                Found = match;
+                return tree as J;
+            }
+            return base.Visit(tree, p);
+        }
     }
 
     private static void AssertContentEquals(string expected, string actual, string sourcePath,

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/LiteralTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/LiteralTests.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using OpenRewrite.Java;
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;
@@ -102,5 +103,24 @@ public class LiteralTests : RewriteTest
                 """
             )
         );
+    }
+
+    [Theory]
+    [InlineData("0L", JavaType.PrimitiveKind.Long)]
+    [InlineData("0l", JavaType.PrimitiveKind.Long)]
+    [InlineData("42", JavaType.PrimitiveKind.Int)]
+    [InlineData("1.0f", JavaType.PrimitiveKind.Float)]
+    [InlineData("1.0F", JavaType.PrimitiveKind.Float)]
+    [InlineData("1.0d", JavaType.PrimitiveKind.Double)]
+    [InlineData("1.0D", JavaType.PrimitiveKind.Double)]
+    [InlineData("1.0", JavaType.PrimitiveKind.Double)]
+    public void NumericLiteralTypeAttribution(string literal, JavaType.PrimitiveKind expectedKind)
+    {
+        var cu = Parse($"{literal};");
+        var lit = FindFirst<Literal>(cu);
+        Assert.NotNull(lit);
+        Assert.NotNull(lit.Type);
+        Assert.IsType<JavaType.Primitive>(lit.Type);
+        Assert.Equal(expectedKind, ((JavaType.Primitive)lit.Type).Kind);
     }
 }


### PR DESCRIPTION
## Motivation

Numeric literals with type suffixes (e.g., `0L`, `1.0F`, `2.0D`) were all attributed as `JavaType.Primitive(Int)` because `GetPrimitiveType` hardcoded `NumericLiteralExpression` to `Int`, ignoring the actual type. This forced downstream recipes like `MarkLocalVariableAsConst` (in recipes-csharp) to implement a workaround (`InferTypeFromLiteralSuffix`) that manually parsed suffixes from `ValueSource` — which itself had bugs (e.g., interpreting `.` in string literals as `double`).

## Summary

- Use Roslyn's `SemanticModel.GetTypeInfo()` via `_typeMapping?.Type(node)` to resolve the correct type for numeric literals, falling back to the hardcoded `Int` only when no semantic model is available
- Add `Parse()` and `FindFirst<T>()` test helpers to `RewriteTest` for tests that need to inspect AST node properties beyond round-trip printing
- Add parameterized test covering `0L`, `0l`, `42`, `1.0f`, `1.0F`, `1.0d`, `1.0D`, and `1.0` with their expected primitive kinds

## Test plan

- [x] All 8 new `NumericLiteralTypeAttribution` test cases pass
- [x] All 15 `LiteralTests` pass (existing + new)
- [x] Full C# test suite passes (1780 tests, 0 failures)