### PR TITLE
C#: Unwrap parentheses in pattern matching comparator

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CSharpPattern.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CSharpPattern.cs
@@ -166,13 +166,17 @@ public sealed class CSharpPattern
     {
         var patternTree = GetTree();
 
+        // Unwrap parentheses for fast-reject so (expr) vs expr aren't rejected early
+        var unwrappedPattern = PatternMatchingComparator.UnwrapParentheses(patternTree);
+        var unwrappedTree = PatternMatchingComparator.UnwrapParentheses(tree);
+
         // Fast reject: if the pattern root is not a capture placeholder and the
         // candidate is a different node type, no match is possible — unless the
         // comparator has a known cross-type equivalence (e.g. Binary ↔ IsPattern).
         // This avoids allocating a PatternMatchingComparator for the common non-matching case.
-        if (patternTree.GetType() != tree.GetType()
-            && !IsCapturePlaceholder(patternTree)
-            && !PatternMatchingComparator.HasCrossTypeEquivalence(patternTree, tree))
+        if (unwrappedPattern.GetType() != unwrappedTree.GetType()
+            && !IsCapturePlaceholder(unwrappedPattern)
+            && !PatternMatchingComparator.HasCrossTypeEquivalence(unwrappedPattern, unwrappedTree))
             return null;
 
         var comparator = new PatternMatchingComparator(_captures);

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/PatternMatchingComparator.cs
@@ -56,8 +56,23 @@ internal class PatternMatchingComparator
     /// </summary>
     internal IReadOnlyDictionary<string, NullSafe> NullSafeBindings => _nullSafeBindings;
 
+    /// <summary>
+    /// Recursively strip <see cref="Parentheses{T}"/> wrappers
+    /// so that <c>(expr)</c> and <c>expr</c> compare as equivalent.
+    /// </summary>
+    internal static J UnwrapParentheses(J node)
+    {
+        while (node is Parentheses p)
+            node = p.InnerTree;
+        return node;
+    }
+
     private bool MatchNode(J pattern, J candidate, Cursor cursor)
     {
+        // Unwrap parentheses from both sides so (expr) matches expr
+        pattern = UnwrapParentheses(pattern);
+        candidate = UnwrapParentheses(candidate);
+
         // Check if pattern node is a placeholder identifier
         if (pattern is Identifier patternId)
         {

--- a/rewrite-csharp/csharp/OpenRewrite/Java/J.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/J.cs
@@ -1731,6 +1731,16 @@ public sealed class TypeCast(
 }
 
 /// <summary>
+/// Non-generic interface for <see cref="Parentheses{T}"/>, allowing type-checks
+/// and unwrapping without knowing the generic type parameter.
+/// </summary>
+public interface Parentheses : Expression
+{
+    /// <summary>The inner expression, unwrapped from parentheses.</summary>
+    J InnerTree { get; }
+}
+
+/// <summary>
 /// A parenthesized expression.
 /// </summary>
 public sealed class Parentheses<T>(
@@ -1738,7 +1748,7 @@ public sealed class Parentheses<T>(
     Space prefix,
     Markers markers,
     JRightPadded<T> tree
-) : J, Expression, IEquatable<Parentheses<T>> where T : J
+) : J, Parentheses, IEquatable<Parentheses<T>> where T : J
 {
     public Guid Id { get; } = id;
     public Space Prefix { get; } = prefix;
@@ -1753,6 +1763,8 @@ public sealed class Parentheses<T>(
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Tree);
     public Parentheses<T> WithTree(JRightPadded<T> tree) =>
         ReferenceEquals(tree, Tree) ? this : new(Id, Prefix, Markers, tree);
+
+    public J InnerTree => Tree.Element;
 
     public JavaType? Type => Tree.Element is Expression expr ? expr.Type : null;
 

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Template/PatternMatchTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Template/PatternMatchTests.cs
@@ -1622,6 +1622,38 @@ public class PatternMatchTests : RewriteTest
     }
 
     // ===============================================================
+    // Parentheses unwrapping
+    // ===============================================================
+
+    [Fact]
+    public void MatchesConcreteArgThroughParentheses()
+    {
+        // Pattern `Console.WriteLine("hello")` should match `Console.WriteLine(("hello"))`
+        // The argument "hello" is wrapped in parens — comparator should unwrap
+        RewriteRun(
+            spec => spec.SetRecipe(FindMethodInvocation("Console.WriteLine(\"hello\")")),
+            CSharp(
+                "class C { void M() { Console.WriteLine((\"hello\")); } }",
+                "class C { void M() { /*~~>*/Console.WriteLine((\"hello\")); } }"
+            )
+        );
+    }
+
+    [Fact]
+    public void ParenthesizedPatternMatchesUnparenthesized()
+    {
+        // Pattern `(x + 1)` should match candidate `x + 1` (unwrap pattern parens)
+        var x = Capture.Of<Expression>("x");
+        RewriteRun(
+            spec => spec.SetRecipe(FindExpression($"({x} + 1)")),
+            CSharp(
+                "class C { int M(int x) => x + 1; }",
+                "class C { int M(int x) => /*~~>*/x + 1; }"
+            )
+        );
+    }
+
+    // ===============================================================
     // Recipe factories
     // ===============================================================
 
@@ -1681,6 +1713,7 @@ public class PatternMatchTests : RewriteTest
     private static OpenRewrite.Core.Recipe FindCsBinary(string c) => Search<CsBinary>(c);
     private static OpenRewrite.Core.Recipe FindCsBinary(TemplateStringHandler h) => Search<CsBinary>(h);
 
+    private static OpenRewrite.Core.Recipe FindExpression(TemplateStringHandler h) => Search<Expression>(h);
     private static OpenRewrite.Core.Recipe FindAnnotation(TemplateStringHandler h) =>
         new PatternSearchRecipe<Annotation>(CSharpPattern.Attribute(h));
 


### PR DESCRIPTION
## Motivation

The C# pattern matcher (`PatternMatchingComparator`) did not ignore optional expression parentheses, so a pattern like `Console.WriteLine("hello")` would fail to match `Console.WriteLine(("hello"))`, and a parenthesized pattern `(x + 1)` wouldn't match the unparenthesized `x + 1`. The JavaScript comparator already handles this via an `unwrap()` step — this brings parity to C#.

## Summary

- Added a non-generic `Parentheses` interface (extending `Expression`) with an `InnerTree` property, so `Parentheses<T>` can be type-checked and unwrapped without reflection
- `Parentheses<T>` now implements the non-generic `Parentheses` interface
- `PatternMatchingComparator.UnwrapParentheses()` recursively strips `Parentheses` wrappers using a simple `while (node is Parentheses p)` loop
- Both pattern and candidate are unwrapped at the top of `MatchNode` and in the fast-reject path in `CSharpPattern.Match`

## Test plan

- [x] `MatchesConcreteArgThroughParentheses` — pattern without parens matches candidate arg wrapped in parens
- [x] `ParenthesizedPatternMatchesUnparenthesized` — parenthesized pattern `(x + 1)` matches `x + 1`
- [x] All 108 existing `PatternMatchTests` pass (no regressions)