### PR TITLE
C#: Fix RPC deserialization error for J.ControlParentheses

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaReceiver.cs
@@ -87,6 +87,7 @@ public class JavaReceiver : JavaVisitor<RpcReceiveQueue>
             ControlParentheses<Expression> cp => VisitControlParentheses(cp, q),
             ControlParentheses<TypeTree> cptt => VisitControlParentheses(cptt, q),
             ControlParentheses<VariableDeclarations> cpvd => VisitControlParentheses(cpvd, q),
+            ControlParentheses<J> cpj => VisitControlParenthesesUntyped(cpj, q),
             ExpressionStatement es => VisitExpressionStatement(es, q),
             VariableDeclarations vd => VisitVariableDeclarations(vd, q),
             NamedVariable nv => VisitVariable(nv, q),
@@ -522,6 +523,13 @@ public class JavaReceiver : JavaVisitor<RpcReceiveQueue>
         var tree = q.Receive(shell.Tree, rp => VisitRightPadded(rp, q));
         var rp = new JRightPadded<Expression>((Expression)tree!.Element, tree.After, tree.Markers);
         return new Parentheses<Expression>(_pvId, _pvPrefix, _pvMarkers, rp);
+    }
+
+    private J VisitControlParenthesesUntyped(ControlParentheses<J> shell, RpcReceiveQueue q)
+    {
+        var tree = q.Receive(shell.Tree, rp => VisitRightPadded(rp, q));
+        var rp = new JRightPadded<Expression>((Expression)tree!.Element, tree.After, tree.Markers);
+        return new ControlParentheses<Expression>(_pvId, _pvPrefix, _pvMarkers, rp);
     }
 
     public override J VisitPrimitive(Primitive primitive, RpcReceiveQueue q)

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/rpc/CSharpRpcTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/rpc/CSharpRpcTest.java
@@ -1649,6 +1649,44 @@ class CSharpRpcTest implements RewriteTest {
         return null;
     }
 
+    /**
+     * Verifies that a tree containing catch-when (ControlParentheses in WhenClause)
+     * survives a Parse → Reset → Print cycle. The Reset clears both sides' caches,
+     * forcing the Java side to re-send the tree to C# via the receiver, which must
+     * correctly handle ControlParentheses deserialized as ControlParentheses&lt;J&gt;.
+     */
+    @Test
+    void catchWithWhenFilterSurvivesResetCycle() {
+        rewriteRun(csharp(
+          """
+            using System;
+
+            namespace Test
+            {
+                public class Foo
+                {
+                    public void Bar()
+                    {
+                        try
+                        {
+                            throw new InvalidOperationException();
+                        }
+                        catch (Exception ex) when (ex.Message != null)
+                        {
+                        }
+                    }
+                }
+            }
+            """,
+          spec -> spec.beforeRecipe(cu -> {
+              // Reset clears both sides' caches, forcing the next print to
+              // re-send the tree from Java to C# via the full receiver path.
+              // This exercises ControlParentheses<J> deserialization.
+              CSharpRewriteRpc.resetCurrent();
+          })
+        ));
+    }
+
     private static J.MethodDeclaration findMethodByName(J.ClassDeclaration classDecl, String name) {
         for (Statement stmt : classDecl.getBody().getStatements()) {
             if (stmt instanceof J.MethodDeclaration md && md.getSimpleName().equals(name)) {


### PR DESCRIPTION
## Motivation

After the bulk RPC fix that resolved ~3200 serialization errors, 4 C# files with `catch ... when` exception filters still failed consistently across all recipes. The root cause: Java's type erasure drops the generic parameter when sending `ControlParentheses<Expression>` via RPC, so the C# receiver constructs a `ControlParentheses<J>` shell that didn't match any case in the `JavaReceiver` dispatch switch.

This single deserialization failure cascaded — once it corrupted the RPC stream for a file, all subsequent recipes on that file failed with different symptoms ("Expected END_OF_OBJECT", "reference to unknown object").

## Summary

- Add `ControlParentheses<J>` fallback case to `JavaReceiver.cs` switch, matching the existing pattern for `Parentheses<J>`
- Add `VisitControlParenthesesUntyped` method that reconstructs as `ControlParentheses<Expression>`
- Add Parse → Reset → Print integration test that exercises the receiver path

## Test plan

- [x] `catchWithWhenFilterSurvivesResetCycle` — Parse → Reset → Print cycle forcing full receiver deserialization of `ControlParentheses<J>`
- [x] C# build succeeds