### PR TITLE
C#: Fix `AutoFormat` not expanding empty constructor bodies with initializers

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/MinimumViableSpacingVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/MinimumViableSpacingVisitor.cs
@@ -20,9 +20,13 @@ namespace OpenRewrite.CSharp.Format;
 
 /// <summary>
 /// Ensures minimum viable spacing between AST elements so that the printed
-/// output is parseable C#. This visitor inserts the minimum whitespace needed
-/// to prevent token merging (e.g., "publicvoid" → "public void") without
-/// attempting indentation or full formatting — Roslyn handles that.
+/// output is parseable C#. This visitor ONLY inserts single spaces where needed
+/// to prevent token merging (e.g., "publicvoid" → "public void").
+///
+/// This visitor must NOT insert indentation or general structural formatting.
+/// Its sole purpose is preventing adjacent tokens from fusing into unparseable output.
+/// All formatting beyond token separation is Roslyn's responsibility — with one
+/// exception documented inline as a workaround for a Roslyn formatter bug.
 /// </summary>
 public class MinimumViableSpacingVisitor : CSharpVisitor<int>
 {
@@ -118,6 +122,20 @@ public class MinimumViableSpacingVisitor : CSharpVisitor<int>
                 dv = dv.WithElement((Expression)EnsureSpace(dv.Element));
             }
             m = m.WithDefaultValue(dv);
+        }
+
+        // Workaround for https://github.com/dotnet/roslyn/issues/82974:
+        // Roslyn's Formatter.Format does not expand empty constructor bodies to
+        // Allman style when a constructor initializer (`: base(...)`) is present.
+        // Insert newlines so the printed source has multi-line braces that Roslyn
+        // can then indent correctly.
+        if (m.DefaultValue != null &&
+            m.Body is { Statements.Count: 0 } body &&
+            body.Prefix.IsEmpty && body.End.IsEmpty)
+        {
+            m = m.WithBody(body
+                .WithPrefix(body.Prefix.WithWhitespace("\n"))
+                .WithEnd(body.End.WithWhitespace("\n")));
         }
 
         return m;

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Format/AutoFormatTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Format/AutoFormatTests.cs
@@ -823,6 +823,33 @@ public class AutoFormatTests : RewriteTest
         );
     }
 
+    /// <summary>
+    /// Workaround test for https://github.com/dotnet/roslyn/issues/82974:
+    /// AutoFormat must expand empty constructor bodies with initializers to Allman style.
+    /// </summary>
+    [Fact]
+    public void AutoFormatEmptyConstructorBodyWithInitializer()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new AutoFormatRecipe()),
+            CSharp(
+                "class Foo : Exception\n{\npublic Foo() : base(){}\npublic Foo(string m) : base(m){}\n}\n",
+                "class Foo : Exception\n{\n    public Foo() : base()\n    {\n    }\n    public Foo(string m) : base(m)\n    {\n    }\n}\n"
+            )
+        );
+    }
+
+}
+
+/// <summary>
+/// Recipe that auto-formats the entire compilation unit.
+/// </summary>
+file class AutoFormatRecipe : OpenRewrite.Core.Recipe
+{
+    public override string DisplayName => "Auto-format";
+    public override string Description => "Formats the entire source file.";
+
+    public override JavaVisitor<ExecutionContext> GetVisitor() => new AutoFormatVisitor<ExecutionContext>();
 }
 
 /// <summary>


### PR DESCRIPTION
## Motivation

`MaybeAutoFormat` in C# recipes produces incorrect output in two scenarios:

1. **Empty constructor bodies with initializers** — Roslyn's `Formatter.Format` does not expand `Constructor() : base(){}` to Allman-style multi-line braces ([dotnet/roslyn#82974](https://github.com/dotnet/roslyn/issues/82974))
2. **SDK consumed via NuGet PackageReference** — When the OpenRewrite SDK is consumed with `PrivateAssets="all"`, `AdhocWorkspace` cannot discover `Microsoft.CodeAnalysis.CSharp.Workspaces` via `Assembly.Load` (the dependency entries are absent from `.deps.json`), making the entire Roslyn formatter a silent no-op

## Summary

- Work around the Roslyn bug in `MinimumViableSpacingVisitor` by inserting newlines into empty constructor body blocks that have a constructor initializer and `Space.Empty` prefix/end
- Fix `AdhocWorkspace` assembly discovery by explicitly providing already-loaded Roslyn assemblies to `MefHostServices.Create`, bypassing the `Assembly.Load` path
- Clarified MVS class documentation

## Test plan

- [x] New test `AutoFormatEmptyConstructorBodyWithInitializer` verifies Allman-style braces for constructors with initializers
- [x] All 1788 existing tests pass
- [ ] Verify with `recipes-csharp` consuming the SDK as a NuGet package