### PR TITLE
C#: Auto-parenthesize IsPattern with or/and combinators

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParenthesizeVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParenthesizeVisitor.cs
@@ -53,6 +53,16 @@ public static class CSharpParenthesizeVisitor
 
         return newTree;
     }
+
+    /// <summary>
+    /// Recursively walks <paramref name="tree"/> and adds parentheses wherever operator
+    /// precedence requires them within the tree itself (not considering the graft site).
+    /// Call this on template results before <see cref="MaybeParenthesize"/>.
+    /// </summary>
+    public static J ParenthesizeDeep(J tree)
+    {
+        return new CSharpParenthesizeVisitor<int>(true).Visit(tree, 0)!;
+    }
 }
 
 /// <summary>
@@ -239,6 +249,11 @@ public class CSharpParenthesizeVisitor<P> : CSharpVisitor<P>
 
         if (parent is IsPattern)
         {
+            // CsBinary with Or/And inside IsPattern is a pattern combinator, not a
+            // boolean expression — it must NOT be wrapped in parentheses.
+            if (expr is CsBinary csb && csb.Operator.Element is CsBinary.OperatorType.Or or CsBinary.OperatorType.And)
+                return false;
+
             return expr is Binary or CsBinary or Ternary or Assignment or AssignmentOperation or Lambda;
         }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrecedences.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrecedences.cs
@@ -48,7 +48,7 @@ internal static class CSharpPrecedences
         Unary => 13,
         CsUnary => 13,
         TypeCast => 13,
-        IsPattern => 7,
+        IsPattern ip => GetIsPatternPrecedence(ip),
         RangeExpression => 12,
         SwitchExpression => 11,
         WithExpression => 11,
@@ -78,6 +78,25 @@ internal static class CSharpPrecedences
         return new Parentheses<Expression>(
             Guid.NewGuid(), expr.Prefix, Markers.Empty,
             new JRightPadded<Expression>(J.SetPrefix(expr, Space.Empty), Space.Empty, Markers.Empty));
+    }
+
+    /// <summary>
+    /// IsPattern with pattern combinators (or/and) has lower effective precedence
+    /// than a plain is-type check, because the combinator keywords extend the pattern
+    /// in a way that can be ambiguous when nested inside binary expressions like &amp;&amp;.
+    /// </summary>
+    private static int GetIsPatternPrecedence(IsPattern ip)
+    {
+        if (ip.Pattern.Element is CsBinary csb)
+        {
+            return csb.Operator.Element switch
+            {
+                CsBinary.OperatorType.Or => 1,  // same as ||
+                CsBinary.OperatorType.And => 2, // same as &&
+                _ => 7
+            };
+        }
+        return 7;
     }
 
     public static bool IsAssociative(Expression expr) => expr switch

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CSharpTemplate.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/CSharpTemplate.cs
@@ -204,7 +204,9 @@ public sealed class CSharpTemplate
             tree = TemplateEngine.ApplySubstitutions(tree, values);
         }
 
-        // Phase 1.5: auto-parenthesization after substitution
+        // Phase 1.5: check if the result needs wrapping when grafted into the cursor position.
+        // Inner precedence is already handled by ApplySubstitutions (which runs a recursive
+        // CSharpParenthesizeVisitor after substitution); this only checks the root vs. cursor parent.
         if (tree is Expression expr && cursorJ != null)
         {
             tree = CSharpParenthesizeVisitor.MaybeParenthesize(expr, cursor);

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/CSharpParenthesizeVisitorTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/CSharpParenthesizeVisitorTests.cs
@@ -156,4 +156,60 @@ public class CSharpParenthesizeVisitorTests
 
         Assert.IsType<Parentheses<Expression>>(result);
     }
+
+    [Fact]
+    public void MaybeParenthesize_IsPatternWithOrCombinatorInsideLogicalAnd_AddsParens()
+    {
+        // placeholder && flag => (m is A or B) && flag — or combinator needs parens inside &&
+        var placeholder = MakeId("placeholder");
+        var parent = MakeBinary(Binary.OperatorType.And, placeholder, MakeId("flag"));
+        var cursor = new Cursor(new Cursor(null, "root"), parent);
+        cursor = new Cursor(cursor, placeholder);
+
+        var orPattern = MakeCsBinary(CsBinary.OperatorType.Or, MakeId("A"), MakeId("B"));
+        var newExpr = MakeIsPattern(MakeId("m"), orPattern);
+        var result = CSharpParenthesizeVisitor.MaybeParenthesize(newExpr, cursor);
+
+        Assert.IsType<Parentheses<Expression>>(result);
+    }
+
+    [Fact]
+    public void MaybeParenthesize_IsPatternWithoutCombinatorInsideLogicalAnd_NoParens()
+    {
+        // placeholder && flag => m is A && flag — simple is pattern doesn't need parens inside &&
+        var placeholder = MakeId("placeholder");
+        var parent = MakeBinary(Binary.OperatorType.And, placeholder, MakeId("flag"));
+        var cursor = new Cursor(new Cursor(null, "root"), parent);
+        cursor = new Cursor(cursor, placeholder);
+
+        var newExpr = MakeIsPattern(MakeId("m"), MakeConstantPattern(MakeId("A")));
+        var result = CSharpParenthesizeVisitor.MaybeParenthesize(newExpr, cursor);
+
+        Assert.IsNotType<Parentheses<Expression>>(result);
+    }
+
+    [Fact]
+    public void ParenthesizeDeep_IsPatternWithOrInsideBinaryAnd_AddsParens()
+    {
+        // (m is A or B) && flag — recursive walk should parenthesize inner IsPattern
+        var orPattern = MakeCsBinary(CsBinary.OperatorType.Or, MakeId("A"), MakeId("B"));
+        var isExpr = MakeIsPattern(MakeId("m"), orPattern);
+        var tree = MakeBinary(Binary.OperatorType.And, isExpr, MakeId("flag"));
+
+        var result = (Binary)CSharpParenthesizeVisitor.ParenthesizeDeep(tree);
+
+        Assert.IsType<Parentheses<Expression>>(result.Left);
+    }
+
+    [Fact]
+    public void ParenthesizeDeep_SimpleIsPatternInsideBinaryAnd_NoParens()
+    {
+        // m is A && flag — no inner parens needed
+        var isExpr = MakeIsPattern(MakeId("m"), MakeConstantPattern(MakeId("A")));
+        var tree = MakeBinary(Binary.OperatorType.And, isExpr, MakeId("flag"));
+
+        var result = (Binary)CSharpParenthesizeVisitor.ParenthesizeDeep(tree);
+
+        Assert.IsType<IsPattern>(result.Left);
+    }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/TestHelpers.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/TestHelpers.cs
@@ -74,4 +74,11 @@ internal static class TestHelpers
     public static Parentheses<Expression> MakeParens(Expression expr) =>
         new(Guid.NewGuid(), Space.Empty, Markers.Empty,
             new JRightPadded<Expression>(expr, Space.Empty, Markers.Empty));
+
+    public static IsPattern MakeIsPattern(Expression expression, Pattern pattern) =>
+        new(Guid.NewGuid(), Space.Empty, Markers.Empty, expression,
+            new JLeftPadded<Pattern>(Space.Empty, pattern));
+
+    public static ConstantPattern MakeConstantPattern(Expression value) =>
+        new(Guid.NewGuid(), Space.Empty, Markers.Empty, value);
 }


### PR DESCRIPTION
## Motivation

`MergeIfWithParentIf` merges nested if-statements using `CSharpTemplate.Expression($"{_left} && {_right}")`. When the outer condition is an `IsPattern` with an `or` combinator, the merged result changes semantics because C# `&&` interacts with the pattern combinator: `x is A or B && y` parses as `x is (A or (B && y))` instead of the intended `(x is A or B) && y`. This also causes a downstream `NullReferenceException` in `CSharpPrinter.VisitIsPattern`.

## Examples

Before (wrong semantics):
```csharp
if (existsMode is FtpRemoteExists.Resume or FtpRemoteExists.AddToEnd && fileExists)
```

After (correct):
```csharp
if ((existsMode is FtpRemoteExists.Resume or FtpRemoteExists.AddToEnd) && fileExists)
```

## Summary

- `CSharpPrecedences.GetPrecedence` is now context-aware for `IsPattern`: when the pattern contains an `or` combinator, effective precedence is lowered to 1 (same as `||`); `and` combinator lowers it to 2 (same as `&&`)
- `CSharpParenthesizeVisitor.NeedsParenthesesInContext` no longer wraps `CsBinary` `Or`/`And` pattern combinators inside `IsPattern` — these are legitimate patterns, not boolean expressions
- Added `ParenthesizeDeep` public entry point for recursive parenthesization
- Clarified `CSharpTemplate.Apply` comment: inner precedence is handled by `ApplySubstitutions`, `MaybeParenthesize` only checks the graft site

## Test plan

- [x] New unit test: `IsPattern` with `or` combinator inside `Binary(&&)` gets parenthesized via `MaybeParenthesize`
- [x] New unit test: plain `IsPattern` (no combinator) inside `Binary(&&)` is NOT parenthesized
- [x] New unit test: `ParenthesizeDeep` recursive walk parenthesizes inner `IsPattern` with `or` inside `Binary(&&)`
- [x] New unit test: `ParenthesizeDeep` does NOT parenthesize simple `IsPattern` inside `Binary(&&)`
- [x] All 59 existing precedence and parenthesization tests continue to pass