### PR TITLE
Allow null Properties to skip YAML placeholder resolution

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
@@ -64,7 +64,7 @@ public class ClasspathScanningLoader implements ResourceLoader {
      * @param properties     Yaml placeholder properties
      * @param acceptPackages Limit scan to specified packages
      */
-    public ClasspathScanningLoader(Properties properties, String[] acceptPackages) {
+    public ClasspathScanningLoader(@Nullable Properties properties, String[] acceptPackages) {
         this.classLoader = ClasspathScanningLoader.class.getClassLoader();
         this.recipeLoader = new RecipeLoader(classLoader);
         this.performScan = () -> {
@@ -82,7 +82,7 @@ public class ClasspathScanningLoader implements ResourceLoader {
      * @param properties  YAML placeholder properties
      * @param classLoader Limit scan to classes loadable by this classloader
      */
-    public ClasspathScanningLoader(Properties properties, ClassLoader classLoader) {
+    public ClasspathScanningLoader(@Nullable Properties properties, ClassLoader classLoader) {
         this.classLoader = classLoader;
         this.recipeLoader = new RecipeLoader(classLoader);
         this.performScan = () -> {
@@ -105,7 +105,7 @@ public class ClasspathScanningLoader implements ResourceLoader {
      * `MavenRecipeBundleReader.marketplaceFromClasspathScan`.
      * Supports both jar files and directories containing class files.
      */
-    public ClasspathScanningLoader(Path jar, Properties properties, Collection<? extends ResourceLoader> dependencyResourceLoaders, ClassLoader classLoader) {
+    public ClasspathScanningLoader(Path jar, @Nullable Properties properties, Collection<? extends ResourceLoader> dependencyResourceLoaders, ClassLoader classLoader) {
         this.classLoader = classLoader;
         this.recipeLoader = new RecipeLoader(classLoader);
 
@@ -174,7 +174,7 @@ public class ClasspathScanningLoader implements ResourceLoader {
      * Construct a ClasspathScanningLoader to load Yaml categories and recipes from the runtime classpath, as part of
      * running tests or inferring local recipe categories.
      */
-    public static ClasspathScanningLoader onlyYaml(Properties properties) {
+    public static ClasspathScanningLoader onlyYaml(@Nullable Properties properties) {
         ClasspathScanningLoader classpathScanningLoader = new ClasspathScanningLoader();
         classpathScanningLoader.scanYaml(
                 new ClassGraph().acceptPaths("META-INF/rewrite"),
@@ -188,7 +188,7 @@ public class ClasspathScanningLoader implements ResourceLoader {
      * Construct a ClasspathScanningLoader to load categories from the provided dependencies only, as part of migration
      * in the CLI.
      */
-    public static ClasspathScanningLoader onlyYaml(Properties properties, Collection<Path> dependencies) {
+    public static ClasspathScanningLoader onlyYaml(@Nullable Properties properties, Collection<Path> dependencies) {
         ClasspathScanningLoader classpathScanningLoader = new ClasspathScanningLoader();
         classpathScanningLoader.scanYaml(
                 new ClassGraph().acceptPaths("META-INF/rewrite").overrideClasspath(dependencies),
@@ -207,7 +207,7 @@ public class ClasspathScanningLoader implements ResourceLoader {
      * This must be called _after_ scanClasses or the descriptors of declarative recipes will be missing any
      * non-declarative recipes they depend on that would be discovered by scanClasses
      */
-    private void scanYaml(ClassGraph classGraph, Properties properties, Collection<? extends ResourceLoader> dependencyResourceLoaders, @Nullable ClassLoader classLoader) {
+    private void scanYaml(ClassGraph classGraph, @Nullable Properties properties, Collection<? extends ResourceLoader> dependencyResourceLoaders, @Nullable ClassLoader classLoader) {
         try (ScanResult scanResult = classGraph.scan()) {
             List<YamlResourceLoader> yamlResourceLoaders = new ArrayList<>();
 

--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -296,7 +296,7 @@ public class Environment {
         this.dependencyResourceLoaders = dependencyResourceLoaders;
     }
 
-    public static Builder builder(Properties properties) {
+    public static Builder builder(@Nullable Properties properties) {
         return new Builder(properties);
     }
 
@@ -305,11 +305,11 @@ public class Environment {
     }
 
     public static class Builder {
-        private final Properties properties;
+        private final @Nullable Properties properties;
         private final Collection<ResourceLoader> resourceLoaders = new ArrayList<>();
         private final Collection<ResourceLoader> dependencyResourceLoaders = new ArrayList<>();
 
-        public Builder(Properties properties) {
+        public Builder(@Nullable Properties properties) {
             this.properties = properties;
         }
 

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -91,7 +91,7 @@ public class YamlResourceLoader implements ResourceLoader {
         }
     }
 
-    public YamlResourceLoader(InputStream yamlInput, URI source, Properties properties, RecipeMarketplace marketplace, Collection<RecipeBundleResolver> resolvers) {
+    public YamlResourceLoader(InputStream yamlInput, URI source, @Nullable Properties properties, RecipeMarketplace marketplace, Collection<RecipeBundleResolver> resolvers) {
         this.source = source;
         this.dependencyResourceLoaders = emptyList();
         this.mapper = ObjectMappers.propertyBasedMapper(getClass().getClassLoader());
@@ -105,18 +105,7 @@ public class YamlResourceLoader implements ResourceLoader {
 
         maybeAddKotlinModule(mapper);
 
-        try {
-            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            int nRead;
-            byte[] data = new byte[8192];
-            while ((nRead = yamlInput.read(data, 0, data.length)) != -1) {
-                buffer.write(data, 0, nRead);
-            }
-            this.yamlSource = propertyPlaceholderHelper.replacePlaceholders(
-                    new String(buffer.toByteArray(), StandardCharsets.UTF_8), properties);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        this.yamlSource = readYamlSource(yamlInput, properties);
     }
 
     /**
@@ -127,7 +116,7 @@ public class YamlResourceLoader implements ResourceLoader {
      * @param properties Placeholder properties
      * @throws UncheckedIOException On unexpected IOException
      */
-    public YamlResourceLoader(InputStream yamlInput, URI source, Properties properties) throws UncheckedIOException {
+    public YamlResourceLoader(InputStream yamlInput, URI source, @Nullable Properties properties) throws UncheckedIOException {
         this(yamlInput, source, properties, (ClassLoader) null);
     }
 
@@ -142,7 +131,7 @@ public class YamlResourceLoader implements ResourceLoader {
      */
     public YamlResourceLoader(InputStream yamlInput,
                               URI source,
-                              Properties properties,
+                              @Nullable Properties properties,
                               @Nullable ClassLoader classLoader) throws UncheckedIOException {
         this(yamlInput, source, properties, classLoader, emptyList());
     }
@@ -160,7 +149,7 @@ public class YamlResourceLoader implements ResourceLoader {
      */
     public YamlResourceLoader(InputStream yamlInput,
                               URI source,
-                              Properties properties,
+                              @Nullable Properties properties,
                               @Nullable ClassLoader classLoader,
                               Collection<? extends ResourceLoader> dependencyResourceLoaders) throws UncheckedIOException {
         this(yamlInput, source, properties, classLoader, dependencyResourceLoaders, jsonMapper -> {
@@ -179,7 +168,7 @@ public class YamlResourceLoader implements ResourceLoader {
      * @param mapperCustomizer          Customizer for the ObjectMapper
      * @throws UncheckedIOException On unexpected IOException
      */
-    public YamlResourceLoader(InputStream yamlInput, URI source, Properties properties,
+    public YamlResourceLoader(InputStream yamlInput, URI source, @Nullable Properties properties,
                               @Nullable ClassLoader classLoader,
                               Collection<? extends ResourceLoader> dependencyResourceLoaders,
                               Consumer<ObjectMapper> mapperCustomizer) {
@@ -193,6 +182,10 @@ public class YamlResourceLoader implements ResourceLoader {
         mapperCustomizer.accept(mapper);
         maybeAddKotlinModule(mapper);
 
+        this.yamlSource = readYamlSource(yamlInput, properties);
+    }
+
+    private static String readYamlSource(InputStream yamlInput, @Nullable Properties properties) {
         try {
             ByteArrayOutputStream buffer = new ByteArrayOutputStream();
             int nRead;
@@ -200,8 +193,8 @@ public class YamlResourceLoader implements ResourceLoader {
             while ((nRead = yamlInput.read(data, 0, data.length)) != -1) {
                 buffer.write(data, 0, nRead);
             }
-            this.yamlSource = propertyPlaceholderHelper.replacePlaceholders(
-                    new String(buffer.toByteArray(), StandardCharsets.UTF_8), properties);
+            String raw = new String(buffer.toByteArray(), StandardCharsets.UTF_8);
+            return properties != null ? propertyPlaceholderHelper.replacePlaceholders(raw, properties) : raw;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
@@ -269,6 +269,38 @@ class YamlResourceLoaderTest implements RewriteTest {
           new Properties());
     }
 
+    @Test
+    void nullPropertiesSkipsPlaceholderResolution() {
+        String yaml = //language=yml
+          """
+            type: specs.openrewrite.org/v1beta/recipe
+            name: test.ChangeTextWithPlaceholder
+            displayName: Change text with placeholder
+            description: Test that placeholder resolution respects null properties.
+            recipeList:
+                - org.openrewrite.text.ChangeText:
+                    toText: "${java_home.jdk21:/bin/java}"
+            """;
+
+        // With null properties, placeholder with default value should be preserved as-is
+        rewriteRun(
+          spec -> spec.recipe(Environment.builder(null)
+            .load(new YamlResourceLoader(new ByteArrayInputStream(yaml.getBytes()),
+              URI.create("rewrite.yml"), null))
+            .build().listRecipes().iterator().next()),
+          text("hello", "${java_home.jdk21:/bin/java}")
+        );
+
+        // With empty properties, the default value gets resolved
+        rewriteRun(
+          spec -> spec.recipe(Environment.builder(new Properties())
+            .load(new YamlResourceLoader(new ByteArrayInputStream(yaml.getBytes()),
+              URI.create("rewrite.yml"), new Properties()))
+            .build().listRecipes().iterator().next()),
+          text("hello", "/bin/java")
+        );
+    }
+
     private static class RecipeWithBadStaticInitializer extends Recipe {
         // Explicitly fail static initialization
         static final int val = 1 / 0;


### PR DESCRIPTION
## Summary
- Makes `Properties` parameter `@Nullable` in `YamlResourceLoader`, `ClasspathScanningLoader`, and `Environment.Builder`
- When `null`, `YamlResourceLoader` skips `PropertyPlaceholderHelper.replacePlaceholders()` entirely, preserving placeholders like `${var:default}` as-is
- Adds test verifying null properties preserves placeholders while empty properties still resolves defaults

## Context
- Fixes openrewrite/rewrite-maven-plugin#1100. When `resolvePropertiesInYaml=false`, the maven plugin passes an empty `Properties` to `YamlResourceLoader`. But `PropertyPlaceholderHelper` still resolves `${var:default}` to the default value because it treats "property not found + has default" as "use default". By passing `null` instead of empty properties, callers can signal "skip resolution entirely".

## Test plan
- [x] `YamlResourceLoaderTest.nullPropertiesSkipsPlaceholderResolution` — verifies null properties preserves `${java_home.jdk21:/bin/java}` as-is, while empty properties resolves to `/bin/java`
- [x] All existing `YamlResourceLoaderTest` and `PropertyPlaceholderHelperTest` tests pass