### PR TITLE
JavaScript: setting RPC metrics file in debugging mode too

### DIFF
--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -357,6 +357,7 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
                         "--enable-source-maps",
                         "--inspect-brk=" + inspectBrk,
                         serverJs.toAbsolutePath().normalize().toString(),
+                        metricsCsv == null ? null : "--metrics-csv=" + metricsCsv.toAbsolutePath().normalize(),
                         log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
                         traceRpcMessages ? "--trace-rpc-messages" : null,
                         recipeInstallDir == null ? null : "--recipe-install-dir=" + recipeInstallDir.toAbsolutePath().normalize()


### PR DESCRIPTION
## What's changed?

Making sure the RPC calls with debug enabled also have RPC metrics collected to a CSV file, as the normal runs do.

## What's your motivation?

- I've just spent 2 hours looking at the wrong files when debugging an issue, when I was kind of assuming the newest `metrics.csv` reflects what happened in the latest RPC run.
- I don't see a reason not to have this file produced. This is some rare path (debug enabled) anyway.