### PR TITLE
Fix slow Lombok initialization caused by ShadowClassLoader scanning entire classpath

### DIFF
--- a/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/LombokSupport.java
+++ b/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/LombokSupport.java
@@ -20,9 +20,13 @@ import org.openrewrite.internal.ReflectionUtils;
 
 import javax.annotation.processing.Processor;
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -77,8 +81,18 @@ public class LombokSupport {
                     Class.forName("java.util.List"));
             shadowLoaderConstructor.setAccessible(true);
 
+            // Wrap parserClassLoader to prevent ShadowClassLoader from scanning every jar
+            // on the parent classpath. ShadowClassLoader.getResources() iterates over all
+            // parent resources and calls isPartOfShadowSuffix() on each URL, which opens
+            // each jar as a ZipInputStream and reads every entry — extremely slow for large
+            // classpaths. By returning empty resource enumerations from the parent, the
+            // ShadowClassLoader relies solely on its override jars (set via
+            // shadow.override.lombok) which already contain everything Lombok needs.
+            // Class loading still delegates normally through the parent chain.
+            ClassLoader resourceFilteredParent = new ResourceFilteredClassLoader(parserClassLoader);
+
             ClassLoader lombokShadowLoader = (ClassLoader) shadowLoaderConstructor.newInstance(
-                    parserClassLoader,
+                    resourceFilteredParent,
                     "lombok",
                     null,
                     emptyList(),
@@ -91,6 +105,28 @@ public class LombokSupport {
             } else {
                 System.clearProperty("shadow.override.lombok");
             }
+        }
+    }
+
+    /**
+     * A classloader that delegates class loading to its parent but returns empty results
+     * for resource enumeration. This prevents Lombok's {@code ShadowClassLoader} from
+     * scanning every jar on the classpath via {@code ZipInputStream} when filtering
+     * parent resources in {@code getResources()}.
+     */
+    static class ResourceFilteredClassLoader extends ClassLoader {
+        ResourceFilteredClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public @Nullable URL getResource(String name) {
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Motivation

When parsing projects that use Lombok on large classpaths (e.g. Moderne CLI), Lombok's `ShadowClassLoader` spends hundreds of seconds of CPU during `LombokProcessor.init()`. The `ShadowClassLoader.getResources()` method calls `isPartOfShadowSuffix()` on every jar URL from the parent classloader, which opens each jar as a `ZipInputStream` and sequentially reads every entry to check for lombok-prefixed paths. On a classpath with many large jars, this is extremely slow.

Stack trace from a `jstack` sample showing the bottleneck (328s CPU / 384s elapsed):
```
lombok.launch.ShadowClassLoader.isPartOfShadowSuffixJarBased(ShadowClassLoader.java:384)
lombok.launch.ShadowClassLoader.isPartOfShadowSuffix(ShadowClassLoader.java:428)
lombok.launch.ShadowClassLoader.getResources(ShadowClassLoader.java:462)
lombok.core.SpiLoadUtil.findServices(SpiLoadUtil.java:94)
lombok.core.configuration.ConfigurationKeysLoader$LoaderLoader.loadAllConfigurationKeys
```

## Summary

- Wrap the parent classloader passed to `ShadowClassLoader` with a `ResourceFilteredClassLoader` that returns empty results for `getResources()` / `getResource()`, while still delegating class loading normally
- This forces the `ShadowClassLoader` to rely solely on its override jars (set via `shadow.override.lombok`), which already contain everything Lombok needs (`lombok.jar` + `rewrite-java-lombok`)
- The change is entirely contained in `LombokSupport.java` — no parser modifications needed

## Test plan

- [x] `rewrite-java-lombok` module tests pass
- [x] `rewrite-java-25` Lombok-specific tests pass
- [x] All 6 modified/dependent modules compile cleanly
- [x] Verified via `jstack` that the `ShadowClassLoader` scanning bottleneck is eliminated — Lombok now proceeds directly to annotation processing