### PR TITLE
C#: Fix `InvalidCastException` in `CSharpPrinter` for expression-bodied methods

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -1547,12 +1547,12 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
         }
 
         // Print body or semicolon (for interface methods without body)
-        if (method.Markers.FindFirst<ExpressionBodied>() != null && method.Body != null)
+        if (method.Markers.FindFirst<ExpressionBodied>() != null && method.Body != null
+            && method.Body.Statements.Count > 0 && method.Body.Statements[0].Element is Return returnStmt)
         {
             // Expression-bodied: print => expr;
             VisitSpace(method.Body.Prefix, p);
             p.Append("=>");
-            var returnStmt = (Return)method.Body.Statements[0].Element;
             Visit(returnStmt.Expression, p);
             p.Append(';');
         }
@@ -3751,12 +3751,13 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
         PrintParameterList("(", operatorDeclaration.Parameters, ")", p);
 
         // Body — expression-bodied (=> expr;) or block body ({...})
-        if (operatorDeclaration.Markers.FindFirst<ExpressionBodied>() != null)
+        if (operatorDeclaration.Markers.FindFirst<ExpressionBodied>() != null
+            && operatorDeclaration.Body.Statements.Count > 0
+            && operatorDeclaration.Body.Statements[0].Element is Return opReturnStmt)
         {
             VisitSpace(operatorDeclaration.Body.Prefix, p);
             p.Append("=>");
-            var returnStmt = (Return)operatorDeclaration.Body.Statements[0].Element;
-            Visit(returnStmt.Expression, p);
+            Visit(opReturnStmt.Expression, p);
             p.Append(';');
         }
         else

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/MethodDeclarationTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Tree/MethodDeclarationTests.cs
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp;
+using OpenRewrite.Java;
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;
@@ -151,5 +154,59 @@ public class MethodDeclarationTests : RewriteTest
                 """
             )
         );
+    }
+
+    [Fact]
+    public void ExpressionBodiedMethod()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Foo {
+                    int Bar() => 42;
+                }
+                """
+            )
+        );
+    }
+
+    /// <summary>
+    /// Verifies that the printer does not crash with an InvalidCastException when a recipe
+    /// transforms the Return statement inside an expression-bodied method into a different
+    /// statement type (e.g., If). The printer should fall back to block-body printing.
+    /// </summary>
+    [Fact]
+    public void PrinterHandlesExpressionBodiedMethodWithNonReturnBody()
+    {
+        var parser = new CSharpParser();
+
+        // Parse an expression-bodied method (contains a Return in the body)
+        var cu = (CompilationUnit)parser.Parse("class C { int M() => 42; }");
+
+        // Parse a source with an If statement to transplant
+        var ifSource = (CompilationUnit)parser.Parse("class D { void N() { if (true) { return 1; } } }");
+        var ifClass = (ClassDeclaration)ifSource.Members[0].Element;
+        var ifMethod = (MethodDeclaration)ifClass.Body.Statements[0].Element;
+        var ifStmt = (If)ifMethod.Body!.Statements[0].Element;
+
+        // Replace the Return in the expression-bodied method's body with the If
+        var visitor = new ReplaceReturnWithIfVisitor(ifStmt);
+        var result = visitor.Visit(cu, new OpenRewrite.Core.ExecutionContext());
+
+        // The printer should not throw — it should fall back to block-body printing
+        var printer = new CSharpPrinter<int>();
+        var printed = printer.Print(result!);
+
+        // The output should contain the if statement, not the => syntax
+        Assert.Contains("if", printed);
+        Assert.DoesNotContain("=>", printed);
+    }
+
+    private class ReplaceReturnWithIfVisitor(If replacement) : CSharpVisitor<OpenRewrite.Core.ExecutionContext>
+    {
+        public override J VisitReturn(Return ret, OpenRewrite.Core.ExecutionContext ctx)
+        {
+            return replacement.WithPrefix(ret.Prefix);
+        }
     }
 }


### PR DESCRIPTION
## Motivation

When running the CodeQuality composite recipe against AngleSharp, two files (`Priority.cs`, `TextPosition.cs`) crash with an `InvalidCastException` in `CSharpPrinter.PrintMethodDeclarationBody`. A recipe transforms the `Return` inside an expression-bodied method into an `If` (e.g., expanding a nested ternary), but the printer hard-casts the body statement to `Return`.

For example, the recipe transforms:
```csharp
public Int32 CompareTo(Priority other) => this == other ? 0 : (this > other ? 1 : -1);
```
into:
```csharp
public Int32 CompareTo(Priority other) {
    if (this == other) {
        return 0;
    } else if (this > other) {
        return 1;
    } else {
        return -1;
    }
}
```

The `ExpressionBodied` marker stays on the `MethodDeclaration`, so the printer still tries `=> expr;` syntax and crashes.

## Summary

- Replace hard `(Return)` casts with `is Return` pattern matching in `PrintMethodDeclarationBody` for both method declarations and operator declarations
- When the body statement is no longer a `Return`, fall back to block-body printing via `VisitBlock`

## Test plan

- [x] New round-trip test for expression-bodied methods (`ExpressionBodiedMethod`)
- [x] New test that replaces `Return` with `If` inside an expression-bodied method and verifies the printer doesn't crash (`PrinterHandlesExpressionBodiedMethodWithNonReturnBody`)
- [x] All existing `MethodDeclarationTests` pass