### PR TITLE
Fix AddProperty duplicating self-closing XML property tags

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPropertyVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPropertyVisitor.java
@@ -43,7 +43,7 @@ public class AddPropertyVisitor extends MavenIsoVisitor<ExecutionContext> {
         if (!properties.isPresent()) {
             Xml.Tag propertiesTag = Xml.Tag.build("<properties>\n<" + key + ">" + value + "</" + key + ">\n</properties>");
             d = (Xml.Document) new AddToTagVisitor<ExecutionContext>(root, propertiesTag, new MavenTagInsertionComparator(root.getChildren())).visitNonNull(d, ctx);
-        } else if (!properties.get().getChildValue(key).isPresent()) {
+        } else if (!properties.get().getChild(key).isPresent()) {
             Xml.Tag propertyTag = Xml.Tag.build("<" + key + ">" + value + "</" + key + ">");
             d = (Xml.Document) new AddToTagVisitor<>(properties.get(), propertyTag, new TagNameComparator()).visitNonNull(d, ctx);
         }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddPropertyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddPropertyTest.java
@@ -386,6 +386,56 @@ class AddPropertyTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2123")
+    @Test
+    void preserveSelfClosingProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new AddProperty("argLine", "", true, false)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <properties>
+                  <argLine/>
+                </properties>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2123")
+    @Test
+    void updateSelfClosingProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new AddProperty("argLine", "some-value", null, false)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <properties>
+                  <argLine/>
+                </properties>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <properties>
+                  <argLine>some-value</argLine>
+                </properties>
+              </project>
+              """
+          )
+        );
+    }
+
     @Test
     void twiceInARow() {
         rewriteRun(


### PR DESCRIPTION
## Summary
- `AddProperty` recipe duplicated properties when the existing tag was self-closing (e.g. `<argLine/>`), producing both `<argLine/>` and `<argLine></argLine>`
- Root cause: the existence check used `getChildValue()` which returns empty for self-closing tags (null content), so the recipe thought the property didn't exist
- Fixed by using `getChild()` to check for tag existence instead of tag value
- Added tests for both preserving and updating self-closing properties

- Fixes https://github.com/moderneinc/customer-requests/issues/2123