### PR TITLE
Fix context-sensitive template replacement for standalone expression statements

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
@@ -257,6 +257,83 @@ class JavaTemplateTest8Test implements RewriteTest {
         );
     }
 
+    @Test
+    void replaceContextSensitiveMethodInvocationStandaloneStatement() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  method = super.visitMethodInvocation(method, ctx);
+                  if (method.getSimpleName().equals("visitClassDeclaration") &&
+                      method.getSelect() != null &&
+                      !(method.getSelect() instanceof J.Identifier &&
+                        "super".equals(((J.Identifier) method.getSelect()).getSimpleName()))) {
+                      return JavaTemplate.builder("#{any()}.visit(#{any()}, #{any()}, getCursor().getParentTreeCursor())")
+                        .contextSensitive()
+                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                        .build()
+                        .apply(getCursor(), method.getCoordinates().replace(),
+                          method.getSelect(), method.getArguments().get(0), method.getArguments().get(1));
+                  }
+                  return method;
+              }
+          })),
+          java(
+            """
+              import org.openrewrite.*;
+              import org.openrewrite.java.JavaIsoVisitor;
+              import org.openrewrite.java.JavaVisitor;
+              import org.openrewrite.java.tree.J;
+
+              class MyRecipe extends Recipe {
+                  @Override
+                  public String getDisplayName() { return ""; }
+                  @Override
+                  public String getDescription() { return ""; }
+
+                  @Override
+                  public TreeVisitor<?, ExecutionContext> getVisitor() {
+                      return new JavaIsoVisitor<ExecutionContext>() {
+                          @Override
+                          public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                              J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+                              new JavaVisitor<ExecutionContext>() {}.visitClassDeclaration(cd, ctx);
+                              return cd;
+                          }
+                      };
+                  }
+              }
+              """,
+            """
+              import org.openrewrite.*;
+              import org.openrewrite.java.JavaIsoVisitor;
+              import org.openrewrite.java.JavaVisitor;
+              import org.openrewrite.java.tree.J;
+
+              class MyRecipe extends Recipe {
+                  @Override
+                  public String getDisplayName() { return ""; }
+                  @Override
+                  public String getDescription() { return ""; }
+
+                  @Override
+                  public TreeVisitor<?, ExecutionContext> getVisitor() {
+                      return new JavaIsoVisitor<ExecutionContext>() {
+                          @Override
+                          public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                              J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+                              new JavaVisitor<ExecutionContext>() {
+                              }.visit(cd, ctx, getCursor().getParentTreeCursor());
+                              return cd;
+                          }
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @DocumentExample
     @Test
     void parameterizedMatch() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -321,8 +321,9 @@ public class BlockStatementTemplateGenerator {
             }
 
             if (prior == insertionPoint && prior instanceof Expression) {
-                // the template represents an expression, so we need to wrap it in a statement
-                after.append(';');
+                // the template represents an expression, so we need to wrap it in a statement.
+                // Use insert(0, ...) so the semicolon comes before any "}\nreturn ...;" from non-void methods.
+                after.insert(0, ';');
             }
             after.append('}');
         } else if (j instanceof J.Annotation) {


### PR DESCRIPTION
## Summary
- Fixes `JavaTemplate` failing with "generated 0 statements" when replacing a standalone method invocation expression statement inside a non-void method using a context-sensitive template
- Root cause: the semicolon terminating the expression was placed after the `if(true)` block close brace and `return` statement in the generated stub, instead of directly after the template content
- Discovered via `UseVisitWithParentCursor` recipe failing on [AbstractLogEnabledToSlf4j.java#L110](https://github.com/openrewrite/rewrite-apache/blob/0e4d4c18c53bda294a215ab0d916855c02db10fd/src/main/java/org/openrewrite/codehaus/plexus/AbstractLogEnabledToSlf4j.java#L110)

## Test plan
- [x] Added `replaceContextSensitiveMethodInvocationStandaloneStatement` test in `JavaTemplateTest8Test`
- [x] All `JavaTemplateTest8Test` tests pass
- [x] All `rewrite-java` and `rewrite-java-test` module tests pass