### PR TITLE
Fix build cache determinism for rewrite-go goBuild task

### DIFF
--- a/rewrite-go/build.gradle.kts
+++ b/rewrite-go/build.gradle.kts
@@ -27,7 +27,8 @@ tasks.withType<Javadoc>().configureEach {
 
 val goBuild = tasks.register<Exec>("goBuild") {
     workingDir = file("rewrite")
-    commandLine("go", "build", "-o", "${layout.buildDirectory.get().asFile}/rewrite-go-rpc", "./cmd/rpc")
+    // Use relative path to avoid absolute paths in cache key (Exec args are cache inputs)
+    commandLine("go", "build", "-o", layout.buildDirectory.file("rewrite-go-rpc").get().asFile.relativeTo(file("rewrite")).path, "./cmd/rpc")
 
     inputs.files(fileTree("rewrite") {
         include("**/*.go")


### PR DESCRIPTION
## Summary

- The `goBuild` Exec task in `rewrite-go` uses an absolute path in its `-o` argument, which is a Gradle cache input. This causes cache misses when the same commit is built from different directories (e.g., Develocity build validation experiment 3). This is the same pattern fixed in #7173 for `pytestTest` and `csharpTest`. The fix replaces the absolute path with a relative path from the task's `workingDir`.

## Test plan
- [ ] Verify `./gradlew :rewrite-go:goBuild` still produces the binary in the correct location
- [ ] Confirm cache key stability across builds from different directories