### PR TITLE
Add ParseError support to rewrite-go parser and RPC

### DIFF
--- a/rewrite-go/rewrite/cmd/rpc/main.go
+++ b/rewrite-go/rewrite/cmd/rpc/main.go
@@ -269,10 +269,30 @@ type parseRequest struct {
 }
 
 // parseInput can be a path-based or text-based input.
+// It supports two JSON forms:
+//   - A bare string (treated as a file path)
+//   - A structured object with path, text, and sourcePath fields
 type parseInput struct {
 	Path       string `json:"path"`
 	Text       string `json:"text"`
 	SourcePath string `json:"sourcePath"`
+}
+
+func (p *parseInput) UnmarshalJSON(data []byte) error {
+	// Try bare string first (Java PathInput serializes as @JsonValue string)
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		p.Path = s
+		return nil
+	}
+	// Otherwise unmarshal as a structured object
+	type alias parseInput
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*p = parseInput(a)
+	return nil
 }
 
 // handleParse parses Go source files and returns their IDs.
@@ -315,10 +335,21 @@ func (s *server) handleParse(params json.RawMessage) (any, *rpcError) {
 			continue
 		}
 
-		cu, err := p.Parse(sourcePath, source)
-		if err != nil {
-			s.logger.Printf("Parse error for %s: %v", sourcePath, err)
-			return nil, &rpcError{Code: -32603, Message: fmt.Sprintf("Parse error: %v", err)}
+		cu, parseErr := func() (cu *tree.CompilationUnit, err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("panic: %v", r)
+				}
+			}()
+			return p.Parse(sourcePath, source)
+		}()
+		if parseErr != nil {
+			s.logger.Printf("Parse error for %s: %v", sourcePath, parseErr)
+			pe := tree.NewParseError(sourcePath, source, parseErr)
+			id := pe.Ident.String()
+			s.localObjects[id] = pe
+			ids = append(ids, id)
+			continue
 		}
 		id := cu.ID.String()
 		s.localObjects[id] = cu

--- a/rewrite-go/rewrite/pkg/parser/go_parser.go
+++ b/rewrite-go/rewrite/pkg/parser/go_parser.go
@@ -101,8 +101,11 @@ type parseContext struct {
 // prefix extracts the whitespace and comments between the current cursor
 // position and the given token position.
 func (ctx *parseContext) prefix(pos token.Pos) tree.Space {
+	if !pos.IsValid() {
+		return tree.EmptySpace
+	}
 	targetOffset := ctx.file.Offset(pos)
-	if targetOffset <= ctx.cursor {
+	if targetOffset <= ctx.cursor || targetOffset > len(ctx.src) {
 		return tree.EmptySpace
 	}
 	raw := string(ctx.src[ctx.cursor:targetOffset])
@@ -117,7 +120,12 @@ func (ctx *parseContext) skip(n int) {
 
 // skipTo advances the cursor to the given position.
 func (ctx *parseContext) skipTo(pos token.Pos) {
-	ctx.cursor = ctx.file.Offset(pos)
+	if pos.IsValid() {
+		off := ctx.file.Offset(pos)
+		if off <= len(ctx.src) {
+			ctx.cursor = off
+		}
+	}
 }
 
 // prefixAndSkip extracts the prefix before pos and advances past length bytes.
@@ -2303,8 +2311,11 @@ func (ctx *parseContext) findNextString(s string) int {
 
 // prefixString returns the raw source between cursor and pos, for debugging.
 func (ctx *parseContext) prefixString(pos token.Pos) string {
+	if !pos.IsValid() {
+		return ""
+	}
 	targetOffset := ctx.file.Offset(pos)
-	if targetOffset <= ctx.cursor {
+	if targetOffset <= ctx.cursor || targetOffset > len(ctx.src) {
 		return ""
 	}
 	return strings.TrimRight(string(ctx.src[ctx.cursor:targetOffset]), " \t\n")

--- a/rewrite-go/rewrite/pkg/rpc/go_receiver.go
+++ b/rewrite-go/rewrite/pkg/rpc/go_receiver.go
@@ -17,6 +17,7 @@
 package rpc
 
 import (
+	"github.com/google/uuid"
 	"github.com/openrewrite/rewrite/pkg/tree"
 )
 
@@ -40,6 +41,12 @@ func NewGoReceiver() *GoReceiver {
 func (r *GoReceiver) Visit(node any, q *ReceiveQueue) any {
 	if node == nil {
 		return nil
+	}
+
+	// ParseError has its own codec — handle before preVisit (no prefix field)
+	if pe, ok := node.(*tree.ParseError); ok {
+		c := *pe
+		return r.receiveParseError(&c, q)
 	}
 
 	// preVisit: receive ID, prefix, markers
@@ -219,6 +226,25 @@ func (r *GoReceiver) preVisit(node any, q *ReceiveQueue) any {
 }
 
 // --- G nodes ---
+
+// receiveParseError deserializes a ParseError matching Java's ParseError.rpcReceive field order:
+// id, markers, sourcePath, charsetName, charsetBomMarked, checksum, fileAttributes, text
+func (r *GoReceiver) receiveParseError(pe *tree.ParseError, q *ReceiveQueue) *tree.ParseError {
+	idStr := receiveScalar[string](q, pe.Ident.String())
+	if idStr != "" {
+		if parsed, err := uuid.Parse(idStr); err == nil {
+			pe.Ident = parsed
+		}
+	}
+	pe.Markers = receiveMarkersCodec(q, pe.Markers)
+	pe.SourcePath = receiveScalar[string](q, pe.SourcePath)
+	pe.CharsetName = receiveScalar[string](q, pe.CharsetName)
+	pe.CharsetBomMarked = receiveScalar[bool](q, pe.CharsetBomMarked)
+	q.Receive(nil, nil) // checksum
+	q.Receive(nil, nil) // fileAttributes
+	pe.Text = receiveScalar[string](q, pe.Text)
+	return pe
+}
 
 func (r *GoReceiver) receiveCompilationUnit(cu *tree.CompilationUnit, q *ReceiveQueue) *tree.CompilationUnit {
 	c := *cu // shallow copy to avoid mutating remoteObjects baseline

--- a/rewrite-go/rewrite/pkg/rpc/go_sender.go
+++ b/rewrite-go/rewrite/pkg/rpc/go_sender.go
@@ -42,6 +42,12 @@ func (s *GoSender) Visit(node any, q *SendQueue) {
 		return
 	}
 
+	// ParseError has its own codec — handle before preVisit (no prefix field)
+	if pe, ok := node.(*tree.ParseError); ok {
+		s.sendParseError(pe, q)
+		return
+	}
+
 	// preVisit: send ID, prefix, markers
 	s.preVisit(node, q)
 
@@ -304,6 +310,20 @@ func (s *GoSender) sendCommClause(cc *tree.CommClause, q *SendQueue) {
 		},
 		func(v any) any { return containerElementID(v) },
 		func(v any) { sendRightPadded(s, v, q) })
+}
+
+// sendParseError serializes a ParseError matching Java's ParseError.rpcSend field order:
+// id, markers, sourcePath, charsetName, charsetBomMarked, checksum, fileAttributes, text
+func (s *GoSender) sendParseError(pe *tree.ParseError, q *SendQueue) {
+	q.GetAndSend(pe, func(v any) any { return v.(*tree.ParseError).Ident.String() }, nil)
+	q.GetAndSend(pe, func(v any) any { return v.(*tree.ParseError).Markers },
+		func(v any) { SendMarkersCodec(v.(tree.Markers), q) })
+	q.GetAndSend(pe, func(v any) any { return v.(*tree.ParseError).SourcePath }, nil)
+	q.GetAndSend(pe, func(v any) any { return v.(*tree.ParseError).CharsetName }, nil)
+	q.GetAndSend(pe, func(v any) any { return v.(*tree.ParseError).CharsetBomMarked }, nil)
+	q.GetAndSend(pe, func(_ any) any { return nil }, nil) // checksum
+	q.GetAndSend(pe, func(_ any) any { return nil }, nil) // fileAttributes
+	q.GetAndSend(pe, func(v any) any { return v.(*tree.ParseError).Text }, nil)
 }
 
 func (s *GoSender) sendIndexList(il *tree.IndexList, q *SendQueue) {

--- a/rewrite-go/rewrite/pkg/rpc/receive_queue.go
+++ b/rewrite-go/rewrite/pkg/rpc/receive_queue.go
@@ -18,6 +18,9 @@ package rpc
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/openrewrite/rewrite/pkg/tree"
 )
 
 // ReceiveQueue deserializes RpcObjectData messages from the RPC channel.
@@ -178,9 +181,14 @@ func RegisterFactory(javaClassName string, factory func() any) {
 }
 
 // newObj creates a new empty instance by Java class name.
+// Unknown marker types are treated as GenericMarker to avoid panics
+// from markers added in newer versions of rewrite-core.
 func newObj(javaClassName string) any {
 	if factory, ok := factories[javaClassName]; ok {
 		return factory()
+	}
+	if strings.HasPrefix(javaClassName, "org.openrewrite.marker.") {
+		return tree.GenericMarker{}
 	}
 	panic(fmt.Sprintf("no factory registered for type: %s", javaClassName))
 }

--- a/rewrite-go/rewrite/pkg/rpc/space_rpc.go
+++ b/rewrite-go/rewrite/pkg/rpc/space_rpc.go
@@ -21,6 +21,14 @@ import (
 	"github.com/openrewrite/rewrite/pkg/tree"
 )
 
+// nilableString converts a *string to an any, returning nil if the pointer is nil.
+func nilableString(s *string) any {
+	if s == nil {
+		return nil
+	}
+	return *s
+}
+
 // sendSpace serializes a Space to the send queue.
 // Matches JavaSender.visitSpace field order: comments (list), whitespace.
 func sendSpace(s tree.Space, q *SendQueue) {
@@ -111,6 +119,13 @@ func SendMarkersCodec(m tree.Markers, q *SendQueue) {
 // This must match the field order in each marker's rpcSend method.
 func sendMarkerCodecFields(v any, q *SendQueue) {
 	switch m := v.(type) {
+	case tree.ParseExceptionResult:
+		// ParseExceptionResult.rpcSend sends: id, parserType, exceptionType, message, treeType
+		q.GetAndSend(m, func(x any) any { return x.(tree.ParseExceptionResult).Ident.String() }, nil)
+		q.GetAndSend(m, func(x any) any { return x.(tree.ParseExceptionResult).ParserType }, nil)
+		q.GetAndSend(m, func(x any) any { return x.(tree.ParseExceptionResult).ExceptionType }, nil)
+		q.GetAndSend(m, func(x any) any { return x.(tree.ParseExceptionResult).Message }, nil)
+		q.GetAndSend(m, func(x any) any { return nilableString(x.(tree.ParseExceptionResult).TreeType) }, nil)
 	case tree.SearchResult:
 		// SearchResult.rpcSend sends: id (UUID string), description (nullable string)
 		q.GetAndSend(m, func(x any) any { return x.(tree.SearchResult).Ident.String() }, nil)
@@ -176,6 +191,25 @@ func receiveMarkersCodec(q *ReceiveQueue, before tree.Markers) tree.Markers {
 		// Markers that implement RpcCodec on the Java side send sub-fields.
 		// We dispatch based on the concrete Go type created by the factory.
 		switch m := v.(type) {
+		case tree.ParseExceptionResult:
+			// ParseExceptionResult.rpcReceive: id, parserType, exceptionType, message, treeType
+			idStr := receiveScalar[string](q, m.Ident.String())
+			if idStr != "" {
+				if parsed, err := uuid.Parse(idStr); err == nil {
+					m.Ident = parsed
+				}
+			}
+			m.ParserType = receiveScalar[string](q, m.ParserType)
+			m.ExceptionType = receiveScalar[string](q, m.ExceptionType)
+			m.Message = receiveScalar[string](q, m.Message)
+			treeTypeVal := q.Receive(nilableString(m.TreeType), nil)
+			if treeTypeVal != nil {
+				s := treeTypeVal.(string)
+				m.TreeType = &s
+			} else {
+				m.TreeType = nil
+			}
+			return m
 		case tree.SearchResult:
 			// SearchResult.rpcSend sends: id (UUID string), description (nullable string)
 			idStr := receiveScalar[string](q, m.Ident.String())

--- a/rewrite-go/rewrite/pkg/rpc/value_types.go
+++ b/rewrite-go/rewrite/pkg/rpc/value_types.go
@@ -79,6 +79,9 @@ func init() {
 	RegisterValueType(reflect.TypeOf((*tree.ControlParentheses)(nil)), "org.openrewrite.java.tree.J$ControlParentheses")
 	RegisterValueType(reflect.TypeOf((*tree.Import)(nil)), "org.openrewrite.java.tree.J$Import")
 
+	// ParseError
+	RegisterValueType(reflect.TypeOf((*tree.ParseError)(nil)), "org.openrewrite.tree.ParseError")
+
 	// Non-tree types that Java needs valueType for
 	RegisterValueType(reflect.TypeOf(tree.Space{}), "org.openrewrite.java.tree.Space")
 	RegisterValueType(reflect.TypeOf(tree.Markers{}), "org.openrewrite.marker.Markers")
@@ -97,6 +100,7 @@ func init() {
 	RegisterValueType(reflect.TypeOf(tree.StructTag{}), "org.openrewrite.golang.marker.StructTag")
 	RegisterValueType(reflect.TypeOf(tree.TrailingComma{}), "org.openrewrite.golang.marker.TrailingComma")
 	RegisterValueType(reflect.TypeOf(tree.SearchResult{}), "org.openrewrite.marker.SearchResult")
+	RegisterValueType(reflect.TypeOf(tree.ParseExceptionResult{}), "org.openrewrite.ParseExceptionResult")
 
 	// JavaType types
 	RegisterValueType(reflect.TypeOf((*tree.JavaTypeClass)(nil)), "org.openrewrite.java.tree.JavaType$Class")
@@ -165,13 +169,24 @@ func init() {
 	RegisterFactory("org.openrewrite.java.tree.J$ControlParentheses", func() any { return &tree.ControlParentheses{} })
 	RegisterFactory("org.openrewrite.java.tree.J$Import", func() any { return &tree.Import{} })
 
+	// ParseError
+	RegisterFactory("org.openrewrite.tree.ParseError", func() any { return &tree.ParseError{} })
+	RegisterFactory("org.openrewrite.ParseExceptionResult", func() any { return tree.ParseExceptionResult{} })
+
 	// SourceFile-level types that implement RpcCodec
 	RegisterFactory("org.openrewrite.Checksum", func() any { return tree.GenericMarker{} })
 	RegisterFactory("org.openrewrite.FileAttributes", func() any { return tree.GenericMarker{} })
 
-	// Java-side markers that may appear when recipes modify trees
-	// RecipesThatMadeChanges: NOT an RpcCodec, serialized as raw value
+	// Java-side markers that may appear when recipes modify trees or during LST writing.
+	// These markers do NOT implement RpcCodec and are serialized as raw values.
 	RegisterFactory("org.openrewrite.marker.RecipesThatMadeChanges", func() any { return tree.GenericMarker{} })
+	RegisterFactory("org.openrewrite.marker.LstProvenance", func() any { return tree.GenericMarker{} })
+	RegisterFactory("org.openrewrite.marker.BuildMetadata", func() any { return tree.GenericMarker{} })
+	RegisterFactory("org.openrewrite.marker.GitTreeEntry", func() any { return tree.GenericMarker{} })
+	RegisterFactory("org.openrewrite.marker.BuildTool", func() any { return tree.GenericMarker{} })
+	RegisterFactory("org.openrewrite.marker.BuildToolFailure", func() any { return tree.GenericMarker{} })
+	RegisterFactory("org.openrewrite.marker.Generated", func() any { return tree.GenericMarker{} })
+	RegisterFactory("org.openrewrite.marker.DeserializationError", func() any { return tree.GenericMarker{} })
 	// SearchResult: IS an RpcCodec, sends 2 sub-fields (id, description)
 	RegisterFactory("org.openrewrite.marker.SearchResult", func() any { return tree.SearchResult{} })
 	// GroupedImport: IS an RpcCodec, sends 2 sub-fields (id, before whitespace)

--- a/rewrite-go/rewrite/pkg/tree/parse_error.go
+++ b/rewrite-go/rewrite/pkg/tree/parse_error.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tree
+
+import "github.com/google/uuid"
+
+// ParseError represents a source file that failed to parse.
+// Mirrors org.openrewrite.tree.ParseError on the Java side.
+type ParseError struct {
+	Ident          uuid.UUID
+	Markers        Markers
+	SourcePath     string
+	CharsetName    string
+	CharsetBomMarked bool
+	Text           string
+}
+
+// NewParseError creates a ParseError from a source path, source text, and error.
+func NewParseError(sourcePath string, source string, err error) *ParseError {
+	marker := ParseExceptionResult{
+		Ident:         uuid.New(),
+		ParserType:    "GolangParser",
+		ExceptionType: "error",
+		Message:       err.Error(),
+	}
+	markers := Markers{
+		ID:      uuid.New(),
+		Entries: []Marker{marker},
+	}
+	return &ParseError{
+		Ident:          uuid.New(),
+		Markers:        markers,
+		SourcePath:     sourcePath,
+		CharsetName:    "UTF-8",
+		CharsetBomMarked: false,
+		Text:           source,
+	}
+}
+
+// ParseExceptionResult is a marker that captures information about a parse failure.
+// Mirrors org.openrewrite.ParseExceptionResult on the Java side.
+type ParseExceptionResult struct {
+	Ident         uuid.UUID
+	ParserType    string
+	ExceptionType string
+	Message       string
+	TreeType      *string // nullable
+}
+
+func (p ParseExceptionResult) ID() uuid.UUID { return p.Ident }


### PR DESCRIPTION
## Summary
- Capture Go parse failures as `ParseError` instead of failing the entire parse request, allowing partial results to flow through the RPC pipeline
- Add RPC send/receive codecs for `ParseError` and `ParseExceptionResult` marker, matching the Java-side `org.openrewrite.tree.ParseError` contract
- Harden the parser with defensive bounds checks and panic recovery, and register additional Java-side markers (LstProvenance, BuildMetadata, etc.) as `GenericMarker` with a fallback for unknown marker types

## Test plan
- [ ] Verify Go parse with a mix of valid and invalid source files returns `ParseError` for bad files and valid LSTs for good files
- [ ] Verify round-trip RPC serialization of `ParseError` and `ParseExceptionResult` marker
- [ ] Verify that unknown markers from newer rewrite-core versions don't panic the Go process