### PR TITLE
Python: Populate declaring type on function declarations

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -781,7 +781,7 @@ class PythonTypeMapping:
 
         return JavaType.Method(
             _flags_bit_map=0,
-            _declaring_type=None,
+            _declaring_type=self._get_declaration_declaring_type(descriptor),
             _name=name,
             _return_type=return_type,
             _parameter_names=param_names if param_names else None,
@@ -1266,3 +1266,20 @@ class PythonTypeMapping:
     def module_to_fqn(module_path: str) -> str:
         """Convert a Python module path to a fully qualified name."""
         return module_path
+
+    def _get_declaration_declaring_type(self, descriptor: Dict[str, Any]) -> Optional[JavaType.FullyQualified]:
+        """Get the declaring type for a function declaration.
+
+        Mirrors the invocation-side logic from _get_declaring_type() to ensure
+        declarations and invocations produce matching FQNs.
+        """
+        class_name = descriptor.get('className')
+        if class_name:
+            module_name = descriptor.get('moduleName')
+            if module_name and module_name != 'builtins':
+                return self._create_class_type(f"{module_name}.{class_name}")
+            return self._create_class_type(class_name)
+        module_name = descriptor.get('moduleName')
+        if module_name and module_name != 'builtins':
+            return self._create_class_type(module_name)
+        return None

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -1846,3 +1846,34 @@ TypeVar
             assert 'typing' in result._fully_qualified_name
         finally:
             _cleanup_mapping(mapping, tmpdir, client)
+
+
+class TestDeclarationDeclaringType:
+    """Tests for declaring type on function declarations."""
+
+    def test_declaration_declaring_type_no_ty_types(self):
+        """Without ty-types, declaring type remains None."""
+        source = 'def greet(name: str) -> str:\n    return name\n'
+        tree = ast.parse(source)
+        mapping = PythonTypeMapping(source)
+        func_node = tree.body[0]
+        result = mapping.method_declaration_type(func_node)
+        assert result is not None
+        assert result._declaring_type is None
+
+    @requires_ty_types_cli
+    def test_declaration_declaring_type_with_ty_types(self):
+        """With ty-types, a function declaration should get a declaring type from the descriptor."""
+        source = 'def greet(name: str) -> str:\n    return name\n'
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            func_node = tree.body[0]
+            result = mapping.method_declaration_type(func_node)
+            assert result is not None
+            assert isinstance(result, JavaType.Method)
+            assert result._declaring_type is not None, \
+                "Declaration should have a declaring type, not None"
+            assert isinstance(result._declaring_type, JavaType.Class)
+            assert result._declaring_type._fully_qualified_name != "<unknown>"
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)


### PR DESCRIPTION
## Summary

- `_method_from_function_descriptor()` previously hardcoded `_declaring_type=None`, which became `JavaType.Unknown` on the Java side. This caused mismatches between declaration and invocation declaring types.
- Added `_get_declaration_declaring_type()` that mirrors the invocation-side logic from `_get_declaring_type()`, using `className`/`moduleName` from ty-types descriptors.
- When no ty-types descriptor is available, declaring type remains `None` (absolute file paths can't reliably produce module FQNs).

- Closes https://github.com/moderneinc/customer-requests/issues/2137 (Python side only; JS/TS side is separate).

## Test plan
- [x] `test_declaration_declaring_type_no_ty_types` — confirms `None` without ty-types
- [x] `test_declaration_declaring_type_with_ty_types` — confirms declaring type is populated
- [x] All 105 existing type attribution tests pass