### PR TITLE
JS: Populate declaring type on standalone function declarations

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -944,7 +944,24 @@ export class JavaScriptTypeMapping {
             }
 
             methodName = node.name ? node.name.getText() : "<anonymous>";
-            declaringType = Type.unknownType as Type.FullyQualified;
+
+            // Derive declaring type from source file module path (like Go's type_mapper.go).
+            // Use the same relativization as getFullyQualifiedName() so that declarations
+            // and invocations produce matching FQNs.
+            let moduleFqn: string;
+            const fileName = node.getSourceFile().fileName;
+            if (this.sourceRoot && path.isAbsolute(fileName)) {
+                moduleFqn = path.relative(this.sourceRoot, fileName);
+            } else {
+                moduleFqn = fileName;
+            }
+            // Strip file extension to get the module name
+            moduleFqn = moduleFqn.replace(/\.[^/.]+$/, '');
+            declaringType = {
+                kind: Type.Kind.Class,
+                flags: 0,
+                fullyQualifiedName: moduleFqn
+            } as Type.FullyQualified;
 
             // Get type parameters from node
             if (node.typeParameters) {

--- a/rewrite-javascript/rewrite/test/javascript/type-mapping.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/type-mapping.test.ts
@@ -1895,6 +1895,44 @@ describe('JavaScript type mapping', () => {
         );
     });
 
+    test('standalone function declaration has module-derived declaringType', async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new class extends Recipe {
+            name = 'Check function declaringType';
+            displayName = 'Check function declaringType';
+            description = 'Checks that standalone function declarations get a module-derived declaringType';
+
+            async editor(): Promise<JavaScriptVisitor<ExecutionContext>> {
+                return new class extends JavaScriptVisitor<ExecutionContext> {
+                    async visitMethodDeclaration(methodDecl: J.MethodDeclaration, p: ExecutionContext): Promise<J.MethodDeclaration> {
+                        const visited = await super.visitMethodDeclaration(methodDecl, p) as J.MethodDeclaration;
+                        if (visited.methodType?.declaringType) {
+                            const dt = visited.methodType.declaringType as Type.FullyQualified;
+                            if (Type.isClass(dt)) {
+                                const fqn = dt.fullyQualifiedName;
+                                return foundSearchResult(visited, fqn);
+                            }
+                        }
+                        return visited;
+                    }
+                };
+            }
+        };
+
+        const src = typescript(
+            `
+                    function helper(): void {}
+                `,
+            //@formatter:off
+            `
+                    /*~~(main)~~>*/function helper(): void {}
+                `
+            //@formatter:on
+        );
+        src.path = 'main.ts';
+        await spec.rewriteRun(src);
+    });
+
     test('FindMissingTypes produces no results on a complex class', async () => {
         const findings: string[] = [];
 


### PR DESCRIPTION
## Summary

Standalone function declarations/expressions in JS/TS previously got `Type.unknownType` as their declaring type, so `JavaType.Method.getDeclaringType()` returned `<unknown>`. This derives the module FQN from the source file path instead, matching how Go's `type_mapper.go` already handles package-level functions. The FQN format (relativized path, extension stripped) aligns with `getFullyQualifiedName()` so declarations and same-file invocations produce matching types.

- Addresses the JS portion of moderneinc/customer-requests#2137.

## Test plan

- Added test verifying a standalone function declaration gets a module-derived `declaringType` FQN
- All 52 existing type-mapping tests continue to pass