### PR TITLE
Replace `ThreadLocal` with cursor-based accumulator in `DeclarativeRecipe`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -26,7 +26,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.*;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
 import static org.openrewrite.Validated.invalid;
@@ -162,16 +161,12 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
         }
     }
 
-    @JsonIgnore
-    private transient ThreadLocal<Accumulator> accumulator = new ThreadLocal<>();
-
     @Override
     public Accumulator getInitialValue(ExecutionContext ctx) {
         Accumulator acc = new Accumulator();
         for (Recipe precondition : preconditions) {
             registerNestedScanningRecipes(precondition, acc, ctx);
         }
-        accumulator.set(acc);
         return acc;
     }
 
@@ -223,7 +218,7 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
         String description = "Evaluates a precondition and makes that result available to the preconditions of other recipes. " +
                    "\"bellwether\", noun - One that serves as a leader or as a leading indicator of future trends.";
 
-        Supplier<TreeVisitor<?, ExecutionContext>> precondition;
+        DeclarativeRecipe declarativeRecipe;
 
         @NonFinal
         transient boolean preconditionApplicable;
@@ -231,18 +226,34 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new TreeVisitor<Tree, ExecutionContext>() {
-                final TreeVisitor<?, ExecutionContext> p = precondition.get();
+                @Nullable
+                TreeVisitor<?, ExecutionContext> p;
 
                 @Override
                 public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-                    return p.isAcceptable(sourceFile, ctx);
+                    // p is lazily resolved in visit() where the cursor is available.
+                    // Before that, conservatively accept all source files.
+                    return p == null || p.isAcceptable(sourceFile, ctx);
                 }
 
                 @Override
                 public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
-                    Tree t = p.visit(tree, ctx);
+                    Tree t = resolve(ctx).visit(tree, ctx);
                     preconditionApplicable = t != tree;
                     return tree;
+                }
+
+                private TreeVisitor<?, ExecutionContext> resolve(ExecutionContext ctx) {
+                    if (p == null) {
+                        Cursor rootCursor = getCursor().getRoot();
+                        List<TreeVisitor<?, ExecutionContext>> andVisitors = new ArrayList<>();
+                        for (Recipe precondition : declarativeRecipe.preconditions) {
+                            andVisitors.add(declarativeRecipe.orVisitors(precondition, rootCursor, ctx));
+                        }
+                        //noinspection unchecked
+                        p = Preconditions.and(andVisitors.toArray(new TreeVisitor[0]));
+                    }
+                    return p;
                 }
             };
         }
@@ -496,36 +507,30 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
             return recipeList;
         }
 
-        List<Supplier<TreeVisitor<?, ExecutionContext>>> andPreconditions = new ArrayList<>();
-        for (Recipe precondition : preconditions) {
-            andPreconditions.add(() -> orVisitors(precondition));
-        }
-        //noinspection unchecked
-        PreconditionBellwether bellwether = new PreconditionBellwether(Preconditions.and(andPreconditions.toArray(new Supplier[]{})));
+        PreconditionBellwether bellwether = new PreconditionBellwether(this);
         List<Recipe> recipeListWithBellwether = new ArrayList<>(recipeList.size() + 1);
         recipeListWithBellwether.add(bellwether);
         recipeListWithBellwether.addAll(decorateWithPreconditionBellwether(bellwether, recipeList));
         return recipeListWithBellwether;
     }
 
-    private TreeVisitor<?, ExecutionContext> orVisitors(Recipe recipe) {
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private TreeVisitor<?, ExecutionContext> orVisitors(Recipe recipe, Cursor rootCursor, ExecutionContext ctx) {
         List<TreeVisitor<?, ExecutionContext>> conditions = new ArrayList<>();
         if (recipe instanceof ScanningRecipe) {
-            //noinspection rawtypes
             ScanningRecipe scanning = (ScanningRecipe) recipe;
-            //noinspection unchecked
-            Accumulator acc = accumulator.get();
-            conditions.add(scanning.getVisitor(acc != null ? acc.recipeToAccumulator.get(scanning) : null));
+            Accumulator acc = getAccumulator(rootCursor, ctx);
+            Object recipeAcc = acc.recipeToAccumulator.get(scanning);
+            conditions.add(scanning.getVisitor(recipeAcc));
         } else {
             conditions.add(recipe.getVisitor());
         }
         for (Recipe r : recipe.getRecipeList()) {
-            conditions.add(orVisitors(r));
+            conditions.add(orVisitors(r, rootCursor, ctx));
         }
         if (conditions.size() == 1) {
             return conditions.get(0);
         }
-        //noinspection unchecked
         return Preconditions.or(conditions.toArray(new TreeVisitor[0]));
     }
 
@@ -609,15 +614,8 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
     }
 
     @Override
-    public void onComplete(ExecutionContext ctx) {
-        accumulator.remove();
-    }
-
-    @Override
     public DeclarativeRecipe clone() {
-        DeclarativeRecipe cloned = (DeclarativeRecipe) super.clone();
-        cloned.accumulator = new ThreadLocal<>();
-        return cloned;
+        return (DeclarativeRecipe) super.clone();
     }
 
     @Override


### PR DESCRIPTION
## Motivation

When a `ScanningRecipe` is used as a precondition in a `DeclarativeRecipe`, the accumulator is stored in a `ThreadLocal` during the scan phase and read back in `orVisitors()` during the edit phase. This means the scan and edit phases must run on the same thread — otherwise the `ThreadLocal` is null, resulting in NPE for any `ScanningRecipe` precondition that uses its accumulator in `getVisitor()`.

This affects `ModuleHasDependency`, `RepositoryHasDependency`, `HasNoJakartaAnnotations`, and similar recipes when used as preconditions. The error manifests as all files in a run failing (not intermittent), because once a thread switch occurs between scan and edit phases, the entire edit phase runs on the new thread where the `ThreadLocal` is empty.

`ScanningRecipe` already has a thread-safe mechanism for storing accumulators: `getAccumulator(Cursor, ExecutionContext)` stores them on the root cursor keyed by UUID (line 94-96). This survives across threads since the cursor is passed through `RecipeRunCycle` boundaries. `DeclarativeRecipe` should use this same mechanism instead of a `ThreadLocal`.

## Summary

- Remove `ThreadLocal<Accumulator>` from `DeclarativeRecipe`
- `PreconditionBellwether` now lazily resolves precondition visitors in `visit()`, where both the cursor and `ExecutionContext` are available
- `orVisitors()` takes `Cursor` + `ExecutionContext` and uses `getAccumulator(rootCursor, ctx)` — the same UUID-keyed cursor message mechanism that `ScanningRecipe.getVisitor()` already uses
- Remove `onComplete()` (only cleared the ThreadLocal) and simplify `clone()`

No public API changes.

## Test plan

- [x] `rewrite-core:test` — all pass
- [x] `rewrite-java-test:test` — all pass
- [x] Existing `DeclarativeRecipeTest.scanningPreconditionMet` and `scanningPreconditionNotMet` cover the happy path

- Fixes #7159