### PR TITLE
Always include Gradle API stubs in GradleParser classpath

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleParser.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleParser.java
@@ -27,7 +27,10 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.kotlin.KotlinParser;
 
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleParser.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleParser.java
@@ -27,8 +27,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.kotlin.KotlinParser;
 
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -65,12 +64,8 @@ public class GradleParser implements Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sources, @Nullable Path relativeTo, ExecutionContext ctx) {
         if (groovyBuildParser == null) {
-            Collection<Path> buildscriptClasspath = base.buildscriptClasspath;
-            if (buildscriptClasspath == null) {
-                buildscriptClasspath = defaultClasspath(ctx);
-            }
             groovyBuildParser = GroovyParser.builder(base.groovyParser)
-                    .classpath(buildscriptClasspath)
+                    .classpath(mergeClasspath(base.buildscriptClasspath, ctx))
                     .compilerCustomizers(
                             new DefaultImportsCustomizer(),
                             config -> config.setScriptBaseClass("RewriteGradleProject")
@@ -78,12 +73,8 @@ public class GradleParser implements Parser {
                     .build();
         }
         if (kotlinBuildParser == null) {
-            Collection<Path> buildscriptClasspath = base.buildscriptClasspath;
-            if (buildscriptClasspath == null) {
-                buildscriptClasspath = defaultClasspath(ctx);
-            }
             kotlinBuildParser = KotlinParser.builder(base.kotlinParser)
-                    .classpath(buildscriptClasspath)
+                    .classpath(mergeClasspath(base.buildscriptClasspath, ctx))
                     .dependsOn(KTS_BUILD_STUBS)
                     .isKotlinScript(true)
                     .scriptImplicitReceivers("org.gradle.api.Project")
@@ -91,12 +82,8 @@ public class GradleParser implements Parser {
                     .build();
         }
         if (groovySettingsParser == null) {
-            Collection<Path> settingsClasspath = base.settingsClasspath;
-            if (settingsClasspath == null) {
-                settingsClasspath = defaultClasspath(ctx);
-            }
             groovySettingsParser = GroovyParser.builder(base.groovyParser)
-                    .classpath(settingsClasspath)
+                    .classpath(mergeClasspath(base.settingsClasspath, ctx))
                     .compilerCustomizers(
                             new DefaultImportsCustomizer(),
                             config -> config.setScriptBaseClass("RewriteSettings")
@@ -104,12 +91,8 @@ public class GradleParser implements Parser {
                     .build();
         }
         if (kotlinSettingsParser == null) {
-            Collection<Path> settingsClasspath = base.settingsClasspath;
-            if (settingsClasspath == null) {
-                settingsClasspath = defaultClasspath(ctx);
-            }
             kotlinSettingsParser = KotlinParser.builder(base.kotlinParser)
-                    .classpath(settingsClasspath)
+                    .classpath(mergeClasspath(base.settingsClasspath, ctx))
                     .dependsOn(KTS_SETTINGS_STUBS)
                     .isKotlinScript(true)
                     .scriptImplicitReceivers("org.gradle.api.initialization.Settings")
@@ -208,6 +191,21 @@ public class GradleParser implements Parser {
         public String getDslName() {
             return "gradle";
         }
+    }
+
+    /**
+     * Always include the default Gradle API stubs alongside any externally-provided classpath.
+     * The external classpath (e.g. settings buildscript dependencies) typically contains custom
+     * plugin jars but not the Gradle API itself, which is needed for correct type attribution
+     * of DSL methods like pluginManagement(), repositories(), gradlePluginPortal(), etc.
+     */
+    private Collection<Path> mergeClasspath(@Nullable Collection<Path> provided, ExecutionContext ctx) {
+        if (provided == null) {
+            return defaultClasspath(ctx);
+        }
+        Set<Path> merged = new LinkedHashSet<>(defaultClasspath(ctx));
+        merged.addAll(provided);
+        return merged;
     }
 
     private List<Path> defaultClasspath(ExecutionContext ctx) {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleParserTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleParserTest.java
@@ -27,6 +27,8 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.tree.ParseError;
 
+import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -569,6 +571,52 @@ class GradleParserTest implements RewriteTest {
         assertThat(optionalSourceFile).isPresent();
         SourceFile sourceFile = optionalSourceFile.get();
         assertThat(sourceFile).isNotInstanceOf(ParseError.class);
+    }
+
+    @Test
+    void settingsKtsTypeAttributionWithEmptyClasspath() {
+        var parser = new GradleParser(GradleParser.builder().settingsClasspath(Collections.emptyList()));
+        Stream<SourceFile> sourceFileStream = parser.parseInputs(
+                List.of(Parser.Input.fromString(Paths.get("settings.gradle.kts"),
+                        "pluginManagement {\n    repositories {\n        gradlePluginPortal()\n    }\n}\n")),
+                null, new InMemoryExecutionContext());
+        Optional<SourceFile> sf = sourceFileStream.findFirst();
+        assertThat(sf).isPresent();
+        new org.openrewrite.TreeVisitor<org.openrewrite.Tree, Integer>() {
+            @Override
+            public org.openrewrite.Tree visit(org.openrewrite.Tree tree, Integer p) {
+                if (tree instanceof J.MethodInvocation mi && "pluginManagement".equals(mi.getSimpleName())) {
+                    assertThat(mi.getMethodType()).isNotNull();
+                    assertThat(mi.getMethodType().getDeclaringType().getFullyQualifiedName())
+                            .as("pluginManagement() should resolve to Settings")
+                            .isEqualTo("org.gradle.api.initialization.Settings");
+                }
+                return super.visit(tree, p);
+            }
+        }.visit(sf.get(), 0);
+    }
+
+    @Test
+    void buildKtsTypeAttributionWithEmptyClasspath() {
+        var parser = new GradleParser(GradleParser.builder().buildscriptClasspath(Collections.emptyList()));
+        Stream<SourceFile> sourceFileStream = parser.parseInputs(
+                List.of(Parser.Input.fromString(Paths.get("build.gradle.kts"),
+                        "repositories {\n    mavenCentral()\n}\n")),
+                null, new InMemoryExecutionContext());
+        Optional<SourceFile> sf = sourceFileStream.findFirst();
+        assertThat(sf).isPresent();
+        new org.openrewrite.TreeVisitor<org.openrewrite.Tree, Integer>() {
+            @Override
+            public org.openrewrite.Tree visit(org.openrewrite.Tree tree, Integer p) {
+                if (tree instanceof J.MethodInvocation mi && "repositories".equals(mi.getSimpleName())) {
+                    assertThat(mi.getMethodType()).isNotNull();
+                    assertThat(mi.getMethodType().getDeclaringType().getFullyQualifiedName())
+                            .as("repositories() should resolve to Project")
+                            .isEqualTo("org.gradle.api.Project");
+                }
+                return super.visit(tree, p);
+            }
+        }.visit(sf.get(), 0);
     }
 
     /**

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepositoryTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepositoryTest.java
@@ -18,10 +18,19 @@ package org.openrewrite.gradle.plugins;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.SourceFile;
+import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.kotlin.KotlinParser;
+import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpec;
+import org.openrewrite.test.SourceSpecs;
+import org.openrewrite.test.TypeValidation;
+
+import java.nio.file.Paths;
+import java.util.Collections;
 
 import static org.openrewrite.gradle.Assertions.settingsGradle;
 import static org.openrewrite.gradle.Assertions.settingsGradleKts;
@@ -678,6 +687,37 @@ class AddSettingsPluginRepositoryTest implements RewriteTest {
               }
 
               rootProject.name = "demo"
+              """
+          )
+        );
+    }
+
+    /**
+     * Helper to create settingsGradleKts specs using a GradleParser with empty settingsClasspath.
+     * When settingsClasspath is explicitly set to empty (e.g. no custom plugins in the settings
+     * buildscript), the Gradle API stubs must still be included for correct type attribution.
+     */
+    private static SourceSpecs settingsGradleKtsWithEmptyClasspath(String before) {
+        GradleParser.Builder parser = GradleParser.builder()
+                .kotlinParser(KotlinParser.builder().logCompilationWarningsAndErrors(true))
+                .settingsClasspath(Collections.emptyList());
+        SourceSpec<K.CompilationUnit> gradle = new SourceSpec<>(K.CompilationUnit.class, "gradle", parser, before, null);
+        gradle.path(Paths.get("settings.gradle.kts"));
+        return gradle;
+    }
+
+    @Test
+    void skipWhenExistsGradlePluginPortalKtsWithEmptyClasspath() {
+        rewriteRun(
+          spec -> spec.recipe(new AddSettingsPluginRepository("gradlePluginPortal", null))
+            .typeValidationOptions(TypeValidation.none()),
+          settingsGradleKtsWithEmptyClasspath(
+            """
+              pluginManagement {
+                  repositories {
+                      gradlePluginPortal()
+                  }
+              }
               """
           )
         );

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepositoryTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepositoryTest.java
@@ -710,7 +710,7 @@ class AddSettingsPluginRepositoryTest implements RewriteTest {
     void skipWhenExistsGradlePluginPortalKtsWithEmptyClasspath() {
         rewriteRun(
           spec -> spec.recipe(new AddSettingsPluginRepository("gradlePluginPortal", null))
-            .typeValidationOptions(TypeValidation.none()),
+            .typeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
           settingsGradleKtsWithEmptyClasspath(
             """
               pluginManagement {


### PR DESCRIPTION
## Problem

When `settingsClasspath` or `buildscriptClasspath` is explicitly set on `GradleParser.Builder` (even to an empty list), the parser replaces the default Gradle API stubs entirely instead of merging them. This causes incorrect type attribution on DSL methods like `pluginManagement()`, `repositories()`, and `gradlePluginPortal()`.

For example, `pluginManagement()` ends up with a garbage declaring type like `org.gradle.api.initialization.org.gradle.api.initialization.13789550265458Kt` instead of the correct `org.gradle.api.initialization.Settings`. Recipes that use `MethodMatcher` (e.g. `FindRepository`) then fail to match these methods, causing downstream recipes like `AddSettingsPluginRepository` to not detect existing entries and add duplicates.

This happens in practice when the Gradle plugin extracts the settings buildscript classpath (typically empty when there are no custom settings plugins) and passes it to `GradleParser`.

## Solution

Introduce `mergeClasspath()` which always includes the default Gradle API stubs (gradle-core-api, gradle-base-services, etc.) alongside any externally-provided classpath, using a `LinkedHashSet` to avoid duplicates. All four parser initialization paths (groovy/kotlin x build/settings) now use this method.

Includes a reproducer test that sets `settingsClasspath` to an empty list and verifies `AddSettingsPluginRepository` correctly detects an existing `gradlePluginPortal()`.

- See also #7230 which adds a recipe-level workaround for the same symptom.