### PR TITLE
Go: function expressions wrapped with `StatementExpression`

### DIFF
--- a/rewrite-go/rewrite/pkg/parser/go_parser.go
+++ b/rewrite-go/rewrite/pkg/parser/go_parser.go
@@ -1964,19 +1964,25 @@ func (ctx *parseContext) mapTypeAssertExpr(expr *ast.TypeAssertExpr) tree.Expres
 }
 
 // mapFuncLit maps a function literal (closure).
+// Wraps the MethodDeclaration in StatementExpression so it can be used as an Expression,
+// since Java's J.MethodDeclaration does not implement Expression.
 func (ctx *parseContext) mapFuncLit(expr *ast.FuncLit) tree.Expression {
 	prefix := ctx.prefixAndSkip(expr.Type.Func, len("func"))
 	params := ctx.mapFieldListAsParams(expr.Type.Params)
 	returnType := ctx.mapReturnType(expr.Type.Results)
 	body := ctx.mapBlockStmt(expr.Body)
 
-	return &tree.MethodDeclaration{
+	md := &tree.MethodDeclaration{
 		ID:         uuid.New(),
 		Prefix:     prefix,
 		Name:       &tree.Identifier{ID: uuid.New(), Name: ""},
 		Parameters: params,
 		ReturnType: returnType,
 		Body:       body,
+	}
+	return &tree.StatementExpression{
+		ID:        uuid.New(),
+		Statement: md,
 	}
 }
 

--- a/rewrite-go/rewrite/pkg/printer/go_printer.go
+++ b/rewrite-go/rewrite/pkg/printer/go_printer.go
@@ -909,6 +909,11 @@ func (p *GoPrinter) VisitTypeDecl(td *tree.TypeDecl, param any) tree.J {
 	return td
 }
 
+func (p *GoPrinter) VisitStatementExpression(se *tree.StatementExpression, param any) tree.J {
+	p.Visit(se.Statement, param)
+	return se
+}
+
 func (p *GoPrinter) VisitEmpty(empty *tree.Empty, param any) tree.J {
 	out := param.(*PrintOutputCapture)
 	p.beforeSyntax(empty.Prefix, empty.Markers, out)

--- a/rewrite-go/rewrite/pkg/rpc/go_receiver.go
+++ b/rewrite-go/rewrite/pkg/rpc/go_receiver.go
@@ -49,6 +49,13 @@ func (r *GoReceiver) Visit(node any, q *ReceiveQueue) any {
 		return r.receiveParseError(&c, q)
 	}
 
+	// StatementExpression delegates prefix/markers to wrapped statement — only receive ID
+	if se, ok := node.(*tree.StatementExpression); ok {
+		c := *se
+		q.Receive(c.ID, nil)
+		return r.receiveStatementExpression(&c, q)
+	}
+
 	// preVisit: receive ID, prefix, markers
 	node = r.preVisit(node, q)
 
@@ -564,6 +571,14 @@ func (r *GoReceiver) receiveCommClause(cc *tree.CommClause, q *ReceiveQueue) *tr
 		}
 	}
 	return cc
+}
+
+func (r *GoReceiver) receiveStatementExpression(se *tree.StatementExpression, q *ReceiveQueue) *tree.StatementExpression {
+	result := q.Receive(se.Statement, func(v any) any { return r.Visit(v, q) })
+	if result != nil {
+		se.Statement = result.(tree.Statement)
+	}
+	return se
 }
 
 func (r *GoReceiver) receiveIndexList(il *tree.IndexList, q *ReceiveQueue) *tree.IndexList {

--- a/rewrite-go/rewrite/pkg/rpc/go_sender.go
+++ b/rewrite-go/rewrite/pkg/rpc/go_sender.go
@@ -48,6 +48,13 @@ func (s *GoSender) Visit(node any, q *SendQueue) {
 		return
 	}
 
+	// StatementExpression delegates prefix/markers to wrapped statement — only send ID
+	if se, ok := node.(*tree.StatementExpression); ok {
+		q.GetAndSend(se, nodeID, nil)
+		s.sendStatementExpression(se, q)
+		return
+	}
+
 	// preVisit: send ID, prefix, markers
 	s.preVisit(node, q)
 
@@ -331,6 +338,11 @@ func (s *GoSender) sendParseError(pe *tree.ParseError, q *SendQueue) {
 	q.GetAndSend(pe, func(_ any) any { return nil }, nil) // checksum
 	q.GetAndSend(pe, func(_ any) any { return nil }, nil) // fileAttributes
 	q.GetAndSend(pe, func(v any) any { return v.(*tree.ParseError).Text }, nil)
+}
+
+func (s *GoSender) sendStatementExpression(se *tree.StatementExpression, q *SendQueue) {
+	q.GetAndSend(se, func(v any) any { return v.(*tree.StatementExpression).Statement },
+		func(v any) { s.Visit(v, q) })
 }
 
 func (s *GoSender) sendIndexList(il *tree.IndexList, q *SendQueue) {

--- a/rewrite-go/rewrite/pkg/rpc/node_helpers.go
+++ b/rewrite-go/rewrite/pkg/rpc/node_helpers.go
@@ -579,6 +579,8 @@ func extractID(v any) any {
 		return t.ID
 	case *tree.IndexList:
 		return t.ID
+	case *tree.StatementExpression:
+		return t.ID
 	// Additional J nodes
 	case *tree.AssignmentOperation:
 		return t.ID

--- a/rewrite-go/rewrite/pkg/rpc/value_types.go
+++ b/rewrite-go/rewrite/pkg/rpc/value_types.go
@@ -45,6 +45,7 @@ func init() {
 	RegisterValueType(reflect.TypeOf((*tree.MultiAssignment)(nil)), "org.openrewrite.golang.tree.Go$MultiAssignment")
 	RegisterValueType(reflect.TypeOf((*tree.CommClause)(nil)), "org.openrewrite.golang.tree.Go$CommClause")
 	RegisterValueType(reflect.TypeOf((*tree.IndexList)(nil)), "org.openrewrite.golang.tree.Go$IndexList")
+	RegisterValueType(reflect.TypeOf((*tree.StatementExpression)(nil)), "org.openrewrite.golang.tree.Go$StatementExpression")
 
 	// J (shared Java-like) node types
 	RegisterValueType(reflect.TypeOf((*tree.Identifier)(nil)), "org.openrewrite.java.tree.J$Identifier")
@@ -137,6 +138,7 @@ func init() {
 	RegisterFactory("org.openrewrite.golang.tree.Go$MultiAssignment", func() any { return &tree.MultiAssignment{} })
 	RegisterFactory("org.openrewrite.golang.tree.Go$CommClause", func() any { return &tree.CommClause{} })
 	RegisterFactory("org.openrewrite.golang.tree.Go$IndexList", func() any { return &tree.IndexList{} })
+	RegisterFactory("org.openrewrite.golang.tree.Go$StatementExpression", func() any { return &tree.StatementExpression{} })
 
 	RegisterFactory("org.openrewrite.java.tree.J$Identifier", func() any { return &tree.Identifier{} })
 	RegisterFactory("org.openrewrite.java.tree.J$Literal", func() any { return &tree.Literal{} })

--- a/rewrite-go/rewrite/pkg/tree/go.go
+++ b/rewrite-go/rewrite/pkg/tree/go.go
@@ -643,6 +643,19 @@ type VarKeyword struct {
 
 func (v VarKeyword) ID() uuid.UUID { return v.Ident }
 
+// StatementExpression wraps a Statement so it can be used as an Expression.
+// Used for Go function literals (mapped to MethodDeclaration) in expression context.
+// Prefix and markers are delegated to the wrapped statement.
+type StatementExpression struct {
+	ID        uuid.UUID
+	Statement Statement
+}
+
+func (*StatementExpression) isTree()       {}
+func (*StatementExpression) isJ()          {}
+func (*StatementExpression) isStatement()  {}
+func (*StatementExpression) isExpression() {}
+
 // TrailingComma is a marker indicating a trailing comma is present in a list.
 // The Before space is the space before the comma; After space is the space after
 // the comma (before the closing delimiter).

--- a/rewrite-go/rewrite/pkg/visitor/go_visitor.go
+++ b/rewrite-go/rewrite/pkg/visitor/go_visitor.go
@@ -141,6 +141,8 @@ func (v *GoVisitor) Visit(t tree.Tree, p any) tree.Tree {
 		return v.self().VisitMultiAssignment(n, p)
 	case *tree.CommClause:
 		return v.self().VisitCommClause(n, p)
+	case *tree.StatementExpression:
+		return v.self().VisitStatementExpression(n, p)
 	default:
 		return t
 	}
@@ -209,6 +211,7 @@ type VisitorI interface {
 	VisitInterfaceType(it *tree.InterfaceType, p any) tree.J
 	VisitMultiAssignment(ma *tree.MultiAssignment, p any) tree.J
 	VisitCommClause(cc *tree.CommClause, p any) tree.J
+	VisitStatementExpression(se *tree.StatementExpression, p any) tree.J
 	VisitSpace(space tree.Space, p any) tree.Space
 	VisitType(javaType tree.JavaType, p any) tree.JavaType
 }
@@ -590,6 +593,14 @@ func (v *GoVisitor) VisitCommClause(cc *tree.CommClause, p any) tree.J {
 	cc = cc.WithPrefix(v.self().VisitSpace(cc.Prefix, p))
 	cc = cc.WithMarkers(v.visitMarkers(cc.Markers, p))
 	return cc
+}
+
+func (v *GoVisitor) VisitStatementExpression(se *tree.StatementExpression, p any) tree.J {
+	result := v.self().Visit(se.Statement, p)
+	if stmt, ok := result.(tree.Statement); ok {
+		se.Statement = stmt
+	}
+	return se
 }
 
 func (v *GoVisitor) VisitSpace(space tree.Space, p any) tree.Space {

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangParserIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangParserIntegTest.java
@@ -379,6 +379,21 @@ class GolangParserIntegTest implements RewriteTest {
     }
 
     @Test
+    void functionLiteralReturnedFromFunction() {
+        rewriteRun(
+                go(
+                        """
+                                package main
+
+                                func wrapper() func() {
+                                \treturn func() {}
+                                }
+                                """
+                )
+        );
+    }
+
+    @Test
     void compositeAndKeyValue() {
         rewriteRun(
                 go(

--- a/rewrite-go/src/main/java/org/openrewrite/golang/GolangVisitor.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/GolangVisitor.java
@@ -239,6 +239,12 @@ public class GolangVisitor<P> extends JavaVisitor<P> {
         return c;
     }
 
+    public J visitStatementExpression(Go.StatementExpression stmtExpr, P p) {
+        Go.StatementExpression s = stmtExpr;
+        s = s.withStatement((Statement) visitAndCast(s.getStatement(), p));
+        return s;
+    }
+
     public J visitIndexList(Go.IndexList indexList, P p) {
         Go.IndexList i = indexList;
         i = i.withPrefix(visitSpace(i.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangReceiver.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangReceiver.java
@@ -45,6 +45,9 @@ public class GolangReceiver extends GolangVisitor<RpcReceiveQueue> {
 
     @Override
     public J preVisit(J j, RpcReceiveQueue q) {
+        if (j instanceof Go.StatementExpression) {
+            return j.withId(q.receiveAndGet(j.getId(), UUID::fromString));
+        }
         return ((J) j.withId(q.receiveAndGet(j.getId(), UUID::fromString)))
                 .withPrefix(q.receive(j.getPrefix(), space -> visitSpace(space, q)))
                 .withMarkers(q.receive(j.getMarkers()));
@@ -187,6 +190,12 @@ public class GolangReceiver extends GolangVisitor<RpcReceiveQueue> {
                 .withComm(q.receive(commClause.getComm(), el -> (Statement) visitNonNull(el, q)))
                 .withColon(q.receive(commClause.getColon(), space -> visitSpace(space, q)))
                 .getPadding().withBody(q.receiveList(commClause.getPadding().getBody(), stmt -> visitRightPadded(stmt, q)));
+    }
+
+    @Override
+    public J visitStatementExpression(Go.StatementExpression stmtExpr, RpcReceiveQueue q) {
+        return stmtExpr
+                .withStatement(q.receive(stmtExpr.getStatement(), stmt -> (Statement) visitNonNull(stmt, q)));
     }
 
     @Override

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangSender.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangSender.java
@@ -38,6 +38,10 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
 
     @Override
     public J preVisit(J j, RpcSendQueue q) {
+        if (j instanceof Go.StatementExpression) {
+            q.getAndSend(j, Tree::getId);
+            return j;
+        }
         q.getAndSend(j, Tree::getId);
         q.getAndSend(j, J::getPrefix, space -> visitSpace(space, q));
         q.getAndSend(j, Tree::getMarkers);
@@ -182,6 +186,12 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
         q.getAndSend(commClause, Go.CommClause::getColon, space -> visitSpace(space, q));
         q.getAndSendList(commClause, c -> c.getPadding().getBody(), stmt -> stmt.getElement().getId(), stmt -> visitRightPadded(stmt, q));
         return commClause;
+    }
+
+    @Override
+    public J visitStatementExpression(Go.StatementExpression stmtExpr, RpcSendQueue q) {
+        q.getAndSend(stmtExpr, Go.StatementExpression::getStatement, el -> visit(el, q));
+        return stmtExpr;
     }
 
     @Override

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
@@ -1622,6 +1622,65 @@ public interface Go extends J {
     }
 
     // ---------------------------------------------------------------
+    // StatementExpression (wraps a Statement for use as an Expression)
+    // ---------------------------------------------------------------
+
+    @ToString
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false)
+    @AllArgsConstructor
+    @SuppressWarnings("unchecked")
+    final class StatementExpression implements Go, Expression, Statement {
+        @With
+        @Getter
+        UUID id;
+
+        @With
+        @Getter
+        Statement statement;
+
+        @Override
+        public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {
+            return v.visitStatementExpression(this, p);
+        }
+
+        @Override
+        public <P2 extends J> P2 withPrefix(Space space) {
+            return (P2) withStatement(statement.withPrefix(space));
+        }
+
+        @Override
+        public Space getPrefix() {
+            return statement.getPrefix();
+        }
+
+        @Override
+        public <P2 extends Tree> P2 withMarkers(Markers markers) {
+            return (P2) withStatement(statement.withMarkers(markers));
+        }
+
+        @Override
+        public Markers getMarkers() {
+            return statement.getMarkers();
+        }
+
+        @Override
+        public @Nullable JavaType getType() {
+            return null;
+        }
+
+        @Override
+        public <T extends J> T withType(@Nullable JavaType type) {
+            return (T) this;
+        }
+
+        @Override
+        public CoordinateBuilder.Statement getCoordinates() {
+            return new CoordinateBuilder.Statement(this);
+        }
+    }
+
+    // ---------------------------------------------------------------
     // IndexList (Map[int, string] - multi-type-param generics)
     // ---------------------------------------------------------------
 


### PR DESCRIPTION
## What's changed?

Changing how functions as expression are parsed.
Since they are parsed as `J.MethodDeclaration`, they need to be wrapped into `StatementExpression`s.

## What's your motivation?

Otherwise it fails during RPC with messages like:
```
ClassCastException: J.MethodDeclaration cannot be cast to Expression
```