### PR TITLE
Propagate updated dependency management model to child modules

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
@@ -28,6 +28,7 @@ import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.RemoveContentVisitor;
 import org.openrewrite.xml.tree.Xml;
 
+import java.nio.file.Path;
 import java.util.*;
 
 import static java.util.Collections.max;
@@ -137,8 +138,29 @@ public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
             private Collection<String> availableVersions;
             private Set<String> safeVersionPlaceholdersToChange = new HashSet<>();
 
+            private static final String MANAGED_DEP_CHANGED_KEY = "org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId.changed";
+
             @Override
+            @SuppressWarnings("unchecked")
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
+                // Apply pending model updates from parent POM processing.
+                // When a parent POM's managed dependency is changed, UpdateMavenModel re-resolves
+                // the parent and its modules, storing updated module results in the execution context.
+                // Child modules that don't have XML changes still need their resolved model updated.
+                // Only apply if this recipe actually changed a managed dependency (tracked via MANAGED_DEP_CHANGED_KEY).
+                Set<Path> changedPoms = ctx.getMessage(MANAGED_DEP_CHANGED_KEY);
+                if (changedPoms != null && !changedPoms.isEmpty()) {
+                    Map<Path, MavenResolutionResult> updatedModules = ctx.getMessage(UpdateMavenModel.UPDATED_MODULES_KEY);
+                    if (updatedModules != null) {
+                        MavenResolutionResult pending = updatedModules.remove(document.getSourcePath());
+                        if (pending != null) {
+                            MavenResolutionResult current = document.getMarkers().findFirst(MavenResolutionResult.class).orElse(null);
+                            if (current != null) {
+                                document = document.withMarkers(document.getMarkers().computeByType(current, (original, ignored) -> pending));
+                            }
+                        }
+                    }
+                }
                 safeVersionPlaceholdersToChange = getSafeVersionPlaceholdersToChange(oldGroupId, oldArtifactId, ctx);
                 return super.visitDocument(document, ctx);
             }
@@ -189,6 +211,7 @@ public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
                         }
                     }
                     if (t != tag) {
+                        ctx.putMessageInSet(MANAGED_DEP_CHANGED_KEY, getResolutionResult().getPom().getRequested().getSourcePath());
                         maybeUpdateModel();
                         doAfterVisit(new RemoveRedundantDependencyVersions(null, null, null, null).getVisitor());
                         String effectiveGroupId = newGroupId != null ? newGroupId : tag.getChildValue("groupId").orElse(null);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
@@ -143,11 +143,7 @@ public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
             @Override
             @SuppressWarnings("unchecked")
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-                // Apply pending model updates from parent POM processing.
-                // When a parent POM's managed dependency is changed, UpdateMavenModel re-resolves
-                // the parent and its modules, storing updated module results in the execution context.
-                // Child modules that don't have XML changes still need their resolved model updated.
-                // Only apply if this recipe actually changed a managed dependency (tracked via MANAGED_DEP_CHANGED_KEY).
+                // Pick up any updated resolution for this document produced when a sibling parent POM was visited.
                 Set<Path> changedPoms = ctx.getMessage(MANAGED_DEP_CHANGED_KEY);
                 if (changedPoms != null && !changedPoms.isEmpty()) {
                     Map<Path, MavenResolutionResult> updatedModules = ctx.getMessage(UpdateMavenModel.UPDATED_MODULES_KEY);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
@@ -25,6 +25,7 @@ import org.openrewrite.xml.tree.Xml;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,6 +34,7 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 public class UpdateMavenModel<P> extends MavenVisitor<P> {
+    static final String UPDATED_MODULES_KEY = "org.openrewrite.maven.UpdateMavenModel.updatedModules";
 
     @Override
     public Xml visitDocument(Xml.Document document, P p) {
@@ -145,8 +147,9 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
                 projectPoms.put(sourcePath, requested);
             }
             MavenResolutionResult updated = updateResult(ctx, resolutionResult.withPom(resolutionResult.getPom().withRequested(requested)),
-                    projectPoms);
+                    projectPoms, false);
             markDirtyForAmbiguityRecipes(ctx, document, updated);
+            storeModuleResults(ctx, updated);
             return document.withMarkers(document.getMarkers().computeByType(getResolutionResult(),
                     (original, ignored) -> updated));
         } catch (MavenDownloadingExceptions e) {
@@ -178,6 +181,22 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private static void storeModuleResults(ExecutionContext ctx, MavenResolutionResult result) {
+        Map<Path, MavenResolutionResult> map = ctx.getMessage(UPDATED_MODULES_KEY);
+        if (map == null) {
+            map = new HashMap<>();
+            ctx.putMessage(UPDATED_MODULES_KEY, map);
+        }
+        for (MavenResolutionResult module : result.getModules()) {
+            Path modulePath = module.getPom().getRequested().getSourcePath();
+            if (modulePath != null) {
+                map.put(modulePath, module);
+            }
+            storeModuleResults(ctx, module);
+        }
+    }
+
     private @Nullable List<GroupArtifact> mapExclusions(Xml.Tag tag) {
         return tag.getChild("exclusions")
                 .map(exclusions -> {
@@ -194,26 +213,52 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
                 .orElse(null);
     }
 
-    private MavenResolutionResult updateResult(ExecutionContext ctx, MavenResolutionResult resolutionResult, Map<Path, Pom> projectPoms) throws MavenDownloadingExceptions {
+    private MavenResolutionResult updateResult(ExecutionContext ctx, MavenResolutionResult resolutionResult,
+                                               Map<Path, Pom> projectPoms, boolean isChildModule) throws MavenDownloadingExceptions {
         MavenPomDownloader downloader = new MavenPomDownloader(projectPoms, ctx, getResolutionResult().getMavenSettings(),
                 getResolutionResult().getActiveProfiles());
 
         try {
             ResolvedPom resolved = resolutionResult.getPom().resolve(ctx, downloader);
-            return resolutionResult
+            MavenResolutionResult mrr = resolutionResult
                     .withPom(resolved)
                     // Re-resolve modules best-effort: a module that is transiently unresolvable mid-recipe keeps
                     // its previous resolution rather than discarding this pom's own valid update.
                     .withModules(ListUtils.map(resolutionResult.getModules(), module -> {
                         try {
-                            return updateResult(ctx, module, projectPoms);
+                            return updateResult(ctx, module, projectPoms, true);
                         } catch (MavenDownloadingExceptions e) {
                             return module;
                         }
-                    }))
-                    .resolveDependencies(downloader, ctx);
+                    }));
+            try {
+                mrr = mrr.resolveDependencies(downloader, ctx);
+            } catch (MavenDownloadingExceptions e) {
+                if (isChildModule) {
+                    // Store the resolved POM model (with updated dependency management inherited from the
+                    // parent) before rethrowing so that this child module's model update can still be picked
+                    // up when the recipe visits the child's document, even though full dependency resolution
+                    // failed on a transiently inconsistent coordinate mid-recipe.
+                    storeSelfResult(ctx, mrr);
+                }
+                throw e;
+            }
+            return mrr;
         } catch (MavenDownloadingException e) {
             throw MavenDownloadingExceptions.append(null, e);
+        }
+    }
+
+    private static void storeSelfResult(ExecutionContext ctx, MavenResolutionResult result) {
+        Path path = result.getPom().getRequested().getSourcePath();
+        if (path != null) {
+            @SuppressWarnings("unchecked")
+            Map<Path, MavenResolutionResult> map = ctx.getMessage(UPDATED_MODULES_KEY);
+            if (map == null) {
+                map = new HashMap<>();
+                ctx.putMessage(UPDATED_MODULES_KEY, map);
+            }
+            map.put(path, result);
         }
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
@@ -191,7 +191,11 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
         for (MavenResolutionResult module : result.getModules()) {
             Path modulePath = module.getPom().getRequested().getSourcePath();
             if (modulePath != null) {
-                map.put(modulePath, module);
+                // Don't clobber a fresher model recorded by storeSelfResult: when a child module's
+                // dependency resolution failed transiently, the best-effort re-resolution above returns the
+                // child's *stale* model here, but storeSelfResult already captured the child's updated POM
+                // (with the parent's new dependency management) during recursion. Prefer that one.
+                map.putIfAbsent(modulePath, module);
             }
             storeModuleResults(ctx, module);
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
@@ -181,24 +181,26 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private static void storeModuleResults(ExecutionContext ctx, MavenResolutionResult result) {
+        Map<Path, MavenResolutionResult> map = getOrCreateUpdatedModules(ctx);
+        for (MavenResolutionResult module : result.getModules()) {
+            Path modulePath = module.getPom().getRequested().getSourcePath();
+            if (modulePath != null) {
+                // putIfAbsent: don't overwrite a fresher entry from storeSelfResult (see updateResult catch)
+                map.putIfAbsent(modulePath, module);
+            }
+            storeModuleResults(ctx, module);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<Path, MavenResolutionResult> getOrCreateUpdatedModules(ExecutionContext ctx) {
         Map<Path, MavenResolutionResult> map = ctx.getMessage(UPDATED_MODULES_KEY);
         if (map == null) {
             map = new HashMap<>();
             ctx.putMessage(UPDATED_MODULES_KEY, map);
         }
-        for (MavenResolutionResult module : result.getModules()) {
-            Path modulePath = module.getPom().getRequested().getSourcePath();
-            if (modulePath != null) {
-                // Don't clobber a fresher model recorded by storeSelfResult: when a child module's
-                // dependency resolution failed transiently, the best-effort re-resolution above returns the
-                // child's *stale* model here, but storeSelfResult already captured the child's updated POM
-                // (with the parent's new dependency management) during recursion. Prefer that one.
-                map.putIfAbsent(modulePath, module);
-            }
-            storeModuleResults(ctx, module);
-        }
+        return map;
     }
 
     private @Nullable List<GroupArtifact> mapExclusions(Xml.Tag tag) {
@@ -239,10 +241,8 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
                 mrr = mrr.resolveDependencies(downloader, ctx);
             } catch (MavenDownloadingExceptions e) {
                 if (isChildModule) {
-                    // Store the resolved POM model (with updated dependency management inherited from the
-                    // parent) before rethrowing so that this child module's model update can still be picked
-                    // up when the recipe visits the child's document, even though full dependency resolution
-                    // failed on a transiently inconsistent coordinate mid-recipe.
+                    // Preserve the child's updated POM (with parent's new management) even when
+                    // full dependency resolution fails on a transiently inconsistent coordinate.
                     storeSelfResult(ctx, mrr);
                 }
                 throw e;
@@ -256,13 +256,7 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
     private static void storeSelfResult(ExecutionContext ctx, MavenResolutionResult result) {
         Path path = result.getPom().getRequested().getSourcePath();
         if (path != null) {
-            @SuppressWarnings("unchecked")
-            Map<Path, MavenResolutionResult> map = ctx.getMessage(UPDATED_MODULES_KEY);
-            if (map == null) {
-                map = new HashMap<>();
-                ctx.putMessage(UPDATED_MODULES_KEY, map);
-            }
-            map.put(path, result);
+            getOrCreateUpdatedModules(ctx).put(path, result);
         }
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.Issue;
 import org.openrewrite.Validated;
 import org.openrewrite.java.ChangePackage;
 import org.openrewrite.java.marker.JavaSourceSet;
+import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
 
@@ -3972,6 +3973,112 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
               .containsPattern("<groupId>org\\.junit\\.jupiter</groupId>\\s*<artifactId>junit-jupiter</artifactId>\\s*<version>5\\.\\d+(\\.\\d+)?</version>")
               .doesNotContain("<groupId>junit</groupId>")
               .actual())
+          )
+        );
+    }
+
+    @Test
+    void childModuleWithUnversionedDependencyOnParentManagedDep() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
+            "javax.activation", "javax.activation-api",
+            "jakarta.activation", "jakarta.activation-api",
+            "2.1.0", null
+          )),
+          mavenProject("parent-project",
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>parent-project</artifactId>
+                    <version>1.0.0</version>
+                    <packaging>pom</packaging>
+                    <modules>
+                        <module>child-module</module>
+                    </modules>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.activation</groupId>
+                                <artifactId>javax.activation-api</artifactId>
+                                <version>1.2.0</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """,
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>parent-project</artifactId>
+                    <version>1.0.0</version>
+                    <packaging>pom</packaging>
+                    <modules>
+                        <module>child-module</module>
+                    </modules>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>jakarta.activation</groupId>
+                                <artifactId>jakarta.activation-api</artifactId>
+                                <version>2.1.0</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """
+            ),
+            mavenProject("child-module",
+              pomXml(
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                          <groupId>com.mycompany.app</groupId>
+                          <artifactId>parent-project</artifactId>
+                          <version>1.0.0</version>
+                          <relativePath>../pom.xml</relativePath>
+                      </parent>
+                      <artifactId>child-module</artifactId>
+                      <dependencies>
+                          <dependency>
+                              <groupId>javax.activation</groupId>
+                              <artifactId>javax.activation-api</artifactId>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """,
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                          <groupId>com.mycompany.app</groupId>
+                          <artifactId>parent-project</artifactId>
+                          <version>1.0.0</version>
+                          <relativePath>../pom.xml</relativePath>
+                      </parent>
+                      <artifactId>child-module</artifactId>
+                      <dependencies>
+                          <dependency>
+                              <groupId>jakarta.activation</groupId>
+                              <artifactId>jakarta.activation-api</artifactId>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """,
+                spec -> spec.path("child-module/pom.xml").afterRecipe(doc -> {
+                    MavenResolutionResult result = doc.getMarkers()
+                      .findFirst(MavenResolutionResult.class).orElseThrow();
+                    assertThat(result.getPom().getDependencyManagement())
+                      .describedAs("Child should see jakarta.activation:jakarta.activation-api:2.1.0 from parent")
+                      .anyMatch(dep -> "jakarta.activation".equals(dep.getGroupId())
+                                       && "jakarta.activation-api".equals(dep.getArtifactId())
+                                       && "2.1.0".equals(dep.getVersion()));
+                })
+              )
+            )
           )
         );
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactIdTest.java
@@ -681,7 +681,6 @@ class ChangeManagedDependencyGroupIdAndArtifactIdTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/moderneinc/customer-requests/issues/1522")
     @Test
     void childModuleSeesUpdatedManagedDependencyFromParent() {
         rewriteRun(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactIdTest.java
@@ -19,9 +19,11 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.Validated;
+import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class ChangeManagedDependencyGroupIdAndArtifactIdTest implements RewriteTest {
@@ -675,6 +677,105 @@ class ChangeManagedDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                   </dependencyManagement>
               </project>
               """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/1522")
+    @Test
+    void childModuleSeesUpdatedManagedDependencyFromParent() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeManagedDependencyGroupIdAndArtifactId(
+            "javax.activation",
+            "javax.activation-api",
+            "jakarta.activation",
+            "jakarta.activation-api",
+            "2.1.0"
+          )),
+          mavenProject(
+            "parent-project",
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>parent-project</artifactId>
+                    <version>1.0.0</version>
+                    <packaging>pom</packaging>
+                    <modules>
+                        <module>child-module</module>
+                    </modules>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.activation</groupId>
+                                <artifactId>javax.activation-api</artifactId>
+                                <version>1.2.0</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """,
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>parent-project</artifactId>
+                    <version>1.0.0</version>
+                    <packaging>pom</packaging>
+                    <modules>
+                        <module>child-module</module>
+                    </modules>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>jakarta.activation</groupId>
+                                <artifactId>jakarta.activation-api</artifactId>
+                                <version>2.1.0</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """
+            ),
+            mavenProject(
+              "child-module",
+              pomXml(
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                          <groupId>com.mycompany.app</groupId>
+                          <artifactId>parent-project</artifactId>
+                          <version>1.0.0</version>
+                          <relativePath>../pom.xml</relativePath>
+                      </parent>
+                      <artifactId>child-module</artifactId>
+                      <dependencies>
+                          <dependency>
+                              <groupId>javax.activation</groupId>
+                              <artifactId>javax.activation-api</artifactId>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """,
+                // Child XML is unchanged (dependency stays version-less); the fix propagates the
+                // parent's managed-dependency change into the child's resolved model, asserted below.
+                spec -> spec.path("child-module/pom.xml").afterRecipe(doc -> {
+                    MavenResolutionResult result = doc.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+                    // The child's resolved dependency management should reflect the parent's change
+                    assertThat(result.getPom().getDependencyManagement())
+                      .describedAs("Child module should see jakarta.activation:jakarta.activation-api:2.1.0 from parent")
+                      .anyMatch(dep -> "jakarta.activation".equals(dep.getGroupId())
+                                       && "jakarta.activation-api".equals(dep.getArtifactId())
+                                       && "2.1.0".equals(dep.getVersion()));
+                    assertThat(result.getPom().getDependencyManagement())
+                      .describedAs("Child module should no longer see javax.activation:javax.activation-api")
+                      .noneMatch(dep -> "javax.activation".equals(dep.getGroupId())
+                                        && "javax.activation-api".equals(dep.getArtifactId()));
+                })
+              )
+            )
           )
         );
     }


### PR DESCRIPTION
## Summary

- When `ChangeManagedDependencyGroupIdAndArtifactId` changes a parent POM's managed dependency coordinates, child modules now get their resolved model updated even though their XML doesn't change
- `UpdateMavenModel` stores resolved module results in the execution context so they can be applied to child documents when visited
- When a child module's dependency resolution fails during parent model update (due to temporarily inconsistent coordinates), the child's resolved POM model is preserved before rethrowing

## Test plan

- [x] `ChangeManagedDependencyGroupIdAndArtifactIdTest.childModuleSeesUpdatedManagedDependencyFromParent` — multi-module project where parent managed dep changes, child has unversioned dependency on old coordinates, verifies child model is updated
- [x] `ChangeDependencyGroupIdAndArtifactIdTest.childModuleWithUnversionedDependencyOnParentManagedDep` — realistic scenario where both dependency and managed dependency are changed together
- [x] Full `rewrite-maven` test suite (1287 tests) passes with no regressions