### PR TITLE
C#: Fix SearchResult.Found using dynamic dispatch instead of reflection

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
@@ -51,6 +51,8 @@ public sealed class ExpressionStatement(
     // ExpressionStatement delegates prefix/markers to its expression
     public Space Prefix => Expression.Prefix;
     public Markers Markers => Expression.Markers;
+    public ExpressionStatement WithMarkers(Markers markers) =>
+        new(Id, (Expression)((dynamic)Expression).WithMarkers(markers));
 
     Tree Tree.WithId(Guid id) => WithId(id);
 

--- a/rewrite-csharp/csharp/OpenRewrite/Core/SearchResult.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/SearchResult.cs
@@ -33,8 +33,7 @@ public sealed class SearchResult(Guid id, string? description) : Marker, IRpcCod
     public static T Found<T>(T tree, string? description = null) where T : J
     {
         var newMarkers = tree.Markers.Add(new SearchResult(Guid.NewGuid(), description));
-        var withMarkers = tree.GetType().GetMethod("WithMarkers", [typeof(Markers)]);
-        return withMarkers != null ? (T)withMarkers.Invoke(tree, [newMarkers])! : tree;
+        return (T)(object)((dynamic)tree).WithMarkers(newMarkers);
     }
 
     public void RpcSend(SearchResult after, RpcSendQueue q)


### PR DESCRIPTION
## Summary

- Replace fragile `GetMethod` reflection in `SearchResult.Found<T>()` with `dynamic` dispatch

The original code used `tree.GetType().GetMethod("WithMarkers", ...)` which silently returned `null`, causing `Found` to return the same tree instance unchanged. Dynamic dispatch reliably resolves `WithMarkers` on any concrete type at runtime.

## Context

Two `PreconditionsCheckTest` tests have been failing on main since 71809c7 invalidated the Gradle build cache, causing `csharpTest` to actually execute for the first time:

1. `CheckDelegatesToVisitorWhenPreconditionMatches` — `Assert.NotSame()` failure (same object returned)
2. `PreconditionMatchesAndVisitorRuns` — "Recipe was expected to make changes" (no marker added)

These tests were never caught earlier because `:rewrite-csharp:csharpTest` was `FROM-CACHE` in CI.

## Test plan

- [x] All 4 `PreconditionsCheckTest` tests pass locally (including both previously failing)
- [ ] CI passes — specifically `:rewrite-csharp:csharpTest`