### PR TITLE
Add Zig language support module (rewrite-zig)

### DIFF
--- a/rewrite-zig/build.gradle.kts
+++ b/rewrite-zig/build.gradle.kts
@@ -1,0 +1,141 @@
+plugins {
+    id("org.openrewrite.build.language-library")
+    id("org.openrewrite.build.moderne-source-available-license")
+    id("jvm-test-suite")
+}
+
+dependencies {
+    api(project(":rewrite-core"))
+    api(project(":rewrite-java"))
+
+    api("org.jetbrains:annotations:latest.release")
+    api("com.fasterxml.jackson.core:jackson-annotations")
+
+    implementation("io.moderne:jsonrpc:latest.integration")
+
+    compileOnly(project(":rewrite-test"))
+
+    testImplementation(project(":rewrite-test"))
+    testImplementation("io.moderne:jsonrpc:latest.integration")
+    testRuntimeOnly(project(":rewrite-java-21"))
+}
+
+tasks.withType<Javadoc>().configureEach {
+    (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:none", "-quiet")
+    exclude("**/Z.java")
+}
+
+val zigBuild = tasks.register<Exec>("zigBuild") {
+    workingDir = file("rewrite")
+
+    // Use zig build-exe directly since `zig build` has linker issues on
+    // macOS Tahoe (26.x) with Zig 0.15.x where the build runner itself
+    // fails to link. Specifying an explicit macOS target range works around this.
+    val dst = layout.buildDirectory.file("rewrite-zig-rpc").get().asFile
+    val isMacOS = System.getProperty("os.name").lowercase().contains("mac")
+    val isArm = System.getProperty("os.arch") == "aarch64"
+    if (isMacOS && isArm) {
+        commandLine(
+            "zig", "build-exe",
+            "src/main.zig",
+            "-target", "aarch64-macos.15.0...26.4",
+            "-lc",
+            "-O", "ReleaseSafe",
+            "--name", "rewrite-zig-rpc"
+        )
+    } else if (isMacOS) {
+        commandLine(
+            "zig", "build-exe",
+            "src/main.zig",
+            "-target", "x86_64-macos.13.0...26.4",
+            "-lc",
+            "-O", "ReleaseSafe",
+            "--name", "rewrite-zig-rpc"
+        )
+    } else {
+        commandLine(
+            "zig", "build-exe",
+            "src/main.zig",
+            "-lc",
+            "-O", "ReleaseSafe",
+            "--name", "rewrite-zig-rpc"
+        )
+    }
+
+    inputs.files(fileTree("rewrite") {
+        include("**/*.zig")
+        include("build.zig")
+        include("build.zig.zon")
+    }).withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.file(layout.buildDirectory.file("rewrite-zig-rpc"))
+
+    doLast {
+        val src = file("rewrite/rewrite-zig-rpc")
+        dst.parentFile.mkdirs()
+        src.copyTo(dst, overwrite = true)
+        dst.setExecutable(true)
+        // Clean up the output in the working directory
+        src.delete()
+    }
+}
+
+val zigTest = tasks.register<Exec>("zigTest") {
+    group = "verification"
+    description = "Run Zig native tests"
+
+    workingDir = file("rewrite")
+
+    // Use zig build-obj -ftest to run tests, similar to zigBuild workaround
+    // for macOS linker issues with zig 0.15.x
+    val isMacOS = System.getProperty("os.name").lowercase().contains("mac")
+    val isArm = System.getProperty("os.arch") == "aarch64"
+    if (isMacOS && isArm) {
+        commandLine(
+            "zig", "test",
+            "src/main.zig",
+            "-target", "aarch64-macos.15.0...26.4",
+            "-lc"
+        )
+    } else if (isMacOS) {
+        commandLine(
+            "zig", "test",
+            "src/main.zig",
+            "-target", "x86_64-macos.13.0...26.4",
+            "-lc"
+        )
+    } else {
+        commandLine("zig", "test", "src/main.zig", "-lc")
+    }
+
+    inputs.files(fileTree("rewrite") {
+        include("**/*.zig")
+    }).withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.cacheIf { true }
+}
+
+tasks.named("check") {
+    dependsOn(zigTest)
+}
+
+testing {
+    suites {
+        register<JvmTestSuite>("integTest") {
+            useJUnitJupiter()
+
+            targets {
+                all {
+                    testTask.configure {
+                        dependsOn(zigBuild)
+                    }
+                }
+            }
+
+            dependencies {
+                implementation(project())
+                implementation(project(":rewrite-java-21"))
+                implementation(project(":rewrite-test"))
+                implementation("org.assertj:assertj-core:latest.release")
+            }
+        }
+    }
+}

--- a/rewrite-zig/rewrite/.gitignore
+++ b/rewrite-zig/rewrite/.gitignore
@@ -1,0 +1,5 @@
+zig-out/
+.zig-cache/
+zig-cache/
+*.o
+*.dSYM/

--- a/rewrite-zig/rewrite/build.zig
+++ b/rewrite-zig/rewrite/build.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe_mod = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "rewrite-zig-rpc",
+        .root_module = exe_mod,
+    });
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    const run_step = b.step("run", "Run the RPC server");
+    run_step.dependOn(&run_cmd.step);
+
+    const test_mod = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const unit_tests = b.addTest(.{
+        .root_module = test_mod,
+    });
+
+    const run_unit_tests = b.addRunArtifact(unit_tests);
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_unit_tests.step);
+}

--- a/rewrite-zig/rewrite/build.zig.zon
+++ b/rewrite-zig/rewrite/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .rewrite_zig_rpc,
+    .version = "0.1.0",
+    .fingerprint = 0x4326d4836bd31a8a,
+    .minimum_zig_version = "0.15.0",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/rewrite-zig/rewrite/src/main.zig
+++ b/rewrite-zig/rewrite/src/main.zig
@@ -1,0 +1,670 @@
+// Copyright 2025 the original author or authors.
+//
+// Licensed under the Moderne Source Available License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://docs.moderne.io/licensing/moderne-source-available-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! JSON-RPC 2.0 server for OpenRewrite Zig language support.
+//! Communicates over stdin/stdout using Content-Length framed messages (LSP protocol).
+
+const std = @import("std");
+const rpc = @import("rpc.zig");
+const parser = @import("parser.zig");
+const printer_mod = @import("printer.zig");
+const sender_mod = @import("sender.zig");
+const tree = @import("tree.zig");
+
+const RpcObjectData = rpc.RpcObjectData;
+const State = rpc.State;
+const SendQueue = rpc.SendQueue;
+const ParseContext = parser.ParseContext;
+const Sender = sender_mod.Sender;
+const LstNode = tree.LstNode;
+
+/// Configuration parsed from command-line arguments.
+const Config = struct {
+    log_file_path: ?[]const u8 = null,
+    trace_rpc_messages: bool = false,
+};
+
+/// The RPC server state.
+const Server = struct {
+    allocator: std.mem.Allocator,
+    local_objects: std.StringHashMap(StoredObject),
+    remote_objects: std.StringHashMap(StoredObject),
+    batch_size: usize = 1000,
+    log_file: ?std.fs.File = null,
+    trace_rpc: bool = false,
+
+    /// A stored parsed compilation unit.
+    const StoredObject = struct {
+        source: []const u8,
+        source_path: []const u8,
+        id: []const u8,
+        /// The parsed LST tree (null if parsing failed, falls back to legacy behavior).
+        lst: ?LstNode = null,
+    };
+
+    fn init(allocator: std.mem.Allocator) Server {
+        return .{
+            .allocator = allocator,
+            .local_objects = std.StringHashMap(StoredObject).init(allocator),
+            .remote_objects = std.StringHashMap(StoredObject).init(allocator),
+        };
+    }
+
+    fn deinit(self: *Server) void {
+        var it = self.local_objects.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.value_ptr.source);
+            self.allocator.free(entry.value_ptr.source_path);
+            self.allocator.free(entry.value_ptr.id);
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.local_objects.deinit();
+
+        var rit = self.remote_objects.iterator();
+        while (rit.next()) |entry| {
+            self.allocator.free(entry.value_ptr.source);
+            self.allocator.free(entry.value_ptr.source_path);
+            self.allocator.free(entry.value_ptr.id);
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.remote_objects.deinit();
+
+        if (self.log_file) |f| f.close();
+    }
+
+    fn log(self: *Server, comptime fmt: []const u8, args: anytype) void {
+        if (self.log_file) |f| {
+            var buf: [4096]u8 = undefined;
+            var w = f.writer(&buf);
+            w.interface.print(fmt, args) catch {};
+            w.interface.print("\n", .{}) catch {};
+            w.interface.flush() catch {};
+        }
+    }
+
+    fn handleRequest(self: *Server, req_json: std.json.Value) !std.json.Value {
+        const obj = if (req_json == .object) req_json.object else return self.makeErrorResponse(null, -32700, "Parse error");
+
+        const id = obj.get("id") orelse std.json.Value.null;
+        const method_val = obj.get("method") orelse return self.makeErrorResponse(id, -32600, "Invalid Request: missing method");
+        const method = if (method_val == .string) method_val.string else return self.makeErrorResponse(id, -32600, "Invalid Request: method must be string");
+        const params = obj.get("params") orelse std.json.Value.null;
+
+        self.log("Handling: {s}", .{method});
+
+        if (std.mem.eql(u8, method, "GetLanguages")) {
+            return self.handleGetLanguages(id);
+        } else if (std.mem.eql(u8, method, "Parse")) {
+            return self.handleParse(id, params);
+        } else if (std.mem.eql(u8, method, "GetObject")) {
+            return self.handleGetObject(id, params);
+        } else if (std.mem.eql(u8, method, "Print")) {
+            return self.handlePrint(id, params);
+        } else if (std.mem.eql(u8, method, "Reset")) {
+            return self.handleReset(id);
+        } else {
+            return self.makeErrorResponseMsg(id, -32601, "Unknown method");
+        }
+    }
+
+    fn handleGetLanguages(self: *Server, id: std.json.Value) !std.json.Value {
+        var result_obj = std.json.ObjectMap.init(self.allocator);
+        try result_obj.put("jsonrpc", std.json.Value{ .string = "2.0" });
+        try result_obj.put("id", id);
+
+        var arr = std.json.Array.init(self.allocator);
+        try arr.append(std.json.Value{ .string = "org.openrewrite.zig.tree.Zig$CompilationUnit" });
+        try result_obj.put("result", std.json.Value{ .array = arr });
+        return std.json.Value{ .object = result_obj };
+    }
+
+    fn handleParse(self: *Server, id: std.json.Value, params: std.json.Value) !std.json.Value {
+        if (params != .object) {
+            return self.makeErrorResponseMsg(id, -32602, "Invalid params: expected object");
+        }
+        const params_obj = params.object;
+
+        // Extract inputs array
+        const inputs_val = params_obj.get("inputs") orelse return self.makeErrorResponseMsg(id, -32602, "Missing 'inputs' parameter");
+        if (inputs_val != .array) {
+            return self.makeErrorResponseMsg(id, -32602, "Invalid params: 'inputs' must be array");
+        }
+        const inputs = inputs_val.array;
+
+        // Get optional relativeTo
+        const relative_to: ?[]const u8 = blk: {
+            if (params_obj.get("relativeTo")) |rt| {
+                if (rt == .string) break :blk rt.string;
+            }
+            break :blk null;
+        };
+
+        var result_ids = std.json.Array.init(self.allocator);
+
+        for (inputs.items) |input_val| {
+            if (input_val != .object) continue;
+            const input_obj = input_val.object;
+
+            var source: ?[]const u8 = null;
+            var source_path: ?[]const u8 = null;
+
+            // Check for path-based input
+            if (input_obj.get("path")) |path_val| {
+                if (path_val == .string and path_val.string.len > 0) {
+                    const file_path = path_val.string;
+                    // Read file content
+                    const file = std.fs.openFileAbsolute(file_path, .{}) catch |err| {
+                        self.log("Failed to open file {s}: {}", .{ file_path, err });
+                        return self.makeErrorResponseMsg(id, -32603, "Failed to read file");
+                    };
+                    defer file.close();
+                    var read_buf: [8192]u8 = undefined;
+                    var reader = file.reader(&read_buf);
+                    const content = reader.interface.allocRemaining(self.allocator, .unlimited) catch |err| {
+                        self.log("Failed to read file {s}: {}", .{ file_path, err });
+                        return self.makeErrorResponseMsg(id, -32603, "Failed to read file");
+                    };
+                    source = content;
+
+                    // Compute relative path if relativeTo is set
+                    if (relative_to) |rel| {
+                        _ = rel;
+                        // For simplicity, use the full path; proper relative path computation
+                        // would need std.fs.path.relative which may differ in 0.15
+                        source_path = try self.allocator.dupe(u8, file_path);
+                    } else {
+                        source_path = try self.allocator.dupe(u8, file_path);
+                    }
+                }
+            }
+
+            // Check for text-based input
+            if (source == null) {
+                if (input_obj.get("text")) |text_val| {
+                    if (text_val == .string and text_val.string.len > 0) {
+                        source = try self.allocator.dupe(u8, text_val.string);
+                        if (input_obj.get("sourcePath")) |sp_val| {
+                            if (sp_val == .string) {
+                                source_path = try self.allocator.dupe(u8, sp_val.string);
+                            }
+                        }
+                        if (source_path == null) {
+                            source_path = try self.allocator.dupe(u8, "<unknown>");
+                        }
+                    }
+                }
+            }
+
+            if (source == null) continue;
+
+            // Generate a UUID for this compilation unit
+            const uuid = generateUuid();
+            const uuid_str = try self.allocator.dupe(u8, &uuid);
+
+            // Parse the source into an LST tree
+            var lst_node: ?LstNode = null;
+            parse_blk: {
+                // We need a null-terminated copy for std.zig.Ast.parse
+                const source_z = self.allocator.dupeZ(u8, source.?) catch break :parse_blk;
+                var ast = std.zig.Ast.parse(self.allocator, source_z, .zig) catch break :parse_blk;
+                _ = &ast; // ast is owned by the allocator, kept alive while server lives
+
+                var ctx = ParseContext.init(self.allocator, source.?, source_z, ast);
+                const mapped = ctx.mapFile(source_path.?, uuid_str) catch break :parse_blk;
+                lst_node = mapped;
+            }
+
+            // Store the parsed object
+            const key = try self.allocator.dupe(u8, uuid_str);
+            try self.local_objects.put(key, .{
+                .source = source.?,
+                .source_path = source_path.?,
+                .id = try self.allocator.dupe(u8, uuid_str),
+                .lst = lst_node,
+            });
+
+            self.log("Parsed {s} -> {s} (lst={s})", .{
+                source_path.?,
+                uuid_str,
+                if (lst_node != null) "yes" else "no",
+            });
+
+            try result_ids.append(std.json.Value{ .string = uuid_str });
+        }
+
+        var result_obj = std.json.ObjectMap.init(self.allocator);
+        try result_obj.put("jsonrpc", std.json.Value{ .string = "2.0" });
+        try result_obj.put("id", id);
+        try result_obj.put("result", std.json.Value{ .array = result_ids });
+        return std.json.Value{ .object = result_obj };
+    }
+
+    fn handleGetObject(self: *Server, id: std.json.Value, params: std.json.Value) !std.json.Value {
+        if (params != .object) {
+            return self.makeErrorResponseMsg(id, -32602, "Invalid params: expected object");
+        }
+        const params_obj = params.object;
+
+        const obj_id_val = params_obj.get("id") orelse return self.makeErrorResponseMsg(id, -32602, "Missing 'id' parameter");
+        const obj_id = if (obj_id_val == .string) obj_id_val.string else return self.makeErrorResponseMsg(id, -32602, "'id' must be string");
+
+        const stored = self.local_objects.get(obj_id) orelse {
+            // Object not found - return DELETE + END_OF_OBJECT
+            var batch = std.json.Array.init(self.allocator);
+            try batch.append(try (RpcObjectData{ .state = .delete }).toJsonValue(self.allocator));
+            try batch.append(try (RpcObjectData{ .state = .end_of_object }).toJsonValue(self.allocator));
+            var result_obj = std.json.ObjectMap.init(self.allocator);
+            try result_obj.put("jsonrpc", std.json.Value{ .string = "2.0" });
+            try result_obj.put("id", id);
+            try result_obj.put("result", std.json.Value{ .array = batch });
+            return std.json.Value{ .object = result_obj };
+        };
+
+        var queue = SendQueue.init(self.allocator, self.batch_size);
+        defer queue.deinit();
+
+        if (stored.lst) |lst| {
+            // Use the Sender to serialize the parsed LST tree
+            var snd = Sender.init(&queue, self.allocator);
+            try snd.send(lst);
+        } else {
+            // No parsed tree, use legacy serialization
+            try self.legacySerialize(&queue, stored);
+        }
+
+        // END_OF_OBJECT sentinel
+        try queue.sendEndOfObject();
+
+        // Build response
+        const result = try queue.toJsonArray(self.allocator);
+        var result_obj = std.json.ObjectMap.init(self.allocator);
+        try result_obj.put("jsonrpc", std.json.Value{ .string = "2.0" });
+        try result_obj.put("id", id);
+        try result_obj.put("result", result);
+        return std.json.Value{ .object = result_obj };
+    }
+
+    fn handlePrint(self: *Server, id: std.json.Value, params: std.json.Value) !std.json.Value {
+        if (params != .object) {
+            return self.wrapResult(id, std.json.Value{ .string = "" });
+        }
+        const params_obj = params.object;
+
+        const obj_id_val = params_obj.get("treeId") orelse
+            params_obj.get("id") orelse
+            return self.wrapResult(id, std.json.Value{ .string = "" });
+
+        const obj_id_str = if (obj_id_val == .string) obj_id_val.string else return self.wrapResult(id, std.json.Value{ .string = "" });
+
+        const stored = self.local_objects.get(obj_id_str) orelse return self.wrapResult(id, std.json.Value{ .string = "" });
+
+        // Use printer if we have a parsed tree
+        if (stored.lst) |t| {
+            const printed = printer_mod.print(self.allocator, t) catch {
+                // Fall back to stored source on printer error
+                return self.wrapResult(id, std.json.Value{ .string = stored.source });
+            };
+            defer self.allocator.free(printed);
+            // Duplicate the string since the response outlives this scope
+            const result = self.allocator.dupe(u8, printed) catch {
+                return self.wrapResult(id, std.json.Value{ .string = stored.source });
+            };
+            return self.wrapResult(id, std.json.Value{ .string = result });
+        }
+        // Fallback to stored source
+        return self.wrapResult(id, std.json.Value{ .string = stored.source });
+    }
+
+    fn handleReset(self: *Server, id: std.json.Value) !std.json.Value {
+        // Clear all local objects
+        var it = self.local_objects.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.value_ptr.source);
+            self.allocator.free(entry.value_ptr.source_path);
+            self.allocator.free(entry.value_ptr.id);
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.local_objects.clearAndFree();
+
+        var rit = self.remote_objects.iterator();
+        while (rit.next()) |entry| {
+            self.allocator.free(entry.value_ptr.source);
+            self.allocator.free(entry.value_ptr.source_path);
+            self.allocator.free(entry.value_ptr.id);
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.remote_objects.clearAndFree();
+
+        self.log("Reset: cleared all cached state", .{});
+
+        var result_obj = std.json.ObjectMap.init(self.allocator);
+        try result_obj.put("jsonrpc", std.json.Value{ .string = "2.0" });
+        try result_obj.put("id", id);
+        try result_obj.put("result", std.json.Value{ .bool = true });
+        return std.json.Value{ .object = result_obj };
+    }
+
+    /// Legacy serialization for when the parser failed or returned null.
+    /// Produces the same output as the old handleGetObject.
+    fn legacySerialize(self: *Server, queue: *SendQueue, stored: StoredObject) !void {
+        // --- Top-level ADD ---
+        try queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.zig.tree.Zig$CompilationUnit",
+        });
+
+        // --- preVisit fields ---
+        try queue.sendAdd(null, std.json.Value{ .string = stored.id });
+        try self.sendSpace(queue, extractPrefix(stored.source));
+        try self.sendEmptyMarkers(queue);
+
+        // --- CompilationUnit fields ---
+        try queue.sendAdd(null, std.json.Value{ .string = stored.source_path });
+        try queue.sendAdd(null, std.json.Value{ .string = "UTF-8" });
+        try queue.sendAdd(null, std.json.Value{ .bool = false });
+        try queue.sendDelete();
+        try queue.sendDelete();
+        try queue.sendDelete();
+        try self.sendEmptyList(queue);
+        try self.sendSpace(queue, extractTrailing(stored.source));
+    }
+
+    /// Send a Space with the given whitespace. Comments list is always empty for now.
+    /// Space serialization order (matches JavaSender.visitSpace):
+    ///   1. comments (list via getAndSendList)
+    ///   2. whitespace (string via getAndSend)
+    fn sendSpace(self: *Server, queue: *SendQueue, ws: []const u8) !void {
+        // The Space object itself: ADD with valueType
+        try queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.Space",
+        });
+        // comments list: ADD (empty list) + CHANGE (positions=[])
+        try self.sendEmptyList(queue);
+        // whitespace
+        try queue.sendAdd(null, std.json.Value{ .string = ws });
+    }
+
+    /// Send empty Markers (id=UUID, markers=[]).
+    /// Markers serialization order (matches Markers.rpcSend):
+    ///   1. id (UUID via getAndSend)
+    ///   2. markers (list via getAndSendListAsRef)
+    fn sendEmptyMarkers(self: *Server, queue: *SendQueue) !void {
+        try queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.marker.Markers",
+        });
+        // Markers.id
+        const markers_uuid = generateUuid();
+        const markers_uuid_str = try self.allocator.dupe(u8, &markers_uuid);
+        try queue.sendAdd(null, std.json.Value{ .string = markers_uuid_str });
+        // Markers.markers (empty list)
+        try self.sendEmptyList(queue);
+    }
+
+    /// Send an empty list: ADD + CHANGE with positions=[].
+    fn sendEmptyList(self: *Server, queue: *SendQueue) !void {
+        try queue.put(.{ .state = .add });
+        try queue.put(.{
+            .state = .change,
+            .value = std.json.Value{ .array = std.json.Array.init(self.allocator) },
+        });
+    }
+
+    fn wrapResult(self: *Server, id: std.json.Value, result: std.json.Value) !std.json.Value {
+        var result_obj = std.json.ObjectMap.init(self.allocator);
+        try result_obj.put("jsonrpc", std.json.Value{ .string = "2.0" });
+        try result_obj.put("id", id);
+        try result_obj.put("result", result);
+        return std.json.Value{ .object = result_obj };
+    }
+
+    fn makeErrorResponse(self: *Server, id: ?std.json.Value, code: i64, message: []const u8) !std.json.Value {
+        return self.makeErrorResponseMsg(id orelse std.json.Value.null, code, message);
+    }
+
+    fn makeErrorResponseMsg(self: *Server, id: std.json.Value, code: i64, message: []const u8) !std.json.Value {
+        var err_obj = std.json.ObjectMap.init(self.allocator);
+        try err_obj.put("code", std.json.Value{ .integer = code });
+        try err_obj.put("message", std.json.Value{ .string = message });
+
+        var result_obj = std.json.ObjectMap.init(self.allocator);
+        try result_obj.put("jsonrpc", std.json.Value{ .string = "2.0" });
+        try result_obj.put("id", id);
+        try result_obj.put("error", std.json.Value{ .object = err_obj });
+        return std.json.Value{ .object = result_obj };
+    }
+};
+
+fn isWhitespace(c: u8) bool {
+    return c == ' ' or c == '\t' or c == '\n' or c == '\r';
+}
+
+/// Extract leading whitespace and line comments before the first real token.
+fn extractPrefix(source: []const u8) []const u8 {
+    var i: usize = 0;
+    while (i < source.len) {
+        if (isWhitespace(source[i])) {
+            i += 1;
+            continue;
+        }
+        // Skip line comments (// ...)
+        if (i + 1 < source.len and source[i] == '/' and source[i + 1] == '/') {
+            while (i < source.len and source[i] != '\n') : (i += 1) {}
+            if (i < source.len) i += 1; // skip the \n
+            continue;
+        }
+        break;
+    }
+    return source[0..i];
+}
+
+/// Extract trailing whitespace after the last non-whitespace character.
+fn extractTrailing(source: []const u8) []const u8 {
+    var end = source.len;
+    while (end > 0 and isWhitespace(source[end - 1])) {
+        end -= 1;
+    }
+    return source[end..];
+}
+
+/// Generate a v4 UUID string.
+fn generateUuid() [36]u8 {
+    var bytes: [16]u8 = undefined;
+    std.crypto.random.bytes(&bytes);
+    // Set version 4
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    // Set variant
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    var result: [36]u8 = undefined;
+    const hex = "0123456789abcdef";
+    var pos: usize = 0;
+    for (bytes, 0..) |b, i| {
+        if (i == 4 or i == 6 or i == 8 or i == 10) {
+            result[pos] = '-';
+            pos += 1;
+        }
+        result[pos] = hex[b >> 4];
+        result[pos + 1] = hex[b & 0x0f];
+        pos += 2;
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------
+// Content-Length framed I/O
+// ---------------------------------------------------------------
+
+/// Read a Content-Length framed message from stdin using raw POSIX reads.
+fn readMessage(allocator: std.mem.Allocator) !?std.json.Value {
+    // Read the Content-Length header line byte-by-byte
+    var header_buf: [256]u8 = undefined;
+    var header_len: usize = 0;
+
+    // Read until we get "\r\n" or "\n"
+    while (header_len < header_buf.len) {
+        var byte: [1]u8 = undefined;
+        const n = std.posix.read(std.posix.STDIN_FILENO, &byte) catch return null;
+        if (n == 0) return null; // EOF
+        header_buf[header_len] = byte[0];
+        header_len += 1;
+
+        // Check for end of line
+        if (header_len >= 1 and header_buf[header_len - 1] == '\n') break;
+    }
+
+    // Trim and parse the header
+    var header_str = header_buf[0..header_len];
+    // Trim trailing \r\n
+    while (header_str.len > 0 and (header_str[header_str.len - 1] == '\n' or header_str[header_str.len - 1] == '\r')) {
+        header_str = header_str[0 .. header_str.len - 1];
+    }
+
+    const prefix = "Content-Length:";
+    if (!std.mem.startsWith(u8, header_str, prefix)) {
+        return error.InvalidHeader;
+    }
+    const length_str = std.mem.trimLeft(u8, header_str[prefix.len..], " ");
+    const content_length = std.fmt.parseInt(usize, length_str, 10) catch return error.InvalidContentLength;
+
+    // Read the empty separator line (\r\n)
+    var sep_buf: [256]u8 = undefined;
+    var sep_len: usize = 0;
+    while (sep_len < sep_buf.len) {
+        var byte: [1]u8 = undefined;
+        const n = std.posix.read(std.posix.STDIN_FILENO, &byte) catch return null;
+        if (n == 0) return null;
+        sep_buf[sep_len] = byte[0];
+        sep_len += 1;
+        if (sep_len >= 1 and sep_buf[sep_len - 1] == '\n') break;
+    }
+
+    // Read the message body
+    const body = try allocator.alloc(u8, content_length);
+    defer allocator.free(body);
+    var total_read: usize = 0;
+    while (total_read < content_length) {
+        const n = std.posix.read(std.posix.STDIN_FILENO, body[total_read..]) catch return null;
+        if (n == 0) return null; // EOF
+        total_read += n;
+    }
+
+    // Parse the JSON
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, body[0..content_length], .{
+        .allocate = .alloc_always,
+    });
+    return parsed.value;
+}
+
+/// Write a Content-Length framed message to stdout using raw POSIX writes.
+fn writeMessage(allocator: std.mem.Allocator, value: std.json.Value) !void {
+    // Serialize the JSON value to bytes
+    const body = try std.json.Stringify.valueAlloc(allocator, value, .{});
+    defer allocator.free(body);
+
+    // Format the header
+    var header_buf: [64]u8 = undefined;
+    const header = std.fmt.bufPrint(&header_buf, "Content-Length: {d}\r\n\r\n", .{body.len}) catch unreachable;
+
+    // Write header + body atomically
+    _ = std.posix.write(std.posix.STDOUT_FILENO, header) catch return error.WriteFailed;
+    _ = std.posix.write(std.posix.STDOUT_FILENO, body) catch return error.WriteFailed;
+}
+
+/// Parse command-line arguments.
+fn parseArgs(allocator: std.mem.Allocator) Config {
+    const args = std.process.argsAlloc(allocator) catch return .{};
+    defer std.process.argsFree(allocator, args);
+
+    var config = Config{};
+    for (args[1..]) |arg| {
+        if (std.mem.startsWith(u8, arg, "--log-file=")) {
+            config.log_file_path = allocator.dupe(u8, arg["--log-file=".len..]) catch null;
+        } else if (std.mem.eql(u8, arg, "--trace-rpc-messages")) {
+            config.trace_rpc_messages = true;
+        }
+    }
+    return config;
+}
+
+pub fn main() !void {
+    var gpa_impl: std.heap.GeneralPurposeAllocator(.{}) = .init;
+    defer _ = gpa_impl.deinit();
+    const allocator = gpa_impl.allocator();
+
+    const config = parseArgs(allocator);
+
+    var server = Server.init(allocator);
+    defer server.deinit();
+
+    // Open log file if specified
+    if (config.log_file_path) |path| {
+        server.log_file = std.fs.createFileAbsolute(path, .{ .truncate = false }) catch null;
+        if (server.log_file) |f| {
+            // Seek to end for appending
+            f.seekFromEnd(0) catch {};
+        }
+    }
+    server.trace_rpc = config.trace_rpc_messages;
+
+    server.log("Zig RPC server starting...", .{});
+
+    // Main message loop
+    while (true) {
+        const req = readMessage(allocator) catch |err| {
+            server.log("Error reading message: {}", .{err});
+            break;
+        };
+        if (req == null) break; // EOF
+
+        const resp = server.handleRequest(req.?) catch |err| {
+            server.log("Error handling request: {}", .{err});
+            break;
+        };
+
+        writeMessage(allocator, resp) catch |err| {
+            server.log("Error writing response: {}", .{err});
+            break;
+        };
+    }
+
+    server.log("Zig RPC server shutting down...", .{});
+}
+
+// Reference all module tests so `zig test src/main.zig` runs them all.
+comptime {
+    _ = rpc;
+    _ = parser;
+    _ = printer_mod;
+    _ = sender_mod;
+    _ = tree;
+}
+
+test "generateUuid format" {
+    const uuid = generateUuid();
+    try std.testing.expect(uuid[8] == '-');
+    try std.testing.expect(uuid[13] == '-');
+    try std.testing.expect(uuid[18] == '-');
+    try std.testing.expect(uuid[23] == '-');
+    try std.testing.expect(uuid.len == 36);
+}
+
+test "isWhitespace" {
+    try std.testing.expect(isWhitespace(' '));
+    try std.testing.expect(isWhitespace('\t'));
+    try std.testing.expect(isWhitespace('\n'));
+    try std.testing.expect(isWhitespace('\r'));
+    try std.testing.expect(!isWhitespace('a'));
+}

--- a/rewrite-zig/rewrite/src/parser.zig
+++ b/rewrite-zig/rewrite/src/parser.zig
@@ -1,0 +1,2095 @@
+// Copyright 2025 the original author or authors.
+//
+// Licensed under the Moderne Source Available License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://docs.moderne.io/licensing/moderne-source-available-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Recursive descent parser that walks std.zig.Ast and maps nodes to
+//! OpenRewrite LST types (tree.zig). Uses a cursor-based context to
+//! extract whitespace between tokens.
+
+const std = @import("std");
+const tree = @import("tree.zig");
+const LstNode = tree.LstNode;
+const Space = tree.Space;
+const RightPadded = tree.RightPadded;
+const LeftPadded = tree.LeftPadded;
+const Ast = std.zig.Ast;
+const Token = std.zig.Token;
+const Node = Ast.Node;
+
+/// ParseContext holds the state for walking through the Zig AST
+/// and extracting whitespace/prefix information.
+pub const ParseContext = struct {
+    ast: Ast,
+    source: []const u8,
+    /// Sentinel-terminated view of source for re-tokenization.
+    source_z: [:0]const u8,
+    cursor: usize,
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator, source: []const u8, source_z: [:0]const u8, ast: Ast) ParseContext {
+        return .{
+            .ast = ast,
+            .source = source,
+            .source_z = source_z,
+            .cursor = 0,
+            .allocator = allocator,
+        };
+    }
+
+    // -----------------------------------------------------------------
+    // Cursor / whitespace helpers
+    // -----------------------------------------------------------------
+
+    /// Extract whitespace from cursor up to the start of the given token,
+    /// then advance cursor past the token.
+    pub fn prefix(self: *ParseContext, token_index: Ast.TokenIndex) Space {
+        const tok_start = self.ast.tokenStart(token_index);
+        const ws = self.extractWhitespace(tok_start);
+        // Advance cursor past this token
+        const tok_len = self.tokenLength(token_index);
+        self.cursor = tok_start + tok_len;
+        return .{ .whitespace = ws };
+    }
+
+    /// Extract whitespace from cursor to a given position without
+    /// advancing past any token.
+    fn extractWhitespace(self: *ParseContext, target: usize) []const u8 {
+        if (target <= self.cursor) return "";
+        return self.source[self.cursor..target];
+    }
+
+    /// Get the text of a token.
+    pub fn tokenSlice(self: *ParseContext, token_index: Ast.TokenIndex) []const u8 {
+        return self.ast.tokenSlice(token_index);
+    }
+
+    /// Advance cursor past a token without extracting whitespace prefix.
+    pub fn skipToken(self: *ParseContext, token_index: Ast.TokenIndex) void {
+        const tok_start = self.ast.tokenStart(token_index);
+        const tok_len = self.tokenLength(token_index);
+        self.cursor = tok_start + tok_len;
+    }
+
+    /// Compute the length of a token. For tokens with known lexemes (keywords,
+    /// operators), use the lexeme length. For identifiers, strings, numbers etc.,
+    /// re-tokenize to find the end.
+    fn tokenLength(self: *ParseContext, token_index: Ast.TokenIndex) usize {
+        const tag = self.ast.tokenTag(token_index);
+        // If the tag has a known lexeme, use its length directly
+        if (tag.lexeme()) |lex| {
+            return lex.len;
+        }
+        // Otherwise re-tokenize from the token start to find the end
+        var tokenizer: std.zig.Tokenizer = .{
+            .buffer = self.source_z,
+            .index = self.ast.tokenStart(token_index),
+        };
+        const tok = tokenizer.next();
+        return tok.loc.end - tok.loc.start;
+    }
+
+    /// Generate a v4 UUID string, allocated.
+    fn genUuid(self: *ParseContext) []const u8 {
+        var bytes: [16]u8 = undefined;
+        std.crypto.random.bytes(&bytes);
+        bytes[6] = (bytes[6] & 0x0f) | 0x40;
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+        var result: [36]u8 = undefined;
+        const hex = "0123456789abcdef";
+        var pos: usize = 0;
+        for (bytes, 0..) |b, i| {
+            if (i == 4 or i == 6 or i == 8 or i == 10) {
+                result[pos] = '-';
+                pos += 1;
+            }
+            result[pos] = hex[b >> 4];
+            result[pos + 1] = hex[b & 0x0f];
+            pos += 2;
+        }
+        return self.allocator.dupe(u8, &result) catch "00000000-0000-0000-0000-000000000000";
+    }
+
+    // -----------------------------------------------------------------
+    // Top-level: map a file
+    // -----------------------------------------------------------------
+
+    /// Parse the full file into a CompilationUnit LstNode.
+    /// The `cu_id` parameter sets the CompilationUnit's UUID (must match the stored object key).
+    pub fn mapFile(self: *ParseContext, source_path: []const u8, cu_id: []const u8) ParseError!LstNode {
+        const root_decls = self.ast.rootDecls();
+
+        // Extract file-level prefix (whitespace before first token)
+        const file_prefix = self.filePrefix();
+
+        // Pre-allocate the statements array based on root decl count
+        var stmts = try self.allocator.alloc(RightPadded(LstNode), root_decls.len);
+        var stmt_count: usize = 0;
+
+        for (root_decls) |decl_node| {
+            const mapped = try self.mapNode(decl_node);
+            // After mapping the node, extract trailing whitespace until next decl or EOF
+            const after = self.trailingWhitespace(decl_node);
+            stmts[stmt_count] = .{
+                .element = mapped,
+                .after = .{ .whitespace = after },
+            };
+            stmt_count += 1;
+        }
+        stmts = stmts[0..stmt_count];
+
+        // EOF space: everything from cursor to end
+        const eof_ws = if (self.cursor < self.source.len)
+            self.source[self.cursor..]
+        else
+            "";
+
+        const cu = try self.allocator.create(tree.CompilationUnit);
+        cu.* = .{
+            .id = cu_id,
+            .prefix = file_prefix,
+            .source_path = source_path,
+            .statements = stmts,
+            .eof = .{ .whitespace = eof_ws },
+        };
+        return LstNode{ .compilation_unit = cu };
+    }
+
+    /// Extract leading whitespace/comments before the first real token.
+    fn filePrefix(self: *ParseContext) Space {
+        const root_decls = self.ast.rootDecls();
+        if (root_decls.len == 0) {
+            // Empty file: all source is prefix
+            const ws = self.source;
+            self.cursor = self.source.len;
+            return .{ .whitespace = ws };
+        }
+        // Get the first token of the first declaration
+        const first_token = self.ast.firstToken(root_decls[0]);
+        const first_start = self.ast.tokenStart(first_token);
+        const ws = self.source[0..first_start];
+        self.cursor = first_start;
+        return .{ .whitespace = ws };
+    }
+
+    /// Extract whitespace between end of a declaration and start of the next
+    /// token (the semicolon after a statement, or just trailing whitespace).
+    fn trailingWhitespace(self: *ParseContext, node: Node.Index) []const u8 {
+        // Find the last token of this node and advance past it
+        const last_tok = self.ast.lastToken(node);
+        const last_start = self.ast.tokenStart(last_tok);
+        const last_len = self.tokenLength(last_tok);
+        const end_pos = last_start + last_len;
+
+        // Check if there's a semicolon immediately after
+        const next_tok = last_tok + 1;
+        if (next_tok < self.ast.tokens.len) {
+            const next_tag = self.ast.tokenTag(next_tok);
+            if (next_tag == .semicolon) {
+                // Skip the semicolon
+                const semi_start = self.ast.tokenStart(next_tok);
+                const semi_end = semi_start + 1;
+                // The trailing includes everything from current cursor to after the semicolon
+                if (self.cursor < semi_end) {
+                    const ws = self.source[self.cursor..semi_end];
+                    self.cursor = semi_end;
+                    return ws;
+                }
+            }
+        }
+
+        // Just advance cursor to end of node
+        if (self.cursor < end_pos) {
+            const ws = self.source[self.cursor..end_pos];
+            self.cursor = end_pos;
+            return ws;
+        }
+        return "";
+    }
+
+    // -----------------------------------------------------------------
+    // Node dispatch
+    // -----------------------------------------------------------------
+
+    pub const ParseError = std.mem.Allocator.Error;
+
+    /// Map a node index to an LstNode, dispatching based on node tag.
+    /// Dispatches to specific mappers for recognized node types,
+    /// falling back to mapUnknown for unrecognized tags.
+    pub fn mapNode(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const tag = self.ast.nodeTag(node);
+        return switch (tag) {
+            // Phase A: Literals and identifiers
+            .identifier, .unreachable_literal, .anyframe_literal,
+            => self.mapIdentifierNode(node),
+            .enum_literal => self.mapEnumLiteral(node),
+            .number_literal, .char_literal => self.mapNumberLiteralNode(node),
+            .string_literal, .multiline_string_literal => self.mapStringLiteralNode(node),
+
+            // Phase B: Blocks and return
+            .block, .block_semicolon, .block_two, .block_two_semicolon => self.mapBlock(node),
+            .@"return" => self.mapReturn(node),
+
+            // Phase C: Declarations
+            .fn_decl => self.mapFnDecl(node),
+            .simple_var_decl, .global_var_decl, .local_var_decl, .aligned_var_decl,
+            => self.mapVarDecl(node),
+
+            // Phase D: Binary operations
+            .add, .sub, .mul, .div, .mod,
+            .add_wrap, .sub_wrap, .mul_wrap,
+            .add_sat, .sub_sat, .mul_sat,
+            .equal_equal, .bang_equal,
+            .less_than, .greater_than, .less_or_equal, .greater_or_equal,
+            .bit_and, .bit_or, .bit_xor,
+            .shl, .shr, .shl_sat,
+            .bool_and, .bool_or,
+            .array_cat, .array_mult,
+            .merge_error_sets,
+            .@"catch", .@"orelse",
+            => self.mapBinary(node),
+
+            // Phase D: Field access
+            .field_access => self.mapFieldAccess(node),
+
+            // Phase D: Function calls
+            .call_one, .call_one_comma, .call, .call_comma,
+            => self.mapCall(node),
+
+            // Phase D: Assignments
+            .assign => self.mapAssign(node),
+            .assign_add, .assign_sub, .assign_mul, .assign_div, .assign_mod,
+            .assign_add_wrap, .assign_sub_wrap, .assign_mul_wrap,
+            .assign_add_sat, .assign_sub_sat, .assign_mul_sat,
+            .assign_shl, .assign_shl_sat, .assign_shr,
+            .assign_bit_and, .assign_bit_xor, .assign_bit_or,
+            => self.mapAssignOp(node),
+
+            // Phase D: Builtin calls
+            .builtin_call_two, .builtin_call_two_comma, .builtin_call, .builtin_call_comma,
+            => self.mapBuiltinCall(node),
+
+            // Phase E: Control flow
+            .if_simple, .@"if" => self.mapIf(node),
+            .while_simple, .while_cont, .@"while" => self.mapWhile(node),
+
+            // Phase E: Unary operations
+            .negation => self.mapUnary(node, "Negative", "-"),
+            .bool_not => self.mapUnary(node, "Not", "!"),
+            .bit_not => self.mapUnary(node, "Complement", "~"),
+            .address_of => self.mapUnary(node, "AddressOf", "&"),
+            .negation_wrap => self.mapUnary(node, "Negative", "-%"),
+            .@"try" => self.mapUnaryKeyword(node, "try"),
+            .deref => self.mapPostfixUnary(node),
+            .unwrap_optional => self.mapPostfixDotOp(node),
+
+            // Phase E: Parenthesized expressions and array access
+            .grouped_expression => self.mapGrouped(node),
+            .array_access => self.mapArrayAccess(node),
+
+            // Phase E: Error union types
+            .error_union => self.mapErrorUnion(node),
+
+            // Phase E: Slice expressions
+            .slice_open, .slice, .slice_sentinel => self.mapSlice(node),
+
+            // Phase F: Switch expressions
+            .@"switch", .switch_comma => self.mapSwitch(node),
+
+            // Phase F: For loops - use ForLoop for Zig-side round-trip,
+            // but fall through to J.Unknown for RPC since J.ForEachLoop's Control
+            // structure doesn't map cleanly to Zig's for syntax.
+            .for_simple, .@"for" => self.mapForLoop(node),
+
+            // Phase F: Zig-specific constructs
+            .@"defer" => self.mapDefer(node, false),
+            .@"errdefer" => self.mapDefer(node, true),
+            .test_decl => self.mapTestDecl(node),
+            .@"comptime" => self.mapComptime(node),
+
+            // Everything else falls back to Unknown
+            else => self.mapUnknown(node),
+        };
+    }
+
+    // -----------------------------------------------------------------
+    // Function declaration → J.MethodDeclaration
+    // -----------------------------------------------------------------
+
+    fn mapFnDecl(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        // fn_decl: data.node_and_node[0] = proto node, [1] = body node
+        const data = self.ast.nodeData(node);
+        const body_node = data.node_and_node[1];
+
+        // Get the full fn proto
+        var proto_buf: [1]Node.Index = undefined;
+        const fn_proto = self.ast.fullFnProto(&proto_buf, node) orelse
+            return self.mapUnknown(node);
+
+        // The fn keyword prefix
+        const fn_first_token = fn_proto.firstToken();
+        const fn_prefix = self.prefix(fn_first_token);
+
+        // Capture keyword text (e.g. "fn", "pub fn", "export fn")
+        // from the start of the first token through the end of the fn token.
+        const fn_token = fn_proto.ast.fn_token;
+        const first_tok_start = self.ast.tokenStart(fn_first_token);
+        const fn_tok_end = self.ast.tokenStart(fn_token) + self.tokenLength(fn_token);
+        const keywords = self.source[first_tok_start..fn_tok_end];
+
+        // Skip tokens between fn keyword and name
+        // fn keyword is fn_proto.ast.fn_token
+        if (fn_first_token != fn_token) {
+            // There are modifier tokens before fn (pub, export, etc.)
+            // We already consumed the first token in prefix, now skip to fn
+            self.skipToken(fn_token);
+        }
+
+        // Function name
+        const name_node = if (fn_proto.name_token) |name_tok|
+            try self.mapIdentifier(name_tok)
+        else
+            try self.makeEmptyIdentifier();
+
+        // Capture the parameter list text including parentheses.
+        // params_prefix is the whitespace before "("; params_text includes "(" through ")".
+        const lparen_tok = fn_proto.lparen;
+        const lparen_start = self.ast.tokenStart(lparen_tok);
+        const params_ws = self.extractWhitespace(lparen_start);
+
+        // Find the rparen by scanning forward from lparen
+        const rparen_tok = self.findRparen(lparen_tok);
+        const rparen_end = self.ast.tokenStart(rparen_tok) + self.tokenLength(rparen_tok);
+
+        // params_text is the full source from "(" to ")" inclusive
+        const params_text = self.source[lparen_start..rparen_end];
+
+        // Advance cursor past the rparen
+        self.cursor = rparen_end;
+
+        // Return type (cursor is now after rparen, so prefix captures space before return type)
+        const return_type: ?LstNode = if (fn_proto.ast.return_type != .none) blk: {
+            const ret_node = fn_proto.ast.return_type.unwrap().?;
+            break :blk try self.mapNode(ret_node);
+        } else null;
+
+        // Body
+        const body: ?LstNode = try self.mapNode(body_node);
+
+        const md = try self.allocator.create(tree.MethodDeclaration);
+        md.* = .{
+            .id = self.genUuid(),
+            .prefix = fn_prefix,
+            .keywords = keywords,
+            .return_type = return_type,
+            .name = name_node,
+            .params_prefix = .{ .whitespace = params_ws },
+            .params_text = params_text,
+            .body = body,
+        };
+        return LstNode{ .method_declaration = md };
+    }
+
+    /// Find the matching right paren token by scanning forward from lparen.
+    fn findRparen(self: *ParseContext, lparen_tok: Ast.TokenIndex) Ast.TokenIndex {
+        var depth: usize = 1;
+        var tok = lparen_tok + 1;
+        while (tok < self.ast.tokens.len) : (tok += 1) {
+            const tag = self.ast.tokenTag(tok);
+            if (tag == .l_paren) {
+                depth += 1;
+            } else if (tag == .r_paren) {
+                depth -= 1;
+                if (depth == 0) return tok;
+            }
+        }
+        // Fallback: return the token after lparen (shouldn't reach here for valid code)
+        return lparen_tok + 1;
+    }
+
+    fn makeEmptyIdentifier(self: *ParseContext) ParseError!LstNode {
+        const ident = try self.allocator.create(tree.Identifier);
+        ident.* = .{
+            .id = self.genUuid(),
+            .prefix = .{ .whitespace = "" },
+            .simple_name = "",
+        };
+        return LstNode{ .identifier = ident };
+    }
+
+    // -----------------------------------------------------------------
+    // Variable declaration → J.VariableDeclarations
+    // -----------------------------------------------------------------
+
+    fn mapVarDecl(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const var_decl = self.ast.fullVarDecl(node) orelse
+            return self.mapUnknown(node);
+
+        // The first token (could be pub, export, const, var)
+        const first_token = var_decl.firstToken();
+        const decl_prefix = self.prefix(first_token);
+
+        // Capture keyword text (e.g. "const", "var", "pub const", "pub var")
+        // from the start of the first token through the end of the mut_token.
+        const first_tok_start = self.ast.tokenStart(first_token);
+        const mut_tok_end = self.ast.tokenStart(var_decl.ast.mut_token) + self.tokenLength(var_decl.ast.mut_token);
+        const keyword = self.source[first_tok_start..mut_tok_end];
+
+        // Skip to the mut_token (const/var) if it's not the first token
+        if (first_token != var_decl.ast.mut_token) {
+            self.skipToken(var_decl.ast.mut_token);
+        }
+
+        // The identifier name is the token after the mut_token
+        const name_tok = var_decl.ast.mut_token + 1;
+        const name_node = try self.mapIdentifier(name_tok);
+
+        // Type expression (after the colon if present)
+        var type_expr: ?LstNode = null;
+        if (var_decl.ast.type_node != .none) {
+            const type_nd = var_decl.ast.type_node.unwrap().?;
+            type_expr = try self.mapNode(type_nd);
+        }
+
+        // Initializer (after the = sign)
+        var init_lp: ?LeftPadded(LstNode) = null;
+        if (var_decl.ast.init_node != .none) {
+            const init_nd = var_decl.ast.init_node.unwrap().?;
+            // Find the = token: it should be somewhere before the init node
+            const init_first_tok = self.ast.firstToken(init_nd);
+            // The = token is typically right before the init expression
+            // We need to find it by scanning backward from init_first_tok
+            var eq_tok = init_first_tok;
+            if (eq_tok > 0) {
+                eq_tok -= 1;
+                while (eq_tok > 0 and self.ast.tokenTag(eq_tok) != .equal) {
+                    eq_tok -= 1;
+                }
+            }
+            const eq_space = self.prefix(eq_tok);
+            const init_node = try self.mapNode(init_nd);
+            init_lp = .{
+                .before = eq_space,
+                .element = init_node,
+            };
+        }
+
+        // Build the NamedVariable
+        const named_var = try self.allocator.create(tree.NamedVariable);
+        named_var.* = .{
+            .id = self.genUuid(),
+            .prefix = .{ .whitespace = "" },
+            .name = name_node,
+            .initializer = init_lp,
+        };
+
+        // For the NamedVariable, we use J.VariableDeclarations.NamedVariable
+        // which is serialized as a visit to the "variable" visitor
+        // We wrap it in a RightPadded list
+        var vars = try self.allocator.alloc(RightPadded(LstNode), 1);
+        // We'll use unknown_source temporarily to carry the named variable data.
+        // Actually, NamedVariable is not in our LstNode union yet.
+        // We need to represent it. For now we'll use the identifier as the variable.
+        // Actually, let's handle this properly by extending LstNode.
+
+        // The NamedVariable's declarator is the name identifier
+        // For now, we synthesize the NamedVariable by storing it inline
+        // Since NamedVariable is visited separately in the sender, we need it in the tree.
+        // We'll store the name identifier directly as the variable element
+        // and handle the initializer at the sender level by inspecting the tree.
+
+        // Actually, let me reconsider. The J.VariableDeclarations sends:
+        //   1. leadingAnnotations (empty list)
+        //   2. modifiers (empty list)
+        //   3. typeExpression (the type)
+        //   4. varargs (null space)
+        //   5. variables (list of RightPadded<NamedVariable>)
+        //
+        // And J.VariableDeclarations.NamedVariable sends:
+        //   1. declarator (the name identifier, which is actually an IdentWithAnnotations)
+        //   2. dimensionsAfterName (empty list)
+        //   3. initializer (JLeftPadded<Expression>)
+        //   4. variableType (null)
+        //
+        // We need to represent this. Let's just use the name directly.
+
+        // We encode: the name_node goes into the variable entry
+        // The sender will need to emit NamedVariable format.
+        // For simplicity in tree.zig, let's just put the ident as element.
+        // But we need the initializer too.
+
+        // Hmm, let me add NamedVariable to LstNode. Actually looking at the tree.zig,
+        // I didn't include it. Let me just store it in Unknown format for now and
+        // use a "named_variable" tag. But that would violate the principle.
+
+        // Let's use a practical approach: store a custom wrapper.
+        // Actually the cleanest approach is: we store name_node as element,
+        // and the sender looks up additional data from the VariableDeclarations parent.
+
+        // For now, wrap the whole thing in an Unknown if we can't do NamedVariable.
+        // Actually, we CAN handle it: we don't need NamedVariable in LstNode because
+        // the sender serializes the whole VariableDeclarations including its variables list.
+        // Each variable is serialized inline by the sender as it walks the tree.
+
+        // Let's store the relevant data in the VariableDeclarations node directly.
+        // The variables field already stores the identity. For the initializer,
+        // we can store it in the VariableDeclarations struct.
+
+        // OK final approach: use NamedVariable stored in a separate list, not as LstNode.
+        // The sender knows how to handle VariableDeclarations by reading its fields directly.
+
+        // Keep the vars as a list but use the identifier as the element placeholder.
+        // The sender will use the VariableDeclarations.type_expression and .variables
+        // to reconstruct the Java-side format.
+
+        // For the named variable we want:
+        //   - preVisit: id, prefix, markers
+        //   - declarator (the name identifier)
+        //   - dimensionsAfterName: empty list
+        //   - initializer: JLeftPadded (if present)
+        //   - variableType: null
+
+        // So we need a way to carry the init info. Let's encode it in the RightPadded
+        // using the `identifier` as element. The sender will walk the VariableDeclarations
+        // and for each variable, emit a full NamedVariable.
+
+        // Actually this is getting complicated. Let me just store it inline.
+        // The named_variable isn't a separate LST node in the node union.
+        // Instead, the sender for VariableDeclarations will handle each variable
+        // element by emitting the NamedVariable protocol directly.
+
+        // We need to store: name identifier + optional initializer.
+        // Let's use the identifier as the element in the RightPadded list.
+
+        vars[0] = .{
+            .element = name_node,
+            .after = .{ .whitespace = "" },
+        };
+
+        const vd = try self.allocator.create(tree.VariableDeclarations);
+        vd.* = .{
+            .id = self.genUuid(),
+            .prefix = decl_prefix,
+            .keyword = keyword,
+            .type_expression = type_expr,
+            .variables = vars,
+            .initializer = init_lp,
+        };
+        return LstNode{ .variable_declarations = vd };
+    }
+
+    // -----------------------------------------------------------------
+    // Block → J.Block
+    // -----------------------------------------------------------------
+
+    fn mapBlock(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const main_token = self.ast.nodeMainToken(node);
+        // main_token is '{', extract its prefix
+        const block_prefix = self.prefix(main_token);
+
+        // Get block statements
+        var buf: [2]Node.Index = undefined;
+        const stmt_nodes = self.ast.blockStatements(&buf, node) orelse &[_]Node.Index{};
+
+        var stmts = try self.allocator.alloc(RightPadded(LstNode), stmt_nodes.len);
+        var stmt_count: usize = 0;
+        for (stmt_nodes) |stmt_node| {
+            const mapped = try self.mapNode(stmt_node);
+            // Trailing whitespace after each statement (includes semicolon)
+            const after = self.trailingWhitespace(stmt_node);
+            stmts[stmt_count] = .{
+                .element = mapped,
+                .after = .{ .whitespace = after },
+            };
+            stmt_count += 1;
+        }
+        stmts = stmts[0..stmt_count];
+
+        // Find the closing brace
+        const last_tok = self.ast.lastToken(node);
+        // The last token should be '}', extract whitespace before it
+        const rbrace_start = self.ast.tokenStart(last_tok);
+        const end_ws = if (rbrace_start > self.cursor)
+            self.source[self.cursor..rbrace_start]
+        else
+            "";
+        // Advance past the closing brace
+        self.skipToken(last_tok);
+
+        const blk = try self.allocator.create(tree.Block);
+        blk.* = .{
+            .id = self.genUuid(),
+            .prefix = block_prefix,
+            .statements = stmts,
+            .end = .{ .whitespace = end_ws },
+        };
+        return LstNode{ .block = blk };
+    }
+
+    // -----------------------------------------------------------------
+    // Return → J.Return
+    // -----------------------------------------------------------------
+
+    fn mapReturn(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const main_token = self.ast.nodeMainToken(node);
+        const ret_prefix = self.prefix(main_token);
+
+        // The return expression is in data.opt_node
+        const data = self.ast.nodeData(node);
+        const expr: ?LstNode = if (data.opt_node.unwrap()) |expr_node| blk: {
+            break :blk try self.mapNode(expr_node);
+        } else null;
+
+        const ret = try self.allocator.create(tree.Return);
+        ret.* = .{
+            .id = self.genUuid(),
+            .prefix = ret_prefix,
+            .expression = expr,
+        };
+        return LstNode{ .@"return" = ret };
+    }
+
+    // -----------------------------------------------------------------
+    // Binary expression → J.Binary
+    // All binary ops have data.node_and_node: [0]=lhs, [1]=rhs
+    // The main_token is the operator token.
+    // -----------------------------------------------------------------
+
+    fn mapBinary(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const data = self.ast.nodeData(node);
+        const lhs_node = data.node_and_node[0];
+        const rhs_node = data.node_and_node[1];
+        const main_token = self.ast.nodeMainToken(node);
+
+        // Map left operand (this consumes cursor up to operator)
+        const left = try self.mapNode(lhs_node);
+
+        // Capture the actual operator source text before prefix() consumes the token
+        const op_source = self.ast.tokenSlice(main_token);
+
+        // The operator token prefix (whitespace before the operator)
+        const op_prefix = self.prefix(main_token);
+
+        // Map the operator to J.Binary.Type enum name
+        const tag = self.ast.nodeTag(node);
+        const op_name = zigBinaryOpToJava(tag);
+
+        // Map right operand
+        const right = try self.mapNode(rhs_node);
+
+        const bin = try self.allocator.create(tree.Binary);
+        bin.* = .{
+            .id = self.genUuid(),
+            .prefix = left.getPrefix(), // Binary prefix is the left operand's prefix
+            .left = left,
+            .operator = .{
+                .before = op_prefix,
+                .element = op_name,
+            },
+            .operator_source = op_source,
+            .right = right,
+        };
+        return LstNode{ .binary = bin };
+    }
+
+    /// Map a Zig AST node tag to the Java J.Binary.Type enum name.
+    fn zigBinaryOpToJava(tag: Node.Tag) []const u8 {
+        return switch (tag) {
+            .add, .add_wrap, .add_sat => "Addition",
+            .sub, .sub_wrap, .sub_sat => "Subtraction",
+            .mul, .mul_wrap, .mul_sat => "Multiplication",
+            .div => "Division",
+            .mod => "Modulo",
+            .equal_equal => "Equal",
+            .bang_equal => "NotEqual",
+            .less_than => "LessThan",
+            .greater_than => "GreaterThan",
+            .less_or_equal => "LessThanOrEqual",
+            .greater_or_equal => "GreaterThanOrEqual",
+            .bit_and => "BitAnd",
+            .bit_or => "BitOr",
+            .bit_xor => "BitXor",
+            .shl, .shl_sat => "LeftShift",
+            .shr => "RightShift",
+            .bool_and => "And",
+            .bool_or => "Or",
+            .array_cat => "Addition", // ++ concatenation mapped to Addition
+            .array_mult => "Multiplication", // ** mapped to Multiplication
+            .merge_error_sets => "BitOr", // || mapped to BitOr
+            .@"catch" => "Or", // catch mapped to Or
+            .@"orelse" => "Or", // orelse mapped to Or
+            else => "Addition", // fallback
+        };
+    }
+
+    // -----------------------------------------------------------------
+    // Field access → J.FieldAccess
+    // data.node_and_token: [0]=target node, [1]=field name token
+    // main_token is the "." token
+    // -----------------------------------------------------------------
+
+    fn mapFieldAccess(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const data = self.ast.nodeData(node);
+        const target_node = data.node_and_token[0];
+        const field_token = data.node_and_token[1];
+
+        // Map the target expression
+        const target = try self.mapNode(target_node);
+
+        // The "." token is the main_token; extract its prefix
+        const dot_token = self.ast.nodeMainToken(node);
+        const dot_prefix = self.prefix(dot_token);
+
+        // Map the field name identifier
+        const field_name = try self.mapIdentifier(field_token);
+
+        const fa = try self.allocator.create(tree.FieldAccess);
+        fa.* = .{
+            .id = self.genUuid(),
+            .prefix = target.getPrefix(), // FieldAccess prefix is the target's prefix
+            .target = target,
+            .name = .{
+                .before = dot_prefix,
+                .element = field_name,
+            },
+        };
+        return LstNode{ .field_access = fa };
+    }
+
+    // -----------------------------------------------------------------
+    // Function call → J.MethodInvocation
+    // call_one: data.node_and_opt_node: [0]=fn expr, [1]=first arg (optional)
+    // call: data.node_and_extra: [0]=fn expr, [1]=extra range of args
+    // main_token is "(" token
+    // -----------------------------------------------------------------
+
+    fn mapCall(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const tag = self.ast.nodeTag(node);
+        const main_token = self.ast.nodeMainToken(node);
+
+        // Get the function expression and arguments based on tag variant
+        var fn_expr_node: Node.Index = undefined;
+        var arg_nodes: []const Node.Index = &.{};
+        var arg_buf: [1]Node.Index = undefined;
+
+        switch (tag) {
+            .call_one, .call_one_comma => {
+                const data = self.ast.nodeData(node);
+                fn_expr_node = data.node_and_opt_node[0];
+                if (data.node_and_opt_node[1].unwrap()) |arg| {
+                    arg_buf[0] = arg;
+                    arg_nodes = &arg_buf;
+                }
+            },
+            .call, .call_comma => {
+                const data = self.ast.nodeData(node);
+                fn_expr_node = data.node_and_extra[0];
+                // Extra data contains a SubRange with start/end indexes into extra_data
+                const extra_start = @intFromEnum(data.node_and_extra[1]);
+                const range_start = self.ast.extra_data[extra_start];
+                const range_end = self.ast.extra_data[extra_start + 1];
+                // The arg node indices are stored between range_start and range_end
+                arg_nodes = @as([]const Node.Index, @ptrCast(self.ast.extra_data[range_start..range_end]));
+            },
+            else => return self.mapUnknown(node),
+        }
+
+        // Determine if this is a method-style call (target.name) or direct call (name)
+        const fn_tag = self.ast.nodeTag(fn_expr_node);
+
+        var select: ?tree.RightPadded(LstNode) = null;
+        var name_node: LstNode = undefined;
+
+        if (fn_tag == .field_access) {
+            // Method-style: target.name(args)
+            const fa_data = self.ast.nodeData(fn_expr_node);
+            const target_nd = fa_data.node_and_token[0];
+            const name_tok = fa_data.node_and_token[1];
+            const dot_tok = self.ast.nodeMainToken(fn_expr_node);
+
+            const target = try self.mapNode(target_nd);
+            const dot_prefix = self.prefix(dot_tok);
+
+            select = .{
+                .element = target,
+                .after = dot_prefix,
+            };
+            name_node = try self.mapIdentifier(name_tok);
+        } else {
+            // Direct call: name(args)
+            name_node = try self.mapNode(fn_expr_node);
+        }
+
+        // The "(" token prefix
+        const lparen_prefix = self.prefix(main_token);
+
+        // Map arguments
+        var args = try self.allocator.alloc(tree.RightPadded(LstNode), arg_nodes.len);
+        for (arg_nodes, 0..) |arg_nd, i| {
+            const mapped_arg = try self.mapNode(arg_nd);
+            // After each argument, extract trailing whitespace (including comma)
+            const after = self.trailingWhitespace(arg_nd);
+            args[i] = .{
+                .element = mapped_arg,
+                .after = .{ .whitespace = after },
+            };
+        }
+
+        // Skip to the rparen
+        const last_tok = self.ast.lastToken(node);
+        const rparen_start = self.ast.tokenStart(last_tok);
+        if (rparen_start > self.cursor) {
+            self.cursor = rparen_start;
+        }
+        self.skipToken(last_tok);
+
+        const mi = try self.allocator.create(tree.MethodInvocation);
+        mi.* = .{
+            .id = self.genUuid(),
+            .prefix = name_node.getPrefix(), // MethodInvocation prefix is the name's prefix
+            .select = select,
+            .name = name_node,
+            .args_prefix = lparen_prefix,
+            .args = args,
+        };
+        return LstNode{ .method_invocation = mi };
+    }
+
+    // -----------------------------------------------------------------
+    // Assignment → J.Assignment
+    // data.node_and_node: [0]=lhs, [1]=rhs
+    // main_token is "=" token
+    // -----------------------------------------------------------------
+
+    fn mapAssign(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const data = self.ast.nodeData(node);
+        const lhs_node = data.node_and_node[0];
+        const rhs_node = data.node_and_node[1];
+        const main_token = self.ast.nodeMainToken(node);
+
+        // Map left side (variable)
+        const variable = try self.mapNode(lhs_node);
+
+        // The "=" token prefix
+        const eq_prefix = self.prefix(main_token);
+
+        // Map right side (value)
+        const value = try self.mapNode(rhs_node);
+
+        const asgn = try self.allocator.create(tree.Assignment);
+        asgn.* = .{
+            .id = self.genUuid(),
+            .prefix = variable.getPrefix(), // Assignment prefix is the variable's prefix
+            .variable = variable,
+            .assignment = .{
+                .before = eq_prefix,
+                .element = value,
+            },
+        };
+        return LstNode{ .assignment = asgn };
+    }
+
+    // -----------------------------------------------------------------
+    // Compound assignment (+=, -=, etc.) → J.AssignmentOperation
+    // data.node_and_node: [0]=lhs, [1]=rhs
+    // main_token is the operator token (+=, -=, etc.)
+    // -----------------------------------------------------------------
+
+    fn mapAssignOp(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const data = self.ast.nodeData(node);
+        const lhs_node = data.node_and_node[0];
+        const rhs_node = data.node_and_node[1];
+        const main_token = self.ast.nodeMainToken(node);
+
+        // Map left side (variable)
+        const variable = try self.mapNode(lhs_node);
+
+        // Capture operator source text
+        const op_source = self.ast.tokenSlice(main_token);
+
+        // The operator token prefix
+        const op_prefix = self.prefix(main_token);
+
+        // Map operator to J.AssignmentOperation.Type enum name
+        const tag = self.ast.nodeTag(node);
+        const op_name = zigAssignOpToJava(tag);
+
+        // Map right side
+        const assignment = try self.mapNode(rhs_node);
+
+        const ao = try self.allocator.create(tree.AssignmentOperation);
+        ao.* = .{
+            .id = self.genUuid(),
+            .prefix = variable.getPrefix(),
+            .variable = variable,
+            .operator = .{
+                .before = op_prefix,
+                .element = op_name,
+            },
+            .operator_source = op_source,
+            .assignment = assignment,
+        };
+        return LstNode{ .assignment_op = ao };
+    }
+
+    fn zigAssignOpToJava(tag: Node.Tag) []const u8 {
+        return switch (tag) {
+            .assign_add, .assign_add_wrap, .assign_add_sat => "Addition",
+            .assign_sub, .assign_sub_wrap, .assign_sub_sat => "Subtraction",
+            .assign_mul, .assign_mul_wrap, .assign_mul_sat => "Multiplication",
+            .assign_div => "Division",
+            .assign_mod => "Modulo",
+            .assign_shl, .assign_shl_sat => "LeftShift",
+            .assign_shr => "RightShift",
+            .assign_bit_and => "BitAnd",
+            .assign_bit_or => "BitOr",
+            .assign_bit_xor => "BitXor",
+            else => "Addition", // fallback
+        };
+    }
+
+    // -----------------------------------------------------------------
+    // Builtin call → J.MethodInvocation
+    // @import("std"), @intCast(x), etc.
+    // builtin_call_two: data.opt_node_and_opt_node: [0]=arg1, [1]=arg2
+    // builtin_call: data.extra_range
+    // main_token is the builtin token (@import, @intCast, etc.)
+    // -----------------------------------------------------------------
+
+    fn mapBuiltinCall(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const tag = self.ast.nodeTag(node);
+        const main_token = self.ast.nodeMainToken(node);
+
+        // Extract the builtin name (e.g., "@import")
+        const builtin_prefix = self.prefix(main_token);
+        const builtin_name = self.ast.tokenSlice(main_token);
+
+        // Create the name identifier with the builtin name
+        const name_ident = try self.allocator.create(tree.Identifier);
+        name_ident.* = .{
+            .id = self.genUuid(),
+            .prefix = builtin_prefix,
+            .simple_name = builtin_name,
+        };
+        const name_node = LstNode{ .identifier = name_ident };
+
+        // Get argument nodes
+        var arg_nodes_buf: [2]Node.Index = undefined;
+        var arg_count: usize = 0;
+
+        switch (tag) {
+            .builtin_call_two, .builtin_call_two_comma => {
+                const data = self.ast.nodeData(node);
+                if (data.opt_node_and_opt_node[0].unwrap()) |a| {
+                    arg_nodes_buf[arg_count] = a;
+                    arg_count += 1;
+                }
+                if (data.opt_node_and_opt_node[1].unwrap()) |a| {
+                    arg_nodes_buf[arg_count] = a;
+                    arg_count += 1;
+                }
+            },
+            .builtin_call, .builtin_call_comma => {
+                // For now, fall back to Unknown for multi-arg builtins
+                // since they use extra_range which requires more complex handling
+                return self.mapUnknown(node);
+            },
+            else => return self.mapUnknown(node),
+        }
+
+        // The "(" token is right after the builtin name
+        const lparen_tok = main_token + 1;
+        const lparen_prefix = self.prefix(lparen_tok);
+
+        // Map arguments
+        var args = try self.allocator.alloc(tree.RightPadded(LstNode), arg_count);
+        for (arg_nodes_buf[0..arg_count], 0..) |arg_nd, i| {
+            const mapped_arg = try self.mapNode(arg_nd);
+            const after = self.trailingWhitespace(arg_nd);
+            args[i] = .{
+                .element = mapped_arg,
+                .after = .{ .whitespace = after },
+            };
+        }
+
+        // Skip to the rparen
+        const last_tok = self.ast.lastToken(node);
+        const rparen_start = self.ast.tokenStart(last_tok);
+        if (rparen_start > self.cursor) {
+            self.cursor = rparen_start;
+        }
+        self.skipToken(last_tok);
+
+        const mi = try self.allocator.create(tree.MethodInvocation);
+        mi.* = .{
+            .id = self.genUuid(),
+            .prefix = name_node.getPrefix(),
+            .name = name_node,
+            .args_prefix = lparen_prefix,
+            .args = args,
+        };
+        return LstNode{ .method_invocation = mi };
+    }
+
+    // -----------------------------------------------------------------
+    // If → J.If
+    // if_simple: data.node_and_opt_node: [0]=cond, [1]=then_expr (optional else)
+    //            main_token = "if"
+    // .@"if":    Uses extra data for full if/else, accessed via fullIf()
+    // -----------------------------------------------------------------
+
+    fn mapIf(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const main_token = self.ast.nodeMainToken(node);
+        const if_prefix = self.prefix(main_token);
+
+        // Use fullIf to access condition, then, else for all if variants
+        const full_if = self.ast.fullIf(node) orelse return self.mapUnknown(node);
+
+        // The "(" token: extract whitespace between "if" and "(" as part of
+        // the lparen prefix, then advance cursor past "("
+        const lparen_tok = main_token + 1;
+        const lparen_prefix = self.prefix(lparen_tok);
+
+        // Map the condition expression (cursor is now right after "(")
+        const condition = try self.mapNode(full_if.ast.cond_expr);
+
+        // Find and consume the ")" token after the condition
+        const cond_last_tok = self.ast.lastToken(full_if.ast.cond_expr);
+        var rparen_tok = cond_last_tok + 1;
+        while (rparen_tok < self.ast.tokens.len and self.ast.tokenTag(rparen_tok) != .r_paren) {
+            rparen_tok += 1;
+        }
+        const rparen_prefix = self.prefix(rparen_tok);
+
+        // Map the then branch
+        const then_part = try self.mapNode(full_if.ast.then_expr);
+        const then_after_ws = self.trailingWhitespace(full_if.ast.then_expr);
+
+        // Map the else branch if present
+        var else_part: ?*tree.IfElse = null;
+        if (full_if.ast.else_expr != .none) {
+            const else_expr_node = full_if.ast.else_expr.unwrap().?;
+            // Find the "else" keyword token
+            const else_first_tok = self.ast.firstToken(else_expr_node);
+            var else_keyword_tok = else_first_tok;
+            if (else_keyword_tok > 0) {
+                else_keyword_tok -= 1;
+                while (else_keyword_tok > 0 and self.ast.tokenTag(else_keyword_tok) != .keyword_else) {
+                    else_keyword_tok -= 1;
+                }
+            }
+            const else_kw_prefix = self.prefix(else_keyword_tok);
+
+            const else_body = try self.mapNode(else_expr_node);
+            const else_body_after = self.trailingWhitespace(else_expr_node);
+
+            const else_node = try self.allocator.create(tree.IfElse);
+            else_node.* = .{
+                .id = self.genUuid(),
+                .prefix = else_kw_prefix,
+                .body = else_body,
+                .body_after = .{ .whitespace = else_body_after },
+            };
+            else_part = else_node;
+        }
+
+        const if_node = try self.allocator.create(tree.If);
+        if_node.* = .{
+            .id = self.genUuid(),
+            .prefix = if_prefix,
+            .lparen_prefix = lparen_prefix,
+            .condition = condition,
+            .condition_after = rparen_prefix,
+            .then_part = then_part,
+            .then_after = .{ .whitespace = then_after_ws },
+            .else_part = else_part,
+        };
+        return LstNode{ .@"if" = if_node };
+    }
+
+    // -----------------------------------------------------------------
+    // While → J.WhileLoop
+    // while_simple: data.node_and_node: [0]=cond, [1]=body
+    //              main_token = "while"
+    // while_cont, .@"while": accessed via fullWhile()
+    // -----------------------------------------------------------------
+
+    fn mapWhile(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const main_token = self.ast.nodeMainToken(node);
+        const while_prefix = self.prefix(main_token);
+
+        // Use fullWhile to access condition and body for all while variants
+        const full_while = self.ast.fullWhile(node) orelse return self.mapUnknown(node);
+
+        // The "(" token: extract whitespace between "while" and "("
+        const lparen_tok = main_token + 1;
+        const lparen_prefix = self.prefix(lparen_tok);
+
+        // Map the condition
+        const condition = try self.mapNode(full_while.ast.cond_expr);
+
+        // Find and consume the ")" token
+        const cond_last_tok = self.ast.lastToken(full_while.ast.cond_expr);
+        var rparen_tok = cond_last_tok + 1;
+        while (rparen_tok < self.ast.tokens.len and self.ast.tokenTag(rparen_tok) != .r_paren) {
+            rparen_tok += 1;
+        }
+        const rparen_prefix = self.prefix(rparen_tok);
+
+        // Map the body
+        const body = try self.mapNode(full_while.ast.then_expr);
+        const body_after = self.trailingWhitespace(full_while.ast.then_expr);
+
+        const wl = try self.allocator.create(tree.WhileLoop);
+        wl.* = .{
+            .id = self.genUuid(),
+            .prefix = while_prefix,
+            .lparen_prefix = lparen_prefix,
+            .condition = condition,
+            .condition_after = rparen_prefix,
+            .body = body,
+            .body_after = .{ .whitespace = body_after },
+        };
+        return LstNode{ .while_loop = wl };
+    }
+
+    // -----------------------------------------------------------------
+    // Unary expression → J.Unary
+    // negation: data.node = operand, main_token = "-"
+    // bool_not: data.node = operand, main_token = "!"
+    // bit_not: data.node = operand, main_token = "~"
+    // -----------------------------------------------------------------
+
+    fn mapUnary(self: *ParseContext, node: Node.Index, op_name: []const u8, op_source: []const u8) ParseError!LstNode {
+        const main_token = self.ast.nodeMainToken(node);
+        const unary_prefix = self.prefix(main_token);
+
+        const data = self.ast.nodeData(node);
+        const operand_node = data.node;
+        const expression = try self.mapNode(operand_node);
+
+        const u = try self.allocator.create(tree.Unary);
+        u.* = .{
+            .id = self.genUuid(),
+            .prefix = unary_prefix,
+            .operator = .{
+                .before = .{ .whitespace = "" }, // prefix unary: no space between op and expr
+                .element = op_name,
+            },
+            .operator_source = op_source,
+            .expression = expression,
+        };
+        return LstNode{ .unary = u };
+    }
+
+    // -----------------------------------------------------------------
+    // Grouped expression → J.Parentheses
+    // grouped_expression: data.node_and_token: [0]=expr, [1]=rparen token
+    // main_token = "(" token
+    // -----------------------------------------------------------------
+
+    fn mapGrouped(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const main_token = self.ast.nodeMainToken(node);
+        const lparen_prefix = self.prefix(main_token);
+
+        const data = self.ast.nodeData(node);
+        const expr_node = data.node_and_token[0];
+        const rparen_tok = data.node_and_token[1];
+
+        // Map the inner expression
+        const expression = try self.mapNode(expr_node);
+
+        // Whitespace before the ")" token
+        const rparen_start = self.ast.tokenStart(rparen_tok);
+        const rparen_ws = if (rparen_start > self.cursor)
+            self.source[self.cursor..rparen_start]
+        else
+            "";
+        self.skipToken(rparen_tok);
+
+        const p = try self.allocator.create(tree.Parentheses);
+        p.* = .{
+            .id = self.genUuid(),
+            .prefix = lparen_prefix,
+            .expression = expression,
+            .after = .{ .whitespace = rparen_ws },
+        };
+        return LstNode{ .parentheses = p };
+    }
+
+    // -----------------------------------------------------------------
+    // Error union type → Zig.ErrorUnion
+    // error_union: data.node_and_node: [0]=error type, [1]=value type
+    // main_token = "!" token
+    // -----------------------------------------------------------------
+
+    fn mapErrorUnion(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const data = self.ast.nodeData(node);
+        const lhs_node = data.node_and_node[0];
+        const rhs_node = data.node_and_node[1];
+        const main_token = self.ast.nodeMainToken(node);
+
+        // Check if there's an explicit error type before the "!" operator
+        const lhs_first_tok = self.ast.firstToken(lhs_node);
+        const lhs_tok_start = self.ast.tokenStart(lhs_first_tok);
+        const bang_start = self.ast.tokenStart(main_token);
+
+        var error_type: ?LstNode = null;
+        var eu_prefix: Space = undefined;
+
+        if (lhs_tok_start < bang_start) {
+            // Explicit error type before "!" (e.g. "MyError!u32")
+            error_type = try self.mapNode(lhs_node);
+            eu_prefix = error_type.?.getPrefix();
+        } else {
+            // Implicit error set (just "!Type") - the "!" is before the type
+            // Extract whitespace before the "!" token
+            eu_prefix = .{ .whitespace = self.extractWhitespace(bang_start) };
+        }
+
+        // Skip the "!" token
+        const bang_len = self.tokenLength(main_token);
+        const after_bang = bang_start + bang_len;
+        if (after_bang > self.cursor) {
+            self.cursor = after_bang;
+        }
+
+        // Map the value type (right side)
+        const value_type = try self.mapNode(rhs_node);
+
+        const eu = try self.allocator.create(tree.ErrorUnion);
+        eu.* = .{
+            .id = self.genUuid(),
+            .prefix = eu_prefix,
+            .error_type = error_type,
+            .value_type = .{
+                .before = .{ .whitespace = "" }, // No space between "!" and type
+                .element = value_type,
+            },
+        };
+        return LstNode{ .zig_error_union = eu };
+    }
+
+    // -----------------------------------------------------------------
+    // Array access → J.ArrayAccess
+    // array_access: data.node_and_node: [0]=target, [1]=index
+    // main_token = "[" token
+    // -----------------------------------------------------------------
+
+    fn mapArrayAccess(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const data = self.ast.nodeData(node);
+        const target_node = data.node_and_node[0];
+        const index_node = data.node_and_node[1];
+        const main_token = self.ast.nodeMainToken(node);
+
+        // Map the target expression
+        const target = try self.mapNode(target_node);
+
+        // The "[" token prefix
+        const lbracket_prefix = self.prefix(main_token);
+
+        // Map the index expression
+        const index = try self.mapNode(index_node);
+
+        // Find the "]" token
+        const last_tok = self.ast.lastToken(node);
+        const rbracket_start = self.ast.tokenStart(last_tok);
+        const rbracket_ws = if (rbracket_start > self.cursor)
+            self.source[self.cursor..rbracket_start]
+        else
+            "";
+        self.skipToken(last_tok);
+
+        const aa = try self.allocator.create(tree.ArrayAccess);
+        aa.* = .{
+            .id = self.genUuid(),
+            .prefix = target.getPrefix(),
+            .indexed = target,
+            .dimension_prefix = lbracket_prefix,
+            .index = index,
+            .index_after = .{ .whitespace = rbracket_ws },
+        };
+        return LstNode{ .array_access = aa };
+    }
+
+    // -----------------------------------------------------------------
+    // Slice expression → Zig.Slice
+    // slice_open: a[start..], data.node_and_node: [0]=target, [1]=start
+    // slice: a[start..end], uses extra data
+    // slice_sentinel: a[start..end:sentinel]
+    // -----------------------------------------------------------------
+
+    fn mapSlice(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const full_slice = self.ast.fullSlice(node) orelse return self.mapUnknown(node);
+
+        // Map the target expression (the thing being sliced)
+        const target = try self.mapNode(full_slice.ast.sliced);
+
+        // The "[" token
+        const lbracket_tok = full_slice.ast.lbracket;
+        const lbracket_prefix = self.prefix(lbracket_tok);
+
+        // Map the start expression
+        const start_node = try self.mapNode(full_slice.ast.start);
+        // After the start expression, there are ".." tokens
+        // The trailing includes everything up to the end or "]"
+        const start_after = self.trailingWhitespace(full_slice.ast.start);
+
+        // Map the end expression if present
+        var end_node: ?LstNode = null;
+        if (full_slice.ast.end != .none) {
+            const end_nd = full_slice.ast.end.unwrap().?;
+            end_node = try self.mapNode(end_nd);
+        }
+
+        // Find the "]" token
+        const last_tok = self.ast.lastToken(node);
+        const rbracket_start = self.ast.tokenStart(last_tok);
+        const rbracket_ws = if (rbracket_start > self.cursor)
+            self.source[self.cursor..rbracket_start]
+        else
+            "";
+        self.skipToken(last_tok);
+
+        const s = try self.allocator.create(tree.Slice);
+        s.* = .{
+            .id = self.genUuid(),
+            .prefix = target.getPrefix(),
+            .target = target,
+            .open_bracket = lbracket_prefix,
+            .start = .{
+                .element = start_node,
+                .after = .{ .whitespace = start_after },
+            },
+            .end = end_node,
+            .close_bracket = .{ .whitespace = rbracket_ws },
+        };
+        return LstNode{ .zig_slice = s };
+    }
+
+    // -----------------------------------------------------------------
+    // Postfix deref (expr.*) → J.FieldAccess
+    // deref: data.node = operand, main_token = "*"
+    // We map this as J.FieldAccess with field name "*"
+    // -----------------------------------------------------------------
+
+    fn mapPostfixUnary(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const data = self.ast.nodeData(node);
+        const operand_node = data.node;
+        const main_token = self.ast.nodeMainToken(node);
+
+        // Map the operand
+        const target = try self.mapNode(operand_node);
+
+        // The main_token is the `.*` (period_asterisk) token which represents both "." and "*"
+        // Extract whitespace before this combined token
+        const tok_start = self.ast.tokenStart(main_token);
+        const dot_prefix_ws = self.extractWhitespace(tok_start);
+        // Advance cursor past the entire token (which includes both "." and "*")
+        const tok_len = self.tokenLength(main_token);
+        self.cursor = tok_start + tok_len;
+
+        // Create a name identifier for "*" with empty prefix
+        // (the "." is part of the combined token, printed by FieldAccess)
+        const star_ident = try self.allocator.create(tree.Identifier);
+        star_ident.* = .{
+            .id = self.genUuid(),
+            .prefix = .{ .whitespace = "" },
+            .simple_name = "*",
+        };
+
+        const fa = try self.allocator.create(tree.FieldAccess);
+        fa.* = .{
+            .id = self.genUuid(),
+            .prefix = target.getPrefix(),
+            .target = target,
+            .name = .{
+                .before = .{ .whitespace = dot_prefix_ws },
+                .element = LstNode{ .identifier = star_ident },
+            },
+        };
+        return LstNode{ .field_access = fa };
+    }
+
+    // -----------------------------------------------------------------
+    // Postfix unwrap optional (expr.?) → J.FieldAccess
+    // unwrap_optional: data.node_and_token: [0]=operand, [1]="?" token
+    // main_token = "." token
+    // -----------------------------------------------------------------
+
+    fn mapPostfixDotOp(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const data = self.ast.nodeData(node);
+        const operand_node = data.node_and_token[0];
+        const question_token = data.node_and_token[1];
+
+        // Map the operand
+        const target = try self.mapNode(operand_node);
+
+        // The "." token is the main_token. Extract whitespace before it.
+        const dot_token = self.ast.nodeMainToken(node);
+        const dot_start = self.ast.tokenStart(dot_token);
+        const dot_ws = self.extractWhitespace(dot_start);
+        // Advance cursor past the "." token
+        self.skipToken(dot_token);
+
+        // Map "?" as a name identifier
+        const question_name = try self.mapIdentifier(question_token);
+
+        const fa = try self.allocator.create(tree.FieldAccess);
+        fa.* = .{
+            .id = self.genUuid(),
+            .prefix = target.getPrefix(),
+            .target = target,
+            .name = .{
+                .before = .{ .whitespace = dot_ws },
+                .element = question_name,
+            },
+        };
+        return LstNode{ .field_access = fa };
+    }
+
+    // -----------------------------------------------------------------
+    // Keyword-style unary (try expr) → Zig.Comptime-like or J.Unary
+    // The keyword is the main_token, data.node = the operand.
+    // We map "try" as Zig.Comptime-like: just keyword + expression.
+    // However, since we have Comptime already, let's just use J.Unary
+    // with the keyword text as operator_source.
+    // -----------------------------------------------------------------
+
+    fn mapUnaryKeyword(self: *ParseContext, node: Node.Index, keyword: []const u8) ParseError!LstNode {
+        const main_token = self.ast.nodeMainToken(node);
+        const unary_prefix = self.prefix(main_token);
+
+        const data = self.ast.nodeData(node);
+        const operand_node = data.node;
+        const expression = try self.mapNode(operand_node);
+
+        const u = try self.allocator.create(tree.Unary);
+        u.* = .{
+            .id = self.genUuid(),
+            .prefix = unary_prefix,
+            .operator = .{
+                .before = .{ .whitespace = "" },
+                .element = "Not", // Map try to an existing J.Unary.Type enum
+            },
+            .operator_source = keyword,
+            .expression = expression,
+        };
+        return LstNode{ .unary = u };
+    }
+
+    // -----------------------------------------------------------------
+    // Switch → Zig.Switch (mapped to J.Switch on Java side)
+    // .@"switch", .switch_comma: fullSwitch() gives condition + case nodes
+    // Each case is a switch_case_one/switch_case/switch_case_inline_one/switch_case_inline
+    // -----------------------------------------------------------------
+
+    fn mapSwitch(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const full_switch = self.ast.fullSwitch(node) orelse return self.mapUnknown(node);
+
+        // "switch" keyword prefix
+        const switch_prefix = self.prefix(full_switch.ast.switch_token);
+
+        // The "(" token comes right after "switch"
+        const lparen_tok = full_switch.ast.switch_token + 1;
+        const lparen_prefix = self.prefix(lparen_tok);
+
+        // Map the condition expression
+        const condition = try self.mapNode(full_switch.ast.condition);
+
+        // Find and consume the ")" token after the condition
+        const cond_last_tok = self.ast.lastToken(full_switch.ast.condition);
+        var rparen_tok = cond_last_tok + 1;
+        while (rparen_tok < self.ast.tokens.len and self.ast.tokenTag(rparen_tok) != .r_paren) {
+            rparen_tok += 1;
+        }
+        const condition_after = self.prefix(rparen_tok);
+
+        // Find and consume the "{" token
+        var lbrace_tok = rparen_tok + 1;
+        while (lbrace_tok < self.ast.tokens.len and self.ast.tokenTag(lbrace_tok) != .l_brace) {
+            lbrace_tok += 1;
+        }
+        const lbrace_prefix = self.prefix(lbrace_tok);
+
+        // Map each switch case/prong
+        const case_nodes = full_switch.ast.cases;
+        var prongs = try self.allocator.alloc(RightPadded(LstNode), case_nodes.len);
+        for (case_nodes, 0..) |case_node, i| {
+            const prong = try self.mapSwitchProng(case_node);
+            // After each prong, consume trailing comma if present.
+            // In switch blocks, prongs are separated by commas, not semicolons.
+            const last_tok = self.ast.lastToken(case_node);
+            const next_tok = last_tok + 1;
+            var after: []const u8 = "";
+            if (next_tok < self.ast.tokens.len and self.ast.tokenTag(next_tok) == .comma) {
+                // Include everything from cursor through the comma
+                const comma_end = self.ast.tokenStart(next_tok) + self.tokenLength(next_tok);
+                if (self.cursor < comma_end) {
+                    after = self.source[self.cursor..comma_end];
+                    self.cursor = comma_end;
+                }
+            }
+            prongs[i] = .{
+                .element = prong,
+                .after = .{ .whitespace = after },
+            };
+        }
+
+        // Find the closing "}" token
+        const last_tok = self.ast.lastToken(node);
+        const rbrace_start = self.ast.tokenStart(last_tok);
+        const end_ws = if (rbrace_start > self.cursor)
+            self.source[self.cursor..rbrace_start]
+        else
+            "";
+        self.skipToken(last_tok);
+
+        const sw = try self.allocator.create(tree.Switch);
+        sw.* = .{
+            .id = self.genUuid(),
+            .prefix = switch_prefix,
+            .lparen_prefix = lparen_prefix,
+            .condition = condition,
+            .condition_after = condition_after,
+            .lbrace_prefix = lbrace_prefix,
+            .prongs = prongs,
+            .end = .{ .whitespace = end_ws },
+        };
+        return LstNode{ .zig_switch = sw };
+    }
+
+    fn mapSwitchProng(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const full_case = self.ast.fullSwitchCase(node) orelse return self.mapUnknown(node);
+
+        // Map the case values. Empty values = else case.
+        const values = full_case.ast.values;
+
+        var cases: []RightPadded(LstNode) = undefined;
+        // Prong prefix is empty -- the whitespace before the prong is captured
+        // by the first case value's prefix (or the "else" identifier's prefix).
+        const prong_prefix: Space = .{ .whitespace = "" };
+        if (values.len == 0) {
+            // This is an "else" case. Create an identifier for the "else" keyword.
+            // The first token is the "else" keyword (or "inline" if inline else).
+            const first_tok = self.ast.firstToken(node);
+            var else_tok = first_tok;
+            if (full_case.inline_token) |_| {
+                // Skip "inline" token, find the actual "else" keyword
+                else_tok = first_tok + 1;
+                // Consume the "inline" keyword prefix
+                _ = self.prefix(first_tok);
+            }
+
+            // Consume the "else" keyword, getting its prefix (whitespace before it)
+            const else_ws = self.prefix(else_tok);
+
+            cases = try self.allocator.alloc(RightPadded(LstNode), 1);
+            const else_ident = try self.allocator.create(tree.Identifier);
+            else_ident.* = .{
+                .id = self.genUuid(),
+                .prefix = else_ws,
+                .simple_name = "else",
+            };
+            cases[0] = .{
+                .element = LstNode{ .identifier = else_ident },
+                .after = .{ .whitespace = "" },
+            };
+        } else {
+            // For value cases, let mapNode handle the prefix extraction for each value.
+            // The first value's prefix will capture the whitespace before the prong.
+            cases = try self.allocator.alloc(RightPadded(LstNode), values.len);
+            for (values, 0..) |val_node, i| {
+                const val = try self.mapNode(val_node);
+                const after = self.trailingWhitespace(val_node);
+                cases[i] = .{
+                    .element = val,
+                    .after = .{ .whitespace = after },
+                };
+            }
+        }
+
+        // Handle payload if present (|val|)
+        var payload: ?LstNode = null;
+        if (full_case.payload_token) |payload_tok| {
+            // payload_token points to the first identifier after the "|"
+            // We need to capture from the "|" through to the closing "|"
+            // The "|" token is payload_tok - 1
+            const pipe_tok = payload_tok - 1;
+            const pipe_start = self.ast.tokenStart(pipe_tok);
+            const pipe_ws = if (pipe_start > self.cursor)
+                self.source[self.cursor..pipe_start]
+            else
+                "";
+
+            // Find the closing "|" by scanning forward
+            var close_pipe = payload_tok;
+            while (close_pipe < self.ast.tokens.len and self.ast.tokenTag(close_pipe) != .pipe) {
+                close_pipe += 1;
+            }
+            // Capture the full payload text from "|" through "|"
+            const close_pipe_end = self.ast.tokenStart(close_pipe) + self.tokenLength(close_pipe);
+            const payload_text = self.source[pipe_start..close_pipe_end];
+            self.cursor = close_pipe_end;
+
+            // Create an identifier node with the full payload text
+            const payload_ident = try self.allocator.create(tree.Identifier);
+            payload_ident.* = .{
+                .id = self.genUuid(),
+                .prefix = .{ .whitespace = pipe_ws },
+                .simple_name = payload_text,
+            };
+            payload = LstNode{ .identifier = payload_ident };
+        }
+
+        // The arrow token ("=>") - extract its prefix
+        const arrow_tok = full_case.ast.arrow_token;
+        const arrow_prefix = self.prefix(arrow_tok);
+
+        // Map the target expression (the body of this prong)
+        const target_expr = try self.mapNode(full_case.ast.target_expr);
+
+        const sp = try self.allocator.create(tree.SwitchProng);
+        sp.* = .{
+            .id = self.genUuid(),
+            .prefix = prong_prefix,
+            .cases_prefix = .{ .whitespace = "" }, // prefix is already in prong_prefix
+            .cases = cases,
+            .payload = payload,
+            .arrow = .{
+                .before = arrow_prefix,
+                .element = target_expr,
+            },
+        };
+        return LstNode{ .zig_switch_prong = sp };
+    }
+
+    // -----------------------------------------------------------------
+    // For loop → Zig.ForLoop
+    // for_simple: data.node_and_node: [0]=iterable, [1]=body
+    //             main_token = "for"
+    // .@"for": accessed via fullFor()
+    // -----------------------------------------------------------------
+
+    fn mapForLoop(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const full_for = self.ast.fullFor(node) orelse return self.mapUnknown(node);
+
+        // "for" keyword prefix
+        const for_prefix = self.prefix(full_for.ast.for_token);
+
+        // Capture the iterable section text: from "(" through ")"
+        // The "(" token is right after "for"
+        const lparen_tok = full_for.ast.for_token + 1;
+        const lparen_start = self.ast.tokenStart(lparen_tok);
+        const lparen_ws = self.extractWhitespace(lparen_start);
+
+        // Find the last token of the last input, then scan for ")"
+        const last_input = full_for.ast.inputs[full_for.ast.inputs.len - 1];
+        const last_input_tok = self.ast.lastToken(last_input);
+        var rparen_tok = last_input_tok + 1;
+        while (rparen_tok < self.ast.tokens.len and self.ast.tokenTag(rparen_tok) != .r_paren) {
+            rparen_tok += 1;
+        }
+        const rparen_end = self.ast.tokenStart(rparen_tok) + self.tokenLength(rparen_tok);
+        const iterable_text = self.source[lparen_start..rparen_end];
+        self.cursor = rparen_end;
+
+        // Capture the payload text: include whitespace between ")" and "|",
+        // plus from first "|" through closing "|".
+        // This captures " |item|" or " |item, index|" faithfully.
+        const payload_tok = full_for.payload_token;
+        const payload_text_start = self.cursor; // right after ")"
+
+        // Find the closing "|" by scanning forward from payload_token
+        var close_pipe = payload_tok;
+        while (close_pipe < self.ast.tokens.len and self.ast.tokenTag(close_pipe) != .pipe) {
+            close_pipe += 1;
+        }
+        const close_pipe_end = self.ast.tokenStart(close_pipe) + self.tokenLength(close_pipe);
+        const payload_text = self.source[payload_text_start..close_pipe_end];
+        self.cursor = close_pipe_end;
+
+        // Map the body
+        const body = try self.mapNode(full_for.ast.then_expr);
+        const body_after = self.trailingWhitespace(full_for.ast.then_expr);
+
+        // Map the else branch if present
+        var else_body: ?*tree.ForLoopElse = null;
+        if (full_for.ast.else_expr != .none) {
+            const else_expr_node = full_for.ast.else_expr.unwrap().?;
+            // Find the "else" keyword token
+            const else_first_tok = self.ast.firstToken(else_expr_node);
+            var else_keyword_tok = else_first_tok;
+            if (else_keyword_tok > 0) {
+                else_keyword_tok -= 1;
+                while (else_keyword_tok > 0 and self.ast.tokenTag(else_keyword_tok) != .keyword_else) {
+                    else_keyword_tok -= 1;
+                }
+            }
+            const else_kw_prefix = self.prefix(else_keyword_tok);
+
+            const else_expr = try self.mapNode(else_expr_node);
+            const else_body_after = self.trailingWhitespace(else_expr_node);
+
+            const else_node = try self.allocator.create(tree.ForLoopElse);
+            else_node.* = .{
+                .id = self.genUuid(),
+                .prefix = else_kw_prefix,
+                .body = else_expr,
+                .body_after = .{ .whitespace = else_body_after },
+            };
+            else_body = else_node;
+        }
+
+        const fl = try self.allocator.create(tree.ForLoop);
+        fl.* = .{
+            .id = self.genUuid(),
+            .prefix = for_prefix,
+            .lparen_prefix = .{ .whitespace = lparen_ws },
+            .iterable_text = iterable_text,
+            .payload_text = payload_text,
+            .body = body,
+            .body_after = .{ .whitespace = body_after },
+            .else_body = else_body,
+        };
+        return LstNode{ .zig_for_loop = fl };
+    }
+
+    // -----------------------------------------------------------------
+    // Defer / Errdefer → Zig.Defer
+    // defer: data.node = the deferred expression, main_token = "defer"
+    // errdefer: data.opt_token_and_node: [0]=payload token (optional), [1]=expr node
+    //           main_token = "errdefer"
+    // -----------------------------------------------------------------
+
+    fn mapDefer(self: *ParseContext, node: Node.Index, is_errdefer: bool) ParseError!LstNode {
+        const main_token = self.ast.nodeMainToken(node);
+        const defer_prefix = self.prefix(main_token);
+
+        const payload: ?LstNode = null;
+        var expr_node: Node.Index = undefined;
+
+        if (is_errdefer) {
+            // errdefer: data is opt_token_and_node
+            const data = self.ast.nodeData(node);
+            expr_node = data.opt_token_and_node[1];
+            // Payload token if present (|err|)
+            if (data.opt_token_and_node[0].unwrap()) |_| {
+                // For now, skip payload mapping (would need Zig.Payload type)
+                // Just advance cursor past payload tokens
+            }
+        } else {
+            // defer: data is node
+            const data = self.ast.nodeData(node);
+            expr_node = data.node;
+        }
+
+        const expression = try self.mapNode(expr_node);
+
+        const d = try self.allocator.create(tree.Defer);
+        d.* = .{
+            .id = self.genUuid(),
+            .prefix = defer_prefix,
+            .is_errdefer = is_errdefer,
+            .payload = payload,
+            .expression = expression,
+        };
+        return LstNode{ .zig_defer = d };
+    }
+
+    // -----------------------------------------------------------------
+    // Test declaration → Zig.TestDecl
+    // test_decl: data.opt_token_and_node: [0]=name token (optional), [1]=body node
+    // main_token = "test"
+    // -----------------------------------------------------------------
+
+    fn mapTestDecl(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const main_token = self.ast.nodeMainToken(node);
+        const test_prefix = self.prefix(main_token);
+
+        const data = self.ast.nodeData(node);
+        const body_node = data.opt_token_and_node[1];
+
+        // Name token is optional (test "name" {...} or test {...})
+        var name: ?LstNode = null;
+        if (data.opt_token_and_node[0].unwrap()) |name_tok| {
+            // The name is a string literal token
+            const name_prefix = self.prefix(name_tok);
+            const name_text = self.ast.tokenSlice(name_tok);
+
+            const lit = try self.allocator.create(tree.Literal);
+            lit.* = .{
+                .id = self.genUuid(),
+                .prefix = name_prefix,
+                .value = .{ .string = name_text },
+                .value_source = name_text,
+            };
+            name = LstNode{ .literal = lit };
+        }
+
+        const body = try self.mapNode(body_node);
+
+        const td = try self.allocator.create(tree.TestDecl);
+        td.* = .{
+            .id = self.genUuid(),
+            .prefix = test_prefix,
+            .name = name,
+            .body = body,
+        };
+        return LstNode{ .zig_test_decl = td };
+    }
+
+    // -----------------------------------------------------------------
+    // Comptime → Zig.Comptime
+    // comptime: data.node = the expression, main_token = "comptime"
+    // -----------------------------------------------------------------
+
+    fn mapComptime(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const main_token = self.ast.nodeMainToken(node);
+        const comptime_prefix = self.prefix(main_token);
+
+        const data = self.ast.nodeData(node);
+        const expr_node = data.node;
+        const expression = try self.mapNode(expr_node);
+
+        const ct = try self.allocator.create(tree.Comptime);
+        ct.* = .{
+            .id = self.genUuid(),
+            .prefix = comptime_prefix,
+            .expression = expression,
+        };
+        return LstNode{ .zig_comptime = ct };
+    }
+
+    // -----------------------------------------------------------------
+    // Identifier (from token) → J.Identifier
+    // -----------------------------------------------------------------
+
+    pub fn mapIdentifier(self: *ParseContext, token_index: Ast.TokenIndex) ParseError!LstNode {
+        const ident_prefix = self.prefix(token_index);
+        const name = self.ast.tokenSlice(token_index);
+        const ident = try self.allocator.create(tree.Identifier);
+        ident.* = .{
+            .id = self.genUuid(),
+            .prefix = ident_prefix,
+            .simple_name = name,
+        };
+        return LstNode{ .identifier = ident };
+    }
+
+    /// Map an identifier node (as opposed to a token index).
+    fn mapIdentifierNode(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const main_token = self.ast.nodeMainToken(node);
+        return self.mapIdentifier(main_token);
+    }
+
+    /// Map an enum literal (.foo) to an identifier with the dot prefix included.
+    fn mapEnumLiteral(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        // The main_token is the identifier after the dot
+        // But we need to include the preceding dot as part of the prefix
+        const main_token = self.ast.nodeMainToken(node);
+        // The dot token is main_token - 1
+        const dot_token = main_token - 1;
+
+        // Extract whitespace up to the dot, then consume both dot and identifier
+        const dot_start = self.ast.tokenStart(dot_token);
+        const ws = if (dot_start > self.cursor) self.source[self.cursor..dot_start] else "";
+
+        // Now consume the dot and identifier tokens
+        const ident_start = self.ast.tokenStart(main_token);
+        const ident_len = self.tokenLength(main_token);
+        self.cursor = ident_start + ident_len;
+
+        // The full name including the dot prefix
+        const dot_text = self.source[dot_start .. ident_start + ident_len];
+
+        const ident = try self.allocator.create(tree.Identifier);
+        ident.* = .{
+            .id = self.genUuid(),
+            .prefix = .{ .whitespace = ws },
+            .simple_name = dot_text,
+        };
+        return LstNode{ .identifier = ident };
+    }
+
+    // -----------------------------------------------------------------
+    // Number literal → J.Literal
+    // -----------------------------------------------------------------
+
+    fn mapNumberLiteralNode(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const main_token = self.ast.nodeMainToken(node);
+        return self.mapNumberLiteral(main_token);
+    }
+
+    pub fn mapNumberLiteral(self: *ParseContext, token_index: Ast.TokenIndex) ParseError!LstNode {
+        const lit_prefix = self.prefix(token_index);
+        const value_source = self.ast.tokenSlice(token_index);
+
+        // Try to parse the number for the value field
+        var value: ?tree.LiteralValue = null;
+        if (std.fmt.parseInt(i64, value_source, 0)) |v| {
+            value = .{ .int = v };
+        } else |_| {
+            if (std.fmt.parseFloat(f64, value_source)) |v| {
+                value = .{ .float = v };
+            } else |_| {}
+        }
+
+        const lit = try self.allocator.create(tree.Literal);
+        lit.* = .{
+            .id = self.genUuid(),
+            .prefix = lit_prefix,
+            .value = value,
+            .value_source = value_source,
+        };
+        return LstNode{ .literal = lit };
+    }
+
+    // -----------------------------------------------------------------
+    // String literal → J.Literal
+    // -----------------------------------------------------------------
+
+    fn mapStringLiteralNode(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const main_token = self.ast.nodeMainToken(node);
+        const lit_prefix = self.prefix(main_token);
+        const value_source = self.ast.tokenSlice(main_token);
+
+        const lit = try self.allocator.create(tree.Literal);
+        lit.* = .{
+            .id = self.genUuid(),
+            .prefix = lit_prefix,
+            .value = .{ .string = value_source },
+            .value_source = value_source,
+        };
+        return LstNode{ .literal = lit };
+    }
+
+    // -----------------------------------------------------------------
+    // Unknown (fallback) → J.Unknown
+    // -----------------------------------------------------------------
+
+    fn mapUnknown(self: *ParseContext, node: Node.Index) ParseError!LstNode {
+        const first_tok = self.ast.firstToken(node);
+        const unknown_prefix = self.prefix(first_tok);
+
+        // Extract the full source text of this node
+        const last_tok = self.ast.lastToken(node);
+        const node_start = self.ast.tokenStart(first_tok);
+        const last_start = self.ast.tokenStart(last_tok);
+        const last_len = self.tokenLength(last_tok);
+        const node_end = last_start + last_len;
+
+        // The text starts after the first token (which was consumed for prefix)
+        // Actually, we need the full text including the first token
+        const text = self.source[node_start..node_end];
+        self.cursor = node_end;
+
+        const source_node = try self.allocator.create(tree.UnknownSource);
+        source_node.* = .{
+            .id = self.genUuid(),
+            .prefix = .{ .whitespace = "" },
+            .text = text,
+        };
+
+        const unknown = try self.allocator.create(tree.Unknown);
+        unknown.* = .{
+            .id = self.genUuid(),
+            .prefix = unknown_prefix,
+            .source = LstNode{ .unknown_source = source_node },
+        };
+        return LstNode{ .unknown = unknown };
+    }
+};
+
+test "ParseContext basic parsing" {
+    // Use arena allocator to avoid leaking tree nodes
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const source = "const x = 42;\n";
+    const source_z: [:0]const u8 = try allocator.dupeZ(u8, source);
+
+    var ast = try std.zig.Ast.parse(allocator, source_z, .zig);
+    defer ast.deinit(allocator);
+
+    var ctx = ParseContext.init(allocator, source, source_z, ast);
+    const result = try ctx.mapFile("test.zig", "test-uuid-1234");
+
+    // Verify we got a compilation_unit
+    switch (result) {
+        .compilation_unit => |cu| {
+            try std.testing.expectEqualStrings("test.zig", cu.source_path);
+            try std.testing.expect(cu.statements.len > 0);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "ParseContext for loop round-trip" {
+    const printer = @import("printer.zig");
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const source =
+        \\fn sum(items: []const i32) i32 {
+        \\    var total: i32 = 0;
+        \\    for (items) |item| {
+        \\        total += item;
+        \\    }
+        \\    return total;
+        \\}
+        \\
+    ;
+    const source_z: [:0]const u8 = try allocator.dupeZ(u8, source);
+    var ast = try std.zig.Ast.parse(allocator, source_z, .zig);
+    defer ast.deinit(allocator);
+
+    var ctx = ParseContext.init(allocator, source, source_z, ast);
+    const result = try ctx.mapFile("test.zig", "test-uuid-1234");
+
+    const output = try printer.print(allocator, result);
+    defer allocator.free(output);
+
+    try std.testing.expectEqualStrings(source, output);
+}
+
+test "ParseContext switch expression round-trip" {
+    const printer = @import("printer.zig");
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const source =
+        \\fn toStr(x: u8) []const u8 {
+        \\    return switch (x) {
+        \\        0 => "zero",
+        \\        1 => "one",
+        \\        else => "other",
+        \\    };
+        \\}
+        \\
+    ;
+    const source_z: [:0]const u8 = try allocator.dupeZ(u8, source);
+    var ast = try std.zig.Ast.parse(allocator, source_z, .zig);
+    defer ast.deinit(allocator);
+
+    var ctx = ParseContext.init(allocator, source, source_z, ast);
+    const result = try ctx.mapFile("test.zig", "test-uuid-1234");
+
+    const output = try printer.print(allocator, result);
+    defer allocator.free(output);
+
+    try std.testing.expectEqualStrings(source, output);
+}

--- a/rewrite-zig/rewrite/src/printer.zig
+++ b/rewrite-zig/rewrite/src/printer.zig
@@ -1,0 +1,622 @@
+// Copyright 2025 the original author or authors.
+//
+// Licensed under the Moderne Source Available License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://docs.moderne.io/licensing/moderne-source-available-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Walks an LstNode tree and emits source text to a buffer.
+//! The pattern follows the Go printer: for each node emit prefix whitespace,
+//! emit the node's keyword/operator/text, then recurse into children.
+
+const std = @import("std");
+const tree = @import("tree.zig");
+
+const LstNode = tree.LstNode;
+const Space = tree.Space;
+const RightPadded = tree.RightPadded;
+const LeftPadded = tree.LeftPadded;
+
+pub const Printer = struct {
+    buf: std.ArrayListUnmanaged(u8),
+    allocator: std.mem.Allocator,
+
+    pub const PrintError = std.mem.Allocator.Error;
+
+    pub fn create(allocator: std.mem.Allocator) Printer {
+        return .{
+            .buf = .{},
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *Printer) void {
+        self.buf.deinit(self.allocator);
+    }
+
+    pub fn getOutput(self: *const Printer) []const u8 {
+        return self.buf.items;
+    }
+
+    // -----------------------------------------------------------------
+    // Entry point: print any LstNode
+    // -----------------------------------------------------------------
+
+    pub fn printNode(self: *Printer, node: LstNode) PrintError!void {
+        switch (node) {
+            .compilation_unit => |cu| try self.printCompilationUnit(cu),
+            .method_declaration => |md| try self.printMethodDeclaration(md),
+            .variable_declarations => |vd| try self.printVariableDeclarations(vd),
+            .identifier => |id| try self.printIdentifier(id),
+            .literal => |lit| try self.printLiteral(lit),
+            .binary => |bin| try self.printBinary(bin),
+            .block => |blk| try self.printBlock(blk),
+            .field_access => |fa| try self.printFieldAccess(fa),
+            .method_invocation => |mi| try self.printMethodInvocation(mi),
+            .@"return" => |ret| try self.printReturn(ret),
+            .assignment => |asgn| try self.printAssignment(asgn),
+            .@"if" => |i| try self.printIf(i),
+            .while_loop => |wl| try self.printWhileLoop(wl),
+            .unary => |u| try self.printUnary(u),
+            .parentheses => |p| try self.printParentheses(p),
+            .array_access => |aa| try self.printArrayAccess(aa),
+            .assignment_op => |ao| try self.printAssignmentOp(ao),
+            .zig_slice => |s| try self.printSlice(s),
+            .zig_error_union => |eu| try self.printErrorUnion(eu),
+            .zig_switch => |sw| try self.printSwitch(sw),
+            .zig_switch_prong => |sp| try self.printSwitchProng(sp),
+            .zig_for_loop => |fl| try self.printForLoop(fl),
+            .zig_defer => |d| try self.printDefer(d),
+            .zig_comptime => |ct| try self.printComptime(ct),
+            .zig_test_decl => |td| try self.printTestDecl(td),
+            .unknown => |u| try self.printUnknown(u),
+            .unknown_source => |us| try self.printUnknownSource(us),
+            .empty => |emp| try self.printEmpty(emp),
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Helper: emit whitespace/prefix text
+    // -----------------------------------------------------------------
+
+    pub fn emit(self: *Printer, text: []const u8) PrintError!void {
+        if (text.len > 0) {
+            try self.buf.appendSlice(self.allocator, text);
+        }
+    }
+
+    fn emitByte(self: *Printer, byte: u8) PrintError!void {
+        try self.buf.append(self.allocator, byte);
+    }
+
+    pub fn printSpace(self: *Printer, space: Space) PrintError!void {
+        try self.emit(space.whitespace);
+    }
+
+    // -----------------------------------------------------------------
+    // CompilationUnit
+    // -----------------------------------------------------------------
+
+    fn printCompilationUnit(self: *Printer, cu: *const tree.CompilationUnit) PrintError!void {
+        try self.printSpace(cu.prefix);
+        for (cu.statements) |stmt| {
+            try self.printNode(stmt.element);
+            try self.printSpace(stmt.after);
+        }
+        try self.printSpace(cu.eof);
+    }
+
+    // -----------------------------------------------------------------
+    // MethodDeclaration
+    // prefix + keywords + name + params_prefix + params_text + return_type + body
+    // -----------------------------------------------------------------
+
+    fn printMethodDeclaration(self: *Printer, md: *const tree.MethodDeclaration) PrintError!void {
+        try self.printSpace(md.prefix);
+        // Keywords: "fn", "pub fn", "export fn", etc.
+        try self.emit(md.keywords);
+        // Function name (with its own prefix for spacing)
+        try self.printNode(md.name);
+        // Parameter list: prefix space + full params text "(a: i32, b: i32)"
+        try self.printSpace(md.params_prefix);
+        try self.emit(md.params_text);
+        // Return type (if present) -- its prefix captures the space after ")"
+        if (md.return_type) |rt| {
+            try self.printNode(rt);
+        }
+        // Body block (if present)
+        if (md.body) |body| {
+            try self.printNode(body);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // VariableDeclarations
+    // prefix + keyword + variables[0].name + type_expression + initializer
+    // -----------------------------------------------------------------
+
+    fn printVariableDeclarations(self: *Printer, vd: *const tree.VariableDeclarations) PrintError!void {
+        try self.printSpace(vd.prefix);
+        // Keyword: "const", "var", "pub const", "pub var", etc.
+        try self.emit(vd.keyword);
+        // Variables (typically one for Zig)
+        for (vd.variables) |v| {
+            // The element is the name identifier
+            try self.printNode(v.element);
+        }
+        // Type expression (prefix includes ": ")
+        if (vd.type_expression) |te| {
+            try self.printNode(te);
+        }
+        // Initializer (left-padded by "=" whitespace)
+        if (vd.initializer) |initializer| {
+            try self.printSpace(initializer.before);
+            try self.emitByte('=');
+            try self.printNode(initializer.element);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Identifier
+    // prefix + simple_name
+    // -----------------------------------------------------------------
+
+    fn printIdentifier(self: *Printer, id: *const tree.Identifier) PrintError!void {
+        try self.printSpace(id.prefix);
+        try self.emit(id.simple_name);
+    }
+
+    // -----------------------------------------------------------------
+    // Literal
+    // prefix + value_source
+    // -----------------------------------------------------------------
+
+    fn printLiteral(self: *Printer, lit: *const tree.Literal) PrintError!void {
+        try self.printSpace(lit.prefix);
+        if (lit.value_source) |vs| {
+            try self.emit(vs);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Binary
+    // left + operator.before + operator_source + right
+    // (prefix = left's prefix, so we don't emit it separately)
+    // -----------------------------------------------------------------
+
+    fn printBinary(self: *Printer, bin: *const tree.Binary) PrintError!void {
+        // The binary prefix IS the left operand's prefix (set by parser),
+        // so we don't emit bin.prefix separately -- it's emitted when we print left.
+        try self.printNode(bin.left);
+        try self.printSpace(bin.operator.before);
+        try self.emit(bin.operator_source);
+        try self.printNode(bin.right);
+    }
+
+    // -----------------------------------------------------------------
+    // Block
+    // prefix + "{" + statements + end + "}"
+    // -----------------------------------------------------------------
+
+    fn printBlock(self: *Printer, blk: *const tree.Block) PrintError!void {
+        try self.printSpace(blk.prefix);
+        try self.emitByte('{');
+        for (blk.statements) |stmt| {
+            try self.printNode(stmt.element);
+            try self.printSpace(stmt.after);
+        }
+        try self.printSpace(blk.end);
+        try self.emitByte('}');
+    }
+
+    // -----------------------------------------------------------------
+    // Return
+    // prefix + "return" + expression
+    // -----------------------------------------------------------------
+
+    fn printReturn(self: *Printer, ret: *const tree.Return) PrintError!void {
+        try self.printSpace(ret.prefix);
+        try self.emit("return");
+        if (ret.expression) |expr| {
+            try self.printNode(expr);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // FieldAccess
+    // target + name.before + "." + name.element
+    // (prefix = target's prefix, so we don't emit it separately)
+    // -----------------------------------------------------------------
+
+    fn printFieldAccess(self: *Printer, fa: *const tree.FieldAccess) PrintError!void {
+        // The field access prefix IS the target's prefix (set by parser).
+        try self.printNode(fa.target);
+        try self.printSpace(fa.name.before);
+        try self.emitByte('.');
+        try self.printNode(fa.name.element);
+    }
+
+    // -----------------------------------------------------------------
+    // MethodInvocation
+    // select + "." + name + args_prefix + "(" + args + ")"
+    // (prefix = name's prefix / select's prefix)
+    // -----------------------------------------------------------------
+
+    fn printMethodInvocation(self: *Printer, mi: *const tree.MethodInvocation) PrintError!void {
+        if (mi.select) |sel| {
+            // Method-style call: target.name(args)
+            try self.printNode(sel.element);
+            try self.printSpace(sel.after);
+            try self.emitByte('.');
+        }
+        try self.printNode(mi.name);
+        try self.printSpace(mi.args_prefix);
+        try self.emitByte('(');
+        for (mi.args) |arg| {
+            try self.printNode(arg.element);
+            try self.printSpace(arg.after);
+        }
+        try self.emitByte(')');
+    }
+
+    // -----------------------------------------------------------------
+    // Assignment
+    // variable + assignment.before + "=" + assignment.element
+    // (prefix = variable's prefix)
+    // -----------------------------------------------------------------
+
+    fn printAssignment(self: *Printer, asgn: *const tree.Assignment) PrintError!void {
+        try self.printNode(asgn.variable);
+        try self.printSpace(asgn.assignment.before);
+        try self.emitByte('=');
+        try self.printNode(asgn.assignment.element);
+    }
+
+    // -----------------------------------------------------------------
+    // If
+    // prefix + "if" + " (" + condition + ")" + then + else?
+    // -----------------------------------------------------------------
+
+    fn printIf(self: *Printer, i: *const tree.If) PrintError!void {
+        try self.printSpace(i.prefix);
+        try self.emit("if");
+        try self.printSpace(i.lparen_prefix);
+        try self.emitByte('(');
+        try self.printNode(i.condition);
+        try self.printSpace(i.condition_after);
+        try self.emitByte(')');
+        try self.printNode(i.then_part);
+        try self.printSpace(i.then_after);
+        if (i.else_part) |else_part| {
+            try self.printSpace(else_part.prefix);
+            try self.emit("else");
+            try self.printNode(else_part.body);
+            try self.printSpace(else_part.body_after);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // WhileLoop
+    // prefix + "while" + " (" + condition + ")" + body
+    // -----------------------------------------------------------------
+
+    fn printWhileLoop(self: *Printer, wl: *const tree.WhileLoop) PrintError!void {
+        try self.printSpace(wl.prefix);
+        try self.emit("while");
+        try self.printSpace(wl.lparen_prefix);
+        try self.emitByte('(');
+        try self.printNode(wl.condition);
+        try self.printSpace(wl.condition_after);
+        try self.emitByte(')');
+        try self.printNode(wl.body);
+        try self.printSpace(wl.body_after);
+    }
+
+    // -----------------------------------------------------------------
+    // Unary
+    // prefix + operator_source + expression
+    // -----------------------------------------------------------------
+
+    fn printUnary(self: *Printer, u: *const tree.Unary) PrintError!void {
+        try self.printSpace(u.prefix);
+        try self.emit(u.operator_source);
+        try self.printNode(u.expression);
+    }
+
+    // -----------------------------------------------------------------
+    // AssignmentOperation
+    // variable + operator + assignment
+    // -----------------------------------------------------------------
+
+    fn printAssignmentOp(self: *Printer, ao: *const tree.AssignmentOperation) PrintError!void {
+        // prefix IS the variable's prefix (set by parser)
+        try self.printNode(ao.variable);
+        try self.printSpace(ao.operator.before);
+        try self.emit(ao.operator_source);
+        try self.printNode(ao.assignment);
+    }
+
+    // -----------------------------------------------------------------
+    // ArrayAccess
+    // target + "[" + index + "]"
+    // -----------------------------------------------------------------
+
+    fn printArrayAccess(self: *Printer, aa: *const tree.ArrayAccess) PrintError!void {
+        // prefix IS the target's prefix (set by parser)
+        try self.printNode(aa.indexed);
+        try self.printSpace(aa.dimension_prefix);
+        try self.emitByte('[');
+        try self.printNode(aa.index);
+        try self.printSpace(aa.index_after);
+        try self.emitByte(']');
+    }
+
+    // -----------------------------------------------------------------
+    // Parentheses
+    // prefix + "(" + expression + after + ")"
+    // -----------------------------------------------------------------
+
+    fn printParentheses(self: *Printer, p: *const tree.Parentheses) PrintError!void {
+        try self.printSpace(p.prefix);
+        try self.emitByte('(');
+        try self.printNode(p.expression);
+        try self.printSpace(p.after);
+        try self.emitByte(')');
+    }
+
+    // -----------------------------------------------------------------
+    // Slice
+    // target + "[" + start + ".." + end? + "]"
+    // -----------------------------------------------------------------
+
+    fn printSlice(self: *Printer, s: *const tree.Slice) PrintError!void {
+        // prefix IS the target's prefix (set by parser)
+        try self.printNode(s.target);
+        try self.printSpace(s.open_bracket);
+        try self.emitByte('[');
+        try self.printNode(s.start.element);
+        try self.printSpace(s.start.after);
+        if (s.end) |end| {
+            try self.printNode(end);
+        }
+        try self.printSpace(s.close_bracket);
+        try self.emitByte(']');
+    }
+
+    // -----------------------------------------------------------------
+    // ErrorUnion
+    // error_type? + "!" + value_type
+    // For implicit error sets: prefix + "!" + value_type
+    // For explicit: error_type + "!" + value_type
+    // -----------------------------------------------------------------
+
+    fn printErrorUnion(self: *Printer, eu: *const tree.ErrorUnion) PrintError!void {
+        if (eu.error_type) |et| {
+            try self.printNode(et);
+        } else {
+            try self.printSpace(eu.prefix);
+        }
+        try self.emitByte('!');
+        try self.printSpace(eu.value_type.before);
+        try self.printNode(eu.value_type.element);
+    }
+
+    // -----------------------------------------------------------------
+    // Switch
+    // prefix + "switch" + "(" + condition + ")" + "{" + prongs + "}"
+    // -----------------------------------------------------------------
+
+    fn printSwitch(self: *Printer, sw: *const tree.Switch) PrintError!void {
+        try self.printSpace(sw.prefix);
+        try self.emit("switch");
+        try self.printSpace(sw.lparen_prefix);
+        try self.emitByte('(');
+        try self.printNode(sw.condition);
+        try self.printSpace(sw.condition_after);
+        try self.emitByte(')');
+        try self.printSpace(sw.lbrace_prefix);
+        try self.emitByte('{');
+        for (sw.prongs) |prong| {
+            try self.printNode(prong.element);
+            try self.printSpace(prong.after);
+        }
+        try self.printSpace(sw.end);
+        try self.emitByte('}');
+    }
+
+    // -----------------------------------------------------------------
+    // SwitchProng
+    // prefix + cases + payload? + "=>" + arrow expression
+    // For else case: cases is empty, prefix contains "else"
+    // -----------------------------------------------------------------
+
+    fn printSwitchProng(self: *Printer, sp: *const tree.SwitchProng) PrintError!void {
+        try self.printSpace(sp.prefix);
+        // Print case values
+        try self.printSpace(sp.cases_prefix);
+        for (sp.cases) |c| {
+            try self.printNode(c.element);
+            try self.printSpace(c.after);
+        }
+        // Print payload if present
+        if (sp.payload) |pl| {
+            try self.printNode(pl);
+        }
+        // Print arrow (=> + target expression)
+        try self.printSpace(sp.arrow.before);
+        try self.emit("=>");
+        try self.printNode(sp.arrow.element);
+    }
+
+    // -----------------------------------------------------------------
+    // ForLoop
+    // prefix + "for" + " " + iterable_text + " " + payload_text + body
+    // -----------------------------------------------------------------
+
+    fn printForLoop(self: *Printer, fl: *const tree.ForLoop) PrintError!void {
+        try self.printSpace(fl.prefix);
+        try self.emit("for");
+        try self.printSpace(fl.lparen_prefix);
+        try self.emit(fl.iterable_text);
+        // Payload text already has its leading space baked in
+        try self.emit(fl.payload_text);
+        try self.printNode(fl.body);
+        try self.printSpace(fl.body_after);
+        if (fl.else_body) |else_body| {
+            try self.printSpace(else_body.prefix);
+            try self.emit("else");
+            try self.printNode(else_body.body);
+            try self.printSpace(else_body.body_after);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Defer
+    // prefix + "defer"/"errdefer" + expression
+    // -----------------------------------------------------------------
+
+    fn printDefer(self: *Printer, d: *const tree.Defer) PrintError!void {
+        try self.printSpace(d.prefix);
+        if (d.is_errdefer) {
+            try self.emit("errdefer");
+        } else {
+            try self.emit("defer");
+        }
+        if (d.payload) |p| {
+            try self.printNode(p);
+        }
+        try self.printNode(d.expression);
+    }
+
+    // -----------------------------------------------------------------
+    // Comptime
+    // prefix + "comptime" + expression
+    // -----------------------------------------------------------------
+
+    fn printComptime(self: *Printer, ct: *const tree.Comptime) PrintError!void {
+        try self.printSpace(ct.prefix);
+        try self.emit("comptime");
+        try self.printNode(ct.expression);
+    }
+
+    // -----------------------------------------------------------------
+    // TestDecl
+    // prefix + "test" + name + body
+    // -----------------------------------------------------------------
+
+    fn printTestDecl(self: *Printer, td: *const tree.TestDecl) PrintError!void {
+        try self.printSpace(td.prefix);
+        try self.emit("test");
+        if (td.name) |name| {
+            try self.printNode(name);
+        }
+        try self.printNode(td.body);
+    }
+
+    // -----------------------------------------------------------------
+    // Unknown
+    // prefix + source
+    // -----------------------------------------------------------------
+
+    fn printUnknown(self: *Printer, u: *const tree.Unknown) PrintError!void {
+        try self.printSpace(u.prefix);
+        try self.printNode(u.source);
+    }
+
+    // -----------------------------------------------------------------
+    // UnknownSource
+    // prefix + text
+    // -----------------------------------------------------------------
+
+    fn printUnknownSource(self: *Printer, us: *const tree.UnknownSource) PrintError!void {
+        try self.printSpace(us.prefix);
+        try self.emit(us.text);
+    }
+
+    // -----------------------------------------------------------------
+    // Empty
+    // prefix only
+    // -----------------------------------------------------------------
+
+    fn printEmpty(self: *Printer, emp: *const tree.Empty) PrintError!void {
+        try self.printSpace(emp.prefix);
+    }
+};
+
+/// Top-level print function: create a printer, walk the tree, return owned output.
+pub fn print(allocator: std.mem.Allocator, node: LstNode) ![]const u8 {
+    var p = Printer.create(allocator);
+    defer p.deinit();
+    try p.printNode(node);
+    return try allocator.dupe(u8, p.getOutput());
+}
+
+// -----------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------
+
+test "print identifier" {
+    const allocator = std.testing.allocator;
+    var ident = tree.Identifier{
+        .id = "test-uuid",
+        .prefix = .{ .whitespace = " " },
+        .simple_name = "foo",
+    };
+    const node = LstNode{ .identifier = &ident };
+    const result = try print(allocator, node);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings(" foo", result);
+}
+
+test "print literal" {
+    const allocator = std.testing.allocator;
+    var lit = tree.Literal{
+        .id = "test-uuid",
+        .prefix = .{ .whitespace = " " },
+        .value = .{ .int = 42 },
+        .value_source = "42",
+    };
+    const node = LstNode{ .literal = &lit };
+    const result = try print(allocator, node);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings(" 42", result);
+}
+
+test "print block" {
+    const allocator = std.testing.allocator;
+    var blk = tree.Block{
+        .id = "test-uuid",
+        .prefix = .{ .whitespace = " " },
+        .statements = &.{},
+        .end = .{ .whitespace = "" },
+    };
+    const node = LstNode{ .block = &blk };
+    const result = try print(allocator, node);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings(" {}", result);
+}
+
+test "print unknown source" {
+    const allocator = std.testing.allocator;
+    var src = tree.UnknownSource{
+        .id = "test-uuid",
+        .prefix = .{ .whitespace = "" },
+        .text = "some_code()",
+    };
+    var unk = tree.Unknown{
+        .id = "test-uuid-2",
+        .prefix = .{ .whitespace = "\n" },
+        .source = LstNode{ .unknown_source = &src },
+    };
+    const node = LstNode{ .unknown = &unk };
+    const result = try print(allocator, node);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("\nsome_code()", result);
+}

--- a/rewrite-zig/rewrite/src/rpc.zig
+++ b/rewrite-zig/rewrite/src/rpc.zig
@@ -1,0 +1,204 @@
+// Copyright 2025 the original author or authors.
+//
+// Licensed under the Moderne Source Available License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://docs.moderne.io/licensing/moderne-source-available-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+
+/// State represents the state of an RPC object data message.
+/// Matches the Java RpcObjectData.State enum.
+pub const State = enum {
+    no_change,
+    add,
+    delete,
+    change,
+    end_of_object,
+
+    pub fn toString(self: State) []const u8 {
+        return switch (self) {
+            .no_change => "NO_CHANGE",
+            .add => "ADD",
+            .delete => "DELETE",
+            .change => "CHANGE",
+            .end_of_object => "END_OF_OBJECT",
+        };
+    }
+
+    pub fn fromString(s: []const u8) State {
+        if (std.mem.eql(u8, s, "NO_CHANGE")) return .no_change;
+        if (std.mem.eql(u8, s, "ADD")) return .add;
+        if (std.mem.eql(u8, s, "DELETE")) return .delete;
+        if (std.mem.eql(u8, s, "CHANGE")) return .change;
+        if (std.mem.eql(u8, s, "END_OF_OBJECT")) return .end_of_object;
+        return .no_change;
+    }
+};
+
+/// RpcObjectData is the wire format for RPC messages.
+/// Each field of each AST node is sent as a separate RpcObjectData message.
+pub const RpcObjectData = struct {
+    state: State,
+    value_type: ?[]const u8 = null,
+    value: ?std.json.Value = null,
+    ref: ?i64 = null,
+
+    /// Serialize to a JSON value suitable for inclusion in a JSON array.
+    pub fn toJsonValue(self: RpcObjectData, allocator: std.mem.Allocator) !std.json.Value {
+        var obj = std.json.ObjectMap.init(allocator);
+        try obj.put("state", std.json.Value{ .string = self.state.toString() });
+
+        if (self.value_type) |vt| {
+            try obj.put("valueType", std.json.Value{ .string = vt });
+        } else {
+            try obj.put("valueType", std.json.Value.null);
+        }
+
+        if (self.value) |v| {
+            try obj.put("value", v);
+        } else {
+            try obj.put("value", std.json.Value.null);
+        }
+
+        if (self.ref) |r| {
+            try obj.put("ref", std.json.Value{ .integer = r });
+        } else {
+            try obj.put("ref", std.json.Value.null);
+        }
+
+        return std.json.Value{ .object = obj };
+    }
+
+    /// Parse an RpcObjectData from a JSON object.
+    pub fn fromJsonValue(val: std.json.Value) RpcObjectData {
+        var result = RpcObjectData{ .state = .no_change };
+
+        if (val != .object) return result;
+        const obj = val.object;
+
+        if (obj.get("state")) |s| {
+            if (s == .string) {
+                result.state = State.fromString(s.string);
+            }
+        }
+
+        if (obj.get("valueType")) |vt| {
+            if (vt == .string) {
+                result.value_type = vt.string;
+            }
+        }
+
+        if (obj.get("value")) |v| {
+            if (v != .null) {
+                result.value = v;
+            }
+        }
+
+        if (obj.get("ref")) |r| {
+            if (r == .integer) {
+                result.ref = r.integer;
+            }
+        }
+
+        return result;
+    }
+};
+
+/// SendQueue collects RpcObjectData messages into batches for transmission.
+pub const SendQueue = struct {
+    batch: std.ArrayListUnmanaged(RpcObjectData),
+    batch_size: usize,
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator, batch_size: usize) SendQueue {
+        return SendQueue{
+            .batch = .{},
+            .batch_size = batch_size,
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *SendQueue) void {
+        self.batch.deinit(self.allocator);
+    }
+
+    /// Add a message to the batch.
+    pub fn put(self: *SendQueue, data: RpcObjectData) !void {
+        try self.batch.append(self.allocator, data);
+    }
+
+    /// Send a simple value with ADD state.
+    pub fn sendAdd(self: *SendQueue, value_type: ?[]const u8, value: ?std.json.Value) !void {
+        try self.put(.{
+            .state = .add,
+            .value_type = value_type,
+            .value = value,
+        });
+    }
+
+    /// Send a NO_CHANGE state.
+    pub fn sendNoChange(self: *SendQueue) !void {
+        try self.put(.{ .state = .no_change });
+    }
+
+    /// Send a DELETE state.
+    pub fn sendDelete(self: *SendQueue) !void {
+        try self.put(.{ .state = .delete });
+    }
+
+    /// Send an END_OF_OBJECT sentinel.
+    pub fn sendEndOfObject(self: *SendQueue) !void {
+        try self.put(.{ .state = .end_of_object });
+    }
+
+    /// Get all accumulated messages as a JSON array.
+    pub fn toJsonArray(self: *const SendQueue, allocator: std.mem.Allocator) !std.json.Value {
+        var arr = std.json.Array.init(allocator);
+        for (self.batch.items) |item| {
+            const json_val = try item.toJsonValue(allocator);
+            try arr.append(json_val);
+        }
+        return std.json.Value{ .array = arr };
+    }
+
+    /// Clear the batch.
+    pub fn clear(self: *SendQueue) void {
+        self.batch.clearRetainingCapacity();
+    }
+};
+
+test "State round-trip" {
+    const states = [_]State{ .no_change, .add, .delete, .change, .end_of_object };
+    for (states) |s| {
+        const str = s.toString();
+        const parsed = State.fromString(str);
+        try std.testing.expectEqual(s, parsed);
+    }
+}
+
+test "RpcObjectData toJson and fromJson" {
+    const allocator = std.testing.allocator;
+    const data = RpcObjectData{
+        .state = .add,
+        .value_type = "org.openrewrite.zig.tree.Zig$CompilationUnit",
+        .value = null,
+        .ref = 1,
+    };
+    const json_val = try data.toJsonValue(allocator);
+    defer {
+        var val = json_val;
+        val.object.deinit();
+    }
+    const parsed = RpcObjectData.fromJsonValue(json_val);
+    try std.testing.expectEqual(State.add, parsed.state);
+    try std.testing.expectEqualStrings("org.openrewrite.zig.tree.Zig$CompilationUnit", parsed.value_type.?);
+    try std.testing.expectEqual(@as(?i64, 1), parsed.ref);
+}

--- a/rewrite-zig/rewrite/src/sender.zig
+++ b/rewrite-zig/rewrite/src/sender.zig
@@ -1,0 +1,1330 @@
+// Copyright 2025 the original author or authors.
+//
+// Licensed under the Moderne Source Available License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://docs.moderne.io/licensing/moderne-source-available-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Walks an LstNode tree and calls SendQueue methods to produce
+//! RpcObjectData batches. Field ordering MUST match JavaSender.java exactly.
+
+const std = @import("std");
+const rpc = @import("rpc.zig");
+const tree = @import("tree.zig");
+
+const LstNode = tree.LstNode;
+const Space = tree.Space;
+const RightPadded = tree.RightPadded;
+const LeftPadded = tree.LeftPadded;
+const SendQueue = rpc.SendQueue;
+
+/// Serializes an LST tree into RPC batches.
+pub const Sender = struct {
+    queue: *SendQueue,
+    allocator: std.mem.Allocator,
+
+    pub fn init(queue: *SendQueue, allocator: std.mem.Allocator) Sender {
+        return .{
+            .queue = queue,
+            .allocator = allocator,
+        };
+    }
+
+    // -----------------------------------------------------------------
+    // Entry point: serialize any LstNode
+    // -----------------------------------------------------------------
+
+    pub const SendError = std.mem.Allocator.Error;
+
+    pub fn send(self: *Sender, node: LstNode) SendError!void {
+        switch (node) {
+            .compilation_unit => |cu| try self.sendCompilationUnit(cu),
+            .method_declaration => |md| try self.sendMethodDeclaration(md),
+            .method_invocation => |mi| try self.sendMethodInvocation(mi),
+            .variable_declarations => |vd| try self.sendVariableDeclarations(vd),
+            .identifier => |id| try self.sendIdentifier(id),
+            .literal => |lit| try self.sendLiteral(lit),
+            .binary => |bin| try self.sendBinary(bin),
+            .block => |blk| try self.sendBlock(blk),
+            .field_access => |fa| try self.sendFieldAccess(fa),
+            .@"return" => |ret| try self.sendReturn(ret),
+            .assignment => |asgn| try self.sendAssignment(asgn),
+            .@"if" => |i| try self.sendIf(i),
+            .while_loop => |wl| try self.sendWhileLoop(wl),
+            .unary => |u| try self.sendUnary(u),
+            .parentheses => |p| try self.sendParentheses(p),
+            .array_access => |aa| try self.sendArrayAccess(aa),
+            .assignment_op => |ao| try self.sendAssignmentOp(ao),
+            .zig_slice => |s| try self.sendSlice(s),
+            .zig_error_union => |eu| try self.sendErrorUnion(eu),
+            .zig_switch => |sw| try self.sendSwitch(sw),
+            .zig_switch_prong => |sp| try self.sendSwitchProng(sp),
+            .zig_for_loop => |fl| try self.sendForLoop(fl),
+            .zig_defer => |d| try self.sendDefer(d),
+            .zig_comptime => |ct| try self.sendComptime(ct),
+            .zig_test_decl => |td| try self.sendTestDecl(td),
+            .unknown => |unk| try self.sendUnknown(unk),
+            .unknown_source => |src| try self.sendUnknownSource(src),
+            .empty => |emp| try self.sendEmpty(emp),
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Common: preVisit pattern (sent for EVERY node)
+    // Matches JavaSender.preVisit:
+    //   1. id (UUID)
+    //   2. prefix (Space)
+    //   3. markers (Markers)
+    // -----------------------------------------------------------------
+
+    fn preVisit(self: *Sender, id: tree.Uuid, pfx: Space) SendError!void {
+        // id
+        try self.queue.sendAdd(null, std.json.Value{ .string = id });
+        // prefix (Space object)
+        try self.sendSpace(pfx);
+        // markers (empty Markers)
+        try self.sendEmptyMarkers();
+    }
+
+    // -----------------------------------------------------------------
+    // Zig.CompilationUnit
+    // Matches ZigSender.visitZigCompilationUnit:
+    //   1. sourcePath
+    //   2. charset
+    //   3. charsetBomMarked
+    //   4. checksum (null)
+    //   5. fileAttributes (null)
+    //   6. imports (JContainer - null)
+    //   7. statements (list of RightPadded<Statement>)
+    //   8. eof (Space)
+    // -----------------------------------------------------------------
+
+    fn sendCompilationUnit(self: *Sender, cu: *const tree.CompilationUnit) SendError!void {
+        // Top-level ADD
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.zig.tree.Zig$CompilationUnit",
+        });
+
+        // preVisit
+        try self.preVisit(cu.id, cu.prefix);
+
+        // sourcePath
+        try self.queue.sendAdd(null, std.json.Value{ .string = cu.source_path });
+        // charset
+        try self.queue.sendAdd(null, std.json.Value{ .string = cu.charset });
+        // charsetBomMarked
+        try self.queue.sendAdd(null, std.json.Value{ .bool = cu.charset_bom_marked });
+        // checksum (null)
+        try self.queue.sendDelete();
+        // fileAttributes (null)
+        try self.queue.sendDelete();
+        // imports (JContainer<J.Import>) - null
+        try self.queue.sendDelete();
+        // statements (list of RightPadded<Statement>)
+        try self.sendRightPaddedList(cu.statements);
+        // eof (Space)
+        try self.sendSpace(cu.eof);
+    }
+
+    // -----------------------------------------------------------------
+    // J.MethodDeclaration
+    // Matches JavaSender.visitMethodDeclaration:
+    //   1. leadingAnnotations (empty list)
+    //   2. modifiers (empty list)
+    //   3. typeParameters (null)
+    //   4. returnTypeExpression
+    //   5. name annotations (empty list, from annotations.getName().getAnnotations())
+    //   6. name (Identifier)
+    //   7. parameters (JContainer)
+    //   8. throws (null JContainer)
+    //   9. body (Block)
+    //  10. defaultValue (null)
+    //  11. methodType (null)
+    // -----------------------------------------------------------------
+
+    fn sendMethodDeclaration(self: *Sender, md: *const tree.MethodDeclaration) SendError!void {
+        // Top-level ADD
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$MethodDeclaration",
+        });
+
+        // preVisit
+        try self.preVisit(md.id, md.prefix);
+
+        // 1. leadingAnnotations (empty list)
+        try self.sendEmptyList();
+        // 2. modifiers (empty list)
+        try self.sendEmptyList();
+        // 3. typeParameters (null - J.TypeParameters via padding)
+        try self.queue.sendDelete();
+        // 4. returnTypeExpression
+        if (md.return_type) |rt| {
+            try self.send(rt);
+        } else {
+            try self.queue.sendDelete();
+        }
+        // 5. name annotations (empty list from annotations.getName().getAnnotations())
+        try self.sendEmptyList();
+        // 6. name (Identifier)
+        try self.send(md.name);
+        // 7. parameters (JContainer) - send as an empty container for now
+        try self.sendEmptyContainer(md.params_prefix);
+        // 8. throws (null JContainer)
+        try self.queue.sendDelete();
+        // 9. body (Block)
+        if (md.body) |body| {
+            try self.send(body);
+        } else {
+            try self.queue.sendDelete();
+        }
+        // 10. defaultValue (null JLeftPadded)
+        try self.queue.sendDelete();
+        // 11. methodType (null)
+        try self.queue.sendDelete();
+    }
+
+    // -----------------------------------------------------------------
+    // J.VariableDeclarations
+    // Matches JavaSender.visitVariableDeclarations:
+    //   1. leadingAnnotations (empty list)
+    //   2. modifiers (empty list)
+    //   3. typeExpression
+    //   4. varargs (null Space)
+    //   5. variables (list of RightPadded<NamedVariable>)
+    // -----------------------------------------------------------------
+
+    fn sendVariableDeclarations(self: *Sender, vd: *const tree.VariableDeclarations) SendError!void {
+        // Top-level ADD
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$VariableDeclarations",
+        });
+
+        // preVisit
+        try self.preVisit(vd.id, vd.prefix);
+
+        // 1. leadingAnnotations (empty list)
+        try self.sendEmptyList();
+        // 2. modifiers (empty list)
+        try self.sendEmptyList();
+        // 3. typeExpression
+        if (vd.type_expression) |te| {
+            try self.send(te);
+        } else {
+            try self.queue.sendDelete();
+        }
+        // 4. varargs (null Space)
+        try self.queue.sendDelete();
+        // 5. variables (list of RightPadded<NamedVariable>)
+        //    Each element is a NamedVariable, which needs its own serialization.
+        try self.sendNamedVariableList(vd.variables);
+    }
+
+    /// Send a list of NamedVariables as RightPadded list.
+    /// Each NamedVariable is serialized matching JavaSender.visitVariable:
+    ///   preVisit: id, prefix, markers
+    ///   1. declarator (the name Identifier, visited via visit())
+    ///   2. dimensionsAfterName (empty list)
+    ///   3. initializer (JLeftPadded<Expression> or null)
+    ///   4. variableType (null)
+    fn sendNamedVariableList(self: *Sender, vars: []const RightPadded(LstNode)) SendError!void {
+        // Send list header: ADD + CHANGE with positions
+        try self.queue.put(.{ .state = .add });
+
+        // Positions array
+        var positions = std.json.Array.init(self.allocator);
+        for (0..vars.len) |_| {
+            // -1 = ADDED_LIST_ITEM
+            try positions.append(std.json.Value{ .integer = -1 });
+        }
+        try self.queue.put(.{
+            .state = .change,
+            .value = std.json.Value{ .array = positions },
+        });
+
+        // Each RightPadded<NamedVariable>
+        for (vars) |v| {
+            // ADD for the RightPadded wrapper
+            try self.queue.put(.{
+                .state = .add,
+                .value_type = "org.openrewrite.java.tree.JRightPadded",
+            });
+
+            // visitRightPadded protocol:
+            //   1. element (NamedVariable via visit)
+            //   2. after (Space)
+            //   3. markers (Markers)
+
+            // The element is a NamedVariable (sent as a new ADD typed object)
+            try self.queue.put(.{
+                .state = .add,
+                .value_type = "org.openrewrite.java.tree.J$VariableDeclarations$NamedVariable",
+            });
+
+            // preVisit for the NamedVariable (uses a fresh UUID separate from the identifier)
+            try self.preVisit(
+                self.genUuid(),
+                .{ .whitespace = "" }, // NamedVariable prefix is empty
+            );
+
+            // visitVariable (JavaSender.visitVariable) fields:
+            //   1. declarator (the name identifier, visited via visit())
+            //   2. dimensionsAfterName (empty list)
+            //   3. initializer (JLeftPadded<Expression> or null)
+            //   4. variableType (null)
+            try self.send(v.element);
+            try self.sendEmptyList();
+            try self.queue.sendDelete();
+            try self.queue.sendDelete();
+
+            // RightPadded: after space
+            try self.sendSpace(v.after);
+            // RightPadded: markers
+            try self.sendEmptyMarkers();
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // J.Identifier
+    // Matches JavaSender.visitIdentifier:
+    //   1. annotations (empty list)
+    //   2. simpleName (string)
+    //   3. type (null JavaType)
+    //   4. fieldType (null JavaType)
+    // -----------------------------------------------------------------
+
+    fn sendIdentifier(self: *Sender, id: *const tree.Identifier) SendError!void {
+        // Top-level ADD
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$Identifier",
+        });
+
+        // preVisit
+        try self.preVisit(id.id, id.prefix);
+
+        // 1. annotations (empty list)
+        try self.sendEmptyList();
+        // 2. simpleName
+        try self.queue.sendAdd(null, std.json.Value{ .string = id.simple_name });
+        // 3. type (null)
+        try self.queue.sendDelete();
+        // 4. fieldType (null)
+        try self.queue.sendDelete();
+    }
+
+    // -----------------------------------------------------------------
+    // J.Literal
+    // Matches JavaSender.visitLiteral:
+    //   1. value (the actual value)
+    //   2. valueSource (original source text)
+    //   3. unicodeEscapes (empty list)
+    //   4. type (null JavaType)
+    // -----------------------------------------------------------------
+
+    fn sendLiteral(self: *Sender, lit: *const tree.Literal) SendError!void {
+        // Top-level ADD
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$Literal",
+        });
+
+        // preVisit
+        try self.preVisit(lit.id, lit.prefix);
+
+        // 1. value
+        if (lit.value) |val| {
+            switch (val) {
+                .int => |i| try self.queue.sendAdd(null, std.json.Value{ .integer = i }),
+                .float => |f| try self.queue.sendAdd(null, std.json.Value{ .float = f }),
+                .string => |s| try self.queue.sendAdd(null, std.json.Value{ .string = s }),
+                .boolean => |b| try self.queue.sendAdd(null, std.json.Value{ .bool = b }),
+            }
+        } else {
+            try self.queue.sendDelete();
+        }
+        // 2. valueSource
+        if (lit.value_source) |vs| {
+            try self.queue.sendAdd(null, std.json.Value{ .string = vs });
+        } else {
+            try self.queue.sendDelete();
+        }
+        // 3. unicodeEscapes (empty list)
+        try self.sendEmptyList();
+        // 4. type (null)
+        try self.queue.sendDelete();
+    }
+
+    // -----------------------------------------------------------------
+    // J.Block
+    // Matches JavaSender.visitBlock:
+    //   1. static (RightPadded<Boolean>)
+    //   2. statements (list of RightPadded<Statement>)
+    //   3. end (Space)
+    // -----------------------------------------------------------------
+
+    fn sendBlock(self: *Sender, blk: *const tree.Block) SendError!void {
+        // Top-level ADD
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$Block",
+        });
+
+        // preVisit
+        try self.preVisit(blk.id, blk.prefix);
+
+        // 1. static (RightPadded<Boolean>)
+        //    The static flag is sent as a RightPadded<Boolean>:
+        //      element (boolean value)
+        //      after (Space)
+        //      markers (Markers)
+        try self.sendRightPaddedBool(blk.is_static, blk.static_prefix);
+
+        // 2. statements (list of RightPadded<Statement>)
+        try self.sendRightPaddedList(blk.statements);
+
+        // 3. end (Space)
+        try self.sendSpace(blk.end);
+    }
+
+    // -----------------------------------------------------------------
+    // J.Return
+    // Matches JavaSender.visitReturn:
+    //   1. expression (nullable)
+    // -----------------------------------------------------------------
+
+    fn sendReturn(self: *Sender, ret: *const tree.Return) SendError!void {
+        // Top-level ADD
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$Return",
+        });
+
+        // preVisit
+        try self.preVisit(ret.id, ret.prefix);
+
+        // 1. expression
+        if (ret.expression) |expr| {
+            try self.send(expr);
+        } else {
+            try self.queue.sendDelete();
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // J.Binary
+    // Matches JavaSender.visitBinary:
+    //   1. left (visit)
+    //   2. operator (JLeftPadded<J.Binary.Type> via visitLeftPadded)
+    //   3. right (visit)
+    //   4. type (null)
+    // -----------------------------------------------------------------
+
+    fn sendBinary(self: *Sender, bin: *const tree.Binary) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$Binary",
+        });
+
+        // preVisit
+        try self.preVisit(bin.id, bin.prefix);
+
+        // 1. left
+        try self.send(bin.left);
+        // 2. operator (LeftPadded<enum value>)
+        try self.sendLeftPaddedEnum(bin.operator.before, bin.operator.element);
+        // 3. right
+        try self.send(bin.right);
+        // 4. type (null)
+        try self.queue.sendDelete();
+    }
+
+    // -----------------------------------------------------------------
+    // J.FieldAccess
+    // Matches JavaSender.visitFieldAccess:
+    //   1. target (visit)
+    //   2. name (JLeftPadded<J.Identifier> via visitLeftPadded)
+    //   3. type (null)
+    // -----------------------------------------------------------------
+
+    fn sendFieldAccess(self: *Sender, fa: *const tree.FieldAccess) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$FieldAccess",
+        });
+
+        // preVisit
+        try self.preVisit(fa.id, fa.prefix);
+
+        // 1. target
+        try self.send(fa.target);
+        // 2. name (LeftPadded<Identifier>)
+        //    LeftPadded protocol: before (Space), element (visit J), markers
+        try self.sendLeftPaddedNode(fa.name.before, fa.name.element);
+        // 3. type (null)
+        try self.queue.sendDelete();
+    }
+
+    // -----------------------------------------------------------------
+    // J.MethodInvocation
+    // Matches JavaSender.visitMethodInvocation:
+    //   1. select (RightPadded, nullable)
+    //   2. typeParameters (JContainer, nullable)
+    //   3. name (visit)
+    //   4. arguments (JContainer)
+    //   5. methodType (null)
+    // -----------------------------------------------------------------
+
+    fn sendMethodInvocation(self: *Sender, mi: *const tree.MethodInvocation) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$MethodInvocation",
+        });
+
+        // preVisit
+        try self.preVisit(mi.id, mi.prefix);
+
+        // 1. select (RightPadded, nullable)
+        if (mi.select) |sel| {
+            try self.queue.put(.{
+                .state = .add,
+                .value_type = "org.openrewrite.java.tree.JRightPadded",
+            });
+            try self.send(sel.element);
+            try self.sendSpace(sel.after);
+            try self.sendEmptyMarkers();
+        } else {
+            try self.queue.sendDelete();
+        }
+        // 2. typeParameters (null JContainer)
+        try self.queue.sendDelete();
+        // 3. name
+        try self.send(mi.name);
+        // 4. arguments (JContainer)
+        try self.sendContainer(mi.args_prefix, mi.args);
+        // 5. methodType (null)
+        try self.queue.sendDelete();
+    }
+
+    // -----------------------------------------------------------------
+    // J.Assignment
+    // Matches JavaSender.visitAssignment:
+    //   1. variable (visit)
+    //   2. assignment (JLeftPadded<Expression>)
+    //   3. type (null)
+    // -----------------------------------------------------------------
+
+    fn sendAssignment(self: *Sender, asgn: *const tree.Assignment) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$Assignment",
+        });
+
+        // preVisit
+        try self.preVisit(asgn.id, asgn.prefix);
+
+        // 1. variable
+        try self.send(asgn.variable);
+        // 2. assignment (LeftPadded<Expression>)
+        try self.sendLeftPaddedNode(asgn.assignment.before, asgn.assignment.element);
+        // 3. type (null)
+        try self.queue.sendDelete();
+    }
+
+    // -----------------------------------------------------------------
+    // J.If
+    // Matches JavaSender.visitIf:
+    //   1. ifCondition (ControlParentheses - visit)
+    //   2. thenPart (RightPadded<Statement> via visitRightPadded)
+    //   3. elsePart (If.Else - nullable, visit)
+    //
+    // J.ControlParentheses:
+    //   preVisit: id, prefix, markers
+    //   1. tree (RightPadded<Expression> via visitRightPadded)
+    //
+    // J.If.Else:
+    //   preVisit: id, prefix, markers
+    //   1. body (RightPadded<Statement> via visitRightPadded)
+    // -----------------------------------------------------------------
+
+    fn sendIf(self: *Sender, i: *const tree.If) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$If",
+        });
+
+        // preVisit
+        try self.preVisit(i.id, i.prefix);
+
+        // 1. ifCondition (ControlParentheses)
+        //    ControlParentheses is a J node, so visit() is called on it.
+        //    We need to emit: ADD typed, preVisit, then tree (RightPadded)
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$ControlParentheses",
+        });
+        // ControlParentheses.preVisit: id, prefix (empty - the "(" space is already in If prefix), markers
+        try self.preVisit(self.genUuid(), .{ .whitespace = "" });
+        // ControlParentheses field: tree (RightPadded<Expression>)
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.JRightPadded",
+        });
+        try self.send(i.condition);
+        try self.sendSpace(i.condition_after);
+        try self.sendEmptyMarkers();
+
+        // 2. thenPart (RightPadded<Statement>)
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.JRightPadded",
+        });
+        try self.send(i.then_part);
+        try self.sendSpace(i.then_after);
+        try self.sendEmptyMarkers();
+
+        // 3. elsePart (nullable If.Else)
+        if (i.else_part) |else_part| {
+            try self.queue.put(.{
+                .state = .add,
+                .value_type = "org.openrewrite.java.tree.J$If$Else",
+            });
+            try self.preVisit(else_part.id, else_part.prefix);
+            // Else field: body (RightPadded<Statement>)
+            try self.queue.put(.{
+                .state = .add,
+                .value_type = "org.openrewrite.java.tree.JRightPadded",
+            });
+            try self.send(else_part.body);
+            try self.sendSpace(else_part.body_after);
+            try self.sendEmptyMarkers();
+        } else {
+            try self.queue.sendDelete();
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // J.WhileLoop
+    // Matches JavaSender.visitWhileLoop:
+    //   1. condition (ControlParentheses - visit)
+    //   2. body (RightPadded<Statement> via visitRightPadded)
+    // -----------------------------------------------------------------
+
+    fn sendWhileLoop(self: *Sender, wl: *const tree.WhileLoop) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$WhileLoop",
+        });
+
+        // preVisit
+        try self.preVisit(wl.id, wl.prefix);
+
+        // 1. condition (ControlParentheses)
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$ControlParentheses",
+        });
+        try self.preVisit(self.genUuid(), .{ .whitespace = "" });
+        // ControlParentheses field: tree (RightPadded<Expression>)
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.JRightPadded",
+        });
+        try self.send(wl.condition);
+        try self.sendSpace(wl.condition_after);
+        try self.sendEmptyMarkers();
+
+        // 2. body (RightPadded<Statement>)
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.JRightPadded",
+        });
+        try self.send(wl.body);
+        try self.sendSpace(wl.body_after);
+        try self.sendEmptyMarkers();
+    }
+
+    // -----------------------------------------------------------------
+    // J.Unary
+    // Matches JavaSender.visitUnary:
+    //   1. operator (JLeftPadded<J.Unary.Type> via visitLeftPadded)
+    //   2. expression (visit)
+    //   3. type (null JavaType)
+    // -----------------------------------------------------------------
+
+    fn sendUnary(self: *Sender, u: *const tree.Unary) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$Unary",
+        });
+
+        // preVisit
+        try self.preVisit(u.id, u.prefix);
+
+        // 1. operator (LeftPadded<enum value>)
+        try self.sendLeftPaddedEnum(u.operator.before, u.operator.element);
+        // 2. expression
+        try self.send(u.expression);
+        // 3. type (null)
+        try self.queue.sendDelete();
+    }
+
+    // -----------------------------------------------------------------
+    // J.Parentheses
+    // Matches JavaSender.visitParentheses:
+    //   1. tree (RightPadded via visitRightPadded)
+    // -----------------------------------------------------------------
+
+    fn sendParentheses(self: *Sender, p: *const tree.Parentheses) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$Parentheses",
+        });
+
+        // preVisit
+        try self.preVisit(p.id, p.prefix);
+
+        // 1. tree (RightPadded<Expression>)
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.JRightPadded",
+        });
+        try self.send(p.expression);
+        try self.sendSpace(p.after);
+        try self.sendEmptyMarkers();
+    }
+
+    // -----------------------------------------------------------------
+    // J.AssignmentOperation
+    // Matches JavaSender.visitAssignmentOperation:
+    //   1. variable (visit)
+    //   2. operator (JLeftPadded<J.AssignmentOperation.Type> via visitLeftPadded)
+    //   3. assignment (visit)
+    //   4. type (null JavaType)
+    // -----------------------------------------------------------------
+
+    fn sendAssignmentOp(self: *Sender, ao: *const tree.AssignmentOperation) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$AssignmentOperation",
+        });
+
+        // preVisit
+        try self.preVisit(ao.id, ao.prefix);
+
+        // 1. variable
+        try self.send(ao.variable);
+        // 2. operator (LeftPadded<enum value>)
+        try self.sendLeftPaddedEnum(ao.operator.before, ao.operator.element);
+        // 3. assignment
+        try self.send(ao.assignment);
+        // 4. type (null)
+        try self.queue.sendDelete();
+    }
+
+    // -----------------------------------------------------------------
+    // J.ArrayAccess
+    // Matches JavaSender.visitArrayAccess:
+    //   1. indexed (visit)
+    //   2. dimension (J.ArrayDimension - visit)
+    //
+    // J.ArrayDimension:
+    //   preVisit: id, prefix, markers
+    //   1. index (RightPadded<Expression> via visitRightPadded)
+    // -----------------------------------------------------------------
+
+    fn sendArrayAccess(self: *Sender, aa: *const tree.ArrayAccess) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$ArrayAccess",
+        });
+
+        // preVisit
+        try self.preVisit(aa.id, aa.prefix);
+
+        // 1. indexed (the target expression)
+        try self.send(aa.indexed);
+
+        // 2. dimension (J.ArrayDimension)
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$ArrayDimension",
+        });
+        // ArrayDimension preVisit: id, prefix, markers
+        try self.preVisit(self.genUuid(), aa.dimension_prefix);
+        // ArrayDimension field: index (RightPadded<Expression>)
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.JRightPadded",
+        });
+        try self.send(aa.index);
+        try self.sendSpace(aa.index_after);
+        try self.sendEmptyMarkers();
+    }
+
+    // -----------------------------------------------------------------
+    // Zig.Slice
+    // Matches ZigSender.visitSlice:
+    //   1. target (visit)
+    //   2. openBracket (Space)
+    //   3. start (RightPadded via visitRightPadded)
+    //   4. end (nullable visit)
+    //   5. closeBracket (Space)
+    // -----------------------------------------------------------------
+
+    fn sendSlice(self: *Sender, s: *const tree.Slice) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.zig.tree.Zig$Slice",
+        });
+
+        // preVisit
+        try self.preVisit(s.id, s.prefix);
+
+        // 1. target
+        try self.send(s.target);
+        // 2. openBracket (Space)
+        try self.sendSpace(s.open_bracket);
+        // 3. start (RightPadded)
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.JRightPadded",
+        });
+        try self.send(s.start.element);
+        try self.sendSpace(s.start.after);
+        try self.sendEmptyMarkers();
+        // 4. end (nullable)
+        if (s.end) |end| {
+            try self.send(end);
+        } else {
+            try self.queue.sendDelete();
+        }
+        // 5. closeBracket (Space)
+        try self.sendSpace(s.close_bracket);
+    }
+
+    // -----------------------------------------------------------------
+    // Zig.ErrorUnion
+    // Matches ZigSender.visitErrorUnion:
+    //   1. errorType (nullable visit)
+    //   2. valueType (JLeftPadded via visitLeftPadded)
+    // -----------------------------------------------------------------
+
+    fn sendErrorUnion(self: *Sender, eu: *const tree.ErrorUnion) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.zig.tree.Zig$ErrorUnion",
+        });
+
+        // preVisit
+        try self.preVisit(eu.id, eu.prefix);
+
+        // 1. errorType (nullable)
+        if (eu.error_type) |et| {
+            try self.send(et);
+        } else {
+            try self.queue.sendDelete();
+        }
+        // 2. valueType (LeftPadded)
+        try self.sendLeftPaddedNode(eu.value_type.before, eu.value_type.element);
+    }
+
+    // -----------------------------------------------------------------
+    // Zig.Switch → J.SwitchExpression
+    // Matches JavaSender.visitSwitchExpression:
+    //   1. selector (ControlParentheses - visit)
+    //   2. cases (J.Block - visit)
+    //   3. type (nullable JavaType)
+    //
+    // We use J.SwitchExpression (not J.Switch) because Zig's switch
+    // is an expression, and J.Switch is a statement that doesn't
+    // implement Expression (can't be used in return, assignment, etc.)
+    // -----------------------------------------------------------------
+
+    fn sendSwitch(self: *Sender, sw: *const tree.Switch) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$SwitchExpression",
+        });
+
+        // preVisit
+        try self.preVisit(sw.id, sw.prefix);
+
+        // 1. selector (ControlParentheses wrapping the condition)
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$ControlParentheses",
+        });
+        try self.preVisit(self.genUuid(), sw.lparen_prefix);
+        // ControlParentheses field: tree (RightPadded<Expression>)
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.JRightPadded",
+        });
+        try self.send(sw.condition);
+        try self.sendSpace(sw.condition_after);
+        try self.sendEmptyMarkers();
+
+        // 2. cases (J.Block containing SwitchProng nodes)
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$Block",
+        });
+        try self.preVisit(self.genUuid(), sw.lbrace_prefix);
+
+        // Block static (RightPadded<Boolean>) - always false
+        try self.sendRightPaddedBool(false, .{ .whitespace = "" });
+
+        // Block statements (list of RightPadded<Statement> = prongs)
+        try self.sendRightPaddedList(sw.prongs);
+
+        // Block end (Space before "}")
+        try self.sendSpace(sw.end);
+
+        // 3. type (null JavaType)
+        try self.queue.sendDelete();
+    }
+
+    // -----------------------------------------------------------------
+    // Zig.SwitchProng
+    // Matches ZigSender.visitSwitchProng:
+    //   1. cases (JContainer of Expression)
+    //   2. payload (nullable, visit)
+    //   3. arrow (JLeftPadded<Expression>)
+    // -----------------------------------------------------------------
+
+    fn sendSwitchProng(self: *Sender, sp: *const tree.SwitchProng) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.zig.tree.Zig$SwitchProng",
+        });
+
+        // preVisit
+        try self.preVisit(sp.id, sp.prefix);
+
+        // 1. cases (JContainer of Expression)
+        try self.sendContainer(sp.cases_prefix, sp.cases);
+
+        // 2. payload (nullable, visit)
+        if (sp.payload) |pl| {
+            try self.send(pl);
+        } else {
+            try self.queue.sendDelete();
+        }
+
+        // 3. arrow (JLeftPadded<Expression>)
+        try self.sendLeftPaddedNode(sp.arrow.before, sp.arrow.element);
+    }
+
+    // -----------------------------------------------------------------
+    // Zig.ForLoop
+    // Zig for-loops don't map cleanly to J.ForEachLoop because the
+    // Control type expects a J.VariableDeclarations and iterable, while
+    // Zig uses a different syntax (multiple inputs, payload captures).
+    // We send it as J.Unknown for RPC (the Java side only gets a
+    // skeleton), but preserve it as Zig.ForLoop on the Zig side for
+    // faithful printing. The Zig printer handles the actual output.
+    // -----------------------------------------------------------------
+
+    fn sendForLoop(self: *Sender, fl: *const tree.ForLoop) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$Unknown",
+        });
+
+        // preVisit: the Java side creates a J.Unknown with null source.
+        // The Zig printer handles printing via the ForLoop struct.
+        try self.preVisit(fl.id, fl.prefix);
+    }
+
+    // -----------------------------------------------------------------
+    // Zig.Defer
+    // Matches ZigSender.visitDefer:
+    //   1. isErrdefer (boolean)
+    //   2. payload (nullable, visit)
+    //   3. expression (visit)
+    // -----------------------------------------------------------------
+
+    fn sendDefer(self: *Sender, d: *const tree.Defer) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.zig.tree.Zig$Defer",
+        });
+
+        // preVisit
+        try self.preVisit(d.id, d.prefix);
+
+        // 1. isErrdefer
+        try self.queue.sendAdd(null, std.json.Value{ .bool = d.is_errdefer });
+        // 2. payload (nullable)
+        if (d.payload) |pl| {
+            try self.send(pl);
+        } else {
+            try self.queue.sendDelete();
+        }
+        // 3. expression
+        try self.send(d.expression);
+    }
+
+    // -----------------------------------------------------------------
+    // Zig.Comptime
+    // Matches ZigSender.visitComptime:
+    //   1. expression (visit)
+    // -----------------------------------------------------------------
+
+    fn sendComptime(self: *Sender, ct: *const tree.Comptime) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.zig.tree.Zig$Comptime",
+        });
+
+        // preVisit
+        try self.preVisit(ct.id, ct.prefix);
+
+        // 1. expression
+        try self.send(ct.expression);
+    }
+
+    // -----------------------------------------------------------------
+    // Zig.TestDecl
+    // Matches ZigSender.visitTestDecl:
+    //   1. name (nullable, visit)
+    //   2. body (visit)
+    // -----------------------------------------------------------------
+
+    fn sendTestDecl(self: *Sender, td: *const tree.TestDecl) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.zig.tree.Zig$TestDecl",
+        });
+
+        // preVisit
+        try self.preVisit(td.id, td.prefix);
+
+        // 1. name (nullable)
+        if (td.name) |n| {
+            try self.send(n);
+        } else {
+            try self.queue.sendDelete();
+        }
+        // 2. body
+        try self.send(td.body);
+    }
+
+    // -----------------------------------------------------------------
+    // J.Unknown
+    // The default visitor traversal for Unknown visits:
+    //   preVisit: id, prefix, markers
+    //   Then visits the source child (Unknown.Source)
+    // -----------------------------------------------------------------
+
+    fn sendUnknown(self: *Sender, unk: *const tree.Unknown) SendError!void {
+        // Top-level ADD
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$Unknown",
+        });
+
+        // preVisit
+        try self.preVisit(unk.id, unk.prefix);
+
+        // The source child is visited via the default visitor traversal (visitAndCast),
+        // which calls sendUnknownSource for the Unknown.Source child node.
+    }
+
+    // -----------------------------------------------------------------
+    // J.Unknown.Source
+    // Send id/prefix/markers via preVisit, then send the text field
+    // so visitUnknownSource on the Java side can receive it.
+    // -----------------------------------------------------------------
+
+    fn sendUnknownSource(self: *Sender, src: *const tree.UnknownSource) SendError!void {
+        try self.preVisit(src.id, src.prefix);
+        // Send the text field to match ZigSenderDelegate.visitUnknownSource
+        try self.queue.sendAdd(null, std.json.Value{ .string = src.text });
+    }
+
+    // -----------------------------------------------------------------
+    // J.Empty
+    // JavaSender.visitEmpty returns empty with no fields beyond preVisit.
+    // -----------------------------------------------------------------
+
+    fn sendEmpty(self: *Sender, emp: *const tree.Empty) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.J$Empty",
+        });
+        try self.preVisit(emp.id, emp.prefix);
+    }
+
+    // -----------------------------------------------------------------
+    // Helper: send a Space
+    // Matches JavaSender.visitSpace:
+    //   1. comments (list - getAndSendList)
+    //   2. whitespace (string - getAndSend)
+    // -----------------------------------------------------------------
+
+    fn sendSpace(self: *Sender, space: Space) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.Space",
+        });
+        // 1. comments (empty list)
+        try self.sendEmptyList();
+        // 2. whitespace
+        try self.queue.sendAdd(null, std.json.Value{ .string = space.whitespace });
+    }
+
+    // -----------------------------------------------------------------
+    // Helper: send empty Markers
+    // Matches Markers.rpcSend:
+    //   1. id (UUID)
+    //   2. markers (list as ref - empty)
+    // -----------------------------------------------------------------
+
+    fn sendEmptyMarkers(self: *Sender) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.marker.Markers",
+        });
+        // Markers.id
+        try self.queue.sendAdd(null, std.json.Value{ .string = self.genUuid() });
+        // Markers.markers (empty list)
+        try self.sendEmptyList();
+    }
+
+    // -----------------------------------------------------------------
+    // Helper: send an empty list
+    // Protocol: ADD + CHANGE with positions=[]
+    // -----------------------------------------------------------------
+
+    fn sendEmptyList(self: *Sender) SendError!void {
+        try self.queue.put(.{ .state = .add });
+        try self.queue.put(.{
+            .state = .change,
+            .value = std.json.Value{ .array = std.json.Array.init(self.allocator) },
+        });
+    }
+
+    // -----------------------------------------------------------------
+    // Helper: send a list of RightPadded<LstNode>
+    // Protocol:
+    //   ADD (list exists)
+    //   CHANGE with positions array
+    //   For each element:
+    //     visit(element)
+    //     sendSpace(after)
+    //     sendEmptyMarkers()
+    // -----------------------------------------------------------------
+
+    fn sendRightPaddedList(self: *Sender, items: []const RightPadded(LstNode)) SendError!void {
+        // List header: ADD + CHANGE with positions
+        try self.queue.put(.{ .state = .add });
+
+        var positions = std.json.Array.init(self.allocator);
+        for (0..items.len) |_| {
+            // -1 = ADDED_LIST_ITEM (all items are new)
+            try positions.append(std.json.Value{ .integer = -1 });
+        }
+        try self.queue.put(.{
+            .state = .change,
+            .value = std.json.Value{ .array = positions },
+        });
+
+        // Each RightPadded element needs its own ADD wrapper with valueType
+        for (items) |item| {
+            // ADD for the RightPadded wrapper
+            try self.queue.put(.{
+                .state = .add,
+                .value_type = "org.openrewrite.java.tree.JRightPadded",
+            });
+            // visitRightPadded protocol:
+            //   1. element (J node via visit)
+            //   2. after (Space)
+            //   3. markers (Markers)
+            try self.send(item.element);
+            try self.sendSpace(item.after);
+            try self.sendEmptyMarkers();
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Helper: send a RightPadded<Boolean>
+    // Protocol:
+    //   element (boolean - ADD with value)
+    //   after (Space)
+    //   markers (Markers)
+    // -----------------------------------------------------------------
+
+    fn sendRightPaddedBool(self: *Sender, val: bool, after: Space) SendError!void {
+        // The RightPadded wrapper itself
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.JRightPadded",
+        });
+        // visitRightPadded protocol for non-J element:
+        //   element (boolean - ADD with value, no valueType since java.lang)
+        try self.queue.sendAdd(null, std.json.Value{ .bool = val });
+        // after (Space)
+        try self.sendSpace(after);
+        // markers (Markers)
+        try self.sendEmptyMarkers();
+    }
+
+    // -----------------------------------------------------------------
+    // Helper: send an empty JContainer with a given before-space
+    // Protocol (matches JavaSender.visitContainer):
+    //   before (Space)
+    //   elements (list of RightPadded - empty)
+    //   markers (Markers)
+    // -----------------------------------------------------------------
+
+    fn sendEmptyContainer(self: *Sender, before: Space) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.JContainer",
+        });
+        // before
+        try self.sendSpace(before);
+        // elements (empty list)
+        try self.sendEmptyList();
+        // markers
+        try self.sendEmptyMarkers();
+    }
+
+    // -----------------------------------------------------------------
+    // Helper: send a LeftPadded<enum value> (e.g., Binary operator)
+    // Protocol:
+    //   ADD with valueType JLeftPadded (the wrapper)
+    //   Then visitLeftPadded content:
+    //     before (Space)
+    //     element (plain value via ADD)
+    //     markers (Markers)
+    // -----------------------------------------------------------------
+
+    fn sendLeftPaddedEnum(self: *Sender, before: Space, val: []const u8) SendError!void {
+        // ADD wrapper for JLeftPadded
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.JLeftPadded",
+        });
+        // before
+        try self.sendSpace(before);
+        // element (enum value as string)
+        try self.queue.sendAdd(null, std.json.Value{ .string = val });
+        // markers
+        try self.sendEmptyMarkers();
+    }
+
+    // -----------------------------------------------------------------
+    // Helper: send a LeftPadded<J node> (e.g., FieldAccess name)
+    // Protocol:
+    //   ADD with valueType JLeftPadded (the wrapper)
+    //   Then visitLeftPadded content:
+    //     before (Space)
+    //     element (visit J)
+    //     markers (Markers)
+    // -----------------------------------------------------------------
+
+    fn sendLeftPaddedNode(self: *Sender, before: Space, element: LstNode) SendError!void {
+        // ADD wrapper for JLeftPadded
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.JLeftPadded",
+        });
+        // before
+        try self.sendSpace(before);
+        // element (J node via visit)
+        try self.send(element);
+        // markers
+        try self.sendEmptyMarkers();
+    }
+
+    // -----------------------------------------------------------------
+    // Helper: send a JContainer with elements
+    // Protocol (matches JavaSender.visitContainer):
+    //   before (Space)
+    //   elements (list of RightPadded)
+    //   markers (Markers)
+    // -----------------------------------------------------------------
+
+    fn sendContainer(self: *Sender, before: Space, items: []const RightPadded(LstNode)) SendError!void {
+        try self.queue.put(.{
+            .state = .add,
+            .value_type = "org.openrewrite.java.tree.JContainer",
+        });
+        // before
+        try self.sendSpace(before);
+        // elements (list of RightPadded)
+        try self.sendRightPaddedList(items);
+        // markers
+        try self.sendEmptyMarkers();
+    }
+
+    // -----------------------------------------------------------------
+    // UUID generation
+    // -----------------------------------------------------------------
+
+    fn genUuid(self: *Sender) []const u8 {
+        var bytes: [16]u8 = undefined;
+        std.crypto.random.bytes(&bytes);
+        bytes[6] = (bytes[6] & 0x0f) | 0x40;
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+        var result: [36]u8 = undefined;
+        const hex = "0123456789abcdef";
+        var pos: usize = 0;
+        for (bytes, 0..) |b, i| {
+            if (i == 4 or i == 6 or i == 8 or i == 10) {
+                result[pos] = '-';
+                pos += 1;
+            }
+            result[pos] = hex[b >> 4];
+            result[pos + 1] = hex[b & 0x0f];
+            pos += 2;
+        }
+        return self.allocator.dupe(u8, &result) catch "00000000-0000-0000-0000-000000000000";
+    }
+};
+
+test "Sender basic compilation unit" {
+    // Use arena allocator to avoid leaking UUIDs generated during send
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var queue = SendQueue.init(allocator, 1000);
+    defer queue.deinit();
+
+    var cu = tree.CompilationUnit{
+        .id = "test-cu-id",
+        .prefix = .{ .whitespace = "" },
+        .source_path = "test.zig",
+        .statements = &.{},
+        .eof = .{ .whitespace = "\n" },
+    };
+    const node = LstNode{ .compilation_unit = &cu };
+
+    var sender = Sender.init(&queue, allocator);
+    try sender.send(node);
+
+    // Verify we got some data in the queue
+    try std.testing.expect(queue.batch.items.len > 0);
+
+    // First item should be the ADD with valueType for CompilationUnit
+    const first = queue.batch.items[0];
+    try std.testing.expectEqual(rpc.State.add, first.state);
+    try std.testing.expectEqualStrings(
+        "org.openrewrite.zig.tree.Zig$CompilationUnit",
+        first.value_type.?,
+    );
+}

--- a/rewrite-zig/rewrite/src/tree.zig
+++ b/rewrite-zig/rewrite/src/tree.zig
@@ -1,0 +1,538 @@
+// Copyright 2025 the original author or authors.
+//
+// Licensed under the Moderne Source Available License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://docs.moderne.io/licensing/moderne-source-available-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Zig-side LST node types.
+//! Each variant is a struct holding the data needed for RPC serialization:
+//! an id (UUID string), prefix (whitespace string), and type-specific fields.
+
+const std = @import("std");
+
+/// A unique identifier string (UUID v4, 36 chars).
+pub const Uuid = []const u8;
+
+/// Represents whitespace/formatting before a syntax element.
+pub const Space = struct {
+    whitespace: []const u8,
+};
+
+/// Right-padded element: element + whitespace after it.
+pub fn RightPadded(comptime T: type) type {
+    return struct {
+        element: T,
+        after: Space,
+    };
+}
+
+/// Left-padded element: whitespace before + element.
+pub fn LeftPadded(comptime T: type) type {
+    return struct {
+        before: Space,
+        element: T,
+    };
+}
+
+/// The top-level tagged union for all LST node types.
+pub const LstNode = union(enum) {
+    compilation_unit: *CompilationUnit,
+    method_declaration: *MethodDeclaration,
+    method_invocation: *MethodInvocation,
+    variable_declarations: *VariableDeclarations,
+    identifier: *Identifier,
+    literal: *Literal,
+    binary: *Binary,
+    block: *Block,
+    field_access: *FieldAccess,
+    @"return": *Return,
+    assignment: *Assignment,
+    // Control flow
+    @"if": *If,
+    while_loop: *WhileLoop,
+    unary: *Unary,
+    parentheses: *Parentheses,
+    array_access: *ArrayAccess,
+    assignment_op: *AssignmentOperation,
+    // Zig-specific types
+    zig_defer: *Defer,
+    zig_comptime: *Comptime,
+    zig_test_decl: *TestDecl,
+    zig_slice: *Slice,
+    zig_error_union: *ErrorUnion,
+    zig_switch: *Switch,
+    zig_switch_prong: *SwitchProng,
+    zig_for_loop: *ForLoop,
+    // Fallback types
+    unknown: *Unknown,
+    unknown_source: *UnknownSource,
+    empty: *Empty,
+
+    /// Get the id of any LST node.
+    pub fn getId(self: LstNode) Uuid {
+        return switch (self) {
+            inline else => |node| node.id,
+        };
+    }
+
+    /// Get the prefix of any LST node.
+    pub fn getPrefix(self: LstNode) Space {
+        return switch (self) {
+            inline else => |node| node.prefix,
+        };
+    }
+};
+
+/// Zig.CompilationUnit - the root of a Zig source file.
+pub const CompilationUnit = struct {
+    id: Uuid,
+    prefix: Space,
+    source_path: []const u8,
+    charset: []const u8 = "UTF-8",
+    charset_bom_marked: bool = false,
+    statements: []RightPadded(LstNode),
+    eof: Space,
+};
+
+/// J.MethodDeclaration - maps to Zig fn declarations.
+pub const MethodDeclaration = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The keyword text from the start of this declaration up to (not including)
+    /// the function name. E.g. "fn", "pub fn", "export fn".
+    /// This text is consumed by the parser cursor but not stored in any Space field.
+    keywords: []const u8 = "fn",
+    /// Return type expression (e.g. "void", "i32")
+    return_type: ?LstNode = null,
+    /// Function name
+    name: LstNode,
+    /// Parameter list container prefix (the "(" token prefix)
+    params_prefix: Space,
+    /// Source text of the parameter list including parentheses, e.g. "(a: i32, b: i32)".
+    /// The parser skips parameter details; this text enables faithful printing.
+    params_text: []const u8 = "()",
+    /// The function body block
+    body: ?LstNode = null,
+};
+
+/// J.VariableDeclarations - maps to Zig const/var declarations.
+pub const VariableDeclarations = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The keyword text from the start of this declaration up to (not including)
+    /// the variable name. E.g. "const", "var", "pub const".
+    /// This text is consumed by the parser cursor but not stored in any Space field.
+    keyword: []const u8 = "const",
+    /// Type expression (e.g., "u32")
+    type_expression: ?LstNode = null,
+    /// The named variables (typically one for Zig)
+    variables: []RightPadded(LstNode),
+    /// The initializer expression for the first variable (left-padded by "=" whitespace).
+    /// In Zig, each const/var has exactly one variable, so this is stored here directly.
+    initializer: ?LeftPadded(LstNode) = null,
+};
+
+/// J.VariableDeclarations.NamedVariable - a single variable within a declaration.
+pub const NamedVariable = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The variable name identifier (as the declarator)
+    name: LstNode,
+    /// The initializer expression, if present (left-padded with "=" space)
+    initializer: ?LeftPadded(LstNode) = null,
+};
+
+/// J.Identifier - a simple name reference.
+pub const Identifier = struct {
+    id: Uuid,
+    prefix: Space,
+    simple_name: []const u8,
+};
+
+/// J.Literal - a literal value (number, string, etc.).
+pub const Literal = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The value as a JSON-compatible value (null for now since Zig doesn't have Java types)
+    value: ?LiteralValue = null,
+    /// The original source text of the literal
+    value_source: ?[]const u8 = null,
+};
+
+/// Possible literal values for serialization.
+pub const LiteralValue = union(enum) {
+    int: i64,
+    float: f64,
+    string: []const u8,
+    boolean: bool,
+};
+
+/// J.Block - a block of statements delimited by braces.
+pub const Block = struct {
+    id: Uuid,
+    prefix: Space,
+    /// Whether this is a static block (always false for Zig)
+    is_static: bool = false,
+    /// The prefix for the static keyword (empty for Zig)
+    static_prefix: Space = .{ .whitespace = "" },
+    /// Statements within the block
+    statements: []RightPadded(LstNode),
+    /// Whitespace before the closing brace
+    end: Space,
+};
+
+/// J.Return - a return statement.
+pub const Return = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The expression being returned (null if bare return)
+    expression: ?LstNode = null,
+};
+
+/// J.Unknown - fallback for unmapped syntax elements.
+pub const Unknown = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The source text wrapped in an UnknownSource
+    source: LstNode,
+};
+
+/// J.Unknown.Source - the source text of an unknown element.
+pub const UnknownSource = struct {
+    id: Uuid,
+    prefix: Space,
+    text: []const u8,
+};
+
+/// J.Binary - a binary expression (a + b, a == b, etc.).
+pub const Binary = struct {
+    id: Uuid,
+    prefix: Space,
+    /// Left operand
+    left: LstNode,
+    /// Operator (left-padded with the operator token text as a string enum)
+    operator: LeftPadded([]const u8),
+    /// The actual source text of the operator token (e.g. "+", "==", "++").
+    /// The `operator.element` field stores the Java enum name for RPC, while
+    /// this field stores the Zig source text for faithful printing.
+    operator_source: []const u8 = "+",
+    /// Right operand
+    right: LstNode,
+};
+
+/// J.FieldAccess - a field access expression (a.b).
+pub const FieldAccess = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The target expression
+    target: LstNode,
+    /// The field name (left-padded with the "." token space)
+    name: LeftPadded(LstNode),
+};
+
+/// J.MethodInvocation - a function/method call (a(b, c)).
+pub const MethodInvocation = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The select expression (the target before the method name, if a.foo() style)
+    /// For Zig, this is null for simple calls like foo(x).
+    select: ?RightPadded(LstNode) = null,
+    /// The function name identifier
+    name: LstNode,
+    /// The argument list container prefix (the "(" token prefix)
+    args_prefix: Space,
+    /// The arguments
+    args: []RightPadded(LstNode),
+};
+
+/// J.Assignment - an assignment expression (a = b).
+pub const Assignment = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The variable (left side)
+    variable: LstNode,
+    /// The assignment expression (right side, left-padded with "=" space)
+    assignment: LeftPadded(LstNode),
+};
+
+/// J.If - an if/else statement.
+/// JavaSender.visitIf:
+///   1. ifCondition (ControlParentheses - visit)
+///   2. thenPart (RightPadded<Statement>)
+///   3. elsePart (If.Else - nullable, visit)
+pub const If = struct {
+    id: Uuid,
+    prefix: Space,
+    /// Whitespace before the "(" token (between "if" and "(")
+    lparen_prefix: Space,
+    /// The condition expression (inside parens in Zig: if (cond))
+    condition: LstNode,
+    /// Whitespace before the ")" token (between condition and ")")
+    condition_after: Space,
+    /// The "then" branch statement
+    then_part: LstNode,
+    /// Whitespace after the then part (inside RightPadded)
+    then_after: Space,
+    /// The "else" part (null if no else)
+    else_part: ?*IfElse = null,
+};
+
+/// J.If.Else - the else branch of an if statement.
+/// JavaSender.visitElse:
+///   1. body (RightPadded<Statement>)
+pub const IfElse = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The else body statement
+    body: LstNode,
+    /// Whitespace after the body (inside RightPadded)
+    body_after: Space,
+};
+
+/// J.WhileLoop - a while loop.
+/// JavaSender.visitWhileLoop:
+///   1. condition (ControlParentheses - visit)
+///   2. body (RightPadded<Statement>)
+pub const WhileLoop = struct {
+    id: Uuid,
+    prefix: Space,
+    /// Whitespace before the "(" token (between "while" and "(")
+    lparen_prefix: Space,
+    /// The condition expression (inside parens: while (cond))
+    condition: LstNode,
+    /// Whitespace before the ")" token (between condition and ")")
+    condition_after: Space,
+    /// The loop body
+    body: LstNode,
+    /// Whitespace after the body (inside RightPadded)
+    body_after: Space,
+};
+
+/// J.Unary - a unary expression (prefix or postfix operator).
+/// JavaSender.visitUnary:
+///   1. operator (LeftPadded<J.Unary.Type>)
+///   2. expression (visit)
+///   3. type (null JavaType)
+pub const Unary = struct {
+    id: Uuid,
+    prefix: Space,
+    /// Operator enum name (e.g. "Negative", "Not", "Complement")
+    operator: LeftPadded([]const u8),
+    /// The actual source text of the operator (e.g. "-", "!", "~")
+    operator_source: []const u8,
+    /// The operand expression
+    expression: LstNode,
+};
+
+/// J.AssignmentOperation - compound assignment (a += b, a -= b, etc.).
+/// JavaSender.visitAssignmentOperation:
+///   1. variable (visit)
+///   2. operator (JLeftPadded<J.AssignmentOperation.Type> via visitLeftPadded)
+///   3. assignment (visit)
+///   4. type (null JavaType)
+pub const AssignmentOperation = struct {
+    id: Uuid,
+    prefix: Space,
+    /// Left operand (variable)
+    variable: LstNode,
+    /// Operator enum name (e.g. "Addition", "Subtraction")
+    operator: LeftPadded([]const u8),
+    /// The actual source text of the operator token (e.g. "+=", "-=")
+    operator_source: []const u8,
+    /// Right operand (assignment value)
+    assignment: LstNode,
+};
+
+/// J.ArrayAccess - array/pointer indexing (lhs[rhs]).
+/// JavaSender.visitArrayAccess:
+///   1. indexed (visit - the array/pointer expression)
+///   2. dimension (J.ArrayDimension - visit)
+/// J.ArrayDimension:
+///   1. index (RightPadded<Expression> via visitRightPadded)
+pub const ArrayAccess = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The indexed expression (the array/pointer)
+    indexed: LstNode,
+    /// Whitespace before the "[" token
+    dimension_prefix: Space,
+    /// The index expression
+    index: LstNode,
+    /// Whitespace before the "]" token
+    index_after: Space,
+};
+
+/// J.Parentheses - a parenthesized expression (expr).
+/// JavaSender.visitParentheses:
+///   1. tree (RightPadded<Expression> via visitRightPadded)
+pub const Parentheses = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The contained expression
+    expression: LstNode,
+    /// Whitespace before the ")" token
+    after: Space,
+};
+
+/// Zig.Defer - a defer or errdefer statement.
+pub const Defer = struct {
+    id: Uuid,
+    prefix: Space,
+    /// Whether this is an errdefer (true) or defer (false)
+    is_errdefer: bool = false,
+    /// The error payload (for errdefer |err| only), null for plain defer
+    payload: ?LstNode = null,
+    /// The deferred expression
+    expression: LstNode,
+};
+
+/// Zig.Comptime - a comptime expression/block.
+pub const Comptime = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The comptime expression
+    expression: LstNode,
+};
+
+/// Zig.TestDecl - a test declaration (test "name" { ... }).
+pub const TestDecl = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The test name (a string literal, or null for unnamed tests)
+    name: ?LstNode = null,
+    /// The test body block
+    body: LstNode,
+};
+
+/// Zig.ErrorUnion - an error union type (ErrorSet!ValueType or !ValueType).
+/// ZigSender.visitErrorUnion:
+///   1. errorType (nullable visit)
+///   2. valueType (JLeftPadded via visitLeftPadded)
+pub const ErrorUnion = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The error set expression (null for implicit error sets like "!T")
+    error_type: ?LstNode = null,
+    /// The value type, left-padded by the "!" token whitespace
+    value_type: LeftPadded(LstNode),
+};
+
+/// Zig.Slice - a slice expression (a[start..end]).
+/// ZigSender.visitSlice:
+///   1. target (visit)
+///   2. openBracket (Space)
+///   3. start (RightPadded via visitRightPadded)
+///   4. end (nullable visit)
+///   5. closeBracket (Space)
+pub const Slice = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The target expression being sliced
+    target: LstNode,
+    /// Whitespace before the "[" token
+    open_bracket: Space,
+    /// The start expression
+    start: RightPadded(LstNode),
+    /// The end expression (null for open-ended slices)
+    end: ?LstNode = null,
+    /// Whitespace before the "]" token
+    close_bracket: Space,
+};
+
+/// Zig.Switch - a switch expression.
+/// Maps to J.Switch with a selector (ControlParentheses) and cases (Block of SwitchProng).
+/// ZigSender field order:
+///   (via J.Switch) selector (ControlParentheses), cases (Block)
+pub const Switch = struct {
+    id: Uuid,
+    prefix: Space,
+    /// Whitespace before the "(" token (between "switch" and "(")
+    lparen_prefix: Space,
+    /// The scrutinee expression (inside parens: switch (expr))
+    condition: LstNode,
+    /// Whitespace before the ")" token
+    condition_after: Space,
+    /// Whitespace before the "{" token
+    lbrace_prefix: Space,
+    /// The switch prongs/cases
+    prongs: []RightPadded(LstNode),
+    /// Whitespace before the closing "}"
+    end: Space,
+};
+
+/// Zig.SwitchProng - a single case arm in a switch expression.
+/// ZigSender.visitSwitchProng:
+///   1. cases (JContainer of Expression)
+///   2. payload (nullable visit, Zig.Payload)
+///   3. arrow (JLeftPadded<Expression>)
+pub const SwitchProng = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The case values (list of expressions, empty = else case)
+    /// The container prefix captures the whitespace before the first case value.
+    cases_prefix: Space,
+    cases: []RightPadded(LstNode),
+    /// Optional payload (|val|), null if not present
+    payload: ?LstNode = null,
+    /// The arrow expression (the target/body of this prong), left-padded by "=>" whitespace
+    arrow: LeftPadded(LstNode),
+};
+
+/// Zig.ForLoop - a for loop.
+/// Mapped as J.ForEachLoop.
+/// JavaSender.visitForEachLoop:
+///   1. control (J.ForEachLoop.Control - visit)
+///   2. body (RightPadded<Statement>)
+///
+/// The Zig for loop syntax is: for (items) |captures| body
+/// We store the full source text for the control section for faithful round-tripping.
+pub const ForLoop = struct {
+    id: Uuid,
+    prefix: Space,
+    /// Whitespace before the "(" token
+    lparen_prefix: Space,
+    /// Full source text of the iterable list including parens, e.g. "(items)"
+    iterable_text: []const u8,
+    /// Full source text of the payload captures, e.g. "|item|" or "|item, index|"
+    payload_text: []const u8,
+    /// The loop body
+    body: LstNode,
+    /// Whitespace after the body (inside RightPadded)
+    body_after: Space,
+    /// Optional else expression
+    else_body: ?*ForLoopElse = null,
+};
+
+/// Zig.ForLoop.Else - the else branch of a for loop.
+pub const ForLoopElse = struct {
+    id: Uuid,
+    prefix: Space,
+    /// The else body expression
+    body: LstNode,
+    /// Whitespace after the body
+    body_after: Space,
+};
+
+/// J.Empty - an empty expression placeholder.
+pub const Empty = struct {
+    id: Uuid,
+    prefix: Space,
+};
+
+test "LstNode getId" {
+    var ident = Identifier{
+        .id = "test-uuid",
+        .prefix = .{ .whitespace = "" },
+        .simple_name = "foo",
+    };
+    const node = LstNode{ .identifier = &ident };
+    try std.testing.expectEqualStrings("test-uuid", node.getId());
+}

--- a/rewrite-zig/src/integTest/java/org/openrewrite/zig/rpc/ZigParserIntegTest.java
+++ b/rewrite-zig/src/integTest/java/org/openrewrite/zig/rpc/ZigParserIntegTest.java
@@ -1,0 +1,781 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.rpc;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+import org.openrewrite.zig.tree.Zig;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.zig.Assertions.zig;
+
+/**
+ * Integration tests that parse Zig source via the RPC subprocess and verify
+ * the resulting LST round-trips through Java correctly.
+ */
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class ZigParserIntegTest implements RewriteTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void before() {
+        // The zigBuild task places the binary at build/rewrite-zig-rpc
+        Path binaryPath = Paths.get("build/rewrite-zig-rpc").toAbsolutePath();
+        ZigRewriteRpc.setFactory(ZigRewriteRpc.builder()
+                .zigBinaryPath(binaryPath)
+                .log(tempDir.resolve("zig-rpc.log"))
+                .traceRpcMessages());
+    }
+
+    @AfterEach
+    void after() {
+        ZigRewriteRpc.shutdownCurrent();
+    }
+
+    @Override
+    public void defaults(org.openrewrite.test.RecipeSpec spec) {
+        spec.typeValidationOptions(TypeValidation.builder()
+                .allowNonWhitespaceInWhitespace(true)
+                .build());
+    }
+
+    @Test
+    void helloWorld() {
+        rewriteRun(
+                zig(
+                        """
+                                const std = @import("std");
+
+                                pub fn main() void {
+                                    std.debug.print("Hello, World!\\n", .{});
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(2);
+                            assertThat(zigCu.getStatements().get(0)).isInstanceOf(J.VariableDeclarations.class);
+                            assertThat(zigCu.getStatements().get(1)).isInstanceOf(J.MethodDeclaration.class);
+                        })
+                )
+        );
+    }
+
+    @Test
+    void simpleFunction() {
+        rewriteRun(
+                zig(
+                        """
+                                fn add(a: i32, b: i32) i32 {
+                                    return a + b;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(1);
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getSimpleName()).isEqualTo("add");
+                            assertThat(fn.getBody()).isNotNull();
+                            assertThat(fn.getBody()).isInstanceOf(J.Block.class);
+                        })
+                )
+        );
+    }
+
+    @Test
+    void constAndVar() {
+        rewriteRun(
+                zig(
+                        """
+                                const x: u32 = 42;
+                                var y: u32 = 0;
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(2);
+                            assertThat(zigCu.getStatements().get(0)).isInstanceOf(J.VariableDeclarations.class);
+                            assertThat(zigCu.getStatements().get(1)).isInstanceOf(J.VariableDeclarations.class);
+                        })
+                )
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Task 9: Structural validation tests
+    // ---------------------------------------------------------------
+
+    @Test
+    void verifyFunctionParsedAsMethodDeclaration() {
+        rewriteRun(
+                zig("""
+                                fn add(a: i32, b: i32) i32 {
+                                    return a + b;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).isNotEmpty();
+                            assertThat(zigCu.getStatements().get(0))
+                                    .isInstanceOf(J.MethodDeclaration.class);
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getSimpleName()).isEqualTo("add");
+                        })
+                )
+        );
+    }
+
+    @Test
+    void verifyConstParsedAsVariableDeclarations() {
+        rewriteRun(
+                zig("""
+                                const x: u32 = 42;
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(1);
+                            assertThat(zigCu.getStatements().get(0))
+                                    .isInstanceOf(J.VariableDeclarations.class);
+                        })
+                )
+        );
+    }
+
+    @Test
+    void verifyNoOpVisitorPreservesTree() {
+        rewriteRun(
+                zig("""
+                                const x: u32 = 42;
+                                fn main() void {}
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            var noopVisitor = new JavaIsoVisitor<ExecutionContext>() {};
+                            var result = (Zig.CompilationUnit) noopVisitor.visit(
+                                    zigCu, new InMemoryExecutionContext());
+                            assertThat(result).isNotNull();
+                            assertThat(result.getStatements()).hasSameSizeAs(zigCu.getStatements());
+                        })
+                )
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Task 10: Round-trip tests
+    // ---------------------------------------------------------------
+
+    @Test
+    void structDeclaration() {
+        rewriteRun(
+                zig("""
+                                const Point = struct {
+                                    x: f64,
+                                    y: f64,
+                                };
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(1);
+                            // const Point = struct { ... } parses as a variable declaration
+                            assertThat(zigCu.getStatements().get(0)).isInstanceOf(J.VariableDeclarations.class);
+                        }))
+        );
+    }
+
+    @Test
+    void enumDeclaration() {
+        rewriteRun(
+                zig("""
+                                const Color = enum {
+                                    red,
+                                    green,
+                                    blue,
+                                };
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(1);
+                            // const Color = enum { ... } parses as a variable declaration
+                            assertThat(zigCu.getStatements().get(0)).isInstanceOf(J.VariableDeclarations.class);
+                        }))
+        );
+    }
+
+    @Test
+    void deferStatement() {
+        rewriteRun(
+                zig("""
+                                const std = @import("std");
+                                fn open() void {
+                                    defer std.debug.print("cleanup\\n", .{});
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(2);
+                            assertThat(zigCu.getStatements().get(0)).isInstanceOf(J.VariableDeclarations.class);
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(1);
+                            assertThat(fn.getBody()).isNotNull();
+                            assertThat(fn.getBody().getStatements().get(0)).isInstanceOf(Zig.Defer.class);
+                        }))
+        );
+    }
+
+    @Test
+    void testBlock() {
+        rewriteRun(
+                zig("""
+                                const std = @import("std");
+                                test "addition" {
+                                    const x: i32 = 1 + 2;
+                                    try std.testing.expectEqual(@as(i32, 3), x);
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(2);
+                            assertThat(zigCu.getStatements().get(1)).isInstanceOf(Zig.TestDecl.class);
+                        }))
+        );
+    }
+
+    @Test
+    void errorHandling() {
+        rewriteRun(
+                zig("""
+                                fn divide(a: f64, b: f64) !f64 {
+                                    if (b == 0) return error.DivisionByZero;
+                                    return a / b;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(1);
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            assertThat(fn.getBody().getStatements()).hasSize(2);
+                        }))
+        );
+    }
+
+    @Test
+    void comments() {
+        rewriteRun(
+                zig("""
+                                // Top-level comment
+                                const x: u32 = 42;
+
+                                /// Doc comment
+                                fn documented() void {}
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(2);
+                            // Both statements should be proper types, not J.Unknown
+                            assertThat(zigCu.getStatements().get(0)).isInstanceOf(J.VariableDeclarations.class);
+                            assertThat(zigCu.getStatements().get(1)).isInstanceOf(J.MethodDeclaration.class);
+                        }))
+        );
+    }
+
+    @Test
+    void multipleDeclarations() {
+        rewriteRun(
+                zig("""
+                                const std = @import("std");
+
+                                const MAX_SIZE: usize = 1024;
+                                var global_count: u32 = 0;
+
+                                pub fn main() void {
+                                    std.debug.print("Hello\\n", .{});
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(4);
+                            assertThat(zigCu.getStatements().get(0)).isInstanceOf(J.VariableDeclarations.class); // const std
+                            assertThat(zigCu.getStatements().get(1)).isInstanceOf(J.VariableDeclarations.class); // const MAX_SIZE
+                            assertThat(zigCu.getStatements().get(2)).isInstanceOf(J.VariableDeclarations.class); // var global_count
+                            assertThat(zigCu.getStatements().get(3)).isInstanceOf(J.MethodDeclaration.class);    // pub fn main
+                        }))
+        );
+    }
+
+    @Test
+    void emptyFunction() {
+        rewriteRun(
+                zig("""
+                                fn noop() void {}
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(1);
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            assertThat(fn.getBody()).isInstanceOf(J.Block.class);
+                            assertThat(fn.getBody().getStatements()).isEmpty();
+                        }))
+        );
+    }
+
+    @Test
+    void functionWithMultipleStatements() {
+        rewriteRun(
+                zig("""
+                                fn compute(x: i32, y: i32) i32 {
+                                    const sum = x + y;
+                                    const product = x * y;
+                                    return sum + product;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(1);
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            assertThat(fn.getBody().getStatements()).hasSize(3);
+                        }))
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Control flow: if/else round-trip tests
+    // ---------------------------------------------------------------
+
+    @Test
+    void ifStatement() {
+        rewriteRun(
+                zig("""
+                                fn abs(x: i32) i32 {
+                                    if (x < 0) return -x;
+                                    return x;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            assertThat(fn.getBody().getStatements().get(0)).isInstanceOf(J.If.class);
+                        }))
+        );
+    }
+
+    @Test
+    void ifElseStatement() {
+        rewriteRun(
+                zig("""
+                                fn abs(x: i32) i32 {
+                                    if (x < 0) return -x else return x;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            J.If ifStmt = (J.If) fn.getBody().getStatements().get(0);
+                            assertThat(ifStmt.getElsePart()).isNotNull();
+                        }))
+        );
+    }
+
+    @Test
+    void ifElseBlock() {
+        rewriteRun(
+                zig("""
+                                fn classify(x: i32) i32 {
+                                    if (x > 0) {
+                                        return 1;
+                                    } else {
+                                        return 0;
+                                    }
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            J.If ifStmt = (J.If) fn.getBody().getStatements().get(0);
+                            assertThat(ifStmt.getElsePart()).isNotNull();
+                        }))
+        );
+    }
+
+    @Test
+    void verifyIfParsedCorrectly() {
+        rewriteRun(
+                zig("""
+                                fn abs(x: i32) i32 {
+                                    if (x < 0) return -x;
+                                    return x;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            assertThat(fn.getBody().getStatements().get(0)).isInstanceOf(J.If.class);
+                        })
+                )
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Control flow: while round-trip tests
+    // ---------------------------------------------------------------
+
+    @Test
+    void whileLoop() {
+        rewriteRun(
+                zig("""
+                                fn count() void {
+                                    while (true) {
+                                        return;
+                                    }
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            assertThat(fn.getBody().getStatements().get(0)).isInstanceOf(J.WhileLoop.class);
+                        }))
+        );
+    }
+
+    @Test
+    void verifyWhileParsedCorrectly() {
+        rewriteRun(
+                zig("""
+                                fn count() void {
+                                    while (true) {
+                                        return;
+                                    }
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            assertThat(fn.getBody().getStatements().get(0)).isInstanceOf(J.WhileLoop.class);
+                        })
+                )
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Unary operations round-trip tests
+    // ---------------------------------------------------------------
+
+    @Test
+    void unaryNegation() {
+        rewriteRun(
+                zig("""
+                                fn neg(x: i32) i32 {
+                                    return -x;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            J.Return ret = (J.Return) fn.getBody().getStatements().get(0);
+                            assertThat(ret.getExpression()).isInstanceOf(J.Unary.class);
+                        }))
+        );
+    }
+
+    @Test
+    void verifyUnaryParsedCorrectly() {
+        rewriteRun(
+                zig("""
+                                fn neg(x: i32) i32 {
+                                    return -x;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            J.Return ret = (J.Return) fn.getBody().getStatements().get(0);
+                            assertThat(ret.getExpression()).isInstanceOf(J.Unary.class);
+                        })
+                )
+        );
+    }
+
+    @Test
+    void boolNot() {
+        rewriteRun(
+                zig("""
+                                fn invert(b: bool) bool {
+                                    return !b;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            J.Return ret = (J.Return) fn.getBody().getStatements().get(0);
+                            assertThat(ret.getExpression()).isInstanceOf(J.Unary.class);
+                        }))
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Try/catch/orelse round-trip tests
+    // ---------------------------------------------------------------
+
+    @Test
+    void tryCatch() {
+        rewriteRun(
+                zig("""
+                                fn read(buf: []u8) usize {
+                                    return doRead(buf) catch 0;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            J.Return ret = (J.Return) fn.getBody().getStatements().get(0);
+                            // catch is mapped as J.Binary
+                            assertThat(ret.getExpression()).isInstanceOf(J.Binary.class);
+                        }))
+        );
+    }
+
+    @Test
+    void orelseExpression() {
+        rewriteRun(
+                zig("""
+                                fn unwrap(opt: ?i32) i32 {
+                                    return opt orelse 0;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            J.Return ret = (J.Return) fn.getBody().getStatements().get(0);
+                            // orelse is mapped as J.Binary
+                            assertThat(ret.getExpression()).isInstanceOf(J.Binary.class);
+                        }))
+        );
+    }
+
+    @Test
+    void tryExpression() {
+        rewriteRun(
+                zig("""
+                                fn doSomething(x: i32) !i32 {
+                                    return try compute(x);
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            J.Return ret = (J.Return) fn.getBody().getStatements().get(0);
+                            // try is mapped as J.Unary
+                            assertThat(ret.getExpression()).isInstanceOf(J.Unary.class);
+                        }))
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Slice round-trip tests
+    // ---------------------------------------------------------------
+
+    @Test
+    void sliceExpression() {
+        rewriteRun(
+                zig("""
+                                fn first(buf: []const u8) []const u8 {
+                                    return buf[0..1];
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            J.Return ret = (J.Return) fn.getBody().getStatements().get(0);
+                            assertThat(ret.getExpression()).isInstanceOf(Zig.Slice.class);
+                        }))
+        );
+    }
+
+    @Test
+    void arrayAccess() {
+        rewriteRun(
+                zig("""
+                                fn getFirst(buf: []const u8) u8 {
+                                    return buf[0];
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            J.Return ret = (J.Return) fn.getBody().getStatements().get(0);
+                            assertThat(ret.getExpression()).isInstanceOf(J.ArrayAccess.class);
+                        }))
+        );
+    }
+
+    @Test
+    void compoundAssignment() {
+        rewriteRun(
+                zig("""
+                                fn accumulate(x: *i32) void {
+                                    x.* += 1;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            assertThat(fn.getBody().getStatements().get(0)).isInstanceOf(J.AssignmentOperation.class);
+                        }))
+        );
+    }
+
+    @Test
+    void errorUnionType() {
+        rewriteRun(
+                zig("""
+                                fn parse(buf: []const u8) !usize {
+                                    return 0;
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            assertThat(zigCu.getStatements()).hasSize(1);
+                            // function parsed as MethodDeclaration even with error union return type
+                            assertThat(zigCu.getStatements().get(0)).isInstanceOf(J.MethodDeclaration.class);
+                        }))
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Switch expression round-trip tests
+    // ---------------------------------------------------------------
+
+    @Test
+    void switchExpression() {
+        rewriteRun(zig("""
+                        fn toStr(x: u8) []const u8 {
+                            return switch (x) {
+                                0 => "zero",
+                                1 => "one",
+                                else => "other",
+                            };
+                        }
+                        """,
+                spec -> spec.afterRecipe(cu -> {
+                    Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                    J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                    assertThat(fn.getBody()).isNotNull();
+                    // Verify switch is NOT J.Unknown
+                    J.Return ret = (J.Return) fn.getBody().getStatements().get(0);
+                    assertThat(ret.getExpression()).isNotNull();
+                    assertThat(ret.getExpression()).isNotInstanceOf(J.Unknown.class);
+                })));
+    }
+
+    @Test
+    void switchExpressionSimple() {
+        rewriteRun(zig("""
+                        fn classify(x: i32) i32 {
+                            return switch (x) {
+                                0 => 100,
+                                else => 0,
+                            };
+                        }
+                        """,
+                spec -> spec.afterRecipe(cu -> {
+                    Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                    J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                    assertThat(fn.getBody()).isNotNull();
+                    J.Return ret = (J.Return) fn.getBody().getStatements().get(0);
+                    assertThat(ret.getExpression()).isInstanceOf(J.SwitchExpression.class);
+                })));
+    }
+
+    // ---------------------------------------------------------------
+    // For loop round-trip tests
+    // ---------------------------------------------------------------
+
+    @Test
+    void forLoop() {
+        // For loops are mapped to J.Unknown on the Java side because Zig's
+        // multi-input/payload-capture for syntax doesn't fit J.ForEachLoop.Control.
+        // This test explicitly asserts J.Unknown so it breaks when for loops get
+        // a proper mapping — at which point update to assert the rich type.
+        rewriteRun(zig("""
+                        fn sum(items: []const i32) i32 {
+                            var total: i32 = 0;
+                            for (items) |item| {
+                                total += item;
+                            }
+                            return total;
+                        }
+                        """,
+                spec -> spec.afterRecipe(cu -> {
+                    Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                    J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                    assertThat(fn.getBody()).isNotNull();
+                    assertThat(fn.getBody().getStatements()).hasSize(3);
+                    // Known gap: for loop is J.Unknown, not a structured type.
+                    // Update this assertion when for loop mapping is implemented.
+                    assertThat(fn.getBody().getStatements().get(1))
+                            .isInstanceOf(J.Unknown.class);
+                })));
+    }
+
+    @Test
+    void verifySliceParsedCorrectly() {
+        rewriteRun(
+                zig("""
+                                fn first(buf: []const u8) []const u8 {
+                                    return buf[0..1];
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            Zig.CompilationUnit zigCu = (Zig.CompilationUnit) cu;
+                            J.MethodDeclaration fn = (J.MethodDeclaration) zigCu.getStatements().get(0);
+                            assertThat(fn.getBody()).isNotNull();
+                            J.Return ret = (J.Return) fn.getBody().getStatements().get(0);
+                            assertThat(ret.getExpression()).isInstanceOf(Zig.Slice.class);
+                        })
+                )
+        );
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/Assertions.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/Assertions.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.zig.tree.Zig;
+import org.openrewrite.test.SourceSpec;
+import org.openrewrite.test.SourceSpecs;
+
+import java.util.function.Consumer;
+
+public final class Assertions {
+    private Assertions() {
+    }
+
+    public static SourceSpecs zig(@Nullable String before) {
+        return zig(before, s -> {
+        });
+    }
+
+    public static SourceSpecs zig(@Nullable String before, Consumer<SourceSpec<Zig.CompilationUnit>> spec) {
+        SourceSpec<Zig.CompilationUnit> zig = new SourceSpec<>(Zig.CompilationUnit.class, null, ZigParser.builder(), before, null);
+        spec.accept(zig);
+        return zig;
+    }
+
+    public static SourceSpecs zig(@Nullable String before, String after) {
+        return zig(before, after, s -> {
+        });
+    }
+
+    public static SourceSpecs zig(@Nullable String before, String after,
+                                       Consumer<SourceSpec<Zig.CompilationUnit>> spec) {
+        SourceSpec<Zig.CompilationUnit> zig = new SourceSpec<>(Zig.CompilationUnit.class, null, ZigParser.builder(), before, s -> after);
+        spec.accept(zig);
+        return zig;
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/ZigParser.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/ZigParser.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
+import org.openrewrite.zig.rpc.ZigRewriteRpc;
+import org.openrewrite.zig.tree.Zig;
+
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+/**
+ * Parser for Zig source files.
+ * <p>
+ * This parser uses RPC to communicate with a Zig process that performs the actual parsing.
+ * The Zig process uses Zig's standard library parser to parse source code and converts it to
+ * the OpenRewrite LST format.
+ */
+public class ZigParser implements Parser {
+
+    @Override
+    public Stream<SourceFile> parseInputs(Iterable<Input> sources, @Nullable Path relativeTo, ExecutionContext ctx) {
+        return ZigRewriteRpc.getOrStart().parse(sources, relativeTo, this,
+                Zig.CompilationUnit.class.getName(), ctx);
+    }
+
+    @Override
+    public boolean accept(Path path) {
+        return path.toString().endsWith(".zig");
+    }
+
+    @Override
+    public Path sourcePathFromSourceText(Path prefix, String sourceCode) {
+        return prefix.resolve("file.zig");
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends Parser.Builder {
+
+        public Builder() {
+            super(Zig.CompilationUnit.class);
+        }
+
+        @Override
+        public ZigParser build() {
+            return new ZigParser();
+        }
+
+        @Override
+        public String getDslName() {
+            return "zig";
+        }
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/ZigVisitor.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/ZigVisitor.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.SourceFile;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.zig.tree.Zig;
+
+public class ZigVisitor<P> extends JavaVisitor<P> {
+
+    @Override
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
+        return sourceFile instanceof Zig.CompilationUnit;
+    }
+
+    @Override
+    public String getLanguage() {
+        return "zig";
+    }
+
+    // ---------------------------------------------------------------
+    // Zig-specific visit methods
+    // ---------------------------------------------------------------
+
+    public J visitZigCompilationUnit(Zig.CompilationUnit cu, P p) {
+        Zig.CompilationUnit c = cu;
+        c = c.withPrefix(visitSpace(c.getPrefix(), Space.Location.COMPILATION_UNIT_PREFIX, p));
+        c = c.withMarkers(visitMarkers(c.getMarkers(), p));
+        c = c.getPadding().withImports(ListUtils.map(c.getPadding().getImports(),
+                el -> visitRightPadded(el, JRightPadded.Location.IMPORT, p)));
+        c = c.getPadding().withStatements(visitStatements(c.getPadding().getStatements(), p));
+        c = c.withEof(visitSpace(c.getEof(), Space.Location.COMPILATION_UNIT_EOF, p));
+        return c;
+    }
+
+    private <T extends Statement> java.util.List<JRightPadded<T>> visitStatements(
+            java.util.List<JRightPadded<T>> statements, P p) {
+        java.util.List<JRightPadded<T>> s = statements;
+        for (int i = 0; i < s.size(); i++) {
+            JRightPadded<T> rp = s.get(i);
+            @SuppressWarnings("unchecked")
+            T elem = (T) visitAndCast(rp.getElement(), p);
+            if (elem != rp.getElement()) {
+                if (s == statements) {
+                    s = new java.util.ArrayList<>(statements);
+                }
+                s.set(i, rp.withElement(elem));
+            }
+        }
+        return s;
+    }
+
+    public J visitComptime(Zig.Comptime comptime, P p) {
+        Zig.Comptime c = comptime;
+        c = c.withPrefix(visitSpace(c.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        c = c.withMarkers(visitMarkers(c.getMarkers(), p));
+        c = c.withExpression((Expression) visitAndCast(c.getExpression(), p));
+        return c;
+    }
+
+    public J visitDefer(Zig.Defer defer, P p) {
+        Zig.Defer d = defer;
+        d = d.withPrefix(visitSpace(d.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        d = d.withMarkers(visitMarkers(d.getMarkers(), p));
+        if (d.getPayload() != null) {
+            d = d.withPayload((Zig.Payload) visitAndCast(d.getPayload(), p));
+        }
+        d = d.withExpression((Expression) visitAndCast(d.getExpression(), p));
+        return d;
+    }
+
+    public J visitTestDecl(Zig.TestDecl testDecl, P p) {
+        Zig.TestDecl t = testDecl;
+        t = t.withPrefix(visitSpace(t.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        t = t.withMarkers(visitMarkers(t.getMarkers(), p));
+        t = t.withName((J.Literal) visitAndCast(t.getName(), p));
+        t = t.withBody((J.Block) visitAndCast(t.getBody(), p));
+        return t;
+    }
+
+    public J visitBuiltinCall(Zig.BuiltinCall builtinCall, P p) {
+        Zig.BuiltinCall b = builtinCall;
+        b = b.withPrefix(visitSpace(b.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        b = b.withMarkers(visitMarkers(b.getMarkers(), p));
+        b = b.withName((J.Identifier) visitAndCast(b.getName(), p));
+        b = b.getPadding().withArguments(visitContainer(b.getPadding().getArguments(), JContainer.Location.LANGUAGE_EXTENSION, p));
+        return b;
+    }
+
+    public J visitPayload(Zig.Payload payload, P p) {
+        Zig.Payload pl = payload;
+        pl = pl.withPrefix(visitSpace(pl.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        pl = pl.withMarkers(visitMarkers(pl.getMarkers(), p));
+        pl = pl.getPadding().withNames(visitContainer(pl.getPadding().getNames(), JContainer.Location.LANGUAGE_EXTENSION, p));
+        return pl;
+    }
+
+    public J visitErrorUnion(Zig.ErrorUnion errorUnion, P p) {
+        Zig.ErrorUnion e = errorUnion;
+        e = e.withPrefix(visitSpace(e.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        e = e.withMarkers(visitMarkers(e.getMarkers(), p));
+        if (e.getErrorType() != null) {
+            e = e.withErrorType((Expression) visitAndCast(e.getErrorType(), p));
+        }
+        e = e.getPadding().withValueType(visitLeftPadded(e.getPadding().getValueType(), JLeftPadded.Location.LANGUAGE_EXTENSION, p));
+        return e;
+    }
+
+    public J visitOptional(Zig.Optional optional, P p) {
+        Zig.Optional o = optional;
+        o = o.withPrefix(visitSpace(o.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        o = o.withMarkers(visitMarkers(o.getMarkers(), p));
+        o = o.withValueType((Expression) visitAndCast(o.getValueType(), p));
+        return o;
+    }
+
+    public J visitSlice(Zig.Slice slice, P p) {
+        Zig.Slice s = slice;
+        s = s.withPrefix(visitSpace(s.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        s = s.withMarkers(visitMarkers(s.getMarkers(), p));
+        s = s.withTarget((Expression) visitAndCast(s.getTarget(), p));
+        s = s.withOpenBracket(visitSpace(s.getOpenBracket(), Space.Location.LANGUAGE_EXTENSION, p));
+        if (s.getPadding().getStart() != null) {
+            s = s.getPadding().withStart(visitRightPadded(s.getPadding().getStart(), JRightPadded.Location.LANGUAGE_EXTENSION, p));
+        }
+        if (s.getEnd() != null) {
+            s = s.withEnd((Expression) visitAndCast(s.getEnd(), p));
+        }
+        s = s.withCloseBracket(visitSpace(s.getCloseBracket(), Space.Location.LANGUAGE_EXTENSION, p));
+        return s;
+    }
+
+    public J visitSwitchProng(Zig.SwitchProng switchProng, P p) {
+        Zig.SwitchProng sp = switchProng;
+        sp = sp.withPrefix(visitSpace(sp.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        sp = sp.withMarkers(visitMarkers(sp.getMarkers(), p));
+        sp = sp.getPadding().withCases(visitContainer(sp.getPadding().getCases(), JContainer.Location.LANGUAGE_EXTENSION, p));
+        if (sp.getPayload() != null) {
+            sp = sp.withPayload((Zig.Payload) visitAndCast(sp.getPayload(), p));
+        }
+        sp = sp.getPadding().withArrow(visitLeftPadded(sp.getPadding().getArrow(), JLeftPadded.Location.LANGUAGE_EXTENSION, p));
+        return sp;
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/format/AutoFormatVisitor.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/format/AutoFormatVisitor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.format;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.zig.ZigVisitor;
+import org.openrewrite.zig.tree.Zig;
+
+/**
+ * Applies zig fmt-style formatting to Zig source code.
+ * Chains specialized sub-visitors in sequence: line break normalization,
+ * blank lines, indentation, and trailing whitespace removal.
+ */
+public class AutoFormatVisitor<P> extends ZigVisitor<P> {
+    @Nullable
+    private final Tree stopAfter;
+
+    public AutoFormatVisitor() {
+        this(null);
+    }
+
+    public AutoFormatVisitor(@Nullable Tree stopAfter) {
+        this.stopAfter = stopAfter;
+    }
+
+    @Override
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
+        return sourceFile instanceof Zig.CompilationUnit;
+    }
+
+    @Override
+    public J visit(@Nullable Tree tree, P p, Cursor cursor) {
+        return doFormat(tree, p, cursor);
+    }
+
+    @Override
+    public J visit(@Nullable Tree tree, P p) {
+        if (tree == null) {
+            return (J) defaultValue(null, p);
+        }
+        return doFormat(tree, p, new Cursor(getCursor(), tree));
+    }
+
+    private J doFormat(Tree tree, P p, Cursor cursor) {
+        // zig fmt formatting passes (order matters):
+        // 1. Normalize line endings first so subsequent visitors see consistent \n
+        J t = new NormalizeLineBreaksVisitor<P>(stopAfter).visitNonNull(tree, p, cursor.fork());
+        // 2. Collapse blank lines (now that \r\n is normalized)
+        t = new BlankLinesVisitor<P>(stopAfter).visitNonNull(t, p, cursor.fork());
+        // 3. Fix indentation (4 spaces at correct depth)
+        t = new TabsAndIndentsVisitor<P>(stopAfter).visitNonNull(t, p, cursor.fork());
+        // 4. Strip trailing whitespace
+        t = new RemoveTrailingWhitespaceVisitor<P>(stopAfter).visitNonNull(t, p, cursor.fork());
+        return t;
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/format/BlankLinesVisitor.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/format/BlankLinesVisitor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.format;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.zig.ZigVisitor;
+
+/**
+ * Applies Zig blank line rules:
+ * <ul>
+ *   <li>Collapse 2+ consecutive blank lines to 1</li>
+ *   <li>No blank line after opening brace</li>
+ *   <li>No blank line before closing brace</li>
+ * </ul>
+ */
+public class BlankLinesVisitor<P> extends ZigVisitor<P> {
+    @Nullable
+    private final Tree stopAfter;
+
+    public BlankLinesVisitor(@Nullable Tree stopAfter) {
+        this.stopAfter = stopAfter;
+    }
+
+    @Override
+    public Space visitSpace(Space space, Space.Location loc, P p) {
+        return collapseBlankLines(space);
+    }
+
+    /**
+     * Collapse runs of 2+ blank lines (3+ newlines) to 1 blank line (2 newlines),
+     * preserving the indentation after the last newline.
+     */
+    static Space collapseBlankLines(Space space) {
+        String ws = space.getWhitespace();
+        if (!ws.contains("\n\n\n")) {
+            return space;
+        }
+        // Count newlines and collapse
+        StringBuilder sb = new StringBuilder();
+        int consecutiveNewlines = 0;
+        for (int i = 0; i < ws.length(); i++) {
+            char c = ws.charAt(i);
+            if (c == '\n') {
+                consecutiveNewlines++;
+                if (consecutiveNewlines <= 2) {
+                    sb.append(c);
+                }
+                // skip additional newlines and any whitespace between them
+            } else if (c == '\r') {
+                // skip \r (handled by NormalizeLineBreaks)
+            } else if (c == ' ' || c == '\t') {
+                if (consecutiveNewlines > 2) {
+                    // skip whitespace in collapsed blank lines
+                } else {
+                    sb.append(c);
+                }
+            } else {
+                consecutiveNewlines = 0;
+                sb.append(c);
+            }
+        }
+        // Preserve original indentation after last newline
+        String collapsed = sb.toString();
+        int lastNewline = collapsed.lastIndexOf('\n');
+        int origLastNewline = ws.lastIndexOf('\n');
+        if (lastNewline >= 0 && origLastNewline >= 0) {
+            String origIndent = ws.substring(origLastNewline + 1);
+            collapsed = collapsed.substring(0, lastNewline + 1) + origIndent;
+        }
+        return collapsed.equals(ws) ? space : space.withWhitespace(collapsed);
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/format/NormalizeLineBreaksVisitor.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/format/NormalizeLineBreaksVisitor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.format;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.zig.ZigVisitor;
+
+public class NormalizeLineBreaksVisitor<P> extends ZigVisitor<P> {
+    @Nullable
+    private final Tree stopAfter;
+
+    public NormalizeLineBreaksVisitor(@Nullable Tree stopAfter) {
+        this.stopAfter = stopAfter;
+    }
+
+    @Override
+    public Space visitSpace(Space space, Space.Location loc, P p) {
+        String ws = space.getWhitespace();
+        if (ws.contains("\r\n")) {
+            return space.withWhitespace(ws.replace("\r\n", "\n"));
+        }
+        return space;
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/format/RemoveTrailingWhitespaceVisitor.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/format/RemoveTrailingWhitespaceVisitor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.format;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.zig.ZigVisitor;
+
+public class RemoveTrailingWhitespaceVisitor<P> extends ZigVisitor<P> {
+    @Nullable
+    private final Tree stopAfter;
+
+    public RemoveTrailingWhitespaceVisitor(@Nullable Tree stopAfter) {
+        this.stopAfter = stopAfter;
+    }
+
+    @Override
+    public Space visitSpace(Space space, Space.Location loc, P p) {
+        String ws = space.getWhitespace();
+        if (ws.contains("\n")) {
+            // Remove spaces/tabs before each newline
+            String normalized = ws.replaceAll("[ \t]+\n", "\n");
+            if (!normalized.equals(ws)) {
+                return space.withWhitespace(normalized);
+            }
+        }
+        return space;
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/format/TabsAndIndentsVisitor.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/format/TabsAndIndentsVisitor.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.format;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.zig.ZigVisitor;
+import org.openrewrite.zig.tree.Zig;
+
+public class TabsAndIndentsVisitor<P> extends ZigVisitor<P> {
+    private static final String INDENT = "    "; // Zig uses 4 spaces
+
+    @Nullable
+    private final Tree stopAfter;
+
+    public TabsAndIndentsVisitor(@Nullable Tree stopAfter) {
+        this.stopAfter = stopAfter;
+    }
+
+    @Override
+    public Space visitSpace(Space space, Space.Location loc, P p) {
+        if (!space.getWhitespace().contains("\n")) {
+            return space;
+        }
+        // Count nesting depth from cursor.
+        // Rules:
+        // - J.Block adds depth, EXCEPT switch body blocks
+        // - J.Case adds depth (for case body statements)
+        // - Zig.SwitchProng adds depth
+        //
+        // This produces:
+        //   fn body:        4 spaces  (fn body Block)
+        //   switch prong:   4 spaces  (fn body Block, skip switch body Block)
+        //   prong body:     8 spaces  (fn body Block + SwitchProng)
+        //   nested blocks:  +4 per Block
+        int depth = 0;
+        // Start from PARENT -- the current cursor value is the node whose prefix we're
+        // formatting, so it shouldn't count toward its own indentation.
+        for (Cursor c = getCursor().getParent(); c != null && c.getParent() != null; c = c.getParent()) {
+            Object val = c.getValue();
+            if (val instanceof J.Block) {
+                // Skip the switch body block -- zig fmt does not indent case labels
+                // relative to the switch body brace.
+                if (isSwitchBody(c)) {
+                    continue;
+                }
+                depth++;
+            } else if (val instanceof J.Case) {
+                depth++;
+            } else if (val instanceof Zig.SwitchProng) {
+                depth++;
+            }
+        }
+        // Build indentation: newlines preserved, then 4 spaces per depth level
+        String ws = space.getWhitespace();
+        int lastNewline = ws.lastIndexOf('\n');
+        if (lastNewline >= 0) {
+            String beforeLastNewline = ws.substring(0, lastNewline + 1);
+            StringBuilder indent = new StringBuilder();
+            for (int i = 0; i < depth; i++) {
+                indent.append(INDENT);
+            }
+            return space.withWhitespace(beforeLastNewline + indent);
+        }
+        return space;
+    }
+
+    /**
+     * Checks if the Block at the given cursor position is the body of a J.Switch.
+     * The cursor may have padding entries between Block and Switch, so we check
+     * up to several levels of parents.
+     */
+    private static boolean isSwitchBody(Cursor blockCursor) {
+        // Walk up to find if ANY ancestor is a J.Switch -- but stop at the first
+        // J.Block (another block means we've left the switch body scope)
+        for (Cursor c = blockCursor.getParent(); c != null && c.getParent() != null; c = c.getParent()) {
+            Object val = c.getValue();
+            if (val instanceof J.Switch) {
+                return true;
+            }
+            if (val instanceof J.Block) {
+                // Hit another block -- we're past the switch
+                return false;
+            }
+        }
+        return false;
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigContainerRpcCodec.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigContainerRpcCodec.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.internal.rpc;
+
+import lombok.Getter;
+import org.openrewrite.java.tree.JContainer;
+import org.openrewrite.zig.tree.Zig;
+import org.openrewrite.rpc.DynamicDispatchRpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+@Getter
+@SuppressWarnings("rawtypes")
+public class ZigContainerRpcCodec extends DynamicDispatchRpcCodec<JContainer> {
+
+    @Override
+    public String getSourceFileType() {
+        return Zig.CompilationUnit.class.getName();
+    }
+
+    @Override
+    public Class<? extends JContainer> getType() {
+        return JContainer.class;
+    }
+
+    @Override
+    public void rpcSend(JContainer after, RpcSendQueue q) {
+        //noinspection unchecked
+        new ZigSender().visitContainer(after, q);
+    }
+
+    @Override
+    public JContainer rpcReceive(JContainer before, RpcReceiveQueue q) {
+        //noinspection unchecked
+        return new ZigReceiver().visitContainer(before, q);
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigLeftPaddedRpcCodec.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigLeftPaddedRpcCodec.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.internal.rpc;
+
+import lombok.Getter;
+import org.openrewrite.java.tree.JLeftPadded;
+import org.openrewrite.zig.tree.Zig;
+import org.openrewrite.rpc.DynamicDispatchRpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+@Getter
+@SuppressWarnings("rawtypes")
+public class ZigLeftPaddedRpcCodec extends DynamicDispatchRpcCodec<JLeftPadded> {
+
+    @Override
+    public String getSourceFileType() {
+        return Zig.CompilationUnit.class.getName();
+    }
+
+    @Override
+    public Class<? extends JLeftPadded> getType() {
+        return JLeftPadded.class;
+    }
+
+    @Override
+    public void rpcSend(JLeftPadded after, RpcSendQueue q) {
+        //noinspection unchecked
+        new ZigSender().visitLeftPadded(after, q);
+    }
+
+    @Override
+    public JLeftPadded rpcReceive(JLeftPadded before, RpcReceiveQueue q) {
+        //noinspection unchecked
+        return new ZigReceiver().visitLeftPadded(before, q);
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigReceiver.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigReceiver.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.internal.rpc;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.java.internal.rpc.JavaReceiver;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.zig.ZigVisitor;
+import org.openrewrite.zig.tree.Zig;
+import org.openrewrite.rpc.RpcReceiveQueue;
+
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+public class ZigReceiver extends ZigVisitor<RpcReceiveQueue> {
+    private final ZigReceiverDelegate delegate = new ZigReceiverDelegate(this);
+
+    @Override
+    public @Nullable J visit(@Nullable Tree tree, RpcReceiveQueue p) {
+        if (tree instanceof Zig) {
+            return super.visit(tree, p);
+        }
+        return delegate.visit(tree, p);
+    }
+
+    @Override
+    public J preVisit(J j, RpcReceiveQueue q) {
+        return ((J) j.withId(q.receiveAndGet(j.getId(), UUID::fromString)))
+                .withPrefix(q.receive(j.getPrefix(), space -> visitSpace(space, q)))
+                .withMarkers(q.receive(j.getMarkers()));
+    }
+
+    @Override
+    public J visitZigCompilationUnit(Zig.CompilationUnit cu, RpcReceiveQueue q) {
+        return cu.withSourcePath(q.<Path, String>receiveAndGet(cu.getSourcePath(), Paths::get))
+                .withCharset(q.<Charset, String>receiveAndGet(cu.getCharset(), Charset::forName))
+                .withCharsetBomMarked(q.receive(cu.isCharsetBomMarked()))
+                .withChecksum(q.receive(cu.getChecksum()))
+                .<Zig.CompilationUnit>withFileAttributes(q.receive(cu.getFileAttributes()))
+                .withImportsContainer(q.receive(cu.getImportsContainer(), c -> visitContainer(c, q)))
+                .getPadding().withStatements(q.receiveList(cu.getPadding().getStatements(), stmt -> visitRightPadded(stmt, q)))
+                .withEof(q.receive(cu.getEof(), space -> visitSpace(space, q)));
+    }
+
+    @Override
+    public J visitComptime(Zig.Comptime comptime, RpcReceiveQueue q) {
+        return comptime
+                .withExpression(q.receive(comptime.getExpression(), el -> (Expression) visitNonNull(el, q)));
+    }
+
+    @Override
+    public J visitDefer(Zig.Defer defer, RpcReceiveQueue q) {
+        return defer
+                .withErrdefer(q.receive(defer.isErrdefer()))
+                .withPayload(q.receive(defer.getPayload(), el -> (Zig.Payload) visitNonNull(el, q)))
+                .withExpression(q.receive(defer.getExpression(), el -> (Expression) visitNonNull(el, q)));
+    }
+
+    @Override
+    public J visitTestDecl(Zig.TestDecl testDecl, RpcReceiveQueue q) {
+        return testDecl
+                .withName(q.receive(testDecl.getName(), el -> (J.Literal) visitNonNull(el, q)))
+                .withBody(q.receive(testDecl.getBody(), el -> (J.Block) visitNonNull(el, q)));
+    }
+
+    @Override
+    public J visitBuiltinCall(Zig.BuiltinCall builtinCall, RpcReceiveQueue q) {
+        return builtinCall
+                .withName(q.receive(builtinCall.getName(), el -> (J.Identifier) visitNonNull(el, q)))
+                .getPadding().withArguments(q.receive(builtinCall.getPadding().getArguments(), el -> visitContainer(el, q)));
+    }
+
+    @Override
+    public J visitPayload(Zig.Payload payload, RpcReceiveQueue q) {
+        return payload
+                .getPadding().withNames(q.receive(payload.getPadding().getNames(), el -> visitContainer(el, q)));
+    }
+
+    @Override
+    public J visitErrorUnion(Zig.ErrorUnion errorUnion, RpcReceiveQueue q) {
+        return errorUnion
+                .withErrorType(q.receive(errorUnion.getErrorType(), el -> (Expression) visitNonNull(el, q)))
+                .getPadding().withValueType(q.receive(errorUnion.getPadding().getValueType(), el -> visitLeftPadded(el, q)));
+    }
+
+    @Override
+    public J visitOptional(Zig.Optional optional, RpcReceiveQueue q) {
+        return optional
+                .withValueType(q.receive(optional.getValueType(), el -> (Expression) visitNonNull(el, q)));
+    }
+
+    @Override
+    public J visitSlice(Zig.Slice slice, RpcReceiveQueue q) {
+        return slice
+                .withTarget(q.receive(slice.getTarget(), el -> (Expression) visitNonNull(el, q)))
+                .withOpenBracket(q.receive(slice.getOpenBracket(), space -> visitSpace(space, q)))
+                .getPadding().withStart(q.receive(slice.getPadding().getStart(), el -> visitRightPadded(el, q)))
+                .withEnd(q.receive(slice.getEnd(), el -> (Expression) visitNonNull(el, q)))
+                .withCloseBracket(q.receive(slice.getCloseBracket(), space -> visitSpace(space, q)));
+    }
+
+    @Override
+    public J visitSwitchProng(Zig.SwitchProng switchProng, RpcReceiveQueue q) {
+        return switchProng
+                .getPadding().withCases(q.receive(switchProng.getPadding().getCases(), el -> visitContainer(el, q)))
+                .withPayload(q.receive(switchProng.getPayload(), el -> (Zig.Payload) visitNonNull(el, q)))
+                .getPadding().withArrow(q.receive(switchProng.getPadding().getArrow(), el -> visitLeftPadded(el, q)));
+    }
+
+    // Delegation methods to JavaReceiver for RPC-specific visit methods
+    public <T> JLeftPadded<T> visitLeftPadded(JLeftPadded<T> left, RpcReceiveQueue q) {
+        return delegate.visitLeftPadded(left, q);
+    }
+
+    public <T> JLeftPadded<T> visitLeftPadded(JLeftPadded<T> left, RpcReceiveQueue q, java.util.function.Function<Object, T> mapValue) {
+        return delegate.visitLeftPadded(left, q, mapValue);
+    }
+
+    public <T> JRightPadded<T> visitRightPadded(JRightPadded<T> right, RpcReceiveQueue q) {
+        return delegate.visitRightPadded(right, q);
+    }
+
+    public <J2 extends J> JContainer<J2> visitContainer(JContainer<J2> container, RpcReceiveQueue q) {
+        return delegate.visitContainer(container, q);
+    }
+
+    public Space visitSpace(Space space, RpcReceiveQueue q) {
+        return delegate.visitSpace(space, q);
+    }
+
+    @Override
+    public @Nullable JavaType visitType(@Nullable JavaType javaType, RpcReceiveQueue q) {
+        return delegate.visitType(javaType, q);
+    }
+
+    private static class ZigReceiverDelegate extends JavaReceiver {
+        private final ZigReceiver delegate;
+
+        public ZigReceiverDelegate(ZigReceiver delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public @Nullable J visit(@Nullable Tree tree, RpcReceiveQueue p) {
+            if (tree instanceof Zig) {
+                return delegate.visit(tree, p);
+            }
+            return super.visit(tree, p);
+        }
+
+        @Override
+        public J visitUnknownSource(J.Unknown.Source source, RpcReceiveQueue q) {
+            return source.withText(q.receive(source.getText()));
+        }
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigRightPaddedRpcCodec.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigRightPaddedRpcCodec.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.internal.rpc;
+
+import lombok.Getter;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.zig.tree.Zig;
+import org.openrewrite.rpc.DynamicDispatchRpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+@Getter
+@SuppressWarnings("rawtypes")
+public class ZigRightPaddedRpcCodec extends DynamicDispatchRpcCodec<JRightPadded> {
+
+    @Override
+    public String getSourceFileType() {
+        return Zig.CompilationUnit.class.getName();
+    }
+
+    @Override
+    public Class<? extends JRightPadded> getType() {
+        return JRightPadded.class;
+    }
+
+    @Override
+    public void rpcSend(JRightPadded after, RpcSendQueue q) {
+        //noinspection unchecked
+        new ZigSender().visitRightPadded(after, q);
+    }
+
+    @Override
+    public JRightPadded rpcReceive(JRightPadded before, RpcReceiveQueue q) {
+        //noinspection unchecked
+        return new ZigReceiver().visitRightPadded(before, q);
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigRpcCodec.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigRpcCodec.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.internal.rpc;
+
+import org.openrewrite.java.tree.J;
+import org.openrewrite.zig.tree.Zig;
+import org.openrewrite.rpc.DynamicDispatchRpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+public class ZigRpcCodec extends DynamicDispatchRpcCodec<J> {
+
+    @Override
+    public String getSourceFileType() {
+        return Zig.CompilationUnit.class.getName();
+    }
+
+    @Override
+    public Class<? extends J> getType() {
+        return J.class;
+    }
+
+    @Override
+    public void rpcSend(J after, RpcSendQueue q) {
+        new ZigSender().visit(after, q);
+    }
+
+    @Override
+    public J rpcReceive(J before, RpcReceiveQueue q) {
+        return new ZigReceiver().visitNonNull(before, q);
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigSender.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigSender.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.internal.rpc;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.java.internal.rpc.JavaSender;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.zig.ZigVisitor;
+import org.openrewrite.zig.tree.Zig;
+import org.openrewrite.rpc.RpcSendQueue;
+
+public class ZigSender extends ZigVisitor<RpcSendQueue> {
+    private final ZigSenderDelegate delegate = new ZigSenderDelegate(this);
+
+    @Override
+    public @Nullable J visit(@Nullable Tree tree, RpcSendQueue p) {
+        if (tree instanceof Zig) {
+            return super.visit(tree, p);
+        }
+        return delegate.visit(tree, p);
+    }
+
+    @Override
+    public J preVisit(J j, RpcSendQueue q) {
+        q.getAndSend(j, Tree::getId);
+        q.getAndSend(j, J::getPrefix, space -> visitSpace(space, q));
+        q.getAndSend(j, Tree::getMarkers);
+        return j;
+    }
+
+    @Override
+    public J visitZigCompilationUnit(Zig.CompilationUnit cu, RpcSendQueue q) {
+        q.getAndSend(cu, c -> c.getSourcePath().toString());
+        q.getAndSend(cu, c -> c.getCharset().name());
+        q.getAndSend(cu, Zig.CompilationUnit::isCharsetBomMarked);
+        q.getAndSend(cu, Zig.CompilationUnit::getChecksum);
+        q.getAndSend(cu, Zig.CompilationUnit::getFileAttributes);
+        q.getAndSend(cu, Zig.CompilationUnit::getImportsContainer, c -> visitContainer(c, q));
+        q.getAndSendList(cu, c -> c.getPadding().getStatements(), stmt -> stmt.getElement().getId(), stmt -> visitRightPadded(stmt, q));
+        q.getAndSend(cu, Zig.CompilationUnit::getEof, space -> visitSpace(space, q));
+        return cu;
+    }
+
+    @Override
+    public J visitComptime(Zig.Comptime comptime, RpcSendQueue q) {
+        q.getAndSend(comptime, Zig.Comptime::getExpression, el -> visit(el, q));
+        return comptime;
+    }
+
+    @Override
+    public J visitDefer(Zig.Defer defer, RpcSendQueue q) {
+        q.getAndSend(defer, Zig.Defer::isErrdefer);
+        q.getAndSend(defer, Zig.Defer::getPayload, el -> visit(el, q));
+        q.getAndSend(defer, Zig.Defer::getExpression, el -> visit(el, q));
+        return defer;
+    }
+
+    @Override
+    public J visitTestDecl(Zig.TestDecl testDecl, RpcSendQueue q) {
+        q.getAndSend(testDecl, Zig.TestDecl::getName, el -> visit(el, q));
+        q.getAndSend(testDecl, Zig.TestDecl::getBody, el -> visit(el, q));
+        return testDecl;
+    }
+
+    @Override
+    public J visitBuiltinCall(Zig.BuiltinCall builtinCall, RpcSendQueue q) {
+        q.getAndSend(builtinCall, Zig.BuiltinCall::getName, el -> visit(el, q));
+        q.getAndSend(builtinCall, b -> b.getPadding().getArguments(), el -> visitContainer(el, q));
+        return builtinCall;
+    }
+
+    @Override
+    public J visitPayload(Zig.Payload payload, RpcSendQueue q) {
+        q.getAndSend(payload, pl -> pl.getPadding().getNames(), el -> visitContainer(el, q));
+        return payload;
+    }
+
+    @Override
+    public J visitErrorUnion(Zig.ErrorUnion errorUnion, RpcSendQueue q) {
+        q.getAndSend(errorUnion, Zig.ErrorUnion::getErrorType, el -> visit(el, q));
+        q.getAndSend(errorUnion, e -> e.getPadding().getValueType(), el -> visitLeftPadded(el, q));
+        return errorUnion;
+    }
+
+    @Override
+    public J visitOptional(Zig.Optional optional, RpcSendQueue q) {
+        q.getAndSend(optional, Zig.Optional::getValueType, el -> visit(el, q));
+        return optional;
+    }
+
+    @Override
+    public J visitSlice(Zig.Slice slice, RpcSendQueue q) {
+        q.getAndSend(slice, Zig.Slice::getTarget, el -> visit(el, q));
+        q.getAndSend(slice, Zig.Slice::getOpenBracket, space -> visitSpace(space, q));
+        q.getAndSend(slice, s -> s.getPadding().getStart(), el -> visitRightPadded(el, q));
+        q.getAndSend(slice, Zig.Slice::getEnd, el -> visit(el, q));
+        q.getAndSend(slice, Zig.Slice::getCloseBracket, space -> visitSpace(space, q));
+        return slice;
+    }
+
+    @Override
+    public J visitSwitchProng(Zig.SwitchProng switchProng, RpcSendQueue q) {
+        q.getAndSend(switchProng, sp -> sp.getPadding().getCases(), el -> visitContainer(el, q));
+        q.getAndSend(switchProng, Zig.SwitchProng::getPayload, el -> visit(el, q));
+        q.getAndSend(switchProng, sp -> sp.getPadding().getArrow(), el -> visitLeftPadded(el, q));
+        return switchProng;
+    }
+
+    // Delegation methods to JavaSender for RPC-specific visit methods
+    public <T> void visitLeftPadded(JLeftPadded<T> left, RpcSendQueue q) {
+        delegate.visitLeftPadded(left, q);
+    }
+
+    public <T> void visitRightPadded(JRightPadded<T> right, RpcSendQueue q) {
+        delegate.visitRightPadded(right, q);
+    }
+
+    public <J2 extends J> void visitContainer(JContainer<J2> container, RpcSendQueue q) {
+        delegate.visitContainer(container, q);
+    }
+
+    public void visitSpace(Space space, RpcSendQueue q) {
+        delegate.visitSpace(space, q);
+    }
+
+    @Override
+    public @Nullable JavaType visitType(@Nullable JavaType javaType, RpcSendQueue q) {
+        return delegate.visitType(javaType, q);
+    }
+
+    private static class ZigSenderDelegate extends JavaSender {
+        private final ZigSender delegate;
+
+        public ZigSenderDelegate(ZigSender delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public @Nullable J visit(@Nullable Tree tree, RpcSendQueue p) {
+            if (tree instanceof Zig) {
+                return delegate.visit(tree, p);
+            }
+            return super.visit(tree, p);
+        }
+
+        @Override
+        public J visitUnknownSource(J.Unknown.Source source, RpcSendQueue q) {
+            q.getAndSend(source, J.Unknown.Source::getText);
+            return source;
+        }
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigSpaceRpcCodec.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/internal/rpc/ZigSpaceRpcCodec.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.internal.rpc;
+
+import lombok.Getter;
+import org.openrewrite.zig.tree.Zig;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.rpc.DynamicDispatchRpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+@Getter
+public class ZigSpaceRpcCodec extends DynamicDispatchRpcCodec<Space> {
+
+    @Override
+    public String getSourceFileType() {
+        return Zig.CompilationUnit.class.getName();
+    }
+
+    @Override
+    public Class<? extends Space> getType() {
+        return Space.class;
+    }
+
+    @Override
+    public void rpcSend(Space after, RpcSendQueue q) {
+        new ZigSender().visitSpace(after, q);
+    }
+
+    @Override
+    public Space rpcReceive(Space before, RpcReceiveQueue q) {
+        return new ZigReceiver().visitSpace(before, q);
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/marker/PubModifier.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/marker/PubModifier.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.rpc.RpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.util.UUID;
+
+@Value
+@With
+public class PubModifier implements Marker, RpcCodec<PubModifier> {
+    UUID id;
+
+    @Override
+    public void rpcSend(PubModifier after, RpcSendQueue q) {
+        q.getAndSend(after, Marker::getId);
+    }
+
+    @Override
+    public PubModifier rpcReceive(PubModifier before, RpcReceiveQueue q) {
+        return before.withId(q.receiveAndGet(before.getId(), UUID::fromString));
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/rpc/InstallRecipesByFile.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/rpc/InstallRecipesByFile.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.rpc;
+
+import lombok.Value;
+import org.openrewrite.rpc.request.RpcRequest;
+
+import java.nio.file.Path;
+
+@Value
+class InstallRecipesByFile implements RpcRequest {
+    Path recipes;
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/rpc/InstallRecipesByPackage.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/rpc/InstallRecipesByPackage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.rpc;
+
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.rpc.request.RpcRequest;
+
+@Value
+class InstallRecipesByPackage implements RpcRequest {
+    Package recipes;
+
+    @Value
+    public static class Package {
+        String packageName;
+
+        @Nullable
+        String version;
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/rpc/InstallRecipesResponse.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/rpc/InstallRecipesResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.rpc;
+
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+
+@Value
+public class InstallRecipesResponse {
+    int recipesInstalled;
+    @Nullable String version;
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/rpc/ZigRewriteRpc.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/rpc/ZigRewriteRpc.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.rpc;
+
+import lombok.Getter;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.marketplace.RecipeBundleResolver;
+import org.openrewrite.marketplace.RecipeMarketplace;
+import org.openrewrite.rpc.RewriteRpc;
+import org.openrewrite.rpc.RewriteRpcProcess;
+import org.openrewrite.rpc.RewriteRpcProcessManager;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * RPC client that communicates with a Zig process for parsing and printing Zig source code.
+ */
+@Getter
+public class ZigRewriteRpc extends RewriteRpc {
+
+    private static final RewriteRpcProcessManager<ZigRewriteRpc> MANAGER = new RewriteRpcProcessManager<>(builder());
+
+    private final String command;
+    private final RewriteRpcProcess process;
+
+    ZigRewriteRpc(RewriteRpcProcess process, RecipeMarketplace marketplace, List<RecipeBundleResolver> resolvers, String command) {
+        super(process.getRpcClient(), marketplace, resolvers);
+        this.command = command;
+        this.process = process;
+    }
+
+    public static @Nullable ZigRewriteRpc get() {
+        return MANAGER.get();
+    }
+
+    public static ZigRewriteRpc getOrStart() {
+        return MANAGER.getOrStart();
+    }
+
+    public static void setFactory(Builder builder) {
+        MANAGER.setFactory(builder);
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        process.shutdown();
+    }
+
+    public static void shutdownCurrent() {
+        MANAGER.shutdown();
+    }
+
+    /**
+     * Install recipes from a local file path (e.g., a local Zig module).
+     *
+     * @param recipes Path to the local package directory
+     * @return Response with installation details
+     */
+    public InstallRecipesResponse installRecipes(File recipes) {
+        return send(
+                "InstallRecipes",
+                new InstallRecipesByFile(recipes.getAbsoluteFile().toPath()),
+                InstallRecipesResponse.class
+        );
+    }
+
+    /**
+     * Install recipes from a package name.
+     *
+     * @param packageName The package name to install (e.g., a Git repository URL)
+     * @return Response with installation details
+     */
+    public InstallRecipesResponse installRecipes(String packageName) {
+        return installRecipes(packageName, null);
+    }
+
+    /**
+     * Install recipes from a package name with a specific version.
+     *
+     * @param packageName The package name to install (e.g., a Git repository URL)
+     * @param version     Optional version specification
+     * @return Response with installation details
+     */
+    public InstallRecipesResponse installRecipes(String packageName, @Nullable String version) {
+        return send(
+                "InstallRecipes",
+                new InstallRecipesByPackage(
+                        new InstallRecipesByPackage.Package(packageName, version)),
+                InstallRecipesResponse.class
+        );
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder implements Supplier<ZigRewriteRpc> {
+        private RecipeMarketplace marketplace = new RecipeMarketplace();
+        private List<RecipeBundleResolver> resolvers = Collections.emptyList();
+        private @Nullable Path zigBinaryPath;
+        private Duration timeout = Duration.ofSeconds(60);
+        private @Nullable Path log;
+        private boolean traceRpcMessages;
+
+        public Builder marketplace(RecipeMarketplace marketplace) {
+            this.marketplace = marketplace;
+            return this;
+        }
+
+        public Builder resolvers(List<RecipeBundleResolver> resolvers) {
+            this.resolvers = resolvers;
+            return this;
+        }
+
+        public Builder zigBinaryPath(Path path) {
+            this.zigBinaryPath = path;
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Builder log(@Nullable Path log) {
+            this.log = log;
+            return this;
+        }
+
+        public Builder traceRpcMessages() {
+            this.traceRpcMessages = true;
+            return this;
+        }
+
+        @Override
+        public ZigRewriteRpc get() {
+            String binaryPath;
+            if (zigBinaryPath != null) {
+                binaryPath = zigBinaryPath.toString();
+            } else {
+                binaryPath = "rewrite-zig-rpc";
+            }
+
+            Stream<@Nullable String> cmd = Stream.of(
+                    binaryPath,
+                    log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
+                    traceRpcMessages ? "--trace-rpc-messages" : null
+            );
+
+            String[] cmdArr = cmd.filter(Objects::nonNull).toArray(String[]::new);
+            RewriteRpcProcess process = new RewriteRpcProcess(cmdArr);
+            process.start();
+
+            try {
+                return (ZigRewriteRpc) new ZigRewriteRpc(process, marketplace, resolvers, String.join(" ", cmdArr))
+                        .livenessCheck(process::getLivenessCheck)
+                        .timeout(timeout)
+                        .log(log == null ? null : new PrintStream(Files.newOutputStream(log, StandardOpenOption.APPEND, StandardOpenOption.CREATE)));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/service/ZigAutoFormatService.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/service/ZigAutoFormatService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.service;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.service.AutoFormatService;
+import org.openrewrite.zig.format.AutoFormatVisitor;
+
+public class ZigAutoFormatService extends AutoFormatService {
+    @Override
+    public <P> JavaVisitor<P> autoFormatVisitor(@Nullable Tree stopAfter) {
+        return new AutoFormatVisitor<>(stopAfter);
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/service/ZigImportService.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/service/ZigImportService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.service;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.service.ImportService;
+
+/**
+ * Zig-specific import service. Translates import requests for Zig's
+ * {@code @import("module")} syntax.
+ */
+public class ZigImportService extends ImportService {
+
+    @Override
+    public <P> JavaVisitor<P> addImportVisitor(@Nullable String packageName,
+                                               String typeName,
+                                               @Nullable String member,
+                                               @Nullable String alias,
+                                               boolean onlyIfReferenced) {
+        // Return a no-op visitor so cross-language recipes gracefully skip Zig files
+        // rather than crashing. Full import management to be implemented later.
+        return new JavaVisitor<P>() {};
+    }
+}

--- a/rewrite-zig/src/main/java/org/openrewrite/zig/tree/Zig.java
+++ b/rewrite-zig/src/main/java/org/openrewrite/zig/tree/Zig.java
@@ -1,0 +1,974 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.zig.tree;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.NonFinal;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.java.internal.TypesInUse;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.zig.ZigVisitor;
+import org.openrewrite.zig.rpc.ZigRewriteRpc;
+import org.openrewrite.rpc.request.Print;
+
+import java.lang.ref.SoftReference;
+import java.lang.ref.WeakReference;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@SuppressWarnings("unused")
+public interface Zig extends J {
+
+    @Override
+    default <R extends Tree, P> R accept(TreeVisitor<R, P> v, P p) {
+        //noinspection unchecked
+        return (R) acceptZig(v.adapt(ZigVisitor.class), p);
+    }
+
+    @Override
+    default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
+        return v.isAdaptableTo(ZigVisitor.class);
+    }
+
+    default <P> @Nullable J acceptZig(ZigVisitor<P> v, P p) {
+        return v.defaultValue(this, p);
+    }
+
+    @Override
+    default List<Comment> getComments() {
+        return getPrefix().getComments();
+    }
+
+    // ---------------------------------------------------------------
+    // CompilationUnit
+    // ---------------------------------------------------------------
+
+    @ToString
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class CompilationUnit implements Zig, JavaSourceFile, SourceFile {
+        @Nullable
+        @NonFinal
+        transient SoftReference<TypesInUse> typesInUse;
+
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @EqualsAndHashCode.Include
+        @With
+        @Getter
+        UUID id;
+
+        @With
+        @Getter
+        Space prefix;
+
+        @With
+        @Getter
+        Markers markers;
+
+        @With
+        @Getter
+        Path sourcePath;
+
+        @With
+        @Getter
+        @Nullable
+        FileAttributes fileAttributes;
+
+        @Nullable
+        @With(AccessLevel.PRIVATE)
+        String charsetName;
+
+        @With
+        @Getter
+        boolean charsetBomMarked;
+
+        @With
+        @Getter
+        @Nullable
+        Checksum checksum;
+
+        @Override
+        public Charset getCharset() {
+            return charsetName == null ? StandardCharsets.UTF_8 : Charset.forName(charsetName);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public SourceFile withCharset(Charset charset) {
+            return withCharsetName(charset.name());
+        }
+
+        @Nullable
+        JContainer<J.Import> imports;
+
+        public @Nullable JContainer<J.Import> getImportsContainer() {
+            return imports;
+        }
+
+        public Zig.CompilationUnit withImportsContainer(@Nullable JContainer<J.Import> imports) {
+            return this.imports == imports ? this : new Zig.CompilationUnit(
+                    typesInUse, padding, id, prefix, markers, sourcePath,
+                    fileAttributes, charsetName, charsetBomMarked, checksum,
+                    imports, statements, eof);
+        }
+
+        @Override
+        public List<J.Import> getImports() {
+            return imports == null ? java.util.Collections.emptyList() : imports.getElements();
+        }
+
+        @Override
+        public Zig.CompilationUnit withImports(List<J.Import> imports) {
+            if (imports.isEmpty() && this.imports == null) {
+                return this;
+            }
+            if (this.imports == null) {
+                return withImportsContainer(JContainer.build(Space.EMPTY,
+                        JRightPadded.withElements(java.util.Collections.emptyList(), imports), Markers.EMPTY));
+            }
+            return withImportsContainer(JContainer.build(this.imports.getBefore(),
+                    JRightPadded.withElements(this.imports.getPadding().getElements(), imports),
+                    this.imports.getMarkers()));
+        }
+
+        List<JRightPadded<Statement>> statements;
+
+        public List<Statement> getStatements() {
+            return JRightPadded.getElements(statements);
+        }
+
+        public Zig.CompilationUnit withStatements(List<Statement> statements) {
+            return getPadding().withStatements(JRightPadded.withElements(this.statements, statements));
+        }
+
+        @With
+        @Getter
+        Space eof;
+
+        @Override
+        public J.@Nullable Package getPackageDeclaration() {
+            return null;
+        }
+
+        @Override
+        public JavaSourceFile withPackageDeclaration(J.Package pkg) {
+            return this;
+        }
+
+        @Override
+        public List<J.ClassDeclaration> getClasses() {
+            return statements.stream()
+                    .map(JRightPadded::getElement)
+                    .filter(J.ClassDeclaration.class::isInstance)
+                    .map(J.ClassDeclaration.class::cast)
+                    .collect(Collectors.toList());
+        }
+
+        @Override
+        public JavaSourceFile withClasses(List<J.ClassDeclaration> classes) {
+            // Zig doesn't have class declarations in the Java sense
+            return this;
+        }
+
+        @Override
+        public <S, T extends S> T service(Class<S> service) {
+            if (org.openrewrite.java.service.AutoFormatService.class.getName().equals(service.getName())) {
+                @SuppressWarnings("unchecked")
+                T t = (T) new org.openrewrite.zig.service.ZigAutoFormatService();
+                return t;
+            }
+            if (org.openrewrite.java.service.ImportService.class.getName().equals(service.getName())) {
+                @SuppressWarnings("unchecked")
+                T t = (T) new org.openrewrite.zig.service.ZigImportService();
+                return t;
+            }
+            return JavaSourceFile.super.service(service);
+        }
+
+        @Override
+        public <P> @Nullable J acceptZig(ZigVisitor<P> v, P p) {
+            return v.visitZigCompilationUnit(this, p);
+        }
+
+        @Override
+        public @Nullable TypesInUse getTypesInUse() {
+            TypesInUse cache;
+            if (this.typesInUse == null) {
+                cache = TypesInUse.build(this);
+                this.typesInUse = new SoftReference<>(cache);
+            } else {
+                cache = this.typesInUse.get();
+                if (cache == null || cache.getCu() != this) {
+                    cache = TypesInUse.build(this);
+                    this.typesInUse = new SoftReference<>(cache);
+                }
+            }
+            return cache;
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new TreeVisitor<Tree, PrintOutputCapture<P>>() {
+                @Override
+                public @Nullable Tree preVisit(Tree tree, PrintOutputCapture<P> p) {
+                    ZigRewriteRpc rpc = ZigRewriteRpc.getOrStart();
+                    Print.MarkerPrinter mappedMarkerPrinter = Print.MarkerPrinter.from(p.getMarkerPrinter());
+                    p.append(rpc.print(tree, cursor, mappedMarkerPrinter));
+                    stopAfterPreVisit();
+                    return tree;
+                }
+            };
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding implements JavaSourceFile.Padding {
+            private final Zig.CompilationUnit t;
+
+            @Override
+            public List<JRightPadded<J.Import>> getImports() {
+                return t.imports == null ? null : t.imports.getPadding().getElements();
+            }
+
+            @Override
+            public Zig.CompilationUnit withImports(List<JRightPadded<J.Import>> imports) {
+                JContainer<J.Import> container = t.imports;
+                if (imports == null || imports.isEmpty()) {
+                    container = null;
+                } else if (container == null) {
+                    container = JContainer.build(Space.EMPTY, imports, Markers.EMPTY);
+                } else {
+                    container = container.getPadding().withElements(imports);
+                }
+                return container == t.imports ? t : new Zig.CompilationUnit(
+                        t.typesInUse, t.padding, t.id, t.prefix, t.markers, t.sourcePath,
+                        t.fileAttributes, t.charsetName, t.charsetBomMarked, t.checksum,
+                        container, t.statements, t.eof);
+            }
+
+            public List<JRightPadded<Statement>> getStatements() {
+                return t.statements;
+            }
+
+            public Zig.CompilationUnit withStatements(List<JRightPadded<Statement>> statements) {
+                return t.statements == statements ? t : new Zig.CompilationUnit(
+                        t.typesInUse, t.padding, t.id, t.prefix, t.markers, t.sourcePath,
+                        t.fileAttributes, t.charsetName, t.charsetBomMarked, t.checksum,
+                        t.imports, statements, t.eof);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Comptime (comptime { block } / comptime expr)
+    // ---------------------------------------------------------------
+
+    @ToString
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    final class Comptime implements Zig, Expression, Statement {
+        @EqualsAndHashCode.Include
+        @With
+        @Getter
+        UUID id;
+
+        @With
+        @Getter
+        Space prefix;
+
+        @With
+        @Getter
+        Markers markers;
+
+        @With
+        @Getter
+        Expression expression;
+
+        @Override
+        public @Nullable JavaType getType() {
+            return null;
+        }
+
+        @Override
+        public <T extends J> T withType(@Nullable JavaType type) {
+            //noinspection unchecked
+            return (T) this;
+        }
+
+        @Override
+        public <P> @Nullable J acceptZig(ZigVisitor<P> v, P p) {
+            return v.visitComptime(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Statement getCoordinates() {
+            return new CoordinateBuilder.Statement(this);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Defer (defer expr / errdefer expr / errdefer |err| expr)
+    // ---------------------------------------------------------------
+
+    @ToString
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    final class Defer implements Zig, Statement {
+        @EqualsAndHashCode.Include
+        @With
+        @Getter
+        UUID id;
+
+        @With
+        @Getter
+        Space prefix;
+
+        @With
+        @Getter
+        Markers markers;
+
+        @With
+        @Getter
+        boolean errdefer;
+
+        @With
+        @Getter
+        @Nullable
+        Payload payload;
+
+        @With
+        @Getter
+        Expression expression;
+
+        @Override
+        public <P> @Nullable J acceptZig(ZigVisitor<P> v, P p) {
+            return v.visitDefer(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Statement getCoordinates() {
+            return new CoordinateBuilder.Statement(this);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // TestDecl (test "name" { body })
+    // ---------------------------------------------------------------
+
+    @ToString
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    final class TestDecl implements Zig, Statement {
+        @EqualsAndHashCode.Include
+        @With
+        @Getter
+        UUID id;
+
+        @With
+        @Getter
+        Space prefix;
+
+        @With
+        @Getter
+        Markers markers;
+
+        @With
+        @Getter
+        J.Literal name;
+
+        @With
+        @Getter
+        J.Block body;
+
+        @Override
+        public <P> @Nullable J acceptZig(ZigVisitor<P> v, P p) {
+            return v.visitTestDecl(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Statement getCoordinates() {
+            return new CoordinateBuilder.Statement(this);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // BuiltinCall (@import("std"), @intCast(x), etc.)
+    // ---------------------------------------------------------------
+
+    @ToString
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class BuiltinCall implements Zig, Expression, Statement {
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @EqualsAndHashCode.Include
+        @With
+        @Getter
+        UUID id;
+
+        @With
+        @Getter
+        Space prefix;
+
+        @With
+        @Getter
+        Markers markers;
+
+        @With
+        @Getter
+        J.Identifier name;
+
+        JContainer<Expression> arguments;
+
+        public List<Expression> getArguments() {
+            return arguments.getElements();
+        }
+
+        public Zig.BuiltinCall withArguments(List<Expression> arguments) {
+            return getPadding().withArguments(JContainer.withElements(this.arguments, arguments));
+        }
+
+        @Override
+        public @Nullable JavaType getType() {
+            return null;
+        }
+
+        @Override
+        public <T extends J> T withType(@Nullable JavaType type) {
+            //noinspection unchecked
+            return (T) this;
+        }
+
+        @Override
+        public <P> @Nullable J acceptZig(ZigVisitor<P> v, P p) {
+            return v.visitBuiltinCall(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Statement getCoordinates() {
+            return new CoordinateBuilder.Statement(this);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final Zig.BuiltinCall t;
+
+            public JContainer<Expression> getArguments() {
+                return t.arguments;
+            }
+
+            public Zig.BuiltinCall withArguments(JContainer<Expression> arguments) {
+                return t.arguments == arguments ? t : new Zig.BuiltinCall(t.padding, t.id, t.prefix, t.markers, t.name, arguments);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Payload (|val| or |val, idx|)
+    // ---------------------------------------------------------------
+
+    @ToString
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class Payload implements Zig, Expression {
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @EqualsAndHashCode.Include
+        @With
+        @Getter
+        UUID id;
+
+        @With
+        @Getter
+        Space prefix;
+
+        @With
+        @Getter
+        Markers markers;
+
+        JContainer<J.Identifier> names;
+
+        public List<J.Identifier> getNames() {
+            return names.getElements();
+        }
+
+        public Zig.Payload withNames(List<J.Identifier> names) {
+            return getPadding().withNames(JContainer.withElements(this.names, names));
+        }
+
+        @Override
+        public @Nullable JavaType getType() {
+            return null;
+        }
+
+        @Override
+        public <T extends J> T withType(@Nullable JavaType type) {
+            //noinspection unchecked
+            return (T) this;
+        }
+
+        @Override
+        public <P> @Nullable J acceptZig(ZigVisitor<P> v, P p) {
+            return v.visitPayload(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final Zig.Payload t;
+
+            public JContainer<J.Identifier> getNames() {
+                return t.names;
+            }
+
+            public Zig.Payload withNames(JContainer<J.Identifier> names) {
+                return t.names == names ? t : new Zig.Payload(t.padding, t.id, t.prefix, t.markers, names);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // ErrorUnion (ErrorSet!ValueType)
+    // ---------------------------------------------------------------
+
+    @ToString
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class ErrorUnion implements Zig, Expression, TypeTree {
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @EqualsAndHashCode.Include
+        @With
+        @Getter
+        UUID id;
+
+        @With
+        @Getter
+        Space prefix;
+
+        @With
+        @Getter
+        Markers markers;
+
+        @With
+        @Getter
+        @Nullable
+        Expression errorType;
+
+        JLeftPadded<Expression> valueType;
+
+        public Expression getValueType() {
+            return valueType.getElement();
+        }
+
+        public Zig.ErrorUnion withValueType(Expression valueType) {
+            return getPadding().withValueType(this.valueType.withElement(valueType));
+        }
+
+        @Override
+        public @Nullable JavaType getType() {
+            return null;
+        }
+
+        @Override
+        public <T extends J> T withType(@Nullable JavaType type) {
+            //noinspection unchecked
+            return (T) this;
+        }
+
+        @Override
+        public <P> @Nullable J acceptZig(ZigVisitor<P> v, P p) {
+            return v.visitErrorUnion(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final Zig.ErrorUnion t;
+
+            public JLeftPadded<Expression> getValueType() {
+                return t.valueType;
+            }
+
+            public Zig.ErrorUnion withValueType(JLeftPadded<Expression> valueType) {
+                return t.valueType == valueType ? t : new Zig.ErrorUnion(t.padding, t.id, t.prefix, t.markers, t.errorType, valueType);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Optional (?T)
+    // ---------------------------------------------------------------
+
+    @ToString
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    final class Optional implements Zig, Expression, TypeTree {
+        @EqualsAndHashCode.Include
+        @With
+        @Getter
+        UUID id;
+
+        @With
+        @Getter
+        Space prefix;
+
+        @With
+        @Getter
+        Markers markers;
+
+        @With
+        @Getter
+        Expression valueType;
+
+        @Override
+        public @Nullable JavaType getType() {
+            return null;
+        }
+
+        @Override
+        public <T extends J> T withType(@Nullable JavaType type) {
+            //noinspection unchecked
+            return (T) this;
+        }
+
+        @Override
+        public <P> @Nullable J acceptZig(ZigVisitor<P> v, P p) {
+            return v.visitOptional(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Slice (a[start..end])
+    // ---------------------------------------------------------------
+
+    @ToString
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class Slice implements Zig, Expression {
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @EqualsAndHashCode.Include
+        @With
+        @Getter
+        UUID id;
+
+        @With
+        @Getter
+        Space prefix;
+
+        @With
+        @Getter
+        Markers markers;
+
+        @With
+        @Getter
+        Expression target;
+
+        @With
+        @Getter
+        Space openBracket;
+
+        @Nullable
+        JRightPadded<Expression> start;
+
+        public @Nullable Expression getStart() {
+            return start == null ? null : start.getElement();
+        }
+
+        public Zig.Slice withStart(@Nullable Expression start) {
+            if (start == null) {
+                return this.start == null ? this : getPadding().withStart(null);
+            }
+            return getPadding().withStart(
+                    this.start == null ?
+                            JRightPadded.build(start) :
+                            this.start.withElement(start));
+        }
+
+        @With
+        @Getter
+        @Nullable
+        Expression end;
+
+        @With
+        @Getter
+        Space closeBracket;
+
+        @Override
+        public @Nullable JavaType getType() {
+            return null;
+        }
+
+        @Override
+        public <T extends J> T withType(@Nullable JavaType type) {
+            //noinspection unchecked
+            return (T) this;
+        }
+
+        @Override
+        public <P> @Nullable J acceptZig(ZigVisitor<P> v, P p) {
+            return v.visitSlice(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final Zig.Slice t;
+
+            public @Nullable JRightPadded<Expression> getStart() {
+                return t.start;
+            }
+
+            public Zig.Slice withStart(@Nullable JRightPadded<Expression> start) {
+                return t.start == start ? t : new Zig.Slice(t.padding, t.id, t.prefix, t.markers, t.target, t.openBracket, start, t.end, t.closeBracket);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // SwitchProng (case in switch expression)
+    // ---------------------------------------------------------------
+
+    @ToString
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class SwitchProng implements Zig, Expression {
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @EqualsAndHashCode.Include
+        @With
+        @Getter
+        UUID id;
+
+        @With
+        @Getter
+        Space prefix;
+
+        @With
+        @Getter
+        Markers markers;
+
+        JContainer<Expression> cases;
+
+        public List<Expression> getCases() {
+            return cases.getElements();
+        }
+
+        public Zig.SwitchProng withCases(List<Expression> cases) {
+            return getPadding().withCases(JContainer.withElements(this.cases, cases));
+        }
+
+        @With
+        @Getter
+        @Nullable
+        Payload payload;
+
+        JLeftPadded<Expression> arrow;
+
+        public Expression getArrow() {
+            return arrow.getElement();
+        }
+
+        public Zig.SwitchProng withArrow(Expression arrow) {
+            return getPadding().withArrow(this.arrow.withElement(arrow));
+        }
+
+        @Override
+        public @Nullable JavaType getType() {
+            return null;
+        }
+
+        @Override
+        public <T extends J> T withType(@Nullable JavaType type) {
+            //noinspection unchecked
+            return (T) this;
+        }
+
+        @Override
+        public <P> @Nullable J acceptZig(ZigVisitor<P> v, P p) {
+            return v.visitSwitchProng(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final Zig.SwitchProng t;
+
+            public JContainer<Expression> getCases() {
+                return t.cases;
+            }
+
+            public Zig.SwitchProng withCases(JContainer<Expression> cases) {
+                return t.cases == cases ? t : new Zig.SwitchProng(t.padding, t.id, t.prefix, t.markers, cases, t.payload, t.arrow);
+            }
+
+            public JLeftPadded<Expression> getArrow() {
+                return t.arrow;
+            }
+
+            public Zig.SwitchProng withArrow(JLeftPadded<Expression> arrow) {
+                return t.arrow == arrow ? t : new Zig.SwitchProng(t.padding, t.id, t.prefix, t.markers, t.cases, t.payload, arrow);
+            }
+        }
+    }
+}

--- a/rewrite-zig/src/main/resources/META-INF/services/org.openrewrite.rpc.DynamicDispatchRpcCodec
+++ b/rewrite-zig/src/main/resources/META-INF/services/org.openrewrite.rpc.DynamicDispatchRpcCodec
@@ -1,0 +1,5 @@
+org.openrewrite.zig.internal.rpc.ZigRpcCodec
+org.openrewrite.zig.internal.rpc.ZigRightPaddedRpcCodec
+org.openrewrite.zig.internal.rpc.ZigLeftPaddedRpcCodec
+org.openrewrite.zig.internal.rpc.ZigContainerRpcCodec
+org.openrewrite.zig.internal.rpc.ZigSpaceRpcCodec

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,7 @@ val allProjects = listOf(
     "rewrite-toml",
     "rewrite-xml",
     "rewrite-yaml",
+    "rewrite-zig",
 )
 
 // Always included because their paths contain colons which can't be represented in IDE.properties


### PR DESCRIPTION
## Summary

Adds Zig language support to OpenRewrite following the `rewrite-go` module architecture:

- **Java side**: AST model (`Zig.java` with 9 node types), `ZigVisitor`, `ZigParser`, RPC codecs, formatting visitors, services
- **Zig subprocess**: RPC server using `std.zig.Ast` for parsing, cursor-based whitespace extraction, LST serialization, and source printer
- **Rich AST mapping**: Functions, const/var declarations, identifiers, literals, binary/unary ops, if/else, while loops, switch expressions, blocks, return, defer, test decls, comptime, error unions, slices, field access, method calls, assignments, array access, try/catch/orelse
- **36 integration tests** with structural assertions verifying real AST types (not just round-trip)
- **13 Zig-side unit tests** wired into `./gradlew check` via `zigTest` task

### Known gaps
- `for` loops map to `J.Unknown` (Zig's multi-input/payload syntax doesn't fit `J.ForEachLoop.Control`)
- Container declarations (struct/enum/union bodies) map to `J.Unknown`
- No type attribution (Zig stdlib doesn't expose a type-checker API)
- `allowNonWhitespaceInWhitespace` validation escape hatch (same as `rewrite-go`)
- Import management returns no-op visitor (gracefully skips Zig files)

## Test plan
- [ ] `./gradlew :rewrite-zig:zigTest` — 13 Zig-side native tests
- [ ] `./gradlew :rewrite-zig:integTest` — 36 Java integration tests (round-trip + structural)
- [ ] `./gradlew :rewrite-zig:check` — full verification including license headers