### PR TITLE
Fix `BlankLinesVisitor.visitImport()` `IndexOutOfBoundsException` on Python files

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/format/BlankLinesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/BlankLinesVisitor.java
@@ -158,7 +158,7 @@ public class BlankLinesVisitor<P> extends JavaIsoVisitor<P> {
     public J.Import visitImport(J.Import import_, P p) {
         J.Import i = super.visitImport(import_, p);
         JavaSourceFile cu = getCursor().firstEnclosingOrThrow(JavaSourceFile.class);
-        if (i.equals(cu.getImports().get(0)) && cu.getPackageDeclaration() == null && cu.getPrefix().equals(Space.EMPTY)) {
+        if (!cu.getImports().isEmpty() && i.equals(cu.getImports().get(0)) && cu.getPackageDeclaration() == null && cu.getPrefix().equals(Space.EMPTY)) {
             i = i.withPrefix(i.getPrefix().withWhitespace(""));
         }
         return i;

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -216,7 +216,7 @@ def get_object_from_java(obj_id: str, source_file_type: Optional[str] = None) ->
         # Update our understanding of what Java has
         remote_objects[obj_id] = obj
         # Also update local_objects for consistency
-        local_objects[str(obj.id)] = obj
+        local_objects[obj_id] = obj
 
     return obj
 
@@ -924,6 +924,21 @@ _recipe_phases: Dict[str, str] = {}
 # Data table output directory - if set, data tables will be written to CSV files
 _data_table_output_dir: Optional[str] = None
 
+# Registry mapping fully-qualified visitor names to visitor classes.
+# Used to instantiate visitors by name when dispatched via RPC (e.g., auto-format).
+# Lazily initialized to avoid circular imports.
+_VISITOR_REGISTRY: Optional[Dict[str, type]] = None
+
+
+def _get_visitor_registry() -> Dict[str, type]:
+    global _VISITOR_REGISTRY
+    if _VISITOR_REGISTRY is None:
+        from rewrite.python.format.auto_format import AutoFormatVisitor
+        _VISITOR_REGISTRY = {
+            'org.openrewrite.python.format.AutoFormatVisitor': AutoFormatVisitor,
+        }
+    return _VISITOR_REGISTRY
+
 
 def _install_sub_recipes(recipe, marketplace) -> None:
     """Ensure sub-recipes from recipe_list() are registered in the marketplace."""
@@ -1074,9 +1089,16 @@ def handle_visit(params: dict) -> dict:
     # Instantiate the visitor
     visitor = _instantiate_visitor(visitor_name, ctx)
 
-    # Apply the visitor
+    # Reconstruct cursor from cursor IDs (if provided).
+    # Cursor IDs are ordered innermost-to-outermost, so we iterate in reverse
+    # to build the cursor chain from root inward (matching JS implementation).
     from rewrite.visitor import Cursor
     cursor = Cursor(None, Cursor.ROOT_VALUE)
+    if cursor_ids:
+        for cursor_id in reversed(cursor_ids):
+            cursor_obj = get_object_from_java(cursor_id, source_file_type)
+            if cursor_obj is not None:
+                cursor = Cursor(cursor, cursor_obj)
 
     before = tree
     after = visitor.visit(tree, ctx, cursor)
@@ -1264,7 +1286,11 @@ def _instantiate_visitor(visitor_name: str, ctx):
         return recipe.scanner(acc)
 
     else:
-        raise ValueError(f"Unknown visitor name format: {visitor_name}")
+        # Look up visitor by fully-qualified name from registry
+        visitor_cls = _get_visitor_registry().get(visitor_name)
+        if visitor_cls is None:
+            raise ValueError(f"Unknown visitor name format: {visitor_name}")
+        return visitor_cls()
 
 
 def handle_generate(params: dict) -> dict:

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAutoFormatService.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAutoFormatService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.service;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.service.AutoFormatService;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.python.rpc.PythonRewriteRpc;
+
+/**
+ * Auto-format service for Python that dispatches formatting to the Python
+ * RPC side, where the actual formatting visitors (blank lines, spaces,
+ * indentation, etc.) are implemented.
+ */
+public class PythonAutoFormatService extends AutoFormatService {
+
+    private static final String AUTO_FORMAT_VISITOR = "org.openrewrite.python.format.AutoFormatVisitor";
+
+    @Override
+    public <P> JavaVisitor<P> autoFormatVisitor(@Nullable Tree stopAfter) {
+        return new JavaIsoVisitor<P>() {
+            @Override
+            public @Nullable J visit(@Nullable Tree tree, P p, Cursor parent) {
+                if (tree == null) {
+                    return null;
+                }
+                PythonRewriteRpc rpc = PythonRewriteRpc.get();
+                if (rpc == null) {
+                    return (J) tree;
+                }
+                return (J) rpc.visit(tree, AUTO_FORMAT_VISITOR, p, parent);
+            }
+
+            @Override
+            public @Nullable J visit(@Nullable Tree tree, P p) {
+                if (tree == null) {
+                    return null;
+                }
+                if (tree instanceof SourceFile) {
+                    PythonRewriteRpc rpc = PythonRewriteRpc.get();
+                    if (rpc != null) {
+                        return (J) rpc.visit((SourceFile) tree, AUTO_FORMAT_VISITOR, p);
+                    }
+                }
+                return (J) tree;
+            }
+        };
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/tree/Py.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/tree/Py.java
@@ -22,10 +22,12 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.JavaPrinter;
 import org.openrewrite.java.internal.TypesInUse;
+import org.openrewrite.java.service.AutoFormatService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.python.PythonVisitor;
 import org.openrewrite.python.rpc.PythonRewriteRpc;
+import org.openrewrite.python.service.PythonAutoFormatService;
 import org.openrewrite.rpc.request.Print;
 
 import java.beans.Transient;
@@ -545,6 +547,16 @@ public interface Py extends J {
         @Override
         public JavaSourceFile withPackageDeclaration(Package pkg) {
             throw new IllegalStateException("Python does not support package declarations");
+        }
+
+        @Override
+        @Incubating(since = "8.2.0")
+        @SuppressWarnings("unchecked")
+        public <S, T extends S> T service(Class<S> service) {
+            if (AutoFormatService.class.getName().equals(service.getName())) {
+                return (T) new PythonAutoFormatService();
+            }
+            return JavaSourceFile.super.service(service);
         }
 
         @Override

--- a/rewrite-python/src/test/java/org/openrewrite/python/format/AutoFormatTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/format/AutoFormatTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.format;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.python.Assertions.python;
+
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "No remote client/server available")
+class AutoFormatTest implements RewriteTest {
+
+    /**
+     * Verifies that auto-formatting a Python file with imports doesn't crash.
+     * Previously, the Java-side BlankLinesVisitor would throw
+     * IndexOutOfBoundsException because Python stores imports as statements,
+     * so cu.getImports() returns an empty list.
+     */
+    @Test
+    void autoFormatDoesNotCrashOnPythonWithImports() {
+        rewriteRun(
+          spec -> spec.recipe(new AutoFormatSubtreeRecipe()),
+          python(
+            """
+              import os
+
+
+              def foo():
+                  if True:
+                      return 1
+                  else:
+                      return 2
+              """
+          )
+        );
+    }
+
+    /**
+     * Verifies that subtree auto-formatting dispatches to the Python-side
+     * formatter via RPC and produces observable formatting changes.
+     * <p>
+     * Both methods have bad spacing (space before comma in parameters).
+     * Only {@code bar} is auto-formatted, so its spacing is fixed while
+     * {@code foo}'s bad spacing is left untouched.
+     */
+    @Test
+    void autoFormatFixesSpacingOnlyInSubtree() {
+        rewriteRun(
+          spec -> spec.recipe(new AutoFormatBarRecipe()),
+          python(
+            """
+              def foo(a , b):
+                  pass
+
+              def bar(a , b):
+                  pass
+              """,
+            """
+              def foo(a , b):
+                  pass
+
+
+              def bar(a, b):
+                  pass
+              """
+          )
+        );
+    }
+
+    private static class AutoFormatSubtreeRecipe extends Recipe {
+        @Override
+        public String getDisplayName() {
+            return "Auto-format subtree test";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Calls autoFormat on if-else statements to exercise the auto-format service.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            return new JavaIsoVisitor<>() {
+                @Override
+                public J.If visitIf(J.If iff, ExecutionContext ctx) {
+                    J.If i = super.visitIf(iff, ctx);
+                    return autoFormat(i, ctx);
+                }
+            };
+        }
+    }
+
+    /**
+     * A recipe that calls autoFormat only on the method named "bar",
+     * leaving "foo" untouched.
+     */
+    private static class AutoFormatBarRecipe extends Recipe {
+        @Override
+        public String getDisplayName() {
+            return "Auto-format bar method";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Calls autoFormat on the method named 'bar' to verify subtree-scoped formatting.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            return new JavaIsoVisitor<>() {
+                @Override
+                public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                    J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+                    if (m.getSimpleName().equals("bar")) {
+                        return autoFormat(m, ctx);
+                    }
+                    return m;
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

`BlankLinesVisitor.visitImport()` crashes with `IndexOutOfBoundsException` when auto-formatting Python source files. This happens because Python stores imports as statements (not in the dedicated imports list), so `cu.getImports()` returns an empty list and `get(0)` fails. The crash is triggered when Java-side recipes like `UnwrapElseAfterReturn` modify Python files and call `maybeAutoFormat`, which routes through Java's `AutoFormatVisitor` chain — the wrong formatter for Python.

Discovered in the April 10 flagship recipe run on app.moderne.io (run ID: `3vdJH9MBx`).

## Summary

- Add `PythonAutoFormatService` that dispatches auto-formatting to the Python-side `AutoFormatVisitor` via RPC, following the pattern established by Kotlin, C#, and JavaScript modules
- Override `service()` in `Py.CompilationUnit` to return `PythonAutoFormatService` when `AutoFormatService` is requested
- Add visitor registry in Python RPC server's `_instantiate_visitor` for resolving fully-qualified visitor names (matching JS's `Reflect.construct(globalThis[visitorName])` pattern)
- Implement cursor reconstruction in `handle_visit` from cursor IDs (matching the JS implementation), enabling subtree formatting via RPC
- Fix `get_object_from_java` to use `obj_id` instead of `str(obj.id)` so non-Tree cursor objects (like `Cursor.ROOT_VALUE`) don't crash
- Add defensive empty-list guard in `BlankLinesVisitor.visitImport`

## Test plan

- [x] `AutoFormatTest.autoFormatDoesNotCrashOnPythonWithImports` — verifies the original bug is fixed (auto-format on Python file with imports doesn't crash)
- [x] `AutoFormatTest.autoFormatFixesSpacingOnlyInSubtree` — verifies subtree formatting dispatches to Python RPC and only formats the targeted subtree (bad spacing in `foo` is preserved, bad spacing in `bar` is fixed)
- [x] `BlankLinesTest` — existing tests pass with the empty-list guard
- [x] `PythonSpacesTest` — existing Python formatting tests still pass