### PR TITLE
Fix `GroovyTemplate` failure when method invocation has `void` return type

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UsePropertyAssignmentSyntaxTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UsePropertyAssignmentSyntaxTest.java
@@ -215,6 +215,21 @@ class UsePropertyAssignmentSyntaxTest implements RewriteTest {
     }
 
     @Test
+    void methodCallArgConvertedToAssignment() {
+        rewriteRun(
+          spec -> spec.recipe(new UsePropertyAssignmentSyntax("version")),
+          buildGradle(
+            """
+              version computeVersion()
+              """,
+            """
+              version = computeVersion()
+              """
+          )
+        );
+    }
+
+    @Test
     void noArgMethodCallUnchanged() {
         rewriteRun(
           buildGradle(

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/template/GroovyBlockStatementTemplateGenerator.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/template/GroovyBlockStatementTemplateGenerator.java
@@ -34,12 +34,18 @@ public class GroovyBlockStatementTemplateGenerator extends BlockStatementTemplat
     @Override
     protected void contextFreeTemplate(Cursor cursor, J j, Collection<JavaType.GenericTypeVariable> typeVariables, StringBuilder before, StringBuilder after) {
         if (j instanceof J.MethodInvocation) {
-            before.insert(0, "class Template {\n");
             JavaType.Method methodType = ((J.MethodInvocation) j).getMethodType();
-            if (methodType == null || methodType.getReturnType() != JavaType.Primitive.Void) {
+            if (methodType != null && methodType.getReturnType() == JavaType.Primitive.Void) {
+                // Bare statements like `version = expr;` are not valid at class body level
+                // in Groovy (unlike Java where initializer blocks work differently).
+                // Wrap in an initializer block so the template is valid Groovy.
+                before.insert(0, "class Template {{\n");
+                after.append("\n}}");
+            } else {
+                before.insert(0, "class Template {\n");
                 before.append("Object o = ");
+                after.append(";\n}");
             }
-            after.append(";\n}");
         } else if (j instanceof Expression && !(j instanceof J.Assignment)) {
             before.insert(0, "class Template {\n");
             before.append("Object o = ");

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateExplicitTypeArgParsingTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateExplicitTypeArgParsingTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.groovy.Assertions.groovy;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+/**
+ * Tests for GroovyTemplate when the method invocation being replaced has a
+ * resolved void return type. In this case, the template generator must use
+ * an initializer block wrapping instead of a class body field declaration,
+ * because bare assignments like {@code version = expr;} are not valid at
+ * Groovy class body level.
+ */
+class GroovyTemplateExplicitTypeArgParsingTest implements RewriteTest {
+
+    @Test
+    void groovyTemplateWithVoidMethodType() {
+        // When the Groovy compiler resolves a void method, contextFreeTemplate must
+        // use initializer block wrapping — bare assignments at class body level are
+        // not valid Groovy syntax.
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                  if ("version".equals(m.getSimpleName()) && m.getArguments().size() == 1 &&
+                      !(m.getArguments().get(0) instanceof J.Empty)) {
+                      return GroovyTemplate.apply("version = #{any()}",
+                              getCursor(), m.getCoordinates().replace(),
+                              m.getArguments().get(0));
+                  }
+                  return m;
+              }
+          })),
+          groovy(
+            """
+              class Config {
+                  void version(String v) {}
+                  void configure() {
+                      version('1.0')
+                  }
+              }
+              """,
+            """
+              class Config {
+                  void version(String v) {}
+                  void configure() {
+                      version = '1.0'
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

`UsePropertyAssignmentSyntax` (and potentially other recipes using `GroovyTemplate`) fails with `IllegalArgumentException: Could not parse as Java` when the Groovy compiler resolves the target method invocation to a void return type. This was observed on Moderne against repos like finos/symphony-wdk and others.

The root cause is in `GroovyBlockStatementTemplateGenerator.contextFreeTemplate()`: when the method has a resolved void return type, it skips the `Object o = ` prefix, producing a bare assignment like `version = expr;` at class body level. Unlike Java, Groovy does not allow bare assignments at class body level — it requires `def` or a type keyword for field declarations.

## Summary

- Fix `GroovyBlockStatementTemplateGenerator` to use initializer block wrapping (`class Template {{ ... }}`) for void-returning method invocations, instead of class body field declaration wrapping
- Add regression test in `GroovyTemplateExplicitTypeArgParsingTest` that reproduces the failure with a resolved void method type
- Add `methodCallArgConvertedToAssignment` test to `UsePropertyAssignmentSyntaxTest`

## Test plan

- [ ] `GroovyTemplateExplicitTypeArgParsingTest.groovyTemplateWithVoidMethodType` — reproduces the exact failure and verifies the fix
- [ ] All existing `UsePropertyAssignmentSyntaxTest` tests pass
- [ ] Full `:rewrite-groovy:test` suite passes