### PR TITLE
JavaScript: register existing `RemoveDependency` recipe

### DIFF
--- a/rewrite-javascript/rewrite/src/index.ts
+++ b/rewrite-javascript/rewrite/src/index.ts
@@ -40,6 +40,7 @@ export async function activate(marketplace: RecipeMarketplace): Promise<void> {
         AddDependency,
         AsyncCallbackInSyncArrayMethod,
         AutoFormat,
+        RemoveDependency,
         UpgradeDependencyVersion,
         UpgradeTransitiveDependencyVersion,
         OrderImports,
@@ -48,6 +49,7 @@ export async function activate(marketplace: RecipeMarketplace): Promise<void> {
     await marketplace.install(AddDependency, JavaScript);
     await marketplace.install(AsyncCallbackInSyncArrayMethod, JavaScript);
     await marketplace.install(AutoFormat, JavaScript);
+    await marketplace.install(RemoveDependency, JavaScript);
     await marketplace.install(UpgradeDependencyVersion, JavaScript);
     await marketplace.install(UpgradeTransitiveDependencyVersion, JavaScript);
     await marketplace.install(OrderImports, JavaScript);


### PR DESCRIPTION
## What's changed?

Adding the `org.openrewrite.javascript.dependencies.remove-dependency` to the list of recipes activated in the JavaScript module.

## What's your motivation?

It was forgotten and one couldn't use the recipe (as a top-level).
