### PR TITLE
Accept marker-only changes in RewriteTest instead of failing with empty diff

### DIFF
--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -562,7 +562,16 @@ public interface RewriteTest extends SourceSpecs {
                             boolean isRemote = result.getAfter() instanceof Remote;
                             if (!isRemote && Objects.equals(result.getBefore().getSourcePath(), result.getAfter().getSourcePath()) &&
                                 Objects.equals(before, actualAfter)) {
-                                fail("An empty diff was generated. The recipe incorrectly changed a reference without changing its contents.");
+                                // Marker-only changes (e.g. JavaSourceSet updates from dependency
+                                // coordinate changes) produce Results with identical text. Accept
+                                // these silently rather than treating them as errors.
+                                allResults.remove(result);
+                                try {
+                                    //noinspection unchecked
+                                    ((Consumer<SourceFile>) sourceSpec.afterRecipe).accept(result.getAfter());
+                                } catch (ClassCastException ignored) {
+                                }
+                                continue nextSourceFile;
                             }
 
                             assert result.getBefore() != null;


### PR DESCRIPTION
## Summary

- When a `ScanningRecipe` updates only markers (e.g. `JavaSourceSet`) without changing source text, `RewriteTest` now accepts the result silently instead of failing with "An empty diff was generated"
- The `afterRecipe` callback still fires with the updated tree so marker assertions continue to work
- Fixes #7349

## Context

- PR #7202 added `JavaSourceSetUpdater` to `ChangeDependencyGroupIdAndArtifactId`, which correctly updates classpath markers on Java files when dependency coordinates change. However, this caused downstream test failures in repos that assert on Maven dependency changes alongside Java source files — the Java files produce a `Result` (because the marker changed the object identity) but have identical printed text, triggering the "empty diff" guard in `RewriteTest`.

Affected repos: `rewrite-hibernate`, `rewrite-migrate-java`, `rewrite-dropwizard` (all broke on scheduled CI April 11).

## What changed

In `RewriteTest.java`, when a `Result` has identical before/after text, instead of calling `fail()` we now:
1. Remove the result from `allResults` (so no spurious diff is reported)
2. Still invoke the `afterRecipe` consumer with `result.getAfter()` (preserving marker assertions)
3. Continue to the next source file

This does **not** affect:
- `RecipeRunCycle` per-cycle change tracking (marker changes still count for recipe scheduling)
- `InMemoryLargeSourceSet.getChangeset()` (Results are still generated correctly)
- Any recipe behavior — only the test framework assertion changes

## Test plan

- [x] `ChangeDependencyGroupIdAndArtifactIdTest.updatesJavaSourceSetMarkerOnJavaFiles` passes (verifies `afterRecipe` still receives updated markers)
- [x] `ChangeDependencyGroupIdAndArtifactIdTest.javaSourceSetUnchangedWhenModuleDoesNotHaveDependency` passes
- [x] Full `rewrite-test` module tests pass
- [x] Full `rewrite-maven` module tests pass
- [x] Downstream `rewrite-hibernate` `MigrateToHibernate61Test.groupIdHibernateOrmRenamed` passes on `main` with this SNAPSHOT