### PR TITLE
Resolve Maven property references when matching dependency tags

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -146,9 +146,13 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
                             }
                         }
                         Dependency req = resolvedDependency.getRequested();
-                        String reqGroup = req.getGroupId();
-                        if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&
-                                req.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
+                        ResolvedPom pom = getResolutionResult().getPom();
+                        String reqGroup = pom.getValue(req.getGroupId());
+                        String reqArtifact = pom.getValue(req.getArtifactId());
+                        String tagGroupId = pom.getValue(tag.getChildValue("groupId").orElse(null));
+                        String tagArtifactId = pom.getValue(tag.getChildValue("artifactId").orElse(null));
+                        if ((reqGroup == null || reqGroup.equals(tagGroupId)) &&
+                                reqArtifact.equals(tagArtifactId) &&
                                 scope == tagScope) {
                             return true;
                         }
@@ -413,11 +417,14 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
         if (inClasspathOf != null && tagScope != inClasspathOf && !tagScope.isInClasspathOf(inClasspathOf)) {
             return null;
         }
+        ResolvedPom resolvedPom = getResolutionResult().getPom();
         for (Map.Entry<Scope, List<ResolvedDependency>> scope : getResolutionResult().getDependencies().entrySet()) {
             if (inClasspathOf == null || scope.getKey() == inClasspathOf || scope.getKey().isInClasspathOf(inClasspathOf)) {
                 for (ResolvedDependency d : scope.getValue()) {
-                    if (tag.getChildValue("groupId").orElse(getResolutionResult().getPom().getGroupId()).equals(d.getGroupId()) &&
-                            tag.getChildValue("artifactId").orElse(getResolutionResult().getPom().getArtifactId()).equals(d.getArtifactId())) {
+                    String tagGroupId = resolvedPom.getValue(tag.getChildValue("groupId").orElse(null));
+                    String tagArtifactId = resolvedPom.getValue(tag.getChildValue("artifactId").orElse(null));
+                    if ((tagGroupId != null ? tagGroupId : resolvedPom.getGroupId()).equals(d.getGroupId()) &&
+                            (tagArtifactId != null ? tagArtifactId : resolvedPom.getArtifactId()).equals(d.getArtifactId())) {
                         return d;
                     }
                 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDependencyTest.java
@@ -312,4 +312,62 @@ class RemoveDependencyTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4796")
+    void removeDependencyDefinedWithProperties() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveDependency("junit", "junit", null)),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+
+                <properties>
+                  <junit.groupId>junit</junit.groupId>
+                </properties>
+
+                <dependencies>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>29.0-jre</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>${junit.groupId}</groupId>
+                    <artifactId>junit</artifactId>
+                    <version>4.13.1</version>
+                    <scope>test</scope>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+
+                <properties>
+                  <junit.groupId>junit</junit.groupId>
+                </properties>
+
+                <dependencies>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>29.0-jre</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes https://github.com/openrewrite/rewrite/issues/4796

- `isDependencyTag()` and `findDependency()` in `MavenVisitor` compared raw XML tag values (e.g. `${junit.groupId}`) against resolved dependency coordinates (e.g. `junit`) without resolving property placeholders first
- Both methods now use `ResolvedPom.getValue()` to expand Maven properties before comparing groupId and artifactId

## Test plan

- [x] Added test `removeDependencyDefinedWithProperties` that uses `${junit.groupId}` property in a dependency's groupId
- [x] All existing `RemoveDependencyTest` tests pass
- [x] Full `rewrite-maven` test suite passes