### PR TITLE
Add recipes to Maven best practices

### DIFF
--- a/rewrite-maven/src/main/resources/META-INF/rewrite/maven.yml
+++ b/rewrite-maven/src/main/resources/META-INF/rewrite/maven.yml
@@ -29,7 +29,10 @@ recipeList:
   - org.openrewrite.maven.RemoveRedundantDependencyVersions
   - org.openrewrite.maven.RemoveRedundantProperties:
       onlyIfValuesMatch: true
+  - org.openrewrite.maven.cleanup.DependencyManagementDependencyRequiresVersion
+  - org.openrewrite.maven.ModernizeObsoletePoms
   - org.openrewrite.maven.plugin.DependencyPluginGoalResolveSources
+  - org.openrewrite.maven.SortDependencies
   - org.openrewrite.maven.UpdateScmFromGitOrigin
 ---
 type: specs.openrewrite.org/v1beta/recipe


### PR DESCRIPTION
## Summary
- Add `DependencyManagementDependencyRequiresVersion` to catch a common Maven pitfall where dependency management entries lack a version
- Add `ModernizeObsoletePoms` to remove obsolete POM elements
- Add `SortDependencies` to reduce merge conflicts through consistent ordering

These recipes are all standalone today but are universally applicable best practices.