### PR TITLE
Add recipes to Gradle best practices

### DIFF
--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle.yml
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle.yml
@@ -17,12 +17,16 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.gradle.GradleBestPractices
 displayName: Apply Gradle best practices
-description: Apply a set of [Gradle best practices](https://docs.gradle.org/current/userguide/best_practices_general.html) to the build files, for more efficient and ideomatic builds.
+description: Apply a set of [Gradle best practices](https://docs.gradle.org/current/userguide/best_practices_general.html) to the build files, for more efficient and idiomatic builds.
 recipeList:
   - org.openrewrite.gradle.MigrateToGradle9
   - org.openrewrite.gradle.EnableGradleBuildCache
   - org.openrewrite.gradle.EnableGradleParallelExecution
   - org.openrewrite.gradle.ChangeTaskToTasksRegister
+  - org.openrewrite.gradle.RemoveRedundantDependencyVersions
+  - org.openrewrite.gradle.RemoveRedundantSecurityResolutionRules
+  - org.openrewrite.gradle.SortDependencies
+  - org.openrewrite.gradle.security.UseHttpsForRepositories
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.gradle.EnableGradleBuildCache


### PR DESCRIPTION
## Summary
- Add `RemoveRedundantDependencyVersions` to clean up versions already managed by platforms
- Add `RemoveRedundantSecurityResolutionRules` to remove stale CVE resolution rules
- Add `SortDependencies` to reduce merge conflicts through consistent ordering
- Add `UseHttpsForRepositories` as a security best practice
- Fix typo in description ("ideomatic" → "idiomatic")

These recipes are all standalone today but are universally applicable best practices.