### PR TITLE
Auto-deduce valid values for enum @Option fields

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -52,6 +52,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
@@ -274,7 +275,7 @@ public abstract class Recipe implements Cloneable {
                         option.displayName(),
                         option.description(),
                         option.example().isEmpty() ? null : option.example(),
-                        option.valid().length == 1 && option.valid()[0].isEmpty() ? null : Arrays.asList(option.valid()),
+                        validValues(option, field.getType()),
                         option.required(),
                         value));
             }
@@ -289,7 +290,7 @@ public abstract class Recipe implements Cloneable {
                             option.displayName(),
                             option.description(),
                             option.example().isEmpty() ? null : option.example(),
-                            option.valid().length == 1 && option.valid()[0].isEmpty() ? null : Arrays.asList(option.valid()),
+                            validValues(option, method.getReturnType()),
                             option.required(),
                             null));
                 }
@@ -305,7 +306,7 @@ public abstract class Recipe implements Cloneable {
                             option.displayName(),
                             option.description(),
                             option.example().isEmpty() ? null : option.example(),
-                            option.valid().length == 1 && option.valid()[0].isEmpty() ? null : Arrays.asList(option.valid()),
+                            validValues(option, parameter.getType()),
                             option.required(),
                             null));
                 }
@@ -316,6 +317,18 @@ public abstract class Recipe implements Cloneable {
 
         options.trimToSize();
         return options;
+    }
+
+    private static @Nullable List<String> validValues(Option option, Class<?> type) {
+        if (!(option.valid().length == 1 && option.valid()[0].isEmpty())) {
+            return Arrays.asList(option.valid());
+        }
+        if (type.isEnum()) {
+            return Arrays.stream(type.getEnumConstants())
+                    .map(e -> ((Enum<?>) e).name())
+                    .collect(Collectors.toList());
+        }
+        return null;
     }
 
     private static final List<DataTableDescriptor> GLOBAL_DATA_TABLES = Arrays.asList(

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeBasicsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeBasicsTest.java
@@ -16,7 +16,9 @@
 package org.openrewrite;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.config.OptionDescriptor;
 import org.openrewrite.config.RecipeDescriptor;
 import org.openrewrite.text.ChangeText;
 
@@ -125,6 +127,90 @@ class RecipeBasicsTest {
         public String getDescription() {
             return "Recipe with list option.";
         }
+    }
+
+    enum Color { RED, GREEN, BLUE }
+
+    @Getter
+    static class RecipeWithEnumField extends Recipe {
+        private final String displayName = "Enum field recipe";
+        private final String description = "Enum field recipe.";
+
+        @Option(displayName = "Color", description = "Pick a color.")
+        final Color color;
+
+        public RecipeWithEnumField(Color color) {
+            this.color = color;
+        }
+    }
+
+    @Test
+    void enumFieldOptionDeducesValidValues() {
+        RecipeDescriptor d = new RecipeWithEnumField(Color.RED).createRecipeDescriptor();
+        OptionDescriptor opt = d.getOptions().getFirst();
+        assertThat(opt.getValid()).containsExactly("RED", "GREEN", "BLUE");
+    }
+
+    static class RecipeWithEnumMethod extends RecipeBase {
+        Color color;
+
+        public RecipeWithEnumMethod(Color color) {
+            super("ignored");
+            this.color = color;
+        }
+
+        @Option(displayName = "Color", description = "Pick a color.")
+        Color getColor() {
+            return color;
+        }
+    }
+
+    @Test
+    void enumMethodOptionDeducesValidValues() {
+        RecipeDescriptor d = new RecipeWithEnumMethod(Color.GREEN).createRecipeDescriptor();
+        OptionDescriptor opt = d.getOptions().stream()
+                .filter(o -> o.getName().equals("color"))
+                .findFirst().orElseThrow();
+        assertThat(opt.getValid()).containsExactly("RED", "GREEN", "BLUE");
+    }
+
+    @Getter
+    static class RecipeWithEnumConstructorParam extends Recipe {
+        private final String displayName = "Enum constructor param recipe";
+        private final String description = "Enum constructor param recipe.";
+        final Color color;
+
+        public RecipeWithEnumConstructorParam(
+                @Option(displayName = "Color", description = "Pick a color.") Color color) {
+            this.color = color;
+        }
+    }
+
+    @Test
+    void enumConstructorParamOptionDeducesValidValues() {
+        RecipeDescriptor d = new RecipeWithEnumConstructorParam(Color.BLUE).createRecipeDescriptor();
+        OptionDescriptor opt = d.getOptions().getFirst();
+        assertThat(opt.getValid()).containsExactly("RED", "GREEN", "BLUE");
+    }
+
+    @Getter
+    static class RecipeWithExplicitValid extends Recipe {
+        private final String displayName = "Explicit valid recipe";
+        private final String description = "Explicit valid recipe.";
+
+        @Option(displayName = "Color", description = "Pick a color.", valid = {"RED", "GREEN"})
+        final Color color;
+
+        public RecipeWithExplicitValid(Color color) {
+            this.color = color;
+        }
+    }
+
+    @Test
+    void explicitValidTakesPrecedenceOverEnumConstants() {
+        RecipeDescriptor d = new RecipeWithExplicitValid(Color.RED).createRecipeDescriptor();
+        OptionDescriptor opt = d.getOptions().getFirst();
+        assertThat(opt.getValid()).containsExactly("RED", "GREEN");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- When an `@Option` annotation does not explicitly specify `valid` values and the annotated type is an enum, the valid values are now automatically populated from the enum constants via reflection.
- Adds a private `validValues()` helper in `Recipe.java` used by all three option discovery paths (field, getter method, constructor parameter).
- Explicit `valid` values on the annotation still take precedence over auto-deduction.

## Test plan
- [x] Added tests for enum options on fields, getter methods, and constructor parameters
- [x] Added test verifying explicit `valid` takes precedence over enum constants
- [x] All existing `RecipeBasicsTest` tests continue to pass