### PR TITLE
Make AddProfile idempotent

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddProfile.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddProfile.java
@@ -24,6 +24,7 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.xml.AddToTagVisitor;
 import org.openrewrite.xml.RemoveContentVisitor;
+import org.openrewrite.xml.SemanticallyEqual;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.Optional;
@@ -84,6 +85,13 @@ public class AddProfile extends Recipe {
                     profiles = t.getChild("profiles").get();
                 }
 
+                Xml.Tag profileTag = Xml.Tag.build("<profile>\n" +
+                                                   "<id>" + id + "</id>\n" +
+                                                   (activation != null ? activation.trim() + "\n" : "") +
+                                                   (properties != null ? properties.trim() + "\n" : "") +
+                                                   (build != null ? build.trim() + "\n" : "") +
+                                                   "</profile>");
+
                 Optional<Xml.Tag> maybeProfile = profiles.getChildren().stream()
                         .filter(profile ->
                                 profile.getChildValue("id").get().equals(id)
@@ -91,22 +99,18 @@ public class AddProfile extends Recipe {
                         .findAny();
 
                 if (maybeProfile.isPresent()) {
-                    Xml.Tag profile = maybeProfile.get();
-
-                    t = (Xml.Tag) new RemoveContentVisitor(profile, false, false).visitNonNull(t, ctx, getCursor().getParentOrThrow());
-
+                    Xml.Tag existing = maybeProfile.get();
+                    if (SemanticallyEqual.areEqual(existing, profileTag)) {
+                        return t;
+                    }
+                    t = (Xml.Tag) new RemoveContentVisitor(existing, false, false).visitNonNull(t, ctx, getCursor().getParentOrThrow());
                 }
-                Xml.Tag profileTag = Xml.Tag.build("<profile>\n" +
-                                                   "<id>" + id + "</id>\n" +
-                                                   (activation != null ? activation.trim() + "\n" : "") +
-                                                   (properties != null ? properties.trim() + "\n" : "") +
-                                                   (build != null ? build.trim() + "\n" : "") +
-                                                   "</profile>");
                 t = (Xml.Tag) new AddToTagVisitor<>(profiles, profileTag).visitNonNull(t, ctx, getCursor().getParentOrThrow());
 
             }
 
             return t;
         }
+
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddProfileTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddProfileTest.java
@@ -29,7 +29,7 @@ class AddProfileTest implements RewriteTest {
     @Test
     void addProfileToPom() {
         rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2).recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
+          spec -> spec.recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
             "<properties><bar>bar</bar></properties>", "<build><param>value</param></build>")),
           pomXml(
             """
@@ -69,7 +69,7 @@ class AddProfileTest implements RewriteTest {
     @Test
     void preExistingOtherProfile() {
         rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2).recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
+          spec -> spec.recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
             "<properties><bar>bar</bar></properties>", "<build><param>value</param></build>")),
           pomXml(
             """
@@ -122,7 +122,7 @@ class AddProfileTest implements RewriteTest {
     @Test
     void preExistingMatchingProfile() {
         rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2).recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
+          spec -> spec.recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
             "<properties><bar>bar</bar></properties>", "<build><param>value</param></build>")),
           pomXml(
             """
@@ -168,6 +168,37 @@ class AddProfileTest implements RewriteTest {
         );
     }
 
+
+    @Test
+    void preExistingIdenticalProfile() {
+        rewriteRun(
+          spec -> spec.recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
+            "<properties><bar>bar</bar></properties>", "<build><param>value</param></build>")),
+          pomXml(
+            """
+              <project>
+                <groupId>group</groupId>
+                <artifactId>artifact</artifactId>
+                <version>1</version>
+                <profiles>
+                  <profile>
+                    <id>myprofile</id>
+                    <activation>
+                      <foo>foo</foo>
+                    </activation>
+                    <properties>
+                      <bar>bar</bar>
+                    </properties>
+                    <build>
+                      <param>value</param>
+                    </build>
+                  </profile>
+                </profiles>
+              </project>
+              """
+          )
+        );
+    }
 
     @Test
     void notAPom() {


### PR DESCRIPTION
## Summary

- Fixes https://github.com/openrewrite/rewrite/issues/7355

`AddProfile` unconditionally removed and re-added a profile with the same `id` on every recipe cycle, even when the existing profile already matched. This uses `SemanticallyEqual` to compare the existing profile to the desired one and returns early when they already match, making the recipe idempotent.

## Changes
- Build the desired profile tag before checking for an existing one
- Compare existing profile using `SemanticallyEqual.areEqual()` and skip modification when content matches
- Remove `expectedCyclesThatMakeChanges(2)` workaround from all tests
- Add `preExistingIdenticalProfile` test verifying no changes when profile already matches