### PR TITLE
Suppress spurious MockWebServer crash warnings in CI logs

### DIFF
--- a/rewrite-maven/build.gradle.kts
+++ b/rewrite-maven/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     testImplementation("com.squareup.okio:okio-jvm:3.9.1")
     testImplementation("org.mapdb:mapdb:latest.release")
 
+    testRuntimeOnly("org.slf4j:jul-to-slf4j:latest.release")
     testRuntimeOnly("org.mapdb:mapdb:latest.release")
     testRuntimeOnly(project(":rewrite-java-21"))
     testRuntimeOnly("org.rocksdb:rocksdbjni:10.2.1")
@@ -60,6 +61,10 @@ tasks.register<JavaExec>("generateAntlrSources") {
     classpath = sourceSets["main"].runtimeClasspath
 
     finalizedBy("licenseFormat")
+}
+
+tasks.withType<Test>().configureEach {
+    jvmArgs("-Djava.util.logging.config.file=${file("src/test/resources/logging.properties").absolutePath}")
 }
 
 tasks.withType<Javadoc>().configureEach {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -984,7 +984,6 @@ class MavenParserTest implements RewriteTest {
     @Test
     void mirrorsAndAuth() throws Exception {
         // Set up a web server that returns 401 to any request without an Authorization header corresponding to specific credentials
-        // Exceptions in the console output are due to MavenPomDownloader attempting to access via https first before falling back to http
         var username = "admin";
         var password = "password";
         try (var mockRepo = new MockWebServer()) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -346,7 +346,16 @@ class MavenPomDownloaderTest implements RewriteTest {
         void useHttpWhenHttpsFails() throws Exception {
             var downloader = new MavenPomDownloader(emptyMap(), ctx);
             try (var mockRepo = new MockWebServer()) {
-                mockRepo.enqueue(new MockResponse().setResponseCode(200).setBody("body"));
+                // Use a Dispatcher instead of enqueue to avoid flakiness: normalizeRepository()
+                // probes HTTPS first, and TLS bytes sent to this HTTP-only server can sometimes
+                // parse as valid HTTP, consuming an enqueued response before the real HTTP request.
+                mockRepo.setDispatcher(new Dispatcher() {
+                    @Override
+                    public MockResponse dispatch(RecordedRequest recordedRequest) {
+                        return new MockResponse().setResponseCode(200).setBody("body");
+                    }
+                });
+                mockRepo.start();
                 var httpRepo = MavenRepository.builder()
                   .id("id")
                   .uri("http://%s:%d/maven/".formatted(mockRepo.getHostName(), mockRepo.getPort()))

--- a/rewrite-maven/src/test/resources/logging.properties
+++ b/rewrite-maven/src/test/resources/logging.properties
@@ -1,0 +1,20 @@
+#
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Route java.util.logging through SLF4J, which uses slf4j-nop in tests.
+# This suppresses spurious MockWebServer crash logs caused by
+# normalizeRepository() probing HTTPS on HTTP-only mock servers.
+handlers = org.slf4j.bridge.SLF4JBridgeHandler


### PR DESCRIPTION
## Summary
- Route `java.util.logging` through SLF4J via the `jul-to-slf4j` bridge, which discards output through the existing `slf4j-nop` binding in tests
- This suppresses `StringIndexOutOfBoundsException` crash logs from MockWebServer when `normalizeRepository()` probes HTTPS on HTTP-only mock servers
- Fix flaky `useHttpWhenHttpsFails` test by switching from `enqueue` to `Dispatcher`, avoiding TLS probe bytes consuming the single enqueued response

## Test plan
- [x] Verified `mirrorsAndAuth`, `useHttpWhenHttpsFails`, `latestOrReleaseVersionInDependencyManagement`, and `systemPropertyTakesPrecedence` pass with no MockWebServer crash output
- [x] Ran `useHttpWhenHttpsFails` multiple times to confirm flakiness is resolved