### PR TITLE
JavaScript: fail fast if no codec for Json.Document

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
@@ -37,6 +37,25 @@ public abstract class DynamicDispatchRpcCodec<T> implements RpcCodec<T> {
         }
     }
 
+    /**
+     * Verifies that at least one {@link DynamicDispatchRpcCodec} is registered for the
+     * given source file type. Call this at startup to fail fast when the ServiceLoader
+     * has not discovered the expected codec implementations (e.g. missing module on the
+     * classpath).
+     *
+     * @param sourceFileType The fully-qualified class name of the source file type
+     *                       (e.g. {@code "org.openrewrite.json.tree.Json$Document"}).
+     * @throws IllegalStateException if no codec is registered for the given type.
+     */
+    public static void requireCodecFor(String sourceFileType) {
+        if (!CODEC_BY_TYPE.containsKey(sourceFileType)) {
+            throw new IllegalStateException(
+                    "No DynamicDispatchRpcCodec registered for '" + sourceFileType + "'. " +
+                    "The ServiceLoader found zero DynamicDispatchRpcCodec implementations for this type. " +
+                    "Ensure that the module providing this codec is on the classpath.");
+        }
+    }
+
     @SuppressWarnings("unchecked")
     public static <T> @Nullable RpcCodec<T> getCodec(Object t, @Nullable String sourceFileType) {
         if (sourceFileType == null) {

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -23,10 +23,12 @@ import org.openrewrite.internal.StringUtils;
 import org.openrewrite.javascript.JavaScriptParser;
 import org.openrewrite.javascript.internal.rpc.JavaScriptValidator;
 import org.openrewrite.javascript.tree.JS;
+import org.openrewrite.json.tree.Json;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.tree.ParseError;
 import org.openrewrite.marketplace.RecipeBundleResolver;
 import org.openrewrite.marketplace.RecipeMarketplace;
+import org.openrewrite.rpc.DynamicDispatchRpcCodec;
 import org.openrewrite.rpc.RewriteRpc;
 import org.openrewrite.rpc.RewriteRpcProcess;
 import org.openrewrite.rpc.RewriteRpcProcessManager;
@@ -344,6 +346,8 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
 
         @Override
         public JavaScriptRewriteRpc get() {
+            DynamicDispatchRpcCodec.requireCodecFor(Json.Document.class.getName());
+
             Stream<@Nullable String> cmd;
 
             if (inspectBrk != null) {


### PR DESCRIPTION
## What's changed?

A safety mechanism for JavaScript RPC.
Explicitly fail to start the `JavaSciptRewriteRpc` if the Java side doesn't have a codec for JSON.

## What's your motivation?

This has affected Moderne CLI around version 4.1.3, leading to weird and hard-to-diagnose problems running JS recipes. The errors included:
```
 Error: Unknown state type END_OF_OBJECT
```
With this safety mechanism, it'd still fail, but at least explicitly with clear indication of what's wrong.