### PR TITLE
Include java.version and classpath in parser construction errors

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
@@ -93,7 +93,8 @@ public class Java11Parser implements JavaParser {
 
                 return new Java11Parser(delegate);
             } catch (Exception e) {
-                throw new IllegalStateException("Unable to construct Java11Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath(), e);
+                throw new IllegalStateException("Unable to construct Java11Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath() +
+                                                "\nhttps://docs.openrewrite.org/reference/faq#im-getting-unable-to-construct-java21parser-or-similar-when-running-my-recipe-what-does-this-mean", e);
             }
         }
     }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
@@ -93,7 +93,7 @@ public class Java11Parser implements JavaParser {
 
                 return new Java11Parser(delegate);
             } catch (Exception e) {
-                throw new IllegalStateException("Unable to construct Java11Parser.", e);
+                throw new IllegalStateException("Unable to construct Java11Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath(), e);
             }
         }
     }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/Java17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/Java17Parser.java
@@ -93,7 +93,7 @@ public class Java17Parser implements JavaParser {
 
                 return new Java17Parser(delegate);
             } catch (Exception e) {
-                throw new IllegalStateException("Unable to construct Java17Parser.", e);
+                throw new IllegalStateException("Unable to construct Java17Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath(), e);
             }
         }
     }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/Java17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/Java17Parser.java
@@ -93,7 +93,8 @@ public class Java17Parser implements JavaParser {
 
                 return new Java17Parser(delegate);
             } catch (Exception e) {
-                throw new IllegalStateException("Unable to construct Java17Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath(), e);
+                throw new IllegalStateException("Unable to construct Java17Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath() +
+                                                "\nhttps://docs.openrewrite.org/reference/faq#im-getting-unable-to-construct-java21parser-or-similar-when-running-my-recipe-what-does-this-mean", e);
             }
         }
     }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/Java21Parser.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/Java21Parser.java
@@ -93,7 +93,7 @@ public class Java21Parser implements JavaParser {
 
                 return new Java21Parser(delegate);
             } catch (Exception e) {
-                throw new IllegalStateException("Unable to construct Java21Parser.", e);
+                throw new IllegalStateException("Unable to construct Java21Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath(), e);
             }
         }
     }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/Java21Parser.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/Java21Parser.java
@@ -93,7 +93,8 @@ public class Java21Parser implements JavaParser {
 
                 return new Java21Parser(delegate);
             } catch (Exception e) {
-                throw new IllegalStateException("Unable to construct Java21Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath(), e);
+                throw new IllegalStateException("Unable to construct Java21Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath() +
+                                                "\nhttps://docs.openrewrite.org/reference/faq#im-getting-unable-to-construct-java21parser-or-similar-when-running-my-recipe-what-does-this-mean", e);
             }
         }
     }

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/Java25Parser.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/Java25Parser.java
@@ -93,7 +93,8 @@ public class Java25Parser implements JavaParser {
 
                 return new Java25Parser(delegate);
             } catch (Exception e) {
-                throw new IllegalStateException("Unable to construct Java25Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath(), e);
+                throw new IllegalStateException("Unable to construct Java25Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath() +
+                                                "\nhttps://docs.openrewrite.org/reference/faq#im-getting-unable-to-construct-java21parser-or-similar-when-running-my-recipe-what-does-this-mean", e);
             }
         }
     }

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/Java25Parser.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/Java25Parser.java
@@ -93,7 +93,7 @@ public class Java25Parser implements JavaParser {
 
                 return new Java25Parser(delegate);
             } catch (Exception e) {
-                throw new IllegalStateException("Unable to construct Java25Parser.", e);
+                throw new IllegalStateException("Unable to construct Java25Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath(), e);
             }
         }
     }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/Java8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/Java8Parser.java
@@ -139,7 +139,8 @@ public class Java8Parser implements JavaParser {
 
                 return new Java8Parser(delegate);
             } catch (Exception e) {
-                throw new IllegalStateException("Unable to construct Java8Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath(), e);
+                throw new IllegalStateException("Unable to construct Java8Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath() +
+                                                "\nhttps://docs.openrewrite.org/reference/faq#im-getting-unable-to-construct-java21parser-or-similar-when-running-my-recipe-what-does-this-mean", e);
             }
         }
     }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/Java8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/Java8Parser.java
@@ -139,7 +139,7 @@ public class Java8Parser implements JavaParser {
 
                 return new Java8Parser(delegate);
             } catch (Exception e) {
-                throw new IllegalStateException("Unable to construct Java8Parser.", e);
+                throw new IllegalStateException("Unable to construct Java8Parser. java.version: " + System.getProperty("java.version") + ", classpath: " + resolvedClasspath(), e);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Improves the `IllegalStateException` message thrown when versioned Java parsers (8, 11, 17, 21, 25) fail to construct
- Now includes `java.version` and the resolved classpath in the error message, making it easier to diagnose missing classpath entries or JDK version mismatches

- Closes https://github.com/openrewrite/rewrite/issues/7360