### PR TITLE
Add NamedStyles-based Autodetect for YAML and HCL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,13 @@ plugins {
     id("org.openrewrite.build.java-base") version "latest.release"
 }
 
+buildscript {
+    configurations.classpath {
+        exclude(group = "org.openrewrite", module = "rewrite-yaml")
+        exclude(group = "org.openrewrite", module = "rewrite-hcl")
+    }
+}
+
 repositories {
     mavenCentral()
 }

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/style/Autodetect.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/style/Autodetect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2026 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/style/Autodetect.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/style/Autodetect.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hcl.style;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.hcl.HclVisitor;
+import org.openrewrite.hcl.tree.BodyContent;
+import org.openrewrite.hcl.tree.Hcl;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.style.GeneralFormatStyle;
+import org.openrewrite.style.NamedStyles;
+import org.openrewrite.style.Style;
+
+import java.util.*;
+
+import static java.util.Collections.emptySet;
+
+public class Autodetect extends NamedStyles {
+    @JsonCreator
+    public Autodetect(UUID id, Collection<Style> styles) {
+        super(id,
+                "org.openrewrite.hcl.Autodetect",
+                "Auto-detected",
+                "Automatically detect styles from a repository's existing code.",
+                emptySet(), styles);
+    }
+
+    public static Detector detector() {
+        return new Detector();
+    }
+
+    public static class Detector {
+
+        private final IndentStatistics indentStatistics = new IndentStatistics();
+        private final GeneralFormatStatistics generalFormatStatistics = new GeneralFormatStatistics();
+        private final FindIndentHclVisitor findIndentVisitor = new FindIndentHclVisitor();
+        private final FindLineFormatHclVisitor findLineFormatVisitor = new FindLineFormatHclVisitor();
+
+        public Detector sample(SourceFile hcl) {
+            if (hcl instanceof Hcl.ConfigFile) {
+                findIndentVisitor.visit(hcl, indentStatistics);
+                findLineFormatVisitor.visit(hcl, generalFormatStatistics);
+            }
+            return this;
+        }
+
+        public Autodetect build() {
+            return new Autodetect(Tree.randomId(), Arrays.asList(
+                    indentStatistics.getTabsAndIndentsStyle(),
+                    generalFormatStatistics.getFormatStyle()
+            ));
+        }
+    }
+
+    private static class IndentStatistics {
+        private final Map<Integer, Long> spaceIndentFrequencies = new HashMap<>();
+        private final Map<Integer, Long> tabIndentFrequencies = new HashMap<>();
+        private int linesWithSpaceIndents = 0;
+        private int linesWithTabIndents = 0;
+
+        public boolean isIndentedWithSpaces() {
+            return linesWithSpaceIndents >= linesWithTabIndents;
+        }
+
+        public TabsAndIndentsStyle getTabsAndIndentsStyle() {
+            boolean useTabs = !isIndentedWithSpaces();
+
+            int indent = TabsAndIndentsStyle.DEFAULT.getIndentSize();
+            long indentCount = 0;
+
+            Map<Integer, Long> indentFrequencies = useTabs ? tabIndentFrequencies : spaceIndentFrequencies;
+            for (Map.Entry<Integer, Long> current : indentFrequencies.entrySet()) {
+                if (current.getKey() == 0) {
+                    continue;
+                }
+                long currentCount = 0;
+                for (Map.Entry<Integer, Long> candidate : indentFrequencies.entrySet()) {
+                    if (candidate.getKey() == 0) {
+                        continue;
+                    }
+                    if (candidate.getKey() % current.getKey() == 0) {
+                        currentCount += candidate.getValue();
+                    }
+                }
+                if (currentCount > indentCount) {
+                    indent = current.getKey();
+                    indentCount = currentCount;
+                } else if (currentCount == indentCount) {
+                    indent = Math.min(indent, current.getKey());
+                }
+            }
+
+            return new TabsAndIndentsStyle(
+                    useTabs,
+                    useTabs ? indent : 1,
+                    useTabs ? 1 : indent
+            );
+        }
+    }
+
+    private static class GeneralFormatStatistics {
+        private int linesWithCRLFNewLines = 0;
+        private int linesWithLFNewLines = 0;
+
+        public boolean isIndentedWithLFNewLines() {
+            return linesWithLFNewLines >= linesWithCRLFNewLines;
+        }
+
+        public GeneralFormatStyle getFormatStyle() {
+            return new GeneralFormatStyle(!isIndentedWithLFNewLines());
+        }
+    }
+
+    private static class FindLineFormatHclVisitor extends HclVisitor<GeneralFormatStatistics> {
+        @Override
+        public @Nullable Hcl visit(@Nullable Tree tree, GeneralFormatStatistics stats) {
+            if (tree instanceof Hcl) {
+                String prefix = ((Hcl) tree).getPrefix().getWhitespace();
+                char[] chars = prefix.toCharArray();
+                for (int i = 0; i < chars.length; i++) {
+                    char c = chars[i];
+                    if (c == '\n') {
+                        if (i == 0 || chars[i - 1] != '\r') {
+                            stats.linesWithLFNewLines++;
+                        } else {
+                            stats.linesWithCRLFNewLines++;
+                        }
+                    }
+                }
+            }
+            return super.visit(tree, stats);
+        }
+    }
+
+    private static class FindIndentHclVisitor extends HclVisitor<IndentStatistics> {
+        @Override
+        public Hcl visitBlock(Hcl.Block block, IndentStatistics stats) {
+            for (BodyContent content : block.getBody()) {
+                measureFrequencies(content.getPrefix().getWhitespace(), stats);
+            }
+            return super.visitBlock(block, stats);
+        }
+
+        @Override
+        public Hcl visitAttribute(Hcl.Attribute attribute, IndentStatistics stats) {
+            measureFrequencies(attribute.getPrefix().getWhitespace(), stats);
+            return super.visitAttribute(attribute, stats);
+        }
+
+        private void measureFrequencies(String prefix, IndentStatistics stats) {
+            if (!StringUtils.hasLineBreak(prefix)) {
+                return;
+            }
+
+            int tabIndent = 0;
+            int spaceIndent = 0;
+            boolean mixed = false;
+            char[] chars = prefix.toCharArray();
+            for (char c : chars) {
+                if (c == '\n' || c == '\r') {
+                    tabIndent = 0;
+                    spaceIndent = 0;
+                    mixed = false;
+                    continue;
+                }
+                if (mixed) {
+                    continue;
+                }
+                if (c == ' ') {
+                    if (tabIndent > 0) {
+                        mixed = true;
+                        tabIndent = 0;
+                        spaceIndent = 0;
+                        continue;
+                    }
+                    spaceIndent++;
+                } else if (Character.isWhitespace(c)) {
+                    if (spaceIndent > 0) {
+                        mixed = true;
+                        tabIndent = 0;
+                        spaceIndent = 0;
+                        continue;
+                    }
+                    tabIndent++;
+                }
+            }
+
+            stats.spaceIndentFrequencies.merge(spaceIndent, 1L, Long::sum);
+            stats.tabIndentFrequencies.merge(tabIndent, 1L, Long::sum);
+
+            if (spaceIndent > 0 || tabIndent > 0) {
+                if (spaceIndent >= tabIndent) {
+                    stats.linesWithSpaceIndents++;
+                } else {
+                    stats.linesWithTabIndents++;
+                }
+            }
+        }
+    }
+}

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/style/AutodetectTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/style/AutodetectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2026 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/style/AutodetectTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/style/AutodetectTest.java
@@ -81,6 +81,132 @@ class AutodetectTest implements RewriteTest {
     }
 
     @Test
+    void detectsNestedBlockIndent() {
+        rewriteRun(
+          withDetectedStyle(TabsAndIndentsStyle.class, style -> {
+              assertThat(style.getUseTabCharacter()).isFalse();
+              assertThat(style.getIndentSize()).isEqualTo(2);
+          }),
+          hcl(
+            """
+            resource "aws_instance" "example" {
+              ami           = "abc-123"
+              instance_type = "t2.micro"
+
+              provisioner "local-exec" {
+                command = "echo hello"
+              }
+
+              tags = {
+                Name = "example"
+              }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void detectsIndentAcrossMultipleFiles() {
+        rewriteRun(
+          withDetectedStyle(TabsAndIndentsStyle.class, style -> {
+              assertThat(style.getUseTabCharacter()).isFalse();
+              assertThat(style.getIndentSize()).isEqualTo(2);
+          }),
+          hcl(
+            """
+            resource "aws_instance" "a" {
+              ami = "abc-123"
+            }
+            """
+          ),
+          hcl(
+            """
+            resource "aws_instance" "b" {
+              ami = "def-456"
+              instance_type = "t2.micro"
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void spacesWinOverTabsWhenMajority() {
+        rewriteRun(
+          withDetectedStyle(TabsAndIndentsStyle.class, style ->
+            assertThat(style.getUseTabCharacter()).isFalse()),
+          hcl(
+            """
+            resource "aws_instance" "a" {
+              ami = "abc-123"
+              instance_type = "t2.micro"
+            }
+            """
+          ),
+          hcl(
+            """
+            resource "aws_instance" "b" {
+              ami = "def-456"
+            }
+            """
+          ),
+          hcl(
+            """
+            resource "aws_instance" "c" {
+            TABami = "ghi-789"
+            }
+            """.replaceAll("TAB", "\t")
+          )
+        );
+    }
+
+    @Test
+    void tabsWinOverSpacesWhenMajority() {
+        rewriteRun(
+          withDetectedStyle(TabsAndIndentsStyle.class, style ->
+            assertThat(style.getUseTabCharacter()).isTrue()),
+          hcl(
+            """
+            resource "aws_instance" "a" {
+            TABami = "abc-123"
+            TABinstance_type = "t2.micro"
+            }
+            """.replaceAll("TAB", "\t")
+          ),
+          hcl(
+            """
+            resource "aws_instance" "b" {
+            TABami = "def-456"
+            }
+            """.replaceAll("TAB", "\t")
+          ),
+          hcl(
+            """
+            resource "aws_instance" "c" {
+              ami = "ghi-789"
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void defaultsToTwoSpaceWhenNoIndentsDetected() {
+        rewriteRun(
+          withDetectedStyle(TabsAndIndentsStyle.class, style -> {
+              assertThat(style.getUseTabCharacter()).isFalse();
+              assertThat(style.getIndentSize()).isEqualTo(TabsAndIndentsStyle.DEFAULT.getIndentSize());
+          }),
+          hcl(
+            """
+            variable "name" {}
+            """
+          )
+        );
+    }
+
+    @Test
     void detectsLFLineEndings() {
         rewriteRun(
           withDetectedStyle(GeneralFormatStyle.class, style ->
@@ -91,6 +217,17 @@ class AutodetectTest implements RewriteTest {
               ami = "abc-123"
             }
             """
+          )
+        );
+    }
+
+    @Test
+    void detectsCRLFLineEndings() {
+        rewriteRun(
+          withDetectedStyle(GeneralFormatStyle.class, style ->
+            assertThat(style.isUseCRLFNewLines()).isTrue()),
+          hcl(
+            "resource \"aws_instance\" \"example\" {\r\n  ami = \"abc-123\"\r\n}\r\n"
           )
         );
     }

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/style/AutodetectTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/style/AutodetectTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hcl.style;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.style.GeneralFormatStyle;
+import org.openrewrite.style.Style;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.hcl.Assertions.hcl;
+
+class AutodetectTest implements RewriteTest {
+
+    @Test
+    void detectsTwoSpaceIndent() {
+        rewriteRun(
+          withDetectedStyle(TabsAndIndentsStyle.class, style -> {
+              assertThat(style.getUseTabCharacter()).isFalse();
+              assertThat(style.getIndentSize()).isEqualTo(2);
+          }),
+          hcl(
+            """
+            resource "aws_instance" "example" {
+              ami           = "abc-123"
+              instance_type = "t2.micro"
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void detectsFourSpaceIndent() {
+        rewriteRun(
+          withDetectedStyle(TabsAndIndentsStyle.class, style -> {
+              assertThat(style.getUseTabCharacter()).isFalse();
+              assertThat(style.getIndentSize()).isEqualTo(4);
+          }),
+          hcl(
+            """
+            resource "aws_instance" "example" {
+                ami           = "abc-123"
+                instance_type = "t2.micro"
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void detectsTabIndent() {
+        rewriteRun(
+          withDetectedStyle(TabsAndIndentsStyle.class, style ->
+            assertThat(style.getUseTabCharacter()).isTrue()),
+          hcl(
+            """
+            resource "aws_instance" "example" {
+            TABami           = "abc-123"
+            TABinstance_type = "t2.micro"
+            }
+            """.replaceAll("TAB", "\t")
+          )
+        );
+    }
+
+    @Test
+    void detectsLFLineEndings() {
+        rewriteRun(
+          withDetectedStyle(GeneralFormatStyle.class, style ->
+            assertThat(style.isUseCRLFNewLines()).isFalse()),
+          hcl(
+            """
+            resource "aws_instance" "example" {
+              ami = "abc-123"
+            }
+            """
+          )
+        );
+    }
+
+    private static <S extends Style> Consumer<RecipeSpec> withDetectedStyle(Class<S> styleClass, Consumer<S> fn) {
+        return spec -> spec.beforeRecipe(sources -> {
+            Autodetect.Detector detector = Autodetect.detector();
+            sources.forEach(detector::sample);
+
+            @SuppressWarnings("unchecked")
+            var foundStyle = (S) detector.build().getStyles().stream()
+              .filter(styleClass::isInstance)
+              .findAny().orElseThrow();
+            fn.accept(foundStyle);
+        });
+    }
+}

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/style/Autodetect.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/style/Autodetect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2026 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/style/Autodetect.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/style/Autodetect.java
@@ -15,16 +15,39 @@
  */
 package org.openrewrite.yaml.style;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
+import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.style.GeneralFormatStyle;
+import org.openrewrite.style.NamedStyles;
+import org.openrewrite.style.Style;
 import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.search.FindIndentYamlVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 
-public class Autodetect {
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+
+import static java.util.Collections.emptySet;
+
+public class Autodetect extends NamedStyles {
+    @JsonCreator
+    public Autodetect(UUID id, Collection<Style> styles) {
+        super(id,
+                "org.openrewrite.yaml.Autodetect",
+                "Auto-detected",
+                "Automatically detect styles from a repository's existing code.",
+                emptySet(), styles);
+    }
+
+    public static Detector detector() {
+        return new Detector();
+    }
+
     public static IndentsStyle tabsAndIndents(Yaml yaml, IndentsStyle orElse) {
         FindIndentYamlVisitor<Integer> findIndent = new FindIndentYamlVisitor<>();
         FindSequenceIndentStyleVisitor<Integer> findSeqIndent = new FindSequenceIndentStyleVisitor<>();
@@ -47,6 +70,41 @@ public class Autodetect {
         findLineFormat.visit(yaml, 0);
 
         return new GeneralFormatStyle(!findLineFormat.isIndentedWithLFNewLines());
+    }
+
+    public static class Detector {
+
+        private final FindIndentYamlVisitor<Integer> findIndent = new FindIndentYamlVisitor<>();
+        private final FindSequenceIndentStyleVisitor<Integer> findSeqIndent = new FindSequenceIndentStyleVisitor<>();
+        private final FindLineFormatYamlVisitor<Integer> findLineFormat = new FindLineFormatYamlVisitor<>();
+
+        public Detector sample(SourceFile yaml) {
+            if (yaml instanceof Yaml.Documents) {
+                //noinspection ConstantConditions
+                findIndent.visit(yaml, 0);
+                //noinspection ConstantConditions
+                findSeqIndent.visit(yaml, 0);
+                //noinspection ConstantConditions
+                findLineFormat.visit(yaml, 0);
+            }
+            return this;
+        }
+
+        public Autodetect build() {
+            IndentsStyle indentsStyle;
+            if (findIndent.nonZeroIndents() > 0) {
+                indentsStyle = new IndentsStyle(findIndent.getMostCommonIndent(), findSeqIndent.isIndentedSequences());
+            } else {
+                indentsStyle = YamlDefaultStyles.indents();
+            }
+
+            GeneralFormatStyle generalFormatStyle = new GeneralFormatStyle(!findLineFormat.isIndentedWithLFNewLines());
+
+            return new Autodetect(Tree.randomId(), Arrays.asList(
+                    indentsStyle,
+                    generalFormatStyle
+            ));
+        }
     }
 
     /**

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/style/AutodetectTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/style/AutodetectTest.java
@@ -17,12 +17,19 @@ package org.openrewrite.yaml.style;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
+import org.openrewrite.style.GeneralFormatStyle;
+import org.openrewrite.style.Style;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
 import org.openrewrite.yaml.YamlParser;
 import org.openrewrite.yaml.tree.Yaml;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import java.util.function.Consumer;
 
-class AutodetectTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.yaml.Assertions.yaml;
+
+class AutodetectTest implements RewriteTest {
 
     private static Yaml.Documents parse(String code) {
         return (Yaml.Documents) YamlParser.builder().build().parse(code).findFirst().orElseThrow();
@@ -67,5 +74,62 @@ class AutodetectTest {
         ), YamlDefaultStyles.indents());
 
         assertThat(style.isIndentedSequences()).isTrue();
+    }
+
+    @Test
+    void detectorDetectsIndentSize() {
+        rewriteRun(
+          withDetectedStyle(IndentsStyle.class, indentsStyle ->
+            assertThat(indentsStyle.getIndentSize()).isEqualTo(4)),
+          yaml(
+            """
+            root:
+                child:
+                    grandchild: value
+            """
+          )
+        );
+    }
+
+    @Test
+    void detectorDetectsDefaultIndentSize() {
+        rewriteRun(
+          withDetectedStyle(IndentsStyle.class, indentsStyle ->
+            assertThat(indentsStyle.getIndentSize()).isEqualTo(2)),
+          yaml(
+            """
+            root:
+              child:
+                grandchild: value
+            """
+          )
+        );
+    }
+
+    @Test
+    void detectorDetectsGeneralFormat() {
+        rewriteRun(
+          withDetectedStyle(GeneralFormatStyle.class, generalFormatStyle ->
+            assertThat(generalFormatStyle.isUseCRLFNewLines()).isFalse()),
+          yaml(
+            """
+            key: value
+            other: data
+            """
+          )
+        );
+    }
+
+    private static <S extends Style> Consumer<RecipeSpec> withDetectedStyle(Class<S> styleClass, Consumer<S> fn) {
+        return spec -> spec.beforeRecipe(sources -> {
+            Autodetect.Detector detector = Autodetect.detector();
+            sources.forEach(detector::sample);
+
+            @SuppressWarnings("unchecked")
+            var foundStyle = (S) detector.build().getStyles().stream()
+              .filter(styleClass::isInstance)
+              .findAny().orElseThrow();
+            fn.accept(foundStyle);
+        });
     }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/style/AutodetectTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/style/AutodetectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2026 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- **YAML**: Refactored `Autodetect` to extend `NamedStyles` with a `Detector` inner class that samples source files and produces `IndentsStyle` + `GeneralFormatStyle`. Existing static methods preserved for backward compatibility.
- **HCL**: Added new `Autodetect` class extending `NamedStyles` with a `Detector` that detects `TabsAndIndentsStyle` + `GeneralFormatStyle` from parsed `ConfigFile` instances.

This brings YAML and HCL in line with the pattern used by Java, JSON, XML, Kotlin, Groovy, Gradle, Python, and JavaScript, enabling build tools (e.g. mod CLI) to detect and store styles for these languages via the standard `NamedStyles.getName()` mechanism.

Closes #7363

## Build plugin classpath conflict

The `org.openrewrite.build.language-library` Gradle plugin (via `org.openrewrite.build.java-base`) transitively bundles the *published* version of `rewrite-yaml` (8.78.2) on the **buildscript** classpath. In that published version, `Autodetect` does not extend `NamedStyles` and has a zero-arg constructor.

When the `recipeCsvValidateCompleteness` task runs, ClassGraph discovers the *locally-built* `Autodetect` class (which now extends `NamedStyles`), but `classInfo.loadClass()` loads the *old* version from the buildscript classpath instead. This causes a `ClassCastException`:

```
class org.openrewrite.yaml.style.Autodetect cannot be cast to class org.openrewrite.style.NamedStyles
```

As a temporary workaround, the root `build.gradle.kts` excludes `rewrite-yaml` and `rewrite-hcl` from the buildscript classpath. This will resolve itself once a new rewrite release includes these changes and the build plugin picks up the updated dependency.

## Test plan
- [x] YAML Autodetect tests pass (existing + new Detector tests)
- [x] HCL Autodetect tests pass (new)
- [x] Full YAML and HCL test suites pass
- [x] Full local build passes (excluding rewrite-go)