### PR TITLE
`Cursor.firstEnclosing()` micro optimization

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Cursor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Cursor.java
@@ -165,13 +165,14 @@ public class Cursor {
     }
 
     public <T> @Nullable T firstEnclosing(Class<T> tClass) {
-        CursorIterator iter = new CursorIterator(this);
-        while (iter.hasNext()) {
-            Object value = iter.next();
-            if (tClass.isAssignableFrom(value.getClass())) {
+        Cursor current = this;
+        while (current != null) {
+            Object currentValue = current.value;
+            if (tClass.isInstance(currentValue)) {
                 //noinspection unchecked
-                return (T) value;
+                return (T) currentValue;
             }
+            current = current.parent;
         }
         return null;
     }


### PR DESCRIPTION
## What's changed?

Optimizes `Cursor.firstEnclosing()` by replacing the `CursorIterator` allocation with a direct parent-chain walk, and using `Class.isInstance()` instead of `Class.isAssignableFrom(value.getClass())`.

## Origin/Context

- This fix has been suggested in #7259 and in PR:
- https://github.com/HeshamHM28/rewrite/pull/15

- This is the last remaining "Tier 1" improvement from the [prioritized analysis](https://github.com/openrewrite/rewrite/issues/7259#issuecomment-4232506844).

Kudos to @HeshamHM28 🙇‍♂️

## What's your motivation?

`firstEnclosing()` has 174 call sites and is called thousands of times per recipe run in formatting visitors and trait matchers. Avoiding iterator allocation and using `isInstance()` provides a ~94% speedup on the hot path.