### PR TITLE
`LocalRemoteArtifactCache.hashUri()` micro optimization

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/remote/LocalRemoteArtifactCache.java
+++ b/rewrite-core/src/main/java/org/openrewrite/remote/LocalRemoteArtifactCache.java
@@ -30,6 +30,15 @@ import java.util.UUID;
 import java.util.function.Consumer;
 
 public class LocalRemoteArtifactCache implements RemoteArtifactCache {
+    private static final char[] HEX_ARRAY = "0123456789abcdef".toCharArray();
+    private static final ThreadLocal<MessageDigest> DIGEST = ThreadLocal.withInitial(() -> {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    });
+
     private final Path cacheDir;
 
     public LocalRemoteArtifactCache(Path cacheDir) {
@@ -73,22 +82,16 @@ public class LocalRemoteArtifactCache implements RemoteArtifactCache {
     }
 
     public static String hashUri(URI uri) {
-        // hash the string using SHA-256
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hashBytes = digest.digest(uri.toString().getBytes(StandardCharsets.UTF_8));
+        MessageDigest digest = DIGEST.get();
+        digest.reset();
+        byte[] hashBytes = digest.digest(uri.toString().getBytes(StandardCharsets.UTF_8));
 
-            StringBuilder hashStringBuilder = new StringBuilder();
-            for (byte hashByte : hashBytes) {
-                String hex = Integer.toHexString(0xff & hashByte);
-                if (hex.length() == 1) {
-                    hashStringBuilder.append('0');
-                }
-                hashStringBuilder.append(hex);
-            }
-            return hashStringBuilder.toString();
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
+        char[] hexChars = new char[hashBytes.length * 2];
+        for (int i = 0; i < hashBytes.length; i++) {
+            int v = hashBytes[i] & 0xFF;
+            hexChars[i * 2] = HEX_ARRAY[v >>> 4];
+            hexChars[i * 2 + 1] = HEX_ARRAY[v & 0x0F];
         }
+        return new String(hexChars);
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/remote/LocalRemoteArtifactCacheTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/remote/LocalRemoteArtifactCacheTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.remote;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalRemoteArtifactCacheTest {
+
+    @Test
+    void hashUriProducesSha256Hex() {
+        String hash = LocalRemoteArtifactCache.hashUri(URI.create("https://example.com/artifact.jar"));
+        assertThat(hash)
+          .hasSize(64)
+          .matches("[0-9a-f]+");
+    }
+
+    @Test
+    void hashUriIsDeterministic() {
+        URI uri = URI.create("https://example.com/artifact.jar");
+        assertThat(LocalRemoteArtifactCache.hashUri(uri))
+          .isEqualTo(LocalRemoteArtifactCache.hashUri(uri));
+    }
+
+    @Test
+    void hashUriDiffersForDifferentUris() {
+        String hash1 = LocalRemoteArtifactCache.hashUri(URI.create("https://example.com/a.jar"));
+        String hash2 = LocalRemoteArtifactCache.hashUri(URI.create("https://example.com/b.jar"));
+        assertThat(hash1).isNotEqualTo(hash2);
+    }
+}


### PR DESCRIPTION
## What's changed?

Optimizes `LocalRemoteArtifactCache.hashUri()` by:
- Reusing `MessageDigest` via `ThreadLocal` instead of calling `MessageDigest.getInstance("SHA-256")` on every invocation
- Using a pre-computed hex lookup table instead of `Integer.toHexString()` + `StringBuilder`

## Origin/Context

- This fix has been suggested in #7259 and in PR:
- https://github.com/HeshamHM28/rewrite/pull/27

- This was the top "Tier 2" improvement from the [prioritized analysis](https://github.com/openrewrite/rewrite/issues/7259#issuecomment-4232506844).

Kudos to @HeshamHM28 🙇‍♂️

## What's your motivation?

~697% per-call speedup by avoiding repeated `MessageDigest` instantiation and using direct hex encoding. Relevant when downloading many dependencies.