### PR TITLE
Fix ChangeDependency routing Gradle build files to updateJavaSourceSet instead of gradleVisitor

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -546,6 +546,10 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                     }
                     return tree;
                 }
+                // Gradle/Kotlin build scripts are JavaSourceFiles but should be handled by gradleVisitor
+                if (tree instanceof G.CompilationUnit || tree instanceof K.CompilationUnit) {
+                    return gradleVisitor.visit(tree, ctx);
+                }
                 // For Java source files, update JavaSourceSet marker
                 if (hasModulesWithOldDep && tree instanceof JavaSourceFile) {
                     return updateJavaSourceSet((SourceFile) tree, ctx);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -546,11 +546,16 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                     }
                     return tree;
                 }
-                // Gradle/Kotlin build scripts are JavaSourceFiles but should be handled by gradleVisitor
-                if (tree instanceof G.CompilationUnit || tree instanceof K.CompilationUnit) {
-                    return gradleVisitor.visit(tree, ctx);
+                // Gradle build scripts implement JavaSourceFile but must be handled by gradleVisitor,
+                // not routed to updateJavaSourceSet. Check source path to distinguish .gradle/.gradle.kts
+                // build scripts from regular .groovy/.kt source files that need JavaSourceSet updates.
+                if (tree instanceof SourceFile) {
+                    String path = ((SourceFile) tree).getSourcePath().toString();
+                    if (path.endsWith(".gradle") || path.endsWith(".gradle.kts")) {
+                        return gradleVisitor.visit(tree, ctx);
+                    }
                 }
-                // For Java source files, update JavaSourceSet marker
+                // For Java/Kotlin/Groovy source files, update JavaSourceSet marker
                 if (hasModulesWithOldDep && tree instanceof JavaSourceFile) {
                     return updateJavaSourceSet((SourceFile) tree, ctx);
                 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -546,17 +546,9 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                     }
                     return tree;
                 }
-                // Gradle build scripts implement JavaSourceFile but must be handled by gradleVisitor,
-                // not routed to updateJavaSourceSet. Check source path to distinguish .gradle/.gradle.kts
-                // build scripts from regular .groovy/.kt source files that need JavaSourceSet updates.
-                if (tree instanceof SourceFile) {
-                    String path = ((SourceFile) tree).getSourcePath().toString();
-                    if (path.endsWith(".gradle") || path.endsWith(".gradle.kts")) {
-                        return gradleVisitor.visit(tree, ctx);
-                    }
-                }
-                // For Java/Kotlin/Groovy source files, update JavaSourceSet marker
-                if (hasModulesWithOldDep && tree instanceof JavaSourceFile) {
+                // Update JavaSourceSet marker on source files that have one
+                if (hasModulesWithOldDep && tree instanceof SourceFile &&
+                    ((SourceFile) tree).getMarkers().findFirst(JavaSourceSet.class).isPresent()) {
                     return updateJavaSourceSet((SourceFile) tree, ctx);
                 }
                 return gradleVisitor.visit(tree, ctx);

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
@@ -32,6 +32,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.buildGradleKts;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.properties.Assertions.properties;
 
 class ChangeDependencyTest implements RewriteTest {
@@ -1140,6 +1142,52 @@ class ChangeDependencyTest implements RewriteTest {
                   implementation "org.hibernate:hibernate-validator:${hibernateVersion}"
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void changeDependencyWhenJavaSourcesPresent() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependency("commons-lang", "commons-lang", "org.apache.commons", "commons-lang3", "3.11.x", null, null, true)),
+          mavenProject("sample",
+            buildGradle(
+              """
+                plugins {
+                    id "java-library"
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    implementation "commons-lang:commons-lang:2.6"
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    implementation "org.apache.commons:commons-lang3:3.11"
+                }
+                """
+            ),
+            java(
+              """
+                class A {
+                    String foo(String s) {
+                        return s;
+                    }
+                }
+                """
+            )
           )
         );
     }


### PR DESCRIPTION
## Summary

- Fix a bug where `ChangeDependency` made no changes to Gradle build files when Java source files were also present in the source set
- The outer `TreeVisitor` in `getVisitor()` routes `JavaSourceFile` instances to `updateJavaSourceSet` for marker updates, but `G.CompilationUnit` (Gradle build scripts) also implements `JavaSourceFile`, causing build files to be misrouted instead of being handled by `gradleVisitor`
- Guard `updateJavaSourceSet` with a check for the `JavaSourceSet` marker — build scripts don't carry one, so they naturally fall through to `gradleVisitor`

## Context

This was introduced in #7202 which added `JavaSourceSet` marker updating to `ChangeDependency`. The `isAcceptable` method correctly distinguishes Gradle files from Java files, but the `visit` method's `instanceof JavaSourceFile` check catches both.

This breaks `ChangeDependency` for any Gradle project where the scanner finds the old dependency (making `hasModulesWithOldDep` true), which is the common case. Downstream, this causes test failures in rewrite-spring for `RenameDeprecatedStartersManagedVersionsTest`, `MigrateToModularStartersTest`, and `Boot3UpgradeTest`.

## Approach evolution

1. **Initial fix**: Added explicit `G.CompilationUnit` / `K.CompilationUnit` type checks before the `JavaSourceFile` branch
2. **Refined**: Switched from type checks to source path extension checks, since `K.CompilationUnit` is used for both `.gradle.kts` build scripts and regular `.kt` source files — the type check would incorrectly skip `JavaSourceSet` updates for Kotlin source files
3. **Final**: Replaced path checks with a `JavaSourceSet` marker presence check — build scripts don't carry this marker, so they fall through to `gradleVisitor`. This is both simpler and more semantically correct.

## Test plan

- [x] New test `changeDependencyWhenJavaSourcesPresent` — fails before fix, passes after
- [x] All existing `ChangeDependency` tests pass