### PR TITLE
Fix NPE in ChangeDependencyGroupIdAndArtifactId for POMs without dependencyManagement

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -268,6 +268,10 @@ public class ChangeDependencyGroupIdAndArtifactId extends ScanningRecipe<ChangeD
                 MavenResolutionResult result = getResolutionResult();
                 ResolvedPom resolvedPom = result.getPom();
                 Pom requestedPom = resolvedPom.getRequested();
+                // Pom fields default to emptyList() via @Builder.Default, but deserialization can leave them null
+                if (requestedPom.getDependencies() == null) {
+                    return Collections.emptySet();
+                }
                 Set<String> relevantProperties = requestedPom.getDependencies().stream()
                         .filter(d -> isProperty(d.getVersion()) &&
                                 matchesGlob(resolvedPom.getValue(d.getGroupId()), groupId) &&
@@ -597,6 +601,10 @@ public class ChangeDependencyGroupIdAndArtifactId extends ScanningRecipe<ChangeD
                 MavenResolutionResult result = getResolutionResult();
                 ResolvedPom resolvedPom = result.getPom();
                 Pom requestedPom = resolvedPom.getRequested();
+                // Pom fields default to emptyList() via @Builder.Default, but deserialization can leave them null
+                if (requestedPom.getDependencies() == null) {
+                    return Collections.emptySet();
+                }
                 Set<String> relevantProperties = requestedPom.getDependencies().stream()
                         .filter(d -> isProperty(d.getVersion()) &&
                                 matchesGlob(resolvedPom.getValue(d.getGroupId()), groupId) &&

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenDependencyPropertyUsageOverlap.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenDependencyPropertyUsageOverlap.java
@@ -40,6 +40,10 @@ public class MavenDependencyPropertyUsageOverlap {
     ) {
         // resolvedPom being `null` is an indicator of dealing with a remote parent that we can't change
         Set<String> remainingProperties = new HashSet<>(relevantProperties);
+        // Pom fields default to emptyList() via @Builder.Default, but deserialization can leave them null
+        if (requestedPom.getDependencyManagement() == null || requestedPom.getDependencies() == null) {
+            return remainingProperties;
+        }
         for (ManagedDependency md : requestedPom.getDependencyManagement()) {
             if (remainingProperties.isEmpty()) {
                 break;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -3804,4 +3804,54 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
         );
     }
 
+    @Test
+    void noDependencyManagementSection() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
+            "junit",
+            "junit",
+            "org.junit.jupiter",
+            "junit-jupiter",
+            "5.x",
+            null,
+            false,
+            false
+          )),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>junit</groupId>
+                          <artifactId>junit</artifactId>
+                          <version>4.13.2</version>
+                          <scope>test</scope>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.junit.jupiter</groupId>
+                          <artifactId>junit-jupiter</artifactId>
+                          <version>5.14.3</version>
+                          <scope>test</scope>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary
- `Pom` fields use `@Builder.Default` to initialize list fields to `emptyList()`, but deserialization can bypass the builder and leave them `null`
- `ChangeDependencyGroupIdAndArtifactId` crashes with NPE when run against a POM that has no `<dependencyManagement>` section
- Added null guards with early returns in three locations:
  - `MavenDependencyPropertyUsageOverlap.filterPropertiesWithOverlapInDependencies()` — guards both `getDependencyManagement()` and `getDependencies()`
  - Both `getSafeVersionPlaceholdersToChange()` methods in `ChangeDependencyGroupIdAndArtifactId` — guards `getDependencies()`

## Test plan
- [x] Added `noDependencyManagementSection()` test that runs `ChangeDependencyGroupIdAndArtifactId` on a POM with no `<dependencyManagement>` section
- [x] Existing tests pass: `./gradlew :rewrite-maven:test --tests "*ChangeDependencyGroupIdAndArtifactId*"`