### PR TITLE
Fix JavaSourceSet phantom diffs and use cached updates in all wrapping visitors

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
@@ -337,6 +337,7 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
         return new TreeVisitor<Tree, ExecutionContext>() {
             @Nullable
             private JavaSourceSetUpdater updater;
+            private final Map<String, JavaSourceSet> updatedSourceSets = new HashMap<>();
 
             @Override
             public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
@@ -366,7 +367,7 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                 if (updater == null) {
                     updater = new JavaSourceSetUpdater(ctx);
                 }
-                return JavaSourceSet.updateOnSourceFile(sf, sourceSet ->
+                return JavaSourceSet.updateOnSourceFile(sf, updatedSourceSets, sourceSet ->
                         sourceSet.getGavToTypes().isEmpty() ? sourceSet :
                                 updater.addDependency(sourceSet, groupId, artifactId, acc.resolvedVersion, acc.repositories));
             }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
@@ -364,12 +364,15 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                 if (!maybeJp.isPresent() || !acc.configurationsByProject.containsKey(maybeJp.get())) {
                     return sf;
                 }
-                if (updater == null) {
-                    updater = new JavaSourceSetUpdater(ctx);
-                }
-                return JavaSourceSet.updateOnSourceFile(sf, updatedSourceSets, sourceSet ->
-                        sourceSet.getGavToTypes().isEmpty() ? sourceSet :
-                                updater.addDependency(sourceSet, groupId, artifactId, acc.resolvedVersion, acc.repositories));
+                return JavaSourceSet.updateOnSourceFile(sf, updatedSourceSets, sourceSet -> {
+                    if (sourceSet.getGavToTypes().isEmpty()) {
+                        return sourceSet;
+                    }
+                    if (updater == null) {
+                        updater = new JavaSourceSetUpdater(ctx);
+                    }
+                    return updater.addDependency(sourceSet, groupId, artifactId, acc.resolvedVersion, acc.repositories);
+                });
             }
         };
     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -317,6 +317,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
             private final UpdateProperties updateProperties = new UpdateProperties(acc);
             @Nullable
             private JavaSourceSetUpdater jssUpdater;
+            private final Map<String, JavaSourceSet> updatedSourceSets = new HashMap<>();
 
             @Override
             public boolean isAcceptable(SourceFile sf, ExecutionContext ctx) {
@@ -403,33 +404,31 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 if (oldDeps == null || oldDeps.isEmpty()) {
                     return sf;
                 }
-                Optional<JavaSourceSet> maybeSourceSet = sf.getMarkers().findFirst(JavaSourceSet.class);
-                if (!maybeSourceSet.isPresent() || maybeSourceSet.get().getGavToTypes().isEmpty()) {
-                    return sf;
-                }
                 if (jssUpdater == null) {
                     jssUpdater = new JavaSourceSetUpdater(ctx);
                 }
-                JavaSourceSet sourceSet = maybeSourceSet.get();
-                for (ResolvedDependency oldDep : oldDeps) {
-                    GroupArtifact ga = new GroupArtifact(oldDep.getGroupId(), oldDep.getArtifactId());
-                    Object newVersionObj = acc.gaToNewVersion.get(ga);
-                    if (!(newVersionObj instanceof String)) {
-                        continue;
+                return JavaSourceSet.updateOnSourceFile(sf, updatedSourceSets, sourceSet -> {
+                    if (sourceSet.getGavToTypes().isEmpty()) {
+                        return sourceSet;
                     }
-                    String resolvedNewVersion = (String) newVersionObj;
-                    ResolvedGroupArtifactVersion newGav = new ResolvedGroupArtifactVersion(
-                            oldDep.getGav().getRepository(),
-                            oldDep.getGroupId(), oldDep.getArtifactId(), resolvedNewVersion, null);
-                    ResolvedDependency newDep = oldDep
-                            .withGav(newGav)
-                            .withRepository(MavenRepository.MAVEN_CENTRAL);
-                    sourceSet = jssUpdater.changeDependency(sourceSet, oldDep, newDep);
-                }
-                if (sourceSet != maybeSourceSet.get()) {
-                    return sf.withMarkers(sf.getMarkers().setByType(sourceSet));
-                }
-                return sf;
+                    JavaSourceSet result = sourceSet;
+                    for (ResolvedDependency oldDep : oldDeps) {
+                        GroupArtifact ga = new GroupArtifact(oldDep.getGroupId(), oldDep.getArtifactId());
+                        Object newVersionObj = acc.gaToNewVersion.get(ga);
+                        if (!(newVersionObj instanceof String)) {
+                            continue;
+                        }
+                        String resolvedNewVersion = (String) newVersionObj;
+                        ResolvedGroupArtifactVersion newGav = new ResolvedGroupArtifactVersion(
+                                oldDep.getGav().getRepository(),
+                                oldDep.getGroupId(), oldDep.getArtifactId(), resolvedNewVersion, null);
+                        ResolvedDependency newDep = oldDep
+                                .withGav(newGav)
+                                .withRepository(MavenRepository.MAVEN_CENTRAL);
+                        result = jssUpdater.changeDependency(result, oldDep, newDep);
+                    }
+                    return result;
+                });
             }
         };
     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -404,12 +404,12 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 if (oldDeps == null || oldDeps.isEmpty()) {
                     return sf;
                 }
-                if (jssUpdater == null) {
-                    jssUpdater = new JavaSourceSetUpdater(ctx);
-                }
                 return JavaSourceSet.updateOnSourceFile(sf, updatedSourceSets, sourceSet -> {
                     if (sourceSet.getGavToTypes().isEmpty()) {
                         return sourceSet;
+                    }
+                    if (jssUpdater == null) {
+                        jssUpdater = new JavaSourceSetUpdater(ctx);
                     }
                     JavaSourceSet result = sourceSet;
                     for (ResolvedDependency oldDep : oldDeps) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -348,12 +348,15 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                 if (!maybeJp.isPresent() || !acc.scopeByProject.containsKey(maybeJp.get())) {
                     return sf;
                 }
-                if (updater == null) {
-                    updater = new JavaSourceSetUpdater(ctx);
-                }
-                return JavaSourceSet.updateOnSourceFile(sf, updatedSourceSets, sourceSet ->
-                        sourceSet.getGavToTypes().isEmpty() ? sourceSet :
-                                updater.addDependency(sourceSet, groupId, artifactId, acc.resolvedVersion, acc.repositories));
+                return JavaSourceSet.updateOnSourceFile(sf, updatedSourceSets, sourceSet -> {
+                    if (sourceSet.getGavToTypes().isEmpty()) {
+                        return sourceSet;
+                    }
+                    if (updater == null) {
+                        updater = new JavaSourceSetUpdater(ctx);
+                    }
+                    return updater.addDependency(sourceSet, groupId, artifactId, acc.resolvedVersion, acc.repositories);
+                });
             }
         };
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -321,6 +321,7 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
         return new TreeVisitor<Tree, ExecutionContext>() {
             @Nullable
             private JavaSourceSetUpdater updater;
+            private final Map<String, JavaSourceSet> updatedSourceSets = new HashMap<>();
 
             @Override
             public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
@@ -350,7 +351,7 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                 if (updater == null) {
                     updater = new JavaSourceSetUpdater(ctx);
                 }
-                return JavaSourceSet.updateOnSourceFile(sf, sourceSet ->
+                return JavaSourceSet.updateOnSourceFile(sf, updatedSourceSets, sourceSet ->
                         sourceSet.getGavToTypes().isEmpty() ? sourceSet :
                                 updater.addDependency(sourceSet, groupId, artifactId, acc.resolvedVersion, acc.repositories));
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -654,15 +654,18 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 if (updater == null) {
                     updater = new JavaSourceSetUpdater(ctx);
                 }
-                ResolvedGroupArtifactVersion newGav = new ResolvedGroupArtifactVersion(
-                        oldDep.getGav().getRepository(),
-                        oldDep.getGroupId(), oldDep.getArtifactId(), newVersion, null);
-                ResolvedDependency newDep = oldDep
-                        .withGav(newGav)
-                        .withRepository(findRemoteRepository(maybeJp.get()));
-                return JavaSourceSet.updateOnSourceFile(sf, updatedSourceSets, sourceSet ->
-                        sourceSet.getGavToTypes().isEmpty() ? sourceSet :
-                                updater.changeDependency(sourceSet, oldDep, newDep));
+                return JavaSourceSet.updateOnSourceFile(sf, updatedSourceSets, sourceSet -> {
+                    if (sourceSet.getGavToTypes().isEmpty()) {
+                        return sourceSet;
+                    }
+                    ResolvedGroupArtifactVersion newGav = new ResolvedGroupArtifactVersion(
+                            oldDep.getGav().getRepository(),
+                            oldDep.getGroupId(), oldDep.getArtifactId(), newVersion, null);
+                    ResolvedDependency newDep = oldDep
+                            .withGav(newGav)
+                            .withRepository(findRemoteRepository(maybeJp.get()));
+                    return updater.changeDependency(sourceSet, oldDep, newDep);
+                });
             }
 
             private MavenRepository findRemoteRepository(JavaProject jp) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -616,6 +616,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
         return new TreeVisitor<Tree, ExecutionContext>() {
             @Nullable
             private JavaSourceSetUpdater updater;
+            private final Map<String, JavaSourceSet> updatedSourceSets = new HashMap<>();
 
             @Override
             public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
@@ -650,10 +651,6 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 if (newVersion == null) {
                     return sf;
                 }
-                Optional<JavaSourceSet> maybeSourceSet = sf.getMarkers().findFirst(JavaSourceSet.class);
-                if (!maybeSourceSet.isPresent() || maybeSourceSet.get().getGavToTypes().isEmpty()) {
-                    return sf;
-                }
                 if (updater == null) {
                     updater = new JavaSourceSetUpdater(ctx);
                 }
@@ -663,11 +660,9 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 ResolvedDependency newDep = oldDep
                         .withGav(newGav)
                         .withRepository(findRemoteRepository(maybeJp.get()));
-                JavaSourceSet updated = updater.changeDependency(maybeSourceSet.get(), oldDep, newDep);
-                if (updated != maybeSourceSet.get()) {
-                    return sf.withMarkers(sf.getMarkers().setByType(updated));
-                }
-                return sf;
+                return JavaSourceSet.updateOnSourceFile(sf, updatedSourceSets, sourceSet ->
+                        sourceSet.getGavToTypes().isEmpty() ? sourceSet :
+                                updater.changeDependency(sourceSet, oldDep, newDep));
             }
 
             private MavenRepository findRemoteRepository(JavaProject jp) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -651,12 +651,12 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 if (newVersion == null) {
                     return sf;
                 }
-                if (updater == null) {
-                    updater = new JavaSourceSetUpdater(ctx);
-                }
                 return JavaSourceSet.updateOnSourceFile(sf, updatedSourceSets, sourceSet -> {
                     if (sourceSet.getGavToTypes().isEmpty()) {
                         return sourceSet;
+                    }
+                    if (updater == null) {
+                        updater = new JavaSourceSetUpdater(ctx);
                     }
                     ResolvedGroupArtifactVersion newGav = new ResolvedGroupArtifactVersion(
                             oldDep.getGav().getRepository(),

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/JavaSourceSetUpdater.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/JavaSourceSetUpdater.java
@@ -72,10 +72,13 @@ public class JavaSourceSetUpdater {
                                           ResolvedDependency newDep) {
         String oldGavKey = gavKey(oldDep);
         String newGavKey = gavKey(newDep);
-        // Idempotent: if already changed (old absent, new present), skip
-        if (!sourceSet.getGavToTypes().containsKey(oldGavKey) &&
-            sourceSet.getGavToTypes().containsKey(newGavKey)) {
-            return sourceSet;
+        if (!sourceSet.getGavToTypes().containsKey(oldGavKey)) {
+            // Old dependency not tracked. If gavToTypes is non-empty, other dependencies
+            // are being tracked but this one wasn't — nothing to change. If gavToTypes is
+            // empty, we're in initial population mode (first call on this source set).
+            if (!sourceSet.getGavToTypes().isEmpty() || sourceSet.getGavToTypes().containsKey(newGavKey)) {
+                return sourceSet;
+            }
         }
         sourceSet = sourceSet.removeTypesForGav(oldGavKey);
         List<JavaType.FullyQualified> newTypes = downloadAndScanTypes(newDep);


### PR DESCRIPTION
## Summary

- Fix `changeDependency()` idempotency in `JavaSourceSetUpdater` — skip updates when `gavToTypes` is non-empty but doesn't contain the old dependency key (the dep was never part of the tracked classpath)
- Use cached `updateOnSourceFile` overload in all six JavaSourceSet wrapping visitors for consistent cross-file deduplication within a source set
- Defer `JavaSourceSetUpdater` construction and object allocation (newGav/newDep) into the cached lambda so they only execute on cache misses

## Context

PR #7202 added JavaSourceSet marker updating to dependency-modifying recipes. Two issues emerged:

1. **Phantom diffs from non-idempotent `changeDependency()`**: When multiple recipes in a composite like `UpgradeSpringBoot_3_0` run, some JAR downloads succeed in cycle 1 while others fail. In cycle 2, retries succeed and add new types — creating marker-only diffs that trigger extra-cycle assertions.

2. **Inconsistent caching**: `ChangeDependencyGroupIdAndArtifactId` (Maven) and `ChangeDependency` (Gradle) used the cached `updateOnSourceFile(sf, cache, transform)` overload, but `UpgradeDependencyVersion` (Maven/Gradle) and `AddDependency` (Maven/Gradle) did not — causing redundant JAR downloads per file and missing cross-file identity preservation.

## Changes

- `JavaSourceSetUpdater.changeDependency()`: Return early when `gavToTypes` is non-empty but doesn't contain the old GAV key. Preserve the empty-`gavToTypes` path for initial population.
- `UpgradeDependencyVersion` (Maven): Replace manual marker extraction and identity check with `JavaSourceSet.updateOnSourceFile(sf, cache, transform)`
- `UpgradeDependencyVersion` (Gradle): Same refactor, moving the multi-dep loop inside the transform lambda
- `AddDependency` (Maven/Gradle): Switch from non-cached to cached `updateOnSourceFile` overload
- All four recipes: Move `JavaSourceSetUpdater` initialization and object construction (newGav, newDep, remote repo lookup) inside the cached lambda to avoid unnecessary work on cache hits

## Test plan

- [x] `ChangeDependencyGroupIdAndArtifactIdTest.updatesJavaSourceSetMarkerOnJavaFiles` passes
- [x] `ChangeDependencyGroupIdAndArtifactIdTest.composedWithChangePackageUpdatesImports` passes
- [x] Full `rewrite-maven` test suite passes (`UpgradeDependencyVersionTest`, `AddDependencyTest`, `ChangeDependencyGroupIdAndArtifactIdTest`)
- [x] Full `rewrite-gradle` test suite passes (`UpgradeDependencyVersionTest`, `AddDependencyTest`, `ChangeDependencyTest`)
- [x] `rewrite-spring` `Boot3UpgradeTest.xmlBindMissing` passes (was failing with "Expected recipe to complete in 1 cycle, but took 2 cycles")