### PR TITLE
Strip Object bound from Java-origin type parameters surfaced as Library

### DIFF
--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -1190,22 +1190,25 @@ class KotlinTypeMapping(
             for (bound: FirTypeRef in type.bounds) {
                 var boundType = type(bound)
                 val fq = TypeUtils.asFullyQualified(boundType)
-                if (fq != null && "kotlin.Any" == fq.fullyQualifiedName) {
+                val originalWasKotlinAny = fq != null && "kotlin.Any" == fq.fullyQualifiedName
+                if (originalWasKotlinAny) {
                     if (containerFromJava) {
                         continue
                     }
-                    boundType = remapKotlinBuiltin(fq)
+                    boundType = remapKotlinBuiltin(fq!!)
                 } else if (fq != null) {
                     boundType = remapKotlinBuiltin(fq)
                 }
-                // Java-origin type parameters with an explicit `java.lang.Object` bound
-                // (common when Kotlin resolves a Java class's unbounded `<T>` to
-                // `<T : Object>`) should drop the Object bound to match the Java parser's
-                // unbounded form. Otherwise the GTV surfaces as `Generic{T extends java.lang.Object}`
-                // vs the Java parser's `Generic{T}`, blocking cross-parser class dedup.
-                if (containerFromJava) {
-                    val boundFq = TypeUtils.asFullyQualified(boundType)
-                    if (boundFq != null && "java.lang.Object" == boundFq.fullyQualifiedName) {
+                // When the original bound was `java.lang.Object` (not `kotlin.Any`),
+                // strip it to match the Java parser's unbounded `<T>` form. This
+                // handles Java-origin type parameters whose containing declaration's
+                // `origin` may surface as `Library` rather than `Java` (e.g. JDK
+                // classes loaded via Kotlin's classfile loader). Kotlin-source
+                // `<T : Any>` explicitly names `kotlin.Any` and is kept (remapped
+                // to `java.lang.Object`) to preserve the author's intent.
+                if (!originalWasKotlinAny) {
+                    val mappedFq = TypeUtils.asFullyQualified(boundType)
+                    if (mappedFq != null && "java.lang.Object" == mappedFq.fullyQualifiedName) {
                         continue
                     }
                 }


### PR DESCRIPTION
## Summary

- Follow-up to #7364. The existing Object-bound strip in `typeParameterType`
only fires when the containing declaration's `origin is FirDeclarationOrigin.Java`.
But JDK classes loaded through Kotlin's classfile loader surface with
`FirDeclarationOrigin.Library` — `java.util.Optional`'s type parameter `T`
is one such case — and so the Object bound survives.

On the Kotlin side that produces `Generic{T extends java.lang.Object}` while
the Java parser elides it to `Generic{T}`, which blocks cross-parser dedup
of the whole parameterized class (and anything that references it).

Mirror the handling already in `coneTypeProjectionType`: track whether
the original bound was explicitly `kotlin.Any` (so Kotlin-source
`<T : Any>` keeps its author-intended bound, remapped to Object) vs
remapped from `java.lang.Object` (so JVM Object bounds are stripped).

## Test plan

- [x] `./gradlew :rewrite-kotlin:test` — no regressions
- [ ] cross-parser dedup tests in moderne-ast-write observe `java.util.Optional`
      (and the other JDK classes that hit the same path) collapsing to a
      single variant after this change