### PR TITLE
Prevent NPEs in ChangeDependencyGroupIdAndArtifactId

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 import java.util.*;
 
 import static java.util.Collections.max;
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 import static org.openrewrite.Validated.required;
@@ -572,7 +573,13 @@ public class ChangeDependencyGroupIdAndArtifactId extends ScanningRecipe<ChangeD
 
             private boolean isDependencyManaged(Scope scope, String groupId, String artifactId) {
                 MavenResolutionResult result = getResolutionResult();
-                for (ResolvedManagedDependency managedDependency : result.getPom().getDependencyManagement()) {
+
+                List<ManagedDependency> managedDependencies = result.getPom().getDependencyManagement();
+                if (managedDependencies == null) {
+                    return false;
+                }
+
+                for (ResolvedManagedDependency managedDependency : managedDependencies) {
                     if (groupId.equals(managedDependency.getGroupId()) && artifactId.equals(managedDependency.getArtifactId())) {
                         return scope.isInClasspathOf(managedDependency.getScope());
                     }
@@ -584,7 +591,12 @@ public class ChangeDependencyGroupIdAndArtifactId extends ScanningRecipe<ChangeD
                 // We're only going to be able to effect managed dependencies that are either direct or are brought in as direct via a local parent
                 // `ChangeManagedDependencyGroupIdAndArtifactId` cannot manipulate BOM imported managed dependencies nor direct dependencies from remote parents
                 Pom requestedPom = result.getPom().getRequested();
-                for (ManagedDependency requestedManagedDependency : requestedPom.getDependencyManagement()) {
+
+                List<ManagedDependency> managedDependencies = requestedPom.getPom().getDependencyManagement();
+                if (managedDependencies == null) {
+                    return false;
+                }
+                for (ManagedDependency requestedManagedDependency : managedDependencies) {
                     if (matchesGlob(requestedManagedDependency.getGroupId(), groupId) && matchesGlob(requestedManagedDependency.getArtifactId(), artifactId)) {
                         if (requestedManagedDependency instanceof ManagedDependency.Defined) {
                             return scope.isInClasspathOf(Scope.fromName(((ManagedDependency.Defined) requestedManagedDependency).getScope()));

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -574,7 +574,7 @@ public class ChangeDependencyGroupIdAndArtifactId extends ScanningRecipe<ChangeD
             private boolean isDependencyManaged(Scope scope, String groupId, String artifactId) {
                 MavenResolutionResult result = getResolutionResult();
 
-                List<ManagedDependency> managedDependencies = result.getPom().getDependencyManagement();
+                List<ResolvedManagedDependency> managedDependencies = result.getPom().getDependencyManagement();
                 if (managedDependencies == null) {
                     return false;
                 }
@@ -592,7 +592,7 @@ public class ChangeDependencyGroupIdAndArtifactId extends ScanningRecipe<ChangeD
                 // `ChangeManagedDependencyGroupIdAndArtifactId` cannot manipulate BOM imported managed dependencies nor direct dependencies from remote parents
                 Pom requestedPom = result.getPom().getRequested();
 
-                List<ManagedDependency> managedDependencies = requestedPom.getPom().getDependencyManagement();
+                List<ManagedDependency> managedDependencies = requestedPom.getDependencyManagement();
                 if (managedDependencies == null) {
                     return false;
                 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -38,7 +38,6 @@ import java.nio.file.Path;
 import java.util.*;
 
 import static java.util.Collections.max;
-import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 import static org.openrewrite.Validated.required;


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
NPEs can occur ATM due to serialization in combination with Lomboks default handling.

## What's your motivation?
Enable ChangeDependencyGroupIdAndArtifactId in CLI until a new release.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
