### PR TITLE
Remove CLI specific NPE checks

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -268,10 +268,6 @@ public class ChangeDependencyGroupIdAndArtifactId extends ScanningRecipe<ChangeD
                 MavenResolutionResult result = getResolutionResult();
                 ResolvedPom resolvedPom = result.getPom();
                 Pom requestedPom = resolvedPom.getRequested();
-                // Pom fields default to emptyList() via @Builder.Default, but deserialization can leave them null
-                if (requestedPom.getDependencies() == null) {
-                    return Collections.emptySet();
-                }
                 Set<String> relevantProperties = requestedPom.getDependencies().stream()
                         .filter(d -> isProperty(d.getVersion()) &&
                                 matchesGlob(resolvedPom.getValue(d.getGroupId()), groupId) &&
@@ -572,13 +568,7 @@ public class ChangeDependencyGroupIdAndArtifactId extends ScanningRecipe<ChangeD
 
             private boolean isDependencyManaged(Scope scope, String groupId, String artifactId) {
                 MavenResolutionResult result = getResolutionResult();
-
-                List<ResolvedManagedDependency> managedDependencies = result.getPom().getDependencyManagement();
-                if (managedDependencies == null) {
-                    return false;
-                }
-
-                for (ResolvedManagedDependency managedDependency : managedDependencies) {
+                for (ResolvedManagedDependency managedDependency : result.getPom().getDependencyManagement()) {
                     if (groupId.equals(managedDependency.getGroupId()) && artifactId.equals(managedDependency.getArtifactId())) {
                         return scope.isInClasspathOf(managedDependency.getScope());
                     }
@@ -590,12 +580,7 @@ public class ChangeDependencyGroupIdAndArtifactId extends ScanningRecipe<ChangeD
                 // We're only going to be able to effect managed dependencies that are either direct or are brought in as direct via a local parent
                 // `ChangeManagedDependencyGroupIdAndArtifactId` cannot manipulate BOM imported managed dependencies nor direct dependencies from remote parents
                 Pom requestedPom = result.getPom().getRequested();
-
-                List<ManagedDependency> managedDependencies = requestedPom.getDependencyManagement();
-                if (managedDependencies == null) {
-                    return false;
-                }
-                for (ManagedDependency requestedManagedDependency : managedDependencies) {
+                for (ManagedDependency requestedManagedDependency : requestedPom.getDependencyManagement()) {
                     if (matchesGlob(requestedManagedDependency.getGroupId(), groupId) && matchesGlob(requestedManagedDependency.getArtifactId(), artifactId)) {
                         if (requestedManagedDependency instanceof ManagedDependency.Defined) {
                             return scope.isInClasspathOf(Scope.fromName(((ManagedDependency.Defined) requestedManagedDependency).getScope()));
@@ -612,10 +597,6 @@ public class ChangeDependencyGroupIdAndArtifactId extends ScanningRecipe<ChangeD
                 MavenResolutionResult result = getResolutionResult();
                 ResolvedPom resolvedPom = result.getPom();
                 Pom requestedPom = resolvedPom.getRequested();
-                // Pom fields default to emptyList() via @Builder.Default, but deserialization can leave them null
-                if (requestedPom.getDependencies() == null) {
-                    return Collections.emptySet();
-                }
                 Set<String> relevantProperties = requestedPom.getDependencies().stream()
                         .filter(d -> isProperty(d.getVersion()) &&
                                 matchesGlob(resolvedPom.getValue(d.getGroupId()), groupId) &&


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

To enable the usage of `ChangeDependencyArtifactIdAndGroupId` in the Moderne CLI I added the null checks. After we fix the original bug in the CLI we should roll back the changes.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

Don't pollute recipes with CLI specific fixes.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
