### PR TITLE
Harden handleError() against secondary exceptions

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -25,6 +25,7 @@ import org.openrewrite.*;
 import org.openrewrite.config.DeclarativeRecipe;
 import org.openrewrite.internal.ExceptionUtils;
 import org.openrewrite.internal.FindRecipeRunException;
+import org.openrewrite.marker.Markup;
 import org.openrewrite.internal.RecipeRunException;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.marker.*;
@@ -718,8 +719,13 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         ctx.getOnError().accept(t);
 
         if (t instanceof RecipeRunException && after != null) {
-            RecipeRunException vt = (RecipeRunException) t;
-            after = (SourceFile) new FindRecipeRunException(vt).visitNonNull(after, 0);
+            try {
+                RecipeRunException vt = (RecipeRunException) t;
+                after = (SourceFile) new FindRecipeRunException(vt).visitNonNull(after, 0);
+            } catch (Throwable ignored) {
+                // Tree is too broken for node-level marker — fall back to marking the whole file
+                after = Markup.error(after, t);
+            }
         }
 
         // Use the original source file to record the error, not the one that may have been modified by the visitor.

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerPrinter.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerPrinter.java
@@ -157,13 +157,15 @@ public class DockerPrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
     public Docker visitEnv(Docker.Env env, PrintOutputCapture<P> p) {
         beforeSyntax(env, p);
         p.append(env.getKeyword());
-        for (Docker.Env.EnvPair pair : env.getPairs()) {
-            visitSpace(pair.getPrefix(), p);
-            visit(pair.getKey(), p);
-            if (pair.isHasEquals()) {
-                p.append("=");
+        if (env.getPairs() != null) {
+            for (Docker.Env.EnvPair pair : env.getPairs()) {
+                visitSpace(pair.getPrefix(), p);
+                visit(pair.getKey(), p);
+                if (pair.isHasEquals()) {
+                    p.append("=");
+                }
+                visit(pair.getValue(), p);
             }
-            visit(pair.getValue(), p);
         }
         afterSyntax(env, p);
         return env;
@@ -173,13 +175,15 @@ public class DockerPrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
     public Docker visitLabel(Docker.Label label, PrintOutputCapture<P> p) {
         beforeSyntax(label, p);
         p.append(label.getKeyword());
-        for (Docker.Label.LabelPair pair : label.getPairs()) {
-            visitSpace(pair.getPrefix(), p);
-            visit(pair.getKey(), p);
-            if (pair.isHasEquals()) {
-                p.append("=");
+        if (label.getPairs() != null) {
+            for (Docker.Label.LabelPair pair : label.getPairs()) {
+                visitSpace(pair.getPrefix(), p);
+                visit(pair.getKey(), p);
+                if (pair.isHasEquals()) {
+                    p.append("=");
+                }
+                visit(pair.getValue(), p);
             }
-            visit(pair.getValue(), p);
         }
         afterSyntax(label, p);
         return label;

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerPrinter.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerPrinter.java
@@ -157,15 +157,13 @@ public class DockerPrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
     public Docker visitEnv(Docker.Env env, PrintOutputCapture<P> p) {
         beforeSyntax(env, p);
         p.append(env.getKeyword());
-        if (env.getPairs() != null) {
-            for (Docker.Env.EnvPair pair : env.getPairs()) {
-                visitSpace(pair.getPrefix(), p);
-                visit(pair.getKey(), p);
-                if (pair.isHasEquals()) {
-                    p.append("=");
-                }
-                visit(pair.getValue(), p);
+        for (Docker.Env.EnvPair pair : env.getPairs()) {
+            visitSpace(pair.getPrefix(), p);
+            visit(pair.getKey(), p);
+            if (pair.isHasEquals()) {
+                p.append("=");
             }
+            visit(pair.getValue(), p);
         }
         afterSyntax(env, p);
         return env;
@@ -175,15 +173,13 @@ public class DockerPrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
     public Docker visitLabel(Docker.Label label, PrintOutputCapture<P> p) {
         beforeSyntax(label, p);
         p.append(label.getKeyword());
-        if (label.getPairs() != null) {
-            for (Docker.Label.LabelPair pair : label.getPairs()) {
-                visitSpace(pair.getPrefix(), p);
-                visit(pair.getKey(), p);
-                if (pair.isHasEquals()) {
-                    p.append("=");
-                }
-                visit(pair.getValue(), p);
+        for (Docker.Label.LabelPair pair : label.getPairs()) {
+            visitSpace(pair.getPrefix(), p);
+            visit(pair.getKey(), p);
+            if (pair.isHasEquals()) {
+                p.append("=");
             }
+            visit(pair.getValue(), p);
         }
         afterSyntax(label, p);
         return label;


### PR DESCRIPTION
## Summary

- Wraps the `FindRecipeRunException` re-traversal in `RecipeRunCycle.handleError()` with a try-catch
- If the tree is too broken for node-level error marker insertion, falls back to `Markup.error()` on the entire file
- Ensures errors are always visible even when the tree has invariant violations (e.g. null collection fields after deserialization)

## Context

When a recipe throws on a tree with broken invariants, `handleError()` attempts to re-traverse the tree via `FindRecipeRunException` to attach an error marker to the specific node that failed. If that re-traversal itself throws (because the tree is too broken to traverse), the secondary exception could escape `handleError()`. This change catches that secondary exception and falls back to a file-level error marker instead.

## Test plan

- [x] `./gradlew :rewrite-core:test` passes