### PR TITLE
Scala: fix parsing of type parameters applied to method invocations

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -21,6 +21,7 @@ import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.Tree;
 import org.openrewrite.java.JavaPrinter;
 import org.openrewrite.java.marker.ImplicitReturn;
+import org.openrewrite.java.marker.OmitParentheses;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JContainer;
@@ -1175,6 +1176,32 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return method;
         }
         
+        // In Scala, method-level type arguments go AFTER the name (e.g., `foo.bar[T](x)`)
+        // and use square brackets. Also honor OmitParentheses on the arguments container
+        // for parenless calls like `List.newBuilder[Instant]`.
+        if (method.getTypeParameters() != null && !method.getTypeParameters().isEmpty()) {
+            beforeSyntax(method, Space.Location.METHOD_INVOCATION_PREFIX, p);
+            visitRightPadded(method.getPadding().getSelect(), JRightPadded.Location.METHOD_SELECT, ".", p);
+            visit(method.getName(), p);
+            visitContainer("[", method.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, ",", "]", p);
+            JContainer<Expression> args = method.getPadding().getArguments();
+            if (args == null || !args.getMarkers().findFirst(OmitParentheses.class).isPresent()) {
+                visitContainer("(", args, JContainer.Location.METHOD_INVOCATION_ARGUMENTS, ",", ")", p);
+            }
+            afterSyntax(method, p);
+            return method;
+        }
+
+        // If arguments have OmitParentheses (no type args path), suppress the `()` too.
+        JContainer<Expression> args = method.getPadding().getArguments();
+        if (args != null && args.getMarkers().findFirst(OmitParentheses.class).isPresent()) {
+            beforeSyntax(method, Space.Location.METHOD_INVOCATION_PREFIX, p);
+            visitRightPadded(method.getPadding().getSelect(), JRightPadded.Location.METHOD_SELECT, ".", p);
+            visit(method.getName(), p);
+            afterSyntax(method, p);
+            return method;
+        }
+
         // For regular method calls, use the default Java printing
         return super.visitMethodInvocation(method, p);
     }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -23,6 +23,7 @@ import dotty.tools.dotc.util.Spans
 import org.openrewrite.Tree
 import org.openrewrite.java.tree.*
 import org.openrewrite.java.marker.ImplicitReturn
+import org.openrewrite.java.marker.OmitParentheses
 import org.openrewrite.marker.Markers
 import org.openrewrite.scala.marker.Implicit
 import org.openrewrite.scala.marker.LambdaParameter
@@ -781,7 +782,11 @@ class ScalaTreeVisitor(
     }
     
     // Handle the method call target
-    val (select: Expression, selectAfterSpace: Space, methodName: String, typeParams: java.util.List[Expression]) = app.fun match {
+    var select: Expression = null
+    var selectAfterSpace: Space = Space.EMPTY
+    var methodName: String = ""
+    var typeParamsContainer: JContainer[Expression] = null
+    app.fun match {
       case sel: Trees.Select[?] =>
         val target = visitTree(sel.qualifier) match {
           case expr: Expression => expr
@@ -804,13 +809,15 @@ class ScalaTreeVisitor(
           }
         }
 
-        (target, selectAfter, sel.name.toString, Collections.emptyList[Expression]())
+        select = target
+        selectAfterSpace = selectAfter
+        methodName = sel.name.toString
 
       case id: Trees.Ident[?] =>
-        (null, Space.EMPTY, id.name.toString, Collections.emptyList[Expression]())
+        methodName = id.name.toString
 
       case typeApp: Trees.TypeApply[?] =>
-        // TypeApply as method invocation target (e.g., __P__.p[int])
+        // TypeApply as method invocation target (e.g., Option.apply[String]("hi"), __P__.p[int])
         // Extract the Select inside the TypeApply to get target and method name
         typeApp.fun match {
           case sel: Trees.Select[?] =>
@@ -826,12 +833,16 @@ class ScalaTreeVisitor(
               val nameEnd = Math.max(0, sel.nameSpan.end - offsetAdjustment)
               if (nameEnd > cursor) cursor = nameEnd
             }
-            // Skip past type args [int]
-            updateCursor(typeApp.span.end)
-            (target, selectAfter, sel.name.toString, Collections.emptyList[Expression]())
+            // Parse [T] type args — advances cursor past `]`
+            select = target
+            selectAfterSpace = selectAfter
+            methodName = sel.name.toString
+            typeParamsContainer = parseTypeApplyArgs(typeApp)
           case id: Trees.Ident[?] =>
-            updateCursor(typeApp.span.end)
-            (null, Space.EMPTY, id.name.toString, Collections.emptyList[Expression]())
+            val nameEnd = if (id.span.exists) Math.max(0, id.span.end - offsetAdjustment) else cursor
+            if (nameEnd > cursor) cursor = nameEnd
+            methodName = id.name.toString
+            typeParamsContainer = parseTypeApplyArgs(typeApp)
           case _ =>
             cursor = savedCursor; return visitUnknown(app)
         }
@@ -999,7 +1010,7 @@ class ScalaTreeVisitor(
       prefix,
       markers,
       if (select != null) new JRightPadded(select, selectAfterSpace, Markers.EMPTY) else null,
-      null, // typeParameters - handled separately in TypeApply
+      typeParamsContainer,
       name,
       argContainer,
       methodTypeOfTree(app)
@@ -4457,7 +4468,13 @@ class ScalaTreeVisitor(
             null  // type
           )
         }
-        
+
+        // General method reference with type arguments and no value arguments:
+        //   List.newBuilder[Instant], List.empty[Int], Option.empty[String], etc.
+        // Maps to J.MethodInvocation with typeParameters populated and arguments
+        // marked OmitParentheses (since the source has no `(...)`).
+        return visitMethodInvocationFromTypeApply(ta, sel, savedCursor)
+
       case id: Trees.Ident[?] if id.name.toString == "classOf" && ta.args.size == 1 =>
         // classOf[String] — preserve as identifier (Statement + Expression)
         val prefix = extractPrefix(ta.span)
@@ -4486,6 +4503,112 @@ class ScalaTreeVisitor(
 
     // Shouldn't reach here — all cases return above
     visitUnknown(ta)
+  }
+
+  /**
+   * Build a J.MethodInvocation from a TypeApply wrapping a Select, for method references
+   * that have type arguments but no value argument list (e.g., `List.newBuilder[Instant]`,
+   * `List.empty[Int]`). The arguments container is marked with OmitParentheses so the
+   * printer emits the call without `()`.
+   */
+  private def visitMethodInvocationFromTypeApply(ta: Trees.TypeApply[?], sel: Trees.Select[?], savedCursor: Int): J = {
+    val prefix = extractPrefix(ta.span)
+
+    // Visit the qualifier (e.g., `List`)
+    val qual = visitTree(sel.qualifier) match {
+      case e: Expression => e
+      case j: J => new S.StatementExpression(Tree.randomId(), j)
+      case _ => cursor = savedCursor; return visitUnknown(ta)
+    }
+
+    // Capture space between qualifier and the `.`
+    val dotPos = source.indexOf('.', cursor)
+    val selectAfter = if (dotPos > cursor) Space.format(source.substring(cursor, dotPos)) else Space.EMPTY
+    if (dotPos >= 0) cursor = dotPos + 1
+
+    // Method name (e.g., `newBuilder`)
+    val methodNameStr = sel.name.toString
+    val nameStart = if (sel.nameSpan.exists) Math.max(0, sel.nameSpan.start - offsetAdjustment) else cursor
+    val namePrefix = if (nameStart > cursor && nameStart <= source.length) {
+      Space.format(source.substring(cursor, nameStart))
+    } else Space.EMPTY
+    cursor = Math.min(source.length, nameStart + methodNameStr.length)
+    val name = new J.Identifier(Tree.randomId(), namePrefix, Markers.EMPTY,
+      Collections.emptyList(), methodNameStr, null, null)
+
+    // Type arguments between `[` and `]`
+    val typeParams = parseTypeApplyArgs(ta)
+
+    // Empty value-argument container with OmitParentheses marker
+    val omitParens = Markers.build(Collections.singletonList(new OmitParentheses(Tree.randomId())))
+    val args = JContainer.build(Space.EMPTY, Collections.emptyList[JRightPadded[Expression]](), omitParens)
+
+    updateCursor(ta.span.end)
+
+    new J.MethodInvocation(
+      Tree.randomId(),
+      prefix,
+      Markers.EMPTY,
+      new JRightPadded(qual, selectAfter, Markers.EMPTY),
+      typeParams,
+      name,
+      args,
+      methodTypeOfTree(ta)
+    )
+  }
+
+  /**
+   * Parse the `[T, U, ...]` portion of a TypeApply into a JContainer of type-argument
+   * expressions. Assumes `cursor` is positioned at or before the opening `[`.
+   */
+  private def parseTypeApplyArgs(ta: Trees.TypeApply[?]): JContainer[Expression] = {
+    val bracketPos = source.indexOf('[', cursor)
+    val beforeBracket = if (bracketPos > cursor) Space.format(source.substring(cursor, bracketPos)) else Space.EMPTY
+    if (bracketPos >= 0) cursor = bracketPos + 1
+
+    val taEnd = Math.max(0, ta.span.end - offsetAdjustment)
+    val closeBracketPos = if (taEnd > 0 && taEnd <= source.length && source.charAt(taEnd - 1) == ']') {
+      taEnd - 1
+    } else {
+      val idx = source.indexOf(']', cursor)
+      if (idx >= 0) idx else taEnd
+    }
+
+    val elements = new util.ArrayList[JRightPadded[Expression]]()
+
+    for (i <- ta.args.indices) {
+      val arg = ta.args(i)
+      val expr: Expression = visitTree(arg) match {
+        case e: Expression => e
+        case tt: TypeTree => tt.asInstanceOf[Expression]
+        case j: J => new S.StatementExpression(Tree.randomId(), j)
+        case _ => return JContainer.build(beforeBracket, elements, Markers.EMPTY)
+      }
+      val isLast = i == ta.args.size - 1
+      val after = if (isLast) {
+        if (cursor < closeBracketPos && closeBracketPos <= source.length) {
+          Space.format(source.substring(cursor, closeBracketPos))
+        } else Space.EMPTY
+      } else {
+        val commaPos = source.indexOf(',', cursor)
+        if (commaPos > cursor && commaPos < closeBracketPos) {
+          Space.format(source.substring(cursor, commaPos))
+        } else Space.EMPTY
+      }
+      elements.add(new JRightPadded(expr, after, Markers.EMPTY))
+      if (!isLast) {
+        val commaPos = source.indexOf(',', cursor)
+        if (commaPos >= 0) cursor = commaPos + 1
+      } else {
+        cursor = closeBracketPos
+      }
+    }
+
+    if (closeBracketPos < source.length && source.charAt(closeBracketPos) == ']') {
+      cursor = closeBracketPos + 1
+    }
+
+    JContainer.build(beforeBracket, elements, Markers.EMPTY)
   }
   
   private def visitAppliedTypeTree(at: Trees.AppliedTypeTree[?]): J = {

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -4560,22 +4560,11 @@ class ScalaTreeVisitor(
   /**
    * Parse the `[T, U, ...]` portion of a TypeApply into a JContainer of type-argument
    * expressions. Assumes `cursor` is positioned at or before the opening `[`.
+   * Leaves cursor positioned just past the closing `]`.
    */
   private def parseTypeApplyArgs(ta: Trees.TypeApply[?]): JContainer[Expression] = {
-    val bracketPos = source.indexOf('[', cursor)
-    val beforeBracket = if (bracketPos > cursor) Space.format(source.substring(cursor, bracketPos)) else Space.EMPTY
-    if (bracketPos >= 0) cursor = bracketPos + 1
-
-    val taEnd = Math.max(0, ta.span.end - offsetAdjustment)
-    val closeBracketPos = if (taEnd > 0 && taEnd <= source.length && source.charAt(taEnd - 1) == ']') {
-      taEnd - 1
-    } else {
-      val idx = source.indexOf(']', cursor)
-      if (idx >= 0) idx else taEnd
-    }
-
+    val beforeBracket = sourceBefore("[")
     val elements = new util.ArrayList[JRightPadded[Expression]]()
-
     for (i <- ta.args.indices) {
       val arg = ta.args(i)
       val expr: Expression = visitTree(arg) match {
@@ -4585,29 +4574,9 @@ class ScalaTreeVisitor(
         case _ => return JContainer.build(beforeBracket, elements, Markers.EMPTY)
       }
       val isLast = i == ta.args.size - 1
-      val after = if (isLast) {
-        if (cursor < closeBracketPos && closeBracketPos <= source.length) {
-          Space.format(source.substring(cursor, closeBracketPos))
-        } else Space.EMPTY
-      } else {
-        val commaPos = source.indexOf(',', cursor)
-        if (commaPos > cursor && commaPos < closeBracketPos) {
-          Space.format(source.substring(cursor, commaPos))
-        } else Space.EMPTY
-      }
+      val after = if (isLast) sourceBefore("]") else sourceBefore(",")
       elements.add(new JRightPadded(expr, after, Markers.EMPTY))
-      if (!isLast) {
-        val commaPos = source.indexOf(',', cursor)
-        if (commaPos >= 0) cursor = commaPos + 1
-      } else {
-        cursor = closeBracketPos
-      }
     }
-
-    if (closeBracketPos < source.length && source.charAt(closeBracketPos) == ']') {
-      cursor = closeBracketPos + 1
-    }
-
     JContainer.build(beforeBracket, elements, Markers.EMPTY)
   }
   

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
@@ -200,4 +200,46 @@ class MethodInvocationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void methodCallWithTypeArguments() {
+        rewriteRun(
+          scala(
+            """
+              import java.time.Instant
+              object Test {
+                val builder = List.newBuilder[Instant]
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodCallWithTypeArgumentsAndArgs() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                val list = List.empty[Int]
+                val set = Set.apply[String]("a", "b")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodCallWithTypeArgumentsAndValueArgs() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                val builder = List.fill[Int](3)(0)
+                val single = Option.apply[String]("hello")
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Another amendment to the Scala parser. Fixing how method invocations with type parameters applied are parsed, e.g.
```
List.newBuilder[Instant]
```

## What's your motivation?

More complete Scala support.
