### PR TITLE
`EmptyNewlineAtEndOfFile` not to alter empty files

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/EmptyNewlineAtEndOfFileTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/EmptyNewlineAtEndOfFileTest.java
@@ -145,4 +145,15 @@ class EmptyNewlineAtEndOfFileTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void emptyFileStaysEmpty() {
+        rewriteRun(
+          generalFormat(false),
+          java(
+            "",
+            SourceSpec::noTrim
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/EmptyNewlineAtEndOfFile.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/EmptyNewlineAtEndOfFile.java
@@ -66,6 +66,9 @@ public class EmptyNewlineAtEndOfFile extends Recipe {
                         eof.getLastWhitespace().chars().filter(c -> c == '\n').count() != 1) {
                         List<Comment> comments = eof.getComments();
                         if (comments.isEmpty()) {
+                            if (isEffectivelyEmpty(cu)) {
+                                return cu;
+                            }
                             return cu.withEof(Space.format(lineEnding));
                         } else {
                             return cu.withEof(cu.getEof().withComments(ListUtils.mapLast(comments, it -> it.withSuffix(lineEnding))));
@@ -74,6 +77,15 @@ public class EmptyNewlineAtEndOfFile extends Recipe {
                     return cu;
                 }
                 return (J) tree;
+            }
+
+            private boolean isEffectivelyEmpty(JavaSourceFile cu) {
+                return cu.getPackageDeclaration() == null &&
+                       cu.getImports().isEmpty() &&
+                       cu.getClasses().isEmpty() &&
+                       cu.getPrefix().getComments().isEmpty() &&
+                       cu.getPrefix().getWhitespace().isEmpty() &&
+                       cu.getEof().getWhitespace().isEmpty();
             }
         };
     }


### PR DESCRIPTION
## What's changed?

Minor adjustment to the existing `EmptyNewlineAtEndOfFile` recipe. That is not to alter (add newline) to empty (0-byte) files.

## What's your motivation?

While this technically contradicts the name of the recipe, this is the industry expected way of handling this. Thus should be less surprising to the user.