### PR TITLE
Scala: fix support for parsing of underscore numeric literals

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -246,8 +246,11 @@ class ScalaTreeVisitor(
     // Strip them so we can parse the number correctly.
     val valueSource = rawSource.replaceAll("[^0-9a-fA-FxXlLfFdDeE._+-]", "")
 
+    // Strip underscore digit separators; valueSource keeps them for printing.
+    val parseSource = valueSource.replace("_", "")
+
     // Parse the number to determine its type and value
-    val (value: Any, javaType: JavaType.Primitive) = valueSource match {
+    val (value: Any, javaType: JavaType.Primitive) = parseSource match {
       case s if s.startsWith("0x") || s.startsWith("0X") =>
         // Hexadecimal literal
         val hexStr = s.substring(2)
@@ -257,11 +260,11 @@ class ScalaTreeVisitor(
         } else {
           (java.lang.Long.valueOf(longVal), JavaType.Primitive.Long)
         }
-      case s if s.endsWith("L") || s.endsWith("l") => 
+      case s if s.endsWith("L") || s.endsWith("l") =>
         (java.lang.Long.valueOf(s.dropRight(1)), JavaType.Primitive.Long)
-      case s if s.endsWith("F") || s.endsWith("f") => 
+      case s if s.endsWith("F") || s.endsWith("f") =>
         (java.lang.Float.valueOf(s.dropRight(1)), JavaType.Primitive.Float)
-      case s if s.endsWith("D") || s.endsWith("d") => 
+      case s if s.endsWith("D") || s.endsWith("d") =>
         (java.lang.Double.valueOf(s.dropRight(1)), JavaType.Primitive.Double)
       case s if s.contains(".") || s.contains("e") || s.contains("E") =>
         (java.lang.Double.valueOf(s), JavaType.Primitive.Double)

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LiteralTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LiteralTest.java
@@ -30,6 +30,19 @@ class LiteralTest implements RewriteTest {
     }
 
     @Test
+    void numericLiteralsWithUnderscoreSeparator() {
+        rewriteRun(
+          scala(
+            """
+            val i = 60_000
+            val l = 1_000_000L
+            val d = 3.141_592
+            """
+          )
+        );
+    }
+
+    @Test
     void hexLiteral() {
         rewriteRun(
           scala("0xFF")


### PR DESCRIPTION
## What's changed?

Fixing the Scala parser wrt parsing underscore numeric literals like `436_000`.

## What's your motivation?

The parser crashes with `NumberFormatException`