### PR TITLE
Detect cyclic property references instead of StackOverflowError

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/PropertyPlaceholderHelper.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/PropertyPlaceholderHelper.java
@@ -127,10 +127,13 @@ public class PropertyPlaceholderHelper {
                 if (visitedPlaceholders == null) {
                     visitedPlaceholders = new HashSet<>(4);
                 }
-                if (visitedPlaceholders.add(originalPlaceholder)) {
-                    placeholder = parseStringValue(placeholder, placeholderResolver, visitedPlaceholders);
+                if (!visitedPlaceholders.add(originalPlaceholder)) {
+                    // Circular reference detected - leave this placeholder unresolved
+                    startIndex = result.indexOf(placeholderPrefix, endIndex + placeholderSuffix.length());
+                    continue;
                 }
                 // Recursive invocation, parsing placeholders contained in the placeholder key.
+                placeholder = parseStringValue(placeholder, placeholderResolver, visitedPlaceholders);
                 // Now obtain the value for the fully resolved key...
                 String propVal = placeholderResolver.apply(placeholder);
                 if (propVal == null && valueSeparator != null) {

--- a/rewrite-core/src/test/java/org/openrewrite/internal/PropertyPlaceholderHelperTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/PropertyPlaceholderHelperTest.java
@@ -135,6 +135,26 @@ class PropertyPlaceholderHelperTest {
     }
 
     @Test
+    void selfReferencingPropertyDoesNotStackOverflow() {
+        var helper = new PropertyPlaceholderHelper("${", "}", null);
+        var props = new java.util.HashMap<String, String>();
+        props.put("revision", "${revision}");
+        var s = helper.replacePlaceholders("${revision}", props::get);
+        assertThat(s).isEqualTo("${revision}");
+    }
+
+    @Test
+    void cyclicPropertyReferenceDoesNotStackOverflow() {
+        var helper = new PropertyPlaceholderHelper("${", "}", null);
+        var props = new java.util.HashMap<String, String>();
+        props.put("revision", "${project.build.version}");
+        props.put("project.build.version", "${revision}");
+        var s = helper.replacePlaceholders("${revision}", props::get);
+        // The cycle should be detected and the placeholder left unresolved
+        assertThat(s).contains("${");
+    }
+
+    @Test
     void withValueSeparatorAndNullReplacement() {
         var helper = new PropertyPlaceholderHelper("%%{", "}", ",");
         var s = helper.replacePlaceholders("%%{k1,oh}%%{k2}", k -> switch (k) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -3378,6 +3378,71 @@ class MavenParserTest implements RewriteTest {
     }
 
     @Test
+    void selfReferencingPropertyDoesNotStackOverflow() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>pom-with-property-self-reference</artifactId>
+                  <version>${revision}</version>
+
+                  <properties>
+                      <revision>${revision}</revision>
+                  </properties>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void cyclicPropertyReferenceDoesNotStackOverflow() {
+        rewriteRun(
+          mavenProject("root",
+            pomXml(
+              """
+                <project>
+                    <groupId>org.example</groupId>
+                    <artifactId>pom-with-property-cycle-parent</artifactId>
+                    <version>${revision}</version>
+                    <packaging>pom</packaging>
+
+                    <modules>
+                        <module>child</module>
+                    </modules>
+
+                    <properties>
+                        <revision>${project.build.version}</revision>
+                    </properties>
+                </project>
+                """
+            ),
+            mavenProject("child",
+              pomXml(
+                """
+                  <project>
+                      <parent>
+                          <groupId>org.example</groupId>
+                          <artifactId>pom-with-property-cycle-parent</artifactId>
+                          <version>${revision}</version>
+                          <relativePath>../pom.xml</relativePath>
+                      </parent>
+
+                      <artifactId>pom-with-property-cycle-child</artifactId>
+
+                      <properties>
+                          <project.build.version>${revision}</project.build.version>
+                      </properties>
+                  </project>
+                  """
+              )
+            )
+          )
+        );
+    }
+
+    @Test
     void multiModuleProjectVersionPropertyInInterModuleDependency() {
         rewriteRun(
           spec -> spec.parser(MavenParser.builder().skipDependencyResolution(true)),


### PR DESCRIPTION
- Fixes https://github.com/moderneinc/customer-requests/issues/2228

## Background / problem

When Maven properties form a cycle (e.g. `<revision>${revision}</revision>`, or a two-hop cycle like `<revision>${project.build.version}</revision>` with `<project.build.version>${revision}</project.build.version>`), `PropertyPlaceholderHelper.parseStringValue()` produces a `StackOverflowError`. This crashes the Moderne CLI during its POM pre-parsing step before Maven is even invoked.

The existing visited-placeholder tracking only guarded key resolution (nested placeholder keys like `${${foo}}`), but not value resolution. When a resolved value contained a placeholder already being resolved, the value-resolution path re-entered `parseStringValue` without any cycle check, creating infinite recursion.

## Solution

When a placeholder is already in the visited set, skip its resolution entirely and leave it unresolved in the output. This matches the existing cycle-detection intent while covering the value-resolution path that was previously unguarded.

## Test plan

- [x] `PropertyPlaceholderHelperTest.selfReferencingPropertyDoesNotStackOverflow` -- direct self-reference
- [x] `PropertyPlaceholderHelperTest.cyclicPropertyReferenceDoesNotStackOverflow` -- two-hop cycle
- [x] `MavenParserTest.selfReferencingPropertyDoesNotStackOverflow` -- full Maven parse
- [x] `MavenParserTest.cyclicPropertyReferenceDoesNotStackOverflow` -- multi-module POM cycle
- [x] All existing circular reference tests pass (`circularMavenProperty`, `circularProjectVersionReference`, etc.)
- [x] End-to-end: published to Maven local, built CLI fat jar, confirmed `mod build` no longer StackOverflows on reproducer repos