### PR TITLE
Add go.mod parser and GoResolutionResult marker

### DIFF
--- a/rewrite-go/src/main/java/org/openrewrite/golang/Assertions.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/Assertions.java
@@ -19,6 +19,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.golang.tree.Go;
 import org.openrewrite.test.SourceSpec;
 import org.openrewrite.test.SourceSpecs;
+import org.openrewrite.text.PlainText;
 
 import java.util.function.Consumer;
 
@@ -47,5 +48,30 @@ public final class Assertions {
         SourceSpec<Go.CompilationUnit> go = new SourceSpec<>(Go.CompilationUnit.class, null, GolangParser.builder(), before, s -> after);
         spec.accept(go);
         return go;
+    }
+
+    public static SourceSpecs goMod(@Nullable String before) {
+        return goMod(before, s -> {
+        });
+    }
+
+    public static SourceSpecs goMod(@Nullable String before, Consumer<SourceSpec<PlainText>> spec) {
+        SourceSpec<PlainText> goMod = new SourceSpec<>(PlainText.class, null, GoModParser.builder(), before, null);
+        goMod.path("go.mod");
+        spec.accept(goMod);
+        return goMod;
+    }
+
+    public static SourceSpecs goMod(@Nullable String before, String after) {
+        return goMod(before, after, s -> {
+        });
+    }
+
+    public static SourceSpecs goMod(@Nullable String before, String after,
+                                    Consumer<SourceSpec<PlainText>> spec) {
+        SourceSpec<PlainText> goMod = new SourceSpec<>(PlainText.class, null, GoModParser.builder(), before, s -> after);
+        goMod.path("go.mod");
+        spec.accept(goMod);
+        return goMod;
     }
 }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/GoModParser.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/GoModParser.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.golang.marker.GoResolutionResult;
+import org.openrewrite.golang.marker.GoResolutionResult.Exclude;
+import org.openrewrite.golang.marker.GoResolutionResult.Replace;
+import org.openrewrite.golang.marker.GoResolutionResult.ResolvedDependency;
+import org.openrewrite.golang.marker.GoResolutionResult.Retract;
+import org.openrewrite.golang.marker.GoResolutionResult.Require;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.text.PlainTextParser;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * Parses Go {@code go.mod} (and optionally {@code go.sum}) files into a {@link PlainText}
+ * document with an attached {@link GoResolutionResult} marker.
+ * <p>
+ * <b>Why PlainText and not a dedicated tree?</b> go.mod has a very small syntax and doesn't benefit
+ * from lossless AST reconstruction. The marker captures all structured data recipes need.
+ * <p>
+ * <b>go.sum lookup:</b> if {@code includeSumHashes} is set, the parser looks for a sibling
+ * {@code go.sum} file next to each go.mod and parses recorded hashes into
+ * {@link ResolvedDependency} entries on the marker.
+ * <p>
+ * <pre>
+ *   GO.MOD GRAMMAR (relevant subset)
+ *
+ *   module github.com/foo/bar              ← module directive
+ *   go 1.21                                ← toolchain version
+ *   toolchain go1.22.0                     ← optional minimum toolchain
+ *
+ *   require github.com/x/y v1.2.3          ← single-line require
+ *   require (                              ← block require
+ *       github.com/a/b v1.0.0
+ *       github.com/c/d v2.0.0 // indirect
+ *   )
+ *
+ *   replace github.com/old => github.com/new v1.0.0
+ *   replace github.com/old v1 => ../local/path
+ *   replace ( ... )                        ← block form
+ *
+ *   exclude github.com/bad v1.2.3
+ *   exclude ( ... )                        ← block form
+ *
+ *   retract v1.0.0 // buggy
+ *   retract [v1.0.0, v1.1.0]
+ *   retract ( ... )                        ← block form
+ * </pre>
+ * <p>
+ * Comments ({@code // ...}) are preserved in rationale fields where meaningful
+ * (retract lines) and otherwise stripped.
+ */
+public class GoModParser implements Parser {
+
+    private static final Pattern MODULE_LINE = Pattern.compile("^\\s*module\\s+(\\S+)\\s*(?://.*)?$");
+    private static final Pattern GO_LINE = Pattern.compile("^\\s*go\\s+(\\S+)\\s*(?://.*)?$");
+    private static final Pattern TOOLCHAIN_LINE = Pattern.compile("^\\s*toolchain\\s+(\\S+)\\s*(?://.*)?$");
+
+    private static final Pattern REQUIRE_SINGLE = Pattern.compile(
+            "^\\s*require\\s+(\\S+)\\s+(\\S+)\\s*(//\\s*indirect)?\\s*(?://.*)?$");
+    private static final Pattern REQUIRE_ENTRY = Pattern.compile(
+            "^\\s*(\\S+)\\s+(\\S+)\\s*(//\\s*indirect)?\\s*(?://.*)?$");
+
+    private static final Pattern REPLACE_SINGLE = Pattern.compile(
+            "^\\s*replace\\s+(\\S+)(?:\\s+(\\S+))?\\s+=>\\s+(\\S+)(?:\\s+(\\S+))?\\s*(?://.*)?$");
+    private static final Pattern REPLACE_ENTRY = Pattern.compile(
+            "^\\s*(\\S+)(?:\\s+(\\S+))?\\s+=>\\s+(\\S+)(?:\\s+(\\S+))?\\s*(?://.*)?$");
+
+    private static final Pattern EXCLUDE_SINGLE = Pattern.compile(
+            "^\\s*exclude\\s+(\\S+)\\s+(\\S+)\\s*(?://.*)?$");
+    private static final Pattern EXCLUDE_ENTRY = Pattern.compile(
+            "^\\s*(\\S+)\\s+(\\S+)\\s*(?://.*)?$");
+
+    private static final Pattern RETRACT_SINGLE = Pattern.compile(
+            "^\\s*retract\\s+(\\S+|\\[[^\\]]+\\])\\s*(//.*)?$");
+    private static final Pattern RETRACT_ENTRY = Pattern.compile(
+            "^\\s*(\\S+|\\[[^\\]]+\\])\\s*(//.*)?$");
+
+    private static final Pattern GO_SUM_LINE = Pattern.compile(
+            "^\\s*(\\S+)\\s+(\\S+?)(/go\\.mod)?\\s+h1:(\\S+)\\s*$");
+
+    private final PlainTextParser delegate = new PlainTextParser();
+
+    @Override
+    public Stream<SourceFile> parseInputs(Iterable<Input> sources, @Nullable Path relativeTo, ExecutionContext ctx) {
+        return delegate.parseInputs(sources, relativeTo, ctx).map(sf -> {
+            if (!(sf instanceof PlainText)) {
+                return sf;
+            }
+            PlainText pt = (PlainText) sf;
+            GoResolutionResult marker = parseMarker(pt);
+            if (marker == null) {
+                return sf;
+            }
+            return pt.withMarkers(pt.getMarkers().addIfAbsent(marker));
+        });
+    }
+
+    @Override
+    public boolean accept(Path path) {
+        String filename = path.getFileName().toString();
+        return "go.mod".equals(filename);
+    }
+
+    @Override
+    public Path sourcePathFromSourceText(Path prefix, String sourceCode) {
+        return prefix.resolve("go.mod");
+    }
+
+    static @Nullable GoResolutionResult parseMarker(PlainText doc) {
+        String content = doc.getText();
+        if (content == null || content.isEmpty()) {
+            return null;
+        }
+
+        String modulePath = null;
+        String goVersion = null;
+        String toolchain = null;
+        List<Require> requires = new ArrayList<>();
+        List<Replace> replaces = new ArrayList<>();
+        List<Exclude> excludes = new ArrayList<>();
+        List<Retract> retracts = new ArrayList<>();
+
+        String[] lines = content.split("\\r?\\n", -1);
+        BlockState block = BlockState.NONE;
+
+        for (String rawLine : lines) {
+            String line = stripInlineComment(rawLine);
+            if (line.isEmpty()) {
+                continue;
+            }
+
+            // Close block on trailing ')'
+            if (block != BlockState.NONE && line.trim().equals(")")) {
+                block = BlockState.NONE;
+                continue;
+            }
+
+            // Inside a block: parse entries without leading keyword
+            if (block != BlockState.NONE) {
+                parseBlockEntry(block, rawLine, line, requires, replaces, excludes, retracts);
+                continue;
+            }
+
+            // Top-level: identify directive.
+            // Retract rationale is preserved by matching RETRACT_SINGLE against rawLine.
+            Matcher m;
+            if ((m = MODULE_LINE.matcher(line)).matches()) {
+                modulePath = m.group(1);
+            } else if ((m = GO_LINE.matcher(line)).matches()) {
+                goVersion = m.group(1);
+            } else if ((m = TOOLCHAIN_LINE.matcher(line)).matches()) {
+                toolchain = m.group(1);
+            } else if (line.trim().startsWith("require") && line.trim().endsWith("(")) {
+                block = BlockState.REQUIRE;
+            } else if (line.trim().startsWith("replace") && line.trim().endsWith("(")) {
+                block = BlockState.REPLACE;
+            } else if (line.trim().startsWith("exclude") && line.trim().endsWith("(")) {
+                block = BlockState.EXCLUDE;
+            } else if (line.trim().startsWith("retract") && line.trim().endsWith("(")) {
+                block = BlockState.RETRACT;
+            } else if ((m = REQUIRE_SINGLE.matcher(line)).matches()) {
+                requires.add(new Require(m.group(1), m.group(2), m.group(3) != null));
+            } else if ((m = REPLACE_SINGLE.matcher(line)).matches()) {
+                String oldPath = m.group(1);
+                String oldVersion = m.group(2);
+                String newPath = m.group(3);
+                String newVersion = m.group(4);
+                replaces.add(new Replace(oldPath, oldVersion, newPath, newVersion));
+            } else if ((m = EXCLUDE_SINGLE.matcher(line)).matches()) {
+                excludes.add(new Exclude(m.group(1), m.group(2)));
+            } else if ((m = RETRACT_SINGLE.matcher(rawLine)).matches()) {
+                String rationale = m.group(2) != null ? trimComment(m.group(2)) : null;
+                retracts.add(new Retract(m.group(1), rationale));
+            }
+        }
+
+        if (modulePath == null) {
+            return null;
+        }
+
+        List<ResolvedDependency> resolved = parseSumSibling(doc.getSourcePath());
+
+        return new GoResolutionResult(
+                Tree.randomId(),
+                modulePath,
+                goVersion,
+                toolchain,
+                doc.getSourcePath().toString(),
+                requires,
+                replaces,
+                excludes,
+                retracts,
+                resolved
+        );
+    }
+
+    private static void parseBlockEntry(BlockState block, String rawLine, String line,
+                                        List<Require> requires, List<Replace> replaces,
+                                        List<Exclude> excludes, List<Retract> retracts) {
+        Matcher m;
+        switch (block) {
+            case REQUIRE:
+                if ((m = REQUIRE_ENTRY.matcher(line)).matches()) {
+                    requires.add(new Require(m.group(1), m.group(2), m.group(3) != null));
+                }
+                break;
+            case REPLACE:
+                if ((m = REPLACE_ENTRY.matcher(line)).matches()) {
+                    replaces.add(new Replace(m.group(1), m.group(2), m.group(3), m.group(4)));
+                }
+                break;
+            case EXCLUDE:
+                if ((m = EXCLUDE_ENTRY.matcher(line)).matches()) {
+                    excludes.add(new Exclude(m.group(1), m.group(2)));
+                }
+                break;
+            case RETRACT:
+                // Raw line so we can extract rationale from an inline comment preserved there
+                if ((m = RETRACT_ENTRY.matcher(rawLine)).matches()) {
+                    String rationale = m.group(2) != null ? trimComment(m.group(2)) : null;
+                    retracts.add(new Retract(m.group(1), rationale));
+                }
+                break;
+            case NONE:
+                break;
+        }
+    }
+
+    private static List<ResolvedDependency> parseSumSibling(Path goModPath) {
+        List<ResolvedDependency> resolved = new ArrayList<>();
+        Path sumPath = goModPath.resolveSibling("go.sum");
+        java.io.File sumFile = sumPath.toFile();
+        if (!sumFile.isFile()) {
+            return resolved;
+        }
+        try (java.io.BufferedReader reader = new java.io.BufferedReader(new java.io.FileReader(sumFile))) {
+            // go.sum format: "<module> <version>[/go.mod] h1:<hash>"
+            // Each module version appears on two lines: one for the module zip, one for its go.mod file.
+            java.util.Map<String, String[]> byKey = new java.util.LinkedHashMap<>();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                Matcher m = GO_SUM_LINE.matcher(line);
+                if (!m.matches()) {
+                    continue;
+                }
+                String module = m.group(1);
+                String version = m.group(2);
+                boolean isGoMod = m.group(3) != null;
+                String hash = m.group(4);
+                String key = module + "@" + version;
+                String[] slot = byKey.computeIfAbsent(key, k -> new String[2]);
+                if (isGoMod) {
+                    slot[1] = "h1:" + hash;
+                } else {
+                    slot[0] = "h1:" + hash;
+                }
+            }
+            for (java.util.Map.Entry<String, String[]> e : byKey.entrySet()) {
+                String[] parts = e.getKey().split("@", 2);
+                resolved.add(new ResolvedDependency(parts[0], parts[1], e.getValue()[0], e.getValue()[1]));
+            }
+        } catch (java.io.IOException ignored) {
+            // go.sum read failures are non-fatal — return whatever we collected
+        }
+        return resolved;
+    }
+
+    /**
+     * Strip {@code // ...} comment but leave {@code // indirect} marker intact for require directives.
+     * The caller is expected to further handle the "// indirect" suffix via pattern matching.
+     */
+    private static String stripInlineComment(String line) {
+        int idx = line.indexOf("//");
+        if (idx < 0) {
+            return line;
+        }
+        // Preserve "// indirect" marker for requires
+        String tail = line.substring(idx).trim();
+        if (tail.startsWith("// indirect")) {
+            return line;
+        }
+        String head = line.substring(0, idx);
+        int end = head.length();
+        while (end > 0 && Character.isWhitespace(head.charAt(end - 1))) {
+            end--;
+        }
+        return head.substring(0, end);
+    }
+
+    private static String trimComment(String comment) {
+        String trimmed = comment.trim();
+        if (trimmed.startsWith("//")) {
+            trimmed = trimmed.substring(2).trim();
+        }
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private enum BlockState {
+        NONE, REQUIRE, REPLACE, EXCLUDE, RETRACT
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends Parser.Builder {
+        public Builder() {
+            super(PlainText.class);
+        }
+
+        @Override
+        public GoModParser build() {
+            return new GoModParser();
+        }
+
+        @Override
+        public String getDslName() {
+            return "gomod";
+        }
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/marker/GoResolutionResult.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/marker/GoResolutionResult.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.marker;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import lombok.ToString;
+import lombok.Value;
+import lombok.With;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.rpc.RpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * Metadata parsed from a Go module's go.mod (and optionally go.sum) file.
+ * Attached as a {@link Marker} to a PlainText document representing the go.mod file.
+ * <p>
+ * Mirrors {@link org.openrewrite.javascript.marker.NodeResolutionResult} /
+ * {@link org.openrewrite.python.marker.PythonResolutionResult} for cross-language parity.
+ * <p>
+ * Separates requested dependencies (Require) from resolutions (Resolved):
+ * <ul>
+ *   <li>{@link #requires} — what the module asked for in go.mod</li>
+ *   <li>{@link #resolvedDependencies} — what go.sum recorded (with content hashes)</li>
+ * </ul>
+ * <p>
+ * Replace, exclude, and retract directives are captured as separate lists because
+ * they have distinct semantics (version redirection, version blacklisting, version
+ * self-retraction respectively).
+ */
+@Value
+@With
+public class GoResolutionResult implements Marker, RpcCodec<GoResolutionResult> {
+    UUID id;
+
+    /**
+     * Module import path from the {@code module} directive, e.g. {@code github.com/foo/bar}.
+     */
+    @ToString.Include
+    String modulePath;
+
+    /**
+     * Toolchain version from the {@code go} directive, e.g. {@code "1.21"}.
+     */
+    @ToString.Include
+    @Nullable String goVersion;
+
+    /**
+     * Minimum toolchain version from the {@code toolchain} directive, e.g. {@code "go1.22.0"}.
+     */
+    @Nullable String toolchain;
+
+    /**
+     * Absolute or repo-relative path to the go.mod file.
+     */
+    @ToString.Include
+    String path;
+
+    /**
+     * Direct requires from {@code require} directives. Includes both {@code require foo v1}
+     * and items from {@code require ( ... )} blocks. Indirect requires are flagged on {@link Require#indirect}.
+     */
+    List<Require> requires;
+
+    /**
+     * Replace directives: {@code replace old => new} or {@code replace old v1 => new v2}.
+     */
+    List<Replace> replaces;
+
+    /**
+     * Exclude directives: {@code exclude foo v1} — blacklists a specific version.
+     */
+    List<Exclude> excludes;
+
+    /**
+     * Retract directives: {@code retract v1.0.0} or {@code retract [v1.0.0, v1.1.0]} — module
+     * self-retraction of buggy published versions.
+     */
+    List<Retract> retracts;
+
+    /**
+     * Transitive resolutions from go.sum. Each module version appears once with its content hash.
+     */
+    List<ResolvedDependency> resolvedDependencies;
+
+    public @Nullable Require findRequire(String module) {
+        for (Require r : requires) {
+            if (r.getModulePath().equals(module)) {
+                return r;
+            }
+        }
+        return null;
+    }
+
+    public @Nullable ResolvedDependency findResolved(String module) {
+        for (ResolvedDependency rd : resolvedDependencies) {
+            if (rd.getModulePath().equals(module)) {
+                return rd;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void rpcSend(GoResolutionResult after, RpcSendQueue q) {
+        q.getAndSend(after, GoResolutionResult::getId);
+        q.getAndSend(after, GoResolutionResult::getModulePath);
+        q.getAndSend(after, GoResolutionResult::getGoVersion);
+        q.getAndSend(after, GoResolutionResult::getToolchain);
+        q.getAndSend(after, GoResolutionResult::getPath);
+        q.getAndSendListAsRef(after, r -> r.getRequires() != null ? r.getRequires() : emptyList(),
+                req -> req.getModulePath() + "@" + req.getVersion(),
+                req -> req.rpcSend(req, q));
+        q.getAndSendListAsRef(after, r -> r.getReplaces() != null ? r.getReplaces() : emptyList(),
+                rep -> rep.getOldPath() + "@" + rep.getOldVersion() + "=>" + rep.getNewPath() + "@" + rep.getNewVersion(),
+                rep -> rep.rpcSend(rep, q));
+        q.getAndSendListAsRef(after, r -> r.getExcludes() != null ? r.getExcludes() : emptyList(),
+                exc -> exc.getModulePath() + "@" + exc.getVersion(),
+                exc -> exc.rpcSend(exc, q));
+        q.getAndSendListAsRef(after, r -> r.getRetracts() != null ? r.getRetracts() : emptyList(),
+                ret -> ret.getVersionRange(),
+                ret -> ret.rpcSend(ret, q));
+        q.getAndSendListAsRef(after, r -> r.getResolvedDependencies() != null ? r.getResolvedDependencies() : emptyList(),
+                rd -> rd.getModulePath() + "@" + rd.getVersion(),
+                rd -> rd.rpcSend(rd, q));
+    }
+
+    @Override
+    public GoResolutionResult rpcReceive(GoResolutionResult before, RpcReceiveQueue q) {
+        return before
+                .withId(q.receiveAndGet(before.id, UUID::fromString))
+                .withModulePath(q.receive(before.modulePath))
+                .withGoVersion(q.receive(before.goVersion))
+                .withToolchain(q.receive(before.toolchain))
+                .withPath(q.receive(before.path))
+                .withRequires(q.receiveList(before.requires, r -> r.rpcReceive(r, q)))
+                .withReplaces(q.receiveList(before.replaces, r -> r.rpcReceive(r, q)))
+                .withExcludes(q.receiveList(before.excludes, r -> r.rpcReceive(r, q)))
+                .withRetracts(q.receiveList(before.retracts, r -> r.rpcReceive(r, q)))
+                .withResolvedDependencies(q.receiveList(before.resolvedDependencies, r -> r.rpcReceive(r, q)));
+    }
+
+    /**
+     * A {@code require} directive entry.
+     */
+    @Value
+    @With
+    @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
+    public static class Require implements RpcCodec<Require> {
+        String modulePath;
+        String version;
+        /**
+         * True if marked {@code // indirect} — brought in transitively, not directly imported by this module.
+         */
+        boolean indirect;
+
+        @Override
+        public void rpcSend(Require after, RpcSendQueue q) {
+            q.getAndSend(after, Require::getModulePath);
+            q.getAndSend(after, Require::getVersion);
+            q.getAndSend(after, Require::isIndirect);
+        }
+
+        @Override
+        public Require rpcReceive(Require before, RpcReceiveQueue q) {
+            return before
+                    .withModulePath(q.receive(before.modulePath))
+                    .withVersion(q.receive(before.version))
+                    .withIndirect(q.receive(before.indirect));
+        }
+    }
+
+    /**
+     * A {@code replace} directive, e.g. {@code replace github.com/old => github.com/new v1.2.3}
+     * or {@code replace github.com/old v1.0.0 => ../local/path}.
+     */
+    @Value
+    @With
+    @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
+    public static class Replace implements RpcCodec<Replace> {
+        String oldPath;
+        /** Null when the replace targets all versions of oldPath. */
+        @Nullable String oldVersion;
+        String newPath;
+        /** Null when newPath is a local filesystem path (no version). */
+        @Nullable String newVersion;
+
+        @Override
+        public void rpcSend(Replace after, RpcSendQueue q) {
+            q.getAndSend(after, Replace::getOldPath);
+            q.getAndSend(after, Replace::getOldVersion);
+            q.getAndSend(after, Replace::getNewPath);
+            q.getAndSend(after, Replace::getNewVersion);
+        }
+
+        @Override
+        public Replace rpcReceive(Replace before, RpcReceiveQueue q) {
+            return before
+                    .withOldPath(q.receive(before.oldPath))
+                    .withOldVersion(q.receive(before.oldVersion))
+                    .withNewPath(q.receive(before.newPath))
+                    .withNewVersion(q.receive(before.newVersion));
+        }
+    }
+
+    /**
+     * An {@code exclude} directive — blacklists a specific version from resolution.
+     */
+    @Value
+    @With
+    @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
+    public static class Exclude implements RpcCodec<Exclude> {
+        String modulePath;
+        String version;
+
+        @Override
+        public void rpcSend(Exclude after, RpcSendQueue q) {
+            q.getAndSend(after, Exclude::getModulePath);
+            q.getAndSend(after, Exclude::getVersion);
+        }
+
+        @Override
+        public Exclude rpcReceive(Exclude before, RpcReceiveQueue q) {
+            return before
+                    .withModulePath(q.receive(before.modulePath))
+                    .withVersion(q.receive(before.version));
+        }
+    }
+
+    /**
+     * A {@code retract} directive. Either a single version or a range like {@code [v1.0.0, v1.1.0]}.
+     */
+    @Value
+    @With
+    @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
+    public static class Retract implements RpcCodec<Retract> {
+        /** Raw range expression as written in go.mod, e.g. {@code "v1.0.0"} or {@code "[v1.0.0, v1.1.0]"}. */
+        String versionRange;
+        /** Optional rationale from a {@code // ...} comment on the retract line. */
+        @Nullable String rationale;
+
+        @Override
+        public void rpcSend(Retract after, RpcSendQueue q) {
+            q.getAndSend(after, Retract::getVersionRange);
+            q.getAndSend(after, Retract::getRationale);
+        }
+
+        @Override
+        public Retract rpcReceive(Retract before, RpcReceiveQueue q) {
+            return before
+                    .withVersionRange(q.receive(before.versionRange))
+                    .withRationale(q.receive(before.rationale));
+        }
+    }
+
+    /**
+     * A resolved dependency from go.sum. Each module version appears once with its content hash.
+     */
+    @Value
+    @With
+    @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
+    public static class ResolvedDependency implements RpcCodec<ResolvedDependency> {
+        @ToString.Include
+        String modulePath;
+
+        @ToString.Include
+        String version;
+
+        /**
+         * Module zip hash from go.sum (e.g. {@code h1:abc123...}). Null when only the go.mod hash is recorded.
+         */
+        @Nullable String moduleHash;
+
+        /**
+         * Hash of this module's own go.mod file from go.sum. Null when unavailable.
+         */
+        @Nullable String goModHash;
+
+        @Override
+        public void rpcSend(ResolvedDependency after, RpcSendQueue q) {
+            q.getAndSend(after, ResolvedDependency::getModulePath);
+            q.getAndSend(after, ResolvedDependency::getVersion);
+            q.getAndSend(after, ResolvedDependency::getModuleHash);
+            q.getAndSend(after, ResolvedDependency::getGoModHash);
+        }
+
+        @Override
+        public ResolvedDependency rpcReceive(ResolvedDependency before, RpcReceiveQueue q) {
+            return before
+                    .withModulePath(q.receive(before.modulePath))
+                    .withVersion(q.receive(before.version))
+                    .withModuleHash(q.receive(before.moduleHash))
+                    .withGoModHash(q.receive(before.goModHash));
+        }
+    }
+}

--- a/rewrite-go/src/test/java/org/openrewrite/golang/GoModParserTest.java
+++ b/rewrite-go/src/test/java/org/openrewrite/golang/GoModParserTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.golang.marker.GoResolutionResult;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.text.PlainText;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.golang.Assertions.goMod;
+
+class GoModParserTest implements RewriteTest {
+
+    @Test
+    void moduleAndGoDirective() {
+        rewriteRun(
+                goMod(
+                        """
+                                module github.com/foo/bar
+
+                                go 1.21
+                                """,
+                        spec -> spec.afterRecipe(doc -> {
+                            GoResolutionResult marker = extractMarker(doc);
+                            assertThat(marker.getModulePath()).isEqualTo("github.com/foo/bar");
+                            assertThat(marker.getGoVersion()).isEqualTo("1.21");
+                            assertThat(marker.getToolchain()).isNull();
+                            assertThat(marker.getRequires()).isEmpty();
+                        })
+                )
+        );
+    }
+
+    @Test
+    void toolchainDirective() {
+        rewriteRun(
+                goMod(
+                        """
+                                module example.com/m
+
+                                go 1.22
+
+                                toolchain go1.22.0
+                                """,
+                        spec -> spec.afterRecipe(doc -> {
+                            GoResolutionResult marker = extractMarker(doc);
+                            assertThat(marker.getToolchain()).isEqualTo("go1.22.0");
+                        })
+                )
+        );
+    }
+
+    @Test
+    void requireSingleLine() {
+        rewriteRun(
+                goMod(
+                        """
+                                module example.com/m
+
+                                go 1.21
+
+                                require github.com/stretchr/testify v1.8.0
+                                """,
+                        spec -> spec.afterRecipe(doc -> {
+                            GoResolutionResult marker = extractMarker(doc);
+                            assertThat(marker.getRequires()).hasSize(1);
+                            GoResolutionResult.Require r = marker.getRequires().getFirst();
+                            assertThat(r.getModulePath()).isEqualTo("github.com/stretchr/testify");
+                            assertThat(r.getVersion()).isEqualTo("v1.8.0");
+                            assertThat(r.isIndirect()).isFalse();
+                        })
+                )
+        );
+    }
+
+    @Test
+    void requireBlockWithIndirect() {
+        rewriteRun(
+                goMod(
+                        """
+                                module example.com/m
+
+                                go 1.21
+
+                                require (
+                                	github.com/foo/bar v1.0.0
+                                	github.com/baz/qux v2.1.3 // indirect
+                                )
+                                """,
+                        spec -> spec.afterRecipe(doc -> {
+                            GoResolutionResult marker = extractMarker(doc);
+                            assertThat(marker.getRequires()).hasSize(2);
+
+                            GoResolutionResult.Require r1 = marker.getRequires().get(0);
+                            assertThat(r1.getModulePath()).isEqualTo("github.com/foo/bar");
+                            assertThat(r1.getVersion()).isEqualTo("v1.0.0");
+                            assertThat(r1.isIndirect()).isFalse();
+
+                            GoResolutionResult.Require r2 = marker.getRequires().get(1);
+                            assertThat(r2.getModulePath()).isEqualTo("github.com/baz/qux");
+                            assertThat(r2.getVersion()).isEqualTo("v2.1.3");
+                            assertThat(r2.isIndirect()).isTrue();
+                        })
+                )
+        );
+    }
+
+    @Test
+    void replaceSingleLine() {
+        rewriteRun(
+                goMod(
+                        """
+                                module example.com/m
+
+                                go 1.21
+
+                                replace github.com/old/mod => github.com/new/mod v1.2.3
+                                """,
+                        spec -> spec.afterRecipe(doc -> {
+                            GoResolutionResult marker = extractMarker(doc);
+                            assertThat(marker.getReplaces()).hasSize(1);
+                            GoResolutionResult.Replace rep = marker.getReplaces().getFirst();
+                            assertThat(rep.getOldPath()).isEqualTo("github.com/old/mod");
+                            assertThat(rep.getOldVersion()).isNull();
+                            assertThat(rep.getNewPath()).isEqualTo("github.com/new/mod");
+                            assertThat(rep.getNewVersion()).isEqualTo("v1.2.3");
+                        })
+                )
+        );
+    }
+
+    @Test
+    void replaceWithLocalPath() {
+        rewriteRun(
+                goMod(
+                        """
+                                module example.com/m
+
+                                go 1.21
+
+                                replace github.com/old/mod v1.0.0 => ../local/path
+                                """,
+                        spec -> spec.afterRecipe(doc -> {
+                            GoResolutionResult marker = extractMarker(doc);
+                            assertThat(marker.getReplaces()).hasSize(1);
+                            GoResolutionResult.Replace rep = marker.getReplaces().getFirst();
+                            assertThat(rep.getOldPath()).isEqualTo("github.com/old/mod");
+                            assertThat(rep.getOldVersion()).isEqualTo("v1.0.0");
+                            assertThat(rep.getNewPath()).isEqualTo("../local/path");
+                            assertThat(rep.getNewVersion()).isNull();
+                        })
+                )
+        );
+    }
+
+    @Test
+    void excludeDirective() {
+        rewriteRun(
+                goMod(
+                        """
+                                module example.com/m
+
+                                go 1.21
+
+                                exclude github.com/bad/pkg v1.2.3
+                                """,
+                        spec -> spec.afterRecipe(doc -> {
+                            GoResolutionResult marker = extractMarker(doc);
+                            assertThat(marker.getExcludes()).hasSize(1);
+                            GoResolutionResult.Exclude exc = marker.getExcludes().getFirst();
+                            assertThat(exc.getModulePath()).isEqualTo("github.com/bad/pkg");
+                            assertThat(exc.getVersion()).isEqualTo("v1.2.3");
+                        })
+                )
+        );
+    }
+
+    @Test
+    void retractWithRationale() {
+        rewriteRun(
+                goMod(
+                        """
+                                module example.com/m
+
+                                go 1.21
+
+                                retract v1.0.0 // buggy release
+                                retract [v1.1.0, v1.1.5]
+                                """,
+                        spec -> spec.afterRecipe(doc -> {
+                            GoResolutionResult marker = extractMarker(doc);
+                            assertThat(marker.getRetracts()).hasSize(2);
+
+                            GoResolutionResult.Retract r1 = marker.getRetracts().get(0);
+                            assertThat(r1.getVersionRange()).isEqualTo("v1.0.0");
+                            assertThat(r1.getRationale()).isEqualTo("buggy release");
+
+                            GoResolutionResult.Retract r2 = marker.getRetracts().get(1);
+                            assertThat(r2.getVersionRange()).isEqualTo("[v1.1.0, v1.1.5]");
+                            assertThat(r2.getRationale()).isNull();
+                        })
+                )
+        );
+    }
+
+    @Test
+    void replaceBlock() {
+        rewriteRun(
+                goMod(
+                        """
+                                module example.com/m
+
+                                go 1.21
+
+                                replace (
+                                	github.com/a/a => github.com/fork/a v1.0.0
+                                	github.com/b/b v2.0.0 => ../b-local
+                                )
+                                """,
+                        spec -> spec.afterRecipe(doc -> {
+                            GoResolutionResult marker = extractMarker(doc);
+                            assertThat(marker.getReplaces()).hasSize(2);
+
+                            GoResolutionResult.Replace r1 = marker.getReplaces().get(0);
+                            assertThat(r1.getOldPath()).isEqualTo("github.com/a/a");
+                            assertThat(r1.getOldVersion()).isNull();
+                            assertThat(r1.getNewPath()).isEqualTo("github.com/fork/a");
+                            assertThat(r1.getNewVersion()).isEqualTo("v1.0.0");
+
+                            GoResolutionResult.Replace r2 = marker.getReplaces().get(1);
+                            assertThat(r2.getOldPath()).isEqualTo("github.com/b/b");
+                            assertThat(r2.getOldVersion()).isEqualTo("v2.0.0");
+                            assertThat(r2.getNewPath()).isEqualTo("../b-local");
+                            assertThat(r2.getNewVersion()).isNull();
+                        })
+                )
+        );
+    }
+
+    @Test
+    void noModuleDirectiveProducesNoMarker() {
+        rewriteRun(
+                goMod(
+                        """
+                                go 1.21
+                                """,
+                        spec -> spec.afterRecipe(doc -> {
+                            assertThat(doc.getMarkers().findFirst(GoResolutionResult.class)).isEmpty();
+                        })
+                )
+        );
+    }
+
+    @Test
+    void commentsDoNotBreakParsing() {
+        rewriteRun(
+                goMod(
+                        """
+                                // top-level comment
+                                module example.com/m  // module comment
+
+                                go 1.21  // toolchain pin
+
+                                // list of deps
+                                require (
+                                	// important dep
+                                	github.com/foo/bar v1.0.0
+                                	github.com/baz/qux v2.0.0 // indirect
+                                )
+                                """,
+                        spec -> spec.afterRecipe(doc -> {
+                            GoResolutionResult marker = extractMarker(doc);
+                            assertThat(marker.getModulePath()).isEqualTo("example.com/m");
+                            assertThat(marker.getGoVersion()).isEqualTo("1.21");
+                            assertThat(marker.getRequires()).hasSize(2);
+                        })
+                )
+        );
+    }
+
+    private static GoResolutionResult extractMarker(PlainText doc) {
+        List<GoResolutionResult> found = doc.getMarkers().findAll(GoResolutionResult.class);
+        assertThat(found).as("GoResolutionResult marker").hasSize(1);
+        return found.getFirst();
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces `GoModParser` — parses `go.mod` into a `PlainText` document with an attached `GoResolutionResult` marker carrying structured module metadata.
- The marker captures `module`, `go`, `toolchain`, `require` (with `// indirect` flag), `replace` (local paths and pinned versions), `exclude`, `retract` (with rationale comments), and resolved dependency hashes from a sibling `go.sum`.
- Mirrors `NodeResolutionResult` (rewrite-javascript) and `PythonResolutionResult` (rewrite-python), giving Go-targeted recipes parity on how they query project metadata.
- Adds `Assertions.goMod(...)` test helpers.

## Motivation
Enables downstream tooling (e.g. Moderne Prethink's Go support) to extract Go module and dependency information from `go.mod` without having to re-parse it in every recipe.

## Test plan
- [x] 11 new unit tests in `GoModParserTest` exercising module/go/toolchain directives, single-line and block forms of `require`/`replace`/`exclude`/`retract`, local-path replacements, indirect markers, retract rationale, and comments — all pass.
- [x] Existing `rewrite-go` tests continue to pass.