### PR TITLE
Fix/change method target to static constructor wildcard

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodTargetToStaticTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodTargetToStaticTest.java
@@ -463,7 +463,7 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
             """
               import a.A;
               import b.B;
-
+              
               class C {
                  public void test() {
                      A a = new A();

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodTargetToStaticTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodTargetToStaticTest.java
@@ -427,6 +427,54 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
         );
     }
 
+    @Test
+    void constructorNotChangedWhenMethodPatternIsWildcard() {
+        rewriteRun(
+          spec -> spec.recipe(
+            new ChangeMethodTargetToStatic("a.A *(..)", "b.B", null, null, false)
+          ),
+          java(
+            """
+              package a;
+              public class A {
+                 public A() {}
+                 public void doSomething() {}
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              public class B {
+                 public static void doSomething() {}
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+              class C {
+                 public void test() {
+                     A a = new A();
+                     a.doSomething();
+                 }
+              }
+              """,
+            """
+              import a.A;
+              import b.B;
+
+              class C {
+                 public void test() {
+                     A a = new A();
+                     B.doSomething();
+                 }
+              }
+              """
+          )
+        );
+    }
+
     @Disabled
     @Issue("https://github.com/openrewrite/rewrite/issues/3085")
     @SuppressWarnings("ResultOfMethodCallIgnored")

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
@@ -202,6 +202,9 @@ public class ChangeMethodTargetToStatic extends Recipe {
             if (n.getBody() != null || n.getEnclosing() != null) {
                 return n;
             }
+            if (!methodPattern.contains("<constructor>") && !methodPattern.contains("<init>")) {
+                return n;
+            }
             if (methodMatcher.matches(n)) {
                 String methodName;
                 JavaType.Method transformedType = null;


### PR DESCRIPTION
## What's changed?

Added a guard clause to `ChangeMethodTargetToStatic.visitNewClass` so it only transforms constructors into static method calls when the method pattern explicitly targets a constructor (e.g., using `<constructor>` or `<init>`).

## What's your motivation?

This fixes a bug where `ChangeMethodTargetToStatic` was incorrectly matching and transforming all `new` object creations when provided with a broad wildcard method pattern like `*(..)`. This broke declarative recipes that used wildcards to match all methods on a class.

## Anything in particular you'd like reviewers to focus on?

- The fix ensures that the "Replace Constructor with Factory Method" refactoring use case (Issue #1804) still works, while preventing unintended side effects on wildcard matches.

## Have you considered any alternatives or workarounds?
An alternative would be changing `MethodMatcher` itself so that the `*` wildcard does not match `<init>`, but that would be a much larger breaking change to core matching behavior that has been in place since 2022.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
