### PR TITLE
Scala: handling optional semicolons

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -30,9 +30,11 @@ import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeTree;
+import org.openrewrite.marker.Marker;
 import org.openrewrite.scala.marker.BlockArgument;
 import org.openrewrite.scala.marker.IndentedBlock;
 import org.openrewrite.scala.marker.SObject;
+import org.openrewrite.scala.marker.Semicolon;
 import org.openrewrite.scala.marker.TypeProjection;
 import org.openrewrite.scala.marker.ScalaForLoop;
 import org.openrewrite.scala.marker.TypeAscription;
@@ -436,11 +438,18 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
 
     @Override
     protected void printStatementTerminator(Statement s, PrintOutputCapture<P> p) {
-        // In Scala, semicolons are optional and generally not used
-        // Only print them if they were explicitly in the source
-        // For now, we'll skip semicolons entirely as proper semicolon preservation
-        // would require tracking whether they were present in the original source
+        // In Scala, semicolons are optional. An explicit ';' found in the source
+        // is preserved via a Semicolon marker on the JRightPadded and emitted by
+        // visitMarker below. No default terminator is printed here.
         return;
+    }
+
+    @Override
+    public <M extends Marker> M visitMarker(Marker marker, PrintOutputCapture<P> p) {
+        if (marker instanceof Semicolon) {
+            p.append(';');
+        }
+        return super.visitMarker(marker, p);
     }
     
     /**

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/Semicolon.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/Semicolon.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.marker;
+
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Marks a statement that was followed by an explicit {@code ;} separator in
+ * the source. Scala semicolons are optional; this marker preserves them for
+ * round-trip printing when they are present (e.g. multiple statements on the
+ * same line: {@code a = 1; b = 2}).
+ */
+public class Semicolon implements Marker {
+    private final UUID id;
+
+    public Semicolon(UUID id) {
+        this.id = id;
+    }
+
+    @Override
+    public UUID getId() {
+        return id;
+    }
+
+    @Override
+    public Semicolon withId(UUID id) {
+        return new Semicolon(id);
+    }
+}

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -30,6 +30,7 @@ import org.openrewrite.scala.marker.LambdaParameter
 import org.openrewrite.scala.marker.IndentedBlock
 import org.openrewrite.scala.marker.OmitBraces
 import org.openrewrite.scala.marker.SObject
+import org.openrewrite.scala.marker.Semicolon
 import org.openrewrite.scala.marker.TypeProjection
 import org.openrewrite.scala.marker.ScalaForLoop
 import org.openrewrite.scala.marker.BlockArgument
@@ -3625,13 +3626,35 @@ class ScalaTreeVisitor(
           }
           
           var trailingSpace = Space.EMPTY
+          var rpMarkers = Markers.EMPTY
           val trailStart = Math.max(statEnd, cursor)
           if (trailStart < nextStart && nextStart <= source.length) {
-            trailingSpace = Space.format(source.substring(trailStart, nextStart))
-            cursor = nextStart
+            val between = source.substring(trailStart, nextStart)
+            // An explicit ';' separator appears before any newline and with only
+            // horizontal whitespace between it and the preceding statement.
+            val semiIdx = {
+              var idx = -1
+              var j = 0
+              while (idx < 0 && j < between.length) {
+                val c = between.charAt(j)
+                if (c == ';') idx = j
+                else if (c == '\n' || c == '\r') j = between.length
+                else if (c != ' ' && c != '\t') j = between.length
+                else j += 1
+              }
+              idx
+            }
+            if (semiIdx >= 0) {
+              trailingSpace = if (semiIdx > 0) Space.format(between.substring(0, semiIdx)) else Space.EMPTY
+              rpMarkers = Markers.EMPTY.add(new Semicolon(UUID.randomUUID()))
+              cursor = trailStart + semiIdx + 1
+            } else {
+              trailingSpace = Space.format(between)
+              cursor = nextStart
+            }
           }
-          
-          statements.add(JRightPadded.build(stmt).withAfter(trailingSpace))
+
+          statements.add(new JRightPadded[Statement](stmt, trailingSpace, rpMarkers))
         case _ => // Skip non-statement nodes
       }
     }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/BlockTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/BlockTest.java
@@ -84,4 +84,21 @@ class BlockTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void multipleStatementsSeparatedBySemicolon() {
+        rewriteRun(
+            scala(
+                """
+                class C {
+                  var a = 0
+                  var b = 0
+                  def f(): Unit = {
+                    a = 1; b = 2
+                  }
+                }
+                """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Amending the Scala parser to handle semicolons, which are optional, but allowed in Scala.

Modelling it after what we have for Kotlin and/or TypeScript. A marker called `Semicolon` attached to the right-padded statement.

## What's your motivation?

Currently code with semicolons fails the idempotency test.