### PR TITLE
Scala: introduce `S.FunctionCall` to model non-MethodInvocation function calls

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -500,6 +500,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return visitTypeAlias((S.TypeAlias) tree, p);
         } else if (tree instanceof S.PatternDefinition) {
             return visitPatternDefinition((S.PatternDefinition) tree, p);
+        } else if (tree instanceof S.FunctionCall) {
+            return visitFunctionCall((S.FunctionCall) tree, p);
         }
         return super.visit(tree, p);
     }
@@ -892,6 +894,22 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         visit(typeAscription.getTypeTree(), p);
         afterSyntax(typeAscription, p);
         return typeAscription;
+    }
+
+    public J visitFunctionCall(S.FunctionCall fc, PrintOutputCapture<P> p) {
+        beforeSyntax(fc, Space.Location.LANGUAGE_EXTENSION, p);
+        visitRightPadded(fc.getPadding().getFunction(), JRightPadded.Location.LANGUAGE_EXTENSION, "", p);
+        if (fc.getMarkers().findFirst(BlockArgument.class).isPresent()) {
+            // Trailing block argument: `foo(1) { ... }`. The block prints its own braces,
+            // so we skip the parentheses and delimiters entirely.
+            for (Expression arg : fc.getArguments()) {
+                visit(arg, p);
+            }
+        } else {
+            visitContainer("(", fc.getPadding().getArguments(), JContainer.Location.METHOD_INVOCATION_ARGUMENTS, ",", ")", p);
+        }
+        afterSyntax(fc, p);
+        return fc;
     }
 
     @Override

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -155,4 +155,13 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         pd = pd.withMarkers(visitMarkers(pd.getMarkers(), p));
         return pd;
     }
+
+    public J visitFunctionCall(S.FunctionCall functionCall, P p) {
+        S.FunctionCall f = functionCall;
+        f = f.withPrefix(visitSpace(f.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        f = f.withMarkers(visitMarkers(f.getMarkers(), p));
+        f = f.getPadding().withFunction(visitRightPadded(f.getPadding().getFunction(), JRightPadded.Location.LANGUAGE_EXTENSION, p));
+        f = f.getPadding().withArguments(visitContainer(f.getPadding().getArguments(), JContainer.Location.METHOD_INVOCATION_ARGUMENTS, p));
+        return f;
+    }
 }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -673,4 +673,126 @@ public interface S extends J {
             return new CoordinateBuilder.Statement(this);
         }
     }
+
+    /**
+     * Represents a function call where the callee is itself an expression rather than a simple
+     * method select. Used for Scala forms that are not adequately modelled by
+     * {@link J.MethodInvocation}, such as curried application of another application's result:
+     * <pre>{@code
+     * f(1)(2)
+     * matrix(0)(1)
+     * Array.fill(5)(0)
+     * }</pre>
+     * Mirrors the {@code JS.FunctionCall} concept in rewrite-javascript.
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class FunctionCall implements S, Expression, Statement, TypedTree {
+
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @With
+        @EqualsAndHashCode.Include
+        @Getter
+        UUID id;
+
+        @With
+        @Getter
+        Space prefix;
+
+        @With
+        @Getter
+        Markers markers;
+
+        JRightPadded<Expression> function;
+
+        public Expression getFunction() {
+            return function.getElement();
+        }
+
+        public S.FunctionCall withFunction(Expression function) {
+            return getPadding().withFunction(JRightPadded.withElement(this.function, function));
+        }
+
+        JContainer<Expression> arguments;
+
+        public List<Expression> getArguments() {
+            return arguments.getElements();
+        }
+
+        public S.FunctionCall withArguments(List<Expression> arguments) {
+            return getPadding().withArguments(JContainer.withElements(this.arguments, arguments));
+        }
+
+        @With
+        @Getter
+        JavaType.@Nullable Method methodType;
+
+        public static FunctionCall build(UUID id, Space prefix, Markers markers,
+                                         JRightPadded<Expression> function,
+                                         JContainer<Expression> arguments,
+                                         JavaType.@Nullable Method methodType) {
+            return new FunctionCall(null, id, prefix, markers, function, arguments, methodType);
+        }
+
+        @Override
+        public @Nullable JavaType getType() {
+            return methodType == null ? null : methodType.getReturnType();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public S.FunctionCall withType(@Nullable JavaType type) {
+            return this;
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitFunctionCall(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Statement getCoordinates() {
+            return new CoordinateBuilder.Statement(this);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final S.FunctionCall t;
+
+            public JRightPadded<Expression> getFunction() {
+                return t.function;
+            }
+
+            public S.FunctionCall withFunction(JRightPadded<Expression> function) {
+                return t.function == function ? t : new S.FunctionCall(null, t.id, t.prefix, t.markers, function, t.arguments, t.methodType);
+            }
+
+            public JContainer<Expression> getArguments() {
+                return t.arguments;
+            }
+
+            public S.FunctionCall withArguments(JContainer<Expression> arguments) {
+                return t.arguments == arguments ? t : new S.FunctionCall(null, t.id, t.prefix, t.markers, t.function, arguments, t.methodType);
+            }
+        }
+    }
 }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -846,12 +846,111 @@ class ScalaTreeVisitor(
         }
 
       case innerApp: Trees.Apply[?] =>
-        // Curried call: matrix(0)(1), Array.fill(5)(0)
-        // Visit the full expression as source-preserving identifier
-        val text = extractSource(app.span)
-        updateCursor(app.span.end)
-        return new J.Identifier(Tree.randomId(), prefix, Markers.EMPTY,
-          Collections.emptyList(), text, typeFor(app.span), null)
+        // Curried call: f(1)(2), matrix(0)(1), Array.fill(5)(0), foo(1) { in => bar(in) }.
+        // Emit as S.FunctionCall — the function part is the inner Apply as a rich expression,
+        // the outer arg list (parenthesized or brace block) is a JContainer.
+        val fnJ = visitApply(innerApp)
+        val fn: Expression = fnJ match {
+          case e: Expression => e
+          case s: Statement => new S.StatementExpression(Tree.randomId(), s)
+          case _ => cursor = savedCursor; return visitUnknown(app)
+        }
+        val innerEnd = Math.max(0, innerApp.span.end - offsetAdjustment)
+        if (innerEnd > cursor && innerEnd <= source.length) cursor = innerEnd
+
+        // Decide between `(...)` and `{ ... }` outer arg list by looking at the next non-ws char.
+        val firstNonWs = indexOfNextNonWhitespace(cursor)
+        val isOuterBlockArg = firstNonWs < source.length && source.charAt(firstNonWs) == '{'
+
+        val outerArgs = new util.ArrayList[JRightPadded[Expression]]()
+        val argsContainer: JContainer[Expression] = if (isOuterBlockArg) {
+          // Curried call with a trailing block: foo(1) { ... }.
+          // Leave `fn` with no trailing space — the block's own prefix captures the space
+          // between `foo(1)` and `{` when we visit it below.
+          val fnRightPaddedBlock = new JRightPadded[Expression](fn, Space.EMPTY, Markers.EMPTY)
+
+          for (arg <- app.args) {
+            visitTree(arg) match {
+              case expr: Expression =>
+                outerArgs.add(JRightPadded.build(expr))
+              case block: J.Block =>
+                val blockExpr = new S.StatementExpression(Tree.randomId(), block)
+                outerArgs.add(JRightPadded.build(blockExpr.asInstanceOf[Expression]))
+              case other: J =>
+                val wrapped = new S.StatementExpression(Tree.randomId(), other)
+                outerArgs.add(JRightPadded.build(wrapped.asInstanceOf[Expression]))
+              case _ => cursor = savedCursor; return visitUnknown(app)
+            }
+          }
+
+          if (app.span.exists) {
+            val adjustedEnd = Math.max(0, app.span.end - offsetAdjustment)
+            if (adjustedEnd > cursor && adjustedEnd <= source.length) cursor = adjustedEnd
+          }
+          val blockArgMarkers = Markers.build(Collections.singletonList(new BlockArgument(Tree.randomId())))
+          return S.FunctionCall.build(Tree.randomId(), prefix, blockArgMarkers, fnRightPaddedBlock,
+            JContainer.build(Space.EMPTY, outerArgs, Markers.EMPTY),
+            typeFor(app.span) match { case m: JavaType.Method => m; case _ => null })
+        } else {
+          val openParenPos = source.indexOf('(', cursor)
+          val functionAfterSpace = if (openParenPos > cursor) Space.format(source.substring(cursor, openParenPos)) else Space.EMPTY
+          if (openParenPos >= 0) cursor = openParenPos + 1
+
+          for (i <- app.args.indices) {
+            val arg = app.args(i)
+            if (i > 0) {
+              val prevEnd = Math.max(0, app.args(i - 1).span.end - offsetAdjustment)
+              val thisStart = Math.max(0, arg.span.start - offsetAdjustment)
+              if (prevEnd < thisStart && prevEnd >= cursor && thisStart <= source.length) {
+                val between = source.substring(prevEnd, thisStart)
+                val commaIndex = between.indexOf(',')
+                if (commaIndex >= 0) cursor = prevEnd + commaIndex + 1
+              }
+            }
+            visitTree(arg) match {
+              case expr: Expression =>
+                val argEnd = Math.max(0, arg.span.end - offsetAdjustment)
+                val isLastArg = i == app.args.size - 1
+                val afterSpace = if (isLastArg) {
+                  val closePos = source.indexOf(')', Math.max(cursor, argEnd))
+                  if (closePos > argEnd) Space.format(source.substring(argEnd, closePos)) else Space.EMPTY
+                } else Space.EMPTY
+                outerArgs.add(new JRightPadded(expr, afterSpace, Markers.EMPTY))
+              case stmt: Statement =>
+                val stmtExpr = new S.StatementExpression(Tree.randomId(), stmt)
+                val argEnd = Math.max(0, arg.span.end - offsetAdjustment)
+                val isLastArg = i == app.args.size - 1
+                val afterSpace = if (isLastArg) {
+                  val closePos = source.indexOf(')', Math.max(cursor, argEnd))
+                  if (closePos > argEnd) Space.format(source.substring(argEnd, closePos)) else Space.EMPTY
+                } else Space.EMPTY
+                outerArgs.add(new JRightPadded(stmtExpr.asInstanceOf[Expression], afterSpace, Markers.EMPTY))
+              case _ => cursor = savedCursor; return visitUnknown(app)
+            }
+          }
+
+          val container = if (outerArgs.isEmpty) {
+            val closePos = source.indexOf(')', cursor)
+            if (closePos >= 0) cursor = closePos + 1
+            JContainer.build(Space.EMPTY, Collections.emptyList[JRightPadded[Expression]](), Markers.EMPTY)
+          } else {
+            val closeParenPos = source.indexOf(')', cursor)
+            if (closeParenPos >= 0) cursor = closeParenPos + 1
+            JContainer.build(Space.EMPTY, outerArgs, Markers.EMPTY)
+          }
+
+          if (app.span.exists) {
+            val adjustedEnd = Math.max(0, app.span.end - offsetAdjustment)
+            if (adjustedEnd > cursor && adjustedEnd <= source.length) cursor = adjustedEnd
+          }
+
+          val fnRightPadded = new JRightPadded[Expression](fn, functionAfterSpace, Markers.EMPTY)
+          val methodType = typeFor(app.span) match {
+            case m: JavaType.Method => m
+            case _ => null
+          }
+          return S.FunctionCall.build(Tree.randomId(), prefix, Markers.EMPTY, fnRightPadded, container, methodType)
+        }
 
       case _ =>
         // Other function applications — preserve source

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -847,110 +847,59 @@ class ScalaTreeVisitor(
 
       case innerApp: Trees.Apply[?] =>
         // Curried call: f(1)(2), matrix(0)(1), Array.fill(5)(0), foo(1) { in => bar(in) }.
-        // Emit as S.FunctionCall — the function part is the inner Apply as a rich expression,
-        // the outer arg list (parenthesized or brace block) is a JContainer.
-        val fnJ = visitApply(innerApp)
-        val fn: Expression = fnJ match {
+        // Emit as S.FunctionCall — inner Apply is the function, outer arg list is a JContainer.
+        def asExpression(j: J): Expression = j match {
           case e: Expression => e
-          case s: Statement => new S.StatementExpression(Tree.randomId(), s)
-          case _ => cursor = savedCursor; return visitUnknown(app)
+          case _ => new S.StatementExpression(Tree.randomId(), j)
         }
+        def finishAtAppEnd(): Unit = if (app.span.exists) {
+          val adjustedEnd = Math.max(0, app.span.end - offsetAdjustment)
+          if (adjustedEnd > cursor && adjustedEnd <= source.length) cursor = adjustedEnd
+        }
+        val methodType = typeFor(app.span) match { case m: JavaType.Method => m; case _ => null }
+
+        val fn = asExpression(visitApply(innerApp))
         val innerEnd = Math.max(0, innerApp.span.end - offsetAdjustment)
         if (innerEnd > cursor && innerEnd <= source.length) cursor = innerEnd
 
-        // Decide between `(...)` and `{ ... }` outer arg list by looking at the next non-ws char.
+        // Outer arg list is `{ ... }` when next non-ws is `{`, otherwise `(...)`.
         val firstNonWs = indexOfNextNonWhitespace(cursor)
-        val isOuterBlockArg = firstNonWs < source.length && source.charAt(firstNonWs) == '{'
-
         val outerArgs = new util.ArrayList[JRightPadded[Expression]]()
-        val argsContainer: JContainer[Expression] = if (isOuterBlockArg) {
-          // Curried call with a trailing block: foo(1) { ... }.
-          // Leave `fn` with no trailing space — the block's own prefix captures the space
-          // between `foo(1)` and `{` when we visit it below.
-          val fnRightPaddedBlock = new JRightPadded[Expression](fn, Space.EMPTY, Markers.EMPTY)
 
-          for (arg <- app.args) {
-            visitTree(arg) match {
-              case expr: Expression =>
-                outerArgs.add(JRightPadded.build(expr))
-              case block: J.Block =>
-                val blockExpr = new S.StatementExpression(Tree.randomId(), block)
-                outerArgs.add(JRightPadded.build(blockExpr.asInstanceOf[Expression]))
-              case other: J =>
-                val wrapped = new S.StatementExpression(Tree.randomId(), other)
-                outerArgs.add(JRightPadded.build(wrapped.asInstanceOf[Expression]))
-              case _ => cursor = savedCursor; return visitUnknown(app)
-            }
-          }
-
-          if (app.span.exists) {
-            val adjustedEnd = Math.max(0, app.span.end - offsetAdjustment)
-            if (adjustedEnd > cursor && adjustedEnd <= source.length) cursor = adjustedEnd
-          }
-          val blockArgMarkers = Markers.build(Collections.singletonList(new BlockArgument(Tree.randomId())))
-          return S.FunctionCall.build(Tree.randomId(), prefix, blockArgMarkers, fnRightPaddedBlock,
-            JContainer.build(Space.EMPTY, outerArgs, Markers.EMPTY),
-            typeFor(app.span) match { case m: JavaType.Method => m; case _ => null })
-        } else {
-          val openParenPos = source.indexOf('(', cursor)
-          val functionAfterSpace = if (openParenPos > cursor) Space.format(source.substring(cursor, openParenPos)) else Space.EMPTY
-          if (openParenPos >= 0) cursor = openParenPos + 1
-
-          for (i <- app.args.indices) {
-            val arg = app.args(i)
-            if (i > 0) {
-              val prevEnd = Math.max(0, app.args(i - 1).span.end - offsetAdjustment)
-              val thisStart = Math.max(0, arg.span.start - offsetAdjustment)
-              if (prevEnd < thisStart && prevEnd >= cursor && thisStart <= source.length) {
-                val between = source.substring(prevEnd, thisStart)
-                val commaIndex = between.indexOf(',')
-                if (commaIndex >= 0) cursor = prevEnd + commaIndex + 1
-              }
-            }
-            visitTree(arg) match {
-              case expr: Expression =>
-                val argEnd = Math.max(0, arg.span.end - offsetAdjustment)
-                val isLastArg = i == app.args.size - 1
-                val afterSpace = if (isLastArg) {
-                  val closePos = source.indexOf(')', Math.max(cursor, argEnd))
-                  if (closePos > argEnd) Space.format(source.substring(argEnd, closePos)) else Space.EMPTY
-                } else Space.EMPTY
-                outerArgs.add(new JRightPadded(expr, afterSpace, Markers.EMPTY))
-              case stmt: Statement =>
-                val stmtExpr = new S.StatementExpression(Tree.randomId(), stmt)
-                val argEnd = Math.max(0, arg.span.end - offsetAdjustment)
-                val isLastArg = i == app.args.size - 1
-                val afterSpace = if (isLastArg) {
-                  val closePos = source.indexOf(')', Math.max(cursor, argEnd))
-                  if (closePos > argEnd) Space.format(source.substring(argEnd, closePos)) else Space.EMPTY
-                } else Space.EMPTY
-                outerArgs.add(new JRightPadded(stmtExpr.asInstanceOf[Expression], afterSpace, Markers.EMPTY))
-              case _ => cursor = savedCursor; return visitUnknown(app)
-            }
-          }
-
-          val container = if (outerArgs.isEmpty) {
-            val closePos = source.indexOf(')', cursor)
-            if (closePos >= 0) cursor = closePos + 1
-            JContainer.build(Space.EMPTY, Collections.emptyList[JRightPadded[Expression]](), Markers.EMPTY)
-          } else {
-            val closeParenPos = source.indexOf(')', cursor)
-            if (closeParenPos >= 0) cursor = closeParenPos + 1
-            JContainer.build(Space.EMPTY, outerArgs, Markers.EMPTY)
-          }
-
-          if (app.span.exists) {
-            val adjustedEnd = Math.max(0, app.span.end - offsetAdjustment)
-            if (adjustedEnd > cursor && adjustedEnd <= source.length) cursor = adjustedEnd
-          }
-
-          val fnRightPadded = new JRightPadded[Expression](fn, functionAfterSpace, Markers.EMPTY)
-          val methodType = typeFor(app.span) match {
-            case m: JavaType.Method => m
-            case _ => null
-          }
-          return S.FunctionCall.build(Tree.randomId(), prefix, Markers.EMPTY, fnRightPadded, container, methodType)
+        if (firstNonWs < source.length && source.charAt(firstNonWs) == '{') {
+          // Block's own prefix captures the space between `)` and `{`, so leave fn's after-space empty.
+          for (arg <- app.args) outerArgs.add(JRightPadded.build(asExpression(visitTree(arg))))
+          finishAtAppEnd()
+          val markers = Markers.build(Collections.singletonList(new BlockArgument(Tree.randomId())))
+          return S.FunctionCall.build(Tree.randomId(), prefix, markers,
+            JRightPadded.build(fn), JContainer.build(Space.EMPTY, outerArgs, Markers.EMPTY), methodType)
         }
+
+        val functionAfterSpace = if (firstNonWs > cursor) Space.format(source.substring(cursor, firstNonWs)) else Space.EMPTY
+        if (firstNonWs < source.length) cursor = firstNonWs + 1 // past `(`
+
+        for (i <- app.args.indices) {
+          val arg = app.args(i)
+          if (i > 0) {
+            val prevEnd = Math.max(0, app.args(i - 1).span.end - offsetAdjustment)
+            val commaIndex = source.indexOf(',', prevEnd)
+            if (commaIndex >= cursor) cursor = commaIndex + 1
+          }
+          val argExpr = asExpression(visitTree(arg))
+          val afterSpace = if (i == app.args.size - 1) {
+            val argEnd = Math.max(0, arg.span.end - offsetAdjustment)
+            val closePos = source.indexOf(')', Math.max(cursor, argEnd))
+            if (closePos > argEnd) Space.format(source.substring(argEnd, closePos)) else Space.EMPTY
+          } else Space.EMPTY
+          outerArgs.add(new JRightPadded(argExpr, afterSpace, Markers.EMPTY))
+        }
+
+        val closeParen = source.indexOf(')', cursor)
+        if (closeParen >= 0) cursor = closeParen + 1
+        finishAtAppEnd()
+        return S.FunctionCall.build(Tree.randomId(), prefix, Markers.EMPTY,
+          new JRightPadded(fn, functionAfterSpace, Markers.EMPTY),
+          JContainer.build(Space.EMPTY, outerArgs, Markers.EMPTY), methodType)
 
       case _ =>
         // Other function applications — preserve source

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
@@ -255,4 +255,18 @@ class MethodInvocationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void curriedCall() {
+        rewriteRun(
+          scala(
+            """
+              class Test {
+                def f(x: Int)(y: Int): Int = x + y
+                f(1)(2)
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Introducing `S.FunctionCall` LST element modelled after `JS.FunctionCall`.
It handles these function calls in Scala code, which are not method invocations. Java doesn't allow for such syntax. Scala does.

## What's your motivation?

Fix broken parsing. Currently results in idempotency issues.