### PR TITLE
Scala: model partial functions with short match syntax

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -36,6 +36,7 @@ import org.openrewrite.scala.marker.SObject;
 import org.openrewrite.scala.marker.TypeProjection;
 import org.openrewrite.scala.marker.ScalaForLoop;
 import org.openrewrite.scala.marker.TypeAscription;
+import org.openrewrite.scala.marker.PartialFunctionLiteral;
 import org.openrewrite.scala.marker.UnderscorePlaceholderLambda;
 import org.openrewrite.scala.tree.S;
 
@@ -1223,12 +1224,26 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
     
     public J visitLambda(J.Lambda lambda, PrintOutputCapture<P> p) {
         beforeSyntax(lambda, Space.Location.LAMBDA_PREFIX, p);
-        
+
         // Check if this is an underscore placeholder lambda
         if (lambda.getMarkers().findFirst(UnderscorePlaceholderLambda.class).isPresent()) {
             // For underscore placeholder lambdas, just print the body
             // The underscores in the body will be printed as S.Wildcard
             visit(lambda.getBody(), p);
+            afterSyntax(lambda, p);
+            return lambda;
+        }
+
+        // Partial-function literal `{ case pat => ... }` — the body is a J.Block of J.Case.
+        if (lambda.getMarkers().findFirst(PartialFunctionLiteral.class).isPresent() &&
+                lambda.getBody() instanceof J.Block) {
+            J.Block cases = (J.Block) lambda.getBody();
+            p.append('{');
+            for (Statement caseStmt : cases.getStatements()) {
+                visit(caseStmt, p);
+            }
+            visitSpace(cases.getEnd(), Space.Location.BLOCK_END, p);
+            p.append('}');
             afterSyntax(lambda, p);
             return lambda;
         }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/PartialFunctionLiteral.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/PartialFunctionLiteral.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.marker;
+
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Marker for a partial-function literal: {@code { case pat => ... }}.
+ * Modeled as a {@link org.openrewrite.java.tree.J.Lambda} with no declared parameters
+ * whose body holds the case clauses. The printer uses this marker to emit the
+ * {@code { case ... => ... }} form instead of the desugared lambda shape.
+ */
+public class PartialFunctionLiteral implements Marker {
+    private final UUID id;
+
+    public PartialFunctionLiteral(UUID id) {
+        this.id = id;
+    }
+
+    @Override
+    public UUID getId() {
+        return id;
+    }
+
+    @Override
+    public PartialFunctionLiteral withId(UUID id) {
+        return new PartialFunctionLiteral(id);
+    }
+}

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -35,6 +35,7 @@ import org.openrewrite.scala.marker.ScalaForLoop
 import org.openrewrite.scala.marker.BlockArgument
 import org.openrewrite.scala.marker.TypeAscription
 import org.openrewrite.scala.marker.UnderscorePlaceholderLambda
+import org.openrewrite.scala.marker.PartialFunctionLiteral
 import org.openrewrite.scala.marker.Curried
 import org.openrewrite.scala.tree.S
 
@@ -5623,6 +5624,23 @@ class ScalaTreeVisitor(
 
   private def visitMatchImpl(matchTree: Trees.Match[?]): J = {
     val prefix = extractPrefix(matchTree.span)
+
+    // Partial-function literal `{ case pat => ... }` has a synthetic selector with NoSpan.
+    // Emit a J.Lambda (no params) whose body is the cases block; printer uses the marker
+    // to emit the `{ case ... => ... }` form.
+    if (!matchTree.selector.span.exists) {
+      val bs = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 20, source.length)) else ""
+      val bi = bs.indexOf('{'); if (bi >= 0) cursor = cursor + bi + 1
+      val casesBlock = buildCasesBlock(matchTree)
+      updateCursor(matchTree.span.end)
+      val parameters = new J.Lambda.Parameters(
+        Tree.randomId(), Space.EMPTY, Markers.EMPTY, false, Collections.emptyList())
+      return new J.Lambda(
+        Tree.randomId(), prefix,
+        Markers.build(Collections.singletonList(new PartialFunctionLiteral(UUID.randomUUID()))),
+        parameters, Space.EMPTY, casesBlock, null)
+    }
+
     // `x match { ... }` — the selector can itself be a compound expression (if/block/match).
     // Wrap non-Expression J via StatementExpression so chained expressions parse.
     val selector = visitTree(matchTree.selector) match {
@@ -5636,6 +5654,13 @@ class ScalaTreeVisitor(
     val bs = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 20, source.length)) else ""
     val bi = bs.indexOf('{'); if (bi >= 0) cursor = cursor + bi + 1
 
+    val casesBlock = buildCasesBlock(matchTree)
+    updateCursor(matchTree.span.end)
+    val selectorParens = new J.ControlParentheses[Expression](Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(selector))
+    new J.Switch(Tree.randomId(), prefix, Markers.EMPTY, selectorParens, casesBlock)
+  }
+
+  private def buildCasesBlock(matchTree: Trees.Match[?]): J.Block = {
     val caseStatements = new util.ArrayList[JRightPadded[Statement]]()
     for (caseDef <- matchTree.cases) {
       val casePrefix = extractPrefix(caseDef.span)
@@ -5684,10 +5709,7 @@ class ScalaTreeVisitor(
         matchEndSpace = Space.format(remaining.substring(0, closeIdx))
       }
     }
-    val casesBlock = new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), caseStatements, matchEndSpace)
-    updateCursor(matchTree.span.end)
-    val selectorParens = new J.ControlParentheses[Expression](Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(selector))
-    new J.Switch(Tree.randomId(), prefix, Markers.EMPTY, selectorParens, casesBlock)
+    new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), caseStatements, matchEndSpace)
   }
 
   private def visitThis(thisTree: Trees.This[?]): J.Identifier = {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LambdaTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LambdaTest.java
@@ -144,4 +144,40 @@ class LambdaTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void partialFunctionLiteral() {
+        // A partial-function literal `{ case pat => ... }` is modeled by the Scala
+        // compiler as a Match tree with a synthetic NoSpan selector, which the parser
+        // must handle without falling through to visitUnknown.
+        rewriteRun(
+            scala(
+                """
+                val f: Int => Int = {
+                  case 1 => 1
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void partialFunctionLiteralAsMapArgument() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def run(): Unit = {
+                    List((1, "a")).collect {
+                      case (n, s) if n > 0 =>
+                        val label = s
+                        println(label)
+                      case (_, s) => println(s)
+                    }
+                  }
+                }
+                """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fixing how Scala partial function literals with short match syntax are parsed, e.g.
```scala
                val f: Int => Int = {
                  case 1 => 1
                }
```

Squeezing them into a J.Lambda, but with a marker to denote the short syntax is used.

## What's your motivation?

Currently it fails idempotency expectation.