### PR TITLE
Python: add RPC codec for `JavaType.Annotation`

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/java/support_types.py
+++ b/rewrite-python/rewrite/src/rewrite/java/support_types.py
@@ -238,6 +238,20 @@ class JavaType(ABC):
                 return t.fully_qualified_name
             return ''
 
+    class Annotation(FullyQualified):
+        _type: JavaType.FullyQualified
+
+        @property
+        def type(self) -> JavaType.FullyQualified:
+            return self._type
+
+        @property
+        def fully_qualified_name(self) -> str:
+            t = getattr(self, '_type', None)
+            if t is not None and hasattr(t, 'fully_qualified_name'):
+                return t.fully_qualified_name
+            return ''
+
     @dataclass
     class GenericTypeVariable:
         _name: str = field(default="")

--- a/rewrite-python/rewrite/src/rewrite/java/support_types.pyi
+++ b/rewrite-python/rewrite/src/rewrite/java/support_types.pyi
@@ -98,6 +98,14 @@ class JavaType(ABC):
         @property
         def fully_qualified_name(self) -> str: ...
 
+    class Annotation(FullyQualified):
+        _type: JavaType.FullyQualified
+
+        @property
+        def type(self) -> JavaType.FullyQualified: ...
+        @property
+        def fully_qualified_name(self) -> str: ...
+
 
     @dataclass
     class GenericTypeVariable:

--- a/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
@@ -1444,6 +1444,17 @@ def _receive_java_type_parameterized(param, q: RpcReceiveQueue):
     return p
 
 
+def _receive_java_type_annotation(annotation, q: RpcReceiveQueue):
+    """Codec for receiving JavaType.Annotation - consumes type only (values TODO on Java side)."""
+    from rewrite.java.support_types import JavaType as JT
+
+    type_ = q.receive(getattr(annotation, '_type', None))
+
+    a = JT.Annotation()
+    a._type = type_  # ty: ignore[invalid-assignment]  # RPC deserialization
+    return a
+
+
 def _receive_java_type_array(array, q: RpcReceiveQueue):
     """Codec for receiving JavaType.Array - consumes elemType and annotations."""
     from rewrite.java.support_types import JavaType as JT
@@ -1555,6 +1566,14 @@ def _register_java_type_codecs():
         JT.Parameterized,
         _receive_java_type_parameterized,
         lambda: JT.Parameterized()  # Factory creates empty Parameterized
+    )
+
+    # JavaType.Annotation - type only (values TODO on Java side)
+    register_codec_with_both_names(
+        'org.openrewrite.java.tree.JavaType$Annotation',
+        JT.Annotation,
+        _receive_java_type_annotation,
+        lambda: JT.Annotation()  # Factory creates empty Annotation
     )
 
     # JavaType.Array - element type and annotations

--- a/rewrite-python/rewrite/src/rewrite/rpc/python_sender.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_sender.py
@@ -871,6 +871,10 @@ class PythonRpcSender:
             q.get_and_send_as_ref(java_type, lambda x: getattr(x, '_type', None), lambda t: self._visit_type(t, q))
             q.get_and_send_list_as_ref(java_type, lambda x: getattr(x, '_type_parameters', None) or [], self._type_signature, lambda t: self._visit_type(t, q))
 
+        elif isinstance(java_type, JT.Annotation):
+            # Annotation: type (FullyQualified) — values TODO on Java side
+            q.get_and_send_as_ref(java_type, lambda x: getattr(x, '_type', None), lambda t: self._visit_type(t, q))
+
         elif isinstance(java_type, JT.Class):
             # Class: flagsBitMap, kind, fullyQualifiedName, typeParameters, supertype,
             #        owningClass, annotations, interfaces, members, methods


### PR DESCRIPTION
## Motivation

Running OpenRewrite recipes against Python repos (e.g. `finos/symphony-bdk-python`) fails on any source file where the Java side serializes a `JavaType.Annotation`. The Python RPC layer has no codec registered for that type, so the receive queue desynchronizes and the recipe aborts:

```
io.moderne.jsonrpc.JsonRpcException: {code=-32603, message='No RPC codec registered on
the Python side for 'org.openrewrite.java.tree.JavaType$Annotation'. The remote side
has a codec and sent property messages that will not be consumed, causing RPC queue
desynchronization.'}
```

Observed in flagship recipe runs against Python repos. Affected recipes include `ReplaceStringConcatenationWithStringValueOf` (CSA) and `UpdateManagedBeanToNamed` (SB4).

## Summary

- Add `JavaType.Annotation` class in `rewrite-python/rewrite/src/rewrite/java/support_types.py` (and `.pyi`), extending `JavaType.FullyQualified` with a single `_type` field.
- Add an `Annotation` branch in `python_sender.py::_visit_type()` that emits only `_type`, mirroring the Java `JavaTypeSender.visitAnnotation` behavior.
- Add `_receive_java_type_annotation()` and register it under `org.openrewrite.java.tree.JavaType$Annotation` in `python_receiver.py`.

Element `values[]` are intentionally not wired — the Java side currently leaves them as TODO in `JavaTypeSender.visitAnnotation`, and parity with the Java sender is sufficient to unblock the failing recipe runs.

## Test plan

- [x] `pytest tests/ --ignore=tests/rpc` — 1156 passed, 6 skipped.
- [x] Verified `org.openrewrite.java.tree.JavaType$Annotation` appears in the receive codec registry after import.
- [x] `./gradlew :rewrite-python:assemble` — clean.
- [x] `./gradlew :rewrite-python:generateTestClasspath` followed by `pytest tests/rpc/` — same 4 pre-existing failures as on `main`, no new regressions.