### PR TITLE
Fix KotlinBlockStatementTemplateGenerator for Unit-returning method invocations

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinBlockStatementTemplateGenerator.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinBlockStatementTemplateGenerator.java
@@ -33,14 +33,7 @@ public class KotlinBlockStatementTemplateGenerator extends BlockStatementTemplat
 
     @Override
     protected void contextFreeTemplate(Cursor cursor, J j, Collection<JavaType.GenericTypeVariable> typeVariables, StringBuilder before, StringBuilder after) {
-        if (j instanceof J.MethodInvocation) {
-            before.insert(0, "class Template {\n");
-            JavaType.Method methodType = ((J.MethodInvocation) j).getMethodType();
-            if (methodType == null || methodType.getReturnType() != JavaType.Primitive.Void) {
-                before.append("var o : Any = ");
-            }
-            after.append(";\n}");
-        } else if (j instanceof Expression && !(j instanceof J.Assignment)) {
+        if (j instanceof Expression && !(j instanceof J.Assignment)) {
             before.insert(0, "class Template {\n");
             before.append("var o : Any = ");
             after.append(";\n}");

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -105,6 +105,39 @@ class KotlinTemplateTest implements RewriteTest {
     }
 
     @Test
+    void replaceUnitReturningMethodInvocation() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none())
+            .recipe(toRecipe(() -> new KotlinVisitor<>() {
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  if ("foo".equals(method.getSimpleName())) {
+                      return KotlinTemplate.builder("bar()")
+                        .build()
+                        .apply(getCursor(), method.getCoordinates().replace());
+                  }
+                  return super.visitMethodInvocation(method, ctx);
+              }
+          })),
+          kotlin(
+            """
+              fun foo() {}
+              fun bar() {}
+              fun test() {
+                  foo()
+              }
+              """,
+            """
+              fun foo() {}
+              fun bar() {}
+              fun test() {
+                  bar()
+              }
+              """
+          ));
+    }
+
+    @Test
     void parserClasspath() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new KotlinVisitor<>() {


### PR DESCRIPTION
## Summary

- `KotlinBlockStatementTemplateGenerator.contextFreeTemplate` emitted a bare expression at Kotlin class body level for Unit-returning method invocations, which is not valid Kotlin syntax and caused `KotlinTemplateParser` to reject the template with `IllegalArgumentException: Could not parse as Java: ...`.
- Since Kotlin's `Unit` is assignable to `Any`, always emit `var o : Any = ` for expressions. This collapses the `J.MethodInvocation` and `Expression` branches and works for both Unit and non-Unit returns.
- Added `replaceUnitReturningMethodInvocation` test reproducing the original failure.

- Fixes #7406

## Test plan

- [x] `./gradlew :rewrite-kotlin:test --tests org.openrewrite.kotlin.KotlinTemplateTest`