### PR TITLE
Scala: support for right-associative operators in infix syntax

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -1186,20 +1186,29 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         // Check if this is infix notation (list map func instead of list.map(func))
         if (method.getMarkers().findFirst(org.openrewrite.scala.marker.InfixNotation.class).isPresent()) {
             beforeSyntax(method, Space.Location.METHOD_INVOCATION_PREFIX, p);
-            
-            // Print the select (e.g., "list")
-            visitRightPadded(method.getPadding().getSelect(), JRightPadded.Location.METHOD_SELECT, "", p);
-            
-            // Print the method name with its prefix space (e.g., " map")
-            visit(method.getName(), p);
-            
-            // Print the arguments without parentheses, just with their prefix space
-            if (method.getArguments() != null && !method.getArguments().isEmpty()) {
-                for (Expression arg : method.getArguments()) {
-                    visit(arg, p);
+
+            boolean rightAssoc = method.getMarkers().findFirst(org.openrewrite.scala.marker.RightAssociative.class).isPresent();
+
+            if (rightAssoc) {
+                // AST stores right-associative ops semantically (select = right, arg = left).
+                // Restore source order on output: <argument> <name> <select>.
+                if (method.getArguments() != null) {
+                    for (Expression arg : method.getArguments()) {
+                        visit(arg, p);
+                    }
+                }
+                visit(method.getName(), p);
+                visitRightPadded(method.getPadding().getSelect(), JRightPadded.Location.METHOD_SELECT, "", p);
+            } else {
+                visitRightPadded(method.getPadding().getSelect(), JRightPadded.Location.METHOD_SELECT, "", p);
+                visit(method.getName(), p);
+                if (method.getArguments() != null) {
+                    for (Expression arg : method.getArguments()) {
+                        visit(arg, p);
+                    }
                 }
             }
-            
+
             afterSyntax(method, p);
             return method;
         }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/RightAssociative.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/RightAssociative.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Marks a J.MethodInvocation that uses Scala's right-associative infix notation.
+ * In Scala, any operator ending in ':' is right-associative, so {@code xs :: ys}
+ * is desugared to {@code ys.::(xs)} — the receiver is the right operand and the
+ * left operand becomes the single argument.
+ *
+ * The AST stores the call semantically (select = right operand, argument = left
+ * operand). This marker instructs the printer to reverse the order back to the
+ * original source form when rendering: {@code <argument> <name> <select>}.
+ *
+ * Always used together with {@link InfixNotation}.
+ */
+@Value
+@With
+public class RightAssociative implements Marker {
+    UUID id;
+
+    public static RightAssociative create() {
+        return new RightAssociative(Tree.randomId());
+    }
+}

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -38,6 +38,8 @@ import org.openrewrite.scala.marker.TypeAscription
 import org.openrewrite.scala.marker.UnderscorePlaceholderLambda
 import org.openrewrite.scala.marker.PartialFunctionLiteral
 import org.openrewrite.scala.marker.Curried
+import org.openrewrite.scala.marker.InfixNotation
+import org.openrewrite.scala.marker.RightAssociative
 import org.openrewrite.scala.tree.S
 
 import java.util
@@ -1517,17 +1519,18 @@ class ScalaTreeVisitor(
 
   private def visitInfixMethodCall(infixOp: untpd.InfixOp): J = {
     val prefix = extractPrefix(infixOp.span)
-    
-    // Visit the select (left side)
-    val select = visitTree(infixOp.left) match {
+
+    // Visit the left-hand-side expression as it appears in source
+    val leftExpr = visitTree(infixOp.left) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
       case _ => return visitUnknown(infixOp)
     }
-    
-    // Extract method name
+
     val methodName = infixOp.op.name.toString
-    
+    // Scala: any operator ending in ':' is right-associative, so `a op: b` means `b.op:(a)`.
+    val rightAssoc = methodName.endsWith(":")
+
     // Extract space before the method name
     val leftEnd = Math.max(0, infixOp.left.span.end - offsetAdjustment)
     val opStart = Math.max(0, infixOp.op.span.start - offsetAdjustment)
@@ -1537,30 +1540,30 @@ class ScalaTreeVisitor(
     } else {
       Space.format(" ")
     }
-    
+
     // Move cursor past the method name
     cursor = Math.max(0, infixOp.op.span.end - offsetAdjustment)
-    
-    // Extract space before the argument
+
+    // Extract space between the operator and the right-hand-side expression
     val opEnd = Math.max(0, infixOp.op.span.end - offsetAdjustment)
     val rightStart = Math.max(0, infixOp.right.span.start - offsetAdjustment)
-    val argSpace = if (opEnd < rightStart && opEnd >= cursor && rightStart <= source.length) {
+    val rhsSpace = if (opEnd < rightStart && opEnd >= cursor && rightStart <= source.length) {
       cursor = rightStart
       Space.format(source.substring(opEnd, rightStart))
     } else {
       Space.format(" ")
     }
-    
-    // Visit the argument (right side)
+
+    // Visit the right-hand-side expression as it appears in source
     val savedCursorArg = cursor
-    val arg = visitTree(infixOp.right) match {
+    val rightExpr = visitTree(infixOp.right) match {
       case expr: Expression => expr
       case block: J.Block =>
         // Block arguments in infix calls: `"test" should { ... }`
-        new S.StatementExpression(Tree.randomId(), block.withPrefix(argSpace))
+        new S.StatementExpression(Tree.randomId(), block.withPrefix(rhsSpace))
       case _ => cursor = savedCursorArg; return visitUnknown(infixOp)
     }
-    
+
     // Create the method name identifier
     val name = new J.Identifier(
       Tree.randomId(),
@@ -1571,20 +1574,25 @@ class ScalaTreeVisitor(
       null,
       null
     )
-    
-    // Create the arguments container
+
+    // For right-associative operators, store semantically: select = right, argument = left.
+    // The printer checks for RightAssociative to restore the syntactic order on output.
+    val (selectExpr, argExpr) =
+      if (rightAssoc) (rightExpr.withPrefix(rhsSpace), leftExpr)
+      else (leftExpr, rightExpr.withPrefix(rhsSpace))
+
     val args = new util.ArrayList[JRightPadded[Expression]]()
-    args.add(JRightPadded.build(arg.withPrefix(argSpace)).withAfter(Space.EMPTY))
-    
-    // Import the InfixNotation marker
-    import org.openrewrite.scala.marker.InfixNotation
-    
-    // Create the method invocation with the InfixNotation marker
+    args.add(JRightPadded.build(argExpr).withAfter(Space.EMPTY))
+
+    val markersList = new util.ArrayList[org.openrewrite.marker.Marker]()
+    markersList.add(InfixNotation.create())
+    if (rightAssoc) markersList.add(RightAssociative.create())
+
     new J.MethodInvocation(
       Tree.randomId(),
       prefix,
-      Markers.build(Collections.singletonList(InfixNotation.create())),
-      JRightPadded.build(select),
+      Markers.build(markersList),
+      JRightPadded.build(selectExpr),
       null, // typeParameters
       name,
       JContainer.build(Space.EMPTY, args, Markers.EMPTY),

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.scala.marker.InfixNotation;
+import org.openrewrite.scala.marker.RightAssociative;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.scala.Assertions.scala;
+
+class InfixTest implements RewriteTest {
+
+    @Test
+    void namedInfix() {
+        rewriteRun(
+          scala("val x = list map func")
+        );
+    }
+
+    @Test
+    void namedInfixMax() {
+        rewriteRun(
+          scala("val x = 1 max 2")
+        );
+    }
+
+    @Test
+    void rightAssocCons() {
+        rewriteRun(
+          scala("val xs = 1 :: Nil")
+        );
+    }
+
+    @Test
+    void rightAssocConsChain() {
+        rewriteRun(
+          scala("val xs = 1 :: 2 :: 3 :: Nil")
+        );
+    }
+
+    @Test
+    void rightAssocPrepend() {
+        rewriteRun(
+          scala("val xs = 1 +: List(2, 3)")
+        );
+    }
+
+    @Test
+    void rightAssocWithExtraWhitespace() {
+        rewriteRun(
+          scala("val xs = 1  ::  Nil")
+        );
+    }
+
+    @Test
+    void leftAssocPreservesSelectAndArgument() {
+        rewriteRun(
+          scala(
+            "val x = list map func",
+            spec -> spec.afterRecipe(cu -> {
+                AtomicReference<J.MethodInvocation> call = new AtomicReference<>();
+                new JavaIsoVisitor<Integer>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation m, Integer p) {
+                        if (m.getMarkers().findFirst(InfixNotation.class).isPresent()) {
+                            call.set(m);
+                        }
+                        return super.visitMethodInvocation(m, p);
+                    }
+                }.visit(cu, 0);
+
+                J.MethodInvocation m = call.get();
+                assertThat(m).as("should find infix call").isNotNull();
+                assertThat(m.getMarkers().findFirst(RightAssociative.class)).isEmpty();
+                assertThat(((J.Identifier) m.getSelect()).getSimpleName()).isEqualTo("list");
+                assertThat(m.getSimpleName()).isEqualTo("map");
+                assertThat(((J.Identifier) m.getArguments().get(0)).getSimpleName()).isEqualTo("func");
+            })
+          )
+        );
+    }
+
+    @Test
+    void rightAssocStoresSemantically() {
+        rewriteRun(
+          scala(
+            "val xs = 1 :: Nil",
+            spec -> spec.afterRecipe(cu -> {
+                AtomicReference<J.MethodInvocation> call = new AtomicReference<>();
+                new JavaIsoVisitor<Integer>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation m, Integer p) {
+                        if (m.getMarkers().findFirst(RightAssociative.class).isPresent()) {
+                            call.set(m);
+                        }
+                        return super.visitMethodInvocation(m, p);
+                    }
+                }.visit(cu, 0);
+
+                J.MethodInvocation m = call.get();
+                assertThat(m).as("should find right-associative infix call").isNotNull();
+                assertThat(m.getMarkers().findFirst(InfixNotation.class)).isPresent();
+                assertThat(m.getSimpleName()).isEqualTo("::");
+                // Semantic storage: receiver is the right operand (Nil), argument is the left (1).
+                assertThat(((J.Identifier) m.getSelect()).getSimpleName()).isEqualTo("Nil");
+                assertThat(m.getArguments()).hasSize(1);
+                assertThat(m.getArguments().get(0)).isInstanceOf(J.Literal.class);
+                assertThat(((J.Literal) m.getArguments().get(0)).getValue()).isEqualTo(1);
+            })
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's your motivation?

In Scala operators ending in `:` used in infix syntax are right-associative. For instance:
```
val xs = 1 :: Nil
```
means the same as
```
val xs = Nil.::(1)
```

Without the fix, it would parse the tree wrong.

## What's changed?

Adding `RightAssociative` marker to Scala to make sure the parsed LST keeps the semantics. And thanks to the marker, the printer deals with the syntax.
