### PR TITLE
Python: fix AutoFormat crash on `import ... as ...`

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/format/spaces_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/format/spaces_visitor.py
@@ -463,8 +463,9 @@ class SpacesVisitor(PythonVisitor):
     def visit_import(self, import_: Import, p: P) -> J:
         imp: Import = cast(Import, super().visit_import(import_, p))
         if imp.padding.alias:
-            imp = imp.replace(alias=space_before(imp.alias, True))
-            imp = imp.padding.replace(alias=space_before_left_padded(imp.padding.alias, True))
+            new_alias = space_before_left_padded(imp.padding.alias, True)
+            new_alias = space_before_left_padded_element(new_alias, True)
+            imp = imp.padding.replace(alias=new_alias)
         return imp
 
     def visit_type_hint(self, hint: TypeHint, p: P) -> J:

--- a/rewrite-python/rewrite/tests/python/all/format/auto_format_edge_cases_test.py
+++ b/rewrite-python/rewrite/tests/python/all/format/auto_format_edge_cases_test.py
@@ -374,3 +374,21 @@ def test_type_alias():
         spec=RecipeSpec()
         .with_recipe(AutoFormat())
     )
+
+
+def test_import_with_alias_normalizes_spacing():
+    rewrite_run(
+        # language=python
+        python(
+            """\
+            from typing import Tuple  as  T
+            import os as  operating_system
+            """,
+            """\
+            from typing import Tuple as T
+            import os as operating_system
+            """,
+        ),
+        spec=RecipeSpec()
+        .with_recipe(AutoFormat())
+    )


### PR DESCRIPTION
## Motivation

`AutoFormat` crashed on any Python file containing `import X as Y` or `from X import Y as Z`, surfacing as `AttributeError: 'Identifier' object has no attribute 'before'` deep in `SpacesVisitor`. Discovered via flagship recipe alerts while running `UnwrapElseAfterReturn` on real sources.

Root cause is a subtle mismatch between public and private fields on padded LST nodes. `Import._alias` is typed `Optional[JLeftPadded[Identifier]]`, while the public `alias` property unwraps to the bare `Identifier`. The previous code did:

```python
imp = imp.replace(alias=space_before(imp.alias, True))
imp = imp.padding.replace(alias=space_before_left_padded(imp.padding.alias, True))
```

`replace_if_changed` maps the public kwarg `alias` to the private field `_alias` without type-checking the value, so the first line clobbered the `JLeftPadded` wrapper with a raw `Identifier`. The second line then read `imp.padding.alias` back as a bare `Identifier` and crashed on `.before`.

## Summary

- `SpacesVisitor.visit_import` now applies both spacing adjustments to the `JLeftPadded` wrapper (using `space_before_left_padded` for the space before `as`, and `space_before_left_padded_element` for the space before the alias identifier) before a single `padding.replace`.
- Added a regression test covering both `import X as Y` and `from X import Y as Z` with non-normalized spacing.

## Test plan

- [x] New `test_import_with_alias_normalizes_spacing` fails on trunk with the reported `AttributeError` and passes after the fix
- [x] Full format + import parse suite: `pytest tests/python/all/format/ tests/python/all/tree/import_test.py tests/python/format/` — 181 passed
- [x] Broader smoke: `pytest tests/ --ignore=tests/rpc` — 1157 passed, 6 skipped