### PR TITLE
Fix Kotlin method declaringType for primitive receivers

### DIFF
--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -680,11 +680,18 @@ class KotlinTypeMapping(
             null
         )
         typeCache.put(signature, method)
-        var parentType = when {
+        // A method's declaring type is always a class even when its receiver is a Kotlin
+        // primitive (e.g. `kotlin.Char.toInt()` is declared on the `kotlin.Char` class, not
+        // the JVM `char` primitive). Bypass the primitive remap that `type()` applies to
+        // non-nullable Kotlin primitives by going through `asDeclaringType` / `classType`.
+        var parentType: JavaType? = when {
             function.symbol is FirConstructorSymbol -> type(function.returnTypeRef)
+            function.dispatchReceiverType is ConeClassLikeType ->
+                asDeclaringType(function.dispatchReceiverType as ConeClassLikeType)
             function.dispatchReceiverType != null -> type(function.dispatchReceiverType!!)
             function.symbol.getOwnerLookupTag()?.toRegularClassSymbol(firSession)?.fir != null -> {
-                type(function.symbol.getOwnerLookupTag()!!.toRegularClassSymbol(firSession)!!.fir)
+                val fir = function.symbol.getOwnerLookupTag()!!.toRegularClassSymbol(firSession)!!.fir
+                TypeUtils.asFullyQualified(classType(fir, firFile, signatureBuilder.signature(fir)))
             }
 
             parent is FirRegularClass || parent != null -> type(parent)

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -1816,6 +1816,36 @@ class KotlinTypeMappingTest {
             );
         }
 
+        @Issue("https://github.com/openrewrite/rewrite/issues/7408")
+        @Test
+        void declaringTypeOnKotlinPrimitiveReceiver() {
+            rewriteRun(
+              kotlin(
+                """
+                  fun test(c: Char): Int {
+                      return c.toInt()
+                  }
+                  """,
+                spec -> spec.afterRecipe(cu -> {
+                    AtomicBoolean found = new KotlinIsoVisitor<AtomicBoolean>() {
+                        @Override
+                        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean found) {
+                            if ("toInt".equals(method.getSimpleName())) {
+                                JavaType.FullyQualified declaringType = method.getMethodType().getDeclaringType();
+                                assertThat(declaringType).isNotInstanceOf(JavaType.Unknown.class);
+                                assertThat(declaringType.getFullyQualifiedName()).isEqualTo("kotlin.Char");
+                                assertThat(new MethodMatcher("kotlin.Char toInt()").matches(method)).isTrue();
+                                found.set(true);
+                            }
+                            return super.visitMethodInvocation(method, found);
+                        }
+                    }.reduce(cu, new AtomicBoolean());
+                    assertThat(found.get()).isTrue();
+                })
+              )
+            );
+        }
+
         @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/590")
         @Test
         void callWithDefaultedGenericParameters() {


### PR DESCRIPTION
## Summary
- Fixes https://github.com/openrewrite/rewrite/issues/7408 where `method.getMethodType().getDeclaringType()` returned `JavaType.Unknown` for methods called on Kotlin primitive receivers (e.g. `c.toInt()` where `c: Char`), breaking `MethodMatcher` patterns like `kotlin.Char toInt()`. In `methodDeclarationType`, the non-nullable Kotlin primitive remap in `type()` was collapsing `kotlin.Char` to JVM `char` and then `TypeUtils.asFullyQualified` returned null. The fix routes `ConeClassLikeType` dispatch receivers through `asDeclaringType`/`classType` (mirroring what `methodInvocationType` already does), bypassing the primitive remap.

## Test plan
- [x] `./gradlew :rewrite-kotlin:test` passes
- [x] New `declaringTypeOnKotlinPrimitiveReceiver` test in `KotlinTypeMappingTest` asserts `declaringType` is `kotlin.Char` (not `Unknown`) and that a `MethodMatcher("kotlin.Char toInt()")` matches