### PR TITLE
Add YAML StringUtils.quoteIfNeeded() for safe scalar quoting

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/StringUtils.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/StringUtils.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.yaml.internal;
+
+public class StringUtils {
+
+    private StringUtils() {
+    }
+
+    private static final String INDICATOR_CHARS = "-?:,[]{}#&*!|>'\"%@`";
+
+    /**
+     * Quotes a YAML scalar value if needed, per the YAML 1.2.2 spec.
+     * <p>
+     * If the input is already quoted (surrounded by matching single or double quotes),
+     * it is returned as-is. Otherwise, the method determines whether the value requires
+     * quoting and applies the minimal quoting style: single quotes by default, double
+     * quotes only when escape sequences are required.
+     *
+     * @param value the raw string value
+     * @return the value, potentially quoted for safe use as a YAML scalar
+     */
+    public static String quoteIfNeeded(String value) {
+        if (isAlreadyQuoted(value)) {
+            return value;
+        }
+        if (!needsQuoting(value)) {
+            return value;
+        }
+        if (needsDoubleQuotes(value)) {
+            return "\"" + escapeForDoubleQuoting(value) + "\"";
+        }
+        return "'" + value + "'";
+    }
+
+    private static boolean isAlreadyQuoted(String value) {
+        if (value.length() < 2) {
+            return false;
+        }
+        return (value.charAt(0) == '\'' && value.charAt(value.length() - 1) == '\'') ||
+               (value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"');
+    }
+
+    private static boolean needsQuoting(String value) {
+        // Empty string
+        if (value.isEmpty()) {
+            return true;
+        }
+
+        // Leading or trailing whitespace
+        char first = value.charAt(0);
+        char last = value.charAt(value.length() - 1);
+        if (first == ' ' || first == '\t' || last == ' ' || last == '\t') {
+            return true;
+        }
+
+        // Contains line breaks
+        if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+            return true;
+        }
+
+        // Starts with indicator character
+        if (INDICATOR_CHARS.indexOf(first) >= 0) {
+            return true;
+        }
+
+        // Contains colon-space or space-hash mid-string
+        if (value.contains(": ") || value.contains(" #")) {
+            return true;
+        }
+
+        // Document markers
+        if (value.equals("---") || value.equals("...")) {
+            return true;
+        }
+
+        // Contains control characters
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c < 0x20 || c == 0x7F) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean needsDoubleQuotes(String value) {
+        // Need double quotes if value contains single quote
+        if (value.indexOf('\'') >= 0) {
+            return true;
+        }
+        // Need double quotes if value contains control characters
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c < 0x20 || c == 0x7F) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String escapeForDoubleQuoting(String value) {
+        StringBuilder sb = new StringBuilder(value.length() + 16);
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\0':
+                    sb.append("\\0");
+                    break;
+                case '\u0007':
+                    sb.append("\\a");
+                    break;
+                case '\b':
+                    sb.append("\\b");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\u000B':
+                    sb.append("\\v");
+                    break;
+                case '\f':
+                    sb.append("\\f");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\u001B':
+                    sb.append("\\e");
+                    break;
+                default:
+                    if (c < 0x20 || c == 0x7F) {
+                        sb.append("\\x");
+                        sb.append(String.format("%02x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                    break;
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/internal/StringUtilsTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/internal/StringUtilsTest.java
@@ -16,244 +16,151 @@
 package org.openrewrite.yaml.internal;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.yaml.internal.StringUtils.quoteIfNeeded;
 
 class StringUtilsTest {
 
-    // Already-quoted passthrough
-
-    @Test
-    void singleQuotedPassthrough() {
-        assertThat(quoteIfNeeded("'hello'")).isEqualTo("'hello'");
+    @ParameterizedTest
+    @MethodSource
+    void alreadyQuotedPassthrough(String input, String expected) {
+        assertThat(quoteIfNeeded(input)).isEqualTo(expected);
     }
 
-    @Test
-    void doubleQuotedPassthrough() {
-        assertThat(quoteIfNeeded("\"hello\"")).isEqualTo("\"hello\"");
+    static Stream<Arguments> alreadyQuotedPassthrough() {
+        return Stream.of(
+                Arguments.of("'hello'", "'hello'"),
+                Arguments.of("\"hello\"", "\"hello\""),
+                Arguments.of("''", "''")
+        );
     }
 
-    @Test
-    void emptyQuotedPassthrough() {
-        assertThat(quoteIfNeeded("''")).isEqualTo("''");
+    @ParameterizedTest
+    @MethodSource
+    void noQuotingNeeded(String input, String expected) {
+        assertThat(quoteIfNeeded(input)).isEqualTo(expected);
     }
 
-    // No quoting needed
-
-    @Test
-    void plainStringUnchanged() {
-        assertThat(quoteIfNeeded("hello")).isEqualTo("hello");
+    static Stream<Arguments> noQuotingNeeded() {
+        return Stream.of(
+                Arguments.of("hello", "hello"),
+                Arguments.of("hello world", "hello world"),
+                Arguments.of("some-key", "some-key"),
+                Arguments.of("path/to/file", "path/to/file"),
+                Arguments.of("1.0.0", "1.0.0"),
+                Arguments.of("truefalse", "truefalse"),
+                Arguments.of("https://example.com", "https://example.com")
+        );
     }
-
-    @Test
-    void plainStringWithSpacesUnchanged() {
-        assertThat(quoteIfNeeded("hello world")).isEqualTo("hello world");
-    }
-
-    @Test
-    void plainStringWithHyphensUnchanged() {
-        assertThat(quoteIfNeeded("some-key")).isEqualTo("some-key");
-    }
-
-    @Test
-    void pathUnchanged() {
-        assertThat(quoteIfNeeded("path/to/file")).isEqualTo("path/to/file");
-    }
-
-    @Test
-    void versionLikeStringUnchanged() {
-        assertThat(quoteIfNeeded("1.0.0")).isEqualTo("1.0.0");
-    }
-
-    @Test
-    void nonReservedWordUnchanged() {
-        assertThat(quoteIfNeeded("truefalse")).isEqualTo("truefalse");
-    }
-
-    @Test
-    void urlUnchanged() {
-        assertThat(quoteIfNeeded("https://example.com")).isEqualTo("https://example.com");
-    }
-
-    // Empty string
 
     @Test
     void emptyStringQuoted() {
         assertThat(quoteIfNeeded("")).isEqualTo("''");
     }
 
-    // Valid YAML typed values left unchanged
-
-    @Test
-    void nullUnchanged() {
-        assertThat(quoteIfNeeded("null")).isEqualTo("null");
+    @ParameterizedTest
+    @MethodSource
+    void validYamlTypedValuesUnchanged(String input, String expected) {
+        assertThat(quoteIfNeeded(input)).isEqualTo(expected);
     }
 
-    @Test
-    void trueUnchanged() {
-        assertThat(quoteIfNeeded("true")).isEqualTo("true");
+    static Stream<Arguments> validYamlTypedValuesUnchanged() {
+        return Stream.of(
+                Arguments.of("null", "null"),
+                Arguments.of("true", "true"),
+                Arguments.of("false", "false"),
+                Arguments.of("YES", "YES"),
+                Arguments.of("123", "123"),
+                Arguments.of("1.23", "1.23")
+        );
     }
 
-    @Test
-    void falseUnchanged() {
-        assertThat(quoteIfNeeded("false")).isEqualTo("false");
+    @ParameterizedTest
+    @MethodSource
+    void indicatorCharactersQuoted(String input, String expected) {
+        assertThat(quoteIfNeeded(input)).isEqualTo(expected);
     }
 
-    @Test
-    void yesUnchanged() {
-        assertThat(quoteIfNeeded("YES")).isEqualTo("YES");
+    static Stream<Arguments> indicatorCharactersQuoted() {
+        return Stream.of(
+                Arguments.of("~", "~"),
+                Arguments.of("- item", "'- item'"),
+                Arguments.of("-42", "'-42'"),
+                Arguments.of("# comment", "'# comment'"),
+                Arguments.of("*alias", "'*alias'"),
+                Arguments.of("&anchor", "'&anchor'"),
+                Arguments.of("[list]", "'[list]'"),
+                Arguments.of("{map}", "'{map}'"),
+                Arguments.of("!tag", "'!tag'"),
+                Arguments.of("%directive", "'%directive'")
+        );
     }
 
-    @Test
-    void integerUnchanged() {
-        assertThat(quoteIfNeeded("123")).isEqualTo("123");
+    @ParameterizedTest
+    @MethodSource
+    void dangerousMidStringPatternsQuoted(String input, String expected) {
+        assertThat(quoteIfNeeded(input)).isEqualTo(expected);
     }
 
-    @Test
-    void floatUnchanged() {
-        assertThat(quoteIfNeeded("1.23")).isEqualTo("1.23");
+    static Stream<Arguments> dangerousMidStringPatternsQuoted() {
+        return Stream.of(
+                Arguments.of("key: value", "'key: value'"),
+                Arguments.of("TODO: Follow this link https://example.com/page",
+                        "'TODO: Follow this link https://example.com/page'"),
+                Arguments.of("before # after", "'before # after'")
+        );
     }
 
-    // Indicator characters at start
-
-    @Test
-    void tildeUnchanged() {
-        assertThat(quoteIfNeeded("~")).isEqualTo("~");
+    @ParameterizedTest
+    @MethodSource
+    void documentMarkersQuoted(String input, String expected) {
+        assertThat(quoteIfNeeded(input)).isEqualTo(expected);
     }
 
-    @Test
-    void dashSpaceQuoted() {
-        assertThat(quoteIfNeeded("- item")).isEqualTo("'- item'");
+    static Stream<Arguments> documentMarkersQuoted() {
+        return Stream.of(
+                Arguments.of("---", "'---'"),
+                Arguments.of("...", "'...'")
+        );
     }
 
-    @Test
-    void negativeNumberQuotedAsIndicator() {
-        assertThat(quoteIfNeeded("-42")).isEqualTo("'-42'");
+    @ParameterizedTest
+    @MethodSource
+    void leadingTrailingWhitespaceQuoted(String input, String expected) {
+        assertThat(quoteIfNeeded(input)).isEqualTo(expected);
     }
 
-    @Test
-    void hashQuoted() {
-        assertThat(quoteIfNeeded("# comment")).isEqualTo("'# comment'");
+    static Stream<Arguments> leadingTrailingWhitespaceQuoted() {
+        return Stream.of(
+                Arguments.of(" hello", "' hello'"),
+                Arguments.of("hello ", "'hello '"),
+                Arguments.of("\thello", "\"\\thello\"")
+        );
     }
 
-    @Test
-    void asteriskQuoted() {
-        assertThat(quoteIfNeeded("*alias")).isEqualTo("'*alias'");
+    @ParameterizedTest
+    @MethodSource
+    void doubleQuoteCases(String input, String expected) {
+        assertThat(quoteIfNeeded(input)).isEqualTo(expected);
     }
 
-    @Test
-    void ampersandQuoted() {
-        assertThat(quoteIfNeeded("&anchor")).isEqualTo("'&anchor'");
-    }
-
-    @Test
-    void bracketQuoted() {
-        assertThat(quoteIfNeeded("[list]")).isEqualTo("'[list]'");
-    }
-
-    @Test
-    void braceQuoted() {
-        assertThat(quoteIfNeeded("{map}")).isEqualTo("'{map}'");
-    }
-
-    @Test
-    void exclamationQuoted() {
-        assertThat(quoteIfNeeded("!tag")).isEqualTo("'!tag'");
-    }
-
-    @Test
-    void percentQuoted() {
-        assertThat(quoteIfNeeded("%directive")).isEqualTo("'%directive'");
-    }
-
-    // Dangerous mid-string patterns
-
-    @Test
-    void colonSpaceQuoted() {
-        assertThat(quoteIfNeeded("key: value")).isEqualTo("'key: value'");
-    }
-
-    @Test
-    void colonSpaceInTextWithUrlQuoted() {
-        assertThat(quoteIfNeeded("TODO: Follow this link https://example.com/page"))
-                .isEqualTo("'TODO: Follow this link https://example.com/page'");
-    }
-
-    @Test
-    void spaceHashQuoted() {
-        assertThat(quoteIfNeeded("before # after")).isEqualTo("'before # after'");
-    }
-
-    // Document markers
-
-    @Test
-    void documentStartMarkerQuoted() {
-        assertThat(quoteIfNeeded("---")).isEqualTo("'---'");
-    }
-
-    @Test
-    void documentEndMarkerQuoted() {
-        assertThat(quoteIfNeeded("...")).isEqualTo("'...'");
-    }
-
-    // Leading/trailing whitespace
-
-    @Test
-    void leadingSpaceQuoted() {
-        assertThat(quoteIfNeeded(" hello")).isEqualTo("' hello'");
-    }
-
-    @Test
-    void trailingSpaceQuoted() {
-        assertThat(quoteIfNeeded("hello ")).isEqualTo("'hello '");
-    }
-
-    @Test
-    void leadingTabQuoted() {
-        assertThat(quoteIfNeeded("\thello")).isEqualTo("\"\\thello\"");
-    }
-
-    // Double-quote cases
-
-    @Test
-    void singleQuoteInValueUsesDoubleQuotes() {
-        // Contains ': ' (needs quoting) AND single quote (forces double quotes)
-        assertThat(quoteIfNeeded("it's: a test")).isEqualTo("\"it's: a test\"");
-    }
-
-    @Test
-    void newlineUsesDoubleQuotes() {
-        assertThat(quoteIfNeeded("line1\nline2")).isEqualTo("\"line1\\nline2\"");
-    }
-
-    @Test
-    void tabUsesDoubleQuotes() {
-        assertThat(quoteIfNeeded("col1\tcol2")).isEqualTo("\"col1\\tcol2\"");
-    }
-
-    @Test
-    void plainStringWithSingleQuoteMidStringUnchanged() {
-        assertThat(quoteIfNeeded("it's")).isEqualTo("it's");
-    }
-
-    @Test
-    void carriageReturnUsesDoubleQuotes() {
-        assertThat(quoteIfNeeded("line1\rline2")).isEqualTo("\"line1\\rline2\"");
-    }
-
-    @Test
-    void nullCharUsesDoubleQuotes() {
-        assertThat(quoteIfNeeded("abc\0def")).isEqualTo("\"abc\\0def\"");
-    }
-
-    @Test
-    void backslashInDoubleQuotesEscaped() {
-        assertThat(quoteIfNeeded("path\\to")).isEqualTo("path\\to");
-    }
-
-    @Test
-    void doubleQuoteCharInValueEscaped() {
-        assertThat(quoteIfNeeded("say \"hello\"")).isEqualTo("say \"hello\"");
+    static Stream<Arguments> doubleQuoteCases() {
+        return Stream.of(
+                // Contains ': ' (needs quoting) AND single quote (forces double quotes)
+                Arguments.of("it's: a test", "\"it's: a test\""),
+                Arguments.of("line1\nline2", "\"line1\\nline2\""),
+                Arguments.of("col1\tcol2", "\"col1\\tcol2\""),
+                Arguments.of("it's", "it's"),
+                Arguments.of("line1\rline2", "\"line1\\rline2\""),
+                Arguments.of("abc\0def", "\"abc\\0def\""),
+                Arguments.of("path\\to", "path\\to"),
+                Arguments.of("say \"hello\"", "say \"hello\"")
+        );
     }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/internal/StringUtilsTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/internal/StringUtilsTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.yaml.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.yaml.internal.StringUtils.quoteIfNeeded;
+
+class StringUtilsTest {
+
+    // Already-quoted passthrough
+
+    @Test
+    void singleQuotedPassthrough() {
+        assertThat(quoteIfNeeded("'hello'")).isEqualTo("'hello'");
+    }
+
+    @Test
+    void doubleQuotedPassthrough() {
+        assertThat(quoteIfNeeded("\"hello\"")).isEqualTo("\"hello\"");
+    }
+
+    @Test
+    void emptyQuotedPassthrough() {
+        assertThat(quoteIfNeeded("''")).isEqualTo("''");
+    }
+
+    // No quoting needed
+
+    @Test
+    void plainStringUnchanged() {
+        assertThat(quoteIfNeeded("hello")).isEqualTo("hello");
+    }
+
+    @Test
+    void plainStringWithSpacesUnchanged() {
+        assertThat(quoteIfNeeded("hello world")).isEqualTo("hello world");
+    }
+
+    @Test
+    void plainStringWithHyphensUnchanged() {
+        assertThat(quoteIfNeeded("some-key")).isEqualTo("some-key");
+    }
+
+    @Test
+    void pathUnchanged() {
+        assertThat(quoteIfNeeded("path/to/file")).isEqualTo("path/to/file");
+    }
+
+    @Test
+    void versionLikeStringUnchanged() {
+        assertThat(quoteIfNeeded("1.0.0")).isEqualTo("1.0.0");
+    }
+
+    @Test
+    void nonReservedWordUnchanged() {
+        assertThat(quoteIfNeeded("truefalse")).isEqualTo("truefalse");
+    }
+
+    @Test
+    void urlUnchanged() {
+        assertThat(quoteIfNeeded("https://example.com")).isEqualTo("https://example.com");
+    }
+
+    // Empty string
+
+    @Test
+    void emptyStringQuoted() {
+        assertThat(quoteIfNeeded("")).isEqualTo("''");
+    }
+
+    // Valid YAML typed values left unchanged
+
+    @Test
+    void nullUnchanged() {
+        assertThat(quoteIfNeeded("null")).isEqualTo("null");
+    }
+
+    @Test
+    void trueUnchanged() {
+        assertThat(quoteIfNeeded("true")).isEqualTo("true");
+    }
+
+    @Test
+    void falseUnchanged() {
+        assertThat(quoteIfNeeded("false")).isEqualTo("false");
+    }
+
+    @Test
+    void yesUnchanged() {
+        assertThat(quoteIfNeeded("YES")).isEqualTo("YES");
+    }
+
+    @Test
+    void integerUnchanged() {
+        assertThat(quoteIfNeeded("123")).isEqualTo("123");
+    }
+
+    @Test
+    void floatUnchanged() {
+        assertThat(quoteIfNeeded("1.23")).isEqualTo("1.23");
+    }
+
+    // Indicator characters at start
+
+    @Test
+    void tildeUnchanged() {
+        assertThat(quoteIfNeeded("~")).isEqualTo("~");
+    }
+
+    @Test
+    void dashSpaceQuoted() {
+        assertThat(quoteIfNeeded("- item")).isEqualTo("'- item'");
+    }
+
+    @Test
+    void negativeNumberQuotedAsIndicator() {
+        assertThat(quoteIfNeeded("-42")).isEqualTo("'-42'");
+    }
+
+    @Test
+    void hashQuoted() {
+        assertThat(quoteIfNeeded("# comment")).isEqualTo("'# comment'");
+    }
+
+    @Test
+    void asteriskQuoted() {
+        assertThat(quoteIfNeeded("*alias")).isEqualTo("'*alias'");
+    }
+
+    @Test
+    void ampersandQuoted() {
+        assertThat(quoteIfNeeded("&anchor")).isEqualTo("'&anchor'");
+    }
+
+    @Test
+    void bracketQuoted() {
+        assertThat(quoteIfNeeded("[list]")).isEqualTo("'[list]'");
+    }
+
+    @Test
+    void braceQuoted() {
+        assertThat(quoteIfNeeded("{map}")).isEqualTo("'{map}'");
+    }
+
+    @Test
+    void exclamationQuoted() {
+        assertThat(quoteIfNeeded("!tag")).isEqualTo("'!tag'");
+    }
+
+    @Test
+    void percentQuoted() {
+        assertThat(quoteIfNeeded("%directive")).isEqualTo("'%directive'");
+    }
+
+    // Dangerous mid-string patterns
+
+    @Test
+    void colonSpaceQuoted() {
+        assertThat(quoteIfNeeded("key: value")).isEqualTo("'key: value'");
+    }
+
+    @Test
+    void colonSpaceInTextWithUrlQuoted() {
+        assertThat(quoteIfNeeded("TODO: Follow this link https://example.com/page"))
+                .isEqualTo("'TODO: Follow this link https://example.com/page'");
+    }
+
+    @Test
+    void spaceHashQuoted() {
+        assertThat(quoteIfNeeded("before # after")).isEqualTo("'before # after'");
+    }
+
+    // Document markers
+
+    @Test
+    void documentStartMarkerQuoted() {
+        assertThat(quoteIfNeeded("---")).isEqualTo("'---'");
+    }
+
+    @Test
+    void documentEndMarkerQuoted() {
+        assertThat(quoteIfNeeded("...")).isEqualTo("'...'");
+    }
+
+    // Leading/trailing whitespace
+
+    @Test
+    void leadingSpaceQuoted() {
+        assertThat(quoteIfNeeded(" hello")).isEqualTo("' hello'");
+    }
+
+    @Test
+    void trailingSpaceQuoted() {
+        assertThat(quoteIfNeeded("hello ")).isEqualTo("'hello '");
+    }
+
+    @Test
+    void leadingTabQuoted() {
+        assertThat(quoteIfNeeded("\thello")).isEqualTo("\"\\thello\"");
+    }
+
+    // Double-quote cases
+
+    @Test
+    void singleQuoteInValueUsesDoubleQuotes() {
+        // Contains ': ' (needs quoting) AND single quote (forces double quotes)
+        assertThat(quoteIfNeeded("it's: a test")).isEqualTo("\"it's: a test\"");
+    }
+
+    @Test
+    void newlineUsesDoubleQuotes() {
+        assertThat(quoteIfNeeded("line1\nline2")).isEqualTo("\"line1\\nline2\"");
+    }
+
+    @Test
+    void tabUsesDoubleQuotes() {
+        assertThat(quoteIfNeeded("col1\tcol2")).isEqualTo("\"col1\\tcol2\"");
+    }
+
+    @Test
+    void plainStringWithSingleQuoteMidStringUnchanged() {
+        assertThat(quoteIfNeeded("it's")).isEqualTo("it's");
+    }
+
+    @Test
+    void carriageReturnUsesDoubleQuotes() {
+        assertThat(quoteIfNeeded("line1\rline2")).isEqualTo("\"line1\\rline2\"");
+    }
+
+    @Test
+    void nullCharUsesDoubleQuotes() {
+        assertThat(quoteIfNeeded("abc\0def")).isEqualTo("\"abc\\0def\"");
+    }
+
+    @Test
+    void backslashInDoubleQuotesEscaped() {
+        assertThat(quoteIfNeeded("path\\to")).isEqualTo("path\\to");
+    }
+
+    @Test
+    void doubleQuoteCharInValueEscaped() {
+        assertThat(quoteIfNeeded("say \"hello\"")).isEqualTo("say \"hello\"");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `StringUtils.quoteIfNeeded(String)` in `org.openrewrite.yaml.internal` that quotes YAML scalar values only when syntactically necessary
- Quotes when: value is empty, starts with an indicator character, contains `: ` or ` #`, starts with `---`/`...`, has leading/trailing whitespace, or contains control characters
- Uses minimal quoting: single quotes by default, double quotes only when escape sequences are needed (e.g., value contains `'` or control chars)
- Does **not** quote valid typed values like `true`, `null`, `123` — those are valid YAML as-is

## Motivation

- This utility addresses the root cause of [openrewrite/rewrite-spring#999](https://github.com/openrewrite/rewrite-spring/issues/999), where `AddSpringProperty` fails to quote values containing colons. The [`quoteValue` method](https://github.com/openrewrite/rewrite-spring/blob/main/src/main/java/org/openrewrite/java/spring/AddSpringProperty.java#L132) in `rewrite-spring` uses a regex that only matches strings made entirely of special characters, missing mixed values like `TODO: Follow this link https://example.com/page`.

With this utility in `rewrite-yaml`, `rewrite-spring` (and other modules) can replace ad-hoc quoting logic with a spec-compliant implementation.

## Test plan

- [x] 43 unit tests covering: already-quoted passthrough, plain strings, empty strings, indicator characters, colon-space/space-hash patterns, document markers, whitespace, control characters, double-quote escaping, URLs, and the exact scenario from rewrite-spring#999
- [x] `./gradlew :rewrite-yaml:test --tests "org.openrewrite.yaml.internal.StringUtilsTest"`