### PR TITLE
`AppendToTextFile`: support glob patterns for the relative file name

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/text/AppendToTextFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/AppendToTextFile.java
@@ -34,7 +34,8 @@ import static java.util.stream.Collectors.toSet;
 @EqualsAndHashCode(callSuper = false)
 public class AppendToTextFile extends ScanningRecipe<AtomicBoolean> {
     @Option(displayName = "Relative file name",
-            description = "File name, using a relative path. If a non-plaintext file already exists at this location, then this recipe will do nothing.",
+            description = "File name, using a relative path. May also be a glob expression (e.g. `**/*.txt`) to match one or more existing files; " +
+                          "when a glob is supplied no new file is created. If a non-plaintext file matches, that file is left unchanged.",
             example = "foo/bar/baz.txt")
     String relativeFileName;
 
@@ -93,7 +94,7 @@ public class AppendToTextFile extends ScanningRecipe<AtomicBoolean> {
             @Override
             public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
                 SourceFile sourceFile = (SourceFile) requireNonNull(tree);
-                if (!fileExists.get() && sourceFile.getSourcePath().toString().equals(Paths.get(relativeFileName).toString())) {
+                if (!fileExists.get() && matchesTarget(sourceFile.getSourcePath())) {
                     fileExists.set(true);
                 }
                 return sourceFile;
@@ -103,6 +104,11 @@ public class AppendToTextFile extends ScanningRecipe<AtomicBoolean> {
 
     @Override
     public Collection<PlainText> generate(AtomicBoolean fileExists, Collection<SourceFile> generatedInThisCycle, ExecutionContext ctx) {
+        // A glob can match multiple existing files but doesn't specify a concrete path to create.
+        if (relativeFileName.matches(".*[*?\\[{].*")) {
+            return emptyList();
+        }
+
         String maybeNewline = !Boolean.FALSE.equals(appendNewline) ? "\n" : "";
         String content = this.content + maybeNewline;
         String preamble = this.preamble != null ? this.preamble + maybeNewline : "";
@@ -132,7 +138,7 @@ public class AppendToTextFile extends ScanningRecipe<AtomicBoolean> {
             @Override
             public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
                 SourceFile sourceFile = (SourceFile) requireNonNull(tree);
-                if (sourceFile.getSourcePath().toString().equals(Paths.get(relativeFileName).toString())) {
+                if (sourceFile instanceof PlainText && matchesTarget(sourceFile.getSourcePath())) {
                     String maybeNewline = !Boolean.FALSE.equals(appendNewline) ? "\n" : "";
                     String content = AppendToTextFile.this.content + maybeNewline;
                     String preamble = AppendToTextFile.this.preamble != null ? AppendToTextFile.this.preamble + maybeNewline : "";
@@ -153,6 +159,10 @@ public class AppendToTextFile extends ScanningRecipe<AtomicBoolean> {
                 return sourceFile;
             }
         });
+    }
+
+    private boolean matchesTarget(Path sourcePath) {
+        return sourcePath.getFileSystem().getPathMatcher("glob:" + relativeFileName).matches(sourcePath);
     }
 
     /**

--- a/rewrite-core/src/test/java/org/openrewrite/text/AppendToTextFileTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/text/AppendToTextFileTest.java
@@ -317,6 +317,59 @@ class AppendToTextFileTest implements RewriteTest {
     }
 
     @Nested
+    class Glob {
+
+        @Test
+        void globMatchesMultipleFiles() {
+            rewriteRun(
+              spec -> spec.recipe(new AppendToTextFile("**/*.txt", "content", null, true, AppendToTextFile.Strategy.Continue)),
+              text(
+                "existing1",
+                """
+                  existing1
+                  content
+                  """,
+                spec -> spec.path("a/file1.txt").noTrim()
+              ),
+              text(
+                "existing2",
+                """
+                  existing2
+                  content
+                  """,
+                spec -> spec.path("b/file2.txt").noTrim()
+              )
+            );
+        }
+
+        @Test
+        void globDoesNotCreateNewFile() {
+            rewriteRun(
+              spec -> spec.recipe(new AppendToTextFile("**/*.txt", "content", "preamble", true, AppendToTextFile.Strategy.Leave))
+            );
+        }
+
+        @Test
+        void globSkipsNonMatchingFiles() {
+            rewriteRun(
+              spec -> spec.recipe(new AppendToTextFile("**/*.txt", "content", null, true, AppendToTextFile.Strategy.Continue)),
+              text(
+                "keep me",
+                spec -> spec.path("a/file.md")
+              ),
+              text(
+                "existing",
+                """
+                  existing
+                  content
+                  """,
+                spec -> spec.path("a/file.txt").noTrim()
+              )
+            );
+        }
+    }
+
+    @Nested
     class Merge {
         /**
          * Demonstrates the @{code Merge} strategy with smart line-based deduplication.


### PR DESCRIPTION
## Summary
- `AppendToTextFile` now accepts a glob expression (e.g. `**/*.txt`) as `relativeFileName`, letting a single recipe invocation append to many existing files.
- Matching is delegated to `PathMatcher` with `glob:` syntax, aligning with the convention in `DeleteSourceFiles`, `RenameFile`, `MoveFile`, and `SetFilePermissions`. A literal path still works because it matches itself as a glob.
- When the pattern contains glob metacharacters no new file is generated (a glob does not specify a concrete path to create); literal paths preserve the existing create-if-missing behavior. The visitor also now guards its `PlainText` cast with `instanceof`, avoiding a `ClassCastException` when a glob matches a non-plaintext file.

## Test plan
- [x] `./gradlew :rewrite-core:test --tests "org.openrewrite.text.AppendToTextFileTest"` — new `Glob` nested class covers multi-file match, non-creation for globs, and skipping non-matching files.