### PR TITLE
Fix `ChangeType` UOE on `JS.ComputedPropertyMethodDeclaration`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -225,6 +225,9 @@ public class ChangeType extends Recipe {
             } else if (j instanceof MethodCall) {
                 MethodCall call = (MethodCall) j;
                 j = (J) call.withMethodType(updateType(call.getMethodType()));
+            } else if (j instanceof MethodDeclarationLike) {
+                MethodDeclarationLike mdl = (MethodDeclarationLike) j;
+                j = (J) mdl.withMethodType(updateType(mdl.getMethodType()));
             } else if (tree instanceof TypedTree) {
                 j = ((TypedTree) tree).withType(updateType(((TypedTree) tree).getType()));
             } else if (tree instanceof JavaSourceFile) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -3884,7 +3884,7 @@ public interface J extends Tree {
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    final class MethodDeclaration implements J, Statement, TypedTree {
+    final class MethodDeclaration implements J, Statement, TypedTree, MethodDeclarationLike {
         @Nullable
         @NonFinal
         transient WeakReference<Padding> padding;

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/MethodDeclarationLike.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/MethodDeclarationLike.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.tree;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Either a {@link org.openrewrite.java.tree.J.MethodDeclaration} or a method-declaration-shaped
+ * node from another language (e.g. {@code JS.ComputedPropertyMethodDeclaration}).
+ * <p>
+ * Implementations' {@link #withType(JavaType)} is expected to throw
+ * {@link UnsupportedOperationException}; callers wishing to change the declared return type
+ * must use {@link #withMethodType(JavaType.Method)} instead.
+ */
+public interface MethodDeclarationLike extends TypedTree {
+
+    JavaType.@Nullable Method getMethodType();
+
+    MethodDeclarationLike withMethodType(JavaType.@Nullable Method methodType);
+}

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/ChangeTypeAdaptabilityTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/ChangeTypeAdaptabilityTest.java
@@ -28,7 +28,8 @@ import static org.openrewrite.javascript.Assertions.javascript;
 
 /**
  * Prove that {@link ChangeType}, written for Java, does not fail on JavaScript source files
- * containing {@link JS.FunctionCall} nodes.
+ * containing nodes like {@link JS.FunctionCall} or {@link JS.ComputedPropertyMethodDeclaration}
+ * whose {@code withType(..)} throws {@link UnsupportedOperationException} by design.
  */
 class ChangeTypeAdaptabilityTest implements RewriteTest {
 
@@ -68,6 +69,38 @@ class ChangeTypeAdaptabilityTest implements RewriteTest {
                 assertThat(cu.getClasses().getFirst().getType())
                   .as("Expected JS ClassDeclaration to have type attribution")
                   .isNotNull();
+            })
+          )
+        );
+    }
+
+    @Test
+    void computedPropertyMethodDeclarationDoesNotThrow() {
+        AtomicBoolean hasComputedPropertyMethodDeclaration = new AtomicBoolean(false);
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("Foo", "Bar", false)),
+          javascript(
+            """
+              class Foo {
+                  ["bar"](): number { return 1; }
+              }
+              """,
+            """
+              class Bar {
+                  ["bar"](): number { return 1; }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                new JavaScriptVisitor<Integer>() {
+                    @Override
+                    public J visitComputedPropertyMethodDeclaration(JS.ComputedPropertyMethodDeclaration m, Integer p) {
+                        hasComputedPropertyMethodDeclaration.set(true);
+                        return super.visitComputedPropertyMethodDeclaration(m, p);
+                    }
+                }.visit(cu, 0);
+                assertThat(hasComputedPropertyMethodDeclaration.get())
+                  .as("Expected parsed JavaScript to contain a JS.ComputedPropertyMethodDeclaration node")
+                  .isTrue();
             })
           )
         );

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
@@ -3819,7 +3819,7 @@ public interface JS extends J {
     @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     @Data
-    final class ComputedPropertyMethodDeclaration implements JS, Statement, TypedTree {
+    final class ComputedPropertyMethodDeclaration implements JS, Statement, TypedTree, MethodDeclarationLike {
         @Nullable
         @NonFinal
         transient WeakReference<ComputedPropertyMethodDeclaration.Padding> padding;


### PR DESCRIPTION
## Motivation

`ChangeType.postVisit` crashes with `UnsupportedOperationException` when it encounters `JS.ComputedPropertyMethodDeclaration`:

```
java.lang.UnsupportedOperationException: To change the return type of this method declaration, use withMethodType(..)
  org.openrewrite.javascript.tree.JS$ComputedPropertyMethodDeclaration.withType(JS.java:3899)
  org.openrewrite.java.ChangeType$JavaChangeTypeVisitor.postVisit(ChangeType.java:229)
```

This is the third variant of the same underlying issue:

- #7239 added a `MethodCall` catch-all for `JS.FunctionCall` etc.
- #7314 caught UOE inside `Py.ExpressionTypeTree.withType()` itself.
- Neither covers `JS.ComputedPropertyMethodDeclaration`, which implements `JS, Statement, TypedTree` (not `MethodCall`, not `J.MethodDeclaration`), so it hit the generic `TypedTree` fallback.

Observed volume: ~13 per-file errors/day on production runs of `NoGuavaPredicate` (a sub-recipe of "Java best practices") against TypeScript repositories.

## Summary

- New interface `org.openrewrite.java.tree.MethodDeclarationLike` (parallel to `MethodCall`) exposes `getMethodType()` / `withMethodType(..)`.
- `J.MethodDeclaration` and `JS.ComputedPropertyMethodDeclaration` now implement it (signatures were already there).
- `ChangeType.postVisit` has a new branch for `MethodDeclarationLike`, placed after the `MethodCall` branch and before the generic `TypedTree` fallback.
- New test `ChangeTypeAdaptabilityTest#computedPropertyMethodDeclarationDoesNotThrow` exercises the path end-to-end.

### Known follow-up

`K.SpreadArgument` and `K.StatementExpression` also throw UOE from `withType(..)`, but their semantics ("cannot be changed directly" / "cannot have a type") do not fit `MethodDeclarationLike`. Those are not addressed here and would need separate handling.

## Test plan

- [x] New `ChangeTypeAdaptabilityTest#computedPropertyMethodDeclarationDoesNotThrow` reproduces the UOE on `main` and passes on this branch.
- [x] `./gradlew :rewrite-java-test:test --tests org.openrewrite.java.ChangeTypeTest` — 81 tests, all pass.
- [x] `./gradlew :rewrite-javascript:integTest --tests org.openrewrite.javascript.ChangeTypeAdaptabilityTest` — 2 tests, all pass.
- [x] `./gradlew assemble` — clean build across all modules.
- [x] `./gradlew :rewrite-javascript:test` — green.