### PR TITLE
Fix TypeTable round-trip for Kotlin top-level functions

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -753,8 +753,7 @@ public class TypeTable implements JavaParserClasspathLoader {
              */
             public void writeResource(String resourcePath, byte[] content) {
                 out.println(TsvRow.resourceRow(groupId, artifactId, version,
-                        resourcePath, Base64.getEncoder().encodeToString(content))
-                        .build());
+                        resourcePath, Base64.getEncoder().encodeToString(content)));
             }
 
             /**
@@ -1018,8 +1017,7 @@ public class TypeTable implements JavaParserClasspathLoader {
                             jar.groupId, jar.artifactId, jar.version,
                             classAccess, className,
                             classSignature, classSuperclassName, classSuperinterfaceSignatures,
-                            classAnnotations, classTypeAnnotations, innerClasses)
-                            .build());
+                            classAnnotations, classTypeAnnotations, innerClasses));
 
                     for (Writer.Member member : members) {
                         member.writeMember(jar, this);
@@ -1067,8 +1065,7 @@ public class TypeTable implements JavaParserClasspathLoader {
                             parameterNames, exceptions,
                             elementAnnotations,
                             serializeParameterAnnotations(parameterAnnotations, descriptor),
-                            typeAnnotations, constantValue)
-                            .build());
+                            typeAnnotations, constantValue));
                 }
             }
         }
@@ -1309,23 +1306,24 @@ public class TypeTable implements JavaParserClasspathLoader {
                     constantValue, innerClasses);
         }
 
-        static TsvRowBuilder resourceRow(String groupId, String artifactId, String version,
-                                         String path, String base64) {
+        static TsvRow resourceRow(String groupId, String artifactId, String version,
+                                  String path, String base64) {
             return TsvRow.builder()
                     .groupId(groupId).artifactId(artifactId).version(version)
                     .classAccess(Kind.RESOURCE.getSentinel())
                     .className(path)
-                    .constantValue(base64);
+                    .constantValue(base64)
+                    .build();
         }
 
-        static TsvRowBuilder classRow(String groupId, String artifactId, String version,
-                                      int classAccess, String className,
-                                      @Nullable String classSignature,
-                                      @Nullable String classSuperclassName,
-                                      String @Nullable [] classSuperinterfaceSignatures,
-                                      List<String> classAnnotations,
-                                      List<String> classTypeAnnotations,
-                                      List<String> innerClasses) {
+        static TsvRow classRow(String groupId, String artifactId, String version,
+                               int classAccess, String className,
+                               @Nullable String classSignature,
+                               @Nullable String classSuperclassName,
+                               String @Nullable [] classSuperinterfaceSignatures,
+                               List<String> classAnnotations,
+                               List<String> classTypeAnnotations,
+                               List<String> innerClasses) {
             return TsvRow.builder()
                     .groupId(groupId).artifactId(artifactId).version(version)
                     .classAccess(classAccess).className(className)
@@ -1337,22 +1335,23 @@ public class TypeTable implements JavaParserClasspathLoader {
                     .typeAnnotations(classTypeAnnotations.isEmpty() ? "" :
                             PipeDelimitedJoiner.joinWithPipes(classTypeAnnotations))
                     .innerClasses(innerClasses.isEmpty() ? "" :
-                            PipeDelimitedJoiner.joinWithPipes(innerClasses));
+                            PipeDelimitedJoiner.joinWithPipes(innerClasses))
+                    .build();
         }
 
-        static TsvRowBuilder memberRow(String groupId, String artifactId, String version,
-                                       int classAccess, String className,
-                                       @Nullable String classSignature,
-                                       @Nullable String classSuperclassName,
-                                       String @Nullable [] classSuperinterfaceSignatures,
-                                       int memberAccess, String memberName, String descriptor,
-                                       @Nullable String signature,
-                                       List<String> parameterNames,
-                                       String @Nullable [] exceptions,
-                                       List<String> elementAnnotations,
-                                       String parameterAnnotations,
-                                       List<String> typeAnnotations,
-                                       @Nullable String constantValue) {
+        static TsvRow memberRow(String groupId, String artifactId, String version,
+                                int classAccess, String className,
+                                @Nullable String classSignature,
+                                @Nullable String classSuperclassName,
+                                String @Nullable [] classSuperinterfaceSignatures,
+                                int memberAccess, String memberName, String descriptor,
+                                @Nullable String signature,
+                                List<String> parameterNames,
+                                String @Nullable [] exceptions,
+                                List<String> elementAnnotations,
+                                String parameterAnnotations,
+                                List<String> typeAnnotations,
+                                @Nullable String constantValue) {
             return TsvRow.builder()
                     .groupId(groupId).artifactId(artifactId).version(version)
                     .classAccess(classAccess).className(className)
@@ -1368,7 +1367,8 @@ public class TypeTable implements JavaParserClasspathLoader {
                     .parameterAnnotations(parameterAnnotations)
                     .typeAnnotations(typeAnnotations.isEmpty() ? "" :
                             PipeDelimitedJoiner.joinWithPipes(typeAnnotations))
-                    .constantValue(constantValue == null ? "" : constantValue);
+                    .constantValue(constantValue == null ? "" : constantValue)
+                    .build();
         }
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -437,15 +437,13 @@ public class TypeTable implements JavaParserClasspathLoader {
 
             if (classDef.getInnerClasses() != null) {
                 for (String entry : classDef.getInnerClasses()) {
-                    // Format: name,outerName,innerName,access (outerName/innerName empty means null)
-                    String[] parts = entry.split(",", 4);
-                    if (parts.length == 4) {
+                    InnerClassRef ref = InnerClassRef.parse(entry);
+                    if (ref != null) {
                         classVisitor.visitInnerClass(
-                                parts[0],
-                                parts[1].isEmpty() ? null : parts[1],
-                                parts[2].isEmpty() ? null : parts[2],
-                                Integer.parseInt(parts[3])
-                        );
+                                ref.getName(),
+                                ref.getOuterName(),
+                                ref.getInnerName(),
+                                ref.getAccess());
                     }
                 }
             } else {
@@ -974,10 +972,7 @@ public class TypeTable implements JavaParserClasspathLoader {
                     public void visitInnerClass(String name, @Nullable String outerName, @Nullable String innerName, int access) {
                         if (classDefinition != null) {
                             classDefinition.innerClasses.add(
-                                    name + "," +
-                                            (outerName == null ? "" : outerName) + "," +
-                                            (innerName == null ? "" : innerName) + "," +
-                                            access);
+                                    new InnerClassRef(name, outerName, innerName, access).toString());
                         }
                     }
 
@@ -1369,6 +1364,34 @@ public class TypeTable implements JavaParserClasspathLoader {
                             PipeDelimitedJoiner.joinWithPipes(typeAnnotations))
                     .constantValue(constantValue == null ? "" : constantValue)
                     .build();
+        }
+    }
+
+    @Value
+    static class InnerClassRef {
+        String name;
+        @Nullable String outerName;
+        @Nullable String innerName;
+        int access;
+
+        @Override
+        public String toString() {
+            return name + "," +
+                    (outerName == null ? "" : outerName) + "," +
+                    (innerName == null ? "" : innerName) + "," +
+                    access;
+        }
+
+        static @Nullable InnerClassRef parse(String entry) {
+            String[] parts = entry.split(",", 4);
+            if (parts.length != 4) {
+                return null;
+            }
+            return new InnerClassRef(
+                    parts[0],
+                    parts[1].isEmpty() ? null : parts[1],
+                    parts[2].isEmpty() ? null : parts[2],
+                    Integer.parseInt(parts[3]));
         }
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -237,10 +237,22 @@ public class TypeTable implements JavaParserClasspathLoader {
          * @param visitorSupplier Supplier to create a ClassVisitor for each class
          */
         public void read(InputStream is, Options options, Supplier<ClassVisitor> visitorSupplier) throws IOException {
+            read(is, options, visitorSupplier, (path, content) -> {});
+        }
+
+        /**
+         * Read a type table and process classes with custom ClassVisitors, and route non-class
+         * resources (e.g., {@code .kotlin_module} files) to the given consumer.
+         */
+        public void read(InputStream is, Options options, Supplier<ClassVisitor> visitorSupplier,
+                         ResourceConsumer resourceConsumer) throws IOException {
             parseTsvAndProcess(is, options,
-                    (gav, classes, nestedTypes) -> {
+                    (gav, classes, nestedTypes, resources) -> {
                         for (ClassDefinition classDef : classes.values()) {
                             processClass(classDef, nestedTypes.getOrDefault(classDef.getName(), emptyList()), visitorSupplier.get());
+                        }
+                        for (Map.Entry<String, byte[]> e : resources.entrySet()) {
+                            resourceConsumer.accept(e.getKey(), e.getValue());
                         }
                     });
         }
@@ -255,6 +267,7 @@ public class TypeTable implements JavaParserClasspathLoader {
             Map<String, ClassDefinition> classesByName = new HashMap<>();
             // nested types appear first in type tables and therefore not stored in a `ClassDefinition` field
             Map<String, List<ClassDefinition>> nestedTypesByOwner = new HashMap<>();
+            Map<String, byte[]> resourcesByPath = new LinkedHashMap<>();
 
             try (BufferedReader in = new BufferedReader(new InputStreamReader(is))) {
                 AtomicReference<@Nullable GroupArtifactVersion> lastGav = new AtomicReference<>();
@@ -264,11 +277,12 @@ public class TypeTable implements JavaParserClasspathLoader {
 
                     if (!Objects.equals(rowGav, lastGav.get())) {
                         if (matchedGav.get() != null) {
-                            processor.accept(matchedGav.get(), classesByName, nestedTypesByOwner);
+                            processor.accept(matchedGav.get(), classesByName, nestedTypesByOwner, resourcesByPath);
                         }
                         matchedGav.set(null);
                         classesByName.clear();
                         nestedTypesByOwner.clear();
+                        resourcesByPath.clear();
 
                         String artifactVersion = fields[1] + "-" + fields[2];
 
@@ -280,16 +294,25 @@ public class TypeTable implements JavaParserClasspathLoader {
                     lastGav.set(rowGav);
 
                     if (matchedGav.get() != null) {
+                        int classAccess = Integer.parseInt(fields[3]);
+                        if (classAccess == -2) {
+                            // Resource row — see Writer.Jar.writeResource
+                            String resourcePath = fields[4];
+                            String base64 = fields.length > 17 ? fields[17] : "";
+                            resourcesByPath.put(resourcePath, Base64.getDecoder().decode(base64));
+                            return;
+                        }
                         String className = fields[4];
                         ClassDefinition classDefinition = classesByName.computeIfAbsent(className, name ->
                                 new ClassDefinition(
-                                        Integer.parseInt(fields[3]),
+                                        classAccess,
                                         name,
                                         fields[5].isEmpty() ? null : fields[5],
                                         fields[6].isEmpty() ? null : fields[6],
                                         fields[7].isEmpty() ? null : fields[7].split("\\|"),
                                         fields.length > 14 && !fields[14].isEmpty() ? fields[14] : null,  // elementAnnotations - raw string (may have | delimiters)
-                                        fields.length > 17 && !fields[17].isEmpty() ? fields[17] : null  // constantValue moved to column 17
+                                        fields.length > 17 && !fields[17].isEmpty() ? fields[17] : null,  // constantValue moved to column 17
+                                        fields.length > 18 && !fields[18].isEmpty() ? TsvEscapeUtils.splitAnnotationList(fields[18], '|') : null
                                 ));
                         int lastIndexOf$ = className.lastIndexOf('$');
                         if (lastIndexOf$ != -1) {
@@ -319,17 +342,25 @@ public class TypeTable implements JavaParserClasspathLoader {
 
             // Process final GAV if any
             if (matchedGav.get() != null) {
-                processor.accept(matchedGav.get(), classesByName, nestedTypesByOwner);
+                processor.accept(matchedGav.get(), classesByName, nestedTypesByOwner, resourcesByPath);
             }
         }
 
         @FunctionalInterface
         interface ClassesProcessor {
             void accept(@Nullable GroupArtifactVersion gav, Map<String, ClassDefinition> classes,
-                        Map<String, List<ClassDefinition>> nestedTypes);
+                        Map<String, List<ClassDefinition>> nestedTypes,
+                        Map<String, byte[]> resources);
         }
 
-        private void writeClassesDir(@Nullable GroupArtifactVersion gav, Map<String, ClassDefinition> classes, Map<String, List<ClassDefinition>> nestedTypesByOwner) {
+        @FunctionalInterface
+        public interface ResourceConsumer {
+            void accept(String resourcePath, byte[] content);
+        }
+
+        private void writeClassesDir(@Nullable GroupArtifactVersion gav, Map<String, ClassDefinition> classes,
+                                     Map<String, List<ClassDefinition>> nestedTypesByOwner,
+                                     Map<String, byte[]> resources) {
             if (gav == null) {
                 return;
             }
@@ -360,6 +391,15 @@ public class TypeTable implements JavaParserClasspathLoader {
                         throw new UncheckedIOException(e);
                     }
                 });
+                resources.forEach((resourcePath, content) -> {
+                    Path target = classesDir.resolve(resourcePath);
+                    try {
+                        Files.createDirectories(target.getParent());
+                        Files.write(target, content);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
                 future.complete(classesDir);
             } catch (Exception e) {
                 future.completeExceptionally(e);
@@ -385,13 +425,30 @@ public class TypeTable implements JavaParserClasspathLoader {
                 AnnotationApplier.applyAnnotations(classDef.getAnnotations(), classVisitor::visitAnnotation);
             }
 
-            for (ClassDefinition innerClassDef : nestedTypes) {
-                classVisitor.visitInnerClass(
-                        innerClassDef.getName(),
-                        classDef.getName(),
-                        innerClassDef.getName().substring(classDef.getName().length() + 1),
-                        innerClassDef.getAccess() & NESTED_TYPE_ACCESS_MASK
-                );
+            if (classDef.getInnerClasses() != null) {
+                for (String entry : classDef.getInnerClasses()) {
+                    // Format: name,outerName,innerName,access (outerName/innerName empty means null)
+                    String[] parts = entry.split(",", 4);
+                    if (parts.length == 4) {
+                        classVisitor.visitInnerClass(
+                                parts[0],
+                                parts[1].isEmpty() ? null : parts[1],
+                                parts[2].isEmpty() ? null : parts[2],
+                                Integer.parseInt(parts[3])
+                        );
+                    }
+                }
+            } else {
+                // Backward compatibility: replay inner classes derived from name suffixes
+                // for TSV files written before the innerClasses column was added.
+                for (ClassDefinition innerClassDef : nestedTypes) {
+                    classVisitor.visitInnerClass(
+                            innerClassDef.getName(),
+                            classDef.getName(),
+                            innerClassDef.getName().substring(classDef.getName().length() + 1),
+                            innerClassDef.getAccess() & NESTED_TYPE_ACCESS_MASK
+                    );
+                }
             }
 
             for (Member member : classDef.getMembers()) {
@@ -629,7 +686,7 @@ public class TypeTable implements JavaParserClasspathLoader {
         public Writer(OutputStream out) throws IOException {
             this.deflater = new GZIPOutputStream(out);
             this.out = new PrintStream(deflater);
-            this.out.println("groupId\tartifactId\tversion\tclassAccess\tclassName\tclassSignature\tclassSuperclassSignature\tclassSuperinterfaceSignatures\taccess\tname\tdescriptor\tsignature\tparameterNames\texceptions\telementAnnotations\tparameterAnnotations\ttypeAnnotations\tconstantValue");
+            this.out.println("groupId\tartifactId\tversion\tclassAccess\tclassName\tclassSignature\tclassSuperclassSignature\tclassSuperinterfaceSignatures\taccess\tname\tdescriptor\tsignature\tparameterNames\texceptions\telementAnnotations\tparameterAnnotations\ttypeAnnotations\tconstantValue\tinnerClasses");
         }
 
         public Jar jar(String groupId, String artifactId, String version) {
@@ -657,11 +714,45 @@ public class TypeTable implements JavaParserClasspathLoader {
                             try (InputStream inputStream = jarFile.getInputStream(entry)) {
                                 writeClass(inputStream);
                             }
+                        } else if (entry.getName().endsWith(".kotlin_module")) {
+                            try (InputStream inputStream = jarFile.getInputStream(entry)) {
+                                writeResource(entry.getName(), readAllBytes(inputStream));
+                            }
                         }
                     }
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
+            }
+
+            private byte[] readAllBytes(InputStream in) throws IOException {
+                ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                byte[] chunk = new byte[8192];
+                int n;
+                while ((n = in.read(chunk)) != -1) {
+                    buffer.write(chunk, 0, n);
+                }
+                return buffer.toByteArray();
+            }
+
+            /**
+             * Write a non-class resource file (e.g., a Kotlin .kotlin_module file) so that the
+             * synthesized classpath has parity with the source jar for tooling that reads these
+             * files (like the Kotlin compiler, which needs .kotlin_module to resolve top-level
+             * functions in a package).
+             */
+            public void writeResource(String resourcePath, byte[] content) {
+                // Resource row: classAccess sentinel -2, className holds the path, content is
+                // base64-encoded in the constantValue column. All other columns are empty.
+                out.printf(
+                        "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s%n",
+                        groupId, artifactId, version,
+                        -2, resourcePath,
+                        "", "", "",
+                        -1, "", "", "", "", "",
+                        "", "", "",
+                        Base64.getEncoder().encodeToString(content),
+                        "");
             }
 
             /**
@@ -770,8 +861,10 @@ public class TypeTable implements JavaParserClasspathLoader {
                     @Override
                     public @Nullable MethodVisitor visitMethod(int access, @Nullable String name, String descriptor,
                                                                @Nullable String signature, String @Nullable [] exceptions) {
-                        // Repeating check from `writeMethod()` for performance reasons
-                        if (classDefinition != null && ((Opcodes.ACC_PRIVATE | Opcodes.ACC_SYNTHETIC) & access) == 0 &&
+                        // Repeating check from `writeMethod()` for performance reasons.
+                        // Synthetic methods are kept: Kotlin extension functions, $default overloads,
+                        // and Java bridge methods are all synthetic but part of the user-visible API.
+                        if (classDefinition != null && (Opcodes.ACC_PRIVATE & access) == 0 &&
                                 name != null && !"<clinit>".equals(name)) {
                             Writer.Member member = new Writer.Member(access, name, descriptor, signature, exceptions, null);
                             return new MethodVisitor(Opcodes.ASM9) {
@@ -877,6 +970,17 @@ public class TypeTable implements JavaParserClasspathLoader {
                     }
 
                     @Override
+                    public void visitInnerClass(String name, @Nullable String outerName, @Nullable String innerName, int access) {
+                        if (classDefinition != null) {
+                            classDefinition.innerClasses.add(
+                                    name + "," +
+                                            (outerName == null ? "" : outerName) + "," +
+                                            (innerName == null ? "" : innerName) + "," +
+                                            access);
+                        }
+                    }
+
+                    @Override
                     public void visitEnd() {
                         if (classDefinition != null && !"module-info".equals(classDefinition.className)) {
                             // No fields or methods, which can happen for marker annotations for example
@@ -903,12 +1007,13 @@ public class TypeTable implements JavaParserClasspathLoader {
 
             List<String> classAnnotations = new ArrayList<>(4);
             List<String> classTypeAnnotations = new ArrayList<>(4);
+            List<String> innerClasses = new ArrayList<>(4);
             List<Writer.Member> members = new ArrayList<>();
 
             public void writeClass() {
                 if (((Opcodes.ACC_PRIVATE | Opcodes.ACC_SYNTHETIC) & classAccess) == 0) {
                     out.printf(
-                            "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s%n",
+                            "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s%n",
                             jar.groupId, jar.artifactId, jar.version,
                             classAccess, className,
                             classSignature == null ? "" : classSignature,
@@ -918,7 +1023,8 @@ public class TypeTable implements JavaParserClasspathLoader {
                             classAnnotations.isEmpty() ? "" : String.join("", classAnnotations),
                             "", // Empty parameter annotations for class row
                             classTypeAnnotations.isEmpty() ? "" : PipeDelimitedJoiner.joinWithPipes(classTypeAnnotations),
-                            ""); // Empty constant value for class row
+                            "", // Empty constant value for class row
+                            innerClasses.isEmpty() ? "" : PipeDelimitedJoiner.joinWithPipes(innerClasses));
 
                     for (Writer.Member member : members) {
                         member.writeMember(jar, this);
@@ -955,9 +1061,9 @@ public class TypeTable implements JavaParserClasspathLoader {
             String constantValue;
 
             private void writeMember(Jar jar, ClassDefinition classDefinition) {
-                if (((Opcodes.ACC_PRIVATE | Opcodes.ACC_SYNTHETIC) & access) == 0) {
+                if ((Opcodes.ACC_PRIVATE & access) == 0) {
                     out.printf(
-                            "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s%n",
+                            "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s%n",
                             jar.groupId, jar.artifactId, jar.version,
                             classDefinition.classAccess, classDefinition.className,
                             classDefinition.classSignature == null ? "" : classDefinition.classSignature,
@@ -970,7 +1076,8 @@ public class TypeTable implements JavaParserClasspathLoader {
                             elementAnnotations.isEmpty() ? "" : String.join("", elementAnnotations),
                             serializeParameterAnnotations(parameterAnnotations, descriptor),
                             typeAnnotations.isEmpty() ? "" : PipeDelimitedJoiner.joinWithPipes(typeAnnotations),
-                            constantValue == null ? "" : constantValue
+                            constantValue == null ? "" : constantValue,
+                            "" // innerClasses column is written on class row only
                     );
                 }
             }
@@ -1003,6 +1110,8 @@ public class TypeTable implements JavaParserClasspathLoader {
 
         @Nullable
         String constantValue;
+
+        String @Nullable [] innerClasses;
 
         @NonFinal
         @Nullable

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -272,8 +272,8 @@ public class TypeTable implements JavaParserClasspathLoader {
             try (BufferedReader in = new BufferedReader(new InputStreamReader(is))) {
                 AtomicReference<@Nullable GroupArtifactVersion> lastGav = new AtomicReference<>();
                 in.lines().skip(1).forEach(line -> {
-                    String[] fields = line.split("\t", -1);
-                    GroupArtifactVersion rowGav = new GroupArtifactVersion(fields[0], fields[1], fields[2]);
+                    TsvRow row = TsvRow.parse(line);
+                    GroupArtifactVersion rowGav = new GroupArtifactVersion(row.getGroupId(), row.getArtifactId(), row.getVersion());
 
                     if (!Objects.equals(rowGav, lastGav.get())) {
                         if (matchedGav.get() != null) {
@@ -284,7 +284,7 @@ public class TypeTable implements JavaParserClasspathLoader {
                         nestedTypesByOwner.clear();
                         resourcesByPath.clear();
 
-                        String artifactVersion = fields[1] + "-" + fields[2];
+                        String artifactVersion = row.getArtifactId() + "-" + row.getVersion();
 
                         // Check if this artifact matches our predicate
                         if (options.getArtifactMatcher().test(artifactVersion)) {
@@ -294,47 +294,33 @@ public class TypeTable implements JavaParserClasspathLoader {
                     lastGav.set(rowGav);
 
                     if (matchedGav.get() != null) {
-                        int classAccess = Integer.parseInt(fields[3]);
-                        if (classAccess == -2) {
-                            // Resource row — see Writer.Jar.writeResource
-                            String resourcePath = fields[4];
-                            String base64 = fields.length > 17 ? fields[17] : "";
-                            resourcesByPath.put(resourcePath, Base64.getDecoder().decode(base64));
-                            return;
-                        }
-                        String className = fields[4];
-                        ClassDefinition classDefinition = classesByName.computeIfAbsent(className, name ->
-                                new ClassDefinition(
-                                        classAccess,
-                                        name,
-                                        fields[5].isEmpty() ? null : fields[5],
-                                        fields[6].isEmpty() ? null : fields[6],
-                                        fields[7].isEmpty() ? null : fields[7].split("\\|"),
-                                        fields.length > 14 && !fields[14].isEmpty() ? fields[14] : null,  // elementAnnotations - raw string (may have | delimiters)
-                                        fields.length > 17 && !fields[17].isEmpty() ? fields[17] : null,  // constantValue moved to column 17
-                                        fields.length > 18 && !fields[18].isEmpty() ? TsvEscapeUtils.splitAnnotationList(fields[18], '|') : null
+                        switch (row.kind()) {
+                            case RESOURCE: {
+                                resourcesByPath.put(row.getClassName(),
+                                        Base64.getDecoder().decode(row.getConstantValue()));
+                                return;
+                            }
+                            case CLASS: {
+                                getOrCreateClassDefinition(row, classesByName, nestedTypesByOwner);
+                                break;
+                            }
+                            case MEMBER: {
+                                ClassDefinition classDefinition = getOrCreateClassDefinition(row, classesByName, nestedTypesByOwner);
+                                classDefinition.addMember(new Member(
+                                        classDefinition,
+                                        row.getMemberAccess(),
+                                        row.getMemberName(),
+                                        row.getDescriptor(),
+                                        row.getSignature().isEmpty() ? null : row.getSignature(),
+                                        row.getParameterNames().isEmpty() ? null : row.getParameterNames().split("\\|"),
+                                        row.getExceptions().isEmpty() ? null : row.getExceptions().split("\\|"),
+                                        row.getElementAnnotations().isEmpty() ? null : row.getElementAnnotations(),
+                                        row.getParameterAnnotations().isEmpty() ? null : row.getParameterAnnotations(),
+                                        row.getTypeAnnotations().isEmpty() ? null : TsvEscapeUtils.splitAnnotationList(row.getTypeAnnotations(), '|'),
+                                        row.getConstantValue().isEmpty() ? null : row.getConstantValue()
                                 ));
-                        int lastIndexOf$ = className.lastIndexOf('$');
-                        if (lastIndexOf$ != -1) {
-                            String ownerName = className.substring(0, lastIndexOf$);
-                            nestedTypesByOwner.computeIfAbsent(ownerName, k -> new ArrayList<>(4))
-                                    .add(classDefinition);
-                        }
-                        int memberAccess = Integer.parseInt(fields[8]);
-                        if (memberAccess != -1) {
-                            classDefinition.addMember(new Member(
-                                    classDefinition,
-                                    memberAccess,
-                                    fields[9],
-                                    fields[10],
-                                    fields[11].isEmpty() ? null : fields[11],
-                                    fields[12].isEmpty() ? null : fields[12].split("\\|"),
-                                    fields[13].isEmpty() ? null : fields[13].split("\\|"),
-                                    fields.length > 14 && !fields[14].isEmpty() ? fields[14] : null,  // elementAnnotations - raw string
-                                    fields.length > 15 && !fields[15].isEmpty() ? fields[15] : null,
-                                    fields.length > 16 && !fields[16].isEmpty() ? TsvEscapeUtils.splitAnnotationList(fields[16], '|') : null,  // typeAnnotations - keep `|` delimiter between different type contexts
-                                    fields.length > 17 && !fields[17].isEmpty() ? fields[17] : null
-                            ));
+                                break;
+                            }
                         }
                     }
                 });
@@ -344,6 +330,30 @@ public class TypeTable implements JavaParserClasspathLoader {
             if (matchedGav.get() != null) {
                 processor.accept(matchedGav.get(), classesByName, nestedTypesByOwner, resourcesByPath);
             }
+        }
+
+        private static ClassDefinition getOrCreateClassDefinition(TsvRow row,
+                                                                  Map<String, ClassDefinition> classesByName,
+                                                                  Map<String, List<ClassDefinition>> nestedTypesByOwner) {
+            String className = row.getClassName();
+            ClassDefinition classDefinition = classesByName.computeIfAbsent(className, name ->
+                    new ClassDefinition(
+                            row.getClassAccess(),
+                            name,
+                            row.getClassSignature().isEmpty() ? null : row.getClassSignature(),
+                            row.getClassSuperclassName() == null || row.getClassSuperclassName().isEmpty() ? null : row.getClassSuperclassName(),
+                            row.getClassSuperinterfaceSignatures().isEmpty() ? null : row.getClassSuperinterfaceSignatures().split("\\|"),
+                            row.getElementAnnotations().isEmpty() ? null : row.getElementAnnotations(),
+                            row.getConstantValue().isEmpty() ? null : row.getConstantValue(),
+                            row.getInnerClasses().isEmpty() ? null : TsvEscapeUtils.splitAnnotationList(row.getInnerClasses(), '|')
+                    ));
+            int lastIndexOf$ = className.lastIndexOf('$');
+            if (lastIndexOf$ != -1) {
+                String ownerName = className.substring(0, lastIndexOf$);
+                nestedTypesByOwner.computeIfAbsent(ownerName, k -> new ArrayList<>(4))
+                        .add(classDefinition);
+            }
+            return classDefinition;
         }
 
         @FunctionalInterface
@@ -686,7 +696,7 @@ public class TypeTable implements JavaParserClasspathLoader {
         public Writer(OutputStream out) throws IOException {
             this.deflater = new GZIPOutputStream(out);
             this.out = new PrintStream(deflater);
-            this.out.println("groupId\tartifactId\tversion\tclassAccess\tclassName\tclassSignature\tclassSuperclassSignature\tclassSuperinterfaceSignatures\taccess\tname\tdescriptor\tsignature\tparameterNames\texceptions\telementAnnotations\tparameterAnnotations\ttypeAnnotations\tconstantValue\tinnerClasses");
+            this.out.println(TsvRow.HEADER);
         }
 
         public Jar jar(String groupId, String artifactId, String version) {
@@ -742,17 +752,9 @@ public class TypeTable implements JavaParserClasspathLoader {
              * functions in a package).
              */
             public void writeResource(String resourcePath, byte[] content) {
-                // Resource row: classAccess sentinel -2, className holds the path, content is
-                // base64-encoded in the constantValue column. All other columns are empty.
-                out.printf(
-                        "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s%n",
-                        groupId, artifactId, version,
-                        -2, resourcePath,
-                        "", "", "",
-                        -1, "", "", "", "", "",
-                        "", "", "",
-                        Base64.getEncoder().encodeToString(content),
-                        "");
+                out.println(TsvRow.resourceRow(groupId, artifactId, version,
+                        resourcePath, Base64.getEncoder().encodeToString(content))
+                        .build());
             }
 
             /**
@@ -1012,19 +1014,12 @@ public class TypeTable implements JavaParserClasspathLoader {
 
             public void writeClass() {
                 if (((Opcodes.ACC_PRIVATE | Opcodes.ACC_SYNTHETIC) & classAccess) == 0) {
-                    out.printf(
-                            "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s%n",
+                    out.println(TsvRow.classRow(
                             jar.groupId, jar.artifactId, jar.version,
                             classAccess, className,
-                            classSignature == null ? "" : classSignature,
-                            classSuperclassName,
-                            classSuperinterfaceSignatures == null ? "" : String.join("|", classSuperinterfaceSignatures),
-                            -1, "", "", "", "", "",
-                            classAnnotations.isEmpty() ? "" : String.join("", classAnnotations),
-                            "", // Empty parameter annotations for class row
-                            classTypeAnnotations.isEmpty() ? "" : PipeDelimitedJoiner.joinWithPipes(classTypeAnnotations),
-                            "", // Empty constant value for class row
-                            innerClasses.isEmpty() ? "" : PipeDelimitedJoiner.joinWithPipes(innerClasses));
+                            classSignature, classSuperclassName, classSuperinterfaceSignatures,
+                            classAnnotations, classTypeAnnotations, innerClasses)
+                            .build());
 
                     for (Writer.Member member : members) {
                         member.writeMember(jar, this);
@@ -1062,23 +1057,18 @@ public class TypeTable implements JavaParserClasspathLoader {
 
             private void writeMember(Jar jar, ClassDefinition classDefinition) {
                 if ((Opcodes.ACC_PRIVATE & access) == 0) {
-                    out.printf(
-                            "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s%n",
+                    out.println(TsvRow.memberRow(
                             jar.groupId, jar.artifactId, jar.version,
                             classDefinition.classAccess, classDefinition.className,
-                            classDefinition.classSignature == null ? "" : classDefinition.classSignature,
+                            classDefinition.classSignature,
                             classDefinition.classSuperclassName,
-                            classDefinition.classSuperinterfaceSignatures == null ? "" : String.join("|", classDefinition.classSuperinterfaceSignatures),
-                            access, name, descriptor,
-                            signature == null ? "" : signature,
-                            parameterNames.isEmpty() ? "" : String.join("|", parameterNames),
-                            exceptions == null ? "" : String.join("|", exceptions),
-                            elementAnnotations.isEmpty() ? "" : String.join("", elementAnnotations),
+                            classDefinition.classSuperinterfaceSignatures,
+                            access, name, descriptor, signature,
+                            parameterNames, exceptions,
+                            elementAnnotations,
                             serializeParameterAnnotations(parameterAnnotations, descriptor),
-                            typeAnnotations.isEmpty() ? "" : PipeDelimitedJoiner.joinWithPipes(typeAnnotations),
-                            constantValue == null ? "" : constantValue,
-                            "" // innerClasses column is written on class row only
-                    );
+                            typeAnnotations, constantValue)
+                            .build());
                 }
             }
         }
@@ -1202,6 +1192,184 @@ public class TypeTable implements JavaParserClasspathLoader {
             }
         }
         return result.toString();
+    }
+
+    /**
+     * One row of the TSV type table. Owns the column order and the encoding of each
+     * row variety in one place — see {@link Kind}. Used by both reader and writer
+     * so the layout (and the legacy-tolerance for older TSVs missing trailing columns)
+     * is defined exactly once.
+     */
+    @Value
+    @Builder
+    static class TsvRow {
+
+        /**
+         * Discriminates the three row varieties. Real ASM access flags are {@code >= 0},
+         * so negative ints in an access column are reserved as sentinels.
+         */
+        @RequiredArgsConstructor
+        enum Kind {
+            /** {@code -1} in the {@code memberAccess} column → row carries class-level data only. */
+            CLASS(-1),
+            /** No sentinel; both access columns hold real ASM access flags. */
+            MEMBER(0),
+            /** {@code -2} in the {@code classAccess} column → row is a non-class resource. */
+            RESOURCE(-2);
+
+            @Getter
+            private final int sentinel;
+        }
+
+        static final String HEADER = String.join("\t",
+                "groupId", "artifactId", "version",
+                "classAccess", "className", "classSignature",
+                "classSuperclassSignature", "classSuperinterfaceSignatures",
+                "access", "name", "descriptor", "signature",
+                "parameterNames", "exceptions",
+                "elementAnnotations", "parameterAnnotations", "typeAnnotations",
+                "constantValue", "innerClasses");
+
+        String groupId;
+        String artifactId;
+        String version;
+
+        @Builder.Default int classAccess = Kind.CLASS.getSentinel();
+        @Builder.Default String className = "";
+        @Builder.Default String classSignature = "";
+        // Nullable so RESOURCE rows can default to "" while CLASS/MEMBER rows can carry
+        // null through and serialize as the literal "null" — matching the prior printf
+        // behavior on the rare case (e.g. java.lang.Object) where the JVM superName is null.
+        @Nullable
+        @Builder.Default
+        String classSuperclassName = "";
+        @Builder.Default String classSuperinterfaceSignatures = "";
+
+        @Builder.Default int memberAccess = Kind.CLASS.getSentinel();
+        @Builder.Default String memberName = "";
+        @Builder.Default String descriptor = "";
+        @Builder.Default String signature = "";
+        @Builder.Default String parameterNames = "";
+        @Builder.Default String exceptions = "";
+
+        @Builder.Default String elementAnnotations = "";
+        @Builder.Default String parameterAnnotations = "";
+        @Builder.Default String typeAnnotations = "";
+        @Builder.Default String constantValue = "";
+        @Builder.Default String innerClasses = "";
+
+        Kind kind() {
+            if (classAccess == Kind.RESOURCE.getSentinel()) {
+                return Kind.RESOURCE;
+            }
+            if (memberAccess == Kind.CLASS.getSentinel()) {
+                return Kind.CLASS;
+            }
+            return Kind.MEMBER;
+        }
+
+        static TsvRow parse(String line) {
+            String[] f = line.split("\t", -1);
+            TsvRowBuilder b = TsvRow.builder()
+                    .groupId(f[0]).artifactId(f[1]).version(f[2])
+                    .classAccess(Integer.parseInt(f[3])).className(f[4])
+                    .classSignature(f[5]).classSuperclassName(f[6])
+                    .classSuperinterfaceSignatures(f[7])
+                    .memberAccess(Integer.parseInt(f[8]))
+                    .memberName(f[9]).descriptor(f[10]).signature(f[11])
+                    .parameterNames(f[12]).exceptions(f[13]);
+            // Tolerate older TSVs missing trailing columns
+            if (f.length > 14) {
+                b.elementAnnotations(f[14]);
+            }
+            if (f.length > 15) {
+                b.parameterAnnotations(f[15]);
+            }
+            if (f.length > 16) {
+                b.typeAnnotations(f[16]);
+            }
+            if (f.length > 17) {
+                b.constantValue(f[17]);
+            }
+            if (f.length > 18) {
+                b.innerClasses(f[18]);
+            }
+            return b.build();
+        }
+
+        @Override
+        public String toString() {
+            return String.join("\t",
+                    groupId, artifactId, version,
+                    Integer.toString(classAccess), className, classSignature,
+                    classSuperclassName, classSuperinterfaceSignatures,
+                    Integer.toString(memberAccess), memberName, descriptor, signature,
+                    parameterNames, exceptions,
+                    elementAnnotations, parameterAnnotations, typeAnnotations,
+                    constantValue, innerClasses);
+        }
+
+        static TsvRowBuilder resourceRow(String groupId, String artifactId, String version,
+                                         String path, String base64) {
+            return TsvRow.builder()
+                    .groupId(groupId).artifactId(artifactId).version(version)
+                    .classAccess(Kind.RESOURCE.getSentinel())
+                    .className(path)
+                    .constantValue(base64);
+        }
+
+        static TsvRowBuilder classRow(String groupId, String artifactId, String version,
+                                      int classAccess, String className,
+                                      @Nullable String classSignature,
+                                      @Nullable String classSuperclassName,
+                                      String @Nullable [] classSuperinterfaceSignatures,
+                                      List<String> classAnnotations,
+                                      List<String> classTypeAnnotations,
+                                      List<String> innerClasses) {
+            return TsvRow.builder()
+                    .groupId(groupId).artifactId(artifactId).version(version)
+                    .classAccess(classAccess).className(className)
+                    .classSignature(classSignature == null ? "" : classSignature)
+                    .classSuperclassName(classSuperclassName)
+                    .classSuperinterfaceSignatures(classSuperinterfaceSignatures == null ? "" :
+                            String.join("|", classSuperinterfaceSignatures))
+                    .elementAnnotations(classAnnotations.isEmpty() ? "" : String.join("", classAnnotations))
+                    .typeAnnotations(classTypeAnnotations.isEmpty() ? "" :
+                            PipeDelimitedJoiner.joinWithPipes(classTypeAnnotations))
+                    .innerClasses(innerClasses.isEmpty() ? "" :
+                            PipeDelimitedJoiner.joinWithPipes(innerClasses));
+        }
+
+        static TsvRowBuilder memberRow(String groupId, String artifactId, String version,
+                                       int classAccess, String className,
+                                       @Nullable String classSignature,
+                                       @Nullable String classSuperclassName,
+                                       String @Nullable [] classSuperinterfaceSignatures,
+                                       int memberAccess, String memberName, String descriptor,
+                                       @Nullable String signature,
+                                       List<String> parameterNames,
+                                       String @Nullable [] exceptions,
+                                       List<String> elementAnnotations,
+                                       String parameterAnnotations,
+                                       List<String> typeAnnotations,
+                                       @Nullable String constantValue) {
+            return TsvRow.builder()
+                    .groupId(groupId).artifactId(artifactId).version(version)
+                    .classAccess(classAccess).className(className)
+                    .classSignature(classSignature == null ? "" : classSignature)
+                    .classSuperclassName(classSuperclassName)
+                    .classSuperinterfaceSignatures(classSuperinterfaceSignatures == null ? "" :
+                            String.join("|", classSuperinterfaceSignatures))
+                    .memberAccess(memberAccess).memberName(memberName).descriptor(descriptor)
+                    .signature(signature == null ? "" : signature)
+                    .parameterNames(parameterNames.isEmpty() ? "" : String.join("|", parameterNames))
+                    .exceptions(exceptions == null ? "" : String.join("|", exceptions))
+                    .elementAnnotations(elementAnnotations.isEmpty() ? "" : String.join("", elementAnnotations))
+                    .parameterAnnotations(parameterAnnotations)
+                    .typeAnnotations(typeAnnotations.isEmpty() ? "" :
+                            PipeDelimitedJoiner.joinWithPipes(typeAnnotations))
+                    .constantValue(constantValue == null ? "" : constantValue);
+        }
     }
 
     private static class PipeDelimitedJoiner {

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTypeAnnotationsTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTypeAnnotationsTest.java
@@ -268,14 +268,14 @@ class TypeTableTypeAnnotationsTest {
           "groupId\tartifactId\tversion\tclassAccess\tclassName\tclassSignature\t" +
             "classSuperclassSignature\tclassSuperinterfaceSignatures\taccess\tname\t" +
             "descriptor\tsignature\tparameterNames\texceptions\telementAnnotations\t" +
-            "parameterAnnotations\ttypeAnnotations\tconstantValue"
+            "parameterAnnotations\ttypeAnnotations\tconstantValue\tinnerClasses"
         );
 
         // Find the field row and check constantValue is in the right place
         for (String line : lines) {
             if (line.contains("\tCONSTANT\t")) {
                 String[] cols = line.split("\t", -1);
-                assertThat(cols.length).isEqualTo(18);
+                assertThat(cols.length).isEqualTo(19);
                 assertThat(cols[14]).as("elementAnnotations").contains("@Ljava/lang/Deprecated;");
                 assertThat(cols[15]).as("parameterAnnotations").isEmpty();
                 assertThat(cols[16]).as("typeAnnotations").isEmpty();

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTypeAnnotationsTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTypeAnnotationsTest.java
@@ -108,30 +108,20 @@ class TypeTableTypeAnnotationsTest {
 
         String tsvContent = processJarThroughTypeTable(jarFile);
 
-        // Parse TSV to check parameter annotations column (column 16)
-        String[] lines = tsvContent.split("\n");
-
-        // Find method rows
-        for (String line : lines) {
-            if (line.contains("\tsingleParam\t")) {
-                String[] cols = line.split("\t", -1);
-                assertThat(cols.length).isGreaterThanOrEqualTo(18);
-                assertThat(cols[15]).as("parameterAnnotations column for singleParam")
-                  .isEqualTo("@Ltest/annotations/NotNull;");
-            }
-
-            if (line.contains("\tmultipleParams\t")) {
-                String[] cols = line.split("\t", -1);
-                assertThat(cols.length).isGreaterThanOrEqualTo(18);
-                assertThat(cols[15]).as("parameterAnnotations column for multipleParams")
-                  .isEqualTo("@Ltest/annotations/NotNull;|@Ltest/annotations/NotNull;@Ltest/annotations/Valid;");
-            }
-
-            if (line.contains("\tmixedParams\t")) {
-                String[] cols = line.split("\t", -1);
-                assertThat(cols.length).isGreaterThanOrEqualTo(18);
-                assertThat(cols[15]).as("parameterAnnotations column for mixedParams")
-                  .isEqualTo("|@Ltest/annotations/Valid;");
+        for (TypeTable.TsvRow row : parseRows(tsvContent)) {
+            switch (row.getMemberName()) {
+                case "singleParam":
+                    assertThat(row.getParameterAnnotations()).as("parameterAnnotations column for singleParam")
+                      .isEqualTo("@Ltest/annotations/NotNull;");
+                    break;
+                case "multipleParams":
+                    assertThat(row.getParameterAnnotations()).as("parameterAnnotations column for multipleParams")
+                      .isEqualTo("@Ltest/annotations/NotNull;|@Ltest/annotations/NotNull;@Ltest/annotations/Valid;");
+                    break;
+                case "mixedParams":
+                    assertThat(row.getParameterAnnotations()).as("parameterAnnotations column for mixedParams")
+                      .isEqualTo("|@Ltest/annotations/Valid;");
+                    break;
             }
         }
     }
@@ -196,46 +186,34 @@ class TypeTableTypeAnnotationsTest {
 
         String tsvContent = processJarThroughTypeTable(jarFile);
 
-        // Parse TSV to check type annotations column (column 17)
-        String[] lines = tsvContent.split("\n");
-
-        for (String line : lines) {
-            String[] cols = line.split("\t", -1);
-
-            if (line.contains("\tfield\t") && line.contains("Ljava/lang/String;")) {
-                assertThat(cols.length).isGreaterThanOrEqualTo(18);
-                assertThat(cols[16]).as("typeAnnotations for field")
-                  .contains("13000000::@Ltest/annotations/Nullable;");
-            }
-
-            if (line.contains("\tarrayField\t")) {
-                assertThat(cols.length).isGreaterThanOrEqualTo(18);
-                assertThat(cols[16]).as("typeAnnotations for arrayField")
-                  .contains("13000000::@Ltest/annotations/NonNull;");
-            }
-
-            if (line.contains("\tgetField\t")) {
-                assertThat(cols.length).isGreaterThanOrEqualTo(18);
-                assertThat(cols[16]).as("typeAnnotations for getField")
-                  .contains("14000000::@Ltest/annotations/Nullable;");
-            }
-
-            if (line.contains("\tsetField\t")) {
-                assertThat(cols.length).isGreaterThanOrEqualTo(18);
-                assertThat(cols[16]).as("typeAnnotations for setField")
-                  .contains("16000000::@Ltest/annotations/NonNull;");
-            }
-
-            if (line.contains("\tprocessList\t")) {
-                assertThat(cols.length).isGreaterThanOrEqualTo(18);
-                assertThat(cols[16]).as("typeAnnotations for processList")
-                  .contains("16000000:0;:@Ltest/annotations/Nullable;");
-            }
-
-            if (line.contains("\tprocessWildcard\t")) {
-                assertThat(cols.length).isGreaterThanOrEqualTo(18);
-                assertThat(cols[16]).as("typeAnnotations for processWildcard")
-                  .contains("16000000:0;*:@Ltest/annotations/NonNull;");
+        for (TypeTable.TsvRow row : parseRows(tsvContent)) {
+            switch (row.getMemberName()) {
+                case "field":
+                    if (row.getDescriptor().contains("Ljava/lang/String;")) {
+                        assertThat(row.getTypeAnnotations()).as("typeAnnotations for field")
+                          .contains("13000000::@Ltest/annotations/Nullable;");
+                    }
+                    break;
+                case "arrayField":
+                    assertThat(row.getTypeAnnotations()).as("typeAnnotations for arrayField")
+                      .contains("13000000::@Ltest/annotations/NonNull;");
+                    break;
+                case "getField":
+                    assertThat(row.getTypeAnnotations()).as("typeAnnotations for getField")
+                      .contains("14000000::@Ltest/annotations/Nullable;");
+                    break;
+                case "setField":
+                    assertThat(row.getTypeAnnotations()).as("typeAnnotations for setField")
+                      .contains("16000000::@Ltest/annotations/NonNull;");
+                    break;
+                case "processList":
+                    assertThat(row.getTypeAnnotations()).as("typeAnnotations for processList")
+                      .contains("16000000:0;:@Ltest/annotations/Nullable;");
+                    break;
+                case "processWildcard":
+                    assertThat(row.getTypeAnnotations()).as("typeAnnotations for processWildcard")
+                      .contains("16000000:0;*:@Ltest/annotations/NonNull;");
+                    break;
             }
         }
     }
@@ -340,61 +318,44 @@ class TypeTableTypeAnnotationsTest {
         Path jarFile = compileAndPackage(sources, "test.TestClass");
         String tsvContent = processJarThroughTypeTable(jarFile);
 
-        // Parse the TSV content to verify it's valid
-        String[] lines = tsvContent.split("\n");
-        for (String line : lines) {
-            String[] cols = line.split("\t", -1);
-
-            if (line.contains("\tquotes\t")) {
-                // Check that the escaped quotes are properly handled
-                assertThat(cols[15]).as("parameterAnnotations for quotes method")
-                  .contains("@Ltest/Message;")
-                  .contains("value=s\"He said \\\"Hello\\\"\"");
-            }
-
-            if (line.contains("\tcommas\t")) {
-                // Check that commas in values don't break the format
-                // Note: pipes are escaped in TSV format since they're used as delimiters  
-                assertThat(cols[15]).as("parameterAnnotations for commas method")
-                  .contains("@Ltest/Message;")
-                  .contains("value=s\"a,b,c\"")
-                  .contains("tags=[s\"tag1,tag2\",s\"tag3\\|tag4\"]");
-            }
-
-            if (line.contains("\tpipes\t")) {
-                // Check that pipes in values are escaped (pipes are TSV delimiters)
-                assertThat(cols[15]).as("parameterAnnotations for pipes method")
-                  .contains("value=s\"value\\|with\\|pipes\"");
-                // Also verify that the pipe delimiter between parameters is handled correctly
-                // if there were multiple parameters with annotations
-            }
-
-            if (line.contains("\twhitespace\t")) {
-                // Check that newlines and tabs are escaped
-                assertThat(cols[15]).as("parameterAnnotations for whitespace method")
-                  .contains("value=s\"line1\\nline2\\ttab\"");
-            }
-
-            if (line.contains("\tbackslashes\t")) {
-                // Check that backslashes are properly escaped
-                assertThat(cols[15]).as("parameterAnnotations for backslashes method")
-                  .contains("value=s\"C:\\\\Users\\\\file.txt\"");
-            }
-
-            if (line.contains("\tgetDate\t")) {
-                // Check type annotation with regex pattern (pipes and backslashes are escaped in TSV)
-                assertThat(cols[16]).as("typeAnnotations for getDate method")
-                  .contains("14000000::@Ltest/Format;")
-                  .contains("pattern=s\"\\\\d{2,4}-\\\\d{2}-\\\\d{2}\\|\\\\d{4}/\\\\d{2}/\\\\d{2}\"");
-            }
-
-            if (line.contains("\tcomplex\t")) {
-                // Check multiple annotations with complex values
-                // @Message is a parameter annotation, @Format is a type annotation
-                assertThat(cols[15]).as("parameterAnnotations for complex method")
-                  .contains("@Ltest/Message;");
-                assertThat(cols[16]).as("typeAnnotations for complex method")
-                  .contains("16000000::@Ltest/Format;");
+        for (TypeTable.TsvRow row : parseRows(tsvContent)) {
+            switch (row.getMemberName()) {
+                case "quotes":
+                    assertThat(row.getParameterAnnotations()).as("parameterAnnotations for quotes method")
+                      .contains("@Ltest/Message;")
+                      .contains("value=s\"He said \\\"Hello\\\"\"");
+                    break;
+                case "commas":
+                    // Note: pipes are escaped in TSV format since they're used as delimiters
+                    assertThat(row.getParameterAnnotations()).as("parameterAnnotations for commas method")
+                      .contains("@Ltest/Message;")
+                      .contains("value=s\"a,b,c\"")
+                      .contains("tags=[s\"tag1,tag2\",s\"tag3\\|tag4\"]");
+                    break;
+                case "pipes":
+                    assertThat(row.getParameterAnnotations()).as("parameterAnnotations for pipes method")
+                      .contains("value=s\"value\\|with\\|pipes\"");
+                    break;
+                case "whitespace":
+                    assertThat(row.getParameterAnnotations()).as("parameterAnnotations for whitespace method")
+                      .contains("value=s\"line1\\nline2\\ttab\"");
+                    break;
+                case "backslashes":
+                    assertThat(row.getParameterAnnotations()).as("parameterAnnotations for backslashes method")
+                      .contains("value=s\"C:\\\\Users\\\\file.txt\"");
+                    break;
+                case "getDate":
+                    assertThat(row.getTypeAnnotations()).as("typeAnnotations for getDate method")
+                      .contains("14000000::@Ltest/Format;")
+                      .contains("pattern=s\"\\\\d{2,4}-\\\\d{2}-\\\\d{2}\\|\\\\d{4}/\\\\d{2}/\\\\d{2}\"");
+                    break;
+                case "complex":
+                    // @Message is a parameter annotation, @Format is a type annotation
+                    assertThat(row.getParameterAnnotations()).as("parameterAnnotations for complex method")
+                      .contains("@Ltest/Message;");
+                    assertThat(row.getTypeAnnotations()).as("typeAnnotations for complex method")
+                      .contains("16000000::@Ltest/Format;");
+                    break;
             }
         }
     }
@@ -434,20 +395,14 @@ class TypeTableTypeAnnotationsTest {
         Path jarFile = compileAndPackage(sources, "test.TestClass");
         String tsvContent = processJarThroughTypeTable(jarFile);
 
-        // Find the validate method row
-        for (String line : tsvContent.split("\n")) {
-            if (line.contains("\tvalidate\t")) {
-                String[] cols = line.split("\t", -1);
-                String paramAnnotations = cols[15];
-
-                // Verify the parameter annotations are properly formatted
+        for (TypeTable.TsvRow row : parseRows(tsvContent)) {
+            if ("validate".equals(row.getMemberName())) {
                 // The pipe delimiter between parameters should work correctly
                 // even though the annotation values contain escaped pipes
-                assertThat(paramAnnotations).as("parameterAnnotations for validate method")
+                assertThat(row.getParameterAnnotations()).as("parameterAnnotations for validate method")
                   .contains("@Ltest/Pattern;(value=s\"\\\\d+\\|\\\\w+\")")
                   .contains("@Ltest/Description;(text=s\"Options: A\\|B\\|C\")")
                   .contains("@Ltest/Pattern;(value=s\"[a-z]+\\|[A-Z]+\")@Ltest/Description;(text=s\"Letters\\|Digits\")");
-
                 break;
             }
         }
@@ -485,20 +440,34 @@ class TypeTableTypeAnnotationsTest {
         Path jarFile = compileAndPackage(sources, "test.TestClass");
         String tsvContent = processJarThroughTypeTable(jarFile);
 
-        // Find the process method row
-        for (String line : tsvContent.split("\n")) {
-            if (line.contains("\tprocess\t")) {
-                String[] cols = line.split("\t", -1);
-                assertThat(cols[14]).as("elementAnnotations")
+        for (TypeTable.TsvRow row : parseRows(tsvContent)) {
+            if ("process".equals(row.getMemberName())) {
+                assertThat(row.getElementAnnotations()).as("elementAnnotations")
                   .contains("@Ltest/MethodAnnotation;");
-                assertThat(cols[15]).as("parameterAnnotations")
+                assertThat(row.getParameterAnnotations()).as("parameterAnnotations")
                   .contains("@Ltest/ParamAnnotation;");
-                assertThat(cols[16]).as("typeAnnotations")
+                assertThat(row.getTypeAnnotations()).as("typeAnnotations")
                   .contains("14000000::@Ltest/TypeAnnotation;")
                   .contains("16000000::@Ltest/TypeAnnotation;");
                 break;
             }
         }
+    }
+
+    /**
+     * Parse all data rows from gzipped-then-decoded TSV content, skipping the header
+     * and any blank lines. Yields named-field access via {@link TypeTable.TsvRow} so
+     * tests don't have to encode column indices.
+     */
+    private List<TypeTable.TsvRow> parseRows(String tsvContent) {
+        String[] lines = tsvContent.split("\n");
+        List<TypeTable.TsvRow> rows = new java.util.ArrayList<>(lines.length);
+        for (int i = 1; i < lines.length; i++) {
+            String line = lines[i];
+            if (line.isEmpty()) continue;
+            rows.add(TypeTable.TsvRow.parse(line));
+        }
+        return rows;
     }
 
     /**

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/MethodMatcherTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/MethodMatcherTest.java
@@ -18,11 +18,14 @@ package org.openrewrite.kotlin;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
@@ -54,6 +57,54 @@ class MethodMatcherTest implements RewriteTest {
               fun usesFunction() {
                   function()
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void libraryTopLevelFunctionPopulatesMethodType() {
+        rewriteRun(
+          spec -> spec
+            .parser(KotlinParser.builder().classpath("jackson-module-kotlin"))
+            .recipe(toRecipe(() -> new JavaIsoVisitor<ExecutionContext>() {
+                @Override
+                public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
+                    if ("jacksonObjectMapper".equals(mi.getSimpleName())) {
+                        assertThat(mi.getMethodType())
+                          .as("Kotlin parser should resolve method type for library top-level function")
+                          .isNotNull();
+                    }
+                    return super.visitMethodInvocation(mi, ctx);
+                }
+            })),
+          kotlin(
+            """
+              import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+              fun mapper() = jacksonObjectMapper()
+              """
+          )
+        );
+    }
+
+    @Test
+    void usesMethodMatchesLibraryTopLevelFunction() {
+        rewriteRun(
+          spec -> spec
+            .parser(KotlinParser.builder().classpath("jackson-module-kotlin"))
+            .recipe(toRecipe(() -> new UsesMethod<>(
+              "com.fasterxml.jackson.module.kotlin.ExtensionsKt jacksonObjectMapper()", false))),
+          kotlin(
+            """
+              import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+              fun mapper() = jacksonObjectMapper()
+              """,
+            """
+              /*~~>*/import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+              fun mapper() = jacksonObjectMapper()
               """
           )
         );


### PR DESCRIPTION
## Summary

Three interlocking bugs in `TypeTable` caused Kotlin top-level functions (top-level regular functions and extension functions) to lose method type attribution when `KotlinParser` received a classpath sourced from a TypeTable-synthesized directory (as `mod` does for downloaded LSTs) rather than the original jar. The symptom: `J.MethodInvocation.getMethodType()` returns `null` for calls like `jacksonObjectMapper()` (from `jackson-module-kotlin`), and `MethodMatcher`/`UsesMethod` therefore cannot match them.

### The three fixes

1. **`ACC_SYNTHETIC` methods were filtered out.** Kotlin extension functions compile to `public static final synthetic` on a `*Kt` facade class, so they were being dropped at write time. Now filter on `ACC_PRIVATE` only (and skip `<clinit>`), matching what's needed for type attribution.

2. **`InnerClasses` attribute was not captured.** Kotlin FIR silently fails to resolve methods on a class whose `@kotlin.Metadata.d1` protobuf references inner classes (lambdas, companion objects, etc.) unless those inner classes are declared in the class's `InnerClasses` attribute. The Writer's `ClassVisitor` didn't override `visitInnerClass`, so every round-tripped class came out with an empty `InnerClasses` attribute. Now serialize each entry as `name,outerName,innerName,access` into a new `innerClasses` TSV column, and replay them on the Reader side before any other class events so ASM writes them back out.

3. **`META-INF/*.kotlin_module` resources were dropped.** The Kotlin compiler uses these files to map package names to their facade classes (`com.fasterxml.jackson.module.kotlin` → `ExtensionsKt`). Without it, the resolver can't find the top-level function's owner. Store `.kotlin_module` files as resource rows using a `classAccess = -2` sentinel with base64-encoded content in the `constantValue` column, plumbed through a new `ResourceConsumer` callback on `Reader.read()` so callers can persist them alongside the synthesized `.class` files.

### Tests

- `MethodMatcherTest#libraryTopLevelFunctionPopulatesMethodType` — asserts method type is non-null for `jacksonObjectMapper()`.
- `MethodMatcherTest#usesMethodMatchesLibraryTopLevelFunction` — end-to-end `UsesMethod` match on the Kotlin top-level extension function.
- `TypeTableTypeAnnotationsTest#columnOrderCorrect` — updated for the added column.

Both Kotlin tests use `KotlinParser.builder().classpath(\"jackson-module-kotlin\")`, which resolves via the shipped TypeTable — exactly the code path that was broken.

## Test plan

- [x] `./gradlew :rewrite-java:test --tests "org.openrewrite.java.internal.parser.*"`
- [x] `./gradlew :rewrite-kotlin:test --tests "org.openrewrite.kotlin.MethodMatcherTest"`
- [ ] Full CI