### PR TITLE
Minimize the eager resolution of transitive dependencies when upgrading dependency versions.

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -207,7 +207,7 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                     if (maybeJp.isPresent() && !acc.modulesWithOldDependency.containsKey(maybeJp.get())) {
                         outer:
                         for (GradleDependencyConfiguration config : gradleProject.getConfigurations()) {
-                            for (ResolvedDependency resolved : config.getDirectResolved()) {
+                            for (ResolvedDependency resolved : config.getDirectResolvedShallow()) {
                                 if (StringUtils.matchesGlob(resolved.getGroupId(), oldGroupId) &&
                                     StringUtils.matchesGlob(resolved.getArtifactId(), oldArtifactId)) {
                                     acc.modulesWithOldDependency.put(maybeJp.get(), resolved);
@@ -459,7 +459,7 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                         }
                         return requested;
                     }));
-                    newGdc = newGdc.withDirectResolved(ListUtils.map(gdc.getDirectResolved(), resolved -> {
+                    newGdc = newGdc.withDirectResolved(ListUtils.map(gdc.getDirectResolvedShallow(), resolved -> {
                         assert resolved != null;
                         if (depMatcher.matches(resolved.getGroupId(), resolved.getArtifactId())) {
                             resolved = updatedResolved.computeIfAbsent(resolved, r -> {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyArtifactId.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyArtifactId.java
@@ -129,7 +129,7 @@ public class ChangeDependencyArtifactId extends Recipe {
                         }
                         return requested;
                     }));
-                    newGdc = newGdc.withDirectResolved(ListUtils.map(gdc.getDirectResolved(), resolved -> {
+                    newGdc = newGdc.withDirectResolved(ListUtils.map(gdc.getDirectResolvedShallow(), resolved -> {
                         if (depMatcher.matches(resolved.getGroupId(), resolved.getArtifactId())) {
                             return resolved.withGav(resolved.getGav().withArtifactId(newArtifactId));
                         }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyClassifier.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyClassifier.java
@@ -295,7 +295,7 @@ public class ChangeDependencyClassifier extends Recipe {
                         }
                         return requested;
                     }));
-                    newGdc = newGdc.withDirectResolved(ListUtils.map(gdc.getDirectResolved(), resolved -> {
+                    newGdc = newGdc.withDirectResolved(ListUtils.map(gdc.getDirectResolvedShallow(), resolved -> {
                         if (depMatcher.matches(resolved.getGroupId(), resolved.getArtifactId()) && !Objects.equals(resolved.getClassifier(), newClassifier)) {
                             return resolved.withClassifier(newClassifier);
                         }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyGroupId.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyGroupId.java
@@ -129,7 +129,7 @@ public class ChangeDependencyGroupId extends Recipe {
                         }
                         return requested;
                     }));
-                    newGdc = newGdc.withDirectResolved(ListUtils.map(gdc.getDirectResolved(), resolved -> {
+                    newGdc = newGdc.withDirectResolved(ListUtils.map(gdc.getDirectResolvedShallow(), resolved -> {
                         if (depMatcher.matches(resolved.getGroupId(), resolved.getArtifactId())) {
                             return resolved.withGav(resolved.getGav().withGroupId(newGroupId));
                         }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeManagedDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeManagedDependency.java
@@ -189,7 +189,7 @@ public class ChangeManagedDependency extends Recipe {
                         }
                         return requested;
                     }));
-                    newGdc = newGdc.withDirectResolved(ListUtils.map(gdc.getDirectResolved(), resolved -> {
+                    newGdc = newGdc.withDirectResolved(ListUtils.map(gdc.getDirectResolvedShallow(), resolved -> {
                         assert resolved != null;
                         if (depMatcher.matches(resolved.getGroupId(), resolved.getArtifactId())) {
                             resolved = updatedResolved.computeIfAbsent(resolved, r -> {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveDependency.java
@@ -143,7 +143,7 @@ public class RemoveDependency extends Recipe {
                         }
                         return requested;
                     }));
-                    newGdc = newGdc.withDirectResolved(ListUtils.map(gdc.getDirectResolved(), resolved -> {
+                    newGdc = newGdc.withDirectResolved(ListUtils.map(gdc.getDirectResolvedShallow(), resolved -> {
                         if (depMatcher.matches(resolved.getGroupId(), resolved.getArtifactId())) {
                             return null;
                         }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveRedundantDependencyVersions.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveRedundantDependencyVersions.java
@@ -438,7 +438,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                     private @Nullable String getSpringBootVersionFromPlugin() {
                         GradleDependencyConfiguration gdc = gp.getBuildscript().getConfiguration("classpath");
                         if (gdc != null) {
-                            for (ResolvedDependency dependency : gdc.getDirectResolved()) {
+                            for (ResolvedDependency dependency : gdc.getDirectResolvedShallow()) {
                                 if ("org.springframework.boot.gradle.plugin".equals(dependency.getArtifactId())) {
                                     return dependency.getVersion();
                                 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -168,7 +168,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                             DependencyMatcher depMatcher = new DependencyMatcher(groupId, artifactId, null);
                             Set<ResolvedDependency> matched = new HashSet<>();
                             for (GradleDependencyConfiguration config : gradleProject.getConfigurations()) {
-                                for (ResolvedDependency resolved : config.getDirectResolved()) {
+                                for (ResolvedDependency resolved : config.getDirectResolvedShallow()) {
                                     if (depMatcher.matches(resolved.getGroupId(), resolved.getArtifactId())) {
                                         matched.add(resolved);
                                     }
@@ -524,11 +524,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                     continue;
                 }
 
-                for (ResolvedDependency resolved : configuration.getResolved()) {
-                    if (!resolved.isDirect()) {
-                        continue;
-                    }
-
+                for (ResolvedDependency resolved : configuration.getDirectResolvedShallow()) {
                     if (!dependencyMatcher.matches(resolved.getGroupId(), resolved.getArtifactId())) {
                         continue;
                     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/AddDependencyVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/AddDependencyVisitor.java
@@ -275,7 +275,7 @@ public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
                         newRequested));
                 if (newGdc.isCanBeResolved() && resolvedGav != null) {
                     newGdc = newGdc.withDirectResolved(ListUtils.concat(
-                            ListUtils.map(gdc.getDirectResolved(), resolved -> {
+                            ListUtils.map(gdc.getDirectResolvedShallow(), resolved -> {
                                 // Remove any existing dependency with the same group and artifact id
                                 if (Objects.equals(resolved.getGroupId(), resolvedGav.getGroupId()) && Objects.equals(resolved.getArtifactId(), resolvedGav.getArtifactId())) {
                                     return null;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleDependencyConfiguration.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleDependencyConfiguration.java
@@ -96,12 +96,25 @@ public class GradleDependencyConfiguration implements Serializable, Attributed {
     List<ResolvedDependency> directResolved;
 
     /**
-     * The list of direct dependencies resolved for this configuration.
+     * The list of direct dependencies resolved for this configuration. Each returned dependency has its full
+     * transitive tree populated under {@link ResolvedDependency#getDependencies()}.
      */
     public List<ResolvedDependency> getDirectResolved() {
         if (resolutionContext.isResolveRequired()) {
             resolutionContext.resolve();
         }
+        //noinspection ConstantValue
+        return directResolved == null ? emptyList() : directResolved;
+    }
+
+    /**
+     * Like {@link #getDirectResolved()}, but avoids downloading the transitive closure of each direct dependency.
+     * Each returned dependency has an empty {@link ResolvedDependency#getDependencies()} list unless a full
+     * resolution has already been performed previously. Use this when you only need the declared coordinates of
+     * direct dependencies and do not intend to walk into their transitives.
+     */
+    public List<ResolvedDependency> getDirectResolvedShallow() {
+        resolutionContext.resolveDirect();
         //noinspection ConstantValue
         return directResolved == null ? emptyList() : directResolved;
     }
@@ -180,19 +193,29 @@ public class GradleDependencyConfiguration implements Serializable, Attributed {
         return this;
     }
     private class LazyResolutionContext {
-        private @Getter boolean resolveRequired;
+        private boolean resolveRequired;
+        private boolean transitivesResolved;
         private @Nullable List<MavenRepository> repositories;
         private @Nullable ExecutionContext ctx;
         private @Nullable List<ResolvedDependency> resolved;
 
+        public boolean isResolveRequired() {
+            // Resolution (or upgrade-to-deep) is still possible as long as we retain repositories + ctx.
+            return (resolveRequired || !transitivesResolved) && repositories != null && ctx != null;
+        }
+
         public void markForReResolution(List<MavenRepository> repositories, ExecutionContext ctx) {
             this.repositories = repositories;
             this.resolveRequired = true;
+            this.transitivesResolved = false;
             this.ctx = ctx;
         }
 
         /**
-         * Attempt to download the maven poms of the direct dependencies to produce an updated set of resolved dependencies.
+         * Ensure {@code directResolved} is populated with the complete transitive dependency tree under each
+         * direct dependency. If only a shallow resolution has been done previously within this run, this will
+         * upgrade the state to a full resolution. After deep resolution succeeds, the captured repositories and
+         * execution context are released.
          * It is expected that some dependencies may both be valid and beyond our ability to resolve.
          * Anything coming from an ivy repository, flat directory, gcp artifact service, etc., OpenRewrite does not support.
          * This method has not been tested in a Gradle composite build.
@@ -202,7 +225,34 @@ public class GradleDependencyConfiguration implements Serializable, Attributed {
          * It is the responsibility of recipes to report this to the user, typically via GradleProject.maybeWarn()
          */
         public void resolve() {
-            if (!resolveRequired || repositories == null || ctx == null) {
+            if (transitivesResolved || repositories == null || ctx == null) {
+                return;
+            }
+            doResolve(true);
+            transitivesResolved = true;
+            repositories = null;
+            ctx = null;
+        }
+
+        /**
+         * Populate {@code directResolved} with direct dependencies only, skipping the download of their transitive
+         * closure. If a full resolution has already happened this is a no-op. Repositories + ctx are retained so
+         * that a later call to {@link #resolve()} can upgrade the state to a full resolution if a caller that walks
+         * transitive dependencies needs it.
+         */
+        public void resolveDirect() {
+            if (!resolveRequired) {
+                return;
+            }
+            if (repositories == null || ctx == null) {
+                return;
+            }
+            doResolve(false);
+            resolveRequired = false;
+        }
+
+        private void doResolve(boolean resolveTransitives) {
+            if (repositories == null || ctx == null) {
                 return;
             }
             if (isCanBeResolved) {
@@ -222,8 +272,10 @@ public class GradleDependencyConfiguration implements Serializable, Attributed {
                         } else {
                             Pom singlePom = singleDependencyPom(dep, requested, repositories, ctx);
                             ResolvedPom singleDependencyResolved = singlePom.resolve(emptyList(), mpd, ctx);
-                            ResolvedDependency resolved = singleDependencyResolved.resolveDependencies(Scope.Compile, mpd, ctx).get(0);
-                            newResolved.add(resolved);
+                            List<ResolvedDependency> resolvedList = resolveTransitives
+                                    ? singleDependencyResolved.resolveDependencies(Scope.Compile, mpd, ctx)
+                                    : singleDependencyResolved.resolveDirectDependencies(Scope.Compile, mpd, ctx);
+                            newResolved.add(resolvedList.get(0));
                         }
                     } catch (MavenDownloadingException | MavenDownloadingExceptions e) {
                         MavenDownloadingException m;
@@ -253,12 +305,11 @@ public class GradleDependencyConfiguration implements Serializable, Attributed {
                 resolved = null;
             }
             resolveRequired = false;
-            repositories = null;
-            ctx = null;
         }
 
         public List<ResolvedDependency> getResolved() {
             if (resolved == null) {
+                resolve();
                 List<ResolvedDependency> newResolved = new ArrayList<>(getDirectResolved());
                 Map<GroupArtifact, ResolvedDependency> alreadyResolved = new HashMap<>();
                 Map<String, Version> versionCache = new HashMap<>();

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleDependency.java
@@ -1495,7 +1495,7 @@ public class GradleDependency implements Trait<J.MethodInvocation> {
 
             if (gdc != null) {
                 if (gdc.isCanBeResolved()) {
-                    for (ResolvedDependency resolvedDependency : gdc.getDirectResolved()) {
+                    for (ResolvedDependency resolvedDependency : gdc.getDirectResolvedShallow()) {
                         if (matcher == null || matcher.matches(resolvedDependency.getGroupId(), resolvedDependency.getArtifactId())) {
                             Dependency req = resolvedDependency.getRequested();
                             if ((req.getGroupId() == null || req.getGroupId().equals(dependency.getGroupId())) &&
@@ -1507,7 +1507,7 @@ public class GradleDependency implements Trait<J.MethodInvocation> {
                 } else {
                     for (GradleDependencyConfiguration transitiveConfiguration : gradleProject.configurationsExtendingFrom(gdc, true)) {
                         if (transitiveConfiguration.isCanBeResolved()) {
-                            for (ResolvedDependency resolvedDependency : transitiveConfiguration.getDirectResolved()) {
+                            for (ResolvedDependency resolvedDependency : transitiveConfiguration.getDirectResolvedShallow()) {
                                 if (matcher == null || matcher.matches(resolvedDependency.getGroupId(), resolvedDependency.getArtifactId())) {
                                     Dependency req = resolvedDependency.getRequested();
                                     if ((req.getGroupId() == null || req.getGroupId().equals(dependency.getGroupId())) &&

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -15,18 +15,30 @@
  */
 package org.openrewrite.gradle;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.*;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.maven.MavenDownloadingException;
+import org.openrewrite.maven.MavenExecutionContextView;
+import org.openrewrite.maven.cache.InMemoryMavenPomCache;
+import org.openrewrite.maven.cache.MavenPomCache;
+import org.openrewrite.maven.tree.GroupArtifactVersion;
+import org.openrewrite.maven.tree.MavenMetadata;
+import org.openrewrite.maven.tree.MavenRepository;
+import org.openrewrite.maven.tree.Pom;
 import org.openrewrite.maven.tree.ResolvedDependency;
+import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
+import org.openrewrite.maven.tree.ResolvedPom;
 import org.openrewrite.properties.PropertiesParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.text.PlainTextParser;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -100,6 +112,137 @@ class UpgradeDependencyVersionTest implements RewriteTest {
                       assertThat(dep.getVersion()).isEqualTo("30.1.1-jre");
                   });
             })
+          )
+        );
+    }
+
+    @Test
+    void doesNotResolveTransitiveDependencies() {
+        MavenPomCache delegate = new InMemoryMavenPomCache();
+        MavenPomCache failOnFailureAccess = new MavenPomCache() {
+            private void assertNotFailureAccess(String groupId, String artifactId) {
+                if ("com.google.guava".equals(groupId) && "failureaccess".equals(artifactId)) {
+                    throw new AssertionError("UpgradeDependencyVersion should not resolve the transitive dependency " +
+                            "com.google.guava:failureaccess");
+                }
+            }
+
+            @Override
+            public @Nullable ResolvedPom getResolvedDependencyPom(ResolvedGroupArtifactVersion dependency) {
+                assertNotFailureAccess(dependency.getGroupId(), dependency.getArtifactId());
+                return delegate.getResolvedDependencyPom(dependency);
+            }
+
+            @Override
+            public void putResolvedDependencyPom(ResolvedGroupArtifactVersion dependency, ResolvedPom resolved) {
+                assertNotFailureAccess(dependency.getGroupId(), dependency.getArtifactId());
+                delegate.putResolvedDependencyPom(dependency, resolved);
+            }
+
+            @Override
+            public @Nullable Optional<MavenMetadata> getMavenMetadata(URI repo, GroupArtifactVersion gav) {
+                assertNotFailureAccess(gav.getGroupId(), gav.getArtifactId());
+                return delegate.getMavenMetadata(repo, gav);
+            }
+
+            @Override
+            public void putMavenMetadata(URI repo, GroupArtifactVersion gav, @Nullable MavenMetadata metadata) {
+                assertNotFailureAccess(gav.getGroupId(), gav.getArtifactId());
+                delegate.putMavenMetadata(repo, gav, metadata);
+            }
+
+            @Override
+            public @Nullable Optional<Pom> getPom(ResolvedGroupArtifactVersion gav) throws MavenDownloadingException {
+                assertNotFailureAccess(gav.getGroupId(), gav.getArtifactId());
+                return delegate.getPom(gav);
+            }
+
+            @Override
+            public void putPom(ResolvedGroupArtifactVersion gav, @Nullable Pom pom) {
+                assertNotFailureAccess(gav.getGroupId(), gav.getArtifactId());
+                delegate.putPom(gav, pom);
+            }
+
+            @Override
+            public @Nullable Optional<MavenRepository> getNormalizedRepository(MavenRepository repository) {
+                return delegate.getNormalizedRepository(repository);
+            }
+
+            @Override
+            public void putNormalizedRepository(MavenRepository repository, MavenRepository normalized) {
+                delegate.putNormalizedRepository(repository, normalized);
+            }
+        };
+        rewriteRun(
+          spec -> spec.recipeExecutionContext(
+            MavenExecutionContextView.view(new InMemoryExecutionContext()).setPomCache(failOnFailureAccess)),
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+
+              repositories {
+                mavenCentral()
+              }
+
+              dependencies {
+                compileOnly 'com.google.guava:guava:29.0-jre'
+                runtimeOnly ('com.google.guava:guava:29.0-jre')
+              }
+              """,
+            """
+              plugins {
+                id 'java-library'
+              }
+
+              repositories {
+                mavenCentral()
+              }
+
+              dependencies {
+                compileOnly 'com.google.guava:guava:30.1.1-jre'
+                runtimeOnly ('com.google.guava:guava:30.1.1-jre')
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void dependencyInsightFindsUpdatedTransitiveAfterUpgrade() {
+        rewriteRun(
+          spec -> spec.recipes(
+            new UpgradeDependencyVersion("com.google.guava", "guava", "30.x", "-jre"),
+            new org.openrewrite.gradle.search.DependencyInsight("org.checkerframework", "checker-qual", null, null)
+          ),
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+
+              repositories {
+                mavenCentral()
+              }
+
+              dependencies {
+                implementation 'com.google.guava:guava:29.0-jre'
+              }
+              """,
+            """
+              plugins {
+                id 'java-library'
+              }
+
+              repositories {
+                mavenCentral()
+              }
+
+              dependencies {
+                /*~~(org.checkerframework:checker-qual:3.8.0)~~>*/implementation 'com.google.guava:guava:30.1.1-jre'
+              }
+              """
           )
         );
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -996,11 +996,27 @@ public class ResolvedPom {
     }
 
     public List<ResolvedDependency> resolveDependencies(Scope scope, MavenPomDownloader downloader, ExecutionContext ctx) throws MavenDownloadingExceptions {
-        return resolveDependencies(scope, new HashMap<>(), downloader, ctx);
+        return doResolveDependencies(scope, new HashMap<>(), true, downloader, ctx);
     }
 
     public List<ResolvedDependency> resolveDependencies(Scope scope, Map<GroupArtifact, VersionRequirement> requirements,
                                                         MavenPomDownloader downloader, ExecutionContext ctx) throws MavenDownloadingExceptions {
+        return doResolveDependencies(scope, requirements, true, downloader, ctx);
+    }
+
+    /**
+     * Resolves the requested dependencies in the given scope without downloading their transitive closure.
+     * Each returned {@link ResolvedDependency} has an empty {@code dependencies} list. This allows callers who only
+     * need the direct coordinates (for example to re-resolve after a version mutation) to avoid the cost of
+     * transitive POM downloads.
+     */
+    public List<ResolvedDependency> resolveDirectDependencies(Scope scope, MavenPomDownloader downloader, ExecutionContext ctx) throws MavenDownloadingExceptions {
+        return doResolveDependencies(scope, new HashMap<>(), false, downloader, ctx);
+    }
+
+    private List<ResolvedDependency> doResolveDependencies(Scope scope, Map<GroupArtifact, VersionRequirement> requirements,
+                                                           boolean resolveTransitives,
+                                                           MavenPomDownloader downloader, ExecutionContext ctx) throws MavenDownloadingExceptions {
         List<ResolvedDependency> dependencies = new ArrayList<>();
 
         Map<GroupArtifact, DependencyAndDependent> rootDependencies = new LinkedHashMap<>();
@@ -1066,7 +1082,7 @@ public class ResolvedPom {
                             MavenExecutionContextView.view(ctx)
                                     .getResolutionListener()
                                     .clear();
-                            return resolveDependencies(scope, requirements, downloader, ctx);
+                            return doResolveDependencies(scope, requirements, resolveTransitives, downloader, ctx);
                         } else if (contains(dependencies, ga, d.getClassifier())) {
                             // we've already resolved this previously and the requirement didn't change,
                             // so just skip and continue on
@@ -1131,6 +1147,10 @@ public class ResolvedPom {
                     if (dd.getScope().transitiveOf(scope) == scope) {
                         dependencies.add(resolved);
                     } else {
+                        continue;
+                    }
+
+                    if (!resolveTransitives) {
                         continue;
                     }
 


### PR DESCRIPTION
In environments with very slow artifact repositories any unnecessary request can dramatically slow recipe runs.
I observed that UpgradeDependencyVersion is unintentionally eagerly resolving the poms of transitive dependencies post-upgrade of a direct dependency. 
These alterations lead to further deferral of transitive resolution until something actually needs it.