### PR TITLE
JavaScript: fix non-FQ type on enum declarations and harden `parseProject`

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -733,7 +733,7 @@ export class JavaScriptParserVisitor {
                 )),
                 end: this.prefix(node.getLastToken()!)
             },
-            type: this.mapType(node)
+            type: this.mapDeclarationType(node)
         };
     }
 
@@ -2723,7 +2723,7 @@ export class JavaScriptParserVisitor {
                     })),
                     end: this.prefix(node.getLastToken()!)
                 },
-                type: this.mapType(node)
+                type: this.mapDeclarationType(node)
             } satisfies J.ClassDeclaration as J.ClassDeclaration,
         }
     }
@@ -3414,7 +3414,7 @@ export class JavaScriptParserVisitor {
                 })),
                 end: this.prefix(node.getLastToken()!)
             },
-            type: this.mapType(node)
+            type: this.mapDeclarationType(node)
         };
     }
 
@@ -3475,7 +3475,7 @@ export class JavaScriptParserVisitor {
                     emptySpace)],
                 end: this.prefix(node.getLastToken()!)
             },
-            type: this.mapType(node) as Type.Class
+            type: this.mapDeclarationType(node) as Type.Class
         };
     }
 
@@ -4425,6 +4425,10 @@ export class JavaScriptParserVisitor {
 
     private mapType(node: ts.Node): Type | undefined {
         return this.typeMapping?.type(node);
+    }
+
+    private mapDeclarationType(node: ts.ClassDeclaration | ts.ClassExpression | ts.InterfaceDeclaration | ts.EnumDeclaration): Type.FullyQualified | undefined {
+        return this.typeMapping?.declarationType(node);
     }
 
     private mapPrimitiveType(node: ts.Node): Type.Primitive {

--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -83,6 +83,86 @@ export class JavaScriptTypeMapping {
         return type && this.getType(type);
     }
 
+    /**
+     * Resolve the declared type of a class / interface / enum / class-expression.
+     *
+     * Using {@code getTypeAtLocation} on these declaration nodes is unsafe: TypeScript returns
+     * the type of the declared *value*, not the type itself. For string or numeric enums that
+     * ends up being the union of enum literals, which on the JS side resolves to
+     * {@link Type.Primitive} (e.g. String for string enums). The Java-side RPC receiver then
+     * rejects it with "A class can only be type attributed with a fully qualified type name",
+     * because {@code J.ClassDeclaration.type} must be {@link Type.FullyQualified}.
+     *
+     * Instead, we resolve through the declaration's own symbol. For classes and interfaces we
+     * reuse the full type mapping pipeline (so members, methods, supertypes and type parameters
+     * are populated). For enums — which have no class-shaped representation in TypeScript — and
+     * any residual non-FQ result, we build a minimal class shell whose FQN and {@code classKind}
+     * are derived from the declaration itself.
+     */
+    declarationType(node: ts.ClassDeclaration | ts.ClassExpression | ts.InterfaceDeclaration | ts.EnumDeclaration): Type.FullyQualified | undefined {
+        const symbol = (node as { symbol?: ts.Symbol }).symbol
+            ?? (node.name ? this.checker.getSymbolAtLocation(node.name) : undefined);
+        if (!symbol) {
+            return undefined;
+        }
+
+        // For classes and interfaces `getDeclaredTypeOfSymbol` yields a class-shaped ts.Type whose
+        // symbol we can feed through the normal pipeline. For enums, however, TypeScript returns the
+        // union of enum literals — which on the JS side resolves to `Type.Primitive` (e.g. String for
+        // string enums) and therefore is NOT `FullyQualified`. The Java side then rejects it with
+        // "A class can only be type attributed with a fully qualified type name".
+        //
+        // Since JavaScript/TypeScript has no separate enum runtime representation, we build the
+        // class-shaped type directly from the declaration's own symbol. The `classKind` is derived
+        // from the declaration node kind, not the (lossy) resolved type.
+        let classKind: Type.Class.Kind;
+        if (ts.isEnumDeclaration(node)) {
+            classKind = Type.Class.Kind.Enum;
+        } else if (ts.isInterfaceDeclaration(node)) {
+            classKind = Type.Class.Kind.Interface;
+        } else {
+            classKind = Type.Class.Kind.Class;
+        }
+
+        const fullyQualifiedName = this.getFullyQualifiedNameFromSymbol(symbol);
+        const cacheKey = `decl:${classKind}:${fullyQualifiedName}`;
+        const cached = this.typeCache.get(cacheKey);
+        if (cached && Type.isFullyQualified(cached)) {
+            return cached as Type.FullyQualified;
+        }
+
+        // For classes and interfaces reuse the existing type-based path so that members, methods,
+        // supertypes and type parameters are populated. Enums (and any fallback that produced a
+        // non-FQ result) get a minimal class shell with the correct FQN + kind.
+        if (!ts.isEnumDeclaration(node)) {
+            const declaredType = this.checker.getDeclaredTypeOfSymbol(symbol);
+            if (declaredType) {
+                const mapped = this.getType(declaredType);
+                if (Type.isFullyQualified(mapped)) {
+                    this.typeCache.set(cacheKey, mapped);
+                    return mapped;
+                }
+            }
+        }
+
+        const classType: Type.Class = {
+            kind: Type.Kind.Class,
+            flags: 0,
+            classKind,
+            fullyQualifiedName,
+            typeParameters: [],
+            annotations: [],
+            interfaces: [],
+            members: [],
+            methods: [],
+            toJSON: function () {
+                return Type.signature(this);
+            }
+        } as Type.Class;
+        this.typeCache.set(cacheKey, classType);
+        return classType;
+    }
+
     private getType(type: ts.Type): Type {
         // Check for error types first - these indicate type-checking failures
         // and should not be processed further
@@ -990,7 +1070,10 @@ export class JavaScriptTypeMapping {
         if (!symbol) {
             return "unknown";
         }
+        return this.getFullyQualifiedNameFromSymbol(symbol);
+    }
 
+    private getFullyQualifiedNameFromSymbol(symbol: ts.Symbol): string {
         // First, check if this symbol is an import/alias
         // For imported types, we want to use the module specifier instead of the file path
         if (symbol.flags & ts.SymbolFlags.Alias) {

--- a/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
@@ -28,6 +28,12 @@ import {replaceMarkerByKind} from "../../markers";
 export interface ParseProjectResponseItem {
     id: UUID;
     sourceFileType: string;
+    /**
+     * Relative source path of the discovered file. Used by the Java side to report
+     * per-file failures (e.g., a failed `GetObject` deserialization) without aborting
+     * the rest of the stream. Optional for older callers.
+     */
+    sourcePath?: string;
 }
 
 /**
@@ -88,7 +94,7 @@ export class ParseProject {
                         });
                         const generator = parser.parse(...discovered.packageJsonFiles);
 
-                        for (const _ of discovered.packageJsonFiles) {
+                        for (const filePath of discovered.packageJsonFiles) {
                             const id = randomId();
                             localObjects.set(id, async (id: string) => {
                                 const sourceFile: SourceFile = (await generator.next()).value;
@@ -96,7 +102,8 @@ export class ParseProject {
                             });
                             resultItems.push({
                                 id,
-                                sourceFileType: "org.openrewrite.json.tree.Json$Document" // break cycle
+                                sourceFileType: "org.openrewrite.json.tree.Json$Document", // break cycle
+                                sourcePath: path.relative(relativeTo, filePath)
                             });
                         }
                     }
@@ -106,7 +113,7 @@ export class ParseProject {
                         const parser = Parsers.createParser("json", {ctx, relativeTo});
                         const generator = parser.parse(...discovered.lockFiles.json);
 
-                        for (const _ of discovered.lockFiles.json) {
+                        for (const filePath of discovered.lockFiles.json) {
                             const id = randomId();
                             localObjects.set(id, async (id: string) => {
                                 const sourceFile: SourceFile = (await generator.next()).value;
@@ -114,7 +121,8 @@ export class ParseProject {
                             });
                             resultItems.push({
                                 id,
-                                sourceFileType: "org.openrewrite.json.tree.Json$Document" // break cycle
+                                sourceFileType: "org.openrewrite.json.tree.Json$Document", // break cycle
+                                sourcePath: path.relative(relativeTo, filePath)
                             });
                         }
                     }
@@ -124,7 +132,7 @@ export class ParseProject {
                         const parser = Parsers.createParser("yaml", {ctx, relativeTo});
                         const generator = parser.parse(...discovered.lockFiles.yaml);
 
-                        for (const _ of discovered.lockFiles.yaml) {
+                        for (const filePath of discovered.lockFiles.yaml) {
                             const id = randomId();
                             localObjects.set(id, async (id: string) => {
                                 const sourceFile: SourceFile = (await generator.next()).value;
@@ -132,7 +140,8 @@ export class ParseProject {
                             });
                             resultItems.push({
                                 id,
-                                sourceFileType: "org.openrewrite.yaml.tree.Yaml$Documents" // break cycle
+                                sourceFileType: "org.openrewrite.yaml.tree.Yaml$Documents", // break cycle
+                                sourcePath: path.relative(relativeTo, filePath)
                             });
                         }
                     }
@@ -142,7 +151,7 @@ export class ParseProject {
                         const parser = Parsers.createParser("plainText", {ctx, relativeTo});
                         const generator = parser.parse(...discovered.lockFiles.text);
 
-                        for (const _ of discovered.lockFiles.text) {
+                        for (const filePath of discovered.lockFiles.text) {
                             const id = randomId();
                             localObjects.set(id, async (id: string) => {
                                 const sourceFile: SourceFile = (await generator.next()).value;
@@ -150,7 +159,8 @@ export class ParseProject {
                             });
                             resultItems.push({
                                 id,
-                                sourceFileType: "org.openrewrite.text.PlainText" // break cycle
+                                sourceFileType: "org.openrewrite.text.PlainText", // break cycle
+                                sourcePath: path.relative(relativeTo, filePath)
                             });
                         }
                     }
@@ -185,16 +195,18 @@ export class ParseProject {
                                 });
                                 resultItems.push({
                                     id,
-                                    sourceFileType: "org.openrewrite.javascript.tree.JS$CompilationUnit" // break cycle
+                                    sourceFileType: "org.openrewrite.javascript.tree.JS$CompilationUnit", // break cycle
+                                    sourcePath: path.relative(relativeTo, filePath)
                                 });
                             }
                         } else {
                             // Prettier is NOT available: auto-detect styles from parsed files
                             // Parse all files first to sample them
-                            const parsedFiles: {id: string, sourceFile: SourceFile}[] = [];
+                            const parsedFiles: {id: string, sourceFile: SourceFile, filePath: string}[] = [];
+                            let fileIndex = 0;
                             for await (const sourceFile of parser.parse(...discovered.jsFiles)) {
                                 const id = randomId();
-                                parsedFiles.push({id, sourceFile});
+                                parsedFiles.push({id, sourceFile, filePath: discovered.jsFiles[fileIndex++]});
                             }
 
                             // Sample all parsed files and build Autodetect marker using ProjectParser helper
@@ -203,7 +215,7 @@ export class ParseProject {
                             );
 
                             // Store thunks that add the Autodetect marker
-                            for (const {id, sourceFile} of parsedFiles) {
+                            for (const {id, sourceFile, filePath} of parsedFiles) {
                                 localObjects.set(id, async (newId: string) => {
                                     return {
                                         ...sourceFile,
@@ -213,7 +225,8 @@ export class ParseProject {
                                 });
                                 resultItems.push({
                                     id,
-                                    sourceFileType: "org.openrewrite.javascript.tree.JS$CompilationUnit" // break cycle
+                                    sourceFileType: "org.openrewrite.javascript.tree.JS$CompilationUnit", // break cycle
+                                    sourcePath: path.relative(relativeTo, filePath)
                                 });
                             }
                         }
@@ -224,7 +237,7 @@ export class ParseProject {
                         const parser = Parsers.createParser("yaml", {ctx, relativeTo});
                         const generator = parser.parse(...discovered.yamlFiles);
 
-                        for (const _ of discovered.yamlFiles) {
+                        for (const filePath of discovered.yamlFiles) {
                             const id = randomId();
                             localObjects.set(id, async (id: string) => {
                                 const sourceFile: SourceFile = (await generator.next()).value;
@@ -232,7 +245,8 @@ export class ParseProject {
                             });
                             resultItems.push({
                                 id,
-                                sourceFileType: "org.openrewrite.yaml.tree.Yaml$Documents" // break cycle
+                                sourceFileType: "org.openrewrite.yaml.tree.Yaml$Documents", // break cycle
+                                sourcePath: path.relative(relativeTo, filePath)
                             });
                         }
                     }
@@ -242,7 +256,7 @@ export class ParseProject {
                         const parser = Parsers.createParser("json", {ctx, relativeTo});
                         const generator = parser.parse(...discovered.jsonFiles);
 
-                        for (const _ of discovered.jsonFiles) {
+                        for (const filePath of discovered.jsonFiles) {
                             const id = randomId();
                             localObjects.set(id, async (id: string) => {
                                 const sourceFile: SourceFile = (await generator.next()).value;
@@ -250,7 +264,8 @@ export class ParseProject {
                             });
                             resultItems.push({
                                 id,
-                                sourceFileType: "org.openrewrite.json.tree.Json$Document" // break cycle
+                                sourceFileType: "org.openrewrite.json.tree.Json$Document", // break cycle
+                                sourcePath: path.relative(relativeTo, filePath)
                             });
                         }
                     }
@@ -260,7 +275,7 @@ export class ParseProject {
                         const parser = Parsers.createParser("plainText", {ctx, relativeTo});
                         const generator = parser.parse(...discovered.textFiles);
 
-                        for (const _ of discovered.textFiles) {
+                        for (const filePath of discovered.textFiles) {
                             const id = randomId();
                             localObjects.set(id, async (id: string) => {
                                 const sourceFile: SourceFile = (await generator.next()).value;
@@ -268,7 +283,8 @@ export class ParseProject {
                             });
                             resultItems.push({
                                 id,
-                                sourceFileType: "org.openrewrite.text.PlainText" // break cycle
+                                sourceFileType: "org.openrewrite.text.PlainText", // break cycle
+                                sourcePath: path.relative(relativeTo, filePath)
                             });
                         }
                     }

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
@@ -26,6 +26,7 @@ import org.openrewrite.*;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.javascript.JavaScriptIsoVisitor;
 import org.openrewrite.javascript.JavaScriptParser;
 import org.openrewrite.javascript.style.Autodetect;
@@ -615,6 +616,37 @@ class JavaScriptRewriteRpcTest implements RewriteTest {
                 }
                 """
             )
+          )
+        );
+    }
+
+    /**
+     * Regression test for <a href="https://github.com/moderneinc/customer-requests/issues/2234">#2234</a>:
+     * a string enum declaration would send a {@link JavaType.Primitive} (resolved from the union of
+     * enum literals) for {@code J.ClassDeclaration.type}, which the Java-side RPC receiver rejects
+     * with "A class can only be type attributed with a fully qualified type name".
+     */
+    @Test
+    void parseStringEnumDeclaration() {
+        rewriteRun(
+          typescript(
+            """
+              export enum ContentType {
+                APPLICATION_JSON = 'application/json',
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> new JavaScriptIsoVisitor<Integer>() {
+                @Override
+                public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, Integer p) {
+                    assertThat(classDecl.getType())
+                      .as("enum declaration must have a FullyQualified type")
+                      .isInstanceOf(JavaType.Class.class);
+                    JavaType.Class type = (JavaType.Class) classDecl.getType();
+                    assertThat(type.getKind()).isEqualTo(JavaType.FullyQualified.Kind.Enum);
+                    assertThat(type.getFullyQualifiedName()).contains("ContentType");
+                    return classDecl;
+                }
+            }.visit(cu, 0))
           )
         );
     }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -179,27 +179,46 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
                 ParseProjectResponse.Item item = response.get(index);
                 index++;
 
-                SourceFile sourceFile = getObject(item.getId(), item.getSourceFileType());
-                // for status update messages
-                Parser.Input input = Parser.Input.fromFile(sourceFile.getSourcePath());
-                parsingListener.startedParsing(input);
+                SourceFile sourceFile;
                 try {
+                    sourceFile = getObject(item.getId(), item.getSourceFileType());
+                    parsingListener.startedParsing(Parser.Input.fromFile(sourceFile.getSourcePath()));
                     if (sourceFile instanceof JS.CompilationUnit) {
                         validator.visit(sourceFile, 0);
                     }
                 } catch (Exception e) {
-                    sourceFile = new ParseError(
-                            sourceFile.getId(),
-                            new Markers(Tree.randomId(), singletonList(
-                                    ParseExceptionResult.build(JavaScriptParser.class, e, e.getMessage()))),
-                            sourceFile.getSourcePath(),
-                            null,
-                            null,
-                            false,
-                            null,
-                            input.getSource(ctx).readFully(),
-                            null
-                    );
+                    // A single file's RPC deserialization or validation failed. Convert it to a
+                    // ParseError pointing at the offending file and keep the stream going.
+                    //
+                    // `item.sourcePath` may be null when talking to an older TypeScript peer that
+                    // doesn't populate it yet — fall back to the RPC object id so we still produce
+                    // a usable ParseError rather than crashing the whole stream with an NPE.
+                    String relativePath = item.getSourcePath() != null ? item.getSourcePath() : item.getId();
+                    Path sourcePath = Paths.get(relativePath);
+                    Path absoluteSourcePath = projectPath.resolve(sourcePath);
+                    try {
+                        sourceFile = ParseError.build(
+                                JavaScriptParser.builder().build(),
+                                Parser.Input.fromFile(absoluteSourcePath),
+                                projectPath,
+                                ctx,
+                                e);
+                    } catch (Exception readFailure) {
+                        // If the file can't be read (e.g. fallback path from id doesn't exist on
+                        // disk), still emit a ParseError so the stream can continue. Without the
+                        // source text the error is less useful but at least it doesn't abort.
+                        sourceFile = new ParseError(
+                                Tree.randomId(),
+                                new Markers(Tree.randomId(), singletonList(
+                                        ParseExceptionResult.build(JavaScriptParser.class, e, null))),
+                                sourcePath,
+                                null,
+                                null,
+                                false,
+                                null,
+                                "",
+                                null);
+                    }
                 }
                 action.accept(sourceFile);
                 return true;

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/ParseProjectResponse.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/ParseProjectResponse.java
@@ -43,5 +43,10 @@ class ParseProjectResponse extends ArrayList<ParseProjectResponse.Item> {
          * - org.openrewrite.yaml.tree.Yaml$Documents
          */
         String sourceFileType;
+
+        /**
+         * The relative source path of the file.
+         */
+        String sourcePath;
     }
 }


### PR DESCRIPTION
## Motivation

Building certain TypeScript projects — originally reported for [nashtech-garage/yas](https://github.com/nashtech-garage/yas) — fails with:

```
java.lang.IllegalArgumentException: A class can only be type attributed with a fully qualified type name
  at org.openrewrite.java.tree.J$ClassDeclaration.withType(J.java:1362)
  at org.openrewrite.java.internal.rpc.JavaReceiver.visitClassDeclaration(JavaReceiver.java:150)
  ...
  at org.openrewrite.rpc.RewriteRpc.getObject(RewriteRpc.java:553)
  at org.openrewrite.javascript.rpc.JavaScriptRewriteRpc$1.tryAdvance(JavaScriptRewriteRpc.java:182)
```

The trigger turned out to be as small as:

```typescript
export enum ContentType {
  APPLICATION_JSON = 'application/json',
}
```

Two separate problems combined to make this a project-killer rather than a per-file error:

1. **The actual bug.** `visitEnumDeclaration` (and the other `J.ClassDeclaration` producers: `visitClassDeclaration`, `visitClassExpression`, `visitInterfaceDeclaration`) set the node's type via `mapType(node)`, which calls `checker.getTypeAtLocation(node)`. TypeScript resolves this to the type of the *declared value* — for a string enum, that collapses to the union of string-literal members and on the JS side becomes `Type.Primitive.String`. The Java side's `J.ClassDeclaration.withType` validates that the type is `FullyQualified` and throws.

2. **No per-file resilience.** The failure surfaced deep in RPC tree reconstruction (`getObject`), which runs *outside* the try/catch in `parseProject`'s `tryAdvance`. A single bad file therefore aborts the entire stream instead of degrading to a `ParseError` for that file.

## Summary

- Introduce `JavaScriptTypeMapping.declarationType(node)`, used by `visitClassDeclaration`, `visitClassExpression`, `visitInterfaceDeclaration`, and `visitEnumDeclaration`. It resolves the declared type through the declaration's *symbol*:
  - For classes and interfaces, `getDeclaredTypeOfSymbol` yields a class-shaped `ts.Type` that feeds through the existing pipeline (members, methods, supertypes, type parameters preserved).
  - For enums — which have no class-shaped representation in TypeScript — we build a minimal `Type.Class` with `classKind = Enum` and the declaration's own FQN. This preserves the `FullyQualified` invariant.
- Extract a `getFullyQualifiedNameFromSymbol(symbol)` helper so the FQN logic works directly from a symbol.
- Wrap the per-file `getObject(...)` call in `JavaScriptRewriteRpc.parseProject` with a try/catch. On failure we produce a `ParseError` that points at the offending file and continue iterating.
- Add an optional `sourcePath` field to `ParseProjectResponse.Item` / `ParseProjectResponseItem` so the Java side can report which file failed when `getObject` throws.
- Add a regression test `parseStringEnumDeclaration` that parses a string enum over RPC and asserts the resulting `J.ClassDeclaration` carries a `JavaType.Class` with `Kind.Enum` and the right FQN.

## Test plan

- [x] New test `JavaScriptRewriteRpcTest.parseStringEnumDeclaration` passes
- [x] Existing `JavaScriptRewriteRpcTest` suite passes
- [x] TS-side `npm run testhelper -- test/javascript/parser/` — 627 passed / 6 skipped
- [x] License format check passes
- [x] End-to-end: parsing the full `nashtech-garage/yas/backoffice` tree (206 source files) now completes with `parseErrors=0`, where previously it aborted mid-stream.