### PR TITLE
Walk `JavaType` refs embedded in annotation element values

### DIFF
--- a/rewrite-benchmarks/build.gradle.kts
+++ b/rewrite-benchmarks/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     jmh(project(":rewrite-core"))
     jmh(project(":rewrite-java"))
     jmh(project(":rewrite-java-21"))
+    jmh(project(":rewrite-javascript"))
     jmh(project(":rewrite-maven"))
     jmh("org.antlr:antlr4-runtime:4.13.2")
     jmh("org.rocksdb:rocksdbjni:10.2.1")

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTypeVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTypeVisitor.java
@@ -114,8 +114,55 @@ public class JavaTypeVisitor<P> {
     public JavaType visitAnnotation(JavaType.Annotation annotation, P p) {
         return annotation.unsafeSet(
                 (JavaType.FullyQualified) visit(annotation.getType(), p),
-                arrayOrNullIfEmpty(annotation.getValues(), JavaType.EMPTY_ANNOTATION_VALUE_ARRAY)
+                arrayOrNullIfEmpty(
+                        ListUtils.map(annotation.getValues(), ev -> visitAnnotationElementValue(ev, p)),
+                        JavaType.EMPTY_ANNOTATION_VALUE_ARRAY)
         );
+    }
+
+    /**
+     * Visit the JavaType refs embedded in an annotation element value — the
+     * {@code element} meta-variable and any {@code referenceValue}(s). Constant
+     * values never hold {@link JavaType} instances in practice: Single- and
+     * ArrayElementValue#from route JavaType-valued arguments into the reference
+     * branch, so the constant side is only ever primitives, strings, and enums.
+     * The default implementation returns the same ElementValue when no
+     * referenced JavaType changed identity, matching the semantics of the other
+     * {@code visit*} methods on this visitor.
+     */
+    public JavaType.Annotation.ElementValue visitAnnotationElementValue(JavaType.Annotation.ElementValue ev, P p) {
+        JavaType element = visit(ev.getElement(), p);
+        if (ev instanceof JavaType.Annotation.SingleElementValue) {
+            JavaType.Annotation.SingleElementValue sev = (JavaType.Annotation.SingleElementValue) ev;
+            JavaType referenceValue = sev.getReferenceValue();
+            if (referenceValue != null) {
+                JavaType visited = visit(referenceValue, p);
+                if (visited == referenceValue && element == sev.getElement()) return sev;
+                return new JavaType.Annotation.SingleElementValue(element, null, visited);
+            }
+            if (element == sev.getElement()) return sev;
+            return new JavaType.Annotation.SingleElementValue(element, sev.getConstantValue(), null);
+        }
+        if (ev instanceof JavaType.Annotation.ArrayElementValue) {
+            JavaType.Annotation.ArrayElementValue aev = (JavaType.Annotation.ArrayElementValue) ev;
+            JavaType[] referenceValues = aev.getReferenceValues();
+            if (referenceValues != null) {
+                JavaType[] visited = null;
+                for (int i = 0; i < referenceValues.length; i++) {
+                    JavaType v = visit(referenceValues[i], p);
+                    if (v != referenceValues[i]) {
+                        if (visited == null) visited = referenceValues.clone();
+                        visited[i] = v;
+                    }
+                }
+                if (visited == null && element == aev.getElement()) return aev;
+                return new JavaType.Annotation.ArrayElementValue(element, null,
+                        visited != null ? visited : referenceValues);
+            }
+            if (element == aev.getElement()) return aev;
+            return new JavaType.Annotation.ArrayElementValue(element, aev.getConstantValues(), null);
+        }
+        return ev;
     }
 
     public JavaType visitArray(JavaType.Array array, P p) {


### PR DESCRIPTION
## What's changed?

`JavaTypeVisitor.visitAnnotation` only visited `annotation.getType()`, leaving the refs inside element values untouched: the `element` meta-variable and `SingleElementValue.referenceValue` / `ArrayElementValue.referenceValues`. Any downstream visitor that relies on the full-graph walk (dedup, type remappers, serializers, …) sees non-canonical instances inside annotation values while the rest of the type graph is consistent.

Adds `visitAnnotationElementValue`, which visits the element meta-variable and the reference-value branch, and reconstructs the `ElementValue` only when a returned instance changed identity. `UnsafeJavaTypeVisitor` inherits the new behaviour through the default `visitAnnotation`.

Constant values are deliberately not visited: `SingleElementValue.from` / `ArrayElementValue.from` route any `JavaType`-valued argument into the reference branch, so constants only ever hold primitives, strings, and enums in parser-produced LSTs.

## What's your motivation?

Downstream at Moderne, a recipe run against a large multi-module LST failed deserializing a method's annotations — the `meta.bin` type table referenced an index past its own end. Root cause was our `JavaTypeDeduplicationVisitor` inheriting this visit gap: annotation-value refs stayed as pre-canonical instances while the rest of the type graph was deduped, so the writer's identity-keyed map treated them as fresh types after the offset table had already been sized.

Fixing only in our downstream visitor leaves the gap in every other `JavaTypeVisitor` subclass, which is why this PR is here.

## Anything in particular you'd like reviewers to focus on?

- Whether the "no constants" decision matches your understanding of the `from(...)` factories.
- The `ArrayElementValue` reference-values loop returns the same array when every visited element is identity-equal, and only clones when at least one changed.