### PR TITLE
Kotlin: remap builtins on Java-origin method/field types

### DIFF
--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -35,6 +35,7 @@ import org.jetbrains.kotlin.fir.declarations.utils.modality
 import org.jetbrains.kotlin.fir.declarations.utils.visibility
 import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.expressions.impl.FirResolvedArgumentList
+import org.jetbrains.kotlin.fir.java.declarations.FirJavaClass
 import org.jetbrains.kotlin.fir.java.declarations.FirJavaField
 import org.jetbrains.kotlin.fir.references.FirErrorNamedReference
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
@@ -704,7 +705,15 @@ class KotlinTypeMapping(
             parentType = parentType.type
         }
         val resolvedDeclaringType = TypeUtils.asFullyQualified(parentType)
-        var returnType = remapKotlinBuiltin(type(function.returnTypeRef))
+        // Only remap kotlin.* builtins to JVM FQNs for methods declared on Java-origin
+        // classes (third-party Java libraries loaded as FirJavaClass). The Kotlin compiler's
+        // FIR renders a Java method's `String` parameter as `kotlin.String` even though the
+        // bytecode signature is `java.lang.String`; remapping puts the parser's output back
+        // in line with the JVM signature so MethodMatcher patterns written against Java
+        // FQNs match. Kotlin-declared methods are left alone — `kotlin.Any` there is the
+        // author's intent, and Kotlin-aware matching belongs in KotlinTypeUtils.
+        val javaOrigin = parent is FirJavaClass
+        var returnType = if (javaOrigin) remapKotlinBuiltin(type(function.returnTypeRef)) else type(function.returnTypeRef)
         // Java parser uses the raw Class for a constructor's returnType, not the
         // class's parameterized form. Kotlin's FIR renders a constructor's
         // `returnTypeRef` as the class instantiated with its own type parameters
@@ -721,13 +730,14 @@ class KotlinTypeMapping(
             else -> null
         }
         if (function.receiverParameter != null) {
-            parameterTypes!!.add(remapKotlinBuiltin(type(function.receiverParameter!!.typeRef))!!)
+            val rt = type(function.receiverParameter!!.typeRef)
+            parameterTypes!!.add(if (javaOrigin) remapKotlinBuiltin(rt)!! else rt)
         }
         if (function.valueParameters.isNotEmpty()) {
             for (p in function.valueParameters) {
-                val t = remapKotlinBuiltin(type(p.returnTypeRef, function))
+                val t = type(p.returnTypeRef, function)
                 if (t != null) {
-                    parameterTypes!!.add(t)
+                    parameterTypes!!.add(if (javaOrigin) remapKotlinBuiltin(t)!! else t)
                 }
             }
         }
@@ -973,10 +983,20 @@ class KotlinTypeMapping(
         if (declaringType == null) {
             declaringType = TypeUtils.asFullyQualified(type(firFile))
         }
-        val returnType = remapKotlinBuiltin(type(function.resolvedType))
+        // See methodDeclarationType: only remap for Java-origin methods so Kotlin-declared
+        // signatures (e.g. `kotlin.io.ConsoleKt.println(kotlin.Any)`) are preserved.
+        // The discriminator is the containing class FIR — Java-origin classes (third-party
+        // Java libraries on the classpath) are loaded as FirJavaClass even when the
+        // synthesized member FIR is FirConstructorImpl with an Enhancement origin. JDK
+        // classes are special-cased by Kotlin's classfile loader and aren't FirJavaClass —
+        // recipes targeting JDK signatures need a Kotlin-aware matcher instead.
+        val javaOrigin = (sym as? FirCallableSymbol<*>)
+            ?.containingClassLookupTag()?.toRegularClassSymbol(firSession)?.fir is FirJavaClass
+        val returnType = if (javaOrigin) remapKotlinBuiltin(type(function.resolvedType)) else type(function.resolvedType)
 
         if (function.toResolvedCallableSymbol()?.receiverParameterSymbol != null) {
-            paramTypes!!.add(remapKotlinBuiltin(type(function.toResolvedCallableSymbol()?.receiverParameterSymbol!!.fir.typeRef))!!)
+            val rt = type(function.toResolvedCallableSymbol()?.receiverParameterSymbol!!.fir.typeRef)
+            paramTypes!!.add(if (javaOrigin) remapKotlinBuiltin(rt)!! else rt)
         }
         // Build a mapping from parameter name to its corresponding argument expression
         val paramToArg: Map<String, FirExpression>? =
@@ -993,12 +1013,13 @@ class KotlinTypeMapping(
             if (t is GenericTypeVariable) {
                 val arg = paramToArg?.get(p.name.asString())
                 if (arg != null) {
-                    paramTypes.add(remapKotlinBuiltin(type(arg.resolvedType, function))!!)
+                    val argType = type(arg.resolvedType, function)!!
+                    paramTypes.add(if (javaOrigin) remapKotlinBuiltin(argType)!! else argType)
                 } else {
                     paramTypes.add(t)
                 }
             } else {
-                paramTypes.add(remapKotlinBuiltin(t)!!)
+                paramTypes.add(if (javaOrigin) remapKotlinBuiltin(t)!! else t)
             }
         }
         method.unsafeSet(
@@ -1291,7 +1312,13 @@ class KotlinTypeMapping(
             declaringType = declaringType.type
         }
 
-        val typeRef = remapKotlinBuiltin(type(variable.returnTypeRef))
+        // See methodDeclarationType: only remap for Java-origin variables (e.g. fields read
+        // from a Java class file) so Kotlin properties keep their author-intended types.
+        val typeRef = if (variable is FirJavaField) {
+            remapKotlinBuiltin(type(variable.returnTypeRef))
+        } else {
+            type(variable.returnTypeRef)
+        }
         vt.unsafeSet(declaringType!!, typeRef, annotations)
         return vt
     }

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -704,7 +704,7 @@ class KotlinTypeMapping(
             parentType = parentType.type
         }
         val resolvedDeclaringType = TypeUtils.asFullyQualified(parentType)
-        var returnType = type(function.returnTypeRef)
+        var returnType = remapKotlinBuiltin(type(function.returnTypeRef))
         // Java parser uses the raw Class for a constructor's returnType, not the
         // class's parameterized form. Kotlin's FIR renders a constructor's
         // `returnTypeRef` as the class instantiated with its own type parameters
@@ -721,11 +721,11 @@ class KotlinTypeMapping(
             else -> null
         }
         if (function.receiverParameter != null) {
-            parameterTypes!!.add(type(function.receiverParameter!!.typeRef))
+            parameterTypes!!.add(remapKotlinBuiltin(type(function.receiverParameter!!.typeRef))!!)
         }
         if (function.valueParameters.isNotEmpty()) {
             for (p in function.valueParameters) {
-                val t = type(p.returnTypeRef, function)
+                val t = remapKotlinBuiltin(type(p.returnTypeRef, function))
                 if (t != null) {
                     parameterTypes!!.add(t)
                 }
@@ -973,10 +973,10 @@ class KotlinTypeMapping(
         if (declaringType == null) {
             declaringType = TypeUtils.asFullyQualified(type(firFile))
         }
-        val returnType = type(function.resolvedType)
+        val returnType = remapKotlinBuiltin(type(function.resolvedType))
 
         if (function.toResolvedCallableSymbol()?.receiverParameterSymbol != null) {
-            paramTypes!!.add(type(function.toResolvedCallableSymbol()?.receiverParameterSymbol!!.fir.typeRef))
+            paramTypes!!.add(remapKotlinBuiltin(type(function.toResolvedCallableSymbol()?.receiverParameterSymbol!!.fir.typeRef))!!)
         }
         // Build a mapping from parameter name to its corresponding argument expression
         val paramToArg: Map<String, FirExpression>? =
@@ -993,12 +993,12 @@ class KotlinTypeMapping(
             if (t is GenericTypeVariable) {
                 val arg = paramToArg?.get(p.name.asString())
                 if (arg != null) {
-                    paramTypes.add(type(arg.resolvedType, function)!!)
+                    paramTypes.add(remapKotlinBuiltin(type(arg.resolvedType, function))!!)
                 } else {
                     paramTypes.add(t)
                 }
             } else {
-                paramTypes.add(t)
+                paramTypes.add(remapKotlinBuiltin(t)!!)
             }
         }
         method.unsafeSet(
@@ -1112,6 +1112,18 @@ class KotlinTypeMapping(
             return toJvmFqn(outer as BinaryJavaClass) + "$" + type.name.asString()
         }
         return type.fqName.asString()
+    }
+
+    /**
+     * Convenience overload: apply [remapKotlinBuiltin] to any [JavaType], returning the
+     * input unchanged when it is not a [FullyQualified]. Callers use this on method
+     * parameter, receiver, return, and field types so Kotlin builtins (kotlin.String /
+     * kotlin.Throwable / ...) surface as the JVM FQN the Java parser would produce.
+     */
+    private fun remapKotlinBuiltin(t: JavaType?): JavaType? {
+        if (t == null) return null
+        val fq = TypeUtils.asFullyQualified(t)
+        return if (fq != null) remapKotlinBuiltin(fq) else t
     }
 
     private fun remapKotlinBuiltin(fq: FullyQualified): FullyQualified {
@@ -1279,7 +1291,7 @@ class KotlinTypeMapping(
             declaringType = declaringType.type
         }
 
-        val typeRef = type(variable.returnTypeRef)
+        val typeRef = remapKotlinBuiltin(type(variable.returnTypeRef))
         vt.unsafeSet(declaringType!!, typeRef, annotations)
         return vt
     }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -535,7 +535,7 @@ class KotlinTypeMappingTest {
                             @Override
                             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean atomicBoolean) {
                                 if ("println".equals(method.getSimpleName())) {
-                                    assertThat(method.getMethodType().toString()).isEqualTo("kotlin.io.ConsoleKt{name=println,return=void,parameters=[kotlin.Any]}");
+                                    assertThat(method.getMethodType().toString()).isEqualTo("kotlin.io.ConsoleKt{name=println,return=void,parameters=[java.lang.Object]}");
                                     found.set(true);
                                 }
                                 return super.visitMethodInvocation(method, atomicBoolean);
@@ -543,6 +543,39 @@ class KotlinTypeMappingTest {
                         }.visit(cu, found);
                         assertThat(found.get()).isTrue();
                     })
+              )
+            );
+        }
+
+        @Issue("https://github.com/openrewrite/rewrite/issues/7427")
+        @Test
+        void constructorParameterTypesRemapKotlinBuiltins() {
+            // A Kotlin constructor taking `String` / `Throwable` must surface parameter types
+            // as the Java-parser's `java.lang.String` / `java.lang.Throwable`, not the Kotlin
+            // builtins, so `MethodMatcher` patterns written against the Java FQN match.
+            rewriteRun(
+              kotlin(
+                """
+                  fun example(cause: Throwable): IllegalArgumentException {
+                      return IllegalArgumentException("message", cause)
+                  }
+                  """,
+                spec -> spec.afterRecipe(cu -> {
+                    var matcher = new MethodMatcher("java.lang.IllegalArgumentException <constructor>(String, Throwable)");
+                    var found = new AtomicBoolean(false);
+                    new KotlinIsoVisitor<AtomicBoolean>() {
+                        @Override
+                        public J.NewClass visitNewClass(J.NewClass newClass, AtomicBoolean atomicBoolean) {
+                            var paramTypes = newClass.getConstructorType().getParameterTypes();
+                            assertThat(paramTypes.get(0).toString()).isEqualTo("java.lang.String");
+                            assertThat(paramTypes.get(1).toString()).isEqualTo("java.lang.Throwable");
+                            assertThat(matcher.matches(newClass)).isTrue();
+                            atomicBoolean.set(true);
+                            return super.visitNewClass(newClass, atomicBoolean);
+                        }
+                    }.visit(cu, found);
+                    assertThat(found.get()).isTrue();
+                })
               )
             );
         }
@@ -658,13 +691,13 @@ class KotlinTypeMappingTest {
 
         @CsvSource(value = {
           // Method type on overload with no named arguments.
-          "foo(\"\", 1, true)~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[kotlin.String,int,boolean]}",
+          "foo(\"\", 1, true)~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[java.lang.String,int,boolean]}",
           // Method type on overload with named arguments.
           "foo(b = 1)~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[int,boolean]}",
           // Method type when named arguments are declared out of order.
-          "foo(trailingLambda = {}, noDefault = true, c = true, b = 1)~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[kotlin.String,int,boolean,boolean,kotlin.Function0<void>]}",
+          "foo(trailingLambda = {}, noDefault = true, c = true, b = 1)~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[java.lang.String,int,boolean,boolean,kotlin.Function0<void>]}",
           // Method type with trailing lambda
-          "foo(b = 1, noDefault = true) {}~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[kotlin.String,int,boolean,boolean,kotlin.Function0<void>]}"
+          "foo(b = 1, noDefault = true) {}~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[java.lang.String,int,boolean,boolean,kotlin.Function0<void>]}"
         }, delimiter = '~')
         @ParameterizedTest
         void methodInvocationWithDefaults(String invocation, String methodType) {

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -535,7 +535,7 @@ class KotlinTypeMappingTest {
                             @Override
                             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean atomicBoolean) {
                                 if ("println".equals(method.getSimpleName())) {
-                                    assertThat(method.getMethodType().toString()).isEqualTo("kotlin.io.ConsoleKt{name=println,return=void,parameters=[java.lang.Object]}");
+                                    assertThat(method.getMethodType().toString()).isEqualTo("kotlin.io.ConsoleKt{name=println,return=void,parameters=[kotlin.Any]}");
                                     found.set(true);
                                 }
                                 return super.visitMethodInvocation(method, atomicBoolean);
@@ -549,19 +549,25 @@ class KotlinTypeMappingTest {
 
         @Issue("https://github.com/openrewrite/rewrite/issues/7427")
         @Test
-        void constructorParameterTypesRemapKotlinBuiltins() {
-            // A Kotlin constructor taking `String` / `Throwable` must surface parameter types
-            // as the Java-parser's `java.lang.String` / `java.lang.Throwable`, not the Kotlin
-            // builtins, so `MethodMatcher` patterns written against the Java FQN match.
+        void constructorParameterTypesRemapKotlinBuiltinsForJavaOrigin() {
+            // A Kotlin call into a Java-origin constructor taking `String` / `Throwable`
+            // must surface parameter types as the JVM `java.lang.String` /
+            // `java.lang.Throwable`, not the Kotlin builtins, so `MethodMatcher` patterns
+            // written against the Java FQN match. Jackson's JsonGenerationException is the
+            // motivating case from #7427. Kotlin-declared signatures are intentionally
+            // left as-is — see #7428 review discussion.
             rewriteRun(
               kotlin(
                 """
-                  fun example(cause: Throwable): IllegalArgumentException {
-                      return IllegalArgumentException("message", cause)
+                  import com.fasterxml.jackson.core.JsonGenerationException
+                  import com.fasterxml.jackson.core.JsonGenerator
+
+                  fun example(gen: JsonGenerator, cause: Throwable) {
+                      throw JsonGenerationException("message", cause, gen)
                   }
                   """,
                 spec -> spec.afterRecipe(cu -> {
-                    var matcher = new MethodMatcher("java.lang.IllegalArgumentException <constructor>(String, Throwable)");
+                    var matcher = new MethodMatcher("com.fasterxml.jackson.core.JsonGenerationException <constructor>(String, Throwable, com.fasterxml.jackson.core.JsonGenerator)");
                     var found = new AtomicBoolean(false);
                     new KotlinIsoVisitor<AtomicBoolean>() {
                         @Override
@@ -691,13 +697,13 @@ class KotlinTypeMappingTest {
 
         @CsvSource(value = {
           // Method type on overload with no named arguments.
-          "foo(\"\", 1, true)~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[java.lang.String,int,boolean]}",
+          "foo(\"\", 1, true)~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[kotlin.String,int,boolean]}",
           // Method type on overload with named arguments.
           "foo(b = 1)~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[int,boolean]}",
           // Method type when named arguments are declared out of order.
-          "foo(trailingLambda = {}, noDefault = true, c = true, b = 1)~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[java.lang.String,int,boolean,boolean,kotlin.Function0<void>]}",
+          "foo(trailingLambda = {}, noDefault = true, c = true, b = 1)~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[kotlin.String,int,boolean,boolean,kotlin.Function0<void>]}",
           // Method type with trailing lambda
-          "foo(b = 1, noDefault = true) {}~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[java.lang.String,int,boolean,boolean,kotlin.Function0<void>]}"
+          "foo(b = 1, noDefault = true) {}~org.example.openRewriteFile0Kt{name=foo,return=void,parameters=[kotlin.String,int,boolean,boolean,kotlin.Function0<void>]}"
         }, delimiter = '~')
         @ParameterizedTest
         void methodInvocationWithDefaults(String invocation, String methodType) {

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -568,18 +568,17 @@ class KotlinTypeMappingTest {
                   """,
                 spec -> spec.afterRecipe(cu -> {
                     var matcher = new MethodMatcher("com.fasterxml.jackson.core.JsonGenerationException <constructor>(String, Throwable, com.fasterxml.jackson.core.JsonGenerator)");
-                    var found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<AtomicBoolean>() {
+                    AtomicBoolean found = new KotlinIsoVisitor<AtomicBoolean>() {
                         @Override
-                        public J.NewClass visitNewClass(J.NewClass newClass, AtomicBoolean atomicBoolean) {
+                        public J.NewClass visitNewClass(J.NewClass newClass, AtomicBoolean found) {
                             var paramTypes = newClass.getConstructorType().getParameterTypes();
                             assertThat(paramTypes.get(0).toString()).isEqualTo("java.lang.String");
                             assertThat(paramTypes.get(1).toString()).isEqualTo("java.lang.Throwable");
                             assertThat(matcher.matches(newClass)).isTrue();
-                            atomicBoolean.set(true);
-                            return super.visitNewClass(newClass, atomicBoolean);
+                            found.set(true);
+                            return super.visitNewClass(newClass, found);
                         }
-                    }.visit(cu, found);
+                    }.reduce(cu, new AtomicBoolean());
                     assertThat(found.get()).isTrue();
                 })
               )


### PR DESCRIPTION
## Summary

- Fixes #7427.
- Closes https://github.com/moderneinc/customer-requests/issues/2235

`KotlinTypeMapping` applied `remapKotlinBuiltin` to supertypes, interfaces, generic bounds, and annotations in #7364, but not to method parameter/return/receiver types or field types — so a Kotlin call to a Jackson `JsonGenerationException("msg", cause, gen)` constructor produced parameter types `kotlin.String` / `kotlin.Throwable`, and a `MethodMatcher` written against the JVM FQNs failed to match. Per review, the remap is scoped to methods/fields whose declaring class is `FirJavaClass` (third-party Java libraries on the classpath); Kotlin-declared signatures like `kotlin.io.ConsoleKt.println(kotlin.Any)` and user properties keep their author-intended Kotlin builtin names. JDK classes go through Kotlin's classfile loader as a different FIR type and are out of scope here — recipes targeting JDK signatures over Kotlin code need a Kotlin-aware `MethodMatcher`.

## Test plan

- [x] `./gradlew :rewrite-kotlin:test` passes
- [x] New `constructorParameterTypesRemapKotlinBuiltinsForJavaOrigin` test asserts Jackson's `JsonGenerationException(String, Throwable, JsonGenerator)` surfaces JVM FQNs and a Java-FQN `MethodMatcher` matches
- [x] Existing assertions for Kotlin-declared methods (`println`, `methodInvocationWithDefaults`) unchanged — they still expect `kotlin.*` parameter types