### PR TITLE
Resolve groovy multiline interpolation parse error

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1965,7 +1965,7 @@ public class GroovyParserVisitor {
                     }
                 } else if (e instanceof ConstantExpression) {
                     // Get the string literal from the source, so escaping of newlines and the like works out of the box
-                    String value = sourceSubstring(cursor, delimiter.close);
+                    String value = sourceSubstring(cursor, delimiter.close, cursor + e.getText().length());
                     // There could be a closer GString before the end of the closing delimiter, so shorten the string if needs be
                     int indexNextSign = source.indexOf("$", cursor);
                     while (isEscaped(indexNextSign, delimiter)) {
@@ -3099,10 +3099,13 @@ public class GroovyParserVisitor {
 
     /**
      * Returns a string that is a part of this source. The substring begins at the specified beginIndex and extends until delimiter.
+     * The search starts from the fromIndex.
      * The cursor will not be moved.
      */
-    private String sourceSubstring(int beginIndex, String untilDelim) {
-        int fromIndex = Math.max(beginIndex, cursor + untilDelim.length());
+    private String sourceSubstring(int beginIndex, String untilDelim, int fromIndex) {
+        if (fromIndex < beginIndex) {
+            throw new IllegalArgumentException("beginIndex: " + beginIndex + " should be < fromIndex: "+ fromIndex);
+        }
         int endIndex = source.indexOf(untilDelim, fromIndex);
         if (endIndex < 0) {
             throw new IllegalArgumentException(
@@ -3120,6 +3123,15 @@ public class GroovyParserVisitor {
             );
         }
         return source.substring(beginIndex, endIndex);
+    }
+
+    /**
+     * Returns a string that is a part of this source. The substring begins at the specified beginIndex and extends until delimiter.
+     * The cursor will not be moved.
+     */
+    private String sourceSubstring(int beginIndex, String untilDelim) {
+        int fromIndex = Math.max(beginIndex, cursor + 1);
+        return sourceSubstring(beginIndex, untilDelim, fromIndex);
     }
 
     private @Nullable Integer getInsideParenthesesLevel(ASTNode node) {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -3104,12 +3104,12 @@ public class GroovyParserVisitor {
      */
     private String sourceSubstring(int beginIndex, String untilDelim, int fromIndex) {
         if (fromIndex < beginIndex) {
-            throw new IllegalArgumentException("beginIndex: " + beginIndex + " should be < fromIndex: "+ fromIndex);
+            throw new IllegalArgumentException("beginIndex: " + beginIndex + " should be < fromIndex: " + fromIndex);
         }
         int endIndex = source.indexOf(untilDelim, fromIndex);
         if (endIndex < 0) {
             throw new IllegalArgumentException(
-                "Couldn't find delimiter: " + untilDelim + " with fromIndex: " + fromIndex
+                    "Couldn't find delimiter: " + untilDelim + " with fromIndex: " + fromIndex
             );
         }
         // don't stop if the last char is escaped.
@@ -3119,7 +3119,7 @@ public class GroovyParserVisitor {
         }
         if (endIndex < 0) {
             throw new IllegalArgumentException(
-                "Couldn't find unescaped delimiter: " + untilDelim + " with fromIndex: " + fromIndex
+                    "Couldn't find unescaped delimiter: " + untilDelim + " with fromIndex: " + fromIndex
             );
         }
         return source.substring(beginIndex, endIndex);

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1948,6 +1948,7 @@ public class GroovyParserVisitor {
                 sortedByPosition.put(pos(e), e);
             }
             List<org.codehaus.groovy.ast.expr.Expression> rawExprs = new ArrayList<>(sortedByPosition.values());
+            boolean hasInterpolation = !gstring.getValues().isEmpty();
             List<J> strings = new ArrayList<>(rawExprs.size());
             for (int i = 0; i < rawExprs.size(); i++) {
                 org.codehaus.groovy.ast.expr.Expression e = rawExprs.get(i);
@@ -1965,15 +1966,9 @@ public class GroovyParserVisitor {
                     }
                 } else if (e instanceof ConstantExpression) {
                     // Get the string literal from the source, so escaping of newlines and the like works out of the box
-                    String value = sourceSubstring(cursor, delimiter.close, cursor + e.getText().length());
-                    // There could be a closer GString before the end of the closing delimiter, so shorten the string if needs be
-                    int indexNextSign = source.indexOf("$", cursor);
-                    while (isEscaped(indexNextSign, delimiter)) {
-                        indexNextSign = source.indexOf("$", indexNextSign + 1);
-                    }
-                    if (indexNextSign != -1 && indexNextSign < (cursor + value.length())) {
-                        value = source.substring(cursor, indexNextSign);
-                    }
+                    String value = hasInterpolation ?
+                            readConstantSegmentBeforeNextInterpolation(delimiter) :
+                            sourceSubstring(cursor, delimiter.close);
                     strings.add(new J.Literal(randomId(), EMPTY, Markers.EMPTY, value, value, null, JavaType.Primitive.String));
                     skip(value);
                 } else {
@@ -3099,17 +3094,14 @@ public class GroovyParserVisitor {
 
     /**
      * Returns a string that is a part of this source. The substring begins at the specified beginIndex and extends until delimiter.
-     * The search starts from the fromIndex.
      * The cursor will not be moved.
      */
-    private String sourceSubstring(int beginIndex, String untilDelim, int fromIndex) {
-        if (fromIndex < beginIndex) {
-            throw new IllegalArgumentException("beginIndex: " + beginIndex + " should be < fromIndex: " + fromIndex);
-        }
+    private String sourceSubstring(int beginIndex, String untilDelim) {
+        int fromIndex = Math.max(beginIndex, cursor + untilDelim.length());
         int endIndex = source.indexOf(untilDelim, fromIndex);
         if (endIndex < 0) {
             throw new IllegalArgumentException(
-                    "Couldn't find delimiter: " + untilDelim + " with fromIndex: " + fromIndex
+                "Couldn't find delimiter: " + untilDelim + " with fromIndex: " + fromIndex
             );
         }
         // don't stop if the last char is escaped.
@@ -3119,19 +3111,42 @@ public class GroovyParserVisitor {
         }
         if (endIndex < 0) {
             throw new IllegalArgumentException(
-                    "Couldn't find unescaped delimiter: " + untilDelim + " with fromIndex: " + fromIndex
+                "Couldn't find unescaped delimiter: " + untilDelim + " with fromIndex: " + fromIndex
             );
         }
         return source.substring(beginIndex, endIndex);
     }
 
     /**
-     * Returns a string that is a part of this source. The substring begins at the specified beginIndex and extends until delimiter.
-     * The cursor will not be moved.
+     * Reads a constant (literal) segment of a GString, starting at the current {@code cursor} and
+     * ending just before either the next interpolation sign ({@code $}) or the closing delimiter.
+     * Unlike {@link #sourceSubstring(int, String)} this does not scan the entire remaining source
+     * for the closing delimiter, which is unreliable for multi-line strings that may contain
+     * embedded quote sequences.
      */
-    private String sourceSubstring(int beginIndex, String untilDelim) {
-        int fromIndex = Math.max(beginIndex, cursor + 1);
-        return sourceSubstring(beginIndex, untilDelim, fromIndex);
+    private String readConstantSegmentBeforeNextInterpolation(Delimiter delimiter) {
+        int indexNextSign = source.indexOf("$", cursor);
+        while (indexNextSign != -1 && isEscaped(indexNextSign, delimiter)) {
+            indexNextSign = source.indexOf("$", indexNextSign + 1);
+        }
+        int indexCloseDelim = source.indexOf(delimiter.close, cursor);
+        while (indexCloseDelim != -1 && isEscaped(indexCloseDelim)) {
+            indexCloseDelim = source.indexOf(delimiter.close, indexCloseDelim + 1);
+        }
+        int endIndex;
+        if (indexNextSign == -1) {
+            endIndex = indexCloseDelim;
+        } else if (indexCloseDelim == -1) {
+            endIndex = indexNextSign;
+        } else {
+            endIndex = Math.min(indexNextSign, indexCloseDelim);
+        }
+        if (endIndex < 0) {
+            throw new IllegalArgumentException(
+                "Couldn't find end of GString constant segment starting at cursor: " + cursor
+            );
+        }
+        return source.substring(cursor, endIndex);
     }
 
     private @Nullable Integer getInsideParenthesesLevel(ASTNode node) {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -363,4 +363,55 @@ class GroovyParserTest implements RewriteTest {
         );
     }
 
+    @Test
+    void testMultilineStringInterpolationFollowedByTripleQuote() {
+        rewriteRun(
+          groovy(
+            """
+              String name = \"""${foo}\"""
+              """
+          )
+        );
+    }
+
+    @Test
+    void testMultilineStringDollarVariable() {
+        rewriteRun(
+          groovy(
+            """
+              def foo = "x"
+              String name = \"""
+                  $foo bar
+              \"""
+              """
+          )
+        );
+    }
+
+    @Test
+    void testMultilineStringWithEmbeddedQuotes() {
+        rewriteRun(
+          groovy(
+            """
+              String name = \"""
+                  "quoted" and ${foo}
+              \"""
+              """
+          )
+        );
+    }
+
+    @Test
+    void testMultilineStringWithEscapedDollar() {
+        rewriteRun(
+          groovy(
+            """
+              String name = \"""
+                  \\$literal then ${foo}
+              \"""
+              """
+          )
+        );
+    }
+
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -342,22 +342,23 @@ class GroovyParserTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-                String name = \"\"\"
-                    foo
-                \"\"\"
-                """
+              String name = \"""
+                  foo
+              \"""
+              """
           )
         );
     }
+
     @Test
     void testMultilineStringInterpolation() {
         rewriteRun(
           groovy(
             """
-                String name = \"\"\"
-                    ${foo}
-                \"\"\"
-                """
+              String name = \"""
+                  ${foo}
+              \"""
+              """
           )
         );
     }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -337,4 +337,29 @@ class GroovyParserTest implements RewriteTest {
         );
     }
 
+    @Test
+    void testMultilineString() {
+        rewriteRun(
+          groovy(
+            """
+                String name = \"\"\"
+                    foo
+                \"\"\"
+                """
+          )
+        );
+    }
+    @Test
+    void testMultilineStringInterpolation() {
+        rewriteRun(
+          groovy(
+            """
+                String name = \"\"\"
+                    ${foo}
+                \"\"\"
+                """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?

Fix end delimiter search for multi-line groovy strings with interpolation.

## What's your motivation?

- Fixes: https://github.com/openrewrite/rewrite/issues/7429

## Anything in particular you'd like reviewers to focus on?

The test failed in the first place because the cursor moved to extract parts of the multi-line string. Maybe there is a better way? E.g. operate on the extracted value of the full multi-line string instead of the `source`?

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?

The test failed in the first place because the cursor moved to extract parts of the multi-line string. Maybe there is a better way? E.g. operate on the extracted value of the full multi-line string instead of the `source`?
I tried to do a minimal change, but it feels slightly wrong, so maybe it would be good to do a bigger refactoring here.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
