### PR TITLE
Python: bump ty-types to 0.0.31, consume new ParamSpec wire fields

### DIFF
--- a/rewrite-python/rewrite/pyproject.toml
+++ b/rewrite-python/rewrite/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10"
 dependencies = [
     "cbor2>=5.6.5",
     "more_itertools>=10.0.0",
-    "ty-types>=0.0.21",  # Type inference CLI for Python type attribution
+    "ty-types>=0.0.31",  # Type inference CLI for Python type attribution
     "parso>=0.7.1,<0.8",  # Python 2/3 parser with CST support (0.8+ dropped Python 2.7 grammar)
 ]
 

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -771,14 +771,8 @@ class PythonTypeMapping:
             self, descriptor: Dict[str, Any], name: str
     ) -> JavaType.Method:
         """Build a JavaType.Method from a function descriptor with parameters/returnType."""
-        param_names: List[str] = []
-        param_types: List[JavaType] = []
-        for param in descriptor.get('parameters', []):
-            p_name = param.get('name', '')
-            if p_name in ('self', 'cls'):
-                continue
-            param_names.append(p_name)
-            param_types.append(self._resolve_param_type(param))
+        param_names, param_types = self._process_method_params(
+            descriptor.get('parameters', []))
 
         return_type = None
         ret_id = descriptor.get('returnType')
@@ -873,6 +867,40 @@ class PythonTypeMapping:
                 return result
         return _UNKNOWN
 
+    def _process_method_params(
+            self, params: List[Dict[str, Any]]
+    ) -> Tuple[List[str], List[JavaType]]:
+        """Normalize a ParameterInfo list into (names, types) for JavaType.Method.
+
+        Applies:
+        - Skip `self` / `cls`.
+        - Collapse the synthetic `*args` / `**kwargs` pair emitted for a
+          `ParamSpec` tail (both carry the same ``paramSpecName``) into a
+          single entry whose name is the ParamSpec's name and whose type
+          is `_UNKNOWN`. This avoids exposing `P.args` / `P.kwargs` as two
+          distinct variadic parameters on the produced method.
+        - Treat `concatenatePrefix` params as ordinary positional params.
+        """
+        names: List[str] = []
+        types: List[JavaType] = []
+        last_spec_emitted: Optional[str] = None
+        for p in params:
+            p_name = p.get('name', '')
+            if p_name in ('self', 'cls'):
+                continue
+            spec_name = p.get('paramSpecName')
+            if spec_name is not None:
+                if spec_name == last_spec_emitted:
+                    continue
+                names.append(spec_name)
+                types.append(_UNKNOWN)
+                last_spec_emitted = spec_name
+                continue
+            last_spec_emitted = None
+            names.append(p_name)
+            types.append(self._resolve_param_type(p))
+        return names, types
+
     def _get_method_signature(self, node: ast.Call) -> Tuple[List[str], List[JavaType]]:
         """Get parameter names and types from the method signature.
 
@@ -885,11 +913,7 @@ class PythonTypeMapping:
         if sig:
             params = sig.get('parameters', [])
             if params:
-                names = [p['name'] for p in params
-                         if p['name'] not in ('self', 'cls')]
-                types = [self._resolve_param_type(p) for p in params
-                         if p['name'] not in ('self', 'cls')]
-                return names, types
+                return self._process_method_params(params)
 
         # Try function/method descriptor parameters
         func_type_id = self._lookup_func_type_id(node)
@@ -898,11 +922,7 @@ class PythonTypeMapping:
             if descriptor:
                 params = descriptor.get('parameters', [])
                 if params:
-                    names = [p['name'] for p in params
-                             if p['name'] not in ('self', 'cls')]
-                    types = [self._resolve_param_type(p) for p in params
-                             if p['name'] not in ('self', 'cls')]
-                    return names, types
+                    return self._process_method_params(params)
 
         # Fall back to placeholder names
         return self._generate_placeholder_names(node)
@@ -1205,20 +1225,9 @@ class PythonTypeMapping:
         if return_type_id is not None:
             return_type = self._resolve_type(return_type_id)
 
-        # Resolve parameters (skip self/cls)
-        param_names = []
-        param_types = []
-        for param in descriptor.get('parameters', []):
-            p_name = param.get('name', '')
-            if p_name in ('self', 'cls'):
-                continue
-            param_names.append(p_name)
-            p_type_id = param.get('typeId')
-            if p_type_id is not None:
-                p_type = self._resolve_type(p_type_id)
-                param_types.append(p_type if p_type else _UNKNOWN)
-            else:
-                param_types.append(_UNKNOWN)
+        # Resolve parameters (skip self/cls, collapse ParamSpec *args/**kwargs pairs)
+        param_names, param_types = self._process_method_params(
+            descriptor.get('parameters', []))
 
         type_param_names = self._extract_type_param_names(descriptor)
 

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -1240,6 +1240,143 @@ class TestCyclicTypeResolution:
         assert result is JavaType.Primitive.Int
 
 
+class TestParamSpecAndConcatenate:
+    """Unit tests for the ty-types 0.0.31 `paramSpecName` / `concatenatePrefix` fields.
+
+    Use mock descriptors so the logic is exercised without the ty-types CLI.
+    End-to-end tests against real source live in
+    TestParamSpecAndConcatenateIntegration below.
+    """
+
+    def test_paramspec_pair_collapses_to_single_entry(self):
+        """The synthetic `*args` + `**kwargs` pair is folded into one entry
+        whose name is the ParamSpec's name and whose type is Unknown."""
+        mapping = PythonTypeMapping("", file_path=None)
+        params = [
+            {'name': 'args', 'kind': 'variadic', 'paramSpecName': 'P'},
+            {'name': 'kwargs', 'kind': 'keywordVariadic', 'paramSpecName': 'P'},
+        ]
+        names, types = mapping._process_method_params(params)
+        assert names == ['P']
+        assert len(types) == 1
+        assert isinstance(types[0], JavaType.Unknown)
+
+    def test_concatenate_prefix_is_treated_as_positional(self):
+        """A param flagged `concatenatePrefix: True` is emitted as-is;
+        the trailing ParamSpec pair still collapses behind it."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[7] = {'kind': 'instance', 'className': 'int'}
+        params = [
+            {'name': '', 'kind': 'positionalOnly', 'typeId': 7,
+             'concatenatePrefix': True},
+            {'name': 'args', 'kind': 'variadic', 'paramSpecName': 'P'},
+            {'name': 'kwargs', 'kind': 'keywordVariadic', 'paramSpecName': 'P'},
+        ]
+        names, types = mapping._process_method_params(params)
+        assert names == ['', 'P']
+        assert types[0] is JavaType.Primitive.Int
+        assert isinstance(types[1], JavaType.Unknown)
+
+    def test_plain_params_unchanged(self):
+        """Regression: descriptors without the new fields still produce
+        one entry per parameter with the declared type."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[1] = {'kind': 'instance', 'className': 'int'}
+        mapping._type_registry[2] = {'kind': 'instance', 'className': 'int'}
+        params = [
+            {'name': 'a', 'typeId': 1},
+            {'name': 'b', 'typeId': 2},
+        ]
+        names, types = mapping._process_method_params(params)
+        assert names == ['a', 'b']
+        assert types == [JavaType.Primitive.Int, JavaType.Primitive.Int]
+
+    def test_self_and_cls_still_filtered(self):
+        """Filtering of self/cls still works when new fields are present."""
+        mapping = PythonTypeMapping("", file_path=None)
+        params = [
+            {'name': 'self'},
+            {'name': 'args', 'kind': 'variadic', 'paramSpecName': 'P'},
+            {'name': 'kwargs', 'kind': 'keywordVariadic', 'paramSpecName': 'P'},
+        ]
+        names, _ = mapping._process_method_params(params)
+        assert names == ['P']
+
+
+@requires_ty_types_cli
+class TestParamSpecAndConcatenateIntegration:
+    """End-to-end tests exercising ty-types 0.0.31 ParamSpec/Concatenate output."""
+
+    def test_callable_paramspec_collapses_in_invocation(self):
+        """`cb()` where `cb: Callable[P, R]` yields a method type with a
+        single collapsed `P` parameter rather than two variadic entries."""
+        source = '''from typing import Callable, ParamSpec, TypeVar
+P = ParamSpec('P')
+R = TypeVar('R')
+
+def run(cb: Callable[P, R]) -> R:
+    return cb()
+
+run(lambda: 42)
+'''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            cb_call = tree.body[3].body[0].value  # cb() inside run
+            result = mapping.method_invocation_type(cb_call)
+            assert result is not None
+            assert result._parameter_names == ['P']
+            assert result._parameter_types is not None
+            assert len(result._parameter_types) == 1
+            assert isinstance(result._parameter_types[0], JavaType.Unknown)
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_concatenate_keeps_prefix_and_collapses_tail(self):
+        """`cb(1)` where `cb: Callable[Concatenate[int, P], R]` yields a
+        method type with the leading `int` plus a single collapsed `P`."""
+        source = '''from typing import Callable, Concatenate, ParamSpec, TypeVar
+P = ParamSpec('P')
+R = TypeVar('R')
+
+def run(cb: Callable[Concatenate[int, P], R]) -> R:
+    return cb(1)
+
+run(lambda x: x)
+'''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            cb_call = tree.body[3].body[0].value  # cb(1) inside run
+            result = mapping.method_invocation_type(cb_call)
+            assert result is not None
+            assert result._parameter_names is not None
+            assert len(result._parameter_names) == 2
+            assert result._parameter_names[-1] == 'P'
+            assert result._parameter_types is not None
+            assert result._parameter_types[0] == JavaType.Primitive.Int
+            assert isinstance(result._parameter_types[1], JavaType.Unknown)
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_plain_function_method_type_unchanged(self):
+        """Regression: a function with no ParamSpec/Concatenate produces the
+        same (name, type) pairs it did before the 0.0.31 field additions."""
+        source = '''def add(a: int, b: int) -> int:
+    return a + b
+
+add(1, 2)
+'''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            call = tree.body[1].value
+            result = mapping.method_invocation_type(call)
+            assert result is not None
+            assert result._parameter_names == ['a', 'b']
+            assert result._parameter_types == [
+                JavaType.Primitive.Int, JavaType.Primitive.Int]
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+
 @requires_ty_types_cli
 class TestClassKind:
     """Tests for JavaType.Class.Kind inference from ty-types data."""


### PR DESCRIPTION
## Motivation

- [ty-types 0.0.31](https://github.com/openrewrite/ty-types/pull/14) adds two optional fields to every `ParameterInfo` entry in the `--serve` JSON output:

- `concatenatePrefix` (boolean) — set on leading positionals of a `Callable[Concatenate[T1, ..., P], R]` / `Callable[Concatenate[T1, ..., ...], R]` signature.
- `paramSpecName` (string) — set on the synthetic `*args` / `**kwargs` entries that stand in for a `ParamSpec` tail, carrying that `ParamSpec`'s name (e.g. `"P"`).

Before 0.0.31 the client could only see the raw `"*args"` / `"**kwargs"` names and had no way to know they came from a `ParamSpec`. This PR wires up the new fields in the Python client so the `JavaType.Method` produced for a `ParamSpec`-tailed callable is honest rather than exposing `P.args` / `P.kwargs` as two distinct variadic entries.

## Examples

Given a descriptor for `Callable[Concatenate[int, P], R]`:

```json
{
  "kind": "callable",
  "parameters": [
    { "name": "",       "kind": "positionalOnly",  "typeId": 7, "concatenatePrefix": true },
    { "name": "args",   "kind": "variadic",        "typeId": 8, "paramSpecName": "P" },
    { "name": "kwargs", "kind": "keywordVariadic", "typeId": 9, "paramSpecName": "P" }
  ],
  "returnType": 10
}
```

the produced `JavaType.Method` now has:

- `parameterNames = ["", "P"]`
- `parameterTypes = [Primitive.Int, Unknown]`

instead of three entries with `["", "*args", "**kwargs"]`.

Plain functions (no ParamSpec / Concatenate) are unaffected.

## Summary

- Bump `ty-types` requirement in `rewrite-python/rewrite/pyproject.toml` to `>=0.0.31`.
- Add `PythonTypeMapping._process_method_params()` helper that:
  - skips `self` / `cls`,
  - collapses consecutive `paramSpecName`-matching parameters into a single `(name=paramSpecName, type=Unknown)` entry,
  - passes `concatenatePrefix` params through as regular positionals.
- Route `_get_method_signature`, `_create_method_from_descriptor`, and `_method_from_function_descriptor` through the new helper.

## Test plan

- [x] New `TestParamSpecAndConcatenate` unit tests exercise the helper directly with mock descriptors (pair collapse, Concatenate prefix pass-through, plain-param regression, self/cls filtering).
- [x] New `TestParamSpecAndConcatenateIntegration` tests parse real Python source (`Callable[P, R]`, `Callable[Concatenate[int, P], R]`, and a plain `def add`) and assert the expected method-type shape end-to-end via the `ty-types` CLI.
- [x] Full `tests/python/test_type_attribution.py` suite passes (108/108) against `ty-types==0.0.31`.
- [x] Regression suite (pre-existing method-signature tests) still passes against `ty-types==0.0.21`, confirming the refactor is compatible with older wire-format outputs that lack the new fields.