### PR TITLE
Go: support whitespace around `<-` with `ChanDirMarker`

### DIFF
--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -760,7 +760,7 @@ func (ctx *parseContext) mapFieldListAsParams(fl *ast.FieldList) tree.Container[
 	} else {
 		closeParen := ctx.prefix(fl.Closing)
 		ctx.skip(1) // ")"
-		if len(closeParen.Comments) > 0 {
+		if !closeParen.IsEmpty() {
 			elements = append(elements, tree.RightPadded[tree.Statement]{
 				Element: &tree.Empty{ID: uuid.New()},
 				After:   closeParen,
@@ -2193,8 +2193,14 @@ func (ctx *parseContext) mapSliceExpr(expr *ast.SliceExpr) tree.Expression {
 // mapMapType maps a map type expression like `map[K]V`.
 func (ctx *parseContext) mapMapType(expr *ast.MapType) tree.Expression {
 	prefix := ctx.prefixAndSkip(expr.Map, len("map"))
-	lbrackPrefix := ctx.prefix(expr.Map + token.Pos(len("map")))
-	ctx.skip(1) // "["
+	lbrackOff := ctx.findNext('[')
+	var lbrackPrefix tree.Space
+	if lbrackOff >= 0 {
+		lbrackPrefix = ctx.prefix(ctx.file.Pos(lbrackOff))
+		ctx.skip(1) // "["
+	} else {
+		ctx.skip(1) // "["
+	}
 	key := ctx.mapTypeExpr(expr.Key)
 	rbrackOff := ctx.findNext(']')
 	var rbrackPrefix tree.Space
@@ -2216,15 +2222,48 @@ func (ctx *parseContext) mapMapType(expr *ast.MapType) tree.Expression {
 // mapChanType maps a channel type expression.
 func (ctx *parseContext) mapChanType(expr *ast.ChanType) tree.Expression {
 	prefix := ctx.prefix(expr.Begin)
+	var markers tree.Markers
 
 	var dir tree.ChanDir
 	switch expr.Dir {
 	case ast.SEND:
 		dir = tree.ChanSendOnly
-		ctx.skip(len("chan<-"))
+		ctx.skip(len("chan"))
+		arrowOff := ctx.findNext('<')
+		var dirMarkerBefore tree.Space
+		if arrowOff >= 0 {
+			dirMarkerBefore = ctx.prefix(ctx.file.Pos(arrowOff))
+			ctx.cursor = arrowOff
+		}
+		ctx.skip(2) // "<-"
+		if !dirMarkerBefore.IsEmpty() {
+			markers = tree.Markers{
+				ID: uuid.New(),
+				Entries: []tree.Marker{tree.ChanDirMarker{
+					Ident:  uuid.New(),
+					Before: dirMarkerBefore,
+				}},
+			}
+		}
 	case ast.RECV:
 		dir = tree.ChanRecvOnly
-		ctx.skip(len("<-chan"))
+		ctx.skip(2) // "<-"
+		chanOff := ctx.findNext('c')
+		var dirMarkerBefore tree.Space
+		if chanOff >= 0 && chanOff+4 <= len(ctx.src) && string(ctx.src[chanOff:chanOff+4]) == "chan" {
+			dirMarkerBefore = ctx.prefix(ctx.file.Pos(chanOff))
+			ctx.cursor = chanOff
+		}
+		ctx.skip(len("chan"))
+		if !dirMarkerBefore.IsEmpty() {
+			markers = tree.Markers{
+				ID: uuid.New(),
+				Entries: []tree.Marker{tree.ChanDirMarker{
+					Ident:  uuid.New(),
+					Before: dirMarkerBefore,
+				}},
+			}
+		}
 	default:
 		dir = tree.ChanBidi
 		ctx.skip(len("chan"))
@@ -2232,10 +2271,11 @@ func (ctx *parseContext) mapChanType(expr *ast.ChanType) tree.Expression {
 
 	value := ctx.mapTypeExpr(expr.Value)
 	return &tree.Channel{
-		ID:     uuid.New(),
-		Prefix: prefix,
-		Dir:    dir,
-		Value:  value,
+		ID:      uuid.New(),
+		Prefix:  prefix,
+		Markers: markers,
+		Dir:     dir,
+		Value:   value,
 	}
 }
 

--- a/rewrite-go/pkg/printer/go_printer.go
+++ b/rewrite-go/pkg/printer/go_printer.go
@@ -800,13 +800,23 @@ func (p *GoPrinter) VisitPointerType(pt *tree.PointerType, param any) tree.J {
 func (p *GoPrinter) VisitChannel(ch *tree.Channel, param any) tree.J {
 	out := param.(*PrintOutputCapture)
 	p.beforeSyntax(ch.Prefix, ch.Markers, out)
+
+	var dirMarker tree.Space
+	if marker := tree.FindMarker[tree.ChanDirMarker](ch.Markers); marker != nil {
+		dirMarker = marker.Before
+	}
+
 	switch ch.Dir {
 	case tree.ChanBidi:
 		out.Append("chan")
 	case tree.ChanSendOnly:
-		out.Append("chan<-")
+		out.Append("chan")
+		p.visitSpace(dirMarker, out)
+		out.Append("<-")
 	case tree.ChanRecvOnly:
-		out.Append("<-chan")
+		out.Append("<-")
+		p.visitSpace(dirMarker, out)
+		out.Append("chan")
 	}
 	p.Visit(ch.Value, out)
 	p.afterSyntax(ch.Markers, out)

--- a/rewrite-go/pkg/tree/go.go
+++ b/rewrite-go/pkg/tree/go.go
@@ -511,6 +511,16 @@ type ImportBlock struct {
 
 func (b ImportBlock) ID() uuid.UUID { return b.Ident }
 
+// ChanDirMarker stores whitespace around the direction operator in a channel type.
+// For send channels (`chan <- T`), Before holds the space before `<-`.
+// For recv channels (`<- chan T`), Before holds the space before `chan`.
+type ChanDirMarker struct {
+	Ident  uuid.UUID
+	Before Space
+}
+
+func (c ChanDirMarker) ID() uuid.UUID { return c.Ident }
+
 // MultiAssignment represents a multi-value assignment: `x, y = 1, 2` or `x, y := f()`.
 type MultiAssignment struct {
 	ID        uuid.UUID

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/ChanDirMarker.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/ChanDirMarker.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.tree;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.java.tree.Space;
+
+import java.util.UUID;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChanDirMarker implements Marker {
+    UUID id;
+    Space before;
+
+    public ChanDirMarker(UUID id, Space before) {
+        this.id = id;
+        this.before = before;
+    }
+
+    @Override
+    public UUID getId() {
+        return id;
+    }
+
+    @Override
+    public ChanDirMarker withId(UUID id) {
+        return new ChanDirMarker(id, this.before);
+    }
+}

--- a/rewrite-go/test/concurrency_test.go
+++ b/rewrite-go/test/concurrency_test.go
@@ -54,3 +54,16 @@ func TestParseSendStatement(t *testing.T) {
 			}
 		`))
 }
+
+func TestParseConcurrencyIntenseWhitespace(t *testing.T) {
+	NewRecipeSpec().RewriteRun(t,
+		Golang(`
+			package main
+
+			func f(send chan <- int, recv <- chan int) {
+				send <- 42
+				v := <-recv
+				_ = v
+			}
+		`))
+}


### PR DESCRIPTION
## What's changed?

Adding a marker of `ChanDirMarker` to have a place to store the whitespace before the `<-` operator.

## What's your motivation?

Otherwise there's no place.
Current code just swallows the space and causes idempotency issues.