### PR TITLE
Python: fix `ChangeImport` leaving stray leading newline when import is the only statement

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/add_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/add_import.py
@@ -260,7 +260,13 @@ class AddImport(PythonVisitor):
                 break  # Stop after we've passed the import section
 
         # Insert the new import at the padding level
-        if insert_idx == 0 and padded_stmts:
+        if not padded_stmts:
+            # Empty file (e.g., a prior remove-import emptied the statement
+            # list). The new import becomes the sole statement with empty
+            # prefix; any trailing newline lives in cu.eof.
+            new_padded = JRightPadded(new_import.replace(prefix=Space.EMPTY), Space.EMPTY, Markers.EMPTY)
+            padded_stmts.append(new_padded)
+        elif insert_idx == 0:
             first = padded_stmts[0]
             first_prefix = first.element.prefix
             if first_prefix.whitespace and first_prefix.whitespace.startswith('\n'):

--- a/rewrite-python/rewrite/tests/recipes/test_change_import.py
+++ b/rewrite-python/rewrite/tests/recipes/test_change_import.py
@@ -46,6 +46,20 @@ class TestChangeImport:
             )
         )
 
+    def test_change_import_only_statement(self):
+        """Import is the only statement in the file — no leading newline in output."""
+        spec = RecipeSpec(recipe=ChangeImport(
+            old_module='typing',
+            old_name='Callable',
+            new_module='collections.abc',
+        ))
+        spec.rewrite_run(
+            python(
+                "from typing import Callable\n",
+                "from collections.abc import Callable\n",
+            )
+        )
+
     def test_change_direct_import(self):
         """Change: import os -> import pathlib"""
         spec = RecipeSpec(recipe=ChangeImport(


### PR DESCRIPTION
## Motivation

`rewrite.python.recipes.ChangeImport` left a stray leading `\n` at the start of the file when it replaced an import that was the only statement in the file. The bug is masked whenever the test snippet has a statement after the import (the leading `\n` ends up between two lines instead of at file start and isn't visible in `print_all()` output), but surfaces for import-only files.

Discovered while converting search-only recipes in `moderneinc/rewrite-migrate-python` to use `ChangeImport`. As a data point, `rewrite-migrate-python`'s `typing_deprecations.py` `_make_pep585_editor` explicitly strips a leading `\n` from the first remaining statement's prefix in `visit_compilation_unit` as a workaround — this fix should make that workaround unnecessary.

## Example

```python
from rewrite.test import RecipeSpec, python
from rewrite.python.recipes import ChangeImport

spec = RecipeSpec(recipe=ChangeImport(
    old_module="typing",
    old_name="Callable",
    new_module="collections.abc",
))
spec.rewrite_run(python(
    "from typing import Callable\n",
    "from collections.abc import Callable\n",  # expected
))
# Before this PR, actual output was: "\nfrom collections.abc import Callable\n"
```

## Summary

- When `ChangeImport` replaced the only statement in a file, the scheduled `AddImport` pass ran against an empty statement list and fell through to the "inserting after existing imports" branch, prefixing the new import with `\n`.
- Handle the empty-statement-list case explicitly in `add_import.py::_add_import`: the new import becomes the sole statement with empty prefix; the trailing newline stays in `cu.eof`.
- Add regression test `test_change_import_only_statement` covering the import-only case.

## Test plan

- [x] New `test_change_import_only_statement` regression test reproduces the bug and now passes
- [x] All 19 existing `ChangeImport` tests pass
- [x] All 45 import-related tests (`test_add_import.py`, `test_remove_import.py`, `tests/recipes/`) pass
- [x] Full Python test suite passes (1165 tests, excluding RPC)