### PR TITLE
C#: Improve TreeVisitor combining and handle null expression statements

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/Core/Preconditions.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Preconditions.cs
@@ -67,4 +67,15 @@ public static class Preconditions
     {
         return new AndVisitor(visitors);
     }
+
+    public static ITreeVisitor<ExecutionContext> And(this ITreeVisitor<ExecutionContext> first, params ITreeVisitor<ExecutionContext>[] others)
+    {
+        return And(others.Prepend(first).ToArray());
+    }
+
+    public static ITreeVisitor<ExecutionContext> And(
+        params Recipe[] recipes)
+    {
+        return new AndVisitor(recipes.Select(x => x.GetVisitor()).ToArray());
+    }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Core/TreeVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/TreeVisitor.cs
@@ -154,15 +154,13 @@ public static class TreeVisitorExtensions
 {
     public static ITreeVisitor<T> Combine<T>(this ITreeVisitor<T> first, ITreeVisitor<T> second) where T : class
     {
-        return new TreeVisitor<T>(first, second);
+        return new CombinedTreeVisitor<T>(first, second);
     }
-    private class TreeVisitor<T>(ITreeVisitor<T> first, ITreeVisitor<T> second) : ITreeVisitor<T>
+    public static ITreeVisitor<T> Combine<T>(this IEnumerable<ITreeVisitor<T>> visitors) where T : class => new CombinedTreeVisitor<T>(visitors);
+    public static ITreeVisitor<ExecutionContext> GetVisitor(this Recipe[] recipes) => recipes.Select(x => x.GetVisitor()).Combine();
+
+    private class CombinedTreeVisitor<T>(params IEnumerable<ITreeVisitor<T>> visitors) : ITreeVisitor<T>
     {
-        public Tree? Visit(Tree? tree, T p)
-        {
-            tree = first.Visit(tree, p);
-            tree = second.Visit(tree, p);
-            return tree;
-        }
+        public Tree? Visit(Tree? tree, T p) => visitors.Aggregate(tree, (current, visitor) => visitor.Visit(current, p));
     }
 }

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/CSharpVisitor.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/CSharpVisitor.java
@@ -372,7 +372,12 @@ public class CSharpVisitor<P> extends JavaVisitor<P>
         }
         expressionStatement = (Cs.ExpressionStatement) tempStatement;
         expressionStatement = expressionStatement.withMarkers(visitMarkers(expressionStatement.getMarkers(), p));
-        return expressionStatement.getPadding().withExpression(visitRightPadded(expressionStatement.getPadding().getExpression(), CsRightPadded.Location.EXPRESSION_STATEMENT_EXPRESSION, p));
+        JRightPadded<Expression> expr = visitRightPadded(expressionStatement.getPadding().getExpression(), CsRightPadded.Location.EXPRESSION_STATEMENT_EXPRESSION, p);
+        if (expr == null) {
+            //noinspection DataFlowIssue
+            return null;
+        }
+        return expressionStatement.getPadding().withExpression(expr);
     }
 
     public J visitExternAlias(Cs.ExternAlias externAlias, P p) {


### PR DESCRIPTION
## Summary
- Generalized `CombinedTreeVisitor` to support combining an arbitrary number of visitors via `IEnumerable`, replacing the previous two-visitor-only implementation
- Added `Preconditions.And` overloads: an extension method on `ITreeVisitor` and a `Recipe[]`-based variant for composing preconditions from recipes
- Fixed `CSharpVisitor.visitExpressionStatement` to handle null from `visitRightPadded`, allowing expression statement deletion via visitor return-null semantics

## Test plan
- [ ] Verify C# dotnet tests pass (`dotnet test` in rewrite-csharp/csharp)
- [ ] Verify Java-side compilation (`./gradlew :rewrite-csharp:assemble`)