### PR TITLE
Remove stray `[DEBUG-TMPL]` debug prints from `ScalaTreeVisitor`

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -4297,9 +4297,7 @@ class ScalaTreeVisitor(
           val visitedSpans = new java.util.HashSet[Int]()
           // Sort by source position to preserve source order
           val sortedBody = template.body.sortBy(s => if (s.span.exists) s.span.start else Int.MaxValue)
-          System.err.println(s"[DEBUG-TMPL] template.body has ${sortedBody.length} entries")
           for (stat <- sortedBody) {
-            System.err.println(s"[DEBUG-TMPL] stat class=${stat.getClass.getSimpleName} span=${stat.span} isSynthetic=${stat.span.isSynthetic} text=${stat.toString.take(100)}")
             val isSyntheticStat = stat.span.isSynthetic || {
               def hasTripleQ(t: Trees.Tree[?]): Boolean = t match {
                 case sel: Trees.Select[?] => sel.name.toString == "???" || sel.name.toString == "$qmark$qmark$qmark" || hasTripleQ(sel.qualifier)


### PR DESCRIPTION
## Motivation

Two `System.err.println` calls tagged `[DEBUG-TMPL]` were left behind in `ScalaTreeVisitor` as temporary instrumentation. They flood stderr whenever any Scala source is parsed (e.g. during `mod build` on a repo that is partially Scala, such as `openrewrite/rewrite` itself):

```
[DEBUG-TMPL] template.body has 6 entries
[DEBUG-TMPL] stat class=DefDef span=[1742..1746..5896] isSynthetic=false text=DefDef(convertToCompilationUnit,...)
...
```

## Summary

- Delete the two `System.err.println("[DEBUG-TMPL] ...")` calls in `ScalaTreeVisitor.scala`. The surrounding `sortedBody` / `for (stat <- sortedBody)` logic is unchanged — only the prints are removed.

## Test plan

- [x] `grep -r DEBUG-TMPL` returns no matches anywhere in the repo
- [x] `./gradlew :rewrite-scala:compileScala` succeeds