### PR TITLE
Register `JavaType.ShallowClass` codec on the Python RPC side

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
@@ -1382,8 +1382,8 @@ def _receive_java_type_method(method, q: RpcReceiveQueue):
     )
 
 
-def _receive_java_type_class(cls, q: RpcReceiveQueue):
-    """Codec for receiving JavaType.Class - consumes all class fields."""
+def _receive_java_type_class_fields(cls, q: RpcReceiveQueue, result):
+    """Consume the Class field sequence and populate `result` in place."""
     from rewrite.java.support_types import JavaType as JT
 
     # Receive fields in the same order as JavaTypeSender.visitClass:
@@ -1400,20 +1400,32 @@ def _receive_java_type_class(cls, q: RpcReceiveQueue):
     members = q.receive_list(getattr(cls, '_members', None) if cls else None)
     methods = q.receive_list(getattr(cls, '_methods', None) if cls else None)
 
-    # Create a new Class instance and set attributes
-    class_type = JT.Class()
-    class_type._flags_bit_map = flags
-    class_type._kind = kind
-    class_type._fully_qualified_name = fqn
-    class_type._type_parameters = type_params
-    class_type._supertype = supertype
-    class_type._owning_class = owning_class
-    class_type._annotations = annotations
-    class_type._interfaces = interfaces
-    class_type._members = members
-    class_type._methods = methods
+    result._flags_bit_map = flags
+    result._kind = kind
+    result._fully_qualified_name = fqn
+    result._type_parameters = type_params
+    result._supertype = supertype
+    result._owning_class = owning_class
+    result._annotations = annotations
+    result._interfaces = interfaces
+    result._members = members
+    result._methods = methods
 
-    return class_type
+    return result
+
+
+def _receive_java_type_class(cls, q: RpcReceiveQueue):
+    """Codec for receiving JavaType.Class - consumes all class fields."""
+    from rewrite.java.support_types import JavaType as JT
+
+    return _receive_java_type_class_fields(cls, q, JT.Class())
+
+
+def _receive_java_type_shallow_class(cls, q: RpcReceiveQueue):
+    """Codec for receiving JavaType.ShallowClass - same wire shape as Class."""
+    from rewrite.java.support_types import JavaType as JT
+
+    return _receive_java_type_class_fields(cls, q, JT.ShallowClass())
 
 
 def _receive_java_type_parameterized(param, q: RpcReceiveQueue):
@@ -1565,6 +1577,15 @@ def _register_java_type_codecs():
         JT.Class,
         _receive_java_type_class,
         lambda: JT.Class()  # Factory creates empty Class
+    )
+
+    # JavaType.ShallowClass - same wire shape as Class, but preserves the
+    # ShallowClass marker so senders round-trip the correct type name.
+    register_codec_with_both_names(
+        'org.openrewrite.java.tree.JavaType$ShallowClass',
+        JT.ShallowClass,
+        _receive_java_type_shallow_class,
+        lambda: JT.ShallowClass()
     )
 
     # JavaType.Variable - full serialization of variable type info

--- a/rewrite-python/rewrite/src/rewrite/rpc/send_queue.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/send_queue.py
@@ -293,6 +293,10 @@ class RpcSendQueue:
             return 'org.openrewrite.java.tree.JavaType$Method'
         if isinstance(obj, JavaType.Parameterized):
             return 'org.openrewrite.java.tree.JavaType$Parameterized'
+        # ShallowClass extends Class, so check it first — otherwise isinstance(obj, Class)
+        # would return the Class type name and strip the ShallowClass marker.
+        if isinstance(obj, JavaType.ShallowClass):
+            return 'org.openrewrite.java.tree.JavaType$ShallowClass'
         if isinstance(obj, JavaType.Class):
             return 'org.openrewrite.java.tree.JavaType$Class'
         if isinstance(obj, JavaType.GenericTypeVariable):


### PR DESCRIPTION
## Motivation

Production SB4 runs in `rewrite-pip` (the Python-side RPC runtime) were failing with:

```
io.moderne.jsonrpc.JsonRpcException: {code=-32603, message='No RPC codec registered on
the Python side for 'org.openrewrite.java.tree.JavaType$ShallowClass'. The remote side
has a codec and sent property messages that will not be consumed, causing RPC queue
desynchronization.'}
```

`JavaType.ShallowClass` is the placeholder used when full JVM type resolution isn't
available. It's a subclass of `JavaType.Class` with the same wire shape but a distinct
type name — and the Python RPC side wasn't registering a codec for it, so any Java
recipe that sent a `ShallowClass` to the Python process deadlocked the queue.

I audited the three non-Java RPC implementations:

- **Python (`rewrite-python`)** — no codec registered for `JavaType$ShallowClass`.
  Fixed here.
- **C# (`rewrite-csharp`)** — already works. `FromJavaTypeNameByConvention` resolves
  `org.openrewrite.java.tree.JavaType$ShallowClass` to the existing nested
  `OpenRewrite.Java.JavaType+ShallowClass` class via reflection, and
  `JavaReceiver.VisitType`'s `case JavaType.Class cls:` matches `ShallowClass` through
  inheritance. On the send side, `ToJavaTypeName` handles nested types recursively and
  produces the correct Java FQN.
- **Go (`rewrite-go`)** — already works for the receive path. The factory for
  `JavaTypeShallowClassKind` is registered in `rewrite-go/pkg/rpc/registry.go`,
  producing a `*JavaTypeClass` instance that the visitor dispatches to `VisitClass`.
  Go has no separate `JavaTypeShallowClass` struct by design — all class-like types
  collapse to `*JavaTypeClass`, so the Go process never constructs a `ShallowClass`
  to send.

## Summary

- Factored out `_receive_java_type_class_fields` in `python_receiver.py` so the same
  field-consumption logic can populate either a `JT.Class` or a `JT.ShallowClass`.
- Registered a codec + factory for `org.openrewrite.java.tree.JavaType$ShallowClass`
  on the Python side.
- On the sender side, added an `isinstance(obj, JavaType.ShallowClass)` check before
  the `JavaType.Class` check in `send_queue.py` so ShallowClass instances round-trip
  with the correct Java type name (the existing check would have collapsed them into
  `JavaType$Class` because `ShallowClass` inherits from `Class`).

## Test plan

- [x] Verified the codec and factory are registered under the expected Java type
      name, and that `RpcSendQueue._get_value_type()` returns
      `JavaType$ShallowClass` for a `JT.ShallowClass()` and `JavaType$Class` for a
      `JT.Class()`.

This PR **does not by itself fix the production failure** — the fix lands on the
Python-side runtime and needs a `rewrite-pip` release before the next SB4 flagship
run will pick it up.