### PR TITLE
Fix NPE in `KotlinPrinter` when class body is null

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -680,7 +680,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
 
             visitContainer("<", classDecl.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, ",", ">", p);
 
-            if (classDecl.getMarkers().findFirst(PrimaryConstructor.class).isPresent()) {
+            if (classDecl.getBody() != null && classDecl.getMarkers().findFirst(PrimaryConstructor.class).isPresent()) {
                 for (Statement statement : classDecl.getBody().getStatements()) {
                     if (statement instanceof J.MethodDeclaration &&
                         statement.getMarkers().findFirst(PrimaryConstructor.class).isPresent() &&

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -18,13 +18,16 @@ package org.openrewrite.kotlin.tree;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.kotlin.KotlinIsoVisitor;
 import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.kotlin.Assertions.kotlin;
+import static org.openrewrite.test.RewriteTest.toRecipe;
 
 @SuppressWarnings("ALL")
 class ClassDeclarationTest implements RewriteTest {
@@ -744,6 +747,24 @@ class ClassDeclarationTest implements RewriteTest {
             """
               %s
               """.formatted(input)
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7442")
+    @Test
+    void classDeclarationWithNullBody() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<ExecutionContext>() {
+              @Override
+              public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                  J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+                  return cd.withBody(null);
+              }
+          })),
+          kotlin(
+            "class Foo(val bar: Int)",
+            "class Foo"
           )
         );
     }


### PR DESCRIPTION
## Motivation

`J.ClassDeclaration.getBody()` is `@Nullable`, but `KotlinPrinter$KotlinJavaPrinter.visitClassDeclaration0` dereferenced it unconditionally inside the `PrimaryConstructor` branch. When a recipe produced a class declaration carrying the `PrimaryConstructor` marker but a null body, the printer threw:

```
java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.J$Block.getStatements()" because the return value of "org.openrewrite.java.tree.J$ClassDeclaration.getBody()" is null
    at org.openrewrite.kotlin.internal.KotlinPrinter$KotlinJavaPrinter.visitClassDeclaration0(KotlinPrinter.java:684)
```

- Originally surfaced while `MigrateCollectionsSingletonMap` ran against a Kotlin source file (see openrewrite/rewrite-migrate-java#1067). That recipe now skips Kotlin sources, but the printer bug is independent and still needs to be fixed.

## Summary

- Null-guard the `classDecl.getBody()` access in the `PrimaryConstructor` branch of `visitClassDeclaration0`. The sibling body-printing branch further down was already null-guarded. When the body is null, the primary-constructor loop is skipped entirely, and the rest of the declaration (modifiers, name, type parameters, extends/implements) still prints as valid Kotlin.
- Added a regression test `ClassDeclarationTest.classDeclarationWithNullBody` that runs a small recipe stripping the body off a `class Foo(val bar: Int)` declaration and asserts the result prints as `class Foo` without throwing.

## Test plan

- [x] New test `ClassDeclarationTest.classDeclarationWithNullBody` reproduces the NPE on `main` and passes with the fix.
- [x] Full `ClassDeclarationTest` class passes.

- Fixes #7442