### PR TITLE
Handle `J.SwitchExpression` in `BlockStatementTemplateGenerator`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -1497,4 +1497,163 @@ class JavaTemplateTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7443")
+    @Test
+    void replaceExpressionInSwitchExpressionRuleArm() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              final MethodMatcher emptyListMatcher = new MethodMatcher("java.util.Collections emptyList()");
+
+              @Override
+              public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+                  if (emptyListMatcher.matches(m)) {
+                      return JavaTemplate.builder("List.of()")
+                        .contextSensitive()
+                        .imports("java.util.List")
+                        .build()
+                        .apply(getCursor(), m.getCoordinates().replace());
+                  }
+                  return m;
+              }
+          })),
+          java(
+            """
+              import java.util.Collections;
+              import java.util.List;
+
+              class T {
+                  List<Object> m(int i) {
+                      return switch (i) {
+                          case 0 -> Collections.emptyList();
+                          default -> null;
+                      };
+                  }
+              }
+              """,
+            """
+              import java.util.Collections;
+              import java.util.List;
+
+              class T {
+                  List<Object> m(int i) {
+                      return switch (i) {
+                          case 0 -> List.of();
+                          default -> null;
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7443")
+    @Test
+    void replaceExpressionInSwitchExpressionColonArm() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              final MethodMatcher emptyListMatcher = new MethodMatcher("java.util.Collections emptyList()");
+
+              @Override
+              public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+                  if (emptyListMatcher.matches(m)) {
+                      return JavaTemplate.builder("List.of()")
+                        .contextSensitive()
+                        .imports("java.util.List")
+                        .build()
+                        .apply(getCursor(), m.getCoordinates().replace());
+                  }
+                  return m;
+              }
+          })),
+          java(
+            """
+              import java.util.Collections;
+              import java.util.List;
+
+              class T {
+                  List<Object> m(int i) {
+                      return switch (i) {
+                          case 0: yield Collections.emptyList();
+                          default: yield null;
+                      };
+                  }
+              }
+              """,
+            """
+              import java.util.Collections;
+              import java.util.List;
+
+              class T {
+                  List<Object> m(int i) {
+                      return switch (i) {
+                          case 0: yield List.of();
+                          default: yield null;
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7443")
+    @Test
+    void replaceExpressionInSwitchExpressionPreservesUnrelatedArms() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              final MethodMatcher emptyListMatcher = new MethodMatcher("java.util.Collections emptyList()");
+
+              @Override
+              public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+                  if (emptyListMatcher.matches(m)) {
+                      return JavaTemplate.builder("List.of()")
+                        .contextSensitive()
+                        .imports("java.util.List")
+                        .build()
+                        .apply(getCursor(), m.getCoordinates().replace());
+                  }
+                  return m;
+              }
+          })),
+          java(
+            """
+              import java.util.Arrays;
+              import java.util.Collections;
+              import java.util.List;
+
+              class T {
+                  List<Object> m(int i) {
+                      return switch (i) {
+                          case 0 -> Arrays.asList("a");
+                          case 1 -> Collections.emptyList();
+                          case 2 -> Arrays.asList("b");
+                          default -> null;
+                      };
+                  }
+              }
+              """,
+            """
+              import java.util.Arrays;
+              import java.util.Collections;
+              import java.util.List;
+
+              class T {
+                  List<Object> m(int i) {
+                      return switch (i) {
+                          case 0 -> Arrays.asList("a");
+                          case 1 -> List.of();
+                          case 2 -> Arrays.asList("b");
+                          default -> null;
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -311,6 +311,11 @@ public class BlockStatementTemplateGenerator {
                                          .withLeadingAnnotations(emptyList())
                                          .withPrefix(Space.EMPTY)
                                          .printTrimmed(cursor).trim() + '{');
+            } else if (parent instanceof J.SwitchExpression) {
+                // The cases block of a switch expression: emit the label prefix for the case
+                // containing `prior` and print the other cases verbatim so the switch expression
+                // remains a valid expression in its enclosing context.
+                switchExpressionCases(prior, (J.Block) j, before, after, cursor);
             } else {
                 J.Block b = (J.Block) j;
 
@@ -597,10 +602,61 @@ public class BlockStatementTemplateGenerator {
             before.insert(0, ev.getName());
         } else if (j instanceof J.EnumValueSet) {
             after.append(";");
+        } else if (j instanceof J.SwitchExpression) {
+            J.SwitchExpression se = (J.SwitchExpression) j;
+            if (referToSameElement(prior, se.getCases())) {
+                // Wrap with `switch (<selector>) {`. The closing `}` is added by the
+                // enclosing `J.Block` handler's unconditional `after.append('}')`.
+                before.insert(0, "switch " + se.getSelector().withPrefix(Space.EMPTY).printTrimmed(cursor).trim() + " {\n");
+            } else if (referToSameElement(prior, se.getSelector())) {
+                before.insert(0, "Object __b" + cursor.getPathAsStream().count() + "__ =");
+                after.append(";");
+            }
         } else if (j instanceof J.Case) {
             after.append(";");
         }
         contextTemplate(next(cursor), j, before, after, insertionPoint, REPLACEMENT);
+    }
+
+    private void switchExpressionCases(J prior, J.Block casesBlock, StringBuilder before, StringBuilder after, Cursor cursor) {
+        StringBuilder casesBefore = new StringBuilder();
+        StringBuilder casesAfter = new StringBuilder();
+        boolean priorFound = false;
+        for (Statement stmt : casesBlock.getStatements()) {
+            if (referToSameElement(stmt, prior)) {
+                priorFound = true;
+                if (stmt instanceof J.Case) {
+                    casesBefore.append(caseLabelPrefix((J.Case) stmt, cursor));
+                }
+            } else if (priorFound) {
+                casesAfter.append(stmt.printTrimmed(cursor).trim()).append("\n");
+            } else {
+                casesBefore.append(stmt.printTrimmed(cursor).trim()).append("\n");
+            }
+        }
+        before.insert(0, casesBefore);
+        after.append(casesAfter);
+    }
+
+    private String caseLabelPrefix(J.Case c, Cursor cursor) {
+        StringBuilder sb = new StringBuilder();
+        List<J> labels = c.getCaseLabels();
+        J firstLabel = labels.isEmpty() ? null : labels.get(0);
+        boolean isDefault = firstLabel instanceof J.Identifier && "default".equals(((J.Identifier) firstLabel).getSimpleName());
+        if (!isDefault) {
+            sb.append("case ");
+        }
+        for (int i = 0; i < labels.size(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(labels.get(i).printTrimmed(cursor).trim());
+        }
+        if (c.getGuard() != null) {
+            sb.append(" when ").append(c.getGuard().printTrimmed(cursor).trim());
+        }
+        sb.append(c.getType() == J.Case.Type.Statement ? ": " : " -> ");
+        return sb.toString();
     }
 
     private void addLeadingVariableDeclarations(Cursor cursor, J current, J.Block containingBlock, StringBuilder before, J insertionPoint) {


### PR DESCRIPTION
## Motivation

Context-sensitive `JavaTemplate`s that replace an expression inside a switch-expression arm currently fail with:

> Expected a template that would generate exactly one statement to replace one statement, but generated 0

because `BlockStatementTemplateGenerator.contextTemplate` has no case for `J.SwitchExpression`. The cases `J.Block` falls through to the default handler that wraps with `{ ... }`, producing an invalid stub like `return { List.of(); }` — a plain block is not an expression in `return`/assignment contexts.

- The user-visible symptom surfaced in `rewrite-migrate-java` via the `MigrateCollections*` recipes, which worked around it by removing `.contextSensitive()` (openrewrite/rewrite-migrate-java#1067); this PR fixes the underlying gap in `rewrite-core`, so the workaround is no longer strictly required.

- Fixes #7443.

## Examples

A recipe that replaces `Collections.emptyList()` with `List.of()` via `.contextSensitive()` now works on:

```java
return switch (i) {
    case 0 -> Collections.emptyList();
    default -> null;
};
```

…and produces:

```java
return switch (i) {
    case 0 -> List.of();
    default -> null;
};
```

## Summary

- When the `J.Block` parent is a `J.SwitchExpression`, emit the target case's label prefix (`case X ->` or `case X:`) and print the other case arms verbatim — mirroring how `J.Ternary` preserves its untouched branch.
- Add a `J.SwitchExpression` branch that wraps the cases block with `switch (<selector>) {`; the closing `}` is supplied by the existing unconditional block close.
- Also handle the edge case where the template replaces the switch-expression selector expression.

## Test plan

- [x] New `JavaTemplateTest` cases covering:
  - expression replacement in a rule-style arm (`case 0 -> expr`)
  - expression replacement in a colon-style arm (`case 0: yield expr;`)
  - unrelated arms preserved when multiple arms surround the target
- [x] Full `:rewrite-java-test:test` for `JavaTemplate*` passes
- [x] `:rewrite-java:test` passes