### PR TITLE
Fix Scala parser losing type attribution when classpath lacks stdlib

### DIFF
--- a/rewrite-scala/build.gradle.kts
+++ b/rewrite-scala/build.gradle.kts
@@ -23,9 +23,9 @@ dependencies {
     testImplementation(project(":rewrite-test"))
     testImplementation(project(":rewrite-java-test"))
     testImplementation("org.assertj:assertj-core:latest.release")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:latest.release")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:latest.release")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:latest.release")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testRuntimeOnly(project(":rewrite-java-21"))
     testRuntimeOnly("org.antlr:antlr4-runtime:4.13.2")
 }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
@@ -27,7 +27,8 @@ import dotty.tools.dotc.config.ScalaSettings
 
 import scala.collection.mutable.ListBuffer
 import java.io.File
-import java.util.{ArrayList, HashMap, List => JList, Map => JMap}
+import java.nio.file.Paths
+import java.util.{ArrayList, HashMap, LinkedHashSet, List => JList, Map => JMap}
 
 /**
  * Bridge to the Scala 3 (Dotty) compiler for parsing and type-checking Scala source files.
@@ -65,14 +66,9 @@ class ScalaCompilerBridge {
       if (outputDir != null) {
         fresh.setSetting(fresh.settings.outputDir, dotty.tools.io.AbstractFile.getDirectory(outputDir))
       }
-      if (classpath != null && !classpath.isEmpty) {
-        val cp = new StringBuilder()
-        val cpIter = classpath.iterator()
-        while (cpIter.hasNext) {
-          if (cp.nonEmpty) cp.append(File.pathSeparator)
-          cp.append(cpIter.next())
-        }
-        fresh.setSetting(fresh.settings.classpath, cp.toString())
+      val cpString = ScalaCompilerBridge.buildClasspath(classpath)
+      if (cpString.nonEmpty) {
+        fresh.setSetting(fresh.settings.classpath, cpString)
       }
       fresh
     }
@@ -237,6 +233,89 @@ class ScalaCompilerBridge {
     !trimmed.startsWith("//") &&
     !trimmed.startsWith("/*") &&
     trimmed.nonEmpty
+  }
+}
+
+object ScalaCompilerBridge {
+
+  /**
+   * Probe classes covering every jar dotty needs to type-check any Scala source:
+   * scala-library (Scala stdlib), tasty-core (TASTy reader), and scala3-compiler
+   * (dotty itself, needed when parsing code that imports `dotty.tools.*`).
+   *
+   * The bridge code is loaded from these jars, so we can always find them via
+   * `ProtectionDomain.getCodeSource()` regardless of what the caller passes.
+   */
+  private val StdlibProbeClasses: List[Class[?]] = List(
+    classOf[scala.Option[?]],
+    classOf[dotty.tools.tasty.TastyFormat.type],
+    classOf[dotty.tools.dotc.core.Contexts.type]
+  )
+
+  /**
+   * Build the classpath string for dotty. Caller entries come first; stdlib
+   * jars are appended only when the caller's classpath already looks like a
+   * Scala project classpath (i.e. it contains at least one `scala*`, `tasty*`
+   * or `dotty*` artifact) but is missing one of the stdlib jars dotty needs.
+   * Without stdlib on the classpath, dotty's `Definitions` can't resolve
+   * foundational types like `scala.Unit`, leading to `ClassCastException` /
+   * "Bad symbolic reference" failures in the typer. The bridge is loaded from
+   * those same jars so we can always locate them via `ProtectionDomain`.
+   *
+   * Restricting self-heal to Scala-looking classpaths preserves the behaviour
+   * expected by callers (such as `ScalaTemplate`) that intentionally pass a
+   * narrow non-Scala classpath to avoid type resolution.
+   */
+  private[internal] def buildClasspath(classpath: JList[String]): String = {
+    val sb = new StringBuilder()
+    val present = new LinkedHashSet[String]()
+    var hasScalaArtifact = false
+    if (classpath != null) {
+      val it = classpath.iterator()
+      while (it.hasNext) {
+        val e = it.next()
+        if (e != null && !e.isEmpty) {
+          if (sb.nonEmpty) sb.append(File.pathSeparator)
+          sb.append(e)
+          val fn = fileName(e)
+          present.add(fn)
+          if (isScalaArtifact(fn)) hasScalaArtifact = true
+        }
+      }
+    }
+    if (hasScalaArtifact) {
+      for (cls <- StdlibProbeClasses) {
+        locateJar(cls).foreach { jar =>
+          if (!present.contains(fileName(jar))) {
+            if (sb.nonEmpty) sb.append(File.pathSeparator)
+            sb.append(jar)
+            present.add(fileName(jar))
+          }
+        }
+      }
+    }
+    sb.toString()
+  }
+
+  private def isScalaArtifact(fileName: String): Boolean = {
+    val n = fileName.toLowerCase
+    n.startsWith("scala") || n.startsWith("tasty") || n.startsWith("dotty")
+  }
+
+  private def fileName(path: String): String = {
+    val p = Paths.get(path).getFileName
+    if (p == null) path else p.toString
+  }
+
+  private def locateJar(cls: Class[?]): Option[String] = {
+    val pd = cls.getProtectionDomain
+    if (pd == null) return None
+    val cs = pd.getCodeSource
+    if (cs == null) return None
+    val url = cs.getLocation
+    if (url == null) return None
+    try Some(Paths.get(url.toURI).toString)
+    catch { case _: Throwable => None }
   }
 }
 

--- a/rewrite-scala/src/test/scala/org/openrewrite/scala/internal/DottyImportTypeAttributionTest.scala
+++ b/rewrite-scala/src/test/scala/org/openrewrite/scala/internal/DottyImportTypeAttributionTest.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.internal
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.io.TempDir
+import org.openrewrite.java.JavaParser
+
+import java.nio.file.Path
+import java.util.ArrayList
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Regression tests for the stdlib self-heal: when a caller passes a
+ * Scala-ish classpath (one that contains a `scala3-compiler` jar, for
+ * instance) but is missing one of the stdlib jars dotty relies on
+ * (scala-library / tasty-core), the bridge must add the missing stdlib
+ * entries itself. Otherwise dotty's typer blows up with either
+ * `ClassCastException: NoSymbol cannot be cast to ClassSymbol` in
+ * `Definitions.UnitClass` or the related "Bad symbolic reference" TASTy
+ * error when the source imports dotty compiler APIs.
+ */
+class DottyImportTypeAttributionTest {
+
+  /**
+   * Mimic a caller (e.g. `mod build`) that passes only scala3-compiler
+   * without the full transitive stdlib. Without the self-heal, dotty fails.
+   */
+  private def scalaCompilerOnlyClasspath: java.util.List[String] = {
+    val all = new ArrayList[String]()
+    JavaParser.runtimeClasspath().forEach(p => all.add(p.toString))
+    val filtered = new ArrayList[String]()
+    all.asScala.foreach { entry =>
+      if (entry.contains("scala3-compiler_3")) filtered.add(entry)
+    }
+    filtered
+  }
+
+  @Test
+  def typeChecksOrdinaryScalaWithOnlyCompilerOnClasspath(@TempDir outDir: Path): Unit = {
+    val bridge = new ScalaCompilerBridge()
+    val source =
+      """package example
+        |
+        |class Foo {
+        |  def bar(x: Int): Option[Int] = Some(x)
+        |}
+        |""".stripMargin
+
+    val entries = new ArrayList[SourceEntry]()
+    entries.add(SourceEntry("Foo.scala", source))
+
+    val results = bridge.compileAll(entries, scalaCompilerOnlyClasspath, outDir.toString)
+
+    val result = results.get("Foo.scala")
+    assertNotNull(result, "result present")
+    assertNotNull(result.tree, "untyped tree populated")
+    assertTrue(
+      result.typedTree.isDefined,
+      "typed tree should be populated even when caller's classpath only has scala3-compiler"
+    )
+  }
+
+  @Test
+  def typeChecksFileImportingDottyContexts(@TempDir outDir: Path): Unit = {
+    val bridge = new ScalaCompilerBridge()
+    val source =
+      """package example
+        |
+        |import dotty.tools.dotc.core.Contexts.*
+        |
+        |class Foo {
+        |  def bar(using ctx: Context): Int = 42
+        |}
+        |""".stripMargin
+
+    val entries = new ArrayList[SourceEntry]()
+    entries.add(SourceEntry("Foo.scala", source))
+
+    val results = bridge.compileAll(entries, scalaCompilerOnlyClasspath, outDir.toString)
+
+    val result = results.get("Foo.scala")
+    assertNotNull(result, "result present")
+    assertNotNull(result.tree, "untyped tree populated")
+    assertTrue(
+      result.typedTree.isDefined,
+      "typed tree should be populated for a Scala file that imports dotty compiler APIs"
+    )
+  }
+}


### PR DESCRIPTION
## Motivation

`mod build` on `openrewrite/rewrite` fails to type-check 5 Scala files that import dotty compiler APIs, emitting errors such as:

```
Bad symbolic reference. A signature in scala3-compiler_3-3.8.4-RC2.jar(dotty/tools/dotc/core/Contexts.tasty)
refers to */T in object dotty.tools.dotc.core.Contexts which is not available.
```

Root cause: when a caller's classpath includes `scala3-compiler` but is missing one of the stdlib jars dotty relies on (`scala-library`, `tasty-core`), dotty's `Definitions` can't resolve foundational types like `scala.Unit`. Depending on where typechecking blows up, this surfaces as the `Bad symbolic reference` TASTy error above, or as a `ClassCastException: NoSymbol cannot be cast to ClassSymbol` in `Definitions.UnitClass`. Either way, the affected files lose type attribution entirely.

Because `ScalaCompilerBridge` itself is loaded from those same jars, it can locate them at runtime and self-heal — analogous to how `JavaParser` doesn't require callers to pass `rt.jar`.

## Summary

- `ScalaCompilerBridge` now computes the dotty classpath through a new `buildClasspath` helper that appends any missing stdlib jars (`scala-library`, `tasty-core`, `scala3-compiler`), located via `ProtectionDomain.getCodeSource()` on probe classes (`scala.Option`, `dotty.tools.tasty.TastyFormat`, `dotty.tools.dotc.core.Contexts`).
- The self-heal only triggers when the caller's classpath already contains at least one `scala*`/`tasty*`/`dotty*` artifact. This preserves the narrow-classpath contract that `ScalaTemplate` depends on to keep type resolution out of template parsing.
- Dedup is filename-based so callers that pass the same artifact under a different on-disk path (Maven vs. Gradle cache, symlinks) don't end up with duplicate entries.
- New regression test `DottyImportTypeAttributionTest` feeds the bridge a classpath containing only `scala3-compiler` (mimicking the `mod build` scenario) and verifies that both an ordinary Scala file and one importing `dotty.tools.dotc.core.Contexts.*` come back with a populated typed tree.
- Drive-by: drop `:latest.release` from three `junit-jupiter` test dependencies in `rewrite-scala/build.gradle.kts`. `:latest.release` was resolving to `6.1.0-M1` (milestone), whose `junit-platform-commons` removed `CollectionUtils.toUnmodifiableList()` — breaking the `junit-platform-launcher:1.14.0` that Gradle's test runner uses. No tests in this module could run. Inheriting from the junit BOM (as the other modules do) restores consistency.

## Test plan

- [x] `./gradlew :rewrite-scala:test` — full module green, including the new `DottyImportTypeAttributionTest` and the pre-existing template/matching suites.
- [ ] Manual `mod build` on a fresh `openrewrite/rewrite` checkout with the CLI's sibling-Java fix (`moderneinc/moderne-cli#3704`) to confirm the `Bad symbolic reference` errors no longer appear on the 5 files listed in the motivation.