### PR TITLE
Try Maven downloads anonymously first, retry with credentials on 4xx

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/cache/LocalMavenArtifactCache.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/cache/LocalMavenArtifactCache.java
@@ -85,7 +85,7 @@ public class LocalMavenArtifactCache implements MavenArtifactCache {
 
         return resolvedPath.resolve(dependency.getArtifactId() + "-" +
                                     (dependency.getDatedSnapshotVersion() == null ? dependency.getVersion() : dependency.getDatedSnapshotVersion()) +
-                                    (dependency.getRequested().getClassifier() == null ? "" : dependency.getRequested().getClassifier()) +
+                                    (dependency.getRequested().getClassifier() == null ? "" : "-" + dependency.getRequested().getClassifier()) +
                                     ".jar");
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
@@ -109,20 +109,21 @@ public class MavenArtifactDownloader {
             } else if ("file".equals(URI.create(uri).getScheme())) {
                 bodyStream = Files.newInputStream(Paths.get(URI.create(uri)));
             } else {
-                HttpSender.Request.Builder request = applyAuthentication(dependency.getRepository(), httpSender.get(uri));
                 try {
+                    // Try anonymously first, mirroring Apache Maven's DeferredCredentialsProvider behavior
                     byte[] responseBytes = null;
                     int responseCode;
-                    try (HttpSender.Response response = Failsafe.with(retryPolicy).get(() -> httpSender.send(request.build()));
+                    try (HttpSender.Response response = Failsafe.with(retryPolicy).get(() -> httpSender.send(httpSender.get(uri).build()));
                          InputStream body = response.getBody()) {
                         responseCode = response.getCode();
                         if (response.isSuccessful() && body != null) {
                             responseBytes = readAllBytes(body);
                         }
                     }
-                    // Fall back to anonymous if authenticated request fails with a 4xx client error
-                    if (responseBytes == null && hasCredentials(dependency.getRepository()) && responseCode >= 400 && responseCode < 500) {
-                        try (HttpSender.Response response = Failsafe.with(retryPolicy).get(() -> httpSender.send(httpSender.get(uri).build()));
+                    // Retry with credentials if the anonymous request failed with a 4xx and we have credentials
+                    if (responseBytes == null && responseCode >= 400 && responseCode < 500 && hasCredentials(dependency.getRepository())) {
+                        HttpSender.Request.Builder request = applyAuthentication(dependency.getRepository(), httpSender.get(uri));
+                        try (HttpSender.Response response = Failsafe.with(retryPolicy).get(() -> httpSender.send(request.build()));
                              InputStream body = response.getBody()) {
                             responseCode = response.getCode();
                             if (response.isSuccessful() && body != null) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
@@ -110,15 +110,35 @@ public class MavenArtifactDownloader {
                 bodyStream = Files.newInputStream(Paths.get(URI.create(uri)));
             } else {
                 HttpSender.Request.Builder request = applyAuthentication(dependency.getRepository(), httpSender.get(uri));
-                try (HttpSender.Response response = Failsafe.with(retryPolicy).get(() -> httpSender.send(request.build()));
-                     InputStream body = response.getBody()) {
-                    if (!response.isSuccessful() || body == null) {
-                        onError.accept(new MavenDownloadingException(String.format("Unable to download dependency %s:%s:%s from %s. Response was %d",
-                                dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion(), uri, response.getCode()), null,
+                try {
+                    byte[] responseBytes = null;
+                    int responseCode;
+                    try (HttpSender.Response response = Failsafe.with(retryPolicy).get(() -> httpSender.send(request.build()));
+                         InputStream body = response.getBody()) {
+                        responseCode = response.getCode();
+                        if (response.isSuccessful() && body != null) {
+                            responseBytes = readAllBytes(body);
+                        }
+                    }
+                    // Fall back to anonymous if authenticated request fails with a 4xx client error
+                    if (responseBytes == null && hasCredentials(dependency.getRepository()) && responseCode >= 400 && responseCode < 500) {
+                        try (HttpSender.Response response = Failsafe.with(retryPolicy).get(() -> httpSender.send(httpSender.get(uri).build()));
+                             InputStream body = response.getBody()) {
+                            responseCode = response.getCode();
+                            if (response.isSuccessful() && body != null) {
+                                responseBytes = readAllBytes(body);
+                            }
+                        }
+                    }
+                    if (responseBytes == null) {
+                        onError.accept(new MavenDownloadingException(String.format("Unable to download dependency %s:%s:%s%s from %s. Response was %d",
+                                dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion(),
+                                dependency.getClassifier() == null ? "" : ":" + dependency.getClassifier(),
+                                uri, responseCode), null,
                                 dependency.getRequested().getGav()));
                         return null;
                     }
-                    bodyStream = new ByteArrayInputStream(readAllBytes(body));
+                    bodyStream = new ByteArrayInputStream(responseBytes);
                 } catch (Throwable t) {
                     Throwable cause = t instanceof FailsafeException && t.getCause() != null ? t.getCause() : t;
                     throw new MavenDownloadingException("Unable to download dependency", cause,
@@ -130,14 +150,27 @@ public class MavenArtifactDownloader {
     }
 
     private HttpSender.Request.Builder applyAuthentication(MavenRepository repository, HttpSender.Request.Builder request) {
+        MavenSettings.Server authInfo = serverIdToServer.get(repository.getId());
+        if (authInfo != null && authInfo.getConfiguration() != null && authInfo.getConfiguration().getHttpHeaders() != null) {
+            for (MavenSettings.HttpHeader header : authInfo.getConfiguration().getHttpHeaders()) {
+                request.withHeader(header.getName(), header.getValue());
+            }
+        }
+        String[] credentials = resolveCredentials(repository);
+        if (credentials != null) {
+            return request.withBasicAuthentication(credentials[0], credentials[1]);
+        }
+        return request;
+    }
+
+    private boolean hasCredentials(MavenRepository repository) {
+        return resolveCredentials(repository) != null;
+    }
+
+    private String @Nullable [] resolveCredentials(MavenRepository repository) {
         String username, password;
         MavenSettings.Server authInfo = serverIdToServer.get(repository.getId());
         if (authInfo != null) {
-            if (authInfo.getConfiguration() != null && authInfo.getConfiguration().getHttpHeaders() != null) {
-                for (MavenSettings.HttpHeader header : authInfo.getConfiguration().getHttpHeaders()) {
-                    request.withHeader(header.getName(), header.getValue());
-                }
-            }
             username = authInfo.getUsername();
             password = authInfo.getPassword();
         } else {
@@ -146,8 +179,8 @@ public class MavenArtifactDownloader {
         }
         if (username != null && !username.contains("${") &&
                 password != null && !password.contains("${")) {
-            return request.withBasicAuthentication(username, password);
+            return new String[]{username, password};
         }
-        return request;
+        return null;
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/MavenArtifactDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/MavenArtifactDownloaderTest.java
@@ -133,6 +133,63 @@ class MavenArtifactDownloaderTest {
     }
 
     @Test
+    void fallsBackToAnonymousWhenServerReturns401(@TempDir Path tempDir) throws Exception {
+        byte[] jarBytes = {0x50, 0x4B, 0x03, 0x04};
+
+        try (MockWebServer mockRepo = new MockWebServer()) {
+            mockRepo.setDispatcher(new Dispatcher() {
+                @Override
+                public MockResponse dispatch(RecordedRequest request) {
+                    if (request.getHeader("Authorization") != null) {
+                        return new MockResponse().setResponseCode(401);
+                    }
+                    return new MockResponse().setResponseCode(200)
+                      .setBody(new okio.Buffer().write(jarBytes));
+                }
+            });
+            mockRepo.start();
+
+            String repoUrl = "http://" + mockRepo.getHostName() + ":" + mockRepo.getPort();
+            MavenSettings settings = MavenSettings.parse(new Parser.Input(
+              Path.of("settings.xml"), () -> new ByteArrayInputStream(
+              //language=xml
+              """
+                <settings>
+                    <servers>
+                        <server>
+                            <id>mock-repo</id>
+                            <username>bad-user</username>
+                            <password>bad-password</password>
+                        </server>
+                    </servers>
+                </settings>
+                """.getBytes())), new InMemoryExecutionContext());
+
+            MavenArtifactCache artifactCache = new LocalMavenArtifactCache(tempDir);
+            AtomicReference<Throwable> error = new AtomicReference<>();
+            MavenArtifactDownloader downloader = new MavenArtifactDownloader(
+              artifactCache, settings, error::set);
+
+            MavenRepository repo = new MavenRepository(
+              "mock-repo", repoUrl, "true", "false", true, null, null, null, false);
+            GroupArtifactVersion gav = new GroupArtifactVersion("com.example", "test-lib", "1.0.0");
+            ResolvedDependency dep = ResolvedDependency.builder()
+              .repository(repo)
+              .gav(new ResolvedGroupArtifactVersion(repoUrl, gav.getGroupId(), gav.getArtifactId(), gav.getVersion(), null))
+              .requested(Dependency.builder().gav(gav).build())
+              .build();
+
+            Path artifact = downloader.downloadArtifact(dep);
+
+            assertThat(artifact).isNotNull();
+            assertThat(error.get()).isNull();
+            assertThat(mockRepo.getRequestCount()).isEqualTo(2);
+            assertThat(mockRepo.takeRequest().getHeader("Authorization")).isNotNull();
+            assertThat(mockRepo.takeRequest().getHeader("Authorization")).isNull();
+        }
+    }
+
+    @Test
     void fallsBackToAnonymousWhenCredentialsRejected(@TempDir Path tempDir) throws Exception {
         byte[] jarBytes = {0x50, 0x4B, 0x03, 0x04}; // minimal ZIP magic bytes
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/MavenArtifactDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/MavenArtifactDownloaderTest.java
@@ -133,8 +133,8 @@ class MavenArtifactDownloaderTest {
     }
 
     @Test
-    void fallsBackToAnonymousWhenServerReturns401(@TempDir Path tempDir) throws Exception {
-        byte[] jarBytes = {0x50, 0x4B, 0x03, 0x04};
+    void publicArtifactsResolveAnonymouslyEvenWhenCredentialsAreInvalid(@TempDir Path tempDir) throws Exception {
+        byte[] jarBytes = {0x50, 0x4B, 0x03, 0x04}; // minimal ZIP magic bytes
 
         try (MockWebServer mockRepo = new MockWebServer()) {
             mockRepo.setDispatcher(new Dispatcher() {
@@ -183,22 +183,21 @@ class MavenArtifactDownloaderTest {
 
             assertThat(artifact).isNotNull();
             assertThat(error.get()).isNull();
-            assertThat(mockRepo.getRequestCount()).isEqualTo(2);
-            assertThat(mockRepo.takeRequest().getHeader("Authorization")).isNotNull();
+            assertThat(mockRepo.getRequestCount()).isEqualTo(1);
             assertThat(mockRepo.takeRequest().getHeader("Authorization")).isNull();
         }
     }
 
     @Test
-    void fallsBackToAnonymousWhenCredentialsRejected(@TempDir Path tempDir) throws Exception {
-        byte[] jarBytes = {0x50, 0x4B, 0x03, 0x04}; // minimal ZIP magic bytes
+    void retriesWithCredentialsWhenAnonymousReturns401(@TempDir Path tempDir) throws Exception {
+        byte[] jarBytes = {0x50, 0x4B, 0x03, 0x04};
 
         try (MockWebServer mockRepo = new MockWebServer()) {
             mockRepo.setDispatcher(new Dispatcher() {
                 @Override
                 public MockResponse dispatch(RecordedRequest request) {
-                    if (request.getHeader("Authorization") != null) {
-                        return new MockResponse().setResponseCode(403); // Throw if used; it should not be called at all
+                    if (request.getHeader("Authorization") == null) {
+                        return new MockResponse().setResponseCode(401);
                     }
                     return new MockResponse().setResponseCode(200)
                       .setBody(new okio.Buffer().write(jarBytes));
@@ -215,8 +214,8 @@ class MavenArtifactDownloaderTest {
                     <servers>
                         <server>
                             <id>mock-repo</id>
-                            <username>${placeholder}</username>
-                            <password>${placeholder}</password>
+                            <username>good-user</username>
+                            <password>good-password</password>
                         </server>
                     </servers>
                 </settings>
@@ -240,7 +239,9 @@ class MavenArtifactDownloaderTest {
 
             assertThat(artifact).isNotNull();
             assertThat(error.get()).isNull();
-            assertThat(mockRepo.getRequestCount()).isEqualTo(1);
+            assertThat(mockRepo.getRequestCount()).isEqualTo(2);
+            assertThat(mockRepo.takeRequest().getHeader("Authorization")).isNull();
+            assertThat(mockRepo.takeRequest().getHeader("Authorization")).isNotNull();
         }
     }
 }


### PR DESCRIPTION
## Summary

- `MavenArtifactDownloader` now tries each JAR download anonymously first and only sends `settings.xml` credentials if the server challenges with a 4xx — mirroring Apache Maven Resolver's `DeferredCredentialsProvider`. This unblocks anonymous-accessible artifacts when configured credentials are invalid (reported case: 401 against internal Artifactory) and avoids leaking credentials to public artifacts.
- Fix `LocalMavenArtifactCache` cache filename missing the hyphen before the classifier (`foo-1.0.0recipes.jar` → `foo-1.0.0-recipes.jar`).
- Include the classifier in the `MavenDownloadingException` message so artifact coordinates are complete during troubleshooting.

Follow-up to #6845 where this scenario was anticipated; the reporter has now hit it in practice.
- https://github.com/openrewrite/rewrite/pull/6845

## Test plan
- [x] `publicArtifactsResolveAnonymouslyEvenWhenCredentialsAreInvalid` — bad credentials configured, public artifact, single anonymous request, no auth header sent.
- [x] `retriesWithCredentialsWhenAnonymousReturns401` — private artifact, two requests: first anonymous (401), second authenticated (200).