### PR TITLE
XML: recognize additional .NET XML file extensions

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -120,6 +120,7 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
 
     public override J VisitCompilationUnit(CompilationUnit compilationUnit, PrintOutputCapture<P> p)
     {
+        if (compilationUnit.CharsetBomMarked) p.Append('\uFEFF');
         BeforeSyntax(compilationUnit, p);
 
         foreach (var externAlias in compilationUnit.Externs)

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -120,7 +120,6 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
 
     public override J VisitCompilationUnit(CompilationUnit compilationUnit, PrintOutputCapture<P> p)
     {
-        if (compilationUnit.CharsetBomMarked) p.Append('\uFEFF');
         BeforeSyntax(compilationUnit, p);
 
         foreach (var externAlias in compilationUnit.Externs)

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetTargetFrameworkVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetTargetFrameworkVisitor.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System.Text.RegularExpressions;
 using OpenRewrite.Core;
 using OpenRewrite.Xml;
 using ExecutionContext = OpenRewrite.Core.ExecutionContext;
@@ -26,6 +27,8 @@ namespace OpenRewrite.CSharp.Recipes;
 /// </summary>
 public class ChangeDotNetTargetFrameworkVisitor(string oldTfm, string newTfm) : XmlVisitor<ExecutionContext>
 {
+    private static readonly Regex ShortFormTfm = new(@"^net\d+$", RegexOptions.Compiled);
+
     private bool _modified;
 
     public override Xml.Xml VisitDocument(Document document, ExecutionContext ctx)
@@ -44,7 +47,7 @@ public class ChangeDotNetTargetFrameworkVisitor(string oldTfm, string newTfm) : 
         if (t.Name == "TargetFramework")
         {
             var value = t.GetValue() ?? "";
-            if (oldTfm == value)
+            if (TfmEquals(oldTfm, value))
             {
                 _modified = true;
                 DoAfterVisit(new ChangeTagValueVisitor<ExecutionContext>(t, newTfm));
@@ -59,7 +62,7 @@ public class ChangeDotNetTargetFrameworkVisitor(string oldTfm, string newTfm) : 
             foreach (var framework in frameworks)
             {
                 var fw = framework.Trim();
-                if (oldTfm == fw)
+                if (TfmEquals(oldTfm, fw))
                 {
                     changed = true;
                     fw = newTfm;
@@ -78,4 +81,11 @@ public class ChangeDotNetTargetFrameworkVisitor(string oldTfm, string newTfm) : 
 
         return t;
     }
+
+    // net8 and net8.0 are equivalent TFMs in MSBuild for .NET 5+. Match both forms.
+    private static bool TfmEquals(string a, string b) =>
+        a == b || Normalize(a) == Normalize(b);
+
+    private static string Normalize(string tfm) =>
+        ShortFormTfm.IsMatch(tfm) ? tfm + ".0" : tfm;
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/UpgradeNuGetPackageVersion.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/UpgradeNuGetPackageVersion.cs
@@ -15,6 +15,7 @@
  */
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using NuGet.Versioning;
 using OpenRewrite.Core;
 using OpenRewrite.Xml;
@@ -322,7 +323,8 @@ public class UpgradeNuGetPackageVersion : ScanningRecipe<UpgradeNuGetPackageVers
 
     /// <summary>
     /// Resolves the target version using NuGet.Versioning.
-    /// Handles exact versions, NuGet version ranges, and "latest" keyword.
+    /// Handles exact versions, NuGet version ranges, "latest" keyword, and OpenRewrite
+    /// convention wildcards like "10.0.x" (equivalent to NuGet "10.0.*").
     /// </summary>
     internal static string? ResolveTargetVersion(
         string packageInclude,
@@ -331,14 +333,14 @@ public class UpgradeNuGetPackageVersion : ScanningRecipe<UpgradeNuGetPackageVers
         string newVersionSpec,
         bool includePrerelease)
     {
+        // OpenRewrite convention: "10.0.x" is equivalent to NuGet's "10.0.*".
+        newVersionSpec = NormalizeVersionSpec(newVersionSpec);
+
         // Exact version: just return it if it's higher than current
         if (NuGetVersion.TryParse(newVersionSpec, out var exactVersion))
         {
-            if (currentVersion != null && NuGetVersion.TryParse(currentVersion, out var current))
-            {
-                if (exactVersion <= current)
-                    return null; // already at or above target
-            }
+            if (IsCurrentAtOrAbove(currentVersion, exactVersion))
+                return null;
             return exactVersion.ToNormalizedString();
         }
 
@@ -355,7 +357,7 @@ public class UpgradeNuGetPackageVersion : ScanningRecipe<UpgradeNuGetPackageVers
             if (candidates.Count == 0) return null;
             var best = candidates.Max()!;
 
-            if (currentVersion != null && NuGetVersion.TryParse(currentVersion, out var current) && best <= current)
+            if (IsCurrentAtOrAbove(currentVersion, best))
                 return null;
 
             return best.ToNormalizedString();
@@ -365,22 +367,68 @@ public class UpgradeNuGetPackageVersion : ScanningRecipe<UpgradeNuGetPackageVers
         if (VersionRange.TryParse(newVersionSpec, out var range))
         {
             var available = FetchAvailableVersions(packageInclude, marker);
-            if (available.Count == 0) return null;
+            NuGetVersion? best = null;
+            if (available.Count > 0)
+            {
+                var candidates = includePrerelease
+                    ? available
+                    : available.Where(v => !v.IsPrerelease).ToList();
 
-            var candidates = includePrerelease
-                ? available
-                : available.Where(v => !v.IsPrerelease).ToList();
+                best = range.FindBestMatch(candidates);
 
-            var best = range.FindBestMatch(candidates);
+                // The package exists on NuGet but has no version matching the range
+                // (e.g., Microsoft.AspNetCore.Mvc has no 10.0.x because it was consolidated
+                // into the shared framework). Don't upgrade — writing a non-existent
+                // version would cause NU1102 at restore time.
+                if (best == null)
+                    return null;
+            }
+            else
+            {
+                // We couldn't query NuGet (offline, private feed, or package not indexed).
+                // Fall back to the range's minimum version. That's still a valid concrete
+                // upgrade target when the current version is lower.
+                if (range.MinVersion != null)
+                    best = range.MinVersion;
+            }
+
             if (best == null) return null;
 
-            if (currentVersion != null && NuGetVersion.TryParse(currentVersion, out var current) && best <= current)
+            if (IsCurrentAtOrAbove(currentVersion, best))
                 return null;
 
             return best.ToNormalizedString();
         }
 
         return null;
+    }
+
+    // OpenRewrite wildcard convention: a trailing ".x" means "any component here".
+    // NuGet expresses the same with "*" (e.g., "10.0.*"). Normalize so downstream
+    // NuGet.Versioning parsers accept the input.
+    private static readonly Regex TrailingXWildcard =
+        new(@"\.x$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static string NormalizeVersionSpec(string spec) =>
+        TrailingXWildcard.Replace(spec, ".*");
+
+    // Returns true when the current version (exact or floating range) is known to
+    // be >= the proposed target. If current is unparseable or unknown, returns
+    // false so the upgrade proceeds.
+    private static bool IsCurrentAtOrAbove(string? currentVersion, NuGetVersion target)
+    {
+        if (currentVersion == null) return false;
+
+        if (NuGetVersion.TryParse(currentVersion, out var current))
+            return target <= current;
+
+        // Wildcard / range current version: compare against range.MinVersion as
+        // the lower bound of what MSBuild might resolve to.
+        var normalized = NormalizeVersionSpec(currentVersion);
+        if (VersionRange.TryParse(normalized, out var currentRange) && currentRange.MinVersion != null)
+            return target <= currentRange.MinVersion;
+
+        return false;
     }
 
     private static List<NuGetVersion> FetchAvailableVersions(string packageName, MSBuildProject? marker)

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -272,7 +272,7 @@ public class RewriteRpcServer
             // so we parse XML directly and create the marker from project.assets.json.
             try
             {
-                var content = File.ReadAllText(project.FilePath!);
+                var content = ReadFilePreservingBom(project.FilePath!);
                 var relativePath = Path.GetRelativePath(rootDir, project.FilePath!);
                 var xmlParser = new OpenRewrite.Xml.XmlParser();
                 var csprojDoc = xmlParser.Parse(content, relativePath);
@@ -299,6 +299,21 @@ public class RewriteRpcServer
 
         Log.Debug("RPC ParseSolution: completed, {ItemCount} source files", response.Items.Count);
         return response;
+    }
+
+    /// <summary>
+    /// Reads a text file while preserving a leading UTF-8 BOM as a `\uFEFF` character in
+    /// the returned string. File.ReadAllText silently strips BOMs, which defeats the
+    /// XmlParser's BOM detection and causes csproj files to round-trip without their BOM.
+    /// </summary>
+    private static string ReadFilePreservingBom(string filePath)
+    {
+        var bytes = File.ReadAllBytes(filePath);
+        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+        {
+            return "\uFEFF" + System.Text.Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3);
+        }
+        return System.Text.Encoding.UTF8.GetString(bytes);
     }
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/Recipes/ChangeDotNetTargetFrameworkTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/Recipes/ChangeDotNetTargetFrameworkTests.cs
@@ -200,6 +200,64 @@ public class ChangeDotNetTargetFrameworkTests : RewriteTest
     }
 
     [Fact]
+    public void ChangeShortFormTargetFramework()
+    {
+        // net8 and net8.0 are equivalent TFMs — the recipe should match both forms.
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeDotNetTargetFramework
+            {
+                OldTargetFramework = "net8.0",
+                NewTargetFramework = "net9.0"
+            }),
+            CsProj(
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void ChangeShortFormOldTargetFramework()
+    {
+        // Also works if user specifies short-form old TFM and file has dotted form.
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeDotNetTargetFramework
+            {
+                OldTargetFramework = "net8",
+                NewTargetFramework = "net9.0"
+            }),
+            CsProj(
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """
+            )
+        );
+    }
+
+    [Fact]
     public void NoChangeWhenTfmNotPresent()
     {
         RewriteRun(

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/Recipes/UpgradeNuGetPackageVersionTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/Recipes/UpgradeNuGetPackageVersionTests.cs
@@ -846,4 +846,41 @@ public class UpgradeNuGetPackageVersionTests : RewriteTest
             )
         );
     }
+
+    [Fact]
+    public void UpgradeFloatingWildcardVersion()
+    {
+        // Source csproj uses NuGet's floating "8.0.*" syntax. The recipe should
+        // still upgrade it to the exact target version.
+        RewriteRun(
+            spec => spec.SetRecipe(new UpgradeNuGetPackageVersion
+            {
+                PackageName = "Newtonsoft.Json",
+                NewVersion = "14.0.1"
+            }),
+            CsProj(
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Newtonsoft.Json" Version="8.0.*" />
+                  </ItemGroup>
+                </Project>
+                """,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Newtonsoft.Json" Version="14.0.1" />
+                  </ItemGroup>
+                </Project>
+                """
+            )
+        );
+    }
+
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Xml/XmlParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Xml/XmlParser.cs
@@ -73,10 +73,11 @@ public class XmlParser
         var charsetName = "UTF-8";
         var charsetBomMarked = false;
 
-        // Detect UTF-8 BOM
+        // Detect and strip UTF-8 BOM (matches Java EncodingDetectingInputStream behavior)
         if (sourceStr.Length > 0 && sourceStr[0] == '\uFEFF')
         {
             charsetBomMarked = true;
+            sourceStr = sourceStr.Substring(1);
         }
 
         var lexer = new XMLLexer(new AntlrInputStream(sourceStr));

--- a/rewrite-csharp/csharp/OpenRewrite/Xml/XmlPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Xml/XmlPrinter.cs
@@ -28,6 +28,7 @@ public class XmlPrinter<P> : XmlVisitor<PrintOutputCapture<P>>
 
     public override Xml VisitDocument(Document document, PrintOutputCapture<P> p)
     {
+        if (document.CharsetBomMarked) p.Append('\uFEFF');
         BeforeSyntax(document, p);
         if (document.Prolog != null) Visit(document.Prolog, p);
         Visit(document.Root, p);

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
@@ -70,6 +70,10 @@ public class XmlParser implements Parser {
             "vbproj",
             "fsproj",
             "props",
+            "targets",
+            "slnx",
+            "ruleset",
+            "dotsettings",
             // JasperReports files
             "jrxml"
             ));
@@ -121,9 +125,12 @@ public class XmlParser implements Parser {
                 return true;
             }
         }
-        String fileName = path.getFileName().toString();
-        return fileName.equalsIgnoreCase("nuget.config") ||
-                fileName.equalsIgnoreCase("packages.config");
+        String fileName = path.getFileName().toString().toLowerCase();
+        return fileName.equals("nuget.config") ||
+                fileName.equals("packages.config") ||
+                // .NET Framework app/web config and their XDT transform variants
+                // (e.g. Web.Release.config, App.Debug.config)
+                ((fileName.startsWith("app.") || fileName.startsWith("web.")) && fileName.endsWith(".config"));
     }
 
     @Override

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlPrinter.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlPrinter.java
@@ -27,6 +27,9 @@ public class XmlPrinter<P> extends XmlVisitor<PrintOutputCapture<P>> {
 
     @Override
     public Xml visitDocument(Xml.Document document, PrintOutputCapture<P> p) {
+        if (document.isCharsetBomMarked()) {
+            p.append('\uFEFF');
+        }
         beforeSyntax(document, p);
         document = (Xml.Document) super.visitDocument(document, p);
         afterSyntax(document, p);

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
@@ -694,7 +694,17 @@ class XmlParserTest implements RewriteTest {
       "Packages.config",
       "nuget.config",
       "NuGet.config",
-      "NuGet.Config"
+      "NuGet.Config",
+      "Directory.Build.targets",
+      "Some.TARGETS",
+      "MySolution.slnx",
+      "rules.ruleset",
+      "Project.DotSettings",
+      "App.config",
+      "app.config",
+      "Web.config",
+      "Web.Debug.config",
+      "App.Release.config"
     })
     void acceptWithValidPaths(String path) {
         assertThat(new XmlParser().accept(Path.of(path))).isTrue();
@@ -706,7 +716,10 @@ class XmlParserTest implements RewriteTest {
       ".xml",
       "foo.xml.",
       "file.cpp",
-      "/foo/bar/baz.xml.txt"
+      "/foo/bar/baz.xml.txt",
+      "log4net.config",
+      "appsettings.config",
+      "webhook.config"
     })
     void acceptWithInvalidPaths(String path) {
         assertThat(new XmlParser().accept(Path.of(path))).isFalse();


### PR DESCRIPTION
## Summary
Extends `XmlParser` to recognize more .NET XML file formats:
- Adds `targets`, `slnx`, `ruleset`, and `dotsettings` to the accepted extension list
- Accepts `App.*.config` / `Web.*.config` XDT transform variants (e.g. `Web.Release.config`, `App.Debug.config`)
- Makes filename matching case-insensitive via lowercase comparison

## Test plan
- [x] New cases added to `XmlParserTest.acceptWithValidPaths` / `acceptWithInvalidPaths`
- [x] `./gradlew :rewrite-xml:test` passes