### PR TITLE
Scala: pass `-parameters` to `javac` in joint compilation

### DIFF
--- a/rewrite-scala/build.gradle.kts
+++ b/rewrite-scala/build.gradle.kts
@@ -50,6 +50,9 @@ tasks.named<ScalaCompile>("compileScala") {
     javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(JavaLanguageVersion.of(17))
     })
+    // Forwarded to javac during Zinc joint compilation so .java files keep
+    // method parameter names in bytecode (MethodParameters attribute).
+    options.compilerArgs.add("-parameters")
 }
 
 // Ensure Java compilation uses output from Scala compilation


### PR DESCRIPTION
## Motivation

The `rewrite-scala` build excludes `**/*.java` from `compileJava` and feeds Java sources into `compileScala` for Zinc joint compilation. As a result, the `-parameters` flag that the `java-base` convention plugin applies to `JavaCompile` tasks never reaches `javac` for this module, so compiled `.java` classes lacked the `MethodParameters` attribute and lost their parameter names in bytecode.

## Summary

- Add `-parameters` to `compileScala`'s `options.compilerArgs` so Zinc forwards it to `javac` during joint Java/Scala compilation.

## Test plan

- [x] `./gradlew :rewrite-scala:clean :rewrite-scala:compileScala`
- [x] `javap -p -v` on compiled classes under `rewrite-scala/build/classes/scala/main/` shows the `MethodParameters` attribute with original source-level names (e.g. `Assertions` → `before`, `spec`, `scalaSources`; `ScalaParser` → `sourceCode`, `sources`, `relativeTo`, `path`) rather than synthetic `arg0`/`arg1`.