### PR TITLE
Pin bouncycastle 1.84 in kotlinBouncyCastleConfiguration

### DIFF
--- a/rewrite-kotlin/build.gradle.kts
+++ b/rewrite-kotlin/build.gradle.kts
@@ -28,6 +28,15 @@ dependencies {
     testImplementation("com.google.testing.compile:compile-testing:0.+")
 }
 
+configurations.matching { it.name == "kotlinBouncyCastleConfiguration" }.configureEach {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.bouncycastle") {
+            useVersion("1.84")
+            because("CVE-2026-3505, CVE-2026-5598, CVE-2026-5588, CVE-2026-0636")
+        }
+    }
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1047

## Summary

The Kotlin Gradle plugin creates an internal `kotlinBouncyCastleConfiguration` used for library publishing validation, which resolves:
- `org.bouncycastle:bcpg-jdk18on:1.80`
- `org.bouncycastle:bcpkix-jdk18on:1.80`
- `org.bouncycastle:bcprov-jdk18on:1.80`

These versions are flagged for four CVEs, all patched in 1.84:
- [CVE-2026-3505](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2026-3505) — bcpg DoS (HIGH)
- [CVE-2026-5598](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2026-5598) — bcprov covert timing channel in Frodo
- [CVE-2026-5588](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2026-5588) — bcpkix broken/risky crypto
- [CVE-2026-0636](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2026-0636) — bcprov LDAP injection

The configuration is not used at compile time and the jars are not shipped. This override keeps the SOC2 dependency-check report clean.

## Test plan
- `./gradlew :rewrite-kotlin:dependencies --configuration kotlinBouncyCastleConfiguration` reports `1.80 -> 1.84` on all three BC artifacts locally.