### PR TITLE
Share artifact cache across JavaSourceSetUpdater visitors

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
@@ -19,10 +19,17 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.DelegatingExecutionContext;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.maven.cache.InMemoryMavenPomCache;
+import org.openrewrite.maven.cache.LocalMavenArtifactCache;
+import org.openrewrite.maven.cache.MavenArtifactCache;
 import org.openrewrite.maven.cache.MavenPomCache;
 import org.openrewrite.maven.internal.MavenParsingException;
 import org.openrewrite.maven.tree.*;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.*;
 import java.util.stream.Stream;
@@ -44,6 +51,7 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
     private static final String MAVEN_REPOSITORIES = "org.openrewrite.maven.repos";
     private static final String MAVEN_PINNED_SNAPSHOT_VERSIONS = "org.openrewrite.maven.pinnedSnapshotVersions";
     private static final String MAVEN_POM_CACHE = "org.openrewrite.maven.pomCache";
+    private static final String MAVEN_ARTIFACT_CACHE = "org.openrewrite.maven.artifactCache";
     private static final String MAVEN_RESOLUTION_LISTENER = "org.openrewrite.maven.resolutionListener";
     private static final String MAVEN_RESOLUTION_TIME = "org.openrewrite.maven.resolutionTime";
 
@@ -133,6 +141,53 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
 
     public MavenPomCache getPomCache() {
         return (MavenPomCache) getMessages().computeIfAbsent(MAVEN_POM_CACHE, k -> new InMemoryMavenPomCache());
+    }
+
+    public MavenExecutionContextView setArtifactCache(MavenArtifactCache artifactCache) {
+        putMessage(MAVEN_ARTIFACT_CACHE, artifactCache);
+        return this;
+    }
+
+    /**
+     * Get a shared {@link MavenArtifactCache} for this execution context, lazily initializing one
+     * on first access. Defaults to a {@link LocalMavenArtifactCache} at
+     * {@code ~/.rewrite/cache/artifacts}, falling back to a single JVM-lifetime temp directory
+     * if the user home directory is not writable.
+     * <p>
+     * Callers that want to override this (for example, to point at a shared on-disk cache backed
+     * by a persistent volume) can do so via {@link #setArtifactCache(MavenArtifactCache)} before
+     * any recipe visitor resolves artifacts.
+     */
+    public MavenArtifactCache getArtifactCache() {
+        return (MavenArtifactCache) getMessages().computeIfAbsent(MAVEN_ARTIFACT_CACHE, k -> defaultArtifactCache());
+    }
+
+    private static MavenArtifactCache defaultArtifactCache() {
+        try {
+            Path cacheDir = Paths.get(System.getProperty("user.home"), ".rewrite", "cache", "artifacts");
+            Files.createDirectories(cacheDir);
+            return new LocalMavenArtifactCache(cacheDir);
+        } catch (Exception e) {
+            return TempArtifactCacheHolder.INSTANCE;
+        }
+    }
+
+    /**
+     * Holds a single JVM-lifetime temp-directory artifact cache, used as a fallback when
+     * {@code ~/.rewrite/cache/artifacts} cannot be created.
+     */
+    private static final class TempArtifactCacheHolder {
+        static final MavenArtifactCache INSTANCE;
+
+        static {
+            try {
+                Path tempDir = Files.createTempDirectory("rewrite-artifact-cache");
+                tempDir.toFile().deleteOnExit();
+                INSTANCE = new LocalMavenArtifactCache(tempDir);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
     }
 
     public MavenExecutionContextView setLocalRepository(MavenRepository localRepository) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/JavaSourceSetUpdater.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/JavaSourceSetUpdater.java
@@ -21,17 +21,12 @@ import org.openrewrite.ipc.http.HttpSender;
 import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.maven.MavenExecutionContextView;
-import org.openrewrite.maven.cache.LocalMavenArtifactCache;
-import org.openrewrite.maven.cache.MavenArtifactCache;
 import org.openrewrite.maven.tree.Dependency;
 import org.openrewrite.maven.tree.GroupArtifactVersion;
 import org.openrewrite.maven.tree.MavenRepository;
 import org.openrewrite.maven.tree.ResolvedDependency;
 import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;
@@ -50,17 +45,9 @@ public class JavaSourceSetUpdater {
     public JavaSourceSetUpdater(ExecutionContext ctx) {
         MavenExecutionContextView mctx = MavenExecutionContextView.view(ctx);
         HttpSender httpSender = HttpSenderExecutionContextView.view(ctx).getHttpSender();
-        // Use a lenient error handler: download failures are not fatal for JavaSourceSet updates
+        // Download failures are not fatal for JavaSourceSet updates — degrade gracefully
         Consumer<Throwable> onError = t -> {};
-        Path tempDir;
-        try {
-            tempDir = Files.createTempDirectory("rewrite-artifact-cache");
-            tempDir.toFile().deleteOnExit();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-        MavenArtifactCache cache = new LocalMavenArtifactCache(tempDir);
-        this.downloader = new MavenArtifactDownloader(cache, mctx.getSettings(), httpSender, onError);
+        this.downloader = new MavenArtifactDownloader(mctx.getArtifactCache(), mctx.getSettings(), httpSender, onError);
     }
 
     /**

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/JavaSourceSetUpdater.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/JavaSourceSetUpdater.java
@@ -29,6 +29,7 @@ import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
 
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 /**
@@ -40,14 +41,20 @@ import java.util.function.Consumer;
  * scans it for type names, and updates the JavaSourceSet accordingly.
  */
 public class JavaSourceSetUpdater {
-    private final MavenArtifactDownloader downloader;
+    static final String TYPE_CACHE_KEY = "org.openrewrite.maven.jarTypeCache";
 
+    private final MavenArtifactDownloader downloader;
+    private final Map<String, List<JavaType.FullyQualified>> typeCache;
+
+    @SuppressWarnings("unchecked")
     public JavaSourceSetUpdater(ExecutionContext ctx) {
         MavenExecutionContextView mctx = MavenExecutionContextView.view(ctx);
         HttpSender httpSender = HttpSenderExecutionContextView.view(ctx).getHttpSender();
         // Download failures are not fatal for JavaSourceSet updates — degrade gracefully
         Consumer<Throwable> onError = t -> {};
         this.downloader = new MavenArtifactDownloader(mctx.getArtifactCache(), mctx.getSettings(), httpSender, onError);
+        this.typeCache = (Map<String, List<JavaType.FullyQualified>>) ctx.getMessages()
+                .computeIfAbsent(TYPE_CACHE_KEY, k -> new ConcurrentHashMap<>());
     }
 
     /**
@@ -106,12 +113,23 @@ public class JavaSourceSetUpdater {
     }
 
     private List<JavaType.FullyQualified> downloadAndScanTypes(ResolvedDependency dep) {
+        String key = gavKey(dep);
+        List<JavaType.FullyQualified> cached = typeCache.get(key);
+        if (cached != null) {
+            return cached;
+        }
         try {
             Path jarPath = downloader.downloadArtifact(dep);
             if (jarPath == null) {
                 return Collections.emptyList();
             }
-            return JavaSourceSet.typesFromPath(jarPath, null);
+            List<JavaType.FullyQualified> types = JavaSourceSet.typesFromPath(jarPath, null);
+            // Only cache positive results: addDependency tries each repository in order until
+            // one succeeds, so caching an empty result would short-circuit later repos.
+            if (!types.isEmpty()) {
+                typeCache.put(key, types);
+            }
+            return types;
         } catch (Exception e) {
             // Graceful degradation: if download fails, return empty list
             return Collections.emptyList();

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenExecutionContextViewTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenExecutionContextViewTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.maven.cache.LocalMavenArtifactCache;
+import org.openrewrite.maven.cache.MavenArtifactCache;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MavenExecutionContextViewTest {
+
+    @Test
+    void artifactCacheIsMemoizedAcrossCalls() {
+        MavenExecutionContextView ctx = MavenExecutionContextView.view(new InMemoryExecutionContext());
+
+        MavenArtifactCache first = ctx.getArtifactCache();
+        MavenArtifactCache second = ctx.getArtifactCache();
+
+        // Memoization is the whole point — without it, every visitor that constructs a
+        // JavaSourceSetUpdater gets a fresh cache and re-downloads JARs it's already fetched.
+        assertThat(first).isSameAs(second);
+    }
+
+    @Test
+    void setArtifactCacheOverridesDefault(@TempDir Path tempDir) {
+        MavenExecutionContextView ctx = MavenExecutionContextView.view(new InMemoryExecutionContext());
+        MavenArtifactCache override = new LocalMavenArtifactCache(tempDir);
+
+        ctx.setArtifactCache(override);
+
+        assertThat(ctx.getArtifactCache()).isSameAs(override);
+    }
+
+    @Test
+    void artifactCacheIsSharedBetweenViewsOverSameDelegate() {
+        InMemoryExecutionContext delegate = new InMemoryExecutionContext();
+
+        MavenArtifactCache fromFirstView = MavenExecutionContextView.view(delegate).getArtifactCache();
+        MavenArtifactCache fromSecondView = MavenExecutionContextView.view(delegate).getArtifactCache();
+
+        // Each JavaSourceSetUpdater wraps the ctx in a fresh MavenExecutionContextView; the
+        // underlying cache must survive that because the message lives on the delegate's
+        // message map, not the view.
+        assertThat(fromFirstView).isSameAs(fromSecondView);
+    }
+}

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/JavaSourceSetUpdaterTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/JavaSourceSetUpdaterTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.utilities;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JavaSourceSetUpdaterTest {
+
+    @Test
+    void typeCacheIsSharedAcrossUpdaters() {
+        InMemoryExecutionContext ctx = new InMemoryExecutionContext();
+
+        new JavaSourceSetUpdater(ctx);
+        Object firstCache = ctx.getMessage(JavaSourceSetUpdater.TYPE_CACHE_KEY);
+
+        new JavaSourceSetUpdater(ctx);
+        Object secondCache = ctx.getMessage(JavaSourceSetUpdater.TYPE_CACHE_KEY);
+
+        // Memoizing typesFromPath only pays off if every updater built from the same
+        // ExecutionContext sees the same map — otherwise each visitor re-scans the JAR.
+        assertThat(firstCache).isNotNull().isSameAs(secondCache);
+    }
+}


### PR DESCRIPTION
## What

`JavaSourceSetUpdater` (introduced in #7202, refined by #7358 / #7373 / #7376) downloads each newly-added or changed dependency's JAR so it can refresh the in-memory `JavaSourceSet` marker with the new types. Two pieces of state were not shared across visitors:

1. **The artifact cache.** The constructor allocated a fresh `Files.createTempDirectory("rewrite-artifact-cache")` and wrapped it in a `LocalMavenArtifactCache` per visitor instance, so the same JARs were re-downloaded across recipes in a run.
2. **The result of scanning the JAR.** `JavaSourceSet.typesFromPath(jarPath, null)` re-opens the JAR and re-walks its entries on every call, even though the result is a pure function of the GAV's bytes.

Every dependency-mutating recipe (`AddDependency`, `UpgradeDependencyVersion`, `ChangeDependency`, `ChangeDependencyGroupIdAndArtifactId` in both `rewrite-maven` and `rewrite-gradle`) constructs its own updater, so both costs were paid per recipe per source set.

This PR shares both, scoped to the `ExecutionContext`.

## Why

Migration recipe chains (e.g. Spring Boot 3 → 4) trigger dozens of dependency-mutating recipes per repository. Without sharing, the same JARs are re-downloaded and re-scanned across the run — multiplying outbound traffic to Maven Central / artifactory and burning CPU on redundant JAR walks.

## How

### 1. Shared `MavenArtifactCache` on `MavenExecutionContextView`

Mirrors the existing `MavenPomCache` pattern:

- New `MAVEN_ARTIFACT_CACHE` message key.
- New `setArtifactCache(MavenArtifactCache)` setter for embedders that want to override (e.g. point at a persistent volume).
- New `getArtifactCache()` that lazily defaults to a `LocalMavenArtifactCache` at `~/.rewrite/cache/artifacts` (the same directory `JavaRewriteRpc` already uses), falling back to a single JVM-lifetime temp directory if the user home isn't writable.
- `JavaSourceSetUpdater` constructor now resolves its downloader's cache from `mctx.getArtifactCache()` instead of allocating a per-visitor temp dir.

### 2. Memoized `typesFromPath` results on the `ExecutionContext`

- `JavaSourceSetUpdater` reads/writes a `Map<String, List<JavaType.FullyQualified>>` stored on the ctx under `"org.openrewrite.maven.jarTypeCache"`, keyed by `groupId:artifactId:version`.
- Only positive results are cached. `addDependency` tries each repository in order until one succeeds, so caching empty results would short-circuit later repos.

## Tests

New `MavenExecutionContextViewTest`:

- `artifactCacheIsMemoizedAcrossCalls` — repeated `getArtifactCache()` calls return the same instance.
- `setArtifactCacheOverridesDefault` — `setArtifactCache(...)` overrides the lazy default.
- `artifactCacheIsSharedBetweenViewsOverSameDelegate` — load-bearing: each `JavaSourceSetUpdater` calls `MavenExecutionContextView.view(ctx)` freshly, so the cache must live on the underlying delegate's message map, not on the view.

New `JavaSourceSetUpdaterTest`:

- `typeCacheIsSharedAcrossUpdaters` — two updaters built from the same ctx see the same type-cache map.

Existing tests still pass: `ChangeDependencyGroupIdAndArtifactIdTest` (full class, including `updatesJavaSourceSetMarkerOnJavaFiles`), `AddDependencyTest` and `UpgradeDependencyVersionTest` in both `rewrite-maven` and `rewrite-gradle`, and `ChangeDependencyTest` in `rewrite-gradle`.