### PR TITLE
Disable JAR downloading in JavaSourceSetUpdater

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/JavaSourceSetUpdater.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/JavaSourceSetUpdater.java
@@ -59,81 +59,28 @@ public class JavaSourceSetUpdater {
 
     /**
      * Update a JavaSourceSet to reflect a dependency coordinate change.
-     * Removes types from the old dependency and adds types from the new dependency.
+     * Currently a no-op: JAR downloading is disabled while the classpath-update
+     * approach is being reconsidered.
      */
     public JavaSourceSet changeDependency(JavaSourceSet sourceSet,
                                           ResolvedDependency oldDep,
                                           ResolvedDependency newDep) {
-        String oldGavKey = gavKey(oldDep);
-        String newGavKey = gavKey(newDep);
-        if (!sourceSet.getGavToTypes().containsKey(oldGavKey)) {
-            // Old dependency not tracked. If gavToTypes is non-empty, other dependencies
-            // are being tracked but this one wasn't — nothing to change. If gavToTypes is
-            // empty, we're in initial population mode (first call on this source set).
-            if (!sourceSet.getGavToTypes().isEmpty() || sourceSet.getGavToTypes().containsKey(newGavKey)) {
-                return sourceSet;
-            }
-        }
-        sourceSet = sourceSet.removeTypesForGav(oldGavKey);
-        List<JavaType.FullyQualified> newTypes = downloadAndScanTypes(newDep);
-        if (!newTypes.isEmpty()) {
-            sourceSet = sourceSet.addTypesForGav(newGavKey, newTypes);
-        }
         return sourceSet;
     }
 
     /**
      * Update a JavaSourceSet to reflect a newly added dependency.
-     * Tries each repository in order until the JAR is successfully downloaded.
+     * Currently a no-op: JAR downloading is disabled while the classpath-update
+     * approach is being reconsidered.
      */
     public JavaSourceSet addDependency(JavaSourceSet sourceSet,
                                        String groupId, String artifactId, String version,
                                        List<MavenRepository> repositories) {
-        String key = groupId + ":" + artifactId + ":" + version;
-        if (sourceSet.getGavToTypes().containsKey(key)) {
-            return sourceSet;
-        }
-        ResolvedGroupArtifactVersion gav = new ResolvedGroupArtifactVersion(
-                null, groupId, artifactId, version, null);
-        Dependency requested = Dependency.builder()
-                .gav(new GroupArtifactVersion(groupId, artifactId, version))
-                .build();
-        for (MavenRepository repo : repositories) {
-            ResolvedDependency dep = ResolvedDependency.builder()
-                    .gav(gav)
-                    .repository(repo)
-                    .requested(requested)
-                    .build();
-            List<JavaType.FullyQualified> newTypes = downloadAndScanTypes(dep);
-            if (!newTypes.isEmpty()) {
-                return sourceSet.addTypesForGav(key, newTypes);
-            }
-        }
         return sourceSet;
     }
 
     private List<JavaType.FullyQualified> downloadAndScanTypes(ResolvedDependency dep) {
-        String key = gavKey(dep);
-        List<JavaType.FullyQualified> cached = typeCache.get(key);
-        if (cached != null) {
-            return cached;
-        }
-        try {
-            Path jarPath = downloader.downloadArtifact(dep);
-            if (jarPath == null) {
-                return Collections.emptyList();
-            }
-            List<JavaType.FullyQualified> types = JavaSourceSet.typesFromPath(jarPath, null);
-            // Only cache positive results: addDependency tries each repository in order until
-            // one succeeds, so caching an empty result would short-circuit later repos.
-            if (!types.isEmpty()) {
-                typeCache.put(key, types);
-            }
-            return types;
-        } catch (Exception e) {
-            // Graceful degradation: if download fails, return empty list
-            return Collections.emptyList();
-        }
+        return Collections.emptyList();
     }
 
     private static String gavKey(ResolvedDependency dep) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -3545,6 +3545,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
         );
     }
 
+    @Disabled("JavaSourceSetUpdater JAR download is currently disabled; classpath is no longer mutated mid-run")
     @Test
     void updatesJavaSourceSetMarkerOnJavaFiles() {
         rewriteRun(
@@ -3722,6 +3723,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
         );
     }
 
+    @Disabled("JavaSourceSetUpdater JAR download is currently disabled; classpath is no longer mutated mid-run")
     @Test
     void composedWithChangePackageUpdatesImports() {
         rewriteRun(


### PR DESCRIPTION
Short-circuits `JavaSourceSetUpdater.changeDependency` and `addDependency` to return the source set unchanged, and makes `downloadAndScanTypes` return an empty list. This prevents `MavenArtifactDownloader` from being invoked during dependency-mutation recipes (`AddDependency`, `UpgradeDependencyVersion`, `ChangeDependencyGroupIdAndArtifactId` on Maven; `AddDependency`, `UpgradeDependencyVersion`, `ChangeDependency` on Gradle).

## Motivation

- The JAR-download path introduced in #7202 (and refined by #7358/#7373/#7376/#7454) fetches the newly-added/changed dependency's JAR on every visitor invocation so that `JavaSourceSet` can be updated in place. In high-volume migrations (e.g. Spring Boot 4, where a single run performs ~30–90 dependency mutations per repo), this produces a large volume of outbound artifact requests — even with the shared cache added in #7454, each distinct GAV still has to be fetched once.

- This change disables that download path entirely while we reconsider the approach. `JavaSourceSet` reverts to the pre-#7202 behavior of reflecting only the parse-time classpath.

## Behavior change

- Dependency-mutation recipes no longer update `JavaSourceSet` with types from new/changed dependencies.
- Downstream recipes that read `JavaSourceSet` (e.g. `ChangePackage` star-import disambiguation) observe the pre-mutation classpath only.
- No network calls are made from `JavaSourceSetUpdater`.

## Tests

Two tests in [`ChangeDependencyGroupIdAndArtifactIdTest`](https://github.com/openrewrite/rewrite/blob/main/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java) are `@Disabled` because they asserted on the classpath mutation performed by the download path:

- `updatesJavaSourceSetMarkerOnJavaFiles`
- `composedWithChangePackageUpdatesImports`

All other tests in `:rewrite-maven` pass unchanged, including:
- `JavaSourceSetUpdaterTest.typeCacheIsSharedAcrossUpdaters` (checks cache sharing, not downloads)
- `javaSourceSetUnchangedWhenModuleDoesNotHaveDependency` (negative assertion)
- the graceful-failure test for a missing artifact

No Gradle tests reference `JavaSourceSet` / `gavToTypes` on the affected recipes, so nothing to disable there.