### PR TITLE
Skip `META-INF/` entries in classpath scanner

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
@@ -419,7 +419,7 @@ public class JavaSourceSet implements SourceSet {
                     Enumeration<JarEntry> entries = jarFile.entries();
                     while (entries.hasMoreElements()) {
                         String entryName = entries.nextElement().getName();
-                        if (entryName.endsWith(".class")) {
+                        if (entryName.endsWith(".class") && !isMetaInfEntry(entryName)) {
                             String s = entryNameToClassName(entryName);
                             if (isDeclarable(s)) {
                                 types.add(JavaType.ShallowClass.build(s));
@@ -433,6 +433,9 @@ public class JavaSourceSet implements SourceSet {
                     public java.nio.file.FileVisitResult visitFile(Path file, java.nio.file.attribute.BasicFileAttributes attrs) {
                         if (file.getFileName().toString().endsWith(".class")) {
                             String pathStr = file.isAbsolute() ? path.relativize(file).toString() : file.toString();
+                            if (isMetaInfEntry(pathStr)) {
+                                return java.nio.file.FileVisitResult.CONTINUE;
+                            }
                             String s = entryNameToClassName(pathStr);
                             if ((acceptPackage == null || s.startsWith(acceptPackage)) && isDeclarable(s)) {
                                 types.add(JavaType.ShallowClass.build(s));
@@ -446,6 +449,17 @@ public class JavaSourceSet implements SourceSet {
             // Partial results better than no results
         }
         return types;
+    }
+
+    /**
+     * Per the JAR specification {@code META-INF/} is reserved for metadata (manifests, services, multi-release
+     * versioned entries, etc.) and never contains application classes. Any {@code .class} file under this directory
+     * would otherwise yield an FQN like {@code META-INF.versions.9.foo.Bar} that collides with the base-path entry in
+     * downstream consumers that dedupe by FQN.
+     */
+    static boolean isMetaInfEntry(String entryName) {
+        String normalized = entryName.replace('\\', '/');
+        return normalized.startsWith("META-INF/");
     }
 
     private static List<JavaType.FullyQualified> getJavaStandardLibraryTypes() {

--- a/rewrite-java/src/test/java/org/openrewrite/java/marker/JavaSourceSetTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/marker/JavaSourceSetTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.marker;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.java.tree.JavaType;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JavaSourceSetTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void skipsMetaInfEntriesInJar() throws Exception {
+        Path jarFile = tempDir.resolve("multi-release.jar");
+        byte[] dummyClassBytes = new byte[]{(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE};
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarFile))) {
+            writeEntry(jos, "net/bytebuddy/asm/Advice.class", dummyClassBytes);
+            writeEntry(jos, "META-INF/versions/9/net/bytebuddy/asm/Advice.class", dummyClassBytes);
+            writeEntry(jos, "META-INF/versions/11/net/bytebuddy/asm/Advice.class", dummyClassBytes);
+            writeEntry(jos, "META-INF/some/Stray.class", dummyClassBytes);
+        }
+
+        List<JavaType.FullyQualified> types = JavaSourceSet.typesFromPath(jarFile, null);
+
+        assertThat(types)
+          .extracting(JavaType.FullyQualified::getFullyQualifiedName)
+          .containsExactly("net.bytebuddy.asm.Advice");
+    }
+
+    @Test
+    void skipsMetaInfEntriesUnderDirectoryClasspath() throws Exception {
+        byte[] dummyClassBytes = new byte[]{(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE};
+        Files.createDirectories(tempDir.resolve("net/bytebuddy/asm"));
+        Files.write(tempDir.resolve("net/bytebuddy/asm/Advice.class"), dummyClassBytes);
+        Files.createDirectories(tempDir.resolve("META-INF/versions/9/net/bytebuddy/asm"));
+        Files.write(tempDir.resolve("META-INF/versions/9/net/bytebuddy/asm/Advice.class"), dummyClassBytes);
+
+        List<JavaType.FullyQualified> types = JavaSourceSet.typesFromPath(tempDir, null);
+
+        assertThat(types)
+          .extracting(JavaType.FullyQualified::getFullyQualifiedName)
+          .containsExactly("net.bytebuddy.asm.Advice");
+    }
+
+    private static void writeEntry(JarOutputStream jos, String name, byte[] content) throws java.io.IOException {
+        JarEntry entry = new JarEntry(name);
+        jos.putNextEntry(entry);
+        jos.write(content);
+        jos.closeEntry();
+    }
+}


### PR DESCRIPTION
## Motivation

`JavaSourceSet`'s classpath scanner emits a `JavaType.ShallowClass` for every `.class` file it finds in a JAR or classes directory, including multi-release JAR duplicates shipped under `META-INF/versions/N/`. For any class present in an MRJ, this produces two distinct FQNs — e.g. `net.bytebuddy.asm.Advice` and `META-INF.versions.9.net.bytebuddy.asm.Advice` — that downstream consumers deduping types by FQN string cannot merge.

Measured on the openrewrite/rewrite build, the top of a type-table histogram shows pairs with identical counts, one MRJ-versioned and one not:

```
8053  ShallowClass  META-INF.versions.9.net.bytebuddy.asm.Advice
8053  ShallowClass  net.bytebuddy.asm.Advice
6859  ShallowClass  net.bytebuddy.agent.builder.AgentBuilder
6859  ShallowClass  META-INF.versions.9.net.bytebuddy.agent.builder.AgentBuilder
...
```

Each visible pair is ~8-16k entries that should collapse into one. Five such pairs appear in the top 30 alone, with more in the long tail, contributing to `meta.bin` bloat in serialized LST stores.

The classloader is responsible for interpreting MRJ layout at load time; a static classpath scan should never surface the versioned duplicates as distinct types.

## Summary

- `JavaSourceSet.typesFromPath` now skips any `.class` entry whose path starts with `META-INF/` (both the JAR and directory-walk paths). Per the JAR spec that directory is reserved for metadata and never contains application classes, so broadening beyond just `META-INF/versions/N/` costs nothing and also filters any stray tooling artifacts.
- Adds `JavaSourceSetTest` covering a JAR with base + versioned + stray `META-INF/` entries, and the equivalent directory-tree layout.

## Test plan

- [x] New `JavaSourceSetTest` fails before the fix and passes after
- [x] `./gradlew :rewrite-java:test` green
- [x] `./gradlew :rewrite-java-test:test` green
- [x] `./gradlew :rewrite-java:licenseFormat` clean