### PR TITLE
Scala: public canonical ctors for `S.TuplePattern` and `S.FunctionCall`

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -299,6 +299,7 @@ public interface S extends J {
      */
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     @Data
     final class TuplePattern implements S, Expression, TypedTree, VariableDeclarator {
@@ -687,6 +688,7 @@ public interface S extends J {
      */
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     final class FunctionCall implements S, Expression, Statement, TypedTree {
 


### PR DESCRIPTION
## Motivation

`S.TuplePattern` and `S.FunctionCall` previously exposed only a **private** `@AllArgsConstructor`-generated canonical constructor whose first parameter is the padding `WeakReference`.

## Summary

- Added `@RequiredArgsConstructor` to `S.TuplePattern` and `S.FunctionCall`, alongside the existing `@AllArgsConstructor(access = AccessLevel.PRIVATE)`.
- Because the `padding` field is `@NonFinal`, `@RequiredArgsConstructor` excludes it — generating a **public** canonical constructor that omits the `WeakReference`, exactly matching the pattern used by `S.CompilationUnit` in the same file and by rewrite-java types such as `J.MethodInvocation`.
- The private padding-aware constructor is retained for internal use.
- Audited the rest of the `org.openrewrite.scala.tree.*` package: the remaining 6 final tree classes (`CompilationUnit`, `Wildcard`, `StatementExpression`, `TypeAscription`, `TypeAlias`, `PatternDefinition`) already have a public canonical constructor — either via `@RequiredArgsConstructor` or hand-written — so no further changes are needed.

## Test plan

- [x] `./gradlew :rewrite-scala:compileJava` succeeds.