### PR TITLE
Fix print idempotency for Javadoc `<pre><code>` blocks on Java 25

### DIFF
--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25JavadocVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25JavadocVisitor.java
@@ -1055,6 +1055,19 @@ public class ReloadableJava25JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         StringBuilder text = new StringBuilder();
         for (int i = 0; i < node.length(); i++) {
             char c = node.charAt(i);
+            // Java 25's AST may strip leading line breaks from text nodes (e.g. after `<pre><code>`).
+            // If source has a newline here that's missing from the node, emit a LineBreak first.
+            while (c != '\n' && cursor < source.length() && source.charAt(cursor) == '\n') {
+                if (text.length() > 0) {
+                    texts.add(new Javadoc.Text(randomId(), Markers.EMPTY, text.toString()));
+                    text = new StringBuilder();
+                }
+                cursor++;
+                Javadoc.LineBreak lineBreak = lineBreaks.remove(cursor);
+                if (lineBreak != null) {
+                    texts.add(lineBreak);
+                }
+            }
             if (c == '\n') {
                 if (text.length() > 0) {
                     texts.add(new Javadoc.Text(randomId(), Markers.EMPTY, text.toString()));

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
@@ -1544,6 +1544,89 @@ class JavadocTest implements RewriteTest {
         );
     }
 
+    @Test
+    void preCodeBlockWithNewlineAfterOpeningTag() {
+        rewriteRun(
+          java(
+            """
+              /**
+               * <p>Example:
+               *
+               * <pre><code>
+               *   class Outer {
+               *     static class Inner {
+               *     }
+               *   }
+               * </code></pre>
+               */
+              public @interface Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preCodeBlockTwoInstances() {
+        rewriteRun(
+          java(
+            """
+              /**
+               * <pre><code>
+               *   first block
+               * </code></pre>
+               *
+               * <pre><code>
+               *   second block
+               * </code></pre>
+               */
+              public @interface Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preCodeBlockWithInlineLiteralTag() {
+        rewriteRun(
+          java(
+            """
+              /**
+               * Defines a Hilt component.
+               *
+               * <p>Example defining a root component, {@code ParentComponent}:
+               *
+               * <pre><code>
+               *   {@literal @}ParentScoped
+               *   {@literal @}DefineComponent
+               *   interface ParentComponent {}
+               * </code></pre>
+               */
+              public @interface Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preCodeBlockSameLineAsText() {
+        rewriteRun(
+          java(
+            """
+              /**
+               * Some text <pre><code>
+               *   content
+               * </code></pre>
+               */
+              public @interface Test {
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/1409")
     @Test
     void trailingWhitespaceWithWhitespaceOnEmptyLine() {


### PR DESCRIPTION
## Motivation

Parsing Javadoc comments containing `<pre><code>` blocks with a newline after the opening tag failed the parser's print idempotency check on Java 25 (but not on Java 8/11/17/21). This surfaced against Google Dagger in a Moderne CLI run — 18 Java files in `google/dagger` failed to parse with `IllegalStateException: ... is not print idempotent`, all of them Javadoc comments in the common style:

```java
/**
 * <pre><code>
 *   class Outer {
 *     static class Inner {}
 *   }
 * </code></pre>
 */
```

Root cause: Java 25's `DocCommentTree` strips leading whitespace (including newlines) from text nodes, so the raw source has `\n` characters that the `DCText` / `DCRawText` body does not. In `ReloadableJava25JavadocVisitor.visitText`, the `else` branch blindly advanced the cursor past these `\n` characters without emitting a corresponding `LineBreak`. The unconsumed `LineBreak` then got dumped at the end of the comment by the trailing-lineBreaks flush, producing a stray ` *` line before the closing `*/`.

## Summary

- `ReloadableJava25JavadocVisitor.visitText`: before processing each character from the text node, consume any `\n` in the source that is missing from the node and emit the corresponding `LineBreak`.
- Add four parser idempotency tests in `JavadocTest` covering variants of `<pre><code>` blocks (newline after opening tag, two consecutive blocks, blocks containing `{@literal}` inline tags, block starting on the same line as preceding text).

## Test plan

- [x] `./gradlew :rewrite-java-25:test :rewrite-java-25:compatibilityTest` — all green, including the four new `preCodeBlock*` tests
- [ ] CI across all Java versions