### PR TITLE
Add `Supplier<Path>` overloads to RPC builders for lazy tool-path resolution

### DIFF
--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -184,7 +184,8 @@ public class CSharpRewriteRpc extends RewriteRpc {
         private RecipeMarketplace marketplace = new RecipeMarketplace();
         private List<RecipeBundleResolver> resolvers = new ArrayList<>();
         private final Map<String, String> environment = new HashMap<>();
-        private Path dotnetPath = Paths.get("dotnet");
+        private static final Path DEFAULT_DOTNET_PATH = Paths.get("dotnet");
+        private Supplier<@Nullable Path> dotnetPathSupplier = () -> DEFAULT_DOTNET_PATH;
         private @Nullable Path csharpServerEntry;
         private @Nullable Path log;
         private Duration timeout = Duration.ofSeconds(60);
@@ -214,7 +215,20 @@ public class CSharpRewriteRpc extends RewriteRpc {
          * @return This builder
          */
         public Builder dotnetPath(Path dotnetPath) {
-            this.dotnetPath = dotnetPath;
+            return dotnetPath(() -> dotnetPath);
+        }
+
+        /**
+         * Supplies the path to the dotnet executable. The supplier is invoked at most
+         * once, when the RPC is first started. Returning {@code null} uses the built-in
+         * default (same as not configuring the path at all). Exceptions thrown by the
+         * supplier propagate out of the RPC-start call.
+         *
+         * @param dotnetPathSupplier Supplier for the path to the dotnet executable
+         * @return This builder
+         */
+        public Builder dotnetPath(Supplier<@Nullable Path> dotnetPathSupplier) {
+            this.dotnetPathSupplier = dotnetPathSupplier;
             return this;
         }
 
@@ -280,12 +294,17 @@ public class CSharpRewriteRpc extends RewriteRpc {
 
         @Override
         public CSharpRewriteRpc get() {
+            Path dotnetPath = dotnetPathSupplier.get();
+            if (dotnetPath == null) {
+                dotnetPath = DEFAULT_DOTNET_PATH;
+            }
+
             Stream<@Nullable String> cmd;
 
             if (csharpServerEntry != null) {
                 // Explicit override (used by tests)
                 if (csharpServerEntry.toString().endsWith(".csproj")) {
-                    cmd = buildCsprojCommand(csharpServerEntry);
+                    cmd = buildCsprojCommand(dotnetPath, csharpServerEntry);
                 } else {
                     cmd = Stream.of(
                             dotnetPath.toString(),
@@ -299,7 +318,7 @@ public class CSharpRewriteRpc extends RewriteRpc {
                 // dotnet tool exec which has auth issues with private feeds (dotnet/sdk#51375)
                 String version = StringUtils.readFully(
                         CSharpRewriteRpc.class.getResourceAsStream("/META-INF/rewrite-csharp-version.txt")).trim();
-                cmd = buildToolPathCommand(version);
+                cmd = buildToolPathCommand(dotnetPath, version);
             }
 
             return startProcess(cmd);
@@ -341,7 +360,7 @@ public class CSharpRewriteRpc extends RewriteRpc {
             }
         }
 
-        private Stream<@Nullable String> buildCsprojCommand(Path csproj) {
+        private Stream<@Nullable String> buildCsprojCommand(Path dotnetPath, Path csproj) {
             return Stream.of(
                     dotnetPath.toString(),
                     "run",
@@ -362,13 +381,13 @@ public class CSharpRewriteRpc extends RewriteRpc {
          * correctly. The tool-path is version-specific so multiple versions can coexist
          * without file-lock conflicts during parallel execution.
          */
-        private Stream<@Nullable String> buildToolPathCommand(String version) {
+        private Stream<@Nullable String> buildToolPathCommand(Path dotnetPath, String version) {
             Path toolPath = Paths.get(System.getProperty("user.home"),
                     ".dotnet", "rewrite-tools", version);
             Path toolExecutable = toolPath.resolve(TOOL_COMMAND);
 
             if (!Files.isRegularFile(toolExecutable)) {
-                installTool(version, toolPath);
+                installTool(dotnetPath, version, toolPath);
             }
 
             return Stream.of(
@@ -378,7 +397,7 @@ public class CSharpRewriteRpc extends RewriteRpc {
             );
         }
 
-        private void installTool(String version, Path toolPath) {
+        private void installTool(Path dotnetPath, String version, Path toolPath) {
             try {
                 Files.createDirectories(toolPath);
 

--- a/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
@@ -123,7 +123,7 @@ public class GoRewriteRpc extends RewriteRpc {
     public static class Builder implements Supplier<GoRewriteRpc> {
         private RecipeMarketplace marketplace = new RecipeMarketplace();
         private List<RecipeBundleResolver> resolvers = Collections.emptyList();
-        private @Nullable Path goBinaryPath;
+        private Supplier<@Nullable Path> goBinaryPathSupplier = () -> null;
         private Duration timeout = Duration.ofSeconds(60);
         private @Nullable Path log;
         private boolean traceRpcMessages;
@@ -139,7 +139,20 @@ public class GoRewriteRpc extends RewriteRpc {
         }
 
         public Builder goBinaryPath(Path path) {
-            this.goBinaryPath = path;
+            return goBinaryPath(() -> path);
+        }
+
+        /**
+         * Supplies the path to the Go RPC binary. The supplier is invoked at most
+         * once, when the RPC is first started. Returning {@code null} uses the built-in
+         * fallback discovery (same as not configuring the path at all). Exceptions
+         * thrown by the supplier propagate out of the RPC-start call.
+         *
+         * @param goBinaryPathSupplier Supplier for the path to the Go RPC binary
+         * @return This builder
+         */
+        public Builder goBinaryPath(Supplier<@Nullable Path> goBinaryPathSupplier) {
+            this.goBinaryPathSupplier = goBinaryPathSupplier;
             return this;
         }
 
@@ -160,6 +173,7 @@ public class GoRewriteRpc extends RewriteRpc {
 
         @Override
         public GoRewriteRpc get() {
+            @Nullable Path goBinaryPath = goBinaryPathSupplier.get();
             String binaryPath;
             if (goBinaryPath != null) {
                 binaryPath = goBinaryPath.toString();

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -252,7 +252,8 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
         private RecipeMarketplace marketplace = new RecipeMarketplace();
         private List<RecipeBundleResolver> resolvers = Collections.emptyList();
         private final Map<String, String> environment = new HashMap<>();
-        private Path npxPath = System.getProperty("os.name").toLowerCase().contains("windows") ? Paths.get("npx.cmd") : Paths.get("npx");
+        private static final Path DEFAULT_NPX_PATH = System.getProperty("os.name").toLowerCase().contains("windows") ? Paths.get("npx.cmd") : Paths.get("npx");
+        private Supplier<@Nullable Path> npxPathSupplier = () -> DEFAULT_NPX_PATH;
         private @Nullable Path log;
         private @Nullable Path metricsCsv;
         private @Nullable Path recipeInstallDir;
@@ -289,7 +290,20 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
             if (Files.notExists(npxPath) || Files.isDirectory(npxPath)) {
                 throw new IllegalArgumentException("Invalid npx executable " + npxPath.toAbsolutePath().normalize());
             }
-            this.npxPath = npxPath;
+            return npxPath(() -> npxPath);
+        }
+
+        /**
+         * Supplies the path to the `npx` executable. The supplier is invoked at most
+         * once, when the RPC is first started. Returning {@code null} uses the built-in
+         * default (same as not configuring the path at all). Exceptions thrown by the
+         * supplier propagate out of the RPC-start call.
+         *
+         * @param npxPathSupplier Supplier for the path to the `npx` executable
+         * @return This builder
+         */
+        public Builder npxPath(Supplier<@Nullable Path> npxPathSupplier) {
+            this.npxPathSupplier = npxPathSupplier;
             return this;
         }
 
@@ -365,6 +379,11 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
 
         @Override
         public JavaScriptRewriteRpc get() {
+            Path npxPath = npxPathSupplier.get();
+            if (npxPath == null) {
+                npxPath = DEFAULT_NPX_PATH;
+            }
+
             DynamicDispatchRpcCodec.requireCodecFor(Json.Document.class.getName());
 
             Stream<@Nullable String> cmd;

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -365,7 +365,7 @@ public class PythonRewriteRpc extends RewriteRpc {
         private List<RecipeBundleResolver> resolvers = Collections.emptyList();
         private final Map<String, String> environment = new HashMap<>();
         // Default to looking for a venv python, falling back to system python
-        private Path pythonPath = findDefaultPythonPath();
+        private Supplier<@Nullable Path> pythonPathSupplier = Builder::findDefaultPythonPath;
         private @Nullable Path log;
         private @Nullable Path pipPackagesPath;
         private @Nullable Path recipeInstallDir;
@@ -421,7 +421,20 @@ public class PythonRewriteRpc extends RewriteRpc {
          * @return This builder
          */
         public Builder pythonPath(Path pythonPath) {
-            this.pythonPath = pythonPath;
+            return pythonPath(() -> pythonPath);
+        }
+
+        /**
+         * Supplies the path to the Python executable. The supplier is invoked at most
+         * once, when the RPC is first started. Returning {@code null} uses the built-in
+         * default (same as not configuring the path at all). Exceptions thrown by the
+         * supplier propagate out of the RPC-start call.
+         *
+         * @param pythonPathSupplier Supplier for the path to the Python executable
+         * @return This builder
+         */
+        public Builder pythonPath(Supplier<@Nullable Path> pythonPathSupplier) {
+            this.pythonPathSupplier = pythonPathSupplier;
             return this;
         }
 
@@ -526,6 +539,11 @@ public class PythonRewriteRpc extends RewriteRpc {
 
         @Override
         public PythonRewriteRpc get() {
+            Path pythonPath = pythonPathSupplier.get();
+            if (pythonPath == null) {
+                pythonPath = findDefaultPythonPath();
+            }
+
             String version = StringUtils.readFully(
                     PythonRewriteRpc.class.getResourceAsStream("/META-INF/rewrite-python-version.txt")).trim();
             boolean isDevBuild = version.isEmpty() || version.endsWith(".dev0") || "unspecified".equals(version);
@@ -540,7 +558,7 @@ public class PythonRewriteRpc extends RewriteRpc {
                     // Interpreter already has the right version; nothing to do
                 } else if (pipPackagesPath != null) {
                     resolvedPipPackagesPath = pipPackagesPath.resolve(version);
-                    bootstrapOpenrewrite(resolvedPipPackagesPath, version);
+                    bootstrapOpenrewrite(pythonPath, resolvedPipPackagesPath, version);
                 } else if (canImportRewrite(pythonPath)) {
                     // Interpreter has a different version, but no pipPackagesPath to
                     // install the right one — proceed with what's available (e.g., CI
@@ -707,7 +725,7 @@ public class PythonRewriteRpc extends RewriteRpc {
         /**
          * Installs the pinned openrewrite package into the given pip packages directory.
          */
-        private void bootstrapOpenrewrite(Path pipPackagesPath, String version) {
+        private void bootstrapOpenrewrite(Path pythonPath, Path pipPackagesPath, String version) {
             try {
                 Files.createDirectories(pipPackagesPath);
 


### PR DESCRIPTION
## Motivation

The Moderne CLI's `mod run` command eagerly resolves `npx`, `python`, and `dotnet` executable paths before every partition's recipe execution, even when the recipe never spawns the corresponding RPC. On a profiled run, `NodeInstallation.forRepository()` costs ~860ms, `PythonInstallation.findGlobalPythonInstallation()` ~450ms, and `DotNetInstallation.findGlobalDotNetInstallation()` ~390ms per partition — all subprocess-heavy probes (`node --version`, `python --version`, filesystem scans for nvm/fnm/volta/homebrew installs).

The CLI has to resolve eagerly today because the RPC builders accept `Path`, so the Path must be computed before calling `.npxPath(Path)` / `.pythonPath(Path)` / `.dotnetPath(Path)` / `.goBinaryPath(Path)`. Deferring resolution to the point where the RPC actually starts means that if no recipe triggers the corresponding RPC, the subprocess probe never runs.

## Examples

```java
JavaScriptRewriteRpc rpc = JavaScriptRewriteRpc.builder()
        .npxPath(() -> {
            NodeInstallation node = NodeInstallation.forRepository(repo);
            return node != null ? node.getNpx() : null;
        })
        .get();
```

`NodeInstallation.forRepository(repo)` runs only when the RPC is actually started. If no recipe triggers the JS RPC, the supplier is never invoked and the ~860ms probe is skipped entirely.

Same pattern applies to the other three builders:

```java
PythonRewriteRpc.builder().pythonPath(() -> PythonInstallation.findGlobalPythonInstallation()).get();
CSharpRewriteRpc.builder().dotnetPath(() -> DotNetInstallation.findGlobalDotNetInstallation()).get();
GoRewriteRpc.builder().goBinaryPath(() -> GoInstallation.discover()).get();
```

A supplier returning `null` behaves exactly as if the setter were never called — the builder's built-in default takes over (`npx` / `findDefaultPythonPath()` / `dotnet` / Go's fallback discovery).

## Summary

- Added `npxPath(Supplier<@Nullable Path>)` to `JavaScriptRewriteRpc.Builder`.
- Added `pythonPath(Supplier<@Nullable Path>)` to `PythonRewriteRpc.Builder`.
- Added `dotnetPath(Supplier<@Nullable Path>)` to `CSharpRewriteRpc.Builder`.
- Added `goBinaryPath(Supplier<@Nullable Path>)` to `GoRewriteRpc.Builder`.
- Existing eager `Path` overloads preserved on all four builders — implemented as pass-throughs to the new Supplier overloads. JavaScript's pre-existing `Files.notExists`/`isDirectory` validation is retained on the eager overload.
- Supplier is invoked at most once per `Builder.get()` call (read into a local at the top of the method). No cross-invocation memoization on our side — callers wrap their own supplier if they need it.
- Supplier exceptions propagate at RPC-start time, consistent with other startup failures. Documented in Javadoc on each new overload.

## Test plan

- [x] `./gradlew :rewrite-javascript:test` passes
- [x] `./gradlew :rewrite-python:test` passes
- [x] `./gradlew :rewrite-csharp:test` passes
- [x] `./gradlew :rewrite-go:test` passes
- [x] `./gradlew licenseFormat` is a no-op (existing files, headers unchanged)

No new tests added — the change is mechanical (field replacement + pass-through). Existing eager-`Path` tests exercise the new Supplier code path transparently via the pass-through.

## Follow-up

Once released, moderne-cli will migrate in a separate PR to pass lazy suppliers from `io.moderne.cli.commands.Run#visitPartition`, which is where the ~1.7s/partition cost lives today.