### PR TITLE
Fix YAML print idempotency for asterisk placeholders inside block scalars

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -345,9 +345,14 @@ public class YamlParser implements org.openrewrite.Parser {
                                 scalarValue = scalarValue.replace(entry.getKey(), entry.getValue());
                             }
                         }
-                        // Then check for variable UUIDs (these are exact matches)
-                        if (variableByUuid.containsKey(scalarValue)) {
-                            scalarValue = variableByUuid.get(scalarValue);
+                        // Then restore any variable/asterisk placeholder UUIDs. The UUID may be
+                        // the entire scalar value (e.g. `key: @var@`) or embedded within a longer
+                        // scalar (e.g. markdown bold text inside a block scalar that happened to
+                        // match the asterisk placeholder regex).
+                        for (Map.Entry<String, String> entry : variableByUuid.entrySet()) {
+                            if (scalarValue.contains(entry.getKey())) {
+                                scalarValue = scalarValue.replace(entry.getKey(), entry.getValue());
+                            }
                         }
 
                         Yaml.Scalar.Style style;

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -267,6 +267,25 @@ class YamlParserTest implements RewriteTest {
     }
 
     @Test
+    void asteriskPatternInsideBlockScalar() {
+        // Markdown bold text inside a literal block scalar must not be mangled
+        // by the asterisk placeholder preprocessing.
+        rewriteRun(
+          yaml(
+            """
+              jobs:
+                alert:
+                  steps:
+                    - name: Post alert
+                      run: |
+                        echo ":rotating_light: **CI Alert**: repo has been failing for **5 days**"
+                        echo "- **Branch:** main"
+              """
+          )
+        );
+    }
+
+    @Test
     void pipeLiteralInASequenceWithDoubleQuotes() {
         rewriteRun(
           yaml(


### PR DESCRIPTION
## Motivation

- The YAML parser pre-processes credential placeholders like `password: *** REMOVED ***` by swapping the captured text with a UUID before parsing (so SnakeYAML doesn't misread the asterisks as alias references), then restoring it afterward (introduced in #6626). The asterisk regex `:\s+(\*{2,}[^\n\r]*)` unintentionally matches markdown bold text inside multi-line block scalars when a colon-plus-space precedes it (for example `:rotating_light: **CI Alert**: ...` inside a GitHub Actions `run: |` script).

When that happens, the UUID ends up *embedded within* a long multi-line scalar value. The restoration logic on the scalar path used exact-match (`Map.containsKey(scalarValue)`), so it never restored the UUID and the parser reported a print-idempotency failure. This breaks parsing of otherwise valid YAML such as `spring-projects/spring-ai`'s `.github/workflows/dependency-ci-dashboard.yml`.

Tightening the regex wouldn't help: credential placeholders (`**REDACTED**`) and markdown bold (`**CI Alert**`) are indistinguishable without parsing YAML structure. The fix belongs at the restoration layer.

## Summary

- Replace the exact-match `containsKey(scalarValue)` check with a `contains` / `replace` loop, matching how the helm-template and single-brace-template restorations already work on the same code path.
- Add a regression test with markdown bold text inside a `|` block scalar, mirroring the failing case in the wild.

UUIDs are random per-parse and produced only by the parser, so substring replacement is unambiguous.

## Test plan

- [x] New `YamlParserTest.asteriskPatternInsideBlockScalar` reproduces the failure on `main` and passes after the fix.
- [x] Existing `YamlParserTest` suite continues to pass (including `asteriskPlaceholders` and `asteriskPlaceholdersWithAnchors`).
- [x] Full `:rewrite-yaml:test` passes.