### PR TITLE
Fix Kotlin parser handling of unresolved callable references

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleParserTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleParserTest.java
@@ -276,6 +276,17 @@ class GradleParserTest implements RewriteTest {
     }
 
     @Test
+    void kotlinDslWithUnresolvedCallableReference() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              kotlin { jvmToolchain { languageVersion.set(libs.versions.jdk.map(JavaLanguageVersion::of)) } }
+              """
+          )
+        );
+    }
+
+    @Test
     void escapedAndNonEscapedDollarSignsInSingleDoubleQuotes() {
         var gradleParser = new GradleParser(new GradleParser.Builder());
         Stream<SourceFile> sourceFileStream = gradleParser.parseInputs(List.of(Parser.Input.fromString("""

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -269,13 +269,14 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
 
     @Override
     public J visitCallableReferenceExpression(KtCallableReferenceExpression expression, ExecutionContext data) {
-        FirElement firElement = psiElementAssociations.primary(expression.getCallableReference());
-        if (!(firElement instanceof FirResolvedCallableReference || firElement instanceof FirCallableReferenceAccess)) {
+        FirElement exprFir = psiElementAssociations.primary(expression);
+        if (!(exprFir instanceof FirCallableReferenceAccess)) {
             throw new UnsupportedOperationException(java.lang.String.format("Unsupported callable reference: fir class: %s, fir: %s, psi class: %s.",
-                    firElement == null ? "null" : firElement.getClass().getName(),
-                    PsiTreePrinter.print(psiElementAssociations.primary(expression)),
+                    exprFir == null ? "null" : exprFir.getClass().getName(),
+                    PsiTreePrinter.print(exprFir),
                     expression.getClass().getName()));
         }
+        FirElement firElement = psiElementAssociations.primary(expression.getCallableReference());
         JavaType.Method methodReferenceType = null;
         JavaType.Variable fieldReferenceType = null;
         if (firElement instanceof FirResolvedCallableReference) {

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/CompilationUnitTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/CompilationUnitTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
+import static org.openrewrite.kotlin.Assertions.kotlinScript;
 
 class CompilationUnitTest implements RewriteTest {
 
@@ -65,6 +66,18 @@ class CompilationUnitTest implements RewriteTest {
               // C2
               """,
             SourceSpec::noTrim
+          )
+        );
+    }
+
+    @Test
+    void unresolvedCallableReference() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(org.openrewrite.test.TypeValidation.none()),
+          kotlinScript(
+            """
+              kotlin { jvmToolchain { languageVersion.set(libs.versions.jdk.map(JavaLanguageVersion::of)) } }
+              """
           )
         );
     }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/MemberReferenceTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/MemberReferenceTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.kotlin.tree;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
@@ -142,7 +141,6 @@ class MemberReferenceTest implements RewriteTest {
         );
     }
 
-    @Disabled("K2 produces J.Unknown for unresolved callable references (::unresolved)")
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/386")
     @Test
     void firCallableReferenceAccess() {


### PR DESCRIPTION
## Motivation

Parsing the `buildSrc/build.gradle.kts` file from the `google/dagger` repo fails with a print idempotency error:

```
java.lang.IllegalStateException: buildSrc/build.gradle.kts is not print idempotent.
diff --git a/buildSrc/build.gradle.kts b/buildSrc/build.gradle.kts
@@ -28,3 +28,4 @@
 lint {
   baseline = file("lint-baseline.xml")
 }
+
```

The root cause is `KotlinTreeParserVisitor#visitCallableReferenceExpression`. It was checking the FIR mapping of the callable reference's right-hand-side name (`expression.getCallableReference()`). When the receiver type is unresolved — e.g. `JavaLanguageVersion::of` in a `.gradle.kts` parsed without the full Gradle classpath — the RHS maps to `FirErrorNamedReferenceImpl`, even though the whole expression still maps cleanly to `FirCallableReferenceAccess`. The visitor threw, the whole `KtScript` declaration bubbled up into `J.Unknown`, and the `J.Unknown` PSI text range (which included the trailing `\n`) then got duplicated against the file-level EOF space — producing the extra blank line on print.

## Summary

- `KotlinTreeParserVisitor#visitCallableReferenceExpression` now validates the *expression-level* FIR (`FirCallableReferenceAccess`) rather than the RHS-name FIR, and uses the RHS FIR only for optional type resolution; types remain `null` when the reference is unresolved, consistent with other unresolved-type paths.
- Re-enables the previously `@Disabled` `MemberReferenceTest#firCallableReferenceAccess` regression test.
- Adds `CompilationUnitTest#unresolvedCallableReference` (`.kts` path) and `GradleParserTest#kotlinDslWithUnresolvedCallableReference` (Gradle entry point) covering the reproduction.

## Test plan

- [x] `MemberReferenceTest#firCallableReferenceAccess` (re-enabled) passes
- [x] New `CompilationUnitTest#unresolvedCallableReference` passes
- [x] New `GradleParserTest#kotlinDslWithUnresolvedCallableReference` passes
- [x] Full `rewrite-kotlin` test suite passes
- [x] Full `rewrite-gradle` test suite passes