### PR TITLE
Fix GroovyParserVisitor cast dispatch for parenthesized expressions

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1482,8 +1482,10 @@ public class GroovyParserVisitor {
         @Override
         public void visitCastExpression(CastExpression cast) {
             queue.add(insideParentheses(cast, prefix -> {
-                // Might be looking at a Java-style cast "(type)object" or a groovy-style cast "object as type"
-                if (source.charAt(cursor) == '(') {
+                // Java-style cast "(type)object" vs groovy-style cast "object as type".
+                // Can't detect by looking at cursor character because the expression
+                // itself may start with '(' (e.g. "(foo as Bar).name as Set").
+                if (!cast.isCoerce()) {
                     skip("(");
                     return new J.TypeCast(randomId(), prefix, Markers.EMPTY,
                             new J.ControlParentheses<>(randomId(), EMPTY, Markers.EMPTY,

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/CastTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/CastTest.java
@@ -123,4 +123,15 @@ class CastTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void asStyleCastOfParenthesizedCast() {
+        rewriteRun(
+          groovy(
+            """
+              def x = (foo as Bar).name as Set
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Motivation

Parsing `javatests/artifacts/hilt-android/simple/earlyentrypoint/build.gradle` from the `google/dagger` repo fails with:

```
org.openrewrite.groovy.GroovyParsingException: Failed to parse ... at cursor position 1886.
... testImplementation 'com.google.~cursor~>truth:truth:1.0.1' ...
```

The reported cursor is a red herring — the actual offender is earlier in the file:

```groovy
def actualSrcs = (inputs.files as FileCollection).files.name as Set
```

`GroovyParserVisitor#visitCastExpression` distinguished Java-style `(Type) expr` from Groovy `as`-style `expr as Type` by peeking at `source.charAt(cursor)`: if the next character was `(`, assume Java-style. For the outer `... as Set` cast, the expression itself starts with `(`, so the parser took the Java-style branch, mis-parsed, and produced an LST that failed print idempotency. Downstream, this cascaded into later parse errors on unrelated single-quoted strings.

## Examples

Before: this would fail to parse.

```groovy
def x = (foo as Bar).name as Set
```

## Summary

- Use `CastExpression#isCoerce()` — the Groovy AST's authoritative flag for `as`-style coercion — rather than peeking at the source character.
- Adds `CastTest#asStyleCastOfParenthesizedCast` regression test.

## Test plan

- [x] New `CastTest#asStyleCastOfParenthesizedCast` passes
- [x] Existing `CastTest` cases still pass (Java-style, as-style, array casts, cast-and-invoke, parenthesized casts)
- [x] Full `rewrite-groovy` test suite passes
- [x] Full `rewrite-gradle` test suite passes
- [x] The original Dagger `build.gradle` now parses cleanly