### PR TITLE
Align ASM and Kotlin stdlib versions across modules

### DIFF
--- a/rewrite-core/build.gradle.kts
+++ b/rewrite-core/build.gradle.kts
@@ -6,6 +6,13 @@ dependencies {
     api("org.openrewrite.tools:jgit:latest.release")
     implementation("org.openrewrite.tools:java-object-diff:latest.release")
     implementation("io.quarkus.gizmo:gizmo:1.0.+")
+    // Align the four org.ow2.asm artifacts to one version everywhere; gizmo
+    // would otherwise pin -util/-tree/-analysis to 9.3 in modules that don't
+    // request them directly.
+    implementation("org.ow2.asm:asm:latest.release")
+    implementation("org.ow2.asm:asm-util:latest.release")
+    implementation("org.ow2.asm:asm-tree:latest.release")
+    implementation("org.ow2.asm:asm-analysis:latest.release")
     api("com.fasterxml.jackson.core:jackson-core")
     api("com.fasterxml.jackson.core:jackson-databind")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")

--- a/rewrite-gradle/build.gradle.kts
+++ b/rewrite-gradle/build.gradle.kts
@@ -60,6 +60,10 @@ dependencies {
     // No particular reason to hold back upgrading this beyond 3.x, but it takes some effort: https://github.com/openrewrite/rewrite/issues/5270
     compileOnly("com.gradle:develocity-gradle-plugin:3.+")
 
+    // Align kotlin-stdlib-jdk7/-jdk8/-common with kotlin-stdlib
+    // (mockwebserver 4.x would otherwise pin them to 1.9.10 transitively).
+    testImplementation(platform("org.jetbrains.kotlin:kotlin-bom:2.3.20"))
+
     testImplementation(project(":rewrite-test")) {
         // because gradle-api fatjars this implementation already
         exclude("ch.qos.logback", "logback-classic")

--- a/rewrite-kotlin/build.gradle.kts
+++ b/rewrite-kotlin/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
     kotlin("jvm") version "2.2.21"
 }
 
+// When bumping this version, also update the kotlin-bom platform version
+// in rewrite-gradle/build.gradle.kts and rewrite-maven/build.gradle.kts so
+// the kotlin-stdlib alignment stays in lockstep across modules.
 val kotlinVersion = "2.3.20"
 
 dependencies {
@@ -12,6 +15,10 @@ dependencies {
     compileOnly(project(":rewrite-test"))
 
     implementation(project(":rewrite-java"))
+
+    // Align kotlin-stdlib-jdk7/-jdk8/-common with kotlin-stdlib (clikt 3.5.0
+    // would otherwise drag the jdk7/jdk8/common artifacts back to 1.6.20).
+    testImplementation(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
 
     implementation(kotlin("compiler-embeddable", kotlinVersion))
     implementation(kotlin("reflect", kotlinVersion))

--- a/rewrite-maven/build.gradle.kts
+++ b/rewrite-maven/build.gradle.kts
@@ -35,6 +35,10 @@ dependencies {
 
     implementation("org.apache.commons:commons-text:latest.release")
 
+    // Align kotlin-stdlib-jdk7/-jdk8/-common with kotlin-stdlib
+    // (maven-resolver and friends would otherwise pull mixed 1.8.21/1.9.x stdlibs).
+    testImplementation(platform("org.jetbrains.kotlin:kotlin-bom:2.3.20"))
+
     testImplementation(project(":rewrite-test"))
 
     testImplementation("com.squareup.okhttp3:okhttp:4.+")


### PR DESCRIPTION
## Motivation

The classpath partition cache at `~/.rewrite/classpath/.partitions/` keys by exact GAV, so each distinct resolved version of an artifact produces its own partition file even when the underlying types are nearly identical. Surveying the cache showed several artifacts with multiple resolved versions purely from accidental drift in this multi-module build (no intentional cross-version testing). Two patterns drove most of the drift:

1. **ASM artifacts split between 9.3 and 9.9.1.** `io.quarkus.gizmo:gizmo:1.0.11.Final` (declared in `rewrite-core`) pins `asm-util`/`asm-tree`/`asm-analysis` to 9.3. `rewrite-java` requests `asm` and `asm-util` at `latest.release`, but as an `implementation` dependency that does not propagate to project consumers. The result: `:rewrite-java-21:runtimeClasspath` and `:rewrite-java-25:runtimeClasspath` (and most non-Java modules) hold `asm:9.9.1` together with `asm-util/-tree/-analysis:9.3` &mdash; an inconsistent ASM stack and an extra set of cache partitions for every artifact.

2. **Kotlin stdlib family fragmented.** `rewrite-kotlin` deliberately uses Kotlin 2.3.20, but `clikt:3.5.0` drags `kotlin-stdlib-jdk7`/`-jdk8`/`-common` back to 1.6.20. In `rewrite-gradle`, `mockwebserver:4.+` pulls those same artifacts at 1.9.10. In `rewrite-maven`, transitives bring 1.8.21 / 1.9.25. The deprecated `-jdk7`/`-jdk8` artifacts are not aligned to `kotlin-stdlib`, so each module ends up with a different Kotlin minor version mix and another batch of partitions.

Verified with `dependencyInsight` before and after the changes.

## Summary

- Declare `asm`, `asm-util`, `asm-tree`, and `asm-analysis` at `latest.release` in `rewrite-core` (alongside the gizmo dependency that pins them). Conflict resolution then bumps all four artifacts in lockstep across every module that depends on `rewrite-core`.
- Apply `org.jetbrains.kotlin:kotlin-bom` as a `testImplementation` platform dependency in `rewrite-kotlin`, `rewrite-gradle`, and `rewrite-maven`. The BOM constrains the whole `kotlin-stdlib-*` family to a single Kotlin version per test classpath.

## Test plan

- [x] `./gradlew :rewrite-java-21:dependencyInsight --dependency org.ow2.asm:asm-util --configuration runtimeClasspath` resolves to 9.9.1 (was 9.3).
- [x] `./gradlew :rewrite-kotlin:dependencyInsight --dependency org.jetbrains.kotlin:kotlin-stdlib-jdk7 --configuration testRuntimeClasspath` resolves to 2.3.20 by BOM constraint (was 1.6.20).
- [x] Same check for `:rewrite-gradle` (was 1.9.10) and `:rewrite-maven` (was 1.8.21) &mdash; both now 2.3.20.
- [x] `./gradlew :rewrite-core:test :rewrite-kotlin:test :rewrite-gradle:test :rewrite-maven:test` &mdash; `BUILD SUCCESSFUL`.