### PR TITLE
Use version pattern in `noDependencyManagementSection` test

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -3836,22 +3836,10 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                   </dependencies>
               </project>
               """,
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example</groupId>
-                  <artifactId>my-app</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.junit.jupiter</groupId>
-                          <artifactId>junit-jupiter</artifactId>
-                          <version>5.14.3</version>
-                          <scope>test</scope>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """
+            spec -> spec.after(actual -> assertThat(actual)
+              .containsPattern("<groupId>org\\.junit\\.jupiter</groupId>\\s*<artifactId>junit-jupiter</artifactId>\\s*<version>5\\.\\d+(\\.\\d+)?</version>")
+              .doesNotContain("<groupId>junit</groupId>")
+              .actual())
           )
         );
     }


### PR DESCRIPTION
## Motivation

- `ChangeDependencyGroupIdAndArtifactIdTest.noDependencyManagementSection` resolves the latest `5.x` of `org.junit.jupiter:junit-jupiter` from Maven Central at runtime, but asserts against a hardcoded post-recipe version (`5.14.3`). Every new `junit-jupiter` patch release breaks CI for every PR opened thereafter until someone bumps the literal. The most recent break is `5.14.4`, published earlier today &mdash; verified locally on `origin/main` HEAD with the same `5.14.3 → 5.14.4` diff seen in the CI failure on #7474.

## Summary

- Replace the hardcoded post-recipe POM with a regex assertion that matches any `5.x.x` release of `junit-jupiter`, following the convention introduced in #6799 and #6856 for similarly-flaky tests in this same file.

## Test plan

- [x] `./gradlew :rewrite-maven:test --tests "org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactIdTest.noDependencyManagementSection"` &mdash; `BUILD SUCCESSFUL` against today's `junit-jupiter:5.14.4`.