### PR TITLE
Anchor nestmates to their NestHost's defining loader

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
@@ -16,8 +16,12 @@
 package org.openrewrite.marketplace;
 
 import org.jspecify.annotations.Nullable;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -103,6 +107,14 @@ public class RecipeClassLoader extends URLClassLoader {
                 return foundClass;
             }
 
+            foundClass = loadNestMember(name);
+            if (foundClass != null) {
+                if (resolve) {
+                    resolveClass(foundClass);
+                }
+                return foundClass;
+            }
+
             // Determine delegation strategy
             try {
                 if (shouldDelegateToParent(name)) {
@@ -128,6 +140,56 @@ public class RecipeClassLoader extends URLClassLoader {
                 resolveClass(foundClass);
             }
             return foundClass;
+        }
+    }
+
+    /**
+     * Anchors nestmates to the defining loader of their NestHost. The JVM uses the NestHost
+     * attribute to gate private member access between siblings; if members of the same nest
+     * end up on different defining loaders, access checks fail at runtime with
+     * {@link IllegalAccessError}. Routing every member through the host's loader keeps the
+     * nest intact regardless of how delegation rules are configured.
+     *
+     * @return the resolved class when {@code name} declares a NestHost, or {@code null} when
+     *         the class has no NestHost attribute (or is its own host) and normal delegation
+     *         should apply.
+     */
+    private @Nullable Class<?> loadNestMember(String name) throws ClassNotFoundException {
+        String nestHostInternal = peekNestHost(name);
+        if (nestHostInternal == null || nestHostInternal.equals(name.replace('.', '/'))) {
+            return null;
+        }
+        Class<?> hostClass = loadClass(nestHostInternal.replace('/', '.'));
+        ClassLoader hostLoader = hostClass.getClassLoader();
+        if (hostLoader == this) {
+            // Host is defined here: load the member here too. No parent fallback —
+            // surfacing ClassNotFoundException is preferable to silently splitting the nest.
+            return findClass(name);
+        }
+        if (hostLoader != null) {
+            return hostLoader.loadClass(name);
+        }
+        return Class.forName(name, false, null);
+    }
+
+    private @Nullable String peekNestHost(String name) {
+        // getResource already checks this loader's URLs first and falls through to the parent,
+        // so we can detect nest membership even for members the child doesn't ship.
+        URL url = getResource(name.replace('.', '/') + ".class");
+        if (url == null) {
+            return null;
+        }
+        try (InputStream in = url.openStream()) {
+            String[] holder = new String[1];
+            new ClassReader(in).accept(new ClassVisitor(Opcodes.ASM9) {
+                @Override
+                public void visitNestHost(String nestHost) {
+                    holder[0] = nestHost;
+                }
+            }, ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES | ClassReader.SKIP_DEBUG);
+            return holder[0];
+        } catch (IOException e) {
+            return null;
         }
     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeClassLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeClassLoaderTest.java
@@ -23,6 +23,11 @@ import org.openrewrite.config.Environment;
 import org.openrewrite.config.RecipeDescriptor;
 import org.openrewrite.internal.StringUtils;
 
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -31,11 +36,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.Callable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 class RecipeClassLoaderTest {
 
@@ -141,6 +151,151 @@ class RecipeClassLoaderTest {
                 assertThat(resources.nextElement().toString()).contains("lib1/rewrite.txt");
                 assertThat(resources.hasMoreElements()).isFalse();
             }
+        }
+    }
+
+    @Test
+    void nestmatesFollowHostOnChildLoader(@TempDir Path tempDir) throws Exception {
+        Path nestDir = compileSyntheticNest(tempDir);
+        URL[] urls = {nestDir.toUri().toURL()};
+
+        // Both child and parent can see the full nest. Configure the child to delegate the
+        // private inner to the parent — without the NestHost-aware fix this would split the
+        // nest (Outer + Outer$1 on child, Outer$Inner on parent) and produce IllegalAccessError.
+        try (URLClassLoader parent = new URLClassLoader(urls, getClass().getClassLoader())) {
+            try (RecipeClassLoader child = new TestRecipeClassLoader(urls, parent,
+              Collections.singletonList("nest.Outer$Inner"))) {
+
+                Class<?> outer = child.loadClass("nest.Outer");
+                @SuppressWarnings("unchecked")
+                Callable<Integer> caller = (Callable<Integer>) outer.getMethod("caller").invoke(null);
+                assertThat(caller.call()).isEqualTo(42);
+
+                assertThat(outer.getClassLoader()).isSameAs(child);
+                assertThat(caller.getClass().getClassLoader()).isSameAs(child);
+                assertThat(child.loadClass("nest.Outer$Inner").getClassLoader()).isSameAs(child);
+            }
+        }
+    }
+
+    @Test
+    void nestmatesFollowHostOnParentLoader(@TempDir Path tempDir) throws Exception {
+        Path nestDir = compileSyntheticNest(tempDir);
+        URL[] urls = {nestDir.toUri().toURL()};
+
+        // Delegate the host to the parent. With the fix, the anonymous and inner classes
+        // peek their NestHost, see that Outer was defined by the parent, and route there too.
+        try (URLClassLoader parent = new URLClassLoader(urls, getClass().getClassLoader())) {
+            try (RecipeClassLoader child = new TestRecipeClassLoader(urls, parent,
+              Collections.singletonList("nest.Outer"))) {
+
+                Class<?> outer = child.loadClass("nest.Outer");
+                @SuppressWarnings("unchecked")
+                Callable<Integer> caller = (Callable<Integer>) outer.getMethod("caller").invoke(null);
+                assertThat(caller.call()).isEqualTo(42);
+
+                assertThat(outer.getClassLoader()).isSameAs(parent);
+                Class<?> anon = child.loadClass("nest.Outer$1");
+                Class<?> inner = child.loadClass("nest.Outer$Inner");
+                assertThat(anon.getClassLoader()).isSameAs(parent);
+                assertThat(inner.getClassLoader()).isSameAs(parent);
+            }
+        }
+    }
+
+    @Test
+    void nestSplitFailsLoudlyWhenMemberMissing(@TempDir Path tempDir) throws Exception {
+        Path fullNest = compileSyntheticNest(tempDir);
+
+        // Build a child class directory that intentionally omits Outer$Inner.
+        Path childDir = tempDir.resolve("child-classes");
+        Path childPkg = childDir.resolve("nest");
+        Files.createDirectories(childPkg);
+        Files.copy(fullNest.resolve("nest/Outer.class"), childPkg.resolve("Outer.class"));
+        Files.copy(fullNest.resolve("nest/Outer$1.class"), childPkg.resolve("Outer$1.class"));
+
+        URL[] childUrls = {childDir.toUri().toURL()};
+        URL[] parentUrls = {fullNest.toUri().toURL()};
+
+        try (URLClassLoader parent = new URLClassLoader(parentUrls, getClass().getClassLoader())) {
+            try (RecipeClassLoader child = new RecipeClassLoader(childUrls, parent)) {
+                Class<?> outer = child.loadClass("nest.Outer");
+                assertThat(outer.getClassLoader()).isSameAs(child);
+
+                // Outer$Inner is absent from the child. Pre-fix the loader would silently fall
+                // back to the parent, defining the inner there and producing IllegalAccessError
+                // when Outer$1 instantiates it. Post-fix the host check refuses that fallback
+                // and the missing member surfaces as ClassNotFoundException.
+                Throwable thrown = catchThrowable(() -> child.loadClass("nest.Outer$Inner"));
+                assertThat(thrown).isInstanceOf(ClassNotFoundException.class);
+
+                @SuppressWarnings("unchecked")
+                Callable<Integer> caller = (Callable<Integer>) outer.getMethod("caller").invoke(null);
+                assertThatThrownBy(caller::call)
+                  .isInstanceOfAny(NoClassDefFoundError.class, ClassNotFoundException.class);
+            }
+        }
+    }
+
+    /**
+     * Compiles a tiny nest into {@code tempDir/nest-classes}:
+     * <ul>
+     *     <li>{@code nest.Outer} — host</li>
+     *     <li>{@code nest.Outer$1} — anonymous {@link Callable} returning {@code new Inner().value()}</li>
+     *     <li>{@code nest.Outer$Inner} — private static, private {@code value()} returning 42</li>
+     * </ul>
+     * Targets release 11 so the resulting class files carry NestHost/NestMembers attributes.
+     */
+    private static Path compileSyntheticNest(Path tempDir) throws IOException {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            throw new IllegalStateException("Tests require running on a JDK with javac available");
+        }
+
+        Path srcDir = tempDir.resolve("nest-src");
+        Path pkgDir = srcDir.resolve("nest");
+        Files.createDirectories(pkgDir);
+        Path src = pkgDir.resolve("Outer.java");
+        Files.write(src, ("package nest;\n" +
+          "import java.util.concurrent.Callable;\n" +
+          "public class Outer {\n" +
+          "    public static Callable<Integer> caller() {\n" +
+          "        return new Callable<Integer>() {\n" +
+          "            @Override public Integer call() { return new Inner().value(); }\n" +
+          "        };\n" +
+          "    }\n" +
+          "    private static class Inner {\n" +
+          "        private int value() { return 42; }\n" +
+          "    }\n" +
+          "}\n").getBytes());
+
+        Path classDir = tempDir.resolve("nest-classes");
+        Files.createDirectories(classDir);
+
+        try (StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null)) {
+            fm.setLocation(StandardLocation.CLASS_OUTPUT, Collections.singletonList(classDir.toFile()));
+            Iterable<? extends JavaFileObject> units = fm.getJavaFileObjectsFromFiles(
+              Collections.singletonList(src.toFile()));
+            boolean ok = compiler.getTask(null, fm, null,
+              Arrays.asList("--release", "11"), null, units).call();
+            if (!ok) {
+                throw new IllegalStateException("Failed to compile synthetic nest");
+            }
+        }
+        return classDir;
+    }
+
+    private static final class TestRecipeClassLoader extends RecipeClassLoader {
+        private final List<String> additionalDelegated;
+
+        TestRecipeClassLoader(URL[] urls, ClassLoader parent, List<String> additionalDelegated) {
+            super(urls, parent);
+            this.additionalDelegated = additionalDelegated;
+        }
+
+        @Override
+        protected List<String> getAdditionalParentDelegatedPackages() {
+            return additionalDelegated;
         }
     }
 


### PR DESCRIPTION
**This is a fix with a potentially big blast radius.**

## Summary

Fix a latent classloading bug in `RecipeClassLoader` where recipes shaped as `Recipe`/`ScanningRecipe` + anonymous `TreeVisitor` returned from `getVisitor()` + private nested visitor instantiated from inside the anonymous class can fail at runtime with `IllegalAccessError` when nest members end up on different defining loaders.

The fix peeks the `NestHost` attribute via ASM before delegation runs and routes every nest member to whichever loader defined the host. When the host is on this loader, no parent fallback is attempted — a missing member surfaces as `ClassNotFoundException` rather than silently splitting the nest.

## The concrete failure

`org.openrewrite.java.ChangePackage` is the recipe that triggered this:

```
IllegalAccessError: failed to access class org.openrewrite.java.ChangePackage$JavaChangePackageVisitor
  from class org.openrewrite.java.ChangePackage$2
  (...$JavaChangePackageVisitor is in unnamed module of loader java.net.URLClassLoader @3cd1a2f1;
   ...$2          is in unnamed module of loader io.moderne.cli.recipe.CliRecipeClassLoader @731f4b3e)
```

`ChangePackage$2` is the anonymous `TreeVisitor` returned by `getVisitor()`; it instantiates `new JavaChangePackageVisitor()` (`ChangePackage.java:141`). `JavaChangePackageVisitor` is `private` (`ChangePackage.java:158`). When the two end up on different defining loaders the JVM denies the access.

## How we usually patch this in `moderne-cli`

The tactical fix downstream is to add the offending class to [`CliRecipeClassLoader.getAdditionalParentDelegatedPackages()`](https://github.com/moderneinc/moderne-cli/blob/main/core/recipes/src/main/java/io/moderne/cli/recipe/CliRecipeClassLoader.java#L15-L35) (in `moderneinc/moderne-cli`) so the same loader resolves all of the nestmates. It works, but it is reactive: every new affected recipe needs another entry, and third-party recipes with the same shape stay unprotected until someone hits the failure in production.

## Why centralize the fix

This isn't a one-off. ~35 classes in `openrewrite/rewrite` share the exact `Recipe` + anonymous visitor + private nested visitor shape:

| Module | Count | Examples |
|---|---|---|
| `rewrite-java` | 15 | `AddImport`, `AddLiteralMethodArgument`, `AddMethodParameter`, `AddNullMethodArgument`, `ChangeMethodTargetToStatic`, `ChangeMethodTargetToVariable`, `ChangePackage`, `ChangeType`, `DeleteMethodArgument`, `RemoveUnusedImports`, `ReorderMethodArguments`, `ReplaceConstantWithAnotherConstant`, `UseStaticImport`, `BlockStatementTemplateGenerator`, `FindTypes` |
| `rewrite-gradle` | 11 | `MigrateDependenciesToVersionCatalog`, `UpdateGradleWrapper`, `UpgradeDependencyVersion`, `UpgradeTransitiveDependencyVersion` |
| `rewrite-maven` | 7 | `ChangeDependencyGroupIdAndArtifactId`, `ManageDependencies`, `RemoveRedundantDependencyVersions`, `RemoveUnusedProperties`, `UpdateMavenWrapper`, `UpgradeDependencyVersion` |
| `rewrite-yaml` | 2 | `UnfoldProperties` |
| `rewrite-docker` | 1 | `AddOrUpdateLabel` |

Plus the broader recipe ecosystem (`rewrite-spring`, `rewrite-static-analysis`, `rewrite-migrate-java`, …) and any third-party recipe written in this idiomatic shape. None are protected today; the bug is latent across all of them.

Putting the fix in `RecipeClassLoader` itself means every consumer (`moderne-cli`, SaaS, the IntelliJ plugin, anything extending `RecipeClassLoader`) is structurally protected from this entire class of issue, including recipes that don't exist yet.

## What changed

- `rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java` — overrides `loadClass(name, resolve)` to peek the `NestHost` attribute via ASM (already a `rewrite-core` dependency) before the existing delegation logic runs. Three branches:
  - No `NestHost` attribute, or the class is its own host → fall through to existing logic. No behavior change.
  - `NestHost` declares another class → load the host first; the loader that defines the host owns the entire nest. Members route to that loader.
  - When the host is on this loader, member loading uses `findClass(name)` directly with no parent fallback, so a missing member fails loudly as `ClassNotFoundException` instead of silently splitting the nest.
- `rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeClassLoaderTest.java` — adds three tests that build a synthetic nest (`nest.Outer` / `Outer$1` / private `Outer$Inner`) at runtime via `JavaCompiler` and exercise: host-on-child happy path, host-on-parent reverse direction, and the regression case (child missing the inner) failing loudly.

## Follow-up after release

Several entries in `RecipeClassLoader.PARENT_DELEGATED_PREFIXES` and in the downstream `CliRecipeClassLoader.getAdditionalParentDelegatedPackages` list (e.g. `Cobol*Visitor`, `DevCenter*`) appear to be ad-hoc workarounds for this same nest-split issue. Worth auditing each one once the structural fix lands — entries that exist purely as nestmate workarounds can be retired.