### PR TITLE
UpgradeDependencyVersion: warn on install failure instead of throwing

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/recipes/upgrade-dependency-version.ts
+++ b/rewrite-javascript/rewrite/src/javascript/recipes/upgrade-dependency-version.ts
@@ -31,7 +31,7 @@ import {
 import * as path from "path";
 import * as semver from "semver";
 import * as picomatch from "picomatch";
-import {replaceMarkerByKind} from "../../markers";
+import {markupWarn, replaceMarkerByKind} from "../../markers";
 import {TreePrinters} from "../../print";
 import {
     createDependencyRecipeAccumulator,
@@ -301,7 +301,7 @@ export class UpgradeDependencyVersion extends ScanningRecipe<Accumulator> {
                         );
                     if (failureMessage) {
                         const names = updateInfo.matchedDependencies.map(d => d.packageName).join(', ');
-                        throw new Error(`Failed to upgrade ${names} to ${recipe.newVersion}: ${failureMessage}`);
+                        return markupWarn(doc, `Failed to upgrade ${names} to ${recipe.newVersion}`, failureMessage);
                     }
 
                     let modifiedDoc = doc;

--- a/rewrite-javascript/rewrite/test/javascript/recipes/upgrade-dependency-version.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/recipes/upgrade-dependency-version.test.ts
@@ -24,6 +24,7 @@ import {
 import {Json} from "../../../src/json";
 import {RecipeSpec} from "../../../src/test";
 import {withDir} from "tmp-promise";
+import {findMarker, MarkersKind} from "../../../src";
 import * as fs from "fs";
 import * as path from "path";
 import * as semver from "semver";
@@ -294,7 +295,7 @@ describe("UpgradeDependencyVersion", () => {
         }, {unsafeCleanup: true});
     });
 
-    test("throws when install fails for non-existent version", async () => {
+    test("adds warning marker when install fails for non-existent version", async () => {
         const spec = new RecipeSpec();
         spec.recipe = new UpgradeDependencyVersion({
             packageName: "uuid",
@@ -302,25 +303,34 @@ describe("UpgradeDependencyVersion", () => {
         });
 
         await withDir(async (repo) => {
-            await expect(spec.rewriteRun(
+            await spec.rewriteRun(
                 npm(
                     repo.path,
                     typescript(`const x = 1;`),
-                    packageJson(`
-                        {
-                            "name": "test-project",
-                            "version": "1.0.0",
-                            "dependencies": {
-                                "uuid": "^9.0.0"
+                    {
+                        ...packageJson(`
+                            {
+                                "name": "test-project",
+                                "version": "1.0.0",
+                                "dependencies": {
+                                    "uuid": "^9.0.0"
+                                }
                             }
+                        `, (actual: string) => {
+                            expect(actual).toContain('/*~~(Failed to upgrade uuid to ^999.0.0');
+                            return actual;
+                        }), afterRecipe: async (doc: Json.Document) => {
+                            const warnMarker = findMarker(doc, MarkersKind.MarkupWarn);
+                            expect(warnMarker).toBeDefined();
+                            expect((warnMarker as any).message).toContain("Failed to upgrade uuid to ^999.0.0");
                         }
-                    `)
+                    }
                 )
-            )).rejects.toThrow("Failed to upgrade uuid to ^999.0.0");
+            );
         }, {unsafeCleanup: true});
     });
 
-    test("throws when install fails due to engine version mismatch", async () => {
+    test("adds warning marker when install fails due to engine version mismatch", async () => {
         const spec = new RecipeSpec();
         spec.recipe = new UpgradeDependencyVersion({
             packageName: "uuid",
@@ -332,24 +342,33 @@ describe("UpgradeDependencyVersion", () => {
             fs.writeFileSync(path.join(repo.path, '.npmrc'), 'engine-strict=true');
 
             // when / then
-            await expect(spec.rewriteRun(
+            await spec.rewriteRun(
                 npm(
                     repo.path,
                     typescript(`const x = 1;`),
-                    packageJson(`
-                        {
-                            "name": "test-project",
-                            "version": "1.0.0",
-                            "engines": {
-                                "node": "504.436"
-                            },
-                            "dependencies": {
-                                "uuid": "^9.0.0"
+                    {
+                        ...packageJson(`
+                            {
+                                "name": "test-project",
+                                "version": "1.0.0",
+                                "engines": {
+                                    "node": "504.436"
+                                },
+                                "dependencies": {
+                                    "uuid": "^9.0.0"
+                                }
                             }
+                        `, (actual: string) => {
+                            expect(actual).toContain('/*~~(Failed to upgrade uuid to ^10.0.0');
+                            return actual;
+                        }), afterRecipe: async (doc: Json.Document) => {
+                            const warnMarker = findMarker(doc, MarkersKind.MarkupWarn);
+                            expect(warnMarker).toBeDefined();
+                            expect((warnMarker as any).message).toContain("Failed to upgrade uuid to ^10.0.0");
                         }
-                    `)
+                    }
                 )
-            )).rejects.toThrow(/^Error: Failed to upgrade uuid to \^10\.0\.0:/);
+            );
         }, {unsafeCleanup: true});
     });
 


### PR DESCRIPTION
## Summary

When the package-manager install run by `UpgradeDependencyVersion` fails (typically an `ERESOLVE` peer-dep conflict), the recipe currently `throw`s, aborting the entire recipe chain. That prevents *later* recipes — which might be the very ones that resolve the conflict, e.g. by bumping a peer-pinning library — from running at all.

The sibling `AddDependency` recipe already handles install failure by returning `markupWarn(doc, ...)` and letting the chain continue. This PR aligns the two so partial failures degrade gracefully.

## Motivation

Real-world trigger: an Angular 17 project with `@ng-bootstrap/ng-bootstrap@^16.0.0` (strict peer `@angular/core@^17.0.0`) being upgraded via a chain of `UpgradeDependencyVersion` calls (one for `@angular/*`, one for `@ng-bootstrap/ng-bootstrap`). Today the first failing install kills the run, and the dep graph stays in its initial inconsistent state forever. With this change, the chain continues, the marker records the failure, and a subsequent recipe can converge the graph (or a second pass of the same chain reaches fixed-point).

## Diff

```diff
- import {replaceMarkerByKind} from "../../markers";
+ import {markupWarn, replaceMarkerByKind} from "../../markers";
…
  if (failureMessage) {
      const names = updateInfo.matchedDependencies.map(d => d.packageName).join(', ');
-     throw new Error(`Failed to upgrade ${names} to ${recipe.newVersion}: ${failureMessage}`);
+     return markupWarn(doc, `Failed to upgrade ${names} to ${recipe.newVersion}`, failureMessage);
  }
```

## Tests

The two existing tests that asserted on the throw — `throws when install fails for non-existent version` and `throws when install fails due to engine version mismatch` — are reworked to assert on the `MarkupWarn` marker, mirroring the pattern in `add-dependency.test.ts::adds warning marker when package does not exist`. Renamed to `adds warning marker when install fails …` to match the new behaviour.

All 25 tests in `upgrade-dependency-version.test.ts` pass locally.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run test/javascript/recipes/upgrade-dependency-version.test.ts` — 25/25 pass
- [ ] Run full suite in CI
- [ ] Verify the unblocked-recipe-chain behaviour against a known-failing project (Angular 17 + ng-bootstrap@16 → 18 + ng-bootstrap@17)