### PR TITLE
Throw MavenParsingException when a POM is missing groupId or version

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
@@ -36,7 +36,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -404,22 +403,26 @@ public class RawPom {
     }
 
     public @Nullable String getGroupId() {
-        return groupId == null && parent != null ? parent.getGroupId() : groupId;
+        if (!StringUtils.isBlank(groupId)) {
+            return groupId;
+        }
+        if (parent != null && !StringUtils.isBlank(parent.getGroupId())) {
+            return parent.getGroupId();
+        }
+        return null;
     }
 
     public @Nullable String getVersion() {
-        if (version == null) {
-            if (currentVersion == null) {
-                if (parent == null) {
-                    return null;
-                } else {
-                    return parent.getVersion();
-                }
-            } else {
-                return currentVersion;
-            }
+        if (!StringUtils.isBlank(version)) {
+            return version;
         }
-        return version;
+        if (!StringUtils.isBlank(currentVersion)) {
+            return currentVersion;
+        }
+        if (parent != null && !StringUtils.isBlank(parent.getVersion())) {
+            return parent.getVersion();
+        }
+        return null;
     }
 
 
@@ -428,15 +431,26 @@ public class RawPom {
                 getParent().getGroupId(), getParent().getArtifactId(),
                 getParent().getVersion()), getParent().getRelativePath());
 
+        String resolvedGroupId = getGroupId();
+        String resolvedVersion = getVersion();
+        if (resolvedGroupId == null || resolvedVersion == null) {
+            throw new MavenParsingException(
+                    "POM is missing a required coordinate:" +
+                            (resolvedGroupId == null ? " groupId" : "") +
+                            (resolvedVersion == null ? " version" : "") +
+                            " for " + new GroupArtifactVersion(resolvedGroupId, artifactId, resolvedVersion) +
+                            (repo == null ? "" : " (from " + repo.getUri() + ")"));
+        }
+
         Pom.PomBuilder builder = Pom.builder()
                 .sourcePath(inputPath)
                 .repository(repo)
                 .parent(parent)
                 .gav(new ResolvedGroupArtifactVersion(
                         repo == null ? null : repo.getUri(),
-                        Objects.requireNonNull(getGroupId()),
+                        resolvedGroupId,
                         artifactId,
-                        Objects.requireNonNull(getVersion()),
+                        resolvedVersion,
                         null))
                 .name(name)
                 .obsoletePomVersion(pomVersion)

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/RawPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/RawPomTest.java
@@ -610,4 +610,108 @@ class RawPomTest {
         assertThat(plugin.getConfigurationList("grandparent.parent.child.stringList", String.class)).hasSize(4)
           .contains("f", "r", "e", "d");
     }
+
+    @Test
+    void missingGroupIdThrowsParsingException() {
+        RawPom pom = RawPom.parse(
+          //language=xml
+          new ByteArrayInputStream("""
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                </project>
+            """.getBytes()),
+          null
+        );
+
+        assertThatThrownBy(() -> pom.toPom(null, null))
+          .isInstanceOf(MavenParsingException.class)
+          .hasMessageContaining("missing a required coordinate")
+          .hasMessageContaining("groupId")
+          .hasMessageContaining("my-app");
+    }
+
+    @Test
+    void missingVersionThrowsParsingException() {
+        RawPom pom = RawPom.parse(
+          //language=xml
+          new ByteArrayInputStream("""
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                </project>
+            """.getBytes()),
+          null
+        );
+
+        assertThatThrownBy(() -> pom.toPom(null, null))
+          .isInstanceOf(MavenParsingException.class)
+          .hasMessageContaining("missing a required coordinate")
+          .hasMessageContaining("version");
+    }
+
+    @Test
+    void emptyGroupIdElementThrowsParsingException() {
+        RawPom pom = RawPom.parse(
+          //language=xml
+          new ByteArrayInputStream("""
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId/>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                </project>
+            """.getBytes()),
+          null
+        );
+
+        assertThatThrownBy(() -> pom.toPom(null, null))
+          .isInstanceOf(MavenParsingException.class)
+          .hasMessageContaining("groupId");
+    }
+
+    @Test
+    void whitespaceVersionElementThrowsParsingException() {
+        RawPom pom = RawPom.parse(
+          //language=xml
+          new ByteArrayInputStream("""
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>   </version>
+                </project>
+            """.getBytes()),
+          null
+        );
+
+        assertThatThrownBy(() -> pom.toPom(null, null))
+          .isInstanceOf(MavenParsingException.class)
+          .hasMessageContaining("version");
+    }
+
+    @Test
+    void groupIdInheritedFromParentStillResolves() {
+        RawPom pom = RawPom.parse(
+          //language=xml
+          new ByteArrayInputStream("""
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>com.mycompany.app</groupId>
+                        <artifactId>my-parent</artifactId>
+                        <version>1</version>
+                    </parent>
+                    <artifactId>my-app</artifactId>
+                </project>
+            """.getBytes()),
+          null
+        );
+
+        Pom resolved = pom.toPom(null, null);
+        assertThat(resolved.getGroupId()).isEqualTo("com.mycompany.app");
+        assertThat(resolved.getVersion()).isEqualTo("1");
+    }
 }


### PR DESCRIPTION
## What

`RawPom.toPom` calls `Objects.requireNonNull` on the project's `groupId` and `version` ([RawPom.java:437,439](https://github.com/openrewrite/rewrite/blob/main/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java#L437-L439)). When either is absent, the resulting `NullPointerException` propagates out of `mod build` / `MavenParser.parseInputs` with no artifact context, only this stack:

```
Caused by: java.lang.NullPointerException
    at java.util.Objects.requireNonNull (Objects.java:203)
    at org.openrewrite.maven.internal.RawPom.toPom (RawPom.java:437)
    at org.openrewrite.maven.internal.MavenPomDownloader.download (MavenPomDownloader.java:595)
    at org.openrewrite.maven.tree.ResolvedPom.resolveDependencies (ResolvedPom.java:1050)
    ...
```

There is no signal as to which transitive dependency's POM was malformed.

## Why

A POM can legitimately omit a `<groupId>` or `<version>` element (relying on `<parent>` inheritance), but it can also be invalid — for example:

- a stub POM uploaded to an internal Artifactory/Nexus alongside a vendored JAR via `mvn install:install-file` or REST upload (which bypasses `ModelValidator`)
- a POM emitted by non-Maven tooling that wrote `<groupId/>` or `<groupId></groupId>` instead of omitting the element (Jackson-XML's `EMPTY_ELEMENT_AS_NULL` deserializes those to `null`)
- a POM with whitespace-only content like `<version>  </version>` (which `MavenXmlMapper`'s `StringTrimModule` reduces to `""`, then sailed past every downstream null-check)

In each of these cases the resolver cannot construct a usable `Pom`, but the user has no way of telling which artifact is the source.

## How

Two contained changes inside `RawPom`:

1. `getGroupId()` and `getVersion()` now treat blank (null or whitespace-only) values as missing, so an empty `<groupId/>` or `<version>  </version>` is treated the same as an omitted element. Scope is limited to these two methods; nothing outside `RawPom` is affected.
2. `toPom()` checks the resolved coordinates and throws `MavenParsingException` (already used at sibling validation points in `ResolvedPom`) naming the artifact and source repository:

   ```
   POM is missing a required coordinate: groupId for {null:my-app:1} (from https://repo.example.com/...)
   ```

`MavenParsingException` is unchecked, so no signature changes ripple out to `MavenPomDownloader`, `MavenParser`, `Assertions`, or tests.

## Tests

Added five tests to `RawPomTest`:
- `missingGroupIdThrowsParsingException`
- `missingVersionThrowsParsingException`
- `emptyGroupIdElementThrowsParsingException`
- `whitespaceVersionElementThrowsParsingException`
- `groupIdInheritedFromParentStillResolves` (regression check that legitimate parent inheritance still works)