### PR TITLE
Improve AddDependency performance by reducing unnecessary scanning for types in use

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
@@ -160,6 +160,7 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                 if (usesType == null) {
                     usesType = new UsesType<>(onlyIfUsing, true);
                 }
+
                 return usesType.isAcceptable(sourceFile, ctx) && usesType.visit(sourceFile, ctx) != sourceFile;
             }
 
@@ -176,16 +177,25 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                         sourceFile == hasTestSourceSet.visit(sourceFile, ctx)) {
                     return tree;
                 }
-                sourceFile.getMarkers().findFirst(JavaProject.class).ifPresent(javaProject -> {
-                    boolean uses = usesType(sourceFile, ctx);
-                    acc.usingType.compute(javaProject, (jp, usingType) -> Boolean.TRUE.equals(usingType) || uses);
+                JavaProject javaProject = sourceFile.getMarkers().findFirst(JavaProject.class).orElse(null);
+                if (javaProject == null) {
+                    return tree;
+                }
+                JavaSourceSet javaSourceSet = sourceFile.getMarkers().findFirst(JavaSourceSet.class).orElse(null);
+                String configForThisFile = javaSourceSet == null ? null :
+                        "main".equals(javaSourceSet.getName()) ? "implementation" : javaSourceSet.getName() + "Implementation";
+                // Skip the expensive UsesType visit if a previous file in this project's source set already
+                // contributed the same configuration; subsequent files cannot change the answer.
+                Set<String> knownConfigurations = acc.configurationsByProject.get(javaProject);
+                if (configForThisFile != null && knownConfigurations != null && knownConfigurations.contains(configForThisFile)) {
+                    return tree;
+                }
+                boolean uses = usesType(sourceFile, ctx);
+                acc.usingType.compute(javaProject, (jp, usingType) -> Boolean.TRUE.equals(usingType) || uses);
 
-                    if (uses) {
-                        Set<String> configurations = acc.configurationsByProject.computeIfAbsent(javaProject, ignored -> new HashSet<>());
-                        sourceFile.getMarkers().findFirst(JavaSourceSet.class).ifPresent(sourceSet ->
-                                configurations.add("main".equals(sourceSet.getName()) ? "implementation" : sourceSet.getName() + "Implementation"));
-                    }
-                });
+                if (uses && configForThisFile != null) {
+                    acc.configurationsByProject.computeIfAbsent(javaProject, ignored -> new HashSet<>()).add(configForThisFile);
+                }
                 return tree;
             }
         };

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -180,10 +180,19 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                     if ("test".equals(scope) && onlyIfUsing != null && sourceFile == hasTestSourceSet.visit(sourceFile, ctx)) {
                         return sourceFile;
                     }
+                    JavaProject javaProject = sourceFile.getMarkers().findFirst(JavaProject.class).orElse(null);
+                    String knownScope = javaProject == null ? null : acc.scopeByProject.get(javaProject);
+                    // "compile" is the broadest scope; no further file in this project can change the answer
+                    if ("compile".equals(knownScope)) {
+                        return sourceFile;
+                    }
+                    JavaSourceSet javaSourceSet = sourceFile.getMarkers().findFirst(JavaSourceSet.class).orElse(null);
+                    // If we already know "test" scope and this file is also in a test source set, no further info
+                    if ("test".equals(knownScope) && javaSourceSet != null && "test".equals(javaSourceSet.getName())) {
+                        return sourceFile;
+                    }
                     if (onlyIfUsing == null || sourceFile != new UsesType<>(onlyIfUsing, true).visit(sourceFile, ctx)) {
                         acc.usingType = true;
-                        JavaProject javaProject = sourceFile.getMarkers().findFirst(JavaProject.class).orElse(null);
-                        JavaSourceSet javaSourceSet = sourceFile.getMarkers().findFirst(JavaSourceSet.class).orElse(null);
                         if (javaProject != null && javaSourceSet != null) {
                             acc.scopeByProject.compute(javaProject, (jp, scope) -> "compile".equals(scope) ?
                                     scope /* a `compile` scope dependency will also be available in test source set */ :


### PR DESCRIPTION
Once AddDependency finds a type it is looking for stop scanning other files in the same source set.

Data shows that 38% of the time spent on a large spring boot upgrade recipe is spent on AddDependency and up to 99% of that is in the scanning phase. The only thing in the scanning phase which could take so much time is the "onlyIfUsing" calculation. 