### PR TITLE
Groovy: fix parsing of a method with array varargs

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -3002,17 +3002,21 @@ public class GroovyParserVisitor {
 
     private TypeTree mapDimensions(TypeTree baseType, ClassNode classNode) {
         if (classNode.isArray()) {
+            int saveCursor = cursor;
             Space prefix = whitespace();
-            JLeftPadded<Space> dimension = padLeft(sourceBefore("["), sourceBefore("]"));
-            return new J.ArrayType(
-                    randomId(),
-                    prefix,
-                    Markers.EMPTY,
-                    mapDimensions(baseType, classNode.getComponentType()),
-                    null,
-                    dimension,
-                    typeMapping.type(classNode)
-            );
+            if (cursor < source.length() && source.charAt(cursor) == '[') {
+                JLeftPadded<Space> dimension = padLeft(sourceBefore("["), sourceBefore("]"));
+                return new J.ArrayType(
+                        randomId(),
+                        prefix,
+                        Markers.EMPTY,
+                        mapDimensions(baseType, classNode.getComponentType()),
+                        null,
+                        dimension,
+                        typeMapping.type(classNode)
+                );
+            }
+            cursor = saveCursor;
         }
         return baseType;
     }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
@@ -141,6 +141,18 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void arrayVarargsArguments() {
+        rewriteRun(
+          groovy(
+            """
+              def foo(String[]... messages) {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void defaultArgumentValues() {
         rewriteRun(
           groovy(


### PR DESCRIPTION
## What's changed?

Fixing Groovy parser to handle array vargs method parameters, e.g.
```
def foo(String[]... messages)
```

## What's your motivation?

Otherwise the parser suffers from with idempotency issues.