### PR TITLE
Groovy: fix parsing of a dynamic map key with parens

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2011,8 +2011,21 @@ public class GroovyParserVisitor {
 
         @Override
         public void visitMapEntryExpression(MapEntryExpression expression) {
-            G.MapEntry mapEntry = new G.MapEntry(randomId(), whitespace(), Markers.EMPTY,
-                    JRightPadded.build((Expression) doVisit(expression.getKeyExpression())).withAfter(sourceBefore(":")),
+            Space prefix = whitespace();
+            Expression key;
+            int saveCursor = cursor;
+            Space beforeOpenParen = whitespace();
+            if (cursor < source.length() && source.charAt(cursor) == '(') {
+                skip("(");
+                Expression inner = doVisit(expression.getKeyExpression());
+                key = new J.Parentheses<>(randomId(), beforeOpenParen, Markers.EMPTY,
+                        JRightPadded.build((J) inner).withAfter(sourceBefore(")")));
+            } else {
+                cursor = saveCursor;
+                key = doVisit(expression.getKeyExpression());
+            }
+            G.MapEntry mapEntry = new G.MapEntry(randomId(), prefix, Markers.EMPTY,
+                    JRightPadded.build(key).withAfter(sourceBefore(":")),
                     doVisit(expression.getValueExpression()),
                     null
             );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MapEntryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MapEntryTest.java
@@ -68,4 +68,19 @@ class MapEntryTest implements RewriteTest {
           groovy("def a = someMap /*[*/ [ /*'*/ 'someKey' /*]*/ ]")
         );
     }
+
+    @Test
+    void parenthesizedKeyInMethodArgument() {
+        rewriteRun(
+          groovy(
+            """
+              class Defaults {
+                  static final String KEY = "k"
+              }
+              def writeProperties(Map m) {}
+              writeProperties((Defaults.KEY): "value")
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fixing the Groovy parser to handle dynamic keys with parens (which are at least sometimes required), e.g.
```
              writeProperties((Defaults.KEY): "value")
```

## What's your motivation?

The parser would fail with `StringIndexOutOfBoundsException`