### PR TITLE
FindStyles: honor custom @JsonSerialize so ImportLayoutStyle.layout isn't dropped

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/FindStyles.java
+++ b/rewrite-core/src/main/java/org/openrewrite/FindStyles.java
@@ -15,20 +15,18 @@
  */
 package org.openrewrite;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.internal.ObjectMappers;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.style.Style;
 import org.openrewrite.table.StylesInUse;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.introspector.BeanAccess;
-import org.yaml.snakeyaml.introspector.Property;
-import org.yaml.snakeyaml.nodes.MappingNode;
-import org.yaml.snakeyaml.nodes.Tag;
-import org.yaml.snakeyaml.representer.Representer;
 
 import java.util.*;
 
@@ -79,22 +77,15 @@ public class FindStyles extends Recipe {
     }
 
     private static final Yaml SNAKE_YAML;
+    private static final ObjectMapper MAPPER = ObjectMappers.propertyBasedMapper(FindStyles.class.getClassLoader());
+    private static final TypeReference<Map<String, Object>> STYLE_MAP = new TypeReference<Map<String, Object>>() {};
 
     static {
         DumperOptions options = new DumperOptions();
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         options.setIndent(2);
         options.setPrettyFlow(true);
-        // Suppress class tags (e.g. !!com.example.SomeStyle) so beans dump as plain maps
-        Representer representer = new Representer(options) {
-            @Override
-            protected MappingNode representJavaBean(Set<Property> properties, Object javaBean) {
-                addClassTag(javaBean.getClass(), Tag.MAP);
-                return super.representJavaBean(properties, javaBean);
-            }
-        };
-        SNAKE_YAML = new Yaml(representer, options);
-        SNAKE_YAML.setBeanAccess(BeanAccess.FIELD);
+        SNAKE_YAML = new Yaml(options);
     }
 
     private static String stylesToYaml(List<NamedStyles> namedStylesList) {
@@ -115,7 +106,9 @@ public class FindStyles extends Recipe {
             List<Map<String, Object>> styleConfigs = new ArrayList<>();
             for (Style style : styles) {
                 Map<String, Object> entry = new LinkedHashMap<>();
-                entry.put(style.getClass().getName(), style);
+                // Round-trip through Jackson so any custom @JsonSerialize on the Style
+                // (e.g. ImportLayoutStyle.Serializer) is honored before SnakeYAML sees it.
+                entry.put(style.getClass().getName(), MAPPER.convertValue(style, STYLE_MAP));
                 styleConfigs.add(entry);
             }
             doc.put("styleConfigs", styleConfigs);

--- a/rewrite-test/src/test/java/org/openrewrite/FindStylesTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/FindStylesTest.java
@@ -17,6 +17,7 @@ package org.openrewrite;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.internal.InMemoryLargeSourceSet;
+import org.openrewrite.java.style.ImportLayoutStyle;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.style.Style;
 import org.openrewrite.test.RecipeSpec;
@@ -156,6 +157,57 @@ class FindStylesTest implements RewriteTest {
         // Should NOT have multiple YAML documents (no second "---")
         String yamlContent = content.substring(content.indexOf("---"));
         assertThat(yamlContent.indexOf("---", 3)).isEqualTo(-1);
+    }
+
+    @Test
+    void importLayoutStyleSerializesBlocksAsStrings() {
+        ImportLayoutStyle importLayoutStyle = ImportLayoutStyle.builder()
+                .classCountToUseStarImport(9999)
+                .nameCountToUseStarImport(9999)
+                .importPackage("java.*")
+                .blankLine()
+                .importAllOthers()
+                .blankLine()
+                .importStaticAllOthers()
+                .packageToFold("java.util.*")
+                .build();
+
+        NamedStyles namedStyles = new NamedStyles(
+            Tree.randomId(),
+            "org.openrewrite.test.ImportStyles",
+            "Import Styles",
+            "Import layout styles for unit testing",
+            emptySet(),
+            singletonList(importLayoutStyle)
+        );
+
+        PlainText plainText = PlainTextParser.builder().build()
+            .parse("hello world!")
+            .map(PlainText.class::cast)
+            .findFirst()
+            .orElseThrow()
+            .withSourcePath(Paths.get("hello.txt"));
+        plainText = plainText.withMarkers(plainText.getMarkers().add(namedStyles));
+
+        FindStyles recipe = new FindStyles();
+        ExecutionContext ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
+        RecipeRun run = recipe.run(new InMemoryLargeSourceSet(List.of(plainText)), ctx);
+
+        assertThat(run.getChangeset().getAllResults()).hasSize(1);
+        String content = run.getChangeset().getAllResults().get(0).getAfter().printAll();
+
+        assertThat(content).contains("org.openrewrite.java.style.ImportLayoutStyle:");
+        assertThat(content).contains("classCountToUseStarImport: 9999");
+        assertThat(content).contains("nameCountToUseStarImport: 9999");
+        // The Block instances must round-trip through ImportLayoutStyle.Serializer
+        // and appear as readable strings, not be silently dropped to an empty list.
+        assertThat(content).contains("import java.*");
+        assertThat(content).contains("<blank line>");
+        assertThat(content).contains("import all other imports");
+        assertThat(content).contains("import static all other imports");
+        assertThat(content).contains("import java.util.*");
+        assertThat(content).doesNotContain("layout: []");
+        assertThat(content).doesNotContain("packagesToFold: []");
     }
 
     /**


### PR DESCRIPTION
## Summary

- `FindStyles` was dumping each `Style` via SnakeYAML with `BeanAccess.FIELD`, which bypassed any class-level `@JsonSerialize`. For `ImportLayoutStyle` that meant the `Block` instances (sealed interface, `private final` fields, no setters) could not be introspected and the recipe reported empty `layout: []` / `packagesToFold: []` even when the merged style was fully populated — exactly the field people most often want to verify.
- Each `Style` is now routed through `ObjectMappers.propertyBasedMapper(...).convertValue(style, Map.class)` first, so any custom serializer (e.g. `ImportLayoutStyle.Serializer`, which renders Blocks as readable strings like `import java.*`, `<blank line>`, `import all other imports`) is invoked before SnakeYAML sees the value. The `BeanAccess.FIELD` setup and the class-tag-suppressing `Representer` are no longer needed and have been removed.
- Added an `importLayoutStyleSerializesBlocksAsStrings` regression test that builds an `ImportLayoutStyle` via `Builder` with a real layout + `packagesToFold` and asserts the output contains the readable Block strings and not `layout: []` / `packagesToFold: []`. The previous tests only exercised trivial POJO styles and would never have caught this.

### Before

```yaml
- org.openrewrite.java.style.ImportLayoutStyle:
    classCountToUseStarImport: 9999
    layout: [
      ]
    nameCountToUseStarImport: 9999
    packagesToFold: [
      ]
```

### After

```yaml
- org.openrewrite.java.style.ImportLayoutStyle:
    classCountToUseStarImport: 9999
    nameCountToUseStarImport: 9999
    layout:
    - import java.*
    - <blank line>
    - import all other imports
    - <blank line>
    - import static all other imports
    packagesToFold:
    - import java.util.*
```

The fix is general: any `Style` with a custom `@JsonSerialize` benefits, not just `ImportLayoutStyle`.

## Test plan

- [x] `./gradlew :rewrite-test:test --tests "org.openrewrite.FindStylesTest"` (incl. new regression test)
- [x] `./gradlew :rewrite-core:test :rewrite-test:test`
- [x] `./gradlew :rewrite-java:test --tests "*ImportLayoutStyleTest*"` to confirm `Serializer`/`Deserializer` round-trip is untouched
- [x] `./gradlew :rewrite-core:licenseFormat :rewrite-test:licenseFormat`