### PR TITLE
Groovy: fix parsing of @Immutable @ToString

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2774,7 +2774,9 @@ public class GroovyParserVisitor {
         Space prefix = sourceBefore("@");
         NameTree annotationType = visitTypeTree(annotation.getClassNode());
         JContainer<Expression> arguments = null;
-        if (!annotation.getMembers().isEmpty()) {
+        // AST transforms like @Immutable can attach synthetic members to other annotations
+        // (e.g. @ToString) that don't appear in source — only parse arguments if "(" is actually next.
+        if (!annotation.getMembers().isEmpty() && sourceStartsWith("(")) {
             arguments = JContainer.build(
                     sourceBefore("("),
                     annotation.getMembers().entrySet().stream()

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
@@ -276,17 +276,35 @@ class AnnotationTest implements RewriteTest {
           groovy(
             """
             package org.dummy
-            
+
             import groovy.transform.Synchronized
-            
+
             class Foo {
-            
+
                 @Synchronized
                 void bar() {
                     println('Hello World')
                 }
             }
             """
+          )
+        );
+    }
+
+    @Test
+    void immutableAndToString() {
+        rewriteRun(
+          groovy(
+            """
+              import groovy.transform.Immutable
+              import groovy.transform.ToString
+
+              @Immutable @ToString
+              class A {
+                  void foo() {
+                  }
+              }
+              """
           )
         );
     }


### PR DESCRIPTION
## What's changed?

Fix the Groovy parser when it comes to `@Immutable @ToString` annotations happening after each other.

## What's your motivation?

Otherwise the parser suffers from idepmotency issues.