### PR TITLE
Groovy: Fix NPE with generics of an unknown class

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
@@ -133,7 +133,9 @@ public class GroovyParser implements Parser {
                                 StaticTypeCheckingVisitor staticTypeCheckingVisitor = new StaticTypeCheckingVisitor(unit, aClass);
                                 staticTypeCheckingVisitor.setCompilationUnit(compUnit);
                                 staticTypeCheckingVisitor.visitClass(aClass);
-                            } catch (NoClassDefFoundError ignored) {
+                            } catch (NoClassDefFoundError | NullPointerException ignored) {
+                                // Static type checking is best-effort; skip enrichment when Groovy fails internally
+                                // (e.g., NPE in inferDiamondType when diamond is used with an unresolved imported class).
                             }
                         }
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/VariableDeclarationsTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/VariableDeclarationsTest.java
@@ -112,6 +112,18 @@ class VariableDeclarationsTest implements RewriteTest {
     }
 
     @Test
+    void diamondOperatorOnUnresolvedImportedType() {
+        rewriteRun(
+          groovy(
+            """
+              import a.b.Foo
+              def x = new Foo<>()
+              """
+          )
+        );
+    }
+
+    @Test
     void singleTypeMultipleVariableDeclaration() {
         rewriteRun(
           groovy("def a = 1, b = 1")


### PR DESCRIPTION
## What's changed?

Fix Groovy parser in one corner case. When a class is not known (lacking from classpath) and there's generics expression with it, e.g.
```
              import a.b.Foo
              def x = new Foo<>()
```

## What's your motivation?

It currently fails with NullPointerException.