### PR TITLE
Make Java compatibility tests not depend on java-tck JAR

### DIFF
--- a/rewrite-java-11/build.gradle.kts
+++ b/rewrite-java-11/build.gradle.kts
@@ -5,7 +5,15 @@ plugins {
 
 val javaTck = configurations.create("javaTck") {
     isTransitive = false
+    isCanBeConsumed = false
+    isCanBeResolved = true
 }
+
+val javaTckClasses = javaTck.incoming.artifactView {
+    attributes {
+        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.CLASSES))
+    }
+}.files
 
 dependencies {
     api(project(":rewrite-core"))
@@ -84,7 +92,7 @@ testing {
                 all {
                     testTask.configure {
                         useJUnitPlatform()
-                        testClassesDirs += files(javaTck.files.map { zipTree(it) })
+                        testClassesDirs += javaTckClasses
                         jvmArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:+ShowHiddenFrames")
                         shouldRunAfter(test)
                     }

--- a/rewrite-java-17/build.gradle.kts
+++ b/rewrite-java-17/build.gradle.kts
@@ -7,7 +7,15 @@ plugins {
 
 val javaTck = configurations.create("javaTck") {
     isTransitive = false
+    isCanBeConsumed = false
+    isCanBeResolved = true
 }
+
+val javaTckClasses = javaTck.incoming.artifactView {
+    attributes {
+        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.CLASSES))
+    }
+}.files
 
 dependencies {
     api(project(":rewrite-core"))
@@ -75,7 +83,7 @@ testing {
                 all {
                     testTask.configure {
                         useJUnitPlatform()
-                        testClassesDirs += files(javaTck.files.map { zipTree(it) })
+                        testClassesDirs += javaTckClasses
                         jvmArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:+ShowHiddenFrames")
                         shouldRunAfter(test)
                     }

--- a/rewrite-java-21/build.gradle.kts
+++ b/rewrite-java-21/build.gradle.kts
@@ -7,7 +7,15 @@ plugins {
 
 val javaTck = configurations.create("javaTck") {
     isTransitive = false
+    isCanBeConsumed = false
+    isCanBeResolved = true
 }
+
+val javaTckClasses = javaTck.incoming.artifactView {
+    attributes {
+        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.CLASSES))
+    }
+}.files
 
 dependencies {
     api(project(":rewrite-core"))
@@ -76,7 +84,7 @@ testing {
                 all {
                     testTask.configure {
                         useJUnitPlatform()
-                        testClassesDirs += files(javaTck.files.map { zipTree(it) })
+                        testClassesDirs += javaTckClasses
                         jvmArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:+ShowHiddenFrames")
                         shouldRunAfter(test)
                     }

--- a/rewrite-java-25/build.gradle.kts
+++ b/rewrite-java-25/build.gradle.kts
@@ -7,7 +7,15 @@ plugins {
 
 val javaTck = configurations.create("javaTck") {
     isTransitive = false
+    isCanBeConsumed = false
+    isCanBeResolved = true
 }
+
+val javaTckClasses = javaTck.incoming.artifactView {
+    attributes {
+        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.CLASSES))
+    }
+}.files
 
 dependencies {
     api(project(":rewrite-core"))
@@ -79,7 +87,7 @@ testing {
                 all {
                     testTask.configure {
                         useJUnitPlatform()
-                        testClassesDirs += files(javaTck.files.map { zipTree(it) })
+                        testClassesDirs += javaTckClasses
                         jvmArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:+ShowHiddenFrames")
                         shouldRunAfter(test)
                     }

--- a/rewrite-java-8/build.gradle.kts
+++ b/rewrite-java-8/build.gradle.kts
@@ -11,7 +11,15 @@ val tools = compiler.get().metadata.installationPath.file("lib/tools.jar")
 
 val javaTck = configurations.create("javaTck") {
     isTransitive = false
+    isCanBeConsumed = false
+    isCanBeResolved = true
 }
+
+val javaTckClasses = javaTck.incoming.artifactView {
+    attributes {
+        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.CLASSES))
+    }
+}.files
 
 dependencies {
     compileOnly(files(tools))
@@ -81,7 +89,7 @@ testing {
                 all {
                     testTask.configure {
                         useJUnitPlatform()
-                        testClassesDirs += files(javaTck.files.map { zipTree(it) })
+                        testClassesDirs += javaTckClasses
                         jvmArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:+ShowHiddenFrames")
                         shouldRunAfter(test)
                     }


### PR DESCRIPTION
## What's changed?

Changing the internal Gradle configuration of Java compatibility tests.
Namely, the various Java version tests (8, 11, 17, 21, 25) when depending on java-tck, now they depend on the class files of that module, not a jar. JAR is not deterministic and prevents Gradle caching (unless some tricks are applied there).

## What's your motivation?

Speed up CI in this project. These Java compatibility tests have no need to run in every single PR. They are bound to give the same output if nothing changed in the chain.