### PR TITLE
UpgradeDependencyVersion: pass --legacy-peer-deps to npm/pnpm

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/package-manager.ts
+++ b/rewrite-javascript/rewrite/src/javascript/package-manager.ts
@@ -60,9 +60,14 @@ interface PackageManagerConfig {
 const PACKAGE_MANAGER_CONFIGS: Record<PackageManager, PackageManagerConfig> = {
     [PackageManager.Npm]: {
         lockFile: 'package-lock.json',
-        // --ignore-scripts prevents prepublish/prepare scripts from running in temp directory
-        installLockOnlyCommand: ['npm', 'install', '--package-lock-only', '--ignore-scripts'],
-        installCommand: ['npm', 'install', '--ignore-scripts'],
+        // --ignore-scripts prevents prepublish/prepare scripts from running in temp directory.
+        // --legacy-peer-deps disables npm 7+'s strict peer-dep enforcement. The install here is
+        // purely a validity check on the bumped package.json; the resulting node_modules is not
+        // shipped to the user. Strict peer enforcement creates false negatives in common
+        // ecosystem upgrades (e.g. Angular major bumps where third-party libs lag), which would
+        // otherwise prevent the bump from being written even when it is correct.
+        installLockOnlyCommand: ['npm', 'install', '--package-lock-only', '--ignore-scripts', '--legacy-peer-deps'],
+        installCommand: ['npm', 'install', '--ignore-scripts', '--legacy-peer-deps'],
         listCommand: ['npm', 'list', '--json', '--all'],
     },
     [PackageManager.YarnClassic]: {
@@ -81,9 +86,11 @@ const PACKAGE_MANAGER_CONFIGS: Record<PackageManager, PackageManagerConfig> = {
     },
     [PackageManager.Pnpm]: {
         lockFile: 'pnpm-lock.yaml',
-        // --ignore-scripts prevents lifecycle scripts from running in temp directory
-        installLockOnlyCommand: ['pnpm', 'install', '--lockfile-only', '--ignore-scripts'],
-        installCommand: ['pnpm', 'install', '--ignore-scripts'],
+        // --ignore-scripts prevents lifecycle scripts from running in temp directory.
+        // --no-strict-peer-dependencies disables pnpm's strict peer-dep enforcement (see the
+        // `npm` entry above for rationale).
+        installLockOnlyCommand: ['pnpm', 'install', '--lockfile-only', '--ignore-scripts', '--no-strict-peer-dependencies'],
+        installCommand: ['pnpm', 'install', '--ignore-scripts', '--no-strict-peer-dependencies'],
         listCommand: ['pnpm', 'list', '--json', '--depth=Infinity'],
     },
     [PackageManager.Bun]: {


### PR DESCRIPTION
## Summary

The install run inside `runInstallInTempDir` is purely a validity check on the bumped `package.json` — the resulting `node_modules` is **not shipped to the user**. npm 7+ and pnpm enforce strict peer dependencies by default, which creates false negatives in common ecosystem upgrades (e.g. Angular major bumps, where third-party libs lag the framework's release cadence).

- When the strict install fails, `UpgradeDependencyVersion` returns a `markupWarn` (#7479) without writing the bump, leaving the user's `package.json` untouched even though the bump itself is correct and would resolve under the lenient behavior they would normally use locally (`npm install --legacy-peer-deps`).

This PR passes `--legacy-peer-deps` (npm) and `--no-strict-peer-dependencies` (pnpm) to the temp-dir install so that peer-dep mismatches no longer block the bump from being written. Yarn Classic, Yarn Berry, and Bun are non-strict by default and need no equivalent flag.

## Real-world example

Angular 17 → 18 with `@ng-bootstrap/ng-bootstrap@16` (peer-pinned to Angular `<17`) creates a circular peer-dep cascade: bumping Angular alone fails ERESOLVE (because ng-bootstrap@16 still requires `<17`), and bumping ng-bootstrap@16 → 17 alone fails (ng-bootstrap@17 requires Angular `>=18`). With strict enforcement, neither bump is ever written and the recipe leaves the user's `package.json` unchanged. With this change, both bumps are written and the user resolves the install themselves with `npm install --legacy-peer-deps` (which is the standard Angular ecosystem practice anyway — `ng update` itself reaches for these flags).

## Test plan

- [x] `vitest test/javascript/package-manager.test.ts` — all 24 tests pass
- [x] `vitest test/javascript/recipes/upgrade-dependency-version.test.ts` — all 25 tests pass (including the two existing tests that exercise `markupWarn` on install failure, which still pass because `--legacy-peer-deps` doesn't suppress missing-package or engine-version errors)
- [ ] CI green