### PR TITLE
Fix Groovy parser failure on nested annotations in list literals

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -829,7 +829,13 @@ public class GroovyParserVisitor {
 
         private <T> T doVisit(ASTNode node) {
             nodeCursor = new Cursor(nodeCursor, node);
-            node.visit(this);
+            if (node instanceof AnnotationConstantExpression) {
+                // AnnotationConstantExpression.visit() walks the inner annotation's members itself,
+                // which would re-visit them at the wrong cursor position. Dispatch directly instead.
+                queue.add(visitAnnotation((AnnotationNode) ((AnnotationConstantExpression) node).getValue(), classVisitor));
+            } else {
+                node.visit(this);
+            }
             nodeCursor = nodeCursor.getParentOrThrow();
             return pollQueue();
         }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
@@ -141,6 +141,20 @@ class AnnotationTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/286")
+    @Test
+    void nestedAnnotationsInListLiteral() {
+        rewriteRun(
+          groovy(
+            """
+              @Tags(categories = [@Tag("tag1"), @Tag("tag2")])
+              class Main {
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4254")
     @Test
     void groovyTransformAnnotation() {


### PR DESCRIPTION
## Summary
- Fixes `IllegalStateException: Unexpected constant type: <name>` when parsing Groovy code that uses an annotation array literal as an annotation value, e.g. `@Tags(categories = [@Tag("tag1"), @Tag("tag2")])`.
- The exception comes from `GroovyParserVisitor.visitConstantExpression`, but the deeper issue is that `AnnotationConstantExpression.visit()` does two things: it calls `super.visit()` (which routes to `visitConstantExpression`) **and** it walks the inner annotation's members itself afterward. Handling the case only in `visitConstantExpression` would still re-visit those members at the wrong cursor position.
- Fix: special-case `AnnotationConstantExpression` in `RewriteGroovyVisitor.doVisit`, dispatching directly to the existing `visitAnnotation(AnnotationNode, …)` and skipping `node.visit(this)` entirely.

- Closes openrewrite/rewrite-logging-frameworks#286.

## Test plan
- [x] New `AnnotationTest.nestedAnnotationsInListLiteral` covers the failing input.
- [x] Full `:rewrite-groovy:test` passes.