### PR TITLE
Groovy: fix parsing of method calls on int literals

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1662,7 +1662,7 @@ public class GroovyParserVisitor {
                     }
                     for (; i < source.length(); i++) {
                         char c = source.charAt(i);
-                        if (!(isJavaIdentifierPart(c) || (c == '.' && source.length() > (i + 1) && isJavaIdentifierPart(source.charAt(i + 1))))) {
+                        if (!(isJavaIdentifierPart(c) || (c == '.' && source.length() > (i + 1) && Character.isDigit(source.charAt(i + 1))))) {
                             break;
                         }
                     }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -68,6 +68,13 @@ class MethodInvocationTest implements RewriteTest {
     }
 
     @Test
+    void closureArgumentOnNumericLiteralReceiver() {
+        rewriteRun(
+          groovy("50.times { 1 }")
+        );
+    }
+
+    @Test
     void noParentheses() {
         rewriteRun(
           groovy(


### PR DESCRIPTION
## What's changed?

Fix Groovy parser with regards to method calls on int literals, e.g. `50.times { ... }`

## What's your motivation?

Otherwise the Gradle parser suffers from idempotency issues.