### PR TITLE
Groovy: support `@groovy.test.NotYetImplemented`

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -789,6 +789,17 @@ public class GroovyParserVisitor {
                 } else {
                     if (annotations.stream().anyMatch(a -> TypeUtils.isOfClassType(a.getAnnotationType().getType(), "groovy.transform.Synchronized"))) {
                         body = bodyVisitor.doVisit(((SynchronizedStatement) method.getCode()).getCode());
+                    } else if (annotations.stream().anyMatch(a -> TypeUtils.isOfClassType(a.getAnnotationType().getType(), "groovy.test.NotYetImplemented") ||
+                            TypeUtils.isOfClassType(a.getAnnotationType().getType(), "groovy.transform.NotYetImplemented"))) {
+                        // The @NotYetImplemented AST transformation wraps the original method body in a TryCatchStatement
+                        // followed by a ThrowStatement; unwrap it so source positions align with the original body
+                        org.codehaus.groovy.ast.stmt.Statement code = method.getCode();
+                        if (code instanceof BlockStatement && !((BlockStatement) code).getStatements().isEmpty() &&
+                                ((BlockStatement) code).getStatements().get(0) instanceof TryCatchStatement) {
+                            body = bodyVisitor.doVisit(((TryCatchStatement) ((BlockStatement) code).getStatements().get(0)).getTryStatement());
+                        } else {
+                            body = bodyVisitor.doVisit(method.getCode());
+                        }
                     } else {
                         body = bodyVisitor.doVisit(method.getCode());
                     }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
@@ -308,4 +308,22 @@ class AnnotationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void notYetImplementedAnnotation() {
+        rewriteRun(
+          groovy(
+            """
+              import groovy.test.NotYetImplemented
+
+              class Foo {
+                  @NotYetImplemented
+                  void m() {
+                      println("hello")
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Adding support for special Groovy annotation called `@groovy.test.NotYetImplemented`

## What's your motivation?

The support was missing and the synthesised code caused idempotency issues.