### PR TITLE
Groovy: fix parsing method invocations with method names like `.classSomething`

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1099,9 +1099,12 @@ public class GroovyParserVisitor {
                 }
             }
             if (sourceStartsWith(".class")) {
-                String classSuffix = source.substring(cursor, indexOfNextNonWhitespace(cursor, source)) + ".class";
-                name += classSuffix;
-                skip(classSuffix);
+                int afterClass = indexOfNextNonWhitespace(cursor, source) + ".class".length();
+                if (afterClass >= source.length() || !Character.isJavaIdentifierPart(source.charAt(afterClass))) {
+                    String classSuffix = source.substring(cursor, indexOfNextNonWhitespace(cursor, source)) + ".class";
+                    name += classSuffix;
+                    skip(classSuffix);
+                }
             }
             queue.add(TypeTree.build(name)
                     .withType(typeMapping.type(type))

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -760,4 +760,15 @@ class MethodInvocationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void methodNameStartingWithClassKeyword() {
+        rewriteRun(
+          groovy(
+            """
+              Object.className("foo")
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fixing a bug in Groovy parser affecting method invocations with method names starting with `class`.

## What's your motivation?

The Groovy parser would eagerly recognize `.class` as in `MyClass.class` syntax and misinterpret it.
Resulting in idempotency issues.