### PR TITLE
Groovy: add trait support

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -186,6 +186,10 @@ public class GroovyParserVisitor {
         for (ClassNode aClass : ast.getClasses()) {
             // skip over the synthetic script class
             if (!aClass.getName().equals(ast.getMainClassName()) || !aClass.getName().endsWith("doesntmatter")) {
+                // skip over synthetic helper classes Groovy generates for traits (e.g. Foo$Trait$Helper, Foo$Trait$FieldHelper)
+                if (aClass.getName().contains("$Trait$")) {
+                    continue;
+                }
                 sortedByPosition.put(pos(aClass), aClass);
             }
         }
@@ -255,9 +259,14 @@ public class GroovyParserVisitor {
 
             Space kindPrefix = whitespace();
             J.ClassDeclaration.Kind.Type kindType;
+            Markers kindMarkers = Markers.EMPTY;
             if (sourceStartsWith("class")) {
                 kindType = J.ClassDeclaration.Kind.Type.Class;
                 skip("class");
+            } else if (sourceStartsWith("trait")) {
+                kindType = J.ClassDeclaration.Kind.Type.Interface;
+                kindMarkers = kindMarkers.addIfAbsent(new Trait(randomId()));
+                skip("trait");
             } else if (clazz.isAnnotationDefinition()) {
                 kindType = J.ClassDeclaration.Kind.Type.Annotation;
                 skip("@interface");
@@ -273,7 +282,7 @@ public class GroovyParserVisitor {
             } else {
                 throw new IllegalStateException("Unexpected class type: " + name());
             }
-            J.ClassDeclaration.Kind kind = new J.ClassDeclaration.Kind(randomId(), kindPrefix, Markers.EMPTY, emptyList(), kindType);
+            J.ClassDeclaration.Kind kind = new J.ClassDeclaration.Kind(randomId(), kindPrefix, kindMarkers, emptyList(), kindType);
             J.Identifier name = new J.Identifier(randomId(), whitespace(), Markers.EMPTY, emptyList(), name(), typeMapping.type(clazz), null);
             JContainer<J.TypeParameter> typeParameterContainer = null;
             if (clazz.isUsingGenerics() && clazz.getGenericsTypes() != null) {
@@ -440,7 +449,7 @@ public class GroovyParserVisitor {
             Iterator<InnerClassNode> innerClassIterator = clazz.getInnerClasses();
             while (innerClassIterator.hasNext()) {
                 InnerClassNode icn = innerClassIterator.next();
-                if (icn.isSynthetic() || fieldInitializers.contains(icn)) {
+                if (icn.isSynthetic() || fieldInitializers.contains(icn) || icn.getName().contains("$Trait$")) {
                     continue;
                 }
                 sortedByPosition.put(pos(icn), icn);

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -92,6 +92,11 @@ public class GroovyParserVisitor {
 
     private int cursor = 0;
 
+    /** Maps a trait class name to its synthetic Groovy-generated {@code $Trait$Helper} class. */
+    private final Map<String, ClassNode> traitHelpers = new HashMap<>();
+    /** Maps a trait class name to its synthetic Groovy-generated {@code $Trait$FieldHelper} class. */
+    private final Map<String, ClassNode> traitFieldHelpers = new HashMap<>();
+
     private static final Pattern MULTILINE_COMMENT_REGEX = Pattern.compile("(?s)/\\*.*?\\*/");
     private static final Pattern whitespacePrefixPattern = Pattern.compile("^\\s*");
 
@@ -186,8 +191,17 @@ public class GroovyParserVisitor {
         for (ClassNode aClass : ast.getClasses()) {
             // skip over the synthetic script class
             if (!aClass.getName().equals(ast.getMainClassName()) || !aClass.getName().endsWith("doesntmatter")) {
-                // skip over synthetic helper classes Groovy generates for traits (e.g. Foo$Trait$Helper, Foo$Trait$FieldHelper)
-                if (aClass.getName().contains("$Trait$")) {
+                // synthetic helper classes Groovy generates for traits hold the bodies of trait methods/fields;
+                // record them by their owning trait so we can merge bodies back when visiting the trait
+                String name = aClass.getName();
+                int helperIdx = name.indexOf("$Trait$Helper");
+                if (helperIdx > 0) {
+                    traitHelpers.put(name.substring(0, helperIdx), aClass);
+                    continue;
+                }
+                int fieldHelperIdx = name.indexOf("$Trait$FieldHelper");
+                if (fieldHelperIdx > 0) {
+                    traitFieldHelpers.put(name.substring(0, fieldHelperIdx), aClass);
                     continue;
                 }
                 sortedByPosition.put(pos(aClass), aClass);
@@ -375,9 +389,28 @@ public class GroovyParserVisitor {
                     TypeUtils.asFullyQualified(typeMapping.type(clazz))));
         }
 
+        /**
+         * Find the helper method on a trait's {@code $Trait$Helper} class that corresponds to {@code traitMethod}.
+         * The helper version has the trait instance prepended as a synthetic {@code $self} parameter.
+         */
+        private @Nullable MethodNode findTraitHelperMethod(ClassNode helper, MethodNode traitMethod) {
+            for (MethodNode candidate : helper.getMethods(traitMethod.getName())) {
+                Parameter[] params = candidate.getParameters();
+                if (params.length == traitMethod.getParameters().length + 1 &&
+                        ("$self".equals(params[0].getName()) || "$static$self".equals(params[0].getName()))) {
+                    return candidate;
+                }
+            }
+            return null;
+        }
+
         J.Block visitClassBlock(ClassNode clazz) {
             NavigableMap<LineColumn, ASTNode> sortedByPosition = new TreeMap<>();
             List<FieldNode> enumConstants = new ArrayList<>();
+            // Groovy's trait AST transformation strips method bodies from the trait and moves them to a synthetic
+            // $Trait$Helper class, leaving the trait class with only abstract method signatures. Substitute each
+            // trait method with its helper counterpart so we can recover the original body when visiting it.
+            ClassNode helperForTrait = traitHelpers.get(clazz.getName());
             for (MethodNode method : clazz.getMethods()) {
                 // Most synthetic methods do not appear in source code and should be skipped entirely.
                 if (method.isSynthetic()) {
@@ -387,8 +420,15 @@ public class GroovyParserVisitor {
                         org.codehaus.groovy.ast.stmt.Statement statement = ((BlockStatement) method.getCode()).getStatements().get(0);
                         sortedByPosition.put(pos(statement), statement);
                     }
-                } else if (method.getAnnotations(new ClassNode(Generated.class)).isEmpty()) {
-                    sortedByPosition.put(pos(method), method);
+                } else if (method.getAnnotations(new ClassNode(Generated.class)).isEmpty() && appearsInSource(method)) {
+                    MethodNode toAdd = method;
+                    if (helperForTrait != null) {
+                        MethodNode helperMethod = findTraitHelperMethod(helperForTrait, method);
+                        if (helperMethod != null) {
+                            toAdd = helperMethod;
+                        }
+                    }
+                    sortedByPosition.put(pos(toAdd), toAdd);
                 }
             }
             for (org.codehaus.groovy.ast.stmt.Statement objectInitializer : clazz.getObjectInitializerStatements()) {
@@ -722,7 +762,13 @@ public class GroovyParserVisitor {
             Space beforeParen = sourceBefore("(");
             List<JRightPadded<Statement>> params = new ArrayList<>(method.getParameters().length);
             Parameter[] unparsedParams = method.getParameters();
-            int skipParams = isConstructorOfEnum ? 2 : isConstructorOfInnerNonStaticClass ? 1 : 0;
+            // For trait methods (which are stored on the synthetic $Trait$Helper class), skip the
+            // synthetic first parameter ($self / $static$self) the trait transformation prepends.
+            boolean isTraitHelperMethod = method.getDeclaringClass() != null &&
+                    method.getDeclaringClass().getName().contains("$Trait$Helper") &&
+                    unparsedParams.length > 0 &&
+                    ("$self".equals(unparsedParams[0].getName()) || "$static$self".equals(unparsedParams[0].getName()));
+            int skipParams = isConstructorOfEnum ? 2 : isConstructorOfInnerNonStaticClass ? 1 : isTraitHelperMethod ? 1 : 0;
             for (int i = skipParams; i < unparsedParams.length; i++) {
                 Parameter param = unparsedParams[i];
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
@@ -290,6 +290,29 @@ public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
         }
 
         @Override
+        public J visitClassDeclaration(J.ClassDeclaration classDecl, PrintOutputCapture<P> p) {
+            if (!classDecl.getPadding().getKind().getMarkers().findFirst(Trait.class).isPresent()) {
+                return super.visitClassDeclaration(classDecl, p);
+            }
+            beforeSyntax(classDecl, Space.Location.CLASS_DECLARATION_PREFIX, p);
+            visitSpace(Space.EMPTY, Space.Location.ANNOTATIONS, p);
+            visit(classDecl.getLeadingAnnotations(), p);
+            for (J.Modifier m : classDecl.getModifiers()) {
+                visitModifier(m, p);
+            }
+            visit(classDecl.getPadding().getKind().getAnnotations(), p);
+            visitSpace(classDecl.getPadding().getKind().getPrefix(), Space.Location.CLASS_KIND, p);
+            p.append("trait");
+            visit(classDecl.getName(), p);
+            visitContainer("<", classDecl.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, ",", ">", p);
+            visitLeftPadded("extends", classDecl.getPadding().getExtends(), JLeftPadded.Location.EXTENDS, p);
+            visitContainer("extends", classDecl.getPadding().getImplements(), JContainer.Location.IMPLEMENTS, ",", null, p);
+            visit(classDecl.getBody(), p);
+            afterSyntax(classDecl, p);
+            return classDecl;
+        }
+
+        @Override
         public J visitTypeCast(J.TypeCast t, PrintOutputCapture<P> p) {
             if (!t.getMarkers().findFirst(AsStyleTypeCast.class).isPresent()) {
                 return super.visitTypeCast(t, p);

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/marker/Trait.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/marker/Trait.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Marks a {@link org.openrewrite.java.tree.J.ClassDeclaration} that was declared with the Groovy
+ * {@code trait} keyword. The class declaration itself uses {@code Kind.Type.Interface} since a
+ * Groovy trait compiles to a JVM interface.
+ */
+@Value
+@With
+public class Trait implements Marker {
+    UUID id;
+}

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -528,4 +528,30 @@ class ClassDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void trait() {
+        rewriteRun(
+          groovy(
+            """
+              trait Foo {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void traitExtendsTrait() {
+        rewriteRun(
+          groovy(
+            """
+              trait A {
+              }
+              trait B extends A {
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -554,4 +554,54 @@ class ClassDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void traitWithMethod() {
+        rewriteRun(
+          groovy(
+            """
+              trait Greeter {
+                  String greet() {
+                      "hello"
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void traitWithMethodTakingParameter() {
+        rewriteRun(
+          groovy(
+            """
+              trait Greeter {
+                  String greet(String name) {
+                      "hello $name"
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void traitWithMultipleMethods() {
+        rewriteRun(
+          groovy(
+            """
+              trait Greeter {
+                  String greet() {
+                      "hello"
+                  }
+
+                  String shout(String msg) {
+                      msg.toUpperCase()
+                  }
+              }
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?

Adding support for **traits** to Groovy parser.
Modelled after other languages which have traits (or similar structures). I.e. use `J.ClassDeclaration` + a marker.

## What's your motivation?

It looks like we have never supported them yet.