### PR TITLE
Javadoc: preserve multi-line HTML comments inside block tags

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -1158,6 +1158,8 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                 js.addAll(whitespaceBefore());
                 if (dt instanceof DCTree.DCText) {
                     js.addAll(visitText(((DCTree.DCText) dt).getBody()));
+                } else if (dt instanceof DCTree.DCComment) {
+                    js.addAll(visitText(((DCTree.DCComment) dt).getBody()));
                 } else {
                     js.add((Javadoc) scan(dt, emptyList()));
                 }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -1161,6 +1161,8 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                 js.addAll(whitespaceBefore());
                 if (dt instanceof DCTree.DCText) {
                     js.addAll(visitText(((DCTree.DCText) dt).getBody()));
+                } else if (dt instanceof DCTree.DCComment) {
+                    js.addAll(visitText(((DCTree.DCComment) dt).getBody()));
                 } else {
                     js.add((Javadoc) scan(dt, emptyList()));
                 }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
@@ -1196,6 +1196,8 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                 js.addAll(whitespaceBefore());
                 if (dt instanceof DCTree.DCText) {
                     js.addAll(visitText(((DCTree.DCText) dt).getBody()));
+                } else if (dt instanceof DCTree.DCComment) {
+                    js.addAll(visitText(((DCTree.DCComment) dt).getBody()));
                 } else {
                     js.add((Javadoc) scan(dt, emptyList()));
                 }

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25JavadocVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25JavadocVisitor.java
@@ -1339,6 +1339,8 @@ public class ReloadableJava25JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                     js.addAll(visitText(textNode.getBody()));
                 } else if (dt instanceof DCTree.DCRawText rawTextNode) {
                     js.addAll(visitText(rawTextNode.getContent()));
+                } else if (dt instanceof DCTree.DCComment commentNode) {
+                    js.addAll(visitText(commentNode.getBody()));
                 } else {
                     js.add((Javadoc) scan(dt, emptyList()));
                 }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -1086,6 +1086,8 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
                 js.addAll(whitespaceBefore());
                 if (dt instanceof DCTree.DCText) {
                     js.addAll(visitText(((DCTree.DCText) dt).getBody()));
+                } else if (dt instanceof DCTree.DCComment) {
+                    js.addAll(visitText(((DCTree.DCComment) dt).getBody()));
                 } else {
                     js.add((Javadoc) scan(dt, emptyList()));
                 }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
@@ -2214,6 +2214,23 @@ class JavadocTest implements RewriteTest {
         );
     }
 
+    @Test
+    void multilineHtmlCommentInBlockTag() {
+        rewriteRun(
+          java(
+            """
+              /**
+              * @version 0.1
+              *    <!-- xml comment nested
+              *       * [someAuthor] fixed something
+              *    -->
+              **/
+              class Test {}
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/5443")
     @Test
     void parsingIncorrectJavadocValueReference() {


### PR DESCRIPTION
## Summary

- A multi-line `<!-- ... -->` HTML comment inside a Javadoc block tag (e.g. `@version`, `@param`, `@return`) was printed back with the leading `*` margin missing on interior lines and with orphan `*` lines appended after the comment.
- `convertMultiline` already routed `DCText` through `visitText` (which consumes a `LineBreak` per newline). `DCComment` fell through to `scan` -> `visitComment`, which bumped the cursor by the body length in one shot and wrapped the multi-line body in a single `Javadoc.Text` — so interior margins were dropped and the unconsumed `LineBreak`s spilled out at the end of the doc.
- Mirror the `DCText` handling for `DCComment` in `convertMultiline` across `rewrite-java-{8,11,17,21,25}` and add a regression test.
- Closes https://github.com/moderneinc/customer-requests/issues/2277

## Test plan
- [x] `./gradlew :rewrite-java-21:compatibilityTest --tests "*JavadocTest*"`
- [x] `./gradlew :rewrite-java-{8,11,17,25}:compatibilityTest`