### PR TITLE
Groovy: fix parsing syntactic sugar of closure-call expressions

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2071,6 +2071,24 @@ public class GroovyParserVisitor {
 
         @Override
         public void visitMethodCallExpression(MethodCallExpression call) {
+            // Groovy parses control-flow constructs inside a GString interpolation
+            // (e.g. ${if (cond) { a } else { b }}) as a synthetic implicit call() on
+            // a ClosureExpression that wraps the statement. The "call" method name
+            // does not appear in the source, so unwrap and visit the inner statement.
+            if (call.isImplicitThis() &&
+                    call.getObjectExpression() instanceof ClosureExpression &&
+                    "call".equals(call.getMethodAsString()) &&
+                    call.getArguments() instanceof ArgumentListExpression &&
+                    ((ArgumentListExpression) call.getArguments()).getExpressions().isEmpty()) {
+                ClosureExpression closure = (ClosureExpression) call.getObjectExpression();
+                if (closure.getCode() instanceof BlockStatement) {
+                    BlockStatement body = (BlockStatement) closure.getCode();
+                    if (body.getStatements().size() == 1 && body.getStatements().get(0) instanceof IfStatement) {
+                        body.getStatements().get(0).visit(this);
+                        return;
+                    }
+                }
+            }
             queue.add(insideParentheses(call, fmt -> {
                 ImplicitDot implicitDot = null;
                 JRightPadded<Expression> select = null;

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -280,6 +280,17 @@ class LiteralTest implements RewriteTest {
     }
 
     @Test
+    void gStringWithIfElseExpression() {
+        rewriteRun(
+          groovy(
+            """
+              def x = "${if (true) { "a" } else { "b" }}"
+              """
+          )
+        );
+    }
+
+    @Test
     void mapLiteral() {
         rewriteRun(
           groovy(


### PR DESCRIPTION
## What's changed?

Fix parsing of closure-call expressions in Groovy.

## What's your motivation?

They currently suffer from idempotency issues.