### PR TITLE
Groovy: fix parsing of generics class literal

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1168,7 +1168,16 @@ public class GroovyParserVisitor {
                             emptyList(),
                             name,
                             typeMapping.type(type), null);
-                    queue.add(new J.ParameterizedType(randomId(), prefix, Markers.EMPTY, ident, visitTypeParameterizations(generics), typeMapping.type(type)));
+                    J.ParameterizedType parameterizedType = new J.ParameterizedType(randomId(), prefix, Markers.EMPTY, ident, visitTypeParameterizations(generics), typeMapping.type(type));
+                    if (sourceStartsWith(".class")) {
+                        Space beforeDot = sourceBefore(".");
+                        Space classPrefix = whitespace();
+                        skip("class");
+                        J.Identifier classIdent = new J.Identifier(randomId(), classPrefix, Markers.EMPTY, emptyList(), "class", null, null);
+                        queue.add(new J.FieldAccess(randomId(), EMPTY, Markers.EMPTY, parameterizedType, padLeft(beforeDot, classIdent), typeMapping.type(type)));
+                        return;
+                    }
+                    queue.add(parameterizedType);
                     return;
                 }
             }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassExpressionTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassExpressionTest.java
@@ -96,4 +96,15 @@ class ClassExpressionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void parameterizedClassLiteral() {
+        rewriteRun(
+          groovy(
+            """
+              def x = ArrayList<String>.class
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fix parsing of Groovy class literals with generics, e.g. `ArrayList<String>.class`

## What's your motivation?

They currently suffer from idempotency issues.