### PR TITLE
Groovy: more fixes to map key expressions with parens

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2098,7 +2098,9 @@ public class GroovyParserVisitor {
             Expression key;
             int saveCursor = cursor;
             Space beforeOpenParen = whitespace();
-            if (cursor < source.length() && source.charAt(cursor) == '(') {
+            Integer keyParenLevel = getInsideParenthesesLevel(expression.getKeyExpression());
+            if ((keyParenLevel == null || keyParenLevel == 0) &&
+                    cursor < source.length() && source.charAt(cursor) == '(') {
                 skip("(");
                 Expression inner = doVisit(expression.getKeyExpression());
                 key = new J.Parentheses<>(randomId(), beforeOpenParen, Markers.EMPTY,

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MapEntryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MapEntryTest.java
@@ -83,4 +83,71 @@ class MapEntryTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void parenthesizedKeyInMapLiteral() {
+        rewriteRun(
+          groovy(
+            """
+              def first(String key) {
+                  def m = [(key): "v"]
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void parenthesizedKeyInMapLiteralMultipleEntries() {
+        rewriteRun(
+          groovy(
+            """
+              def m(String k1, String k2) {
+                  return [(k1): "v1", (k2): "v2"]
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void parenthesizedKeyExpressionInMapLiteral() {
+        rewriteRun(
+          groovy(
+            """
+              class Defaults {
+                  static final String KEY = "k"
+              }
+              def m = [(Defaults.KEY): "v"]
+              """
+          )
+        );
+    }
+
+    @Test
+    void parenthesizedKeyInMapLiteralAsArgument() {
+        rewriteRun(
+          groovy(
+            """
+              def writeProperties(Map m) {}
+              def call(String key) {
+                  writeProperties([(key): "v"])
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void parenthesizedKeyInNestedMapLiteral() {
+        rewriteRun(
+          groovy(
+            """
+              def first(String key) {
+                  def m = [outer: [(key): "v"]]
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

- Continuation of #7485.

Fixing Groovy parser for dynamic map key expressions in various contexts.

## What's your motivation?

These tend to suffer from idempotency issues.