### PR TITLE
Groovy: fix parsing of negated new expression

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1812,7 +1812,21 @@ public class GroovyParserVisitor {
             queue.add(insideParentheses(expression, fmt -> {
                 skip("!");
                 JLeftPadded<J.Unary.Type> op = padLeft(EMPTY, J.Unary.Type.Not);
-                Expression expr = doVisit(expression.getExpression());
+                // Groovy 3+ does not set _INSIDE_PARENTHESES_LEVEL on PropertyExpression / MethodCallExpression,
+                // so when `!` directly wraps such an expression in parentheses, detect the parentheses from the source.
+                org.codehaus.groovy.ast.expr.Expression operand = expression.getExpression();
+                int savedCursor = cursor;
+                Space beforeParen = whitespace();
+                Expression expr;
+                if (cursor < source.length() && source.charAt(cursor) == '(' && getInsideParenthesesLevel(operand) == null) {
+                    skip("(");
+                    Expression inner = doVisit(operand);
+                    expr = new J.Parentheses<>(randomId(), beforeParen, Markers.EMPTY,
+                            JRightPadded.build((J) inner).withAfter(sourceBefore(")")));
+                } else {
+                    cursor = savedCursor;
+                    expr = doVisit(operand);
+                }
                 return new J.Unary(randomId(), fmt, Markers.EMPTY, op, expr, typeMapping.type(expression.getType()));
             }));
         }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/UnaryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/UnaryTest.java
@@ -70,4 +70,27 @@ class UnaryTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void negationOfParenthesizedPropertyAccess() {
+        rewriteRun(
+          groovy(
+            """
+              !(new String("a").bytes)
+              """
+          )
+        );
+    }
+
+    @Test
+    void negationOfParenthesizedPropertyAccessOnLocal() {
+        rewriteRun(
+          groovy(
+            """
+              def x = "a"
+              def b = !(x.bytes)
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fix Groovy parser behavior for new expressions wrapped with parenthesis with negation, e.g.
```
!(new String("a").bytes)
```

## What's your motivation?

They currently suffer from idepomtency issues.