### PR TITLE
Scope Python RPC marketplace responses to the requested distribution

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/__init__.py
@@ -9,7 +9,7 @@ except ImportError:
 
 from .category import CategoryDescriptor, LOWEST_PRECEDENCE, DEFAULT_PRECEDENCE, HIGHEST_PRECEDENCE
 from .decorators import categorize, get_recipe_category
-from .discovery import discover_recipes, discover_decorated_recipes_in_module
+from .discovery import discover_recipes, discover_decorated_recipes_in_module, RecipeAttribution
 from .execution import ExecutionContext, DelegatingExecutionContext, InMemoryExecutionContext, \
     RecipeRunException, LargeSourceSet, InMemoryLargeSourceSet, Result
 from .marketplace import RecipeMarketplace, Python
@@ -68,6 +68,7 @@ __all__ = [
     'get_recipe_category',
     'discover_recipes',
     'discover_decorated_recipes_in_module',
+    'RecipeAttribution',
     'activate',
 
     # Markers

--- a/rewrite-python/rewrite/src/rewrite/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/__init__.py
@@ -9,7 +9,13 @@ except ImportError:
 
 from .category import CategoryDescriptor, LOWEST_PRECEDENCE, DEFAULT_PRECEDENCE, HIGHEST_PRECEDENCE
 from .decorators import categorize, get_recipe_category
-from .discovery import discover_recipes, discover_decorated_recipes_in_module, RecipeAttribution
+from .discovery import (
+    discover_recipes,
+    discover_decorated_recipes_in_module,
+    RecipeAttribution,
+    RecipeName,
+    NormalizedDistName,
+)
 from .execution import ExecutionContext, DelegatingExecutionContext, InMemoryExecutionContext, \
     RecipeRunException, LargeSourceSet, InMemoryLargeSourceSet, Result
 from .marketplace import RecipeMarketplace, Python
@@ -69,6 +75,8 @@ __all__ = [
     'discover_recipes',
     'discover_decorated_recipes_in_module',
     'RecipeAttribution',
+    'RecipeName',
+    'NormalizedDistName',
     'activate',
 
     # Markers

--- a/rewrite-python/rewrite/src/rewrite/discovery.py
+++ b/rewrite-python/rewrite/src/rewrite/discovery.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import inspect
 from importlib.metadata import entry_points
-from typing import List, Tuple, Type
+from typing import Dict, List, Optional, Set, Tuple, Type
 
 from rewrite.category import CategoryDescriptor
 from rewrite.decorators import get_recipe_category
@@ -26,7 +26,10 @@ from rewrite.marketplace import RecipeMarketplace
 from rewrite.recipe import Recipe
 
 
-def discover_recipes() -> RecipeMarketplace:
+def discover_recipes(
+    marketplace: Optional[RecipeMarketplace] = None,
+    attribution: Optional[Dict[str, Set[str]]] = None,
+) -> RecipeMarketplace:
     """
     Discover all recipes from installed packages via entry points.
 
@@ -34,8 +37,19 @@ def discover_recipes() -> RecipeMarketplace:
     [project.entry-points."openrewrite.recipes"] and calls their
     activate function to install recipes into the marketplace.
 
+    Args:
+        marketplace: Optional existing marketplace to install into; a new one
+            is created when None.
+        attribution: Optional ``{distribution_name: set_of_recipe_names}`` map
+            populated as a side effect. Each entry point's contribution is
+            recorded under its distribution's normalized name so callers can
+            later answer "which recipes came from package X?" without
+            re-walking entry_points. Names not present after activation
+            (e.g., recipes deduplicated by an earlier entry point) are
+            still attributed because deduplication doesn't remove them.
+
     Returns:
-        A RecipeMarketplace containing all discovered recipes.
+        The marketplace containing all discovered recipes.
 
     Example pyproject.toml entry point:
         [project.entry-points."openrewrite.recipes"]
@@ -45,7 +59,8 @@ def discover_recipes() -> RecipeMarketplace:
         def activate(marketplace: RecipeMarketplace) -> None:
             marketplace.install(MyRecipe, [Python, Cleanup])
     """
-    marketplace = RecipeMarketplace()
+    if marketplace is None:
+        marketplace = RecipeMarketplace()
 
     # Python 3.10+ uses select parameter via SelectableGroups
     eps = entry_points(group="openrewrite.recipes")
@@ -54,12 +69,35 @@ def discover_recipes() -> RecipeMarketplace:
         try:
             module = ep.load()
             if hasattr(module, "activate") and callable(module.activate):
-                module.activate(marketplace)
+                if attribution is None:
+                    module.activate(marketplace)
+                else:
+                    dist_name = ep.dist.name if ep.dist is not None else None
+                    before = _recipe_name_set(marketplace)
+                    module.activate(marketplace)
+                    if dist_name:
+                        added = _recipe_name_set(marketplace) - before
+                        if added:
+                            attribution.setdefault(_normalize_package_name(dist_name), set()).update(added)
         except Exception:
             # Log or handle the error - for now, skip failed activations
             pass
 
     return marketplace
+
+
+def _recipe_name_set(marketplace: RecipeMarketplace) -> Set[str]:
+    """Snapshot the set of recipe names currently in the marketplace."""
+    return {r.name for r in marketplace.all_recipes()}
+
+
+def _normalize_package_name(name: str) -> str:
+    """Normalize a python distribution name for attribution lookup.
+
+    PyPI/pip treats hyphens, underscores, and case as equivalent when
+    resolving distribution identity.
+    """
+    return name.replace("-", "_").replace(".", "_").lower()
 
 
 def discover_decorated_recipes_in_module(

--- a/rewrite-python/rewrite/src/rewrite/discovery.py
+++ b/rewrite-python/rewrite/src/rewrite/discovery.py
@@ -17,9 +17,8 @@
 from __future__ import annotations
 
 import inspect
-from dataclasses import dataclass, field
 from importlib.metadata import entry_points
-from typing import Dict, List, Optional, Set, Tuple, Type
+from typing import Dict, List, NewType, Optional, Set, Tuple, Type
 
 from rewrite.category import CategoryDescriptor
 from rewrite.decorators import get_recipe_category
@@ -27,7 +26,19 @@ from rewrite.marketplace import RecipeMarketplace
 from rewrite.recipe import Recipe
 
 
-@dataclass
+# A recipe's fully qualified name (e.g., ``org.openrewrite.python.RemovePass``).
+# NewType is a static-only distinction — at runtime these are plain ``str`` —
+# but it lets type checkers refuse a bare string where a recipe-name set is
+# expected, which catches the kind of "did I just lookup the wrong key" bug
+# that motivated this module's per-distribution attribution in the first place.
+RecipeName = NewType("RecipeName", str)
+
+# A python distribution name in its PEP 503 normalized form (hyphens,
+# underscores, dots all folded to ``_`` and lowercased). Used as the
+# attribution map key. Construct only via :func:`_normalize_package_name`.
+NormalizedDistName = NewType("NormalizedDistName", str)
+
+
 class RecipeAttribution:
     """Tracks which distribution's entry point activated which recipes.
 
@@ -38,9 +49,10 @@ class RecipeAttribution:
     can use any common spelling.
     """
 
-    _by_package: Dict[str, Set[str]] = field(default_factory=dict)
+    def __init__(self) -> None:
+        self._by_package: Dict[NormalizedDistName, Set[RecipeName]] = {}
 
-    def record(self, distribution_name: str, recipe_names: Set[str]) -> None:
+    def record(self, distribution_name: str, recipe_names: Set[RecipeName]) -> None:
         """Attribute ``recipe_names`` to ``distribution_name``.
 
         No-op when ``recipe_names`` is empty; multiple calls for the same
@@ -51,15 +63,12 @@ class RecipeAttribution:
         key = _normalize_package_name(distribution_name)
         self._by_package.setdefault(key, set()).update(recipe_names)
 
-    def recipes_for(self, distribution_name: str) -> Set[str]:
+    def recipes_for(self, distribution_name: str) -> Set[RecipeName]:
         """Return the (possibly empty) set of recipe names attributed to a
         distribution. The returned set is a snapshot — mutating it does not
         change the attribution.
         """
         return set(self._by_package.get(_normalize_package_name(distribution_name), ()))
-
-    def clear(self) -> None:
-        self._by_package.clear()
 
 
 def discover_recipes(
@@ -108,10 +117,10 @@ def discover_recipes(
                 module.activate(marketplace)
                 continue
             dist_name = ep.dist.name if ep.dist is not None else None
-            before = _recipe_name_set(marketplace)
+            before = recipe_name_set(marketplace)
             module.activate(marketplace)
             if dist_name:
-                attribution.record(dist_name, _recipe_name_set(marketplace) - before)
+                attribution.record(dist_name, recipe_name_set(marketplace) - before)
         except Exception:
             # Log or handle the error - for now, skip failed activations
             pass
@@ -119,18 +128,18 @@ def discover_recipes(
     return marketplace
 
 
-def _recipe_name_set(marketplace: RecipeMarketplace) -> Set[str]:
+def recipe_name_set(marketplace: RecipeMarketplace) -> Set[RecipeName]:
     """Snapshot the set of recipe names currently in the marketplace."""
-    return {r.name for r in marketplace.all_recipes()}
+    return {RecipeName(r.name) for r in marketplace.all_recipes()}
 
 
-def _normalize_package_name(name: str) -> str:
+def _normalize_package_name(name: str) -> NormalizedDistName:
     """Normalize a python distribution name for attribution lookup.
 
     PyPI/pip treats hyphens, underscores, and case as equivalent when
     resolving distribution identity.
     """
-    return name.replace("-", "_").replace(".", "_").lower()
+    return NormalizedDistName(name.replace("-", "_").replace(".", "_").lower())
 
 
 def discover_decorated_recipes_in_module(

--- a/rewrite-python/rewrite/src/rewrite/discovery.py
+++ b/rewrite-python/rewrite/src/rewrite/discovery.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import inspect
+from dataclasses import dataclass, field
 from importlib.metadata import entry_points
 from typing import Dict, List, Optional, Set, Tuple, Type
 
@@ -26,9 +27,44 @@ from rewrite.marketplace import RecipeMarketplace
 from rewrite.recipe import Recipe
 
 
+@dataclass
+class RecipeAttribution:
+    """Tracks which distribution's entry point activated which recipes.
+
+    Used to answer "which recipes came from package X?" so callers can scope
+    a marketplace response to a specific distribution instead of returning
+    the whole singleton. Distribution names are PEP 503 normalized (hyphen,
+    underscore, and case folded together) on both write and read, so callers
+    can use any common spelling.
+    """
+
+    _by_package: Dict[str, Set[str]] = field(default_factory=dict)
+
+    def record(self, distribution_name: str, recipe_names: Set[str]) -> None:
+        """Attribute ``recipe_names`` to ``distribution_name``.
+
+        No-op when ``recipe_names`` is empty; multiple calls for the same
+        distribution accumulate.
+        """
+        if not recipe_names:
+            return
+        key = _normalize_package_name(distribution_name)
+        self._by_package.setdefault(key, set()).update(recipe_names)
+
+    def recipes_for(self, distribution_name: str) -> Set[str]:
+        """Return the (possibly empty) set of recipe names attributed to a
+        distribution. The returned set is a snapshot — mutating it does not
+        change the attribution.
+        """
+        return set(self._by_package.get(_normalize_package_name(distribution_name), ()))
+
+    def clear(self) -> None:
+        self._by_package.clear()
+
+
 def discover_recipes(
     marketplace: Optional[RecipeMarketplace] = None,
-    attribution: Optional[Dict[str, Set[str]]] = None,
+    attribution: Optional[RecipeAttribution] = None,
 ) -> RecipeMarketplace:
     """
     Discover all recipes from installed packages via entry points.
@@ -40,13 +76,11 @@ def discover_recipes(
     Args:
         marketplace: Optional existing marketplace to install into; a new one
             is created when None.
-        attribution: Optional ``{distribution_name: set_of_recipe_names}`` map
-            populated as a side effect. Each entry point's contribution is
-            recorded under its distribution's normalized name so callers can
-            later answer "which recipes came from package X?" without
-            re-walking entry_points. Names not present after activation
-            (e.g., recipes deduplicated by an earlier entry point) are
-            still attributed because deduplication doesn't remove them.
+        attribution: Optional sink that records which distribution activated
+            which recipes. When supplied, each entry point's contribution is
+            recorded against its distribution name. Recipes already in the
+            marketplace before this call (e.g., deduped by an earlier entry
+            point) are not re-recorded for the current entry point.
 
     Returns:
         The marketplace containing all discovered recipes.
@@ -68,17 +102,16 @@ def discover_recipes(
     for ep in eps:
         try:
             module = ep.load()
-            if hasattr(module, "activate") and callable(module.activate):
-                if attribution is None:
-                    module.activate(marketplace)
-                else:
-                    dist_name = ep.dist.name if ep.dist is not None else None
-                    before = _recipe_name_set(marketplace)
-                    module.activate(marketplace)
-                    if dist_name:
-                        added = _recipe_name_set(marketplace) - before
-                        if added:
-                            attribution.setdefault(_normalize_package_name(dist_name), set()).update(added)
+            if not hasattr(module, "activate") or not callable(module.activate):
+                continue
+            if attribution is None:
+                module.activate(marketplace)
+                continue
+            dist_name = ep.dist.name if ep.dist is not None else None
+            before = _recipe_name_set(marketplace)
+            module.activate(marketplace)
+            if dist_name:
+                attribution.record(dist_name, _recipe_name_set(marketplace) - before)
         except Exception:
             # Log or handle the error - for now, skip failed activations
             pass

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import Dict, Any, Optional, List, Callable, Set
 from uuid import uuid4
 
-from rewrite.discovery import RecipeAttribution
+from rewrite.discovery import RecipeAttribution, RecipeName
 
 # Deeply nested LST nodes (e.g., 256 implicitly concatenated strings) can
 # overflow the default recursion limit (1000) during RPC serialization.
@@ -605,7 +605,7 @@ def _get_marketplace():
     """
     global _marketplace
     if _marketplace is None:
-        from rewrite.discovery import discover_recipes, _recipe_name_set
+        from rewrite.discovery import discover_recipes, recipe_name_set
         from rewrite.marketplace import RecipeMarketplace
         from rewrite import activate
 
@@ -620,9 +620,9 @@ def _get_marketplace():
         # installed, discovery already covered these and install() will dedupe
         # by name; attribute the source-mode additions to "openrewrite" so
         # they're returned by GetMarketplace/InstallRecipes for that package.
-        before = _recipe_name_set(_marketplace)
+        before = recipe_name_set(_marketplace)
         activate(_marketplace)
-        _attribution.record("openrewrite", _recipe_name_set(_marketplace) - before)
+        _attribution.record("openrewrite", recipe_name_set(_marketplace) - before)
 
     return _marketplace
 
@@ -641,21 +641,23 @@ def handle_install_recipes(params: dict) -> dict:
 
     Returns:
         Dict with:
-            - 'recipesInstalled': count of recipes attributed to this package
-            - 'version': resolved version (if known)
-            - 'recipes': list of {descriptor, categoryPaths} rows for recipes
-              attributed to this package - the cumulative set across all calls
-              for this distribution, not just the diff from this call.
+            - 'recipesInstalled': count of recipes added to the marketplace by
+              this call (zero on idempotent reinstalls).
+            - 'version': resolved version (if known).
+            - 'recipes': cumulative list of {descriptor, categoryPaths} rows
+              for recipes attributed to this distribution. Stable across
+              reinstalls; this is what the caller binds to its bundle.
     """
     import importlib
     import importlib.util
-    from rewrite.discovery import _recipe_name_set
+    from rewrite.discovery import recipe_name_set
 
     marketplace = _get_marketplace()
 
     recipes = params.get('recipes')
     installed_version = None
     package_name: Optional[str] = None
+    recipes_added = 0
 
     if isinstance(recipes, str):
         # Local file path - package should already be installed by caller
@@ -666,9 +668,11 @@ def handle_install_recipes(params: dict) -> dict:
         # For local paths, we look for the package name from setup.py/pyproject.toml
         package_name = _find_package_name(local_path)
         if package_name:
-            before = _recipe_name_set(marketplace)
+            before = recipe_name_set(marketplace)
             _import_and_activate_package(package_name, marketplace, local_path)
-            _attribution.record(package_name, _recipe_name_set(marketplace) - before)
+            added = recipe_name_set(marketplace) - before
+            _attribution.record(package_name, added)
+            recipes_added = len(added)
 
     elif isinstance(recipes, dict):
         # Package spec with name and optional version - package should already be installed
@@ -687,9 +691,11 @@ def handle_install_recipes(params: dict) -> dict:
         except Exception:
             pass
 
-        before = _recipe_name_set(marketplace)
+        before = recipe_name_set(marketplace)
         _import_and_activate_package(package_name, marketplace)
-        _attribution.record(package_name, _recipe_name_set(marketplace) - before)
+        added = recipe_name_set(marketplace) - before
+        _attribution.record(package_name, added)
+        recipes_added = len(added)
     else:
         raise ValueError(f"Invalid recipes parameter: {recipes}")
 
@@ -704,10 +710,10 @@ def handle_install_recipes(params: dict) -> dict:
         )
 
     logger.info(
-        f"InstallRecipes: returning {len(package_rows)} recipes for {package_name}"
+        f"InstallRecipes: {recipes_added} new, {len(package_rows)} cumulative for {package_name}"
     )
     return {
-        'recipesInstalled': len(package_rows),
+        'recipesInstalled': recipes_added,
         'version': installed_version,
         'recipes': package_rows,
     }
@@ -885,7 +891,7 @@ def handle_get_marketplace(params: dict) -> List[dict]:
     """
     marketplace = _get_marketplace()
 
-    recipe_filter: Optional[Set[str]] = None
+    recipe_filter: Optional[Set[RecipeName]] = None
     if isinstance(params, dict):
         package_name = params.get('packageName')
         if isinstance(package_name, str) and package_name:
@@ -898,7 +904,7 @@ def handle_get_marketplace(params: dict) -> List[dict]:
 
 def _collect_marketplace_rows(
     marketplace,
-    recipe_filter: Optional[Set[str]] = None,
+    recipe_filter: Optional[Set[RecipeName]] = None,
 ) -> List[dict]:
     """Walk the marketplace and return recipe rows in GetMarketplaceResponse shape.
 

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -33,7 +33,7 @@ import traceback
 import threading
 
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Callable
+from typing import Dict, Any, Optional, List, Callable, Set
 from uuid import uuid4
 
 # Deeply nested LST nodes (e.g., 256 implicitly concatenated strings) can
@@ -584,21 +584,46 @@ def handle_reset(params: dict) -> bool:
 # Global marketplace instance (lazily initialized)
 _marketplace = None
 
+# Per-package recipe attribution: normalized distribution name -> set of recipe names
+# that were activated by that distribution's entry points (or by an explicit
+# InstallRecipes call for that package). Used by handle_install_recipes to
+# scope its response to the requested package and by handle_get_marketplace
+# to filter the singleton marketplace down to a single package.
+_package_recipes: Dict[str, Set[str]] = {}
+
 
 def _get_marketplace():
-    """Get or create the global marketplace instance."""
+    """Get or create the global marketplace instance.
+
+    Discovery populates ``_package_recipes`` so each recipe is attributed to the
+    distribution whose entry point activated it. Without that attribution, a
+    later GetMarketplace or InstallRecipes for package X would incorrectly
+    return every recipe in the singleton (e.g., the eight built-in
+    ``org.openrewrite.python.*`` recipes activated by the ``openrewrite``
+    distribution itself).
+    """
     global _marketplace
     if _marketplace is None:
-        from rewrite.discovery import discover_recipes
+        from rewrite.discovery import discover_recipes, _normalize_package_name, _recipe_name_set
         from rewrite.marketplace import RecipeMarketplace
         from rewrite import activate
 
-        # First try to discover from installed packages
-        _marketplace = discover_recipes()
+        _marketplace = RecipeMarketplace()
 
-        # Also activate local recipes (in case package isn't installed)
-        # This ensures recipes work during development
+        # Discover from installed packages, tracking which distribution
+        # contributed each recipe.
+        discover_recipes(marketplace=_marketplace, attribution=_package_recipes)
+
+        # Also activate local recipes (in case the openrewrite distribution
+        # isn't pip-installed, e.g., when running from source). When it is
+        # installed, discovery already covered these and install() will dedupe
+        # by name; attribute the source-mode additions to "openrewrite" so
+        # they're returned by GetMarketplace/InstallRecipes for that package.
+        before = _recipe_name_set(_marketplace)
         activate(_marketplace)
+        added = _recipe_name_set(_marketplace) - before
+        if added:
+            _package_recipes.setdefault(_normalize_package_name("openrewrite"), set()).update(added)
 
     return _marketplace
 
@@ -616,16 +641,22 @@ def handle_install_recipes(params: dict) -> dict:
             - 'recipes': {'packageName': str, 'version': str|None} - A package spec
 
     Returns:
-        Dict with 'recipesInstalled' count and 'version' (if resolved)
+        Dict with:
+            - 'recipesInstalled': count of recipes attributed to this package
+            - 'version': resolved version (if known)
+            - 'recipes': list of {descriptor, categoryPaths} rows for recipes
+              attributed to this package - the cumulative set across all calls
+              for this distribution, not just the diff from this call.
     """
     import importlib
     import importlib.util
+    from rewrite.discovery import _normalize_package_name, _recipe_name_set
 
     marketplace = _get_marketplace()
-    before_count = len(list(marketplace.all_recipes()))
 
     recipes = params.get('recipes')
     installed_version = None
+    package_name: Optional[str] = None
 
     if isinstance(recipes, str):
         # Local file path - package should already be installed by caller
@@ -636,7 +667,13 @@ def handle_install_recipes(params: dict) -> dict:
         # For local paths, we look for the package name from setup.py/pyproject.toml
         package_name = _find_package_name(local_path)
         if package_name:
+            before = _recipe_name_set(marketplace)
             _import_and_activate_package(package_name, marketplace, local_path)
+            added = _recipe_name_set(marketplace) - before
+            if added:
+                _package_recipes.setdefault(
+                    _normalize_package_name(package_name), set()
+                ).update(added)
 
     elif isinstance(recipes, dict):
         # Package spec with name and optional version - package should already be installed
@@ -655,17 +692,31 @@ def handle_install_recipes(params: dict) -> dict:
         except Exception:
             pass
 
+        before = _recipe_name_set(marketplace)
         _import_and_activate_package(package_name, marketplace)
+        added = _recipe_name_set(marketplace) - before
+        if added:
+            _package_recipes.setdefault(
+                _normalize_package_name(package_name), set()
+            ).update(added)
     else:
         raise ValueError(f"Invalid recipes parameter: {recipes}")
 
-    after_count = len(list(marketplace.all_recipes()))
-    recipes_installed = after_count - before_count
+    package_rows: List[dict] = []
+    if package_name:
+        # Use an empty set rather than None when the package activated nothing,
+        # so the filter scopes the result to "this package's recipes" (zero of
+        # them) instead of falling back to "no filter" and returning everything.
+        attributed = _package_recipes.get(_normalize_package_name(package_name), set())
+        package_rows = _collect_marketplace_rows(marketplace, recipe_filter=attributed)
 
-    logger.info(f"InstallRecipes: installed {recipes_installed} recipes")
+    logger.info(
+        f"InstallRecipes: returning {len(package_rows)} recipes for {package_name}"
+    )
     return {
-        'recipesInstalled': recipes_installed,
-        'version': installed_version
+        'recipesInstalled': len(package_rows),
+        'version': installed_version,
+        'recipes': package_rows,
     }
 
 
@@ -828,22 +879,50 @@ def _import_and_activate_package(package_name: str, marketplace, local_path: Opt
 def handle_get_marketplace(params: dict) -> List[dict]:
     """Handle a GetMarketplace RPC request.
 
-    Returns all recipes organized by category in a format compatible with Java.
+    Returns recipes organized by category in a format compatible with Java.
+
+    Args:
+        params: Optional dict with a 'packageName' key. When supplied, the
+            response is filtered to recipes attributed to that distribution
+            (via _package_recipes), so callers requesting a specific bundle
+            don't get every recipe in the singleton marketplace.
 
     Returns:
         List of dicts with 'descriptor' and 'categoryPaths' for each recipe.
     """
-    from dataclasses import asdict
+    from rewrite.discovery import _normalize_package_name
 
     marketplace = _get_marketplace()
+
+    recipe_filter: Optional[Set[str]] = None
+    if isinstance(params, dict):
+        package_name = params.get('packageName')
+        if isinstance(package_name, str) and package_name:
+            recipe_filter = _package_recipes.get(_normalize_package_name(package_name), set())
+
+    rows = _collect_marketplace_rows(marketplace, recipe_filter=recipe_filter)
+    logger.info(f"GetMarketplace: returning {len(rows)} recipes")
+    return rows
+
+
+def _collect_marketplace_rows(
+    marketplace,
+    recipe_filter: Optional[Set[str]] = None,
+) -> List[dict]:
+    """Walk the marketplace and return recipe rows in GetMarketplaceResponse shape.
+
+    A recipe that appears in multiple categories produces one row whose
+    ``categoryPaths`` lists each path. When ``recipe_filter`` is provided,
+    recipes whose name isn't in the set are skipped.
+    """
     rows: List[dict] = []
 
-    def collect_recipes(category, category_path: List[dict]):
-        """Recursively collect recipes from a category and its subcategories."""
+    def collect(category, category_path: List[dict]) -> None:
         current_path = [*category_path, _category_descriptor_to_dict(category.descriptor)]
 
-        for recipe_name, (recipe_desc, _recipe_class) in category.recipes.items():
-            # Check if we already have this recipe (it can appear in multiple categories)
+        for _recipe_name, (recipe_desc, _recipe_class) in category.recipes.items():
+            if recipe_filter is not None and recipe_desc.name not in recipe_filter:
+                continue
             existing = next((r for r in rows if r['descriptor']['name'] == recipe_desc.name), None)
             if existing:
                 existing['categoryPaths'].append(current_path)
@@ -854,13 +933,11 @@ def handle_get_marketplace(params: dict) -> List[dict]:
                 })
 
         for subcategory in category.categories:
-            collect_recipes(subcategory, current_path)
+            collect(subcategory, current_path)
 
-    # Start from the root's children (skip the root itself)
     for category in marketplace.categories():
-        collect_recipes(category, [])
+        collect(category, [])
 
-    logger.info(f"GetMarketplace: returning {len(rows)} recipes")
     return rows
 
 

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -36,6 +36,8 @@ from pathlib import Path
 from typing import Dict, Any, Optional, List, Callable, Set
 from uuid import uuid4
 
+from rewrite.discovery import RecipeAttribution
+
 # Deeply nested LST nodes (e.g., 256 implicitly concatenated strings) can
 # overflow the default recursion limit (1000) during RPC serialization.
 sys.setrecursionlimit(sys.getrecursionlimit() * 2)
@@ -584,18 +586,17 @@ def handle_reset(params: dict) -> bool:
 # Global marketplace instance (lazily initialized)
 _marketplace = None
 
-# Per-package recipe attribution: normalized distribution name -> set of recipe names
-# that were activated by that distribution's entry points (or by an explicit
-# InstallRecipes call for that package). Used by handle_install_recipes to
-# scope its response to the requested package and by handle_get_marketplace
-# to filter the singleton marketplace down to a single package.
-_package_recipes: Dict[str, Set[str]] = {}
+# Tracks which distribution's entry point activated which recipes. Used by
+# handle_install_recipes to scope its response to the requested distribution
+# and by handle_get_marketplace to filter the singleton marketplace down to
+# a single package.
+_attribution = RecipeAttribution()
 
 
 def _get_marketplace():
     """Get or create the global marketplace instance.
 
-    Discovery populates ``_package_recipes`` so each recipe is attributed to the
+    Discovery populates ``_attribution`` so each recipe is attributed to the
     distribution whose entry point activated it. Without that attribution, a
     later GetMarketplace or InstallRecipes for package X would incorrectly
     return every recipe in the singleton, including the built-in
@@ -604,7 +605,7 @@ def _get_marketplace():
     """
     global _marketplace
     if _marketplace is None:
-        from rewrite.discovery import discover_recipes, _normalize_package_name, _recipe_name_set
+        from rewrite.discovery import discover_recipes, _recipe_name_set
         from rewrite.marketplace import RecipeMarketplace
         from rewrite import activate
 
@@ -612,7 +613,7 @@ def _get_marketplace():
 
         # Discover from installed packages, tracking which distribution
         # contributed each recipe.
-        discover_recipes(marketplace=_marketplace, attribution=_package_recipes)
+        discover_recipes(marketplace=_marketplace, attribution=_attribution)
 
         # Also activate local recipes (in case the openrewrite distribution
         # isn't pip-installed, e.g., when running from source). When it is
@@ -621,9 +622,7 @@ def _get_marketplace():
         # they're returned by GetMarketplace/InstallRecipes for that package.
         before = _recipe_name_set(_marketplace)
         activate(_marketplace)
-        added = _recipe_name_set(_marketplace) - before
-        if added:
-            _package_recipes.setdefault(_normalize_package_name("openrewrite"), set()).update(added)
+        _attribution.record("openrewrite", _recipe_name_set(_marketplace) - before)
 
     return _marketplace
 
@@ -650,7 +649,7 @@ def handle_install_recipes(params: dict) -> dict:
     """
     import importlib
     import importlib.util
-    from rewrite.discovery import _normalize_package_name, _recipe_name_set
+    from rewrite.discovery import _recipe_name_set
 
     marketplace = _get_marketplace()
 
@@ -669,11 +668,7 @@ def handle_install_recipes(params: dict) -> dict:
         if package_name:
             before = _recipe_name_set(marketplace)
             _import_and_activate_package(package_name, marketplace, local_path)
-            added = _recipe_name_set(marketplace) - before
-            if added:
-                _package_recipes.setdefault(
-                    _normalize_package_name(package_name), set()
-                ).update(added)
+            _attribution.record(package_name, _recipe_name_set(marketplace) - before)
 
     elif isinstance(recipes, dict):
         # Package spec with name and optional version - package should already be installed
@@ -694,21 +689,19 @@ def handle_install_recipes(params: dict) -> dict:
 
         before = _recipe_name_set(marketplace)
         _import_and_activate_package(package_name, marketplace)
-        added = _recipe_name_set(marketplace) - before
-        if added:
-            _package_recipes.setdefault(
-                _normalize_package_name(package_name), set()
-            ).update(added)
+        _attribution.record(package_name, _recipe_name_set(marketplace) - before)
     else:
         raise ValueError(f"Invalid recipes parameter: {recipes}")
 
     package_rows: List[dict] = []
     if package_name:
-        # Use an empty set rather than None when the package activated nothing,
-        # so the filter scopes the result to "this package's recipes" (zero of
-        # them) instead of falling back to "no filter" and returning everything.
-        attributed = _package_recipes.get(_normalize_package_name(package_name), set())
-        package_rows = _collect_marketplace_rows(marketplace, recipe_filter=attributed)
+        # recipes_for returns an empty set (not None) when the package activated
+        # nothing, so the filter scopes the result to "this package's recipes"
+        # (zero of them) instead of falling back to "no filter" and returning
+        # everything.
+        package_rows = _collect_marketplace_rows(
+            marketplace, recipe_filter=_attribution.recipes_for(package_name)
+        )
 
     logger.info(
         f"InstallRecipes: returning {len(package_rows)} recipes for {package_name}"
@@ -883,22 +876,20 @@ def handle_get_marketplace(params: dict) -> List[dict]:
 
     Args:
         params: Optional dict with a 'packageName' key. When supplied, the
-            response is filtered to recipes attributed to that distribution
-            (via _package_recipes), so callers requesting a specific bundle
-            don't get every recipe in the singleton marketplace.
+            response is filtered to recipes attributed to that distribution,
+            so callers requesting a specific bundle don't get every recipe
+            in the singleton marketplace.
 
     Returns:
         List of dicts with 'descriptor' and 'categoryPaths' for each recipe.
     """
-    from rewrite.discovery import _normalize_package_name
-
     marketplace = _get_marketplace()
 
     recipe_filter: Optional[Set[str]] = None
     if isinstance(params, dict):
         package_name = params.get('packageName')
         if isinstance(package_name, str) and package_name:
-            recipe_filter = _package_recipes.get(_normalize_package_name(package_name), set())
+            recipe_filter = _attribution.recipes_for(package_name)
 
     rows = _collect_marketplace_rows(marketplace, recipe_filter=recipe_filter)
     logger.info(f"GetMarketplace: returning {len(rows)} recipes")

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -598,9 +598,9 @@ def _get_marketplace():
     Discovery populates ``_package_recipes`` so each recipe is attributed to the
     distribution whose entry point activated it. Without that attribution, a
     later GetMarketplace or InstallRecipes for package X would incorrectly
-    return every recipe in the singleton (e.g., the eight built-in
+    return every recipe in the singleton, including the built-in
     ``org.openrewrite.python.*`` recipes activated by the ``openrewrite``
-    distribution itself).
+    distribution itself.
     """
     global _marketplace
     if _marketplace is None:

--- a/rewrite-python/rewrite/tests/test_marketplace.py
+++ b/rewrite-python/rewrite/tests/test_marketplace.py
@@ -240,8 +240,8 @@ class TestPerPackageAttribution:
 
     Before the fix, a singleton marketplace was shared across all installs and
     GetMarketplace returned everything in it. Installing a non-recipe package
-    (e.g., a visualization-only pip package) would still report the eight
-    built-in ``org.openrewrite.python.*`` recipes as belonging to that package.
+    (e.g., a visualization-only pip package) would still report every built-in
+    ``org.openrewrite.python.*`` recipe as belonging to that package.
     These tests pin the per-distribution scoping so each package's install
     response carries only the recipes its own entry points activated.
     """
@@ -289,7 +289,7 @@ class TestPerPackageAttribution:
 
         Reproduces the moderne-visualizations-misc case: pkg-a contributed
         recipes earlier; pkg-b is a no-op (no openrewrite.recipes entry point).
-        Installing pkg-b must NOT inherit pkg-a's eight recipes.
+        Installing pkg-b must NOT inherit pkg-a's recipes.
         """
         import rewrite.rpc.server as server
 

--- a/rewrite-python/rewrite/tests/test_marketplace.py
+++ b/rewrite-python/rewrite/tests/test_marketplace.py
@@ -248,19 +248,19 @@ class TestPerPackageAttribution:
 
     def setup_method(self):
         import rewrite.rpc.server as server
+        from rewrite.discovery import RecipeAttribution
 
         # Reset module state so tests don't bleed into each other.
         self._saved_marketplace = server._marketplace
-        self._saved_package_recipes = dict(server._package_recipes)
+        self._saved_attribution = server._attribution
         server._marketplace = RecipeMarketplace()
-        server._package_recipes.clear()
+        server._attribution = RecipeAttribution()
 
     def teardown_method(self):
         import rewrite.rpc.server as server
 
         server._marketplace = self._saved_marketplace
-        server._package_recipes.clear()
-        server._package_recipes.update(self._saved_package_recipes)
+        server._attribution = self._saved_attribution
 
     def test_install_response_returns_only_packages_own_recipes(self, monkeypatch):
         """Installing pkg-a then pkg-b: each response carries only its own recipe."""

--- a/rewrite-python/rewrite/tests/test_marketplace.py
+++ b/rewrite-python/rewrite/tests/test_marketplace.py
@@ -215,3 +215,140 @@ class TestPythonCategory:
         assert len(Cleanup) == 2
         assert Cleanup[0].display_name == "Python"
         assert Cleanup[1].display_name == "Cleanup"
+
+
+class _PkgARecipe(Recipe):
+    @property
+    def name(self): return "org.openrewrite.test.pkga.RecipeA"
+    @property
+    def display_name(self): return "Recipe A"
+    @property
+    def description(self): return "Owned by package A."
+
+
+class _PkgBRecipe(Recipe):
+    @property
+    def name(self): return "org.openrewrite.test.pkgb.RecipeB"
+    @property
+    def display_name(self): return "Recipe B"
+    @property
+    def description(self): return "Owned by package B."
+
+
+class TestPerPackageAttribution:
+    """Regression tests for the over-attribution bug.
+
+    Before the fix, a singleton marketplace was shared across all installs and
+    GetMarketplace returned everything in it. Installing a non-recipe package
+    (e.g., a visualization-only pip package) would still report the eight
+    built-in ``org.openrewrite.python.*`` recipes as belonging to that package.
+    These tests pin the per-distribution scoping so each package's install
+    response carries only the recipes its own entry points activated.
+    """
+
+    def setup_method(self):
+        import rewrite.rpc.server as server
+
+        # Reset module state so tests don't bleed into each other.
+        self._saved_marketplace = server._marketplace
+        self._saved_package_recipes = dict(server._package_recipes)
+        server._marketplace = RecipeMarketplace()
+        server._package_recipes.clear()
+
+    def teardown_method(self):
+        import rewrite.rpc.server as server
+
+        server._marketplace = self._saved_marketplace
+        server._package_recipes.clear()
+        server._package_recipes.update(self._saved_package_recipes)
+
+    def test_install_response_returns_only_packages_own_recipes(self, monkeypatch):
+        """Installing pkg-a then pkg-b: each response carries only its own recipe."""
+        import rewrite.rpc.server as server
+
+        def fake_import_and_activate(name, marketplace, local_path=None):
+            # Simulate the activate(marketplace) call each entry point would make.
+            if name == "pkg-a":
+                marketplace.install(_PkgARecipe, Python)
+            elif name == "pkg-b":
+                marketplace.install(_PkgBRecipe, Python)
+
+        monkeypatch.setattr(server, "_import_and_activate_package", fake_import_and_activate)
+
+        a_response = server.handle_install_recipes({"recipes": {"packageName": "pkg-a"}})
+        b_response = server.handle_install_recipes({"recipes": {"packageName": "pkg-b"}})
+
+        a_names = {r["descriptor"]["name"] for r in a_response["recipes"]}
+        b_names = {r["descriptor"]["name"] for r in b_response["recipes"]}
+
+        assert a_names == {"org.openrewrite.test.pkga.RecipeA"}
+        assert b_names == {"org.openrewrite.test.pkgb.RecipeB"}
+
+    def test_install_response_for_package_with_no_recipes_is_empty(self, monkeypatch):
+        """Visualization-only pip packages (no recipes) must not be assigned others' recipes.
+
+        Reproduces the moderne-visualizations-misc case: pkg-a contributed
+        recipes earlier; pkg-b is a no-op (no openrewrite.recipes entry point).
+        Installing pkg-b must NOT inherit pkg-a's eight recipes.
+        """
+        import rewrite.rpc.server as server
+
+        def fake_import_and_activate(name, marketplace, local_path=None):
+            if name == "pkg-a":
+                marketplace.install(_PkgARecipe, Python)
+            # pkg-b is intentionally a no-op.
+
+        monkeypatch.setattr(server, "_import_and_activate_package", fake_import_and_activate)
+
+        server.handle_install_recipes({"recipes": {"packageName": "pkg-a"}})
+        b_response = server.handle_install_recipes({"recipes": {"packageName": "pkg-b"}})
+
+        assert b_response["recipes"] == []
+        assert b_response["recipesInstalled"] == 0
+
+    def test_get_marketplace_filters_by_package_name(self, monkeypatch):
+        """GetMarketplace with packageName returns only that package's recipes."""
+        import rewrite.rpc.server as server
+
+        def fake_import_and_activate(name, marketplace, local_path=None):
+            if name == "pkg-a":
+                marketplace.install(_PkgARecipe, Python)
+            elif name == "pkg-b":
+                marketplace.install(_PkgBRecipe, Python)
+
+        monkeypatch.setattr(server, "_import_and_activate_package", fake_import_and_activate)
+
+        server.handle_install_recipes({"recipes": {"packageName": "pkg-a"}})
+        server.handle_install_recipes({"recipes": {"packageName": "pkg-b"}})
+
+        # Filter by pkg-a
+        rows_a = server.handle_get_marketplace({"packageName": "pkg-a"})
+        assert {r["descriptor"]["name"] for r in rows_a} == {"org.openrewrite.test.pkga.RecipeA"}
+
+        # Filter by pkg-b
+        rows_b = server.handle_get_marketplace({"packageName": "pkg-b"})
+        assert {r["descriptor"]["name"] for r in rows_b} == {"org.openrewrite.test.pkgb.RecipeB"}
+
+        # No filter still returns everything for callers that want the full marketplace.
+        rows_all = server.handle_get_marketplace({})
+        assert {r["descriptor"]["name"] for r in rows_all} == {
+            "org.openrewrite.test.pkga.RecipeA",
+            "org.openrewrite.test.pkgb.RecipeB",
+        }
+
+    def test_package_name_normalization(self, monkeypatch):
+        """Hyphen/underscore variants resolve to the same package."""
+        import rewrite.rpc.server as server
+
+        def fake_import_and_activate(name, marketplace, local_path=None):
+            if name in ("openrewrite-migrate-python", "openrewrite_migrate_python"):
+                marketplace.install(_PkgARecipe, Python)
+
+        monkeypatch.setattr(server, "_import_and_activate_package", fake_import_and_activate)
+
+        # Install with hyphen form.
+        server.handle_install_recipes({"recipes": {"packageName": "openrewrite-migrate-python"}})
+
+        # Query with underscore form.
+        rows = server.handle_get_marketplace({"packageName": "openrewrite_migrate_python"})
+        assert {r["descriptor"]["name"] for r in rows} == {"org.openrewrite.test.pkga.RecipeA"}

--- a/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleReader.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleReader.java
@@ -19,11 +19,13 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.openrewrite.Recipe;
 import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.python.rpc.InstallRecipesResponse;
 import org.openrewrite.python.rpc.PythonRewriteRpc;
 import org.openrewrite.marketplace.RecipeBundle;
 import org.openrewrite.marketplace.RecipeBundleReader;
 import org.openrewrite.marketplace.RecipeListing;
 import org.openrewrite.marketplace.RecipeMarketplace;
+import org.openrewrite.rpc.request.GetMarketplaceResponse;
 
 import java.util.Map;
 
@@ -31,10 +33,19 @@ import java.util.Map;
 public class PipRecipeBundleReader implements RecipeBundleReader {
     private final @Getter RecipeBundle bundle;
     private final PythonRewriteRpc rpc;
+    /**
+     * The response from the install call that produced this reader. Carrying the
+     * row list directly lets {@link #read()} skip the GetMarketplace round trip
+     * (which returns the singleton marketplace's full contents and would
+     * over-attribute every recipe in the process to {@link #bundle}).
+     */
+    private final InstallRecipesResponse installResponse;
 
     @Override
     public RecipeMarketplace read() {
-        return rpc.getMarketplace(bundle);
+        GetMarketplaceResponse response = new GetMarketplaceResponse();
+        response.addAll(installResponse.recipesOrEmpty());
+        return response.toMarketplace(bundle);
     }
 
     @Override

--- a/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
@@ -47,6 +47,6 @@ public class PipRecipeBundleResolver implements RecipeBundleResolver {
         if (response.getVersion() != null) {
             bundle.setVersion(response.getVersion());
         }
-        return new PipRecipeBundleReader(bundle, rpc);
+        return new PipRecipeBundleReader(bundle, rpc, response);
     }
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/InstallRecipesResponse.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/InstallRecipesResponse.java
@@ -17,9 +17,31 @@ package org.openrewrite.python.rpc;
 
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.rpc.request.GetMarketplaceResponse;
 
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Response to an {@code InstallRecipes} RPC request.
+ * <p>
+ * {@code recipes} carries the descriptor rows for recipes attributed to the
+ * just-installed distribution, so the caller can construct a
+ * {@link org.openrewrite.marketplace.RecipeMarketplace} bound to the bundle
+ * without a follow-up {@code GetMarketplace} round trip. The follow-up call
+ * was the source of the prior over-attribution bug — it returned the entire
+ * singleton marketplace, which on a Python RPC server includes built-in
+ * {@code openrewrite} recipes plus any recipes from previously-installed
+ * sibling packages, all of which were then incorrectly tagged with the
+ * just-requested bundle.
+ */
 @Value
 public class InstallRecipesResponse {
     int recipesInstalled;
     @Nullable String version;
+    @Nullable List<GetMarketplaceResponse.Row> recipes;
+
+    public List<GetMarketplaceResponse.Row> recipesOrEmpty() {
+        return recipes == null ? Collections.emptyList() : recipes;
+    }
 }


### PR DESCRIPTION
## Summary

`discover_recipes()` eagerly walked every `openrewrite.recipes` entry point on `_get_marketplace()` init, and `handle_get_marketplace()` returned the full singleton — so installing any pip package had its `RecipeBundle` tagged with every recipe in the process, including the eight built-in `org.openrewrite.python.*` recipes activated by the `openrewrite` distribution itself. A visualization-only package like `moderne-visualizations-misc` ended up "owning" every Python recipe.

- Track per-distribution attribution at activation time (`{distribution_name -> set(recipe_name)}`).
- Have `handle_install_recipes` return the rows for just the requested package.
- Let `handle_get_marketplace` filter by `packageName` when supplied; behavior is unchanged when no filter is provided.
- `PipRecipeBundleReader` now constructs its marketplace from the install response directly instead of issuing a follow-up `GetMarketplace` call that would still see the full singleton.
- `InstallRecipesResponse` carries the new `recipes` field backwards-compatibly: older Python servers that don't include it deserialize to `null`, accessed via `recipesOrEmpty()`.

Pairs with the moderne-saas fix that re-enables the pip flow into the recipe marketplace.

## Test plan

- [x] `pytest tests/` — 1,125 passed, 56 skipped.
- [x] `./gradlew :rewrite-python:test :rewrite-core:test --tests RewriteRpcTest` — BUILD SUCCESSFUL.
- [x] New regression tests in `test_marketplace.py::TestPerPackageAttribution`:
  - Two recipe-bearing packages each get only their own recipes back.
  - Visualization-only package (no entry points) gets `[]`, not the eight built-ins.
  - `GetMarketplace` filter by `packageName` returns only that package's recipes; no-filter still returns everything.
  - Hyphen/underscore name variants resolve to the same package.