### PR TITLE
Groovy: fix parsing of @groovy.transform.builder.Builder annotation

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -489,7 +489,7 @@ public class GroovyParserVisitor {
             Iterator<InnerClassNode> innerClassIterator = clazz.getInnerClasses();
             while (innerClassIterator.hasNext()) {
                 InnerClassNode icn = innerClassIterator.next();
-                if (icn.isSynthetic() || fieldInitializers.contains(icn) || icn.getName().contains("$Trait$")) {
+                if (icn.isSynthetic() || fieldInitializers.contains(icn) || icn.getName().contains("$Trait$") || !appearsInSource(icn)) {
                     continue;
                 }
                 sortedByPosition.put(pos(icn), icn);

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -260,6 +260,24 @@ class ClassDeclarationTest implements RewriteTest {
         );
     }
 
+    @Test
+    void innerClassWithBuilderAnnotation() {
+        rewriteRun(
+          groovy(
+            """
+              import groovy.transform.builder.Builder
+
+              class Outer {
+                  @Builder
+                  class Inner {
+                      String controller
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4705")
     @Test
     void constructorWithDef() {


### PR DESCRIPTION
## What's changed?

Add support for special annotation in Groovy: `@groovy.transform.builder.Builder`.

## What's your motivation?

The parser suffers from idempotency issues.