### PR TITLE
Groovy: fix parsing of exclusive-right ranges

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2427,7 +2427,7 @@ public class GroovyParserVisitor {
         public void visitRangeExpression(RangeExpression range) {
             queue.add(insideParentheses(range, fmt -> new G.Range(randomId(), fmt, Markers.EMPTY,
                     doVisit(range.getFrom()),
-                    JLeftPadded.build(range.isInclusive()).withBefore(sourceBefore(range.isInclusive() ? ".." : "..>")),
+                    JLeftPadded.build(range.isInclusive()).withBefore(sourceBefore(range.isInclusive() ? ".." : "..<")),
                     doVisit(range.getTo()))));
         }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
@@ -211,7 +211,7 @@ public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
         beforeSyntax(range, GSpace.Location.RANGE_PREFIX, p);
         visit(range.getFrom(), p);
         visitSpace(range.getPadding().getInclusive().getBefore(), GSpace.Location.RANGE_INCLUSION, p);
-        p.append(range.getInclusive() ? ".." : "..>");
+        p.append(range.getInclusive() ? ".." : "..<");
         visit(range.getTo(), p);
         afterSyntax(range, p);
         return range;

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RangeTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RangeTest.java
@@ -59,4 +59,46 @@ class RangeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void exclusiveRightRange() {
+        rewriteRun(
+          groovy(
+            """
+              (1..<10).each { }
+              def a = 0..<10
+              def b = 0 ..< 10
+              def c = (-5)..<5
+              def d = a[0..<a.size()]
+              for (int i = 0; i < (1..<5).size(); i++) { }
+              """
+          )
+        );
+    }
+
+    @Test
+    void allRangeKinds() {
+        rewriteRun(
+          groovy(
+            """
+              def inclusive = 1..10
+              def inclusiveSpaces = 1 .. 10
+              def inclusiveNegative = -3..3
+              def inclusiveReverse = 10..1
+              def inclusiveChars = 'a'..'z'
+              def exclusiveEnd = 1..<10
+              def exclusiveEndSpaces = 1 ..< 10
+              def exclusiveEndNegative = (-5)..<5
+              def list = [10, 20, 30, 40, 50]
+              def slice1 = list[0..2]
+              def slice2 = list[0..<list.size()]
+              def slice3 = list[1..-1]
+              (0..5).each { }
+              (0..<5).each { }
+              for (i in 1..3) { }
+              for (j in 1..<3) { }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fix parsing of right-exclusive ranges in Groovy, e.g. `0..<10`

## What's your motivation?

They suffer from idempotency issues.