### PR TITLE
JavaScript: setupSharedDependencies must search inside recipe directory itself

### DIFF
--- a/rewrite-javascript/rewrite/src/rpc/request/install-recipes.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/install-recipes.ts
@@ -197,7 +197,15 @@ function preloadCoreModules(logger?: rpc.Logger) {
  */
 function setupSharedDependencies(targetModulePath: string, logger?: rpc.Logger) {
     const sharedDeps = ['@openrewrite/rewrite', 'vscode-jsonrpc', 'mutative'];
-    const targetDir = path.dirname(targetModulePath);
+    // For local-path installs, targetModulePath is the package dir itself.
+    let targetDir: string;
+    try {
+        targetDir = fs.statSync(targetModulePath).isDirectory()
+            ? targetModulePath
+            : path.dirname(targetModulePath);
+    } catch {
+        targetDir = path.dirname(targetModulePath);
+    }
 
     sharedDeps.forEach(depName => {
         try {


### PR DESCRIPTION
## Why

Recipe authoring loop: edit, register the local path with `mod config recipes npm install /path/to/my-recipes`, run against a fixture before publishing.

Today this silently no-ops on `package.json` for any `ScanningRecipe` (`UpgradeDependencyVersion`, `AddDependency`, etc.). `setupSharedDependencies` does `path.dirname(targetModulePath)`, which for a directory path jumps to the parent — the upward `node_modules` walk never enters the recipe's own `node_modules`. The host→target `require.cache` mapping is skipped, the recipe loads its own `@openrewrite/rewrite` instance, `recipe instanceof ScanningRecipe` returns false in `visit.ts`, and the `scan:` phase is skipped. Editor still fires, but `acc.projectsToUpdate` is always empty.

`npm install <pkg@version>` is unaffected because `require.resolve` returns a file path, and dirname/walk-up lands on the install dir's hoisted `node_modules`.

## Fix

When `targetModulePath` is a directory, start the walk from the directory itself.

## Test plan

- [x] `vitest run` — 1821/1821 pass
- [x] Manual: cemex `UpgradeTo18` now bumps `package.json` end-to-end. rpc.log changes from `Could not find @openrewrite/rewrite in target's node_modules` to `Mapped 132 modules for @openrewrite/rewrite`.
- [ ] CI green