### PR TITLE
Gradle: keep comments with their dependency when sorting (fixes #7516)

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/SortDependencies.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/SortDependencies.java
@@ -27,6 +27,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.maven.tree.Dependency;
 import org.openrewrite.maven.tree.DependencyNotation;
@@ -78,7 +79,6 @@ public class SortDependencies extends Recipe {
                     return m;
                 }
 
-                // Separate dependency statements from non-dependency statements (comments are whitespace in Gradle AST)
                 List<Statement> sorted = new ArrayList<>(statements);
                 sorted.sort(dependencyComparator);
 
@@ -95,9 +95,20 @@ public class SortDependencies extends Recipe {
                     return m;
                 }
 
-                // Preserve original whitespace prefixes
-                for (int i = 0; i < sorted.size(); i++) {
-                    sorted.set(i, sorted.get(i).withPrefix(statements.get(i).getPrefix()));
+                // Keep each statement's prefix with the statement itself so that any preceding comments
+                // (which the parser stores on the next statement's prefix) move along with the dependency.
+                // Swap only the leading whitespace of the new first statement with the original first
+                // statement's leading whitespace, to keep the block opening formatting consistent.
+                Space originalFirstPrefix = statements.get(0).getPrefix();
+                Space newFirstPrefix = sorted.get(0).getPrefix();
+                sorted.set(0, sorted.get(0).withPrefix(newFirstPrefix.withWhitespace(originalFirstPrefix.getWhitespace())));
+                // Apply the displaced leading whitespace to whichever sorted statement now follows the
+                // original first statement, to preserve the block-internal blank-line layout.
+                int originalFirstIndex = sorted.indexOf(statements.get(0));
+                if (originalFirstIndex > 0) {
+                    Space displacedPrefix = sorted.get(originalFirstIndex).getPrefix();
+                    sorted.set(originalFirstIndex, sorted.get(originalFirstIndex)
+                      .withPrefix(displacedPrefix.withWhitespace(newFirstPrefix.getWhitespace())));
                 }
 
                 body = body.withStatements(sorted);

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/SortDependenciesTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/SortDependenciesTest.java
@@ -220,4 +220,134 @@ class SortDependenciesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void preservesCommentsAttachedToDependencies() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  // Spring web for the controllers
+                  implementation "org.springframework:spring-web:5.3.23"
+                  // Guava for collection helpers
+                  api "com.google.guava:guava:31.1-jre"
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  // Guava for collection helpers
+                  api "com.google.guava:guava:31.1-jre"
+                  // Spring web for the controllers
+                  implementation "org.springframework:spring-web:5.3.23"
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preservesCommentsAttachedToDependenciesKotlinDsl() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              plugins {
+                  `java-library`
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  // Spring web for the controllers
+                  implementation("org.springframework:spring-web:5.3.23")
+
+                  // Guava for collection helpers
+                  api("com.google.guava:guava:31.1-jre")
+              }
+              """,
+            """
+              plugins {
+                  `java-library`
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  // Guava for collection helpers
+                  api("com.google.guava:guava:31.1-jre")
+
+                  // Spring web for the controllers
+                  implementation("org.springframework:spring-web:5.3.23")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preservesCommentsBlocksWithBlankLines() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  // Enable the Swing console
+                  implementation "org.springframework:spring-web:5.3.23"
+
+                  // Enable Guava
+                  api "com.google.guava:guava:31.1-jre"
+
+                  // Enable JUnit
+                  testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.1"
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  // Enable Guava
+                  api "com.google.guava:guava:31.1-jre"
+
+                  // Enable the Swing console
+                  implementation "org.springframework:spring-web:5.3.23"
+
+                  // Enable JUnit
+                  testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.1"
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- `SortDependencies` was misplacing comments because the parser stores preceding line-comments on the next statement's prefix, and the previous implementation overwrote each sorted statement's prefix with the prefix at its new position — leaving comments in place while dependencies moved around them.
- Each statement now keeps its own prefix during sorting, and only the leading whitespace of the new first statement is harmonized so block-opening formatting stays consistent. Blank-line groupings between dependencies are preserved.
- Adds tests for Groovy DSL, Kotlin DSL, and multi-group blank-line layouts.

- Fixes #7516

## Test plan
- [x] `./gradlew :rewrite-gradle:test --tests "org.openrewrite.gradle.SortDependenciesTest"` (8/8 pass)
- [x] `./gradlew :rewrite-gradle:test --tests "org.openrewrite.gradle.GradleBestPracticesTest"` (no regressions)