### PR TITLE
Groovy: fix parsing of variables typed as generics class parameter

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2743,7 +2743,7 @@ public class GroovyParserVisitor {
                     emptyList(),
                     typeName,
                     type, null);
-            if (expression.getOriginType().getGenericsTypes() != null) {
+            if (expression.getOriginType().getGenericsTypes() != null && !expression.getOriginType().isGenericsPlaceHolder() && sourceStartsWith("<")) {
                 return new J.ParameterizedType(randomId(), prefix, Markers.EMPTY, ident, visitTypeParameterizations(
                         staticType((org.codehaus.groovy.ast.expr.Expression) expression).getGenericsTypes()), type);
             }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/VariableDeclarationsTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/VariableDeclarationsTest.java
@@ -233,4 +233,35 @@ class VariableDeclarationsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void typeParameterAsLocalVariableType() {
+        rewriteRun(
+          groovy(
+            """
+              class TaskRunner<E> {
+                  void run() {
+                      E task = null
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void typeParameterAsLocalVariableTypeFromMethodCall() {
+        rewriteRun(
+          groovy(
+            """
+              class TaskRunner<E> {
+                  java.util.concurrent.BlockingQueue<E> queue
+                  void run() {
+                      E task = queue.take()
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fix Groovy parser for parsing variables whose type is the current class' type parameter, e.g.
```
              class TaskRunner<E> {
                  void run() {
                      E task = null
                  }
              }
```

## What's your motivation?

It currently suffers from idempotency issues.