### PR TITLE
Remove java-test dependencies on rewrite-groovy, rewrite-kotlin

### DIFF
--- a/rewrite-java-test/build.gradle.kts
+++ b/rewrite-java-test/build.gradle.kts
@@ -12,8 +12,6 @@ recipeDependencies {
 dependencies {
     implementation("org.assertj:assertj-core:3.+") // CVE-2026-24400 in 4.0.0-M1 and no higher versions available
     implementation(project(":rewrite-java"))
-    implementation(project(":rewrite-kotlin"))
-    implementation(project(":rewrite-groovy"))
     implementation(project(":rewrite-test"))
 
     testImplementation("io.github.classgraph:classgraph:latest.release")

--- a/rewrite-java-test/build.gradle.kts
+++ b/rewrite-java-test/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation(project(":rewrite-java"))
     implementation(project(":rewrite-test"))
 
+    testImplementation(project(":rewrite-groovy"))
+    testImplementation(project(":rewrite-kotlin"))
     testImplementation("io.github.classgraph:classgraph:latest.release")
     testImplementation("org.junit-pioneer:junit-pioneer:2.0.0")
     testRuntimeOnly(project(":rewrite-java-21"))


### PR DESCRIPTION
## What's changed?

Downgrading the dependencies of rewrite-java-test on Groovy and Kotlin modules to `testImplementation`

## What's your motivation?

Continuation of #7489 and #7495. In a hope that PRs which don't change anything for Java don't need to run all the expensive Java compatibility tests.