### PR TITLE
Fix Ubuntu EOL tests

### DIFF
--- a/rewrite-docker/src/main/resources/META-INF/rewrite/examples.yml
+++ b/rewrite-docker/src/main/resources/META-INF/rewrite/examples.yml
@@ -141,7 +141,7 @@ examples:
       RUN apt-get install -y curl
       ENTRYPOINT /app/start.sh
     after: |
-      ~~(EOL: ubuntu:20.04 (ended 2025-05-31, suggest noble (24.04)))~~>~~(Missing HEALTHCHECK instruction)~~>FROM ubuntu:20.04
+      ~~(EOL: ubuntu:20.04 (ended 2025-05-31, suggest plucky (26.04)))~~>~~(Missing HEALTHCHECK instruction)~~>FROM ubuntu:20.04
       COPY app.jar /app/
       RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
       ENTRYPOINT ["/app/start.sh"]

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/DockerBestPracticesTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/DockerBestPracticesTest.java
@@ -42,7 +42,7 @@ class DockerBestPracticesTest implements RewriteTest {
               ENTRYPOINT /app/start.sh
               """,
             """
-              ~~(EOL: ubuntu:20.04 (ended 2025-05-31, suggest noble (24.04)))~~>~~(Missing HEALTHCHECK instruction)~~>FROM ubuntu:20.04
+              ~~(EOL: ubuntu:20.04 (ended 2025-05-31, suggest plucky (26.04)))~~>~~(Missing HEALTHCHECK instruction)~~>FROM ubuntu:20.04
               COPY app.jar /app/
               RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
               ENTRYPOINT ["/app/start.sh"]

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/search/FindEndOfLifeImagesTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/search/FindEndOfLifeImagesTest.java
@@ -102,7 +102,7 @@ class FindEndOfLifeImagesTest implements RewriteTest {
               RUN apt-get update
               """,
             """
-              ~~(EOL: ubuntu:16.04 (ended 2021-04-02, suggest noble (24.04)))~~>FROM ubuntu:16.04
+              ~~(EOL: ubuntu:16.04 (ended 2021-04-02, suggest plucky (26.04)))~~>FROM ubuntu:16.04
               RUN apt-get update
               """
           )
@@ -118,7 +118,7 @@ class FindEndOfLifeImagesTest implements RewriteTest {
               RUN apt-get update
               """,
             """
-              ~~(EOL: ubuntu:bionic (ended 2023-05-31, suggest noble (24.04)))~~>FROM ubuntu:bionic
+              ~~(EOL: ubuntu:bionic (ended 2023-05-31, suggest plucky (26.04)))~~>FROM ubuntu:bionic
               RUN apt-get update
               """
           )


### PR DESCRIPTION
## What's changed?

Update the assertions in the `FindEndOfLifeImagesTest`.

## What's your motivation?

Ubuntu 26.04 plucky got released and the tests started failing with messages like:
```
DockerBestPracticesTest > appliesBestPractices() FAILED
    org.opentest4j.AssertionFailedError: [Unexpected result in "Dockerfile":
    diff --git a/Dockerfile b/Dockerfile
    index 9aabf8a..9482945 100644
    --- a/Dockerfile
    +++ b/Dockerfile
    @@ -1,4 +1,4 @@ 
    -~~(EOL: ubuntu:20.04 (ended 2025-05-31, suggest noble (24.04)))~~>~~(Missing HEALTHCHECK instruction)~~>FROM ubuntu:20.04
    +~~(EOL: ubuntu:20.04 (ended 2025-05-31, suggest plucky (26.04)))~~>~~(Missing HEALTHCHECK instruction)~~>FROM ubuntu:20.04
```
The trigger was https://github.com/openrewrite/rewrite/commit/d49a26bdb6f644341eeb913ddb259aa005e881ed