### PR TITLE
Groovy: fix parsing of Spock assertions/labels

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1196,16 +1196,18 @@ public class GroovyParserVisitor {
 
         @Override
         public void visitAssertStatement(AssertStatement statement) {
-            Space prefix = whitespace();
-            skip("assert");
-            Expression condition = doVisit(statement.getBooleanExpression());
-            JLeftPadded<Expression> message = null;
-            if (!(statement.getMessageExpression() instanceof ConstantExpression) || !((ConstantExpression) statement.getMessageExpression()).isNullExpression()) {
-                Space messagePrefix = whitespace();
-                skip(":");
-                message = padLeft(messagePrefix, doVisit(statement.getMessageExpression()));
-            }
-            queue.add(new J.Assert(randomId(), prefix, Markers.EMPTY, condition, message));
+            queue.add(labeled(statement, () -> {
+                Space prefix = whitespace();
+                skip("assert");
+                Expression condition = doVisit(statement.getBooleanExpression());
+                JLeftPadded<Expression> message = null;
+                if (!(statement.getMessageExpression() instanceof ConstantExpression) || !((ConstantExpression) statement.getMessageExpression()).isNullExpression()) {
+                    Space messagePrefix = whitespace();
+                    skip(":");
+                    message = padLeft(messagePrefix, doVisit(statement.getMessageExpression()));
+                }
+                return new J.Assert(randomId(), prefix, Markers.EMPTY, condition, message);
+            }));
         }
 
         @Override

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LabelsTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LabelsTest.java
@@ -49,4 +49,19 @@ class LabelsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void labelBeforeAssert() {
+        rewriteRun(
+          //language=groovy
+          groovy(
+                """
+            def foo() {
+                then:
+                assert 1 == 0
+            }
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fix Groovy parser handling the assertions and labels, as used in Spock testing library.

## What's your motivation?

They suffer from idempotency issues.