### PR TITLE
Groovy: fix parsing of inner constructor calls

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2516,6 +2516,11 @@ public class GroovyParserVisitor {
 
             List<JRightPadded<Expression>> args = new ArrayList<>(tuple.getExpressions().size());
             for (org.codehaus.groovy.ast.expr.Expression expression : tuple.getExpressions()) {
+                // Skip synthetic args (e.g. the implicit outer-`this` Groovy adds when
+                // constructing a non-static inner class from within the enclosing class)
+                if (!appearsInSource(expression)) {
+                    continue;
+                }
                 NamedArgumentListExpression namedArgList = (NamedArgumentListExpression) expression;
                 List<MapEntryExpression> mapEntryExpressions = namedArgList.getMapEntryExpressions();
                 for (int i = 0; i < mapEntryExpressions.size(); i++) {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ConstructorTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ConstructorTest.java
@@ -152,6 +152,20 @@ class ConstructorTest implements RewriteTest {
     }
 
     @Test
+    void nonStaticInnerClassNamedArgs() {
+        rewriteRun(
+          groovy(
+            """
+              class T {
+                  class Reader { }
+                  def m() { new Reader(a: 1) }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void innerClassConstructorWithOnlySuperCall() {
         rewriteRun(
           groovy(


### PR DESCRIPTION
## What's changed?

Fix Groovy parsing for cases when there's an inner class and a call to its constructor in another place, e.g.
```
              class T {
                  class Reader { }
                  def m() { new Reader(a: 1) }
              }
```

## What's your motivation?

Otherwise `ClassCastException` is thrown when parsing.