### PR TITLE
Fix AddAnnotationProcessor when parent matches by GAV alone

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddAnnotationProcessor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddAnnotationProcessor.java
@@ -33,8 +33,13 @@ import org.openrewrite.xml.XmlIsoVisitor;
 import org.openrewrite.xml.tree.Xml;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -78,47 +83,75 @@ public class AddAnnotationProcessor extends ScanningRecipe<AddAnnotationProcesso
             "Updates the annotation processor version if a newer version is specified.";
 
     /**
-     * Accumulator to track which POMs need modifications and how.
+     * Accumulator populated during the scan phase and resolved into final
+     * parent/orphan path sets via {@link #resolve()} before the visitor runs.
      */
     public static class Scanned {
-        /**
-         * Source paths of POMs that are referenced as parents by at least one child within the reactor.
-         * These should get pluginManagement updates.
-         */
-        Set<Path> parentPomPaths = new HashSet<>();
-
-        /**
-         * Source paths of POMs that have no parent within the reactor.
-         * After scanning, aggregator-only POMs will be filtered out.
-         */
-        Set<Path> candidateOrphanPaths = new HashSet<>();
-
-        /**
-         * Source paths of POMs that have a &lt;modules&gt; section (aggregators).
-         * Used to identify aggregator-only POMs that should not be modified.
-         */
         Set<Path> aggregatorPaths = new HashSet<>();
+        Map<Path, Set<Path>> aggregatorSubmodulePaths = new HashMap<>();
 
         /**
-         * Paths of POMs where the annotation processor is already present in the effective POM
-         * (via a parent POM outside the reactor), but not in the POM's own XML.
-         * These POMs should be skipped to avoid redundant configuration.
+         * Child-to-parent links recorded whenever
+         * {@code MavenResolutionResult.parentPomIsProjectPom()} is true. The
+         * check is GAV-based, so the link is upheld in {@link #resolve()} only
+         * when the child is reachable via some aggregator's &lt;modules&gt;
+         * chain; otherwise the child is treated as an orphan instead.
          */
+        Map<Path, Path> tentativeChildToParent = new HashMap<>();
+
+        Set<Path> noReactorParentPaths = new HashSet<>();
+        Set<Path> packagingPomPaths = new HashSet<>();
         Set<Path> alreadyConfiguredInEffectivePomPaths = new HashSet<>();
 
-        /**
-         * Get the actual orphan paths (candidates minus aggregator-only POMs).
-         * A true orphan has no parent in reactor and is not an aggregator-only POM.
-         */
-        Set<Path> getOrphanPomPaths() {
-            Set<Path> result = new HashSet<>(candidateOrphanPaths);
-            // Remove aggregator-only POMs (aggregators that are not also parents)
-            for (Path aggregatorPath : aggregatorPaths) {
-                if (!parentPomPaths.contains(aggregatorPath)) {
-                    result.remove(aggregatorPath);
+        Set<Path> parentPomPaths = new HashSet<>();
+        Set<Path> orphanPomPaths = new HashSet<>();
+
+        void resolve() {
+            Set<Path> reactorLinked = computeReactorLinkedPaths();
+            Set<Path> orphans = new HashSet<>(noReactorParentPaths);
+
+            for (Map.Entry<Path, Path> e : tentativeChildToParent.entrySet()) {
+                Path child = e.getKey();
+                Path parent = e.getValue();
+                if (reactorLinked.contains(child)) {
+                    parentPomPaths.add(parent);
+                } else {
+                    orphans.add(child);
                 }
             }
-            return result;
+
+            // Aggregator-only POMs are not modified.
+            for (Path aggregator : aggregatorPaths) {
+                if (!parentPomPaths.contains(aggregator)) {
+                    orphans.remove(aggregator);
+                }
+            }
+
+            // Dangling pom-packaging POMs (not claimed as parents, not aggregators)
+            // have nothing to compile; leave them alone.
+            for (Path packagingPom : packagingPomPaths) {
+                if (!parentPomPaths.contains(packagingPom) && !aggregatorPaths.contains(packagingPom)) {
+                    orphans.remove(packagingPom);
+                }
+            }
+
+            orphanPomPaths.addAll(orphans);
+        }
+
+        private Set<Path> computeReactorLinkedPaths() {
+            Set<Path> reachable = new HashSet<>();
+            Deque<Path> queue = new ArrayDeque<>(aggregatorPaths);
+            while (!queue.isEmpty()) {
+                Path p = queue.poll();
+                if (!reachable.add(p)) {
+                    continue;
+                }
+                Set<Path> subs = aggregatorSubmodulePaths.get(p);
+                if (subs != null) {
+                    queue.addAll(subs);
+                }
+            }
+            return reachable;
         }
     }
 
@@ -148,28 +181,54 @@ public class AddAnnotationProcessor extends ScanningRecipe<AddAnnotationProcesso
                     acc.alreadyConfiguredInEffectivePomPaths.add(sourcePath);
                 }
 
-                if (mrr.parentPomIsProjectPom()) {
-                    // This module has a parent within the reactor
-                    // Mark the parent for pluginManagement update
-                    MavenResolutionResult parent = mrr.getParent();
-                    if (parent != null) {
-                        Path parentPath = parent.getPom().getRequested().getSourcePath();
+                if (sourcePath != null) {
+                    if (mrr.parentPomIsProjectPom()) {
+                        // Parent's GAV matches a project pom, but this is a tentative
+                        // signal only — verified at resolution time by checking that
+                        // the child is reactor-linked via an aggregator's <modules>
+                        // chain. Two POMs co-ingested in the LST without a real
+                        // aggregator linking them must not be treated as a reactor.
+                        MavenResolutionResult parent = mrr.getParent();
+                        Path parentPath = parent == null ? null :
+                                parent.getPom().getRequested().getSourcePath();
                         if (parentPath != null) {
-                            acc.parentPomPaths.add(parentPath);
+                            acc.tentativeChildToParent.put(sourcePath, parentPath);
+                        } else {
+                            acc.noReactorParentPaths.add(sourcePath);
                         }
+                    } else {
+                        // No project-pom parent — true single-module root or
+                        // standalone pom-packaging shell.
+                        acc.noReactorParentPaths.add(sourcePath);
                     }
-                } else {
-                    // This module has no parent within the reactor
-                    // Mark as candidate orphan (will be filtered later if it's aggregator-only)
-                    if (sourcePath != null) {
-                        acc.candidateOrphanPaths.add(sourcePath);
+
+                    if ("pom".equals(resolvedPom.getPackaging())) {
+                        acc.packagingPomPaths.add(sourcePath);
                     }
                 }
 
-                // Track aggregator POMs (those with <modules> section)
-                List<String> subprojects = mrr.getPom().getSubprojects();
-                if (sourcePath != null && subprojects != null && !subprojects.isEmpty()) {
+                // Treat this POM as a reactor aggregator only when its raw XML
+                // declared <modules>/<subprojects>. We read that off the
+                // requested (unresolved) Pom — `mrr.getModules()` is unsuitable
+                // because it lists POMs that declare *this* one as their
+                // <parent> (which can happen without any <modules>
+                // declaration on this side).
+                List<String> requestedSubs = mrr.getPom().getRequested().getSubprojects();
+                if (sourcePath != null && requestedSubs != null && !requestedSubs.isEmpty()) {
                     acc.aggregatorPaths.add(sourcePath);
+                    // Resolve each <module> string relative to the aggregator's
+                    // directory. baseDir is null when the aggregator is at the
+                    // root (e.g. "pom.xml"); fall back to the empty path so
+                    // root-level reactors still reach their children.
+                    Path baseDir = sourcePath.getParent();
+                    Set<Path> resolvedSubmodules = new HashSet<>();
+                    for (String sub : requestedSubs) {
+                        Path resolved = baseDir == null ?
+                                Paths.get(sub, "pom.xml").normalize() :
+                                baseDir.resolve(sub).resolve("pom.xml").normalize();
+                        resolvedSubmodules.add(resolved);
+                    }
+                    acc.aggregatorSubmodulePaths.put(sourcePath, resolvedSubmodules);
                 }
 
                 return document;
@@ -179,6 +238,7 @@ public class AddAnnotationProcessor extends ScanningRecipe<AddAnnotationProcesso
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(Scanned acc) {
+        acc.resolve();
         return new TreeVisitor<Tree, ExecutionContext>() {
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
@@ -197,21 +257,23 @@ public class AddAnnotationProcessor extends ScanningRecipe<AddAnnotationProcesso
                 }
 
                 boolean isParent = acc.parentPomPaths.contains(sourcePath);
-                // Skip POMs that are neither parents nor orphans (children with parents in reactor)
-                if (!isParent && !acc.getOrphanPomPaths().contains(sourcePath)) {
+                if (!isParent && !acc.orphanPomPaths.contains(sourcePath)) {
                     return tree;
                 }
-
-                // Skip POMs where the annotation processor is already configured via a parent POM
-                // outside the reactor (present in effective POM but not in own XML)
                 if (acc.alreadyConfiguredInEffectivePomPaths.contains(sourcePath)) {
                     return tree;
                 }
 
-                // First, ensure the plugin exists - use the source path as file pattern
+                // GAV-coincident orphan: AddPluginVisitor.isAcceptable would
+                // otherwise short-circuit via its parentPomIsProjectPom()
+                // check and refuse to add the plugin. Targeting the visitor
+                // at this exact source path bypasses that guard.
+                boolean isGavCoincidentOrphan = !isParent && mrr.parentPomIsProjectPom();
+                String pluginFilePattern = isGavCoincidentOrphan ? sourcePath.toString() : null;
                 tree = new AddPluginVisitor(isParent,
                         MAVEN_COMPILER_PLUGIN_GROUP_ID, MAVEN_COMPILER_PLUGIN_ARTIFACT_ID, null,
-                        "<configuration><annotationProcessorPaths/></configuration>", null, null, null
+                        "<configuration><annotationProcessorPaths/></configuration>", null, null,
+                        pluginFilePattern
                 ).visit(tree, ctx);
 
                 // Then, configure the annotation processor path

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddAnnotationProcessor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddAnnotationProcessor.java
@@ -285,6 +285,14 @@ public class AddAnnotationProcessor extends ScanningRecipe<AddAnnotationProcesso
                             MavenResolutionResult currentMrr = getResolutionResult();
                             AtomicReference<TreeVisitor<?, ExecutionContext>> maybePropertyUpdate = new AtomicReference<>();
 
+                            // Ensure <configuration><annotationProcessorPaths/></configuration>
+                            // exists on the plugin so the path-adding visitor below has
+                            // something to attach to. AddPluginVisitor only seeds this
+                            // template when it adds a *new* plugin; when the plugin is
+                            // pre-declared (e.g. just to set <source>/<target>), the
+                            // structure must be filled in here.
+                            Xml.Tag pluginTree = ensureAnnotationProcessorPathsTag(plugin.getTree());
+
                             Xml.Tag modifiedPlugin = new XmlIsoVisitor<ExecutionContext>() {
                                 @Override
                                 public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
@@ -345,7 +353,7 @@ public class AddAnnotationProcessor extends ScanningRecipe<AddAnnotationProcesso
                                                     groupId, artifactId, version);
                                     return tg.withContent(ListUtils.concat(tg.getChildren(), Xml.Tag.build(pathXml)));
                                 }
-                            }.visitTag(plugin.getTree(), ctx);
+                            }.visitTag(pluginTree, ctx);
 
                             if (maybePropertyUpdate.get() != null) {
                                 doAfterVisit(maybePropertyUpdate.get());
@@ -362,6 +370,27 @@ public class AddAnnotationProcessor extends ScanningRecipe<AddAnnotationProcesso
                 }.visit(tree, ctx);
             }
         };
+    }
+
+    /**
+     * If the matched maven-compiler-plugin lacks {@code <configuration>} or its
+     * {@code <configuration>} lacks {@code <annotationProcessorPaths>}, add the
+     * missing structure so the path-adding visitor has somewhere to attach.
+     * No-op when the structure is already present.
+     */
+    private static Xml.Tag ensureAnnotationProcessorPathsTag(Xml.Tag plugin) {
+        Xml.Tag config = plugin.getChild("configuration").orElse(null);
+        if (config == null) {
+            Xml.Tag newConfig = Xml.Tag.build("<configuration>\n<annotationProcessorPaths/>\n</configuration>");
+            return plugin.withContent(ListUtils.concat(plugin.getChildren(), newConfig));
+        }
+        if (config.getChild("annotationProcessorPaths").isPresent()) {
+            return plugin;
+        }
+        Xml.Tag updatedConfig = config.withContent(
+                ListUtils.concat(config.getChildren(), Xml.Tag.build("<annotationProcessorPaths/>")));
+        return plugin.withContent(ListUtils.map(plugin.getChildren(),
+                child -> child == config ? updatedConfig : child));
     }
 
     /**

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddAnnotationProcessor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddAnnotationProcessor.java
@@ -220,6 +220,15 @@ public class AddAnnotationProcessor extends ScanningRecipe<AddAnnotationProcesso
                     // directory. baseDir is null when the aggregator is at the
                     // root (e.g. "pom.xml"); fall back to the empty path so
                     // root-level reactors still reach their children.
+                    //
+                    // Assumption: aggregator <modules> entries refer only to
+                    // POMs from the same reactor. An externally-ingested
+                    // aggregator that lists modules from its own out-of-LST
+                    // reactor will resolve to paths that almost always point
+                    // nowhere; in the rare case a co-ingested unrelated repo
+                    // happens to occupy a colliding path, two independent
+                    // POMs could be reactor-linked spuriously. Considered
+                    // negligible in practice.
                     Path baseDir = sourcePath.getParent();
                     Set<Path> resolvedSubmodules = new HashSet<>();
                     for (String sub : requestedSubs) {
@@ -269,7 +278,7 @@ public class AddAnnotationProcessor extends ScanningRecipe<AddAnnotationProcesso
                 // check and refuse to add the plugin. Targeting the visitor
                 // at this exact source path bypasses that guard.
                 boolean isGavCoincidentOrphan = !isParent && mrr.parentPomIsProjectPom();
-                String pluginFilePattern = isGavCoincidentOrphan ? sourcePath.toString() : null;
+                String pluginFilePattern = isGavCoincidentOrphan ? PathUtils.separatorsToUnix(sourcePath.toString()) : null;
                 tree = new AddPluginVisitor(isParent,
                         MAVEN_COMPILER_PLUGIN_GROUP_ID, MAVEN_COMPILER_PLUGIN_ARTIFACT_ID, null,
                         "<configuration><annotationProcessorPaths/></configuration>", null, null,
@@ -377,6 +386,12 @@ public class AddAnnotationProcessor extends ScanningRecipe<AddAnnotationProcesso
      * {@code <configuration>} lacks {@code <annotationProcessorPaths>}, add the
      * missing structure so the path-adding visitor has somewhere to attach.
      * No-op when the structure is already present.
+     * <p>
+     * Considered delegating to {@code ChangePluginConfiguration} /
+     * {@code AddOrUpdateChild}, but both replace an existing {@code <configuration>}
+     * wholesale and would clobber sibling entries like {@code <source>} /
+     * {@code <target>}. This helper is intentionally a conservative,
+     * sibling-preserving fill-in.
      */
     private static Xml.Tag ensureAnnotationProcessorPathsTag(Xml.Tag plugin) {
         Xml.Tag config = plugin.getChild("configuration").orElse(null);

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
@@ -1013,6 +1013,118 @@ class AddAnnotationProcessorTest implements RewriteTest {
         }
 
         @Test
+        void addConfigurationToExistingPluginWithNoConfig() {
+            // Single-module: plugin exists in build/plugins with NO <configuration>
+            // block. Common when a module declares maven-compiler-plugin only to
+            // set <source>/<target> elsewhere or for default lifecycle binding,
+            // leaving annotationProcessorPaths unconfigured. Recipe must fill in
+            // the entire configuration tree.
+            rewriteRun(
+              pomXml(
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>my-app</artifactId>
+                      <version>1</version>
+                      <build>
+                          <plugins>
+                              <plugin>
+                                  <groupId>org.apache.maven.plugins</groupId>
+                                  <artifactId>maven-compiler-plugin</artifactId>
+                              </plugin>
+                          </plugins>
+                      </build>
+                  </project>
+                  """,
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>my-app</artifactId>
+                      <version>1</version>
+                      <build>
+                          <plugins>
+                              <plugin>
+                                  <groupId>org.apache.maven.plugins</groupId>
+                                  <artifactId>maven-compiler-plugin</artifactId>
+                                  <configuration>
+                                      <annotationProcessorPaths>
+                                          <path>
+                                              <groupId>org.projectlombok</groupId>
+                                              <artifactId>lombok-mapstruct-binding</artifactId>
+                                              <version>0.2.0</version>
+                                          </path>
+                                      </annotationProcessorPaths>
+                                  </configuration>
+                              </plugin>
+                          </plugins>
+                      </build>
+                  </project>
+                  """
+              )
+            );
+        }
+
+        @Test
+        void addAnnotationProcessorPathsToExistingConfiguration() {
+            // Single-module: plugin exists with a <configuration> block but no
+            // <annotationProcessorPaths>. Recipe must add the inner element
+            // without disturbing other configuration entries.
+            rewriteRun(
+              pomXml(
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>my-app</artifactId>
+                      <version>1</version>
+                      <build>
+                          <plugins>
+                              <plugin>
+                                  <groupId>org.apache.maven.plugins</groupId>
+                                  <artifactId>maven-compiler-plugin</artifactId>
+                                  <configuration>
+                                      <source>17</source>
+                                      <target>17</target>
+                                  </configuration>
+                              </plugin>
+                          </plugins>
+                      </build>
+                  </project>
+                  """,
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>my-app</artifactId>
+                      <version>1</version>
+                      <build>
+                          <plugins>
+                              <plugin>
+                                  <groupId>org.apache.maven.plugins</groupId>
+                                  <artifactId>maven-compiler-plugin</artifactId>
+                                  <configuration>
+                                      <source>17</source>
+                                      <target>17</target>
+                                      <annotationProcessorPaths>
+                                          <path>
+                                              <groupId>org.projectlombok</groupId>
+                                              <artifactId>lombok-mapstruct-binding</artifactId>
+                                              <version>0.2.0</version>
+                                          </path>
+                                      </annotationProcessorPaths>
+                                  </configuration>
+                              </plugin>
+                          </plugins>
+                      </build>
+                  </project>
+                  """
+              )
+            );
+        }
+
+        @Test
         void addToBuildPluginsWhenInBothLocations() {
             // Single-module: plugin exists in both build/plugins AND pluginManagement
             // Expected: adds to build/plugins only (consistent with single-module behavior)

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
@@ -2515,8 +2515,8 @@ class AddAnnotationProcessorTest implements RewriteTest {
               mavenProject("service-module",
                 pomXml(
                   // Service module: declares the corporate parent by GAV (no relativePath
-                  // — externally resolved), has Lombok at provided scope, and declares
-                  // maven-compiler-plugin without annotationProcessorPaths.
+                  // — externally resolved), has Lombok at provided scope, no <build>
+                  // declared (relies on Maven default lifecycle / inherited plugin config).
                   """
                     <project>
                         <modelVersion>4.0.0</modelVersion>
@@ -2541,14 +2541,6 @@ class AddAnnotationProcessorTest implements RewriteTest {
                                 <scope>provided</scope>
                             </dependency>
                         </dependencies>
-                        <build>
-                            <plugins>
-                                <plugin>
-                                    <groupId>org.apache.maven.plugins</groupId>
-                                    <artifactId>maven-compiler-plugin</artifactId>
-                                </plugin>
-                            </plugins>
-                        </build>
                     </project>
                     """,
                   // Expected: the orphan child gets the annotation processor in its own

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
@@ -2457,5 +2457,149 @@ class AddAnnotationProcessorTest implements RewriteTest {
               )
             );
         }
+
+        @DocumentExample
+        @Test
+        void orphanModuleSharedLstWithExternalParent() {
+            // An "orphan" Maven module (its corporate parent lives outside any
+            // aggregator chain) where the parent POM happens to share the same
+            // LST set — e.g. ingested separately as another artifact. There is
+            // NO aggregator <modules> POM linking them, so they are not a real
+            // reactor; the actual build sees only the child.
+            // parentPomIsProjectPom() is GAV-based and returns true because
+            // the parent's GAV is among the project POMs, so
+            // AddAnnotationProcessor routes the child to the in-reactor-parent
+            // branch and never adds it to candidateOrphanPaths. In the visitor
+            // it is neither parent nor orphan and is skipped, so its own
+            // build/plugins is never updated.
+            rewriteRun(
+              mavenProject("corp-parent",
+                pomXml(
+                  // Corporate parent POM resolved externally in real builds.
+                  // No <modules> section — this parent is not aggregating anything.
+                  // Has BOM imports (BOM-driven dependency layout) and
+                  // maven-compiler-plugin in pluginManagement with no annotationProcessorPaths.
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.mycompany.platform</groupId>
+                        <artifactId>corp-parent</artifactId>
+                        <version>1.0.0</version>
+                        <packaging>pom</packaging>
+                        <dependencyManagement>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.springframework.boot</groupId>
+                                    <artifactId>spring-boot-dependencies</artifactId>
+                                    <version>3.2.0</version>
+                                    <type>pom</type>
+                                    <scope>import</scope>
+                                </dependency>
+                            </dependencies>
+                        </dependencyManagement>
+                        <build>
+                            <pluginManagement>
+                                <plugins>
+                                    <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-compiler-plugin</artifactId>
+                                        <version>3.13.0</version>
+                                    </plugin>
+                                </plugins>
+                            </pluginManagement>
+                        </build>
+                    </project>
+                    """
+                )
+              ),
+              mavenProject("service-module",
+                pomXml(
+                  // Service module: declares the corporate parent by GAV (no relativePath
+                  // — externally resolved), has Lombok at provided scope, and declares
+                  // maven-compiler-plugin without annotationProcessorPaths.
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.mycompany.platform</groupId>
+                            <artifactId>corp-parent</artifactId>
+                            <version>1.0.0</version>
+                        </parent>
+                        <artifactId>service-module</artifactId>
+                        <version>0.0.1-SNAPSHOT</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                                <version>1.18.44</version>
+                                <scope>provided</scope>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok-mapstruct-binding</artifactId>
+                                <version>0.2.0</version>
+                                <scope>provided</scope>
+                            </dependency>
+                        </dependencies>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-compiler-plugin</artifactId>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """,
+                  // Expected: the orphan child gets the annotation processor in its own
+                  // build/plugins, exactly as orphanModuleInSeparatedStructure() asserts
+                  // for the genuine-orphan case.
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.mycompany.platform</groupId>
+                            <artifactId>corp-parent</artifactId>
+                            <version>1.0.0</version>
+                        </parent>
+                        <artifactId>service-module</artifactId>
+                        <version>0.0.1-SNAPSHOT</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                                <version>1.18.44</version>
+                                <scope>provided</scope>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok-mapstruct-binding</artifactId>
+                                <version>0.2.0</version>
+                                <scope>provided</scope>
+                            </dependency>
+                        </dependencies>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-compiler-plugin</artifactId>
+                                    <configuration>
+                                        <annotationProcessorPaths>
+                                            <path>
+                                                <groupId>org.projectlombok</groupId>
+                                                <artifactId>lombok-mapstruct-binding</artifactId>
+                                                <version>0.2.0</version>
+                                            </path>
+                                        </annotationProcessorPaths>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """
+                )
+              )
+            );
+        }
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
@@ -1013,7 +1013,7 @@ class AddAnnotationProcessorTest implements RewriteTest {
         }
 
         @Test
-        void addConfigurationToExistingPluginWithNoConfig() {
+        void addConfigurationToExistingPluginWithNoConfigAtPluginLevel() {
             // Single-module: plugin exists in build/plugins with NO <configuration>
             // block. Common when a module declares maven-compiler-plugin only to
             // set <source>/<target> elsewhere or for default lifecycle binding,
@@ -1067,7 +1067,7 @@ class AddAnnotationProcessorTest implements RewriteTest {
         }
 
         @Test
-        void addAnnotationProcessorPathsToExistingConfiguration() {
+        void addAnnotationProcessorPathsToExistingConfigurationAtPluginLevel() {
             // Single-module: plugin exists with a <configuration> block but no
             // <annotationProcessorPaths>. Recipe must add the inner element
             // without disturbing other configuration entries.


### PR DESCRIPTION
## Summary

- Fix orphan modules being silently skipped when their external parent's GAV happens to also exist as a separately ingested LST artifact (`MavenResolutionResult.parentPomIsProjectPom()` is GAV-only).
- Verify each parent→child link by walking aggregator `<modules>` chains; treat the child as an orphan when no aggregator actually links them.
- Fill in missing `<configuration>` / `<annotationProcessorPaths>` when the matched plugin is pre-declared without it (previously `AddPluginVisitor` left such plugins untouched).

## Problem

`AddAnnotationProcessor` produced zero changes on Maven modules that:

1. Have no in-reactor parent in their actual build, but coincidentally co-exist in the same LST as a POM that shares their parent's GAV (e.g. an externally-ingested corporate parent), **or**
2. Pre-declare `maven-compiler-plugin` without `annotationProcessorPaths` (e.g. only to set `<source>`/`<target>` or for inherited config).

In case 1, `parentPomIsProjectPom()` returns true purely because GAVs match, so the child is routed to the in-reactor-parent branch and never added to `candidateOrphanPaths`. In the visitor it is neither parent nor orphan and is skipped, so its own `build/plugins` is never updated.

In case 2, `AddPluginVisitor`'s "plugin already exists" branch leaves the plugin untouched, and the path-adding inner visitor only operates on existing `<annotationProcessorPaths>` tags — so nothing is ever added.

## Solution

1. **Reactor-aware parent classification.** During scan, record `tentativeChildToParent` links and aggregator `<modules>` membership (read off the requested Pom, since `ResolvedPom.subprojects` is unreliable in some LST fixtures and `mrr.getModules()` lists POMs claiming this one as `<parent>` rather than ones aggregated by it). Before the visitor runs, walk aggregator `<modules>` chains via BFS; uphold a tentative link only when the child is reactor-reachable. Otherwise reclassify as orphan and add the processor to its own `build/plugins`. Skip dangling `packaging=pom` POMs that are neither claimed parents nor aggregators.

2. **Bypass for GAV-coincident orphans.** Pass the source path as `AddPluginVisitor`'s `filePattern` only for the GAV-coincident orphan case so its own `parentPomIsProjectPom()` short-circuit doesn't refuse to add the plugin. Genuine in-reactor parents and true single-module orphans hit the existing acceptance path with `filePattern=null`.

3. **Fill in missing `<configuration>` structure.** Before the path-adding visitor runs, ensure the matched plugin has `<configuration><annotationProcessorPaths/></configuration>`. The helper is conservative: only fills in whichever level is missing.

## Test plan

- [x] New `orphanModuleSharedLstWithExternalParent` reproducer fails on `main` and passes after the fix.
- [x] New `addConfigurationToExistingPluginWithNoConfig` and `addAnnotationProcessorPathsToExistingConfiguration` reproducers fail on `main` and pass after the fix.
- [x] All 30 existing `AddAnnotationProcessorTest` cases continue to pass.
- [x] Full `:rewrite-maven:test` passes.