### PR TITLE
Groovy: handle comma as an assert separator

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1454,12 +1454,18 @@ public class GroovyParserVisitor {
                 skip("assert");
                 Expression condition = doVisit(statement.getBooleanExpression());
                 JLeftPadded<Expression> message = null;
+                Markers markers = Markers.EMPTY;
                 if (!(statement.getMessageExpression() instanceof ConstantExpression) || !((ConstantExpression) statement.getMessageExpression()).isNullExpression()) {
                     Space messagePrefix = whitespace();
-                    skip(":");
+                    if (cursor < source.length() && source.charAt(cursor) == ',') {
+                        skip(",");
+                        markers = markers.addIfAbsent(new AssertMessageComma(randomId()));
+                    } else {
+                        skip(":");
+                    }
                     message = padLeft(messagePrefix, doVisit(statement.getMessageExpression()));
                 }
-                return new J.Assert(randomId(), prefix, Markers.EMPTY, condition, message);
+                return new J.Assert(randomId(), prefix, markers, condition, message);
             }));
         }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
@@ -315,6 +315,19 @@ public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
         }
 
         @Override
+        public J visitAssert(J.Assert assert_, PrintOutputCapture<P> p) {
+            if (!assert_.getMarkers().findFirst(AssertMessageComma.class).isPresent()) {
+                return super.visitAssert(assert_, p);
+            }
+            beforeSyntax(assert_, Space.Location.ASSERT_PREFIX, p);
+            p.append("assert");
+            visit(assert_.getCondition(), p);
+            visitLeftPadded(",", assert_.getDetail(), JLeftPadded.Location.ASSERT_DETAIL, p);
+            afterSyntax(assert_, p);
+            return assert_;
+        }
+
+        @Override
         public J visitTypeCast(J.TypeCast t, PrintOutputCapture<P> p) {
             if (!t.getMarkers().findFirst(AsStyleTypeCast.class).isPresent()) {
                 return super.visitTypeCast(t, p);

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/marker/AssertMessageComma.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/marker/AssertMessageComma.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Indicates that a Groovy {@code assert} statement uses {@code ,} (rather than {@code :})
+ * to separate the condition from the message.
+ */
+@Value
+@With
+public class AssertMessageComma implements Marker {
+    UUID id;
+}

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AssertTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AssertTest.java
@@ -49,6 +49,18 @@ class AssertTest implements RewriteTest {
         );
     }
 
+    @Test
+    void withGStringMessageAfterComma() {
+        rewriteRun(
+          groovy(
+            """
+              def x = 1
+              assert x == 2, "value is ${x}"
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/6374")
     @Test
     void withMessageAndSpaceBeforeColon() {


### PR DESCRIPTION
## What's changed?

Add support for alternative syntax of the `assert` statements in Groovy. They can be followed by a comma (instead of a colon), e.g.
```
assert x == 2, "value is ${x}"
```

## What's your motivation?

Without the fix, it fails with an exception.