### PR TITLE
Fix JavaSourceSet#gavFromPath for TypeTable jar layout

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
@@ -471,10 +471,15 @@ public class JavaSourceSet implements SourceSet {
                 version = pathParts.get(pathParts.size() - 3);
             } else if (pathParts.contains(".tt")) {
                 int ttIndex = pathParts.indexOf(".tt");
-                if (pathParts.size() - ttIndex > 3) {
-                    groupId = String.join(".", pathParts.subList(ttIndex + 1, pathParts.size() - 2));
-                    artifactId = pathParts.get(pathParts.size() - 2);
-                    version = pathParts.get(pathParts.size() - 1);
+                int last = pathParts.size() - 1;
+                // Legacy layout ends at the version directory; post-#7528 layout adds
+                // a trailing <artifact>-<version>.jar file inside the version directory.
+                int versionIndex = pathParts.get(last).endsWith(".jar") ? last - 1 : last;
+                int artifactIndex = versionIndex - 1;
+                if (artifactIndex - (ttIndex + 1) >= 1) {
+                    groupId = String.join(".", pathParts.subList(ttIndex + 1, artifactIndex));
+                    artifactId = pathParts.get(artifactIndex);
+                    version = pathParts.get(versionIndex);
                 }
             } else if (pathParts.size() >= 4) {
                 version = pathParts.get(pathParts.size() - 2);

--- a/rewrite-java/src/test/java/org/openrewrite/java/marker/JavaSourceSetTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/marker/JavaSourceSetTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.java.tree.JavaType;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -70,5 +71,29 @@ class JavaSourceSetTest {
         jos.putNextEntry(entry);
         jos.write(content);
         jos.closeEntry();
+    }
+
+    @Test
+    void gavFromTypeTableClassesDirPath() {
+        Path p = Paths.get(System.getProperty("user.home"),
+          ".rewrite/classpath/.tt/org/junit/jupiter/junit-jupiter-api/6.0.2");
+        assertThat(JavaSourceSet.gavFromPath(p))
+          .isEqualTo("org.junit.jupiter:junit-jupiter-api:6.0.2");
+    }
+
+    @Test
+    void gavFromTypeTableJarPath() {
+        Path p = Paths.get(System.getProperty("user.home"),
+          ".rewrite/classpath/.tt/org/junit/jupiter/junit-jupiter-api/6.0.2/junit-jupiter-api-6.0.2.jar");
+        assertThat(JavaSourceSet.gavFromPath(p))
+          .isEqualTo("org.junit.jupiter:junit-jupiter-api:6.0.2");
+    }
+
+    @Test
+    void gavFromGradleCachePath() {
+        Path p = Paths.get(System.getProperty("user.home"),
+          ".gradle/caches/modules-2/files-2.1/org.openrewrite/rewrite-core/8.32.0/64ddcc371f1bf29593b4b27e907757d5554d1a83/rewrite-core-8.32.0.jar");
+        assertThat(JavaSourceSet.gavFromPath(p))
+          .isEqualTo("org.openrewrite:rewrite-core:8.32.0");
     }
 }


### PR DESCRIPTION
## What

Fixes `JavaSourceSet#gavFromPath` to handle the post-#7528 `TypeTable` jar layout, alongside three tests covering both layouts and the Gradle cache:

- `gavFromTypeTableClassesDirPath` — legacy `~/.rewrite/classpath/.tt/<group>/<artifact>/<version>` directory path.
- `gavFromTypeTableJarPath` — current `~/.rewrite/classpath/.tt/<group>/<artifact>/<version>/<artifact>-<version>.jar` jar path produced by `TypeTable` after #7528. Failed before this PR, returning ``org.junit.jupiter.junit-jupiter-api:6.0.2:junit-jupiter-api-6.0.2.jar`` instead of `org.junit.jupiter:junit-jupiter-api:6.0.2`.
- `gavFromGradleCachePath` — guard for the Gradle-cache branch so the fix doesn't regress it.

## Why this regressed

PR #7528 (`23be80c1`) changed `TypeTable` to materialize artifacts as jar files inside the version directory. The `.tt` branch in `gavFromPath` still used fixed offsets `pathParts.size() - 2` / `- 1`, which now point at the version directory and the jar filename respectively, sweeping the artifactId path component into the groupId slice. The dot you see between `jupiter` and `junit-jupiter-api` is just the separator that `String.join(".", …)` inserts between the real groupId tail and the artifactId that drifted into the slice.

Downstream impact: any recipe that scans `JavaSourceSet#getGavToTypes` keys after `JavaParser.dependenciesFromResources(...)` sees malformed GAVs against rewrite ≥ 8.82.0-SNAPSHOT. Concrete failure: [moderneinc/rewrite-devcenter `JUnitJupiterUpgradeTest.junit6` on a scheduled main build](https://github.com/moderneinc/rewrite-devcenter/actions/runs/25179745480/job/73936108253).

## Fix

Compute `versionIndex` / `artifactIndex` off the tail instead of using fixed offsets, and shift left by one when the trailing path component ends with `.jar`, so the slice points at the right components in either layout:

```java
} else if (pathParts.contains(".tt")) {
    int ttIndex = pathParts.indexOf(".tt");
    int last = pathParts.size() - 1;
    // Legacy layout ends at the version directory; post-#7528 layout adds
    // a trailing <artifact>-<version>.jar file inside the version directory.
    int versionIndex = pathParts.get(last).endsWith(".jar") ? last - 1 : last;
    int artifactIndex = versionIndex - 1;
    if (artifactIndex - (ttIndex + 1) >= 1) {
        groupId = String.join(".", pathParts.subList(ttIndex + 1, artifactIndex));
        artifactId = pathParts.get(artifactIndex);
        version = pathParts.get(versionIndex);
    }
}
```

`.jar` is the only file extension that can appear under `.tt/<group>/<artifact>/<version>/`: `TypeTable.getJarPath` is the sole writer, and it always resolves to `<artifactId>-<version>.jar`. Transient `.tmp` files from the atomic-move pattern in `TypeTable.writeJar` never reach `JavaSourceSet`.