### PR TITLE
C#: pass `--skip-duplicate` to `dotnet nuget push`

### DIFF
--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -313,7 +313,8 @@ val csharpPublish by tasks.registering(Exec::class) {
             findDotnet(), "nuget", "push",
             "dist/*.nupkg",
             "--source", "https://api.nuget.org/v3/index.json",
-            "--api-key", project.findProperty("nugetApiKey")?.toString() ?: ""
+            "--api-key", project.findProperty("nugetApiKey")?.toString() ?: "",
+            "--skip-duplicate"
         )
         logger.lifecycle("Publishing C# NuGet package (version: $nugetVersion)")
     }


### PR DESCRIPTION
The scheduled daily CI run fails on the NuGet publish step whenever no new commit has landed since the previous run. The C# snapshot version is derived from the latest commit timestamp, so the `.nupkg` filename is identical to yesterday's; NuGet versions are immutable, so `dotnet nuget push` exits non-zero and turns the whole publish step red (e.g. https://github.com/openrewrite/rewrite/actions/runs/25222223491).

Adding `--skip-duplicate` makes NuGet treat an already-uploaded version as a logged warning instead of an error, matching how Maven `-SNAPSHOT` re-uploads behave.

## Test plan
- [ ] Trigger `ci.yml` via `workflow_dispatch` twice without an intervening commit; second run succeeds with a "package already exists, skipped" log line.
- [ ] Tag-driven `publish.yml` still pushes a fresh release version successfully.