### PR TITLE
Normalize null collections in RecipeDescriptor deserialization

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeDescriptor.java
@@ -16,9 +16,10 @@
 package org.openrewrite.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
-import lombok.Value;
+import lombok.Getter;
+import lombok.ToString;
 import lombok.With;
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
@@ -36,48 +37,86 @@ import java.util.Set;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 
-@Value
+@Getter
+@ToString
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@AllArgsConstructor(onConstructor = @__(@JsonCreator))
 public class RecipeDescriptor {
     @EqualsAndHashCode.Include
-    String name;
+    private final String name;
 
     @NlsRewrite.DisplayName
-    String displayName;
+    private final String displayName;
 
     @NlsRewrite.DisplayName
-    String instanceName;
+    private final String instanceName;
 
     @NlsRewrite.Description
-    String description;
+    private final String description;
 
-    Set<String> tags;
+    private final Set<String> tags;
 
     @Nullable
-    Duration estimatedEffortPerOccurrence;
+    private final Duration estimatedEffortPerOccurrence;
 
     @EqualsAndHashCode.Include
-    List<OptionDescriptor> options;
+    private final List<OptionDescriptor> options;
 
     @With
-    List<RecipeDescriptor> preconditions;
+    private final List<RecipeDescriptor> preconditions;
 
     @With
-    List<RecipeDescriptor> recipeList;
+    private final List<RecipeDescriptor> recipeList;
 
     @With
-    List<DataTableDescriptor> dataTables;
+    private final List<DataTableDescriptor> dataTables;
 
-    List<Maintainer> maintainers;
+    private final List<Maintainer> maintainers;
 
     @Deprecated(/* No longer populated */)
-    List<Contributor> contributors;
+    private final List<Contributor> contributors;
 
-    List<RecipeExample> examples;
+    private final List<RecipeExample> examples;
 
     @Deprecated
-    URI source;
+    private final URI source;
+
+    /**
+     * Recipes constructed locally always pass non-null collections (see
+     * {@link org.openrewrite.Recipe#createRecipeDescriptor()}). Polyglot RPC peers
+     * may omit empty collections from JSON, so normalize null to empty here to
+     * preserve the "never null" contract for collection-valued getters.
+     */
+    @JsonCreator
+    public RecipeDescriptor(
+            @JsonProperty("name") String name,
+            @JsonProperty("displayName") String displayName,
+            @JsonProperty("instanceName") String instanceName,
+            @JsonProperty("description") String description,
+            @JsonProperty("tags") @Nullable Set<String> tags,
+            @JsonProperty("estimatedEffortPerOccurrence") @Nullable Duration estimatedEffortPerOccurrence,
+            @JsonProperty("options") @Nullable List<OptionDescriptor> options,
+            @JsonProperty("preconditions") @Nullable List<RecipeDescriptor> preconditions,
+            @JsonProperty("recipeList") @Nullable List<RecipeDescriptor> recipeList,
+            @JsonProperty("dataTables") @Nullable List<DataTableDescriptor> dataTables,
+            @JsonProperty("maintainers") @Nullable List<Maintainer> maintainers,
+            @JsonProperty("contributors") @Nullable List<Contributor> contributors,
+            @JsonProperty("examples") @Nullable List<RecipeExample> examples,
+            @JsonProperty("source") URI source) {
+        this.name = name;
+        this.displayName = displayName;
+        this.instanceName = instanceName;
+        this.description = description;
+        this.tags = tags == null ? emptySet() : tags;
+        this.estimatedEffortPerOccurrence = estimatedEffortPerOccurrence;
+        this.options = options == null ? emptyList() : options;
+        this.preconditions = preconditions == null ? emptyList() : preconditions;
+        this.recipeList = recipeList == null ? emptyList() : recipeList;
+        this.dataTables = dataTables == null ? emptyList() : dataTables;
+        this.maintainers = maintainers == null ? emptyList() : maintainers;
+        this.contributors = contributors == null ? emptyList() : contributors;
+        this.examples = examples == null ? emptyList() : examples;
+        this.source = source;
+    }
 
     @Deprecated
     public RecipeDescriptor(String name, String displayName, String instanceName, String description,

--- a/rewrite-core/src/test/java/org/openrewrite/config/RecipeDescriptorTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/RecipeDescriptorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecipeDescriptorTest {
+
+    /**
+     * Polyglot RPC peers (rewrite-javascript-remote, rewrite-csharp-remote,
+     * rewrite-python-remote) may omit empty collection-valued fields from the
+     * descriptor JSON they return. Java callers iterate {@code getPreconditions()},
+     * {@code getRecipeList()}, etc. without null checks, so deserialization must
+     * normalize missing fields to empty collections to preserve the "never null"
+     * contract that {@link org.openrewrite.Recipe#createRecipeDescriptor()} maintains
+     * for locally constructed descriptors.
+     */
+    @Test
+    void deserializeOmittedCollectionsAsEmpty() throws Exception {
+        String json = """
+                {
+                  "name": "org.example.Foo",
+                  "displayName": "Foo",
+                  "instanceName": "Foo",
+                  "description": "A recipe."
+                }
+                """;
+
+        RecipeDescriptor descriptor = new ObjectMapper().readValue(json, RecipeDescriptor.class);
+
+        assertThat(descriptor.getTags()).isEmpty();
+        assertThat(descriptor.getOptions()).isEmpty();
+        assertThat(descriptor.getPreconditions()).isEmpty();
+        assertThat(descriptor.getRecipeList()).isEmpty();
+        assertThat(descriptor.getDataTables()).isEmpty();
+        assertThat(descriptor.getMaintainers()).isEmpty();
+        assertThat(descriptor.getContributors()).isEmpty();
+        assertThat(descriptor.getExamples()).isEmpty();
+    }
+}


### PR DESCRIPTION
## What

`Recipe.createRecipeDescriptor()` always passes non-null lists for `tags`, `options`, `preconditions`, `recipeList`, `dataTables`, `maintainers`, `contributors`, and `examples` — and callers across the ecosystem rely on that, iterating these getters without null checks.

When a `RecipeDescriptor` is deserialized from JSON returned by a polyglot RPC peer (rewrite-javascript-remote, rewrite-csharp-remote, rewrite-python-remote), those peers omit empty collection-valued fields. Jackson's default `@AllArgsConstructor(@JsonCreator)` binding then leaves those fields `null`, and downstream code blows up:

```
Cannot invoke "java.util.List.iterator()" because the return value of
"org.openrewrite.config.RecipeDescriptor.getPreconditions()" is null
```

## How

Replace the Lombok `@Value` + `@AllArgsConstructor(onConstructor = @__(@JsonCreator))` with an explicit `@JsonCreator` constructor that normalizes null → empty at the deserialization boundary. Field-level immutability, getters, `equals`/`hashCode`, `toString`, and `@With` are preserved via explicit `private final` + `@Getter` / `@ToString` / `@EqualsAndHashCode`.

Locally constructed `RecipeDescriptor`s are unaffected (they were already passing non-null collections).

## Test plan

- [x] New `RecipeDescriptorTest.deserializeOmittedCollectionsAsEmpty` locks the contract: a JSON document missing `tags`, `options`, `preconditions`, `recipeList`, `dataTables`, `maintainers`, `contributors`, and `examples` deserializes to a descriptor whose getters return empty collections, never null.
- [x] Full `:rewrite-core:test` passes.