### PR TITLE
RPC peers: emit empty arrays for descriptor collections, never omit them

### DIFF
--- a/rewrite-javascript/rewrite/src/recipe.ts
+++ b/rewrite-javascript/rewrite/src/recipe.ts
@@ -89,6 +89,11 @@ export abstract class Recipe {
 
     async descriptor(): Promise<RecipeDescriptor> {
         const optionsRecord: Record<string, OptionDescriptor> = (this as any).constructor[OPTIONS_KEY] || {}
+        // Java's `RecipeDescriptor.getXxx()` getters for collection-valued
+        // fields are treated as never-null by callers (matching what
+        // `Recipe.getDescriptor()` upholds locally). Always emit the
+        // collection keys, even when empty, so Jackson on the Java side
+        // never leaves them null.
         return {
             name: this.name,
             displayName: this.displayName,
@@ -96,14 +101,18 @@ export abstract class Recipe {
             description: this.description,
             tags: this.tags,
             estimatedEffortPerOccurrence: this.estimatedEffortPerOccurrence,
-            recipeList: await mapAsync(await this.recipeList(), async r => r.descriptor()),
             options: Object.entries(optionsRecord).map(([key, descriptor]) => ({
                 name: key,
                 value: (this as any)[key],
                 required: descriptor.required ?? true,
                 ...descriptor
             })),
-            dataTables: this.dataTables
+            preconditions: [],
+            recipeList: await mapAsync(await this.recipeList(), async r => r.descriptor()),
+            dataTables: this.dataTables,
+            maintainers: [],
+            contributors: [],
+            examples: []
         }
     }
 
@@ -135,9 +144,13 @@ export interface RecipeDescriptor {
     readonly description: string
     readonly tags: string[]
     readonly estimatedEffortPerOccurrence: Minutes
-    readonly recipeList: RecipeDescriptor[]
     readonly options: ({ name: string, value?: any } & OptionDescriptor)[]
+    readonly preconditions: RecipeDescriptor[]
+    readonly recipeList: RecipeDescriptor[]
     readonly dataTables: DataTableDescriptor[]
+    readonly maintainers: any[]
+    readonly contributors: any[]
+    readonly examples: any[]
 }
 
 export interface OptionDescriptor {

--- a/rewrite-javascript/rewrite/src/recipe.ts
+++ b/rewrite-javascript/rewrite/src/recipe.ts
@@ -89,11 +89,6 @@ export abstract class Recipe {
 
     async descriptor(): Promise<RecipeDescriptor> {
         const optionsRecord: Record<string, OptionDescriptor> = (this as any).constructor[OPTIONS_KEY] || {}
-        // Java's `RecipeDescriptor.getXxx()` getters for collection-valued
-        // fields are treated as never-null by callers (matching what
-        // `Recipe.getDescriptor()` upholds locally). Always emit the
-        // collection keys, even when empty, so Jackson on the Java side
-        // never leaves them null.
         return {
             name: this.name,
             displayName: this.displayName,

--- a/rewrite-javascript/rewrite/test/recipe.test.ts
+++ b/rewrite-javascript/rewrite/test/recipe.test.ts
@@ -43,9 +43,13 @@ describe("recipes", () => {
                     value: undefined
                 }
             ],
+            preconditions: [],
             recipeList: [],
             tags: [],
-            dataTables: []
+            dataTables: [],
+            maintainers: [],
+            contributors: [],
+            examples: []
         });
     });
 });

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -878,13 +878,7 @@ def _category_descriptor_to_dict(descriptor) -> dict:
 
 
 def _recipe_descriptor_to_dict(descriptor) -> dict:
-    """Convert a RecipeDescriptor to a dict for JSON serialization.
-
-    Java's `RecipeDescriptor.getXxx()` getters for collection-valued fields
-    are treated as never-null by callers (matching what `Recipe.getDescriptor()`
-    upholds locally). Always emit the collection keys, even when empty, so
-    Jackson on the Java side never leaves them null.
-    """
+    """Convert a RecipeDescriptor to a dict for JSON serialization."""
     return {
         'name': descriptor.name,
         'displayName': descriptor.display_name,

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -878,7 +878,13 @@ def _category_descriptor_to_dict(descriptor) -> dict:
 
 
 def _recipe_descriptor_to_dict(descriptor) -> dict:
-    """Convert a RecipeDescriptor to a dict for JSON serialization."""
+    """Convert a RecipeDescriptor to a dict for JSON serialization.
+
+    Java's `RecipeDescriptor.getXxx()` getters for collection-valued fields
+    are treated as never-null by callers (matching what `Recipe.getDescriptor()`
+    upholds locally). Always emit the collection keys, even when empty, so
+    Jackson on the Java side never leaves them null.
+    """
     return {
         'name': descriptor.name,
         'displayName': descriptor.display_name,
@@ -897,8 +903,12 @@ def _recipe_descriptor_to_dict(descriptor) -> dict:
             }
             for name, value, opt in descriptor.options
         ],
-        'dataTables': descriptor.data_tables,
+        'preconditions': [],
         'recipeList': [_recipe_descriptor_to_dict(r) for r in descriptor.recipe_list],
+        'dataTables': descriptor.data_tables,
+        'maintainers': [],
+        'contributors': [],
+        'examples': [],
     }
 
 

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -24,3 +24,30 @@ def test_handle_parse_preserves_empty_text(tmp_path, monkeypatch):
     assert observed["source"] == ""
     assert observed["path"] == str(tmp_path / "pkg" / "__init__.py")
     assert (tmp_path / "pkg" / "__init__.py").read_text(encoding="utf-8") == ""
+
+
+def test_recipe_descriptor_to_dict_emits_all_collection_keys():
+    """Java's RecipeDescriptor.getXxx() collection-valued getters are
+    treated as never-null by callers. Always emit the collection keys —
+    including the ones the Python dataclass doesn't model — so Jackson on
+    the Java side never leaves them null."""
+    from rewrite.recipe import RecipeDescriptor
+    from rewrite.rpc.server import _recipe_descriptor_to_dict
+
+    descriptor = RecipeDescriptor(
+        name="org.example.Foo",
+        display_name="Foo",
+        description="A recipe.",
+        tags=[],
+        estimated_effort_per_occurrence=0,
+        options=[],
+        data_tables=[],
+        recipe_list=[],
+    )
+
+    result = _recipe_descriptor_to_dict(descriptor)
+
+    for key in ("tags", "options", "preconditions", "recipeList",
+                "dataTables", "maintainers", "contributors", "examples"):
+        assert key in result, f"missing key: {key}"
+        assert result[key] == [], f"{key} should be empty list, got {result[key]!r}"

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -27,10 +27,6 @@ def test_handle_parse_preserves_empty_text(tmp_path, monkeypatch):
 
 
 def test_recipe_descriptor_to_dict_emits_all_collection_keys():
-    """Java's RecipeDescriptor.getXxx() collection-valued getters are
-    treated as never-null by callers. Always emit the collection keys —
-    including the ones the Python dataclass doesn't model — so Jackson on
-    the Java side never leaves them null."""
     from rewrite.recipe import RecipeDescriptor
     from rewrite.rpc.server import _recipe_descriptor_to_dict
 


### PR DESCRIPTION
## What

`Recipe.getDescriptor()` on the Java side always returns a descriptor whose collection-valued getters (`tags`, `options`, `preconditions`, `recipeList`, `dataTables`, `maintainers`, `contributors`, `examples`) are non-null. Callers across the ecosystem rely on that and iterate the getters directly:

```java
for (RecipeDescriptor precondition : descriptor.getPreconditions()) { ... }
descriptor.getPreconditions().stream().map(...).toList();
```

When a `RecipeDescriptor` arrives from a polyglot RPC peer, the JSON that peer emits can omit empty collections — Jackson on the Java side then leaves the corresponding fields `null`, and downstream code blows up:

```
Cannot invoke "java.util.List.iterator()" because the return value of
"org.openrewrite.config.RecipeDescriptor.getPreconditions()" is null
```

## How

Fix at the source — each polyglot peer always emits every collection key, even when empty:

**Python** (`rewrite-python/rewrite/src/rewrite/rpc/server.py`)
`_recipe_descriptor_to_dict` now emits `preconditions`, `maintainers`, `contributors`, `examples` as empty lists. The Python `RecipeDescriptor` dataclass doesn't model these fields yet, so they're hardcoded `[]`.

**TypeScript** (`rewrite-javascript/rewrite/src/recipe.ts`)
Extended the `RecipeDescriptor` interface with the four missing fields and updated `Recipe.descriptor()` to populate them. Updates the existing `recipe.test.ts` snapshot.

**C#** — *no change.* `RecipeDescriptorDto` already declares each list/set property with an `= []` initializer and Newtonsoft serializes empty collections as `[]`, so the JSON it produces already matches the contract.

## Test plan

- [x] `rewrite-python/rewrite/tests/rpc/test_server.py::test_recipe_descriptor_to_dict_emits_all_collection_keys` — locks the contract on the Python side.
- [x] `rewrite-javascript/rewrite/test/recipe.test.ts` — updated snapshot now asserts the four empty-collection keys.
- [x] `:rewrite-javascript:compileJava :rewrite-csharp:compileJava :rewrite-python:compileJava` pass.