### PR TITLE
InlineMethodCalls: preserve method select when replacement is bare

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/InlineMethodCalls.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/InlineMethodCalls.java
@@ -35,6 +35,7 @@ import static java.util.Objects.requireNonNull;
 @Value
 public class InlineMethodCalls extends Recipe {
     private static final Pattern TEMPLATE_IDENTIFIER = Pattern.compile("#\\{(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*):any\\(.*?\\)}");
+    private static final Pattern BARE_METHOD_CALL = Pattern.compile("^\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*\\(");
 
     @Option(displayName = "Method pattern",
             description = "A method pattern that is used to find matching method invocations.",
@@ -199,6 +200,11 @@ public class InlineMethodCalls extends Recipe {
                         ((J.MethodInvocation) original).getSelect() == null &&
                         replacement.startsWith("this.")) {
                     templateString = replacement.substring(5);
+                } else if (original instanceof J.MethodInvocation &&
+                        ((J.MethodInvocation) original).getSelect() != null &&
+                        BARE_METHOD_CALL.matcher(replacement).find()) {
+                    // Original had a select but replacement is a bare method call; preserve the select
+                    templateString = "#{this:any()}." + replacement;
                 } else {
                     templateString = replacement.replaceAll("\\bthis\\b", "#{this:any()}");
                 }

--- a/rewrite-java/src/test/java/org/openrewrite/java/InlineMethodCallsTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/InlineMethodCallsTest.java
@@ -509,6 +509,53 @@ class InlineMethodCallsTest implements RewriteTest {
     }
 
     @Test
+    void preserveSelectWhenReplacementIsBareMethodCall() {
+        //language=java
+        rewriteRun(
+          spec -> spec.recipe(new InlineMethodCalls(
+              "Lib getTotalHits()",
+              "getTotalHitsCount()",
+              null,
+              null,
+              null)),
+          java(
+            """
+              class Lib {
+                  @Deprecated
+                  public int getTotalHits() {
+                      return getTotalHitsCount();
+                  }
+
+                  public int getTotalHitsCount() {
+                      return 0;
+                  }
+
+                  static int usage(Lib lib) {
+                      return lib.getTotalHits();
+                  }
+              }
+              """,
+            """
+              class Lib {
+                  @Deprecated
+                  public int getTotalHits() {
+                      return getTotalHitsCount();
+                  }
+
+                  public int getTotalHitsCount() {
+                      return 0;
+                  }
+
+                  static int usage(Lib lib) {
+                      return lib.getTotalHitsCount();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void sameArgumentUsedTwice() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
## Summary
When the original invocation has a select (e.g. `red.getTotalHits()`) and the replacement template is a bare method call (e.g. `getTotalHitsCount()`), the select was being dropped, producing `getTotalHitsCount()` instead of `red.getTotalHitsCount()`. This change detects that case and prepends `#{this:any()}.` to the template so the original receiver is preserved.

- Fixes #7549

## Test plan
- [x] New test `preserveSelectWhenReplacementIsBareMethodCall` covers the bug case
- [x] All 12 existing `InlineMethodCallsTest` tests still pass