### PR TITLE
JS: skip `npm publish` when snapshot version already exists

### DIFF
--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -253,6 +253,24 @@ val npmPublish = tasks.register<NpmTask>("npmPublish") {
     }
 
     workingDir.set(file("rewrite"))
+
+    // npm has no `--skip-duplicate`; the daily scheduled publish would fail with a 403
+    // whenever no new commit had landed since the previous run (the snapshot version is
+    // derived from the latest commit timestamp). Skip the task if the version already exists.
+    onlyIf {
+        val versionToCheck = extractVersionFromJar() ?: datedSnapshotVersion
+        val process = ProcessBuilder("npm", "view", "@openrewrite/rewrite@$versionToCheck", "version")
+            .directory(file("rewrite"))
+            .redirectErrorStream(true)
+            .start()
+        process.waitFor()
+        val output = process.inputStream.bufferedReader().readText().trim()
+        val alreadyPublished = output.contains(versionToCheck)
+        if (alreadyPublished) {
+            logger.lifecycle("Skipping npmPublish: @openrewrite/rewrite@$versionToCheck already published")
+        }
+        !alreadyPublished
+    }
 }
 
 tasks.named("publish") {


### PR DESCRIPTION
## Summary
- The scheduled `main` CI job failed at `:rewrite-javascript:npmPublish` with `npm error 403 ... You cannot publish over the previously published versions: 8.82.0-20260502-150813.` The snapshot version is derived from the latest commit timestamp, so when no new commit lands between scheduled runs, npm rejects the duplicate publish.
- npm has no `--skip-duplicate` equivalent, so this adds an `onlyIf` to `npmPublish` that runs `npm view @openrewrite/rewrite@<version>` and skips the task when the version is already in the registry. Mirrors the intent of #7544 (which added `--skip-duplicate` for NuGet).

## Test plan
- [ ] Next scheduled `main` run succeeds (or logs `Skipping npmPublish: ... already published` if the timestamp hasn't moved).