### PR TITLE
RewriteTest: framework-agnostic ExecutionContext customizer registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,18 +20,40 @@ concurrency:
 
 jobs:
   build:
-    uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main
-    with:
-      java_version: |
-        25
-        21
-    secrets:
-      gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
-      sonatype_token: ${{ secrets.SONATYPE_TOKEN}}
-      ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
-      ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
-      OPS_GITHUB_ACTIONS_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
-      node_auth_token: ${{ secrets.NPM_TOKEN }}
-      pypi_token: ${{ secrets.PYPI_OPENREWRITE_PUBLISH }}
-      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc'
+    steps:
+      - uses: openrewrite/gh-automation/.github/actions/setup@main
+        with:
+          java_version: |
+            25
+            21
+          develocity_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+
+      # Route Maven resolution through Moderne's Artifactory cache to avoid
+      # Maven Central rate-limiting (HTTP 404 + Retry-After) under parallel
+      # test load. Picked up by MavenSettingsAutoLoadingExtension at test time.
+      - uses: s4u/maven-settings-action@v3.1.0
+        with:
+          mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
+
+      - uses: openrewrite/gh-automation/.github/actions/build@main
+
+      - if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+        uses: openrewrite/gh-automation/.github/actions/slack-failure@main
+        with:
+          webhook: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
+
+      - if: >
+          github.event_name != 'pull_request' &&
+          github.ref == 'refs/heads/main' &&
+          (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+        uses: openrewrite/gh-automation/.github/actions/publish-snapshots@main
+        with:
+          sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
+          sonatype_token: ${{ secrets.SONATYPE_TOKEN }}
+          ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
+          ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+          node_auth_token: ${{ secrets.NPM_TOKEN }}
+          pypi_token: ${{ secrets.PYPI_OPENREWRITE_PUBLISH }}
+          nuget_api_key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,20 +18,67 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
+
 jobs:
   build:
-    uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main
-    with:
-      java_version: |
-        25
-        21
-    secrets:
-      gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
-      sonatype_token: ${{ secrets.SONATYPE_TOKEN}}
-      ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
-      ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
-      OPS_GITHUB_ACTIONS_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
-      node_auth_token: ${{ secrets.NPM_TOKEN }}
-      pypi_token: ${{ secrets.PYPI_OPENREWRITE_PUBLISH }}
-      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          show-progress: false
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: |
+            25
+            21
+
+      - uses: astral-sh/setup-uv@v7
+
+      # Route Maven resolution through Moderne's Artifactory cache to avoid
+      # Maven Central rate-limiting (HTTP 404 + Retry-After) under parallel test
+      # load. Picked up by MavenSettingsAutoLoadingExtension at test time. Must
+      # run after setup-java because that action overwrites ~/.m2/settings.xml.
+      - uses: s4u/maven-settings-action@v3.1.0
+        with:
+          mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+
+      - name: build
+        run: ./gradlew ${{ env.GRADLE_SWITCHES }} build
+
+      - name: slackNotificationOfFailure
+        if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
+          MSG_MINIMAL: true
+          SLACK_MESSAGE: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_USERNAME: ${{ github.repository }} CI failure
+          SLACK_COLOR: failure
+          SLACK_FOOTER: ''
+
+      - name: publish-snapshots
+        if: >
+          github.event_name != 'pull_request' &&
+          github.ref == 'refs/heads/main' &&
+          (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+        run: ./gradlew ${{ env.GRADLE_SWITCHES }} snapshot publish -PforceSigning -x test
+        env:
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_TOKEN }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_nodeAuthToken: ${{ secrets.NPM_TOKEN }}
+          ORG_GRADLE_PROJECT_pypiToken: ${{ secrets.PYPI_OPENREWRITE_PUBLISH }}
+          ORG_GRADLE_PROJECT_nugetApiKey: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,67 +18,20 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
-
 jobs:
   build:
-    runs-on: ubuntu-latest
-    if: github.event_name != 'schedule' || github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc'
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          show-progress: false
-
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: |
-            25
-            21
-
-      - uses: astral-sh/setup-uv@v7
-
-      # Route Maven resolution through Moderne's Artifactory cache to avoid
-      # Maven Central rate-limiting (HTTP 404 + Retry-After) under parallel test
-      # load. Picked up by MavenSettingsAutoLoadingExtension at test time. Must
-      # run after setup-java because that action overwrites ~/.m2/settings.xml.
-      - uses: s4u/maven-settings-action@v3.1.0
-        with:
-          mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-        with:
-          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-
-      - name: build
-        run: ./gradlew ${{ env.GRADLE_SWITCHES }} build
-
-      - name: slackNotificationOfFailure
-        if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
-        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
-        continue-on-error: true
-        env:
-          SLACK_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
-          MSG_MINIMAL: true
-          SLACK_MESSAGE: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          SLACK_USERNAME: ${{ github.repository }} CI failure
-          SLACK_COLOR: failure
-          SLACK_FOOTER: ''
-
-      - name: publish-snapshots
-        if: >
-          github.event_name != 'pull_request' &&
-          github.ref == 'refs/heads/main' &&
-          (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
-        run: ./gradlew ${{ env.GRADLE_SWITCHES }} snapshot publish -PforceSigning -x test
-        env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_TOKEN }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_nodeAuthToken: ${{ secrets.NPM_TOKEN }}
-          ORG_GRADLE_PROJECT_pypiToken: ${{ secrets.PYPI_OPENREWRITE_PUBLISH }}
-          ORG_GRADLE_PROJECT_nugetApiKey: ${{ secrets.NUGET_API_KEY }}
+    uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main
+    with:
+      java_version: |
+        25
+        21
+    secrets:
+      gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
+      sonatype_token: ${{ secrets.SONATYPE_TOKEN}}
+      ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
+      ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+      OPS_GITHUB_ACTIONS_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
+      node_auth_token: ${{ secrets.NPM_TOKEN }}
+      pypi_token: ${{ secrets.PYPI_OPENREWRITE_PUBLISH }}
+      nuget_api_key: ${{ secrets.NUGET_API_KEY }}

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/MavenSettingsAutoLoadingExtension.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/MavenSettingsAutoLoadingExtension.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.maven.MavenExecutionContextView;
+import org.openrewrite.maven.MavenSettings;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.tree.MavenRepository.MAVEN_LOCAL_DEFAULT;
+
+/**
+ * Loads {@code ~/.m2/settings.xml} (and {@code $M2_HOME/conf/settings.xml}) into the
+ * default {@link ExecutionContext} for every {@link RewriteTest} in this module, so a
+ * configured Maven mirror or repository is honored by recipes that resolve artifacts.
+ * Auto-registered via {@code META-INF/services/org.junit.jupiter.api.extension.Extension};
+ * Gradle does not normally read the user's Maven settings, so this is opt-in at the
+ * module test classpath level.
+ */
+public class MavenSettingsAutoLoadingExtension implements BeforeAllCallback {
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        RewriteTest.defaultExecutionContextCustomizers.putIfAbsent(
+                MavenSettingsAutoLoadingExtension.class,
+                MavenSettingsAutoLoadingExtension::loadMavenSettings);
+    }
+
+    private static void loadMavenSettings(ExecutionContext ctx) {
+        MavenExecutionContextView mctx = MavenExecutionContextView.view(ctx);
+        boolean nothingConfigured = mctx.getSettings() == null &&
+                                    mctx.getLocalRepository().equals(MAVEN_LOCAL_DEFAULT) &&
+                                    mctx.getRepositories().isEmpty() &&
+                                    mctx.getActiveProfiles().isEmpty() &&
+                                    mctx.getMirrors().isEmpty();
+        if (nothingConfigured) {
+            mctx.setMavenSettings(MavenSettings.readMavenSettingsFromDisk(mctx));
+        }
+    }
+}

--- a/rewrite-gradle/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/rewrite-gradle/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.openrewrite.gradle.MavenSettingsAutoLoadingExtension

--- a/rewrite-gradle/src/test/resources/junit-platform.properties
+++ b/rewrite-gradle/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled=true

--- a/rewrite-gradle/src/test/resources/junit-platform.properties
+++ b/rewrite-gradle/src/test/resources/junit-platform.properties
@@ -1,1 +1,17 @@
+#
+# Copyright 2026 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 junit.jupiter.extensions.autodetection.enabled=true

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -51,6 +52,18 @@ import static org.openrewrite.internal.StringUtils.trimIndentPreserveCRLF;
 
 @SuppressWarnings("unused")
 public interface RewriteTest extends SourceSpecs {
+    /**
+     * Registry of customizers applied to the {@link ExecutionContext} produced by
+     * {@link #defaultExecutionContext(SourceSpec[])}. Test framework integrations
+     * (e.g. a JUnit Jupiter {@code BeforeAllCallback}) can register a customizer
+     * once at startup without {@code rewrite-test} taking a dependency on the
+     * framework.
+     * <p>
+     * The map is keyed by the integration's class so {@code putIfAbsent(MyExt.class, MyExt::load)}
+     * is naturally idempotent — callers do not need their own one-shot guard.
+     */
+    Map<Class<?>, Consumer<ExecutionContext>> defaultExecutionContextCustomizers = new ConcurrentHashMap<>();
+
     static AdHocRecipe toRecipe(Supplier<TreeVisitor<?, ExecutionContext>> visitor) {
         return new AdHocRecipe(null, null, null, visitor, null, null);
     }
@@ -696,6 +709,9 @@ public interface RewriteTest extends SourceSpecs {
             }
             fail("Failed to parse sources or run recipe", t);
         });
+        for (Consumer<ExecutionContext> customizer : defaultExecutionContextCustomizers.values()) {
+            customizer.accept(ctx);
+        }
         return ParsingExecutionContextView.view(ctx).setCharset(StandardCharsets.UTF_8);
     }
 


### PR DESCRIPTION
## Summary
- Adds `RewriteTest.defaultExecutionContextCustomizers` — a `Map<Class<?>, Consumer<ExecutionContext>>` applied to every default `ExecutionContext`. Test-framework integrations (JUnit, TestNG, Spock, etc.) register a customizer keyed by their own class without `rewrite-test` taking a dependency on the framework; `putIfAbsent` makes registration naturally idempotent.
- First consumer: a JUnit Jupiter `BeforeAllCallback` in `rewrite-gradle/src/test`, auto-detected via service loader, that loads `~/.m2/settings.xml` into the ExecutionContext so Gradle tests honor any configured mirror.
- CI workflow now uses the finer-grained composite actions from openrewrite/gh-automation (added in https://github.com/openrewrite/gh-automation/pull/94) so that `s4u/maven-settings-action` can be slotted between `setup` and `build` and write a `~/.m2/settings.xml` whose wildcard mirror points at Moderne's Artifactory cache.

## Why
Recent `rewrite-gradle:test` failures on `main` were `MavenPomDownloader` requests being throttled by Maven Central / Cloudflare with HTTP 404 + `Retry-After` under parallel test load. Routing artifact resolution through a configured mirror via `~/.m2/settings.xml` bypasses the rate limit.

Gradle does not normally read the user's Maven settings, so the loader is opt-in at the `rewrite-gradle` test classpath only — nothing changes for downstream consumers of `org.openrewrite.gradle.Assertions`.

## Test plan
- [x] `./gradlew :rewrite-gradle:test --tests org.openrewrite.gradle.AddPlatformDependencyTest` — 20/20 green locally with `~/.m2/settings.xml` configured (was 8/20 failing without).
- [ ] CI on this PR: confirm the broader `rewrite-gradle:test` and `rewrite-java-test:test` failures clear with the workflow change.
- [ ] Sanity-check that no existing test relies on `defaultExecutionContext` being free of customizations (registry is empty until a framework integration opts in).
