### PR TITLE
Go: Fix comments within method invocation

### DIFF
--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -1758,7 +1758,7 @@ func (ctx *parseContext) mapCallExpr(expr *ast.CallExpr) tree.Expression {
 
 	switch f := fun.(type) {
 	case *tree.FieldAccess:
-		selRP := tree.RightPadded[tree.Expression]{Element: f.Target}
+		selRP := tree.RightPadded[tree.Expression]{Element: f.Target, After: f.Name.Before}
 		sel = &selRP
 		name = f.Name.Element
 	case *tree.Identifier:

--- a/rewrite-go/pkg/printer/go_printer.go
+++ b/rewrite-go/pkg/printer/go_printer.go
@@ -279,6 +279,7 @@ func (p *GoPrinter) VisitMethodInvocation(mi *tree.MethodInvocation, param any) 
 	if mi.Select != nil {
 		p.Visit(mi.Select.Element, out)
 		if mi.Name.Name != "" {
+			p.visitSpace(mi.Select.After, out)
 			out.Append(".")
 		}
 	}

--- a/rewrite-go/test/comment_test.go
+++ b/rewrite-go/test/comment_test.go
@@ -113,6 +113,19 @@ func TestParseCommentInsideEmptyDelimiters(t *testing.T) {
 		`))
 }
 
+func TestParseBlockCommentBeforeSelector(t *testing.T) {
+	NewRecipeSpec().RewriteRun(t,
+		Golang(`
+			package main
+
+			import "unsafe"
+
+			func f(x int) {
+				unsafe /* a comment */ .Alignof(x)
+			}
+		`))
+}
+
 func TestParseMultilineBlockComment(t *testing.T) {
 	NewRecipeSpec().RewriteRun(t,
 		Golang(`


### PR DESCRIPTION
## What's changed?

Fix parsing of Go code with comments in the middle of the method invocation, e.g.
```
unsafe /* a comment */ .Alignof(x)
```

## What's your motivation?

This suffers from idempotency issues.