### PR TITLE
Remove rpc binary

### DIFF
--- a/rewrite-go/.gitignore
+++ b/rewrite-go/.gitignore
@@ -1,1 +1,2 @@
 test-classpath.txt
+/rpc


### PR DESCRIPTION
## What's changed?

Removing `rewrite-go/rpc` binary. And gitignoring it.

## What's your motivation?

This must've been accidentally added in #7557.
We don't need the binary in the repo.
