### PR TITLE
AddToTagVisitor: skip insert when a semantically-equal child already exists

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/AddToTagVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/AddToTagVisitor.java
@@ -33,19 +33,37 @@ public class AddToTagVisitor<P> extends XmlVisitor<P> {
     @Nullable
     private final Comparator<Content> tagComparator;
 
+    private final boolean allowDuplicates;
+
     public AddToTagVisitor(Xml.Tag scope, Xml.Tag tagToAdd) {
-        this(scope, tagToAdd, null);
+        this(scope, tagToAdd, null, false);
+    }
+
+    public AddToTagVisitor(Xml.Tag scope, Xml.Tag tagToAdd, boolean allowDuplicates) {
+        this(scope, tagToAdd, null, allowDuplicates);
     }
 
     public AddToTagVisitor(Xml.Tag scope, Xml.Tag tagToAdd, @Nullable Comparator<Content> tagComparator) {
+        this(scope, tagToAdd, tagComparator, false);
+    }
+
+    public AddToTagVisitor(Xml.Tag scope, Xml.Tag tagToAdd, @Nullable Comparator<Content> tagComparator, boolean allowDuplicates) {
         this.scope = scope;
         this.tagToAdd = tagToAdd;
         this.tagComparator = tagComparator;
+        this.allowDuplicates = allowDuplicates;
     }
 
     @Override
     public Xml visitTag(Xml.Tag t, P p) {
         if (scope.isScope(t)) {
+            if (!allowDuplicates && t.getContent() != null) {
+                for (Content existing : t.getContent()) {
+                    if (existing instanceof Xml.Tag && SemanticallyEqual.areEqual(existing, tagToAdd)) {
+                        return super.visitTag(t, p);
+                    }
+                }
+            }
             assert getCursor().getParent() != null;
             if (t.getClosing() == null) {
                 t = t.withClosing(autoFormat(new Xml.Tag.Closing(Tree.randomId(), "\n",

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/AddToTagTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/AddToTagTest.java
@@ -143,6 +143,102 @@ class AddToTagTest implements RewriteTest {
         );
     }
 
+    @Test
+    void doesNotAddSemanticallyEqualDuplicate() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new XmlVisitor<>() {
+              @Override
+              public Xml visitDocument(Xml.Document x, ExecutionContext ctx) {
+                  doAfterVisit(new AddToTagVisitor<>(x.getRoot(), Xml.Tag.build("<bean id=\"myBean\"/>")));
+                  return super.visitDocument(x, ctx);
+              }
+          })),
+          xml(
+            """
+              <beans>
+                <bean id="myBean"/>
+              </beans>
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotAddDuplicateIgnoringAttributeOrder() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new XmlVisitor<>() {
+              @Override
+              public Xml visitDocument(Xml.Document x, ExecutionContext ctx) {
+                  doAfterVisit(new AddToTagVisitor<>(x.getRoot(),
+                          Xml.Tag.build("<bean class=\"C\" id=\"myBean\"/>")));
+                  return super.visitDocument(x, ctx);
+              }
+          })),
+          xml(
+            """
+              <beans>
+                <bean id="myBean" class="C"/>
+              </beans>
+              """
+          )
+        );
+    }
+
+    @Test
+    void addsSemanticallyEqualDuplicateWhenAllowDuplicatesTrue() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new XmlVisitor<>() {
+              @Override
+              public Xml visitDocument(Xml.Document x, ExecutionContext ctx) {
+                  if (x.getRoot().getChildren().size() == 1) {
+                      doAfterVisit(new AddToTagVisitor<>(x.getRoot(),
+                              Xml.Tag.build("<bean id=\"myBean\"/>"), true));
+                  }
+                  return super.visitDocument(x, ctx);
+              }
+          })),
+          xml(
+            """
+              <beans>
+                <bean id="myBean"/>
+              </beans>
+              """,
+            """
+              <beans>
+                <bean id="myBean"/>
+                <bean id="myBean"/>
+              </beans>
+              """
+          )
+        );
+    }
+
+    @Test
+    void addsWhenChildrenShareNameButDifferentAttributes() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new XmlVisitor<>() {
+              @Override
+              public Xml visitDocument(Xml.Document x, ExecutionContext ctx) {
+                  doAfterVisit(new AddToTagVisitor<>(x.getRoot(), Xml.Tag.build("<bean id=\"myBean2\"/>")));
+                  return super.visitDocument(x, ctx);
+              }
+          })),
+          xml(
+            """
+              <beans>
+                <bean id="myBean"/>
+              </beans>
+              """,
+            """
+              <beans>
+                <bean id="myBean"/>
+                <bean id="myBean2"/>
+              </beans>
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/1392")
     @Test
     void preserveNonTagContent() {


### PR DESCRIPTION
## Summary

Make `AddToTagVisitor` idempotent by default: if the target `scope` already contains a child for which `SemanticallyEqual.areEqual(existingChild, tagToAdd)` holds, return without mutating the tree. `SemanticallyEqual` ignores comments and attribute order, so this catches semantic duplicates that only differ in whitespace, attribute ordering, or interleaved comments.

An `allowDuplicates` opt-out flag is provided for the rare caller that wants the prior unconditional-append behavior. Two new constructor overloads accept the flag without forcing callers to pass `null` for `tagComparator` just to opt out:
- `(Xml.Tag, Xml.Tag, boolean)`
- `(Xml.Tag, Xml.Tag, @Nullable Comparator<Content>, boolean)`

## Why default-on

I audited every in-tree call site of `AddToTagVisitor` (~22, across `rewrite-maven`, `rewrite-csharp`, and the static `addToTag(...)` helpers used by `rewrite-xml`'s `AddOrUpdateChild` and `rewrite-maven`'s `AddPluginDependency`). None want duplicate sibling tags:

- **rewrite-maven**: Maven POM schema forbids duplicate `<dependency>`, `<plugin>`, `<property>`, etc.
- **rewrite-csharp** (`AddNuGetPackageReferenceVisitor`): csproj schema forbids duplicate `<PackageReference>`.
- **rewrite-xml/`AddOrUpdateChild`**: already gates externally by checking for an existing child before delegating to `addToTag`, so the new check is redundant rather than behavior-changing for it.

Centralizing the check here removes existing per-site duplicate prevention and prevents the semantically-equal-but-different-identity output that has tripped up downstream tree-identity checks.

## Why default-on with an opt-out

Raw XML technically allows duplicate sibling tags. Although no in-tree caller wants them, an unknown third-party consumer of `rewrite-xml` could in principle. `allowDuplicates=true` keeps that path available without forcing every in-tree consumer to flip a flag.

## Behavior change

Default-off-then-on. Anyone passing a `tagToAdd` that is `SemanticallyEqual` to a child already present in `scope` will now see a no-op instead of a duplicate insert. A literal "I want a duplicate" use case isn't expected for in-tree callers (XML duplicates of `<dependency>`/`<plugin>`/`<property>` etc. are usually bugs); flagging here so reviewers can call out anything that needs adjustment.

## Test plan

- [x] New `doesNotAddSemanticallyEqualDuplicate` test exercises the basic skip path
- [x] New `doesNotAddDuplicateIgnoringAttributeOrder` test exercises attribute-order tolerance
- [x] New `addsWhenChildrenShareNameButDifferentAttributes` test confirms additions still happen when children only share a tag name
- [x] Existing `AddToTagTest` cases still pass
- [x] Targeted maven recipe tests using `AddToTagVisitor` (Add{Dependency,Property,Repository,ManagedDependency,Profile,Plugin}, ExcludeDependency) all pass