### PR TITLE
Wrap recipe errors with RecipeError to attribute failures to a nested recipe

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/RecipeError.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeError.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import lombok.Getter;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Wraps an exception thrown by a recipe so that {@link ExecutionContext#getOnError()}
+ * consumers can attribute the failure to the specific nested recipe and source file
+ * that produced it. This is especially useful for large declarative recipes (e.g.
+ * thousands of nested recipes) where the underlying stack trace alone does not
+ * reveal which recipe ran into trouble.
+ */
+@Getter
+public class RecipeError extends RuntimeException {
+
+    /**
+     * The names of the recipes from root to leaf at the time of failure.
+     * The last element is the recipe that directly threw.
+     */
+    private final List<String> recipeStack;
+
+    /**
+     * The path of the source file being processed when the error occurred,
+     * or {@code null} when the error was raised outside of a per-source context
+     * (for example, during scanning recipe generation).
+     */
+    private final @Nullable String sourcePath;
+
+    public RecipeError(List<String> recipeStack, @Nullable String sourcePath, Throwable cause) {
+        super(cause);
+        this.recipeStack = Collections.unmodifiableList(recipeStack);
+        this.sourcePath = sourcePath;
+    }
+
+    /**
+     * @return the leaf recipe name (the recipe that directly threw), or
+     * {@code "unknown"} if the recipe stack is empty.
+     */
+    public String getRecipeName() {
+        return recipeStack.isEmpty() ? "unknown" : recipeStack.get(recipeStack.size() - 1);
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -151,7 +151,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                                 return source;
                             });
                         } catch (Throwable t) {
-                            after = handleError(recipe, source, after, t);
+                            after = handleError(recipeStack, source, after, t);
                             // We don't normally consider anything the scanning phase does to be a change
                             // But this simplifies error reporting so that exceptions can all be handled the same
                             assert after != null;
@@ -183,7 +183,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
             batch.rpc.batchVisit(source, ctx, rootCursor, batch.items);
         } catch (Throwable t) {
             if (!batch.recipeStacks.isEmpty()) {
-                handleError(batch.recipeStacks.get(0).peek(), source, source, t);
+                handleError(batch.recipeStacks.get(0), source, source, t);
             }
         }
 
@@ -211,7 +211,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                                     return source;
                                 });
                             } catch (Throwable t) {
-                                handleError(recipe, source, source, t);
+                                handleError(recipeStack, source, source, t);
                             }
                         }
                     }
@@ -243,7 +243,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                             madeChangesInThisCycle.add(recipe);
                         }
                     } catch (Throwable t) {
-                        handleError(recipe, new Quark(Tree.randomId(), Paths.get("error during generation"), Markers.EMPTY, null, null), null, t);
+                        handleError(recipeStack, new Quark(Tree.randomId(), Paths.get("error during generation"), Markers.EMPTY, null, null), null, t);
                     }
                 }
                 return acc;
@@ -316,7 +316,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                 if (duration.compareTo(ctx.getMessage(ExecutionContext.RUN_TIMEOUT, Duration.ofMinutes(4))) > 0) {
                     if (thrownErrorOnTimeout.compareAndSet(false, true)) {
                         RecipeTimeoutException t = new RecipeTimeoutException(recipe);
-                        ctx.getOnError().accept(t);
+                        ctx.getOnError().accept(wrapForAttribution(recipeStack, src.getSourcePath().toString(), t));
                         ctx.getOnTimeout().accept(t, ctx);
                     }
                     return src;
@@ -382,7 +382,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                 if (isInBatch) {
                     batch.clear();
                 }
-                after = handleError(recipe, src, after, t);
+                after = handleError(recipeStack, src, after, t);
             }
             if (after != null && after != src) {
                 after = addRecipesThatMadeChanges(recipeStack, after);
@@ -417,7 +417,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                 if (!(t instanceof RecipeRunException)) {
                     source = Markup.error(source, t);
                 }
-                source = handleError(batch.recipeStacks.get(0).peek(), originalBefore, source, t);
+                source = handleError(batch.recipeStacks.get(0), originalBefore, source, t);
                 if (source != null && source != beforeError) {
                     source = addRecipesThatMadeChanges(batch.recipeStacks.get(0), source);
                 }
@@ -720,9 +720,9 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         recordSourceFileResult(beforePath, afterPath, recipeStack.subList(0, recipeStack.size() - 1), ctx);
     }
 
-    private @Nullable SourceFile handleError(Recipe recipe, SourceFile sourceFile, @Nullable SourceFile after,
+    private @Nullable SourceFile handleError(List<Recipe> recipeStack, SourceFile sourceFile, @Nullable SourceFile after,
                                              Throwable t) {
-        ctx.getOnError().accept(t);
+        ctx.getOnError().accept(wrapForAttribution(recipeStack, sourceFile.getSourcePath().toString(), t));
 
         if (t instanceof RecipeRunException && after != null) {
             try {
@@ -738,11 +738,19 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         // This is so the error is associated with the original source file, and its original source path.
         errorsTable.insertRow(ctx, new SourcesFileErrors.Row(
                 sourceFile.getSourcePath().toString(),
-                recipe.getName(),
+                recipeStack.get(recipeStack.size() - 1).getName(),
                 ExceptionUtils.sanitizeStackTrace(t, RecipeScheduler.class)
         ));
 
         return after;
+    }
+
+    private static RecipeError wrapForAttribution(List<Recipe> recipeStack, @Nullable String sourcePath, Throwable t) {
+        List<String> recipePath = new ArrayList<>(recipeStack.size());
+        for (Recipe r : recipeStack) {
+            recipePath.add(r.getName());
+        }
+        return new RecipeError(recipePath, sourcePath, t);
     }
 
     private static <S extends SourceFile> S addRecipesThatMadeChanges(List<Recipe> recipeStack, S afterFile) {

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -50,6 +50,7 @@ import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
 
 import static java.util.Collections.*;
+import static java.util.stream.Collectors.toList;
 import static org.openrewrite.ExecutionContext.SCANNING_MUTATION_VALIDATION;
 import static org.openrewrite.Recipe.PANIC;
 
@@ -746,11 +747,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
     }
 
     private static RecipeError wrapForAttribution(List<Recipe> recipeStack, @Nullable String sourcePath, Throwable t) {
-        List<String> recipePath = new ArrayList<>(recipeStack.size());
-        for (Recipe r : recipeStack) {
-            recipePath.add(r.getName());
-        }
-        return new RecipeError(recipePath, sourcePath, t);
+        return new RecipeError(recipeStack.stream().map(Recipe::getName).collect(toList()), sourcePath, t);
     }
 
     private static <S extends SourceFile> S addRecipesThatMadeChanges(List<Recipe> recipeStack, S afterFile) {

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeSchedulerTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeSchedulerTest.java
@@ -84,6 +84,79 @@ class RecipeSchedulerTest implements RewriteTest {
     }
 
     @Test
+    void onErrorReceivesRecipeErrorWithLeafRecipeAndSourcePath() {
+        List<RecipeError> captured = new java.util.ArrayList<>();
+        InMemoryExecutionContext ctx = new InMemoryExecutionContext(t -> {
+            if (t instanceof RecipeError) {
+                captured.add((RecipeError) t);
+            }
+        });
+        rewriteRun(
+          spec -> spec.executionContext(ctx).recipe(new BoomRecipe()),
+          text("hello", "~~(boom)~~>hello")
+        );
+        assertThat(captured).isNotEmpty().allSatisfy(err -> {
+            assertThat(err.getRecipeStack()).containsExactly("org.openrewrite.BoomRecipe");
+            assertThat(err.getSourcePath()).isEqualTo("file.txt");
+            // Cause is RecipeRunException (the visitor's throw site wrapper) which in turn wraps BoomException.
+            assertThat(err.getCause()).isInstanceOf(RecipeRunException.class);
+            assertThat(err.getCause().getCause()).isInstanceOf(BoomException.class);
+        });
+    }
+
+    @Test
+    void onErrorReceivesRecipeErrorWithFullStackForNestedRecipe() {
+        List<RecipeError> captured = new java.util.ArrayList<>();
+        InMemoryExecutionContext ctx = new InMemoryExecutionContext(t -> {
+            if (t instanceof RecipeError) {
+                captured.add((RecipeError) t);
+            }
+        });
+        var parent = new DeclarativeRecipe(
+          "io.example.parent",
+          "Parent recipe",
+          "Parent recipe wrapping a boom child.",
+          emptySet(),
+          null,
+          URI.create("dummy:recipe.yml"),
+          false,
+          emptyList()
+        );
+        parent.addUninitialized(new BoomRecipe());
+        parent.initialize(emptyList());
+        rewriteRun(
+          spec -> spec.executionContext(ctx).recipe(parent),
+          text("hello", "~~(boom)~~>hello")
+        );
+        assertThat(captured).isNotEmpty().allSatisfy(err -> {
+            assertThat(err.getRecipeStack())
+              .containsExactly("io.example.parent", "org.openrewrite.BoomRecipe");
+            assertThat(err.getRecipeName()).isEqualTo("org.openrewrite.BoomRecipe");
+            assertThat(err.getSourcePath()).isEqualTo("file.txt");
+        });
+    }
+
+    @Test
+    void onErrorWrapsErrorsThrownDuringGenerate() {
+        List<RecipeError> captured = new java.util.ArrayList<>();
+        InMemoryExecutionContext ctx = new InMemoryExecutionContext(t -> {
+            if (t instanceof RecipeError) {
+                captured.add((RecipeError) t);
+            }
+        });
+        rewriteRun(
+          spec -> spec.executionContext(ctx).recipe(new BoomGenerateRecipe(false))
+        );
+        assertThat(captured)
+          .singleElement()
+          .satisfies(err -> {
+              assertThat(err.getRecipeStack()).containsExactly("org.openrewrite.BoomGenerateRecipe");
+              assertThat(err.getSourcePath()).isEqualTo("error during generation");
+              assertThat(err.getCause()).isInstanceOf(BoomException.class);
+          });
+    }
+
+    @Test
     void exceptionDuringGenerate() {
         rewriteRun(
           spec -> spec.recipe(new BoomGenerateRecipe(false))

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -704,8 +704,9 @@ public interface RewriteTest extends SourceSpecs {
 
     default ExecutionContext defaultExecutionContext(SourceSpec<?>[] sourceSpecs) {
         InMemoryExecutionContext ctx = new InMemoryExecutionContext(t -> {
-            if (t instanceof RecipeRunException) {
-                fail("Failed to run recipe at " + ((RecipeRunException) t).getCursor(), t);
+            Throwable underlying = t instanceof RecipeError ? t.getCause() : t;
+            if (underlying instanceof RecipeRunException) {
+                fail("Failed to run recipe at " + ((RecipeRunException) underlying).getCursor(), t);
             }
             fail("Failed to parse sources or run recipe", t);
         });

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -706,9 +706,9 @@ public interface RewriteTest extends SourceSpecs {
         InMemoryExecutionContext ctx = new InMemoryExecutionContext(t -> {
             Throwable underlying = t instanceof RecipeError ? t.getCause() : t;
             if (underlying instanceof RecipeRunException) {
-                fail("Failed to run recipe at " + ((RecipeRunException) underlying).getCursor(), t);
+                fail("Failed to run recipe at " + ((RecipeRunException) underlying).getCursor(), underlying);
             }
-            fail("Failed to parse sources or run recipe", t);
+            fail("Failed to parse sources or run recipe", underlying);
         });
         for (Consumer<ExecutionContext> customizer : defaultExecutionContextCustomizers.values()) {
             customizer.accept(ctx);


### PR DESCRIPTION
## Summary

The `Consumer<Throwable>` returned by `ExecutionContext#getOnError()` previously received the raw throwable from a failing recipe, leaving downstream tooling no way to tell which nested recipe — in a large declarative recipe with hundreds or thousands of children — actually produced the failure. The stack trace alone does not name the responsible recipe.

This PR introduces `RecipeError`, a `RuntimeException` that carries:

- `List<String> recipeStack` — names from root to leaf at the time of failure
- `String sourcePath` — the source file being processed (or `"error during generation"` for the scanning-generate path)

Wrapping happens at the single chokepoint `RecipeRunCycle.handleError` and at the per-cycle timeout site, immediately before invoking `ctx.getOnError().accept(...)`. All six existing `handleError` callsites pass the recipe stack already in scope (either the lambda parameter from `RecipeStack#reduce` or the per-batch stack list from RPC batching), so no new bookkeeping is needed.

The `SourcesFileErrors` data table continues to receive the original sanitized stack trace via `ExceptionUtils.sanitizeStackTrace`, so attribution there is unchanged.

`RewriteTest`'s default error consumer is updated to unwrap a `RecipeError` before its `instanceof RecipeRunException` check, so existing assertions keep working.

## Test plan

- [x] `rewrite-core` full test suite passes
- [x] Three new tests in `RecipeSchedulerTest` cover: leaf attribution, full nested-stack attribution through a `DeclarativeRecipe` parent, and generate-time error wrapping
- [x] `rewrite-test`, `rewrite-yaml`, `rewrite-properties`, `rewrite-json`, `rewrite-hcl` all compile/test cleanly

## Notes

- Marking as draft pending review of the chosen attribution strategy and sizing of the `RewriteTest` ergonomics change.
- A follow-up issue is planned for batched-RPC error attribution: `RecipeRunCycle#flushBatch` currently attributes a batch failure to the first recipe in the batch regardless of which visitor failed remotely. Properly fixing that requires a new `failedIndex` field on the RPC error response and updates across the Java/.NET/Node RPC implementations — out of scope here.