### PR TITLE
JS: fix npmPublish skip detection that always reported "already published"

### DIFF
--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -264,7 +264,7 @@ val npmPublish = tasks.register<NpmTask>("npmPublish") {
             .redirectErrorStream(true)
             .start()
         val output = process.inputStream.bufferedReader().readText().trim()
-        val alreadyPublished = process.waitFor() == 0 && output.lines().any { it.trim() == versionToCheck }
+        val alreadyPublished = process.waitFor() == 0 && output.contains(versionToCheck)
         if (alreadyPublished) {
             logger.lifecycle("Skipping npmPublish: @openrewrite/rewrite@$versionToCheck already published")
         }

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -263,9 +263,8 @@ val npmPublish = tasks.register<NpmTask>("npmPublish") {
             .directory(file("rewrite"))
             .redirectErrorStream(true)
             .start()
-        process.waitFor()
         val output = process.inputStream.bufferedReader().readText().trim()
-        val alreadyPublished = output.contains(versionToCheck)
+        val alreadyPublished = process.waitFor() == 0 && output.lines().any { it.trim() == versionToCheck }
         if (alreadyPublished) {
             logger.lifecycle("Skipping npmPublish: @openrewrite/rewrite@$versionToCheck already published")
         }


### PR DESCRIPTION
## Summary

- PR #7552 added an `onlyIf` block on `npmPublish` that runs `npm view @openrewrite/rewrite@<version> version` and skips publishing when the captured output contains the version string. With `redirectErrorStream(true)`, npm's 404 error message also contains the requested version:

```
npm error 404 No match found for version 8.82.0-20260505-090457
npm error 404
npm error 404  The requested resource '@openrewrite/rewrite@8.82.0-20260505-090457' could not be found …
```

So `output.contains(versionToCheck)` matches on every miss, and the daily snapshot publish has been silently skipped since 2026-05-02. Maven snapshots keep ticking forward with each new commit timestamp (currently at `8.82.0-20260505-090457`), but the npm prerelease tag is still frozen at `8.82.0-20260502-150813`.

## Downstream impact

Consumers spawn the JS RPC subprocess via:

```
npx --package=@openrewrite/rewrite@<version-from-jar> rewrite-rpc …
```

where `<version-from-jar>` is read from `META-INF/rewrite-javascript-version.txt`. Once the npm/Maven versions diverge, that command fails with `ETARGET` and the subprocess exits 1, surfacing in downstream tests as `RPC process shut down early with exit code 1` or `Expected Content-Length header but received ''`.

This is breaking the rewrite-static-analysis scheduled CI on every full test run since 2026-05-04 (e.g. [run 25335376932](https://github.com/openrewrite/rewrite-static-analysis/actions/runs/25335376932)). Tests `AnnotateNullableMethodsTest.typescriptCode` and `RemoveUnusedLocalVariablesTest$Typescript.noChange` reproduce the failure locally on macOS once the local `npm link` is removed.

## Fix

Switch the skip check to use `npm view`'s exit code (and verify the version appears on its own line in stdout) so we only skip publishing when the version is genuinely already published. Drafting for review and to validate against the next scheduled CI run.

## Test plan

- [ ] Manual: run `npm view @openrewrite/rewrite@<existing> version` and `<nonexistent>` and confirm the new logic agrees with reality
- [ ] Confirm next scheduled CI publishes a new prerelease that matches the Maven snapshot's version stamp
- [ ] Confirm rewrite-static-analysis scheduled CI returns to green