### PR TITLE
Store exceptions for negative lookup results in Maven Pom Downloader

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -72,6 +72,8 @@ public class MavenPomDownloader {
     private static final String RELEASE = "RELEASE";
     private static final List<String> NAMED_VERSIONS = Arrays.asList(LATEST, RELEASE);
 
+    private static final String NEGATIVE_RESULT_MESSAGES = "org.openrewrite.maven.internal.MavenPomDownloader.negativeResultMessages";
+
 
     private final MavenPomCache mavenCache;
     private final Map<Path, Pom> projectPoms;
@@ -170,6 +172,15 @@ public class MavenPomDownloader {
         } finally {
             this.ctx.recordResolutionTime(Duration.ofNanos(System.nanoTime() - start));
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> negativeResultMessages() {
+        return (Map<String, String>) ctx.getMessages().computeIfAbsent(NEGATIVE_RESULT_MESSAGES, k -> new HashMap<String, String>());
+    }
+
+    private static String negativeResultKey(MavenRepository repo, GroupArtifactVersion gav) {
+        return repo.getUri() + '|' + gav.getGroupId() + ':' + gav.getArtifactId() + ':' + gav.getVersion();
     }
 
     private Map<GroupArtifactVersion, Pom> projectPomsByGav(Map<Path, Pom> projectPoms) {
@@ -326,9 +337,15 @@ public class MavenPomDownloader {
                     // If there was no fatal failure while attempting to find metadata and there was no metadata retrieved
                     // from the current repo, cache an empty result.
                     mavenCache.putMavenMetadata(URI.create(repo.getUri()), gav, null);
+                    String originalResponse = repositoryResponses.get(repo);
+                    if (originalResponse != null) {
+                        negativeResultMessages().put(negativeResultKey(repo, gav), originalResponse);
+                    }
                 }
             } else if (!result.isPresent()) {
-                repositoryResponses.put(repo, "Did not attempt to download because of a previous failure to retrieve from this repository.");
+                String originalResponse = negativeResultMessages().get(negativeResultKey(repo, gav));
+                repositoryResponses.put(repo, originalResponse != null ? originalResponse :
+                        "Did not attempt to download because of a previous failure to retrieve from this repository.");
             }
 
             // Merge metadata from repository and cache metadata result.
@@ -718,6 +735,7 @@ public class MavenPomDownloader {
                         if (e.isClientSideException()) {
                             //If the exception is a common, client-side exception, cache an empty result.
                             mavenCache.putPom(resolvedGav, null);
+                            negativeResultMessages().put(negativeResultKey(repo, gav), e.getMessage());
                         }
                     } catch (IOException | UncheckedIOException e) {
                         repositoryResponses.put(repo, e.getMessage());
@@ -727,7 +745,9 @@ public class MavenPomDownloader {
                 sample.stop(timer.tags("outcome", "cached").register(Metrics.globalRegistry));
                 return result.get();
             } else {
-                repositoryResponses.put(repo, "Did not attempt to download because of a previous failure to retrieve from this repository.");
+                String originalResponse = negativeResultMessages().get(negativeResultKey(repo, gav));
+                repositoryResponses.put(repo, originalResponse != null ? originalResponse :
+                        "Did not attempt to download because of a previous failure to retrieve from this repository.");
             }
         }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.maven;
 
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -80,7 +79,6 @@ class AddDependencyTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
     void dontAddDuplicateIfUpdateModelOnPriorRecipeCycleFailed() {
         rewriteRun(
           spec -> spec

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.maven;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.*;
@@ -42,7 +41,6 @@ class MavenDependencyFailuresTest implements RewriteTest {
 
     @DocumentExample
     @Test
-    @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
     void unresolvableParent() { // Dad said he was heading to the corner store for cigarettes, and hasn't been resolvable for the past 20 years :'(
         rewriteRun(
           spec -> spec
@@ -81,7 +79,6 @@ class MavenDependencyFailuresTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
     void unresolvableMavenMetadata() {
         rewriteRun(
           spec -> spec

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -1761,7 +1761,6 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
     void deriveFromNexusUpgrade() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyVersion("*", "*", "latest.patch", null, null, null)),
@@ -1827,7 +1826,6 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
     void badManagedVersion() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyVersion("*", "*", "latest.patch", null, null, null)),

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradePluginVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradePluginVersionTest.java
@@ -208,7 +208,6 @@ class UpgradePluginVersionTest implements RewriteTest {
 
         @Issue("https://github.com/openrewrite/rewrite/issues/5065")
         @Test
-        @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
         void repoUnreachable() {
             rewriteRun(
               spec -> spec.recipe(new UpgradePluginVersion(
@@ -248,7 +247,6 @@ class UpgradePluginVersionTest implements RewriteTest {
 
         @Issue("https://github.com/openrewrite/rewrite/issues/5065")
         @Test
-        @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
         void noNewerVersion() {
             rewriteRun(
               spec -> spec.recipe(new UpgradePluginVersion(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -800,6 +800,74 @@ class MavenPomDownloaderTest implements RewriteTest {
             }
         }
 
+        @Test
+        void replayOriginalMetadataFailureOnSubsequentCall() throws Exception {
+            try (var server = new MockWebServer()) {
+                server.setDispatcher(new Dispatcher() {
+                    @Override
+                    public MockResponse dispatch(RecordedRequest request) {
+                        return new MockResponse().setResponseCode(404).setBody("not found");
+                    }
+                });
+                server.start();
+
+                // given a repository that always 404s for metadata, and a downloader that shares an ExecutionContext
+                MavenRepository repository = MavenRepository.builder()
+                  .id("flaky")
+                  .uri("http://%s:%d/".formatted(server.getHostName(), server.getPort()))
+                  .knownToExist(true)
+                  .build();
+                var downloader = new MavenPomDownloader(emptyMap(), ctx);
+                var ga = new GroupArtifact("does.not", "exist");
+
+                // when downloadMetadata is invoked twice with the same context
+                String firstMessage = assertThrows(MavenDownloadingException.class,
+                  () -> downloader.downloadMetadata(ga, null, List.of(repository))).getMessage();
+                String secondMessage = assertThrows(MavenDownloadingException.class,
+                  () -> downloader.downloadMetadata(ga, null, List.of(repository))).getMessage();
+
+                // then the second failure replays the original 404, not a generic "did not attempt" notice
+                assertThat(firstMessage).contains("404");
+                assertThat(secondMessage)
+                  .contains("404")
+                  .doesNotContain("Did not attempt to download");
+            }
+        }
+
+        @Test
+        void replayOriginalPomFailureOnSubsequentCall() throws Exception {
+            try (var server = new MockWebServer()) {
+                server.setDispatcher(new Dispatcher() {
+                    @Override
+                    public MockResponse dispatch(RecordedRequest request) {
+                        return new MockResponse().setResponseCode(404).setBody("");
+                    }
+                });
+                server.start();
+
+                // given a repository that 404s for both POM and JAR, and a downloader that shares an ExecutionContext
+                MavenRepository repository = MavenRepository.builder()
+                  .id("flaky")
+                  .uri("http://%s:%d/".formatted(server.getHostName(), server.getPort()))
+                  .knownToExist(true)
+                  .build();
+                var downloader = new MavenPomDownloader(emptyMap(), ctx);
+                var gav = new GroupArtifactVersion("does.not", "exist", "1.0.0");
+
+                // when download is invoked twice with the same context
+                String firstMessage = assertThrows(MavenDownloadingException.class,
+                  () -> downloader.download(gav, null, null, List.of(repository))).getMessage();
+                String secondMessage = assertThrows(MavenDownloadingException.class,
+                  () -> downloader.download(gav, null, null, List.of(repository))).getMessage();
+
+                // then the second failure replays the original 404, not a generic "did not attempt" notice
+                assertThat(firstMessage).contains("404");
+                assertThat(secondMessage)
+                  .contains("404")
+                  .doesNotContain("Did not attempt to download");
+            }
+        }
+
         @SuppressWarnings("ConstantConditions")
         @Test
         void mergeMetadata() throws Exception {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
