### PR TITLE
AddRepositoryTest - skip `updateToSpringBoot30Snapshot` in CI

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddRepositoryTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddRepositoryTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.maven;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RewriteTest;
@@ -306,8 +305,7 @@ class AddRepositoryTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
-    void updateToSpringBoot30Snapshot() {
+    void updateToSpringBootSnapshot() {
         rewriteRun(
           spec -> spec.recipes(
             new AddRepository("boot-snapshots", "https://repo.spring.io/snapshot", null, null,
@@ -316,7 +314,7 @@ class AddRepositoryTest implements RewriteTest {
             new UpgradeParentVersion(
               "org.springframework.boot",
               "spring-boot-starter-parent",
-              "3.0.0-SNAPSHOT",
+              "4.0.0-SNAPSHOT",
               null,
               null)
           ),
@@ -326,7 +324,7 @@ class AddRepositoryTest implements RewriteTest {
                 <parent>
                   <groupId>org.springframework.boot</groupId>
                   <artifactId>spring-boot-starter-parent</artifactId>
-                  <version>2.7.3</version>
+                  <version>3.4.0</version>
                 </parent>
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
@@ -338,7 +336,7 @@ class AddRepositoryTest implements RewriteTest {
                 <parent>
                   <groupId>org.springframework.boot</groupId>
                   <artifactId>spring-boot-starter-parent</artifactId>
-                  <version>3.0.0-SNAPSHOT</version>
+                  <version>4.0.0-SNAPSHOT</version>
                 </parent>
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddRepositoryTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddRepositoryTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.maven;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RewriteTest;
 
@@ -305,7 +306,9 @@ class AddRepositoryTest implements RewriteTest {
     }
 
     @Test
-    void updateToSpringBootSnapshot() {
+    @DisabledIfEnvironmentVariable(named = "CI", matches = "true",
+      disabledReason = "Artifactory mirror does not proxy https://repo.spring.io/snapshot")
+    void updateToSpringBoot30Snapshot() {
         rewriteRun(
           spec -> spec.recipes(
             new AddRepository("boot-snapshots", "https://repo.spring.io/snapshot", null, null,
@@ -314,7 +317,7 @@ class AddRepositoryTest implements RewriteTest {
             new UpgradeParentVersion(
               "org.springframework.boot",
               "spring-boot-starter-parent",
-              "4.0.0-SNAPSHOT",
+              "3.0.0-SNAPSHOT",
               null,
               null)
           ),
@@ -324,7 +327,7 @@ class AddRepositoryTest implements RewriteTest {
                 <parent>
                   <groupId>org.springframework.boot</groupId>
                   <artifactId>spring-boot-starter-parent</artifactId>
-                  <version>3.4.0</version>
+                  <version>2.7.3</version>
                 </parent>
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
@@ -336,7 +339,7 @@ class AddRepositoryTest implements RewriteTest {
                 <parent>
                   <groupId>org.springframework.boot</groupId>
                   <artifactId>spring-boot-starter-parent</artifactId>
-                  <version>4.0.0-SNAPSHOT</version>
+                  <version>3.0.0-SNAPSHOT</version>
                 </parent>
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>


### PR DESCRIPTION
## What's changed?

Disabling one of the test cases in CI. This one uses a snapshot Maven repository for Spring, which we the Moderne Artifactory is not configured to serve. And since #7559 we run the tests in CI with Artifactory.

## What's your motivation?

Keep the test, but prevent it from failing in CI. I think it's a fair compromise.
