### PR TITLE
Re-enable some Gradle tests after fixing gradle-plugins in Artifactory

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePluginTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.gradle.plugins;
 
 import org.intellij.lang.annotations.Language;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.groovy.tree.G;
@@ -186,7 +185,6 @@ class AddDevelocityGradlePluginTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite/issues/2697")
     @Test
-    @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
     void withGradleEnterpriseConfigurationInSettings() {
         rewriteRun(
           spec -> spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")))
@@ -195,8 +193,20 @@ class AddDevelocityGradlePluginTest implements RewriteTest {
             ""
           ),
           settingsGradle(
-            "",
+            """
+              pluginManagement {
+                  repositories {
+                      gradlePluginPortal()
+                  }
+              }
+              """,
             interpolateResolvedVersion("""
+              pluginManagement {
+                  repositories {
+                      gradlePluginPortal()
+                  }
+              }
+
               plugins {
                   id 'com.gradle.enterprise' version '%s'
               }
@@ -382,7 +392,6 @@ class AddDevelocityGradlePluginTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite/issues/2697")
     @Test
-    @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
     void withGradleEnterpriseConfigurationInSettingsKts() {
         rewriteRun(
           spec -> spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")))
@@ -391,8 +400,20 @@ class AddDevelocityGradlePluginTest implements RewriteTest {
             ""
           ),
           settingsGradleKts(
-            "",
+            """
+              pluginManagement {
+                  repositories {
+                      gradlePluginPortal()
+                  }
+              }
+              """,
             interpolateResolvedVersionKts("""
+              pluginManagement {
+                  repositories {
+                      gradlePluginPortal()
+                  }
+              }
+
               plugins {
                   id("com.gradle.enterprise") version "%s"
               }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePluginTest.java
@@ -193,20 +193,8 @@ class AddDevelocityGradlePluginTest implements RewriteTest {
             ""
           ),
           settingsGradle(
-            """
-              pluginManagement {
-                  repositories {
-                      gradlePluginPortal()
-                  }
-              }
-              """,
+            "",
             interpolateResolvedVersion("""
-              pluginManagement {
-                  repositories {
-                      gradlePluginPortal()
-                  }
-              }
-
               plugins {
                   id 'com.gradle.enterprise' version '%s'
               }
@@ -400,20 +388,8 @@ class AddDevelocityGradlePluginTest implements RewriteTest {
             ""
           ),
           settingsGradleKts(
-            """
-              pluginManagement {
-                  repositories {
-                      gradlePluginPortal()
-                  }
-              }
-              """,
+            "",
             interpolateResolvedVersionKts("""
-              pluginManagement {
-                  repositories {
-                      gradlePluginPortal()
-                  }
-              }
-
               plugins {
                   id("com.gradle.enterprise") version "%s"
               }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.gradle.plugins;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -115,14 +114,25 @@ class AddSettingsPluginTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
     void addPluginApplyFalse() {
         rewriteRun(
           spec -> spec.beforeRecipe(withToolingApi())
             .recipe(new AddSettingsPlugin("com.gradle.enterprise", "3.11.x", null, false, null)),
           settingsGradle(
-            "",
             """
+              pluginManagement {
+                  repositories {
+                      gradlePluginPortal()
+                  }
+              }
+              """,
+            """
+              pluginManagement {
+                  repositories {
+                      gradlePluginPortal()
+                  }
+              }
+
               plugins {
                   id 'com.gradle.enterprise' version '3.11.4' apply false
               }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginTest.java
@@ -119,20 +119,8 @@ class AddSettingsPluginTest implements RewriteTest {
           spec -> spec.beforeRecipe(withToolingApi())
             .recipe(new AddSettingsPlugin("com.gradle.enterprise", "3.11.x", null, false, null)),
           settingsGradle(
+            "",
             """
-              pluginManagement {
-                  repositories {
-                      gradlePluginPortal()
-                  }
-              }
-              """,
-            """
-              pluginManagement {
-                  repositories {
-                      gradlePluginPortal()
-                  }
-              }
-
               plugins {
                   id 'com.gradle.enterprise' version '3.11.4' apply false
               }


### PR DESCRIPTION
## What's changed?

Re-enabling three test cases which got temporarily disabled after #7559 / #7566.

## What's your motivation?

They should be passing now.
The problem with them was that the `gradle-plugins` remote repository meant to cache Gradle Plugin Portal in our Moderne Artifactory was set into "assumed offline" state. Which I cleared manually by making some trivial edit of the repository configuration in Artifactory. This made Artifactory serve the Gradle Plugins as intended.