### PR TITLE
Transitively collect data tables from composite recipes

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -33,7 +33,6 @@ import lombok.experimental.FieldDefaults;
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.config.*;
-import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.RecipeIntrospectionUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.NullUtils;
@@ -338,8 +337,34 @@ public abstract class Recipe implements Cloneable {
             dataTableDescriptorFromDataTable(new RecipeRunStats(Recipe.noop()))
     );
 
+    private static final Set<String> GLOBAL_DATA_TABLE_NAMES;
+
+    static {
+        Set<String> names = new HashSet<>();
+        for (DataTableDescriptor dt : GLOBAL_DATA_TABLES) {
+            names.add(dt.getName());
+        }
+        GLOBAL_DATA_TABLE_NAMES = names;
+    }
+
     public List<DataTableDescriptor> getDataTableDescriptors() {
-        return ListUtils.concatAll(dataTables == null ? emptyList() : dataTables, GLOBAL_DATA_TABLES);
+        Map<String, DataTableDescriptor> byName = new LinkedHashMap<>();
+        if (dataTables != null) {
+            for (DataTableDescriptor dt : dataTables) {
+                byName.putIfAbsent(dt.getName(), dt);
+            }
+        }
+        for (Recipe sub : getRecipeList()) {
+            for (DataTableDescriptor dt : sub.getDataTableDescriptors()) {
+                if (!GLOBAL_DATA_TABLE_NAMES.contains(dt.getName())) {
+                    byName.putIfAbsent(dt.getName(), dt);
+                }
+            }
+        }
+        for (DataTableDescriptor dt : GLOBAL_DATA_TABLES) {
+            byName.putIfAbsent(dt.getName(), dt);
+        }
+        return new ArrayList<>(byName.values());
     }
 
     /**

--- a/rewrite-core/src/main/java/org/openrewrite/config/CompositeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/CompositeRecipe.java
@@ -21,7 +21,6 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Recipe;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -48,24 +47,5 @@ public class CompositeRecipe extends Recipe {
     @Override
     public List<Recipe> getRecipeList() {
         return recipeList;
-    }
-
-    @Override
-    public List<DataTableDescriptor> getDataTableDescriptors() {
-        List<DataTableDescriptor> dataTableDescriptors = null;
-        for (Recipe recipe : getRecipeList()) {
-            List<DataTableDescriptor> dtds = recipe.getDataTableDescriptors();
-            if (!dtds.isEmpty()) {
-                if (dataTableDescriptors == null) {
-                    dataTableDescriptors = new ArrayList<>();
-                }
-                for (DataTableDescriptor dtd : dtds) {
-                    if (!dataTableDescriptors.contains(dtd)) {
-                        dataTableDescriptors.add(dtd);
-                    }
-                }
-            }
-        }
-        return dataTableDescriptors == null ? super.getDataTableDescriptors() : dataTableDescriptors;
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -710,22 +710,4 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
         return emptyList();
     }
 
-    @Override
-    public List<DataTableDescriptor> getDataTableDescriptors() {
-        List<DataTableDescriptor> dataTableDescriptors = null;
-        for (Recipe recipe : getRecipeList()) {
-            List<DataTableDescriptor> dtds = recipe.getDataTableDescriptors();
-            if (!dtds.isEmpty()) {
-                if (dataTableDescriptors == null) {
-                    dataTableDescriptors = new ArrayList<>();
-                }
-                for (DataTableDescriptor dtd : dtds) {
-                    if (!dataTableDescriptors.contains(dtd)) {
-                        dataTableDescriptors.add(dtd);
-                    }
-                }
-            }
-        }
-        return dataTableDescriptors == null ? super.getDataTableDescriptors() : dataTableDescriptors;
-    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/DataTableTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/DataTableTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import lombok.Value;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.config.CompositeRecipe;
+import org.openrewrite.config.DataTableDescriptor;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
@@ -98,6 +99,77 @@ class DataTableTest implements RewriteTest {
     }
 
     @Test
+    void compositeRecipeUnionsChildDataTables() {
+        Recipe child1 = toRecipe();
+        new TableA(child1);
+        Recipe child2 = toRecipe();
+        new TableB(child2);
+        Recipe parent = new CompositeRecipe(List.of(child1, child2));
+
+        assertThat(parent.getDataTableDescriptors())
+          .extracting(DataTableDescriptor::getName)
+          .containsExactly(
+            TableA.class.getName(),
+            TableB.class.getName(),
+            "org.openrewrite.table.SourcesFileResults",
+            "org.openrewrite.table.SearchResults",
+            "org.openrewrite.table.SourcesFileErrors",
+            "org.openrewrite.table.RecipeRunStats");
+    }
+
+    @Test
+    void compositeRecipeDedupesByName() {
+        Recipe child1 = toRecipe();
+        new TableA(child1);
+        Recipe child2 = toRecipe();
+        new TableA(child2);
+        Recipe parent = new CompositeRecipe(List.of(child1, child2));
+
+        assertThat(parent.getDataTableDescriptors())
+          .extracting(DataTableDescriptor::getName)
+          .containsExactly(
+            TableA.class.getName(),
+            "org.openrewrite.table.SourcesFileResults",
+            "org.openrewrite.table.SearchResults",
+            "org.openrewrite.table.SourcesFileErrors",
+            "org.openrewrite.table.RecipeRunStats");
+    }
+
+    @Test
+    void compositeRecipeOwnDataTablesPrecedeChildren() {
+        Recipe child = toRecipe();
+        new TableA(child);
+        new TableB(child);
+        Recipe parent = toRecipe();
+        new TableA(parent);
+        Recipe composite = new CompositeRecipe(List.of(parent, child));
+
+        // TableA is contributed by parent first via CompositeRecipe -> parent's own,
+        // then TableB comes from child. putIfAbsent-by-name preserves the first instance.
+        assertThat(composite.getDataTableDescriptors())
+          .extracting(DataTableDescriptor::getName)
+          .containsExactly(
+            TableA.class.getName(),
+            TableB.class.getName(),
+            "org.openrewrite.table.SourcesFileResults",
+            "org.openrewrite.table.SearchResults",
+            "org.openrewrite.table.SourcesFileErrors",
+            "org.openrewrite.table.RecipeRunStats");
+    }
+
+    @Test
+    void compositeRecipeWalksMultipleLevels() {
+        Recipe grandchild = toRecipe();
+        new TableC(grandchild);
+        Recipe child = new CompositeRecipe(List.of(grandchild));
+        Recipe parent = new CompositeRecipe(List.of(child));
+
+        assertThat(parent.getDataTableDescriptors())
+          .extracting(DataTableDescriptor::getName)
+          .contains(TableC.class.getName());
+    }
+
+    @Test
     void recipeUsedInPreconditionDoesNotEmitDataTableRows() {
         Recipe preconditionRecipe = toRecipe(r -> new PlainTextVisitor<>() {
             final WordTable wordTable = new WordTable(r);
@@ -144,6 +216,45 @@ class DataTableTest implements RewriteTest {
 
             @Column(displayName = "Text", description = "The text of the word.")
             String text;
+        }
+    }
+
+    @JsonIgnoreType
+    static class TableA extends DataTable<TableA.Row> {
+        public TableA(Recipe recipe) {
+            super(recipe, "A", "A.");
+        }
+
+        @Value
+        static class Row {
+            @Column(displayName = "Value", description = "value")
+            String value;
+        }
+    }
+
+    @JsonIgnoreType
+    static class TableB extends DataTable<TableB.Row> {
+        public TableB(Recipe recipe) {
+            super(recipe, "B", "B.");
+        }
+
+        @Value
+        static class Row {
+            @Column(displayName = "Value", description = "value")
+            String value;
+        }
+    }
+
+    @JsonIgnoreType
+    static class TableC extends DataTable<TableC.Row> {
+        public TableC(Recipe recipe) {
+            super(recipe, "C", "C.");
+        }
+
+        @Value
+        static class Row {
+            @Column(displayName = "Value", description = "value")
+            String value;
         }
     }
 }

--- a/rewrite-java/src/test/java/org/openrewrite/java/search/FindDeprecatedUsesDataTablesTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/search/FindDeprecatedUsesDataTablesTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.DataTableDescriptor;
+import org.openrewrite.java.table.MethodCalls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FindDeprecatedUsesDataTablesTest {
+
+    @Test
+    void exposesMethodCallsTransitivelyFromFindDeprecatedMethods() {
+        FindDeprecatedUses recipe = new FindDeprecatedUses(null, null, null);
+        assertThat(recipe.getDataTableDescriptors())
+          .extracting(DataTableDescriptor::getName)
+          .contains(MethodCalls.class.getName());
+    }
+}


### PR DESCRIPTION
## Summary

- `Recipe.getDataTableDescriptors()` now walks `getRecipeList()` and unions sub-recipe data tables (deduped by name) so Java composites report the data tables their children produce. YAML composites already had this via `DeclarativeRecipe`'s override; that override (and the identical one in `CompositeRecipe`) is removed since the base implementation now covers both.
- Globals are filtered out of child contributions so they only appear once at the end of the list, preserving an "own → transitive → globals" order.
- Concrete repro that motivated the fix: `org.openrewrite.java.search.FindDeprecatedUses` (a Java composite over `FindDeprecatedMethods`/`Classes`/`Fields`) previously reported zero data tables; it now lists `org.openrewrite.java.table.MethodCalls` as expected.

## Why

`RecipeListing.fromDescriptor` sources its `dataTables` field from `RecipeDescriptor.getDataTables()`, which is populated from `Recipe.getDataTableDescriptors()`. Until now, only YAML composites walked their children, so downstream consumers (marketplace CSV `dataTables` cell, Moderne SaaS GraphQL `RecipeDescriptor.dataTables`, DevCenter classification, MCP `describeRecipeDataTables`) under-reported data tables for Java composites. Lifting the walk into the base method fixes everything in one place.

## CSV size impact

Empirically measured against `org.openrewrite.recipe:rewrite-spring:6.30.1` (3,131 recipes, the largest spring-related recipe library): 75 composites gain entries, max 2 new entries per recipe, total `dataTables` JSON grows by 87 KB — about 3% of the full CSV. Not substantially larger.

## Test plan

- [x] `:rewrite-core:test` — passes, including new tests in `DataTableTest`:
  - composite unions child data tables
  - dedup-by-name across siblings
  - parent-declared tables precede child contributions
  - multi-level transitive walk
- [x] `:rewrite-java:test` — passes, including new `FindDeprecatedUsesDataTablesTest` that exercises the concrete repro
- [x] `:rewrite-yaml:test` — passes
- [x] Existing `DeclarativeRecipeTest` (including thread-safety test for `getDataTableDescriptors()`) still green after removing the override
- [x] Marketplace tests in `:rewrite-maven:test` pass (other failures in that module are pre-existing 401s against `artifactory.moderne.ninja`, unrelated)