### PR TITLE
[draft] Defensively null-check K.Return.expression in accessors

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -1545,35 +1545,45 @@ public interface K extends J {
         @EqualsAndHashCode.Include
         UUID id;
 
-        J.Return expression;
+        J.@Nullable Return expression;
 
         J.@Nullable Identifier label;
 
         @Override
         public Space getPrefix() {
-            return expression.getPrefix();
+            return expression == null ? Space.EMPTY : expression.getPrefix();
         }
 
         @Override
         public <J2 extends J> J2 withPrefix(Space space) {
+            if (expression == null) {
+                //noinspection unchecked
+                return (J2) this;
+            }
             //noinspection unchecked
             return (J2) withExpression(expression.withPrefix(space));
         }
 
         @Override
         public Markers getMarkers() {
-            return expression.getMarkers();
+            return expression == null ? Markers.EMPTY : expression.getMarkers();
         }
 
         @Override
         public <J2 extends Tree> J2 withMarkers(Markers markers) {
+            if (expression == null) {
+                //noinspection unchecked
+                return (J2) this;
+            }
             //noinspection unchecked
             return (J2) withExpression(expression.withMarkers(markers));
         }
 
         @Override
         public @Nullable JavaType getType() {
-            //noinspection DataFlowIssue
+            if (expression == null || expression.getExpression() == null) {
+                return null;
+            }
             return expression.getExpression().getType();
         }
 


### PR DESCRIPTION
## Problem

`K.Return` wraps a `J.Return` as its `expression` field. The field is declared without `@Nullable`, but in practice it can become null after a recipe-driven visit:

```java
// KotlinVisitor.visitReturn:
r = r.withExpression(visitAndCast(r.getExpression(), p));
```

If a recipe deletes the inner `J.Return` (the visitor returns null), `withExpression(null)` produces a `K.Return` with a null `expression` field. Any subsequent visitor that calls `K.Return.getPrefix()` then NPEs at `K.java:1554`:

```
java.lang.NullPointerException: Cannot invoke
  "org.openrewrite.java.tree.J$Return.getPrefix()" because "this.expression" is null
  at org.openrewrite.kotlin.tree.K$Return.getPrefix(K.java:1554)
```

In production this surfaces as a `RecipeRunException` aborting the recipe run for the file plus rows in `SourcesFileErrors`. Reproducible locally by running `io.moderne.java.spring.boot4.SpringBoot4BestPractices` on a Kotlin source (e.g. a `build.gradle.kts`).

## Solution

Mark `K.Return.expression` as `@Nullable` and null-check each accessor / `with*` method so a `K.Return` with a null inner expression no longer NPEs:

* `getPrefix()` returns `Space.EMPTY`
* `getMarkers()` returns `Markers.EMPTY`
* `getType()` returns `null`
* `withPrefix(...)` and `withMarkers(...)` are no-ops that return the same instance

This is a **defensive** fix at the accessor layer. The underlying call site that produces a `K.Return` with `null expression` is the bigger concern: a complementary fix in `KotlinVisitor.visitReturn` could treat the inner J.Return being deleted as deletion of the K.Return itself (return null up). I haven't included that here because I'd want a clearer signal on the desired semantics first.

## Draft

Marking as draft:
1. To get review on the approach (defensive accessors vs. `visitReturn` deletion-propagation, or both).
2. To run the local repro before un-drafting.

## Validation

- The unrelated [PR #7582](https://github.com/openrewrite/rewrite/pull/7582) has confirmed this NPE is the residual error after the LinkageError fix. Local validation of this defensive fix is in progress.