### PR TITLE
RPC: avoid defensive copy in RpcSendQueue.flush()

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -28,7 +28,7 @@ import static org.openrewrite.rpc.RpcObjectData.State.*;
 
 public class RpcSendQueue {
     private final int batchSize;
-    private final List<RpcObjectData> batch;
+    private List<RpcObjectData> batch;
     private final Consumer<List<RpcObjectData>> drain;
     private final IdentityHashMap<Object, Integer> refs;
     private final @Nullable String sourceFileType;
@@ -55,13 +55,21 @@ public class RpcSendQueue {
 
     /**
      * Called whenever the batch size is reached or at the end of the tree.
+     * <p>
+     * The batch is handed to {@code drain} directly — no defensive copy. This is
+     * safe because (1) all {@code put}/{@code flush} calls happen on a single
+     * traversal thread, so reassignment of {@code batch} can't race with {@code put},
+     * and (2) the drain consumer (a capacity-1 {@code BlockingQueue.put}) blocks
+     * until the consumer takes the list, so by the time {@code drain.accept} returns
+     * there's no in-flight reader of the just-handed-off list either.
      */
     public void flush() {
         if (batch.isEmpty()) {
             return;
         }
-        drain.accept(new ArrayList<>(batch));
-        batch.clear();
+        List<RpcObjectData> sending = batch;
+        batch = new ArrayList<>(batchSize);
+        drain.accept(sending);
     }
 
     public <T, U> void getAndSend(T parent, Function<T, @Nullable U> value) {


### PR DESCRIPTION
## Summary

`RpcSendQueue.flush()` previously did `drain.accept(new ArrayList<>(batch)); batch.clear();` — an `Arrays.copyOf` of the entire batch's element array into a fresh ArrayList on every flush. The defensive copy was protecting against a race that doesn't exist:

- `put` and `flush` are always invoked on the same producer thread (the `TREE_TRAVERSAL_POOL` worker that owns the `RpcSendQueue` instance), so reassignment of `batch` cannot race with concurrent `put`s.
- The drain consumer is a `BlockingQueue.put` of capacity 1 (in `GetObject.Handler`); it blocks the producer until the consumer takes, so by the time `drain.accept` returns there is no in-flight reader of the just-handed-off list either.

The new `flush()` hands the existing batch list directly to the consumer and allocates a fresh `ArrayList<>(batchSize)` for the next round. Same total `ArrayList` allocations per flush (one), but no per-element copy and no transient `Object[batch.size()]` backing array thrown away after each serialization.

On default `batchSize=1000` runs that's tens-to-hundreds of megabytes of transient allocation eliminated per recipe run, scaling linearly with batch size.

## Test plan

- [x] Existing `RpcSendQueue` / RPC integration tests pass (no behaviour change beyond the elimination of the defensive copy)
- [x] Worktree benchmark: `mod run small --recipe=org.openrewrite.python.migrate.UpgradeToPython314` over 19 Python repos completed within noise of baseline; the change is mostly load-bearing on long-pole repos and on `--parallel=1` runs where allocation pressure on a single thread compounds.