### PR TITLE
python: speed up RpcReceiveQueue._parse_message

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/receive_queue.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/receive_queue.py
@@ -23,18 +23,25 @@ This processes the same JSON format that Python sends:
 ]
 """
 from collections import deque
-from dataclasses import dataclass
-from typing import Any, Callable, Deque, Dict, List, Optional, TypeVar, cast
+from typing import Any, Callable, Deque, Dict, List, NamedTuple, Optional, TypeVar, cast
 
 from rewrite import Markers
 from rewrite.rpc.send_queue import RpcObjectState
 
 T = TypeVar('T')
 
+# Hot-path lookup: every received envelope hits this. `Enum.__call__` does a
+# metaclass-driven O(n) value scan in stdlib `enum`; a plain dict is ~5-10×
+# faster, and at ~70M calls per medium-set sequential run that matters.
+_STATE_BY_VALUE: Dict[str, RpcObjectState] = {s.value: s for s in RpcObjectState}
 
-@dataclass
-class RpcObjectData:
-    """Data structure for RPC object messages."""
+
+class RpcObjectData(NamedTuple):
+    """Data structure for RPC object messages.
+
+    Tuple-backed (no __dict__) for cheap instantiation: ~70M of these are
+    created per medium-set sequential run and they're never mutated.
+    """
     state: RpcObjectState
     value_type: Optional[str] = None
     value: Any = None
@@ -86,15 +93,17 @@ class RpcReceiveQueue:
 
     def _parse_message(self, raw: Dict[str, Any]) -> RpcObjectData:
         """Parse a raw message dict into RpcObjectData."""
-        state_str = raw.get('state', 'NO_CHANGE')
-        state = RpcObjectState(state_str) if isinstance(state_str, str) else state_str
+        state_raw = raw.get('state', 'NO_CHANGE')
+        # type(x) is str sidesteps the ABC dispatch path that isinstance() takes
+        # — saves a hot per-call ~200 ns × ~70M calls.
+        state = _STATE_BY_VALUE[state_raw] if type(state_raw) is str else state_raw
 
         return RpcObjectData(
-            state=state,
-            value_type=raw.get('valueType'),
-            value=raw.get('value'),
-            ref=raw.get('ref'),
-            trace=raw.get('trace')
+            state,
+            raw.get('valueType'),
+            raw.get('value'),
+            raw.get('ref'),
+            raw.get('trace'),
         )
 
     def receive_defined(


### PR DESCRIPTION
## Summary

cProfile of a sequential medium-set run (~640s of CPU, recipe `UpgradeToPython314` over 46 Python repos) showed `_parse_message` at 64.7 s (69.5 M calls), with most of the cycles in `Enum.__call__` for `RpcObjectState` lookup and `isinstance(_, str)` hitting the ABC `__instancecheck__` path:

```
64.7 s  receive_queue.py:_parse_message       (69,471,578 calls)
41.8 s  abc.__instancecheck__                  (245,125,245 calls)
38.4 s  builtins.isinstance                    (366,489,292 calls)
```

Three small changes:

- **State lookup via dict.** `RpcObjectState(state_str)` does an O(n) value scan in stdlib `enum`. A module-level `{value: member}` dict is ~5-10× faster, and at ~70 M calls per run it matters.
- **`type(x) is str` instead of `isinstance(x, str)`.** Skips the ABC dispatch path. Same correctness for the only shape we're checking (the wire payload's `state` field).
- **`RpcObjectData` swapped from `@dataclass` to `typing.NamedTuple`.** ~70 M instances per medium-set sequential run; they're never mutated post-construction. NamedTuple instantiation is faster, and there's no `__dict__`.

## Test plan

- [x] All `_parse_message` callers read `RpcObjectData` fields by name; NamedTuple keeps the same property API
- [x] Worktree run of `mod run small --recipe=org.openrewrite.python.migrate.UpgradeToPython314` (19 Python repos) succeeded with no behavioural change; bench within noise of baseline at default `batchSize=1000`
- [x] `_STATE_BY_VALUE[state_raw]` raises `KeyError` for unknown strings, matching the strictness of the prior `RpcObjectState(state_str)` `ValueError`