### PR TITLE
python: skip dataclasses.replace in hot replace_if_changed path

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/utils.py
+++ b/rewrite-python/rewrite/src/rewrite/utils.py
@@ -1,8 +1,14 @@
-from dataclasses import replace as dataclass_replace
-from typing import Any, Callable, TypeVar, List, Union, cast
+from dataclasses import fields as _dataclass_fields, is_dataclass as _is_dataclass, replace as dataclass_replace
+from typing import Any, Callable, Dict, TypeVar, List, Tuple, Union, cast
 from uuid import UUID, uuid4
 
 T = TypeVar('T')
+
+# Per-class cache of init-field names. `dataclasses.replace` re-walks
+# `__dataclass_fields__` on every call to fill in missing fields via getattr;
+# we'd rather pay the introspection once per class and then construct directly
+# from `__dict__`. ~16.7M `replace_if_changed` calls per medium sequential run.
+_INIT_FIELDS_CACHE: Dict[type, Tuple[str, ...]] = {}
 
 
 def _is_changed(old, new) -> bool:
@@ -45,15 +51,24 @@ def replace_if_changed(obj: T, **kwargs) -> T:
     if not kwargs:
         return obj
 
+    cls = type(obj)
+    init_fields = _INIT_FIELDS_CACHE.get(cls)
+    if init_fields is None:
+        if not _is_dataclass(cls):
+            # Non-dataclass fallback path — should never hit on the LST hot path,
+            # but preserves the original semantics.
+            return cast(T, dataclass_replace(cast(Any, obj), **kwargs))
+        init_fields = tuple(f.name for f in _dataclass_fields(cls) if f.init)
+        _INIT_FIELDS_CACHE[cls] = init_fields
+
     # Map public property names to private field names and check for changes
-    mapped_kwargs = {}
+    mapped_kwargs: Dict[str, Any] = {}
     changed = False
     for key, value in kwargs.items():
         if not key.startswith('_'):
             # Handle Python keyword conflicts: from_ -> _from
-            base_key = key.rstrip('_')
-            private_key = f'_{base_key}'
-            if hasattr(obj, private_key):
+            private_key = f'_{key.rstrip("_")}'
+            if private_key in init_fields:
                 mapped_kwargs[private_key] = value
                 # Use 'or' for short-circuit evaluation - skips check once changed is True
                 changed = changed or _is_changed(getattr(obj, private_key), value)
@@ -64,8 +79,18 @@ def replace_if_changed(obj: T, **kwargs) -> T:
             mapped_kwargs[key] = value
             changed = changed or _is_changed(getattr(obj, key), value)
 
-    # cast needed because Python lacks a public Dataclass protocol (see cpython#102395)
-    return cast(T, dataclass_replace(cast(Any, obj), **mapped_kwargs)) if changed else obj
+    if not changed:
+        return obj
+
+    # Direct construction from __dict__ + overlay — avoids dataclasses.replace's
+    # per-call walk of __dataclass_fields__. Frozen LST dataclasses still have
+    # __dict__ (no __slots__), so vars() is safe here.
+    obj_dict = obj.__dict__
+    new_kwargs = {
+        name: mapped_kwargs[name] if name in mapped_kwargs else obj_dict[name]
+        for name in init_fields
+    }
+    return cast(T, cls(**new_kwargs))
 
 
 def random_id() -> UUID:


### PR DESCRIPTION
## Summary

`replace_if_changed` is called once per LST node visited during a recipe run. cProfile of a sequential medium-set run shows ~16.7M calls, with ~21s of CPU spent in `dataclasses.replace`:

```
26.8 s  utils.replace_if_changed              (16,731,407 calls)
20.8 s  dataclasses.replace                   (16,731,743 calls)
```

`dataclasses.replace` walks `__dataclass_fields__` on every call to fill in missing fields via `getattr`. Two changes here:

1. **Per-class init-field cache.** A module-level `{cls: tuple(field_names)}` dict resolves the field set once per LST class instead of on every call.

2. **Direct construction from `obj.__dict__`.** Once we know the field names, we build the kwargs by reading directly from `__dict__` (LST nodes are frozen dataclasses with no `__slots__`, so `vars()` is safe) and overlaying the changed fields, then calling the class constructor. Skips the `dataclasses.replace` reflection entirely on the hot path.

Public→private name mapping (`prefix` → `_prefix`, `from_` → `_from`) is preserved with the same semantics; the cache lets us check `private_key in init_fields` (a tuple membership test) instead of `hasattr(obj, private_key)` (descriptor walk).

Non-dataclass objects fall through to the original `dataclass_replace` path so callers that pass exotic types continue to work; this should never hit on the LST hot path since LST nodes are dataclasses.

## Test plan

- [x] Worktree run of `mod run small --recipe=org.openrewrite.python.migrate.UpgradeToPython314` (19 Python repos) succeeded with no behavioural change
- [x] LST nodes (`@dataclass(frozen=True, eq=False)`, no `__slots__`) verified to have `__dict__`; `vars(obj)` works
- [x] Public/private name mapping preserved: `private_key in init_fields` is equivalent to `hasattr(obj, private_key)` for dataclass init fields, since `dataclasses.replace` itself only honours init fields