### PR TITLE
python: implement TreeVisitor.adapt() so generic visitors can visit Py/J nodes

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/java/visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/java/visitor.py
@@ -1389,3 +1389,59 @@ class JavaVisitor(TreeVisitor[J, P]):
         erroneous = temp_expr
         erroneous = erroneous.replace(markers=self.visit_markers(erroneous.markers, p))
         return erroneous
+
+
+class _TreeVisitorAsJavaVisitor(JavaVisitor):
+    """Adapts a generic ``TreeVisitor`` as a ``JavaVisitor``.
+
+    Returned by :meth:`TreeVisitor.adapt` when a Java LST node's ``accept``
+    is called with a non-Java visitor. The wrapper is-a ``JavaVisitor`` so
+    Java-specific dispatch (``visit_method_declaration`` and friends) finds
+    the default child-traversal implementations that ``JavaVisitor``
+    provides; ``pre_visit`` / ``post_visit`` / ``default_value`` /
+    ``is_acceptable`` plus ``_cursor`` / ``_visit_count`` / ``_after_visit``
+    are forwarded to the wrapped visitor so user-defined logic still runs
+    against the right state.
+    """
+
+    def __init__(self, wrapped: TreeVisitor):
+        self._wrapped = wrapped
+
+    @property
+    def _cursor(self):
+        return self._wrapped._cursor
+
+    @_cursor.setter
+    def _cursor(self, value):
+        self._wrapped._cursor = value
+
+    @property
+    def _visit_count(self):
+        return self._wrapped._visit_count
+
+    @_visit_count.setter
+    def _visit_count(self, value):
+        self._wrapped._visit_count = value
+
+    @property
+    def _after_visit(self):
+        return self._wrapped._after_visit
+
+    @_after_visit.setter
+    def _after_visit(self, value):
+        self._wrapped._after_visit = value
+
+    def pre_visit(self, tree, p):
+        return self._wrapped.pre_visit(tree, p)
+
+    def post_visit(self, tree, p):
+        return self._wrapped.post_visit(tree, p)
+
+    def default_value(self, tree, p):
+        return self._wrapped.default_value(tree, p)
+
+    def is_acceptable(self, source_file, p):
+        return self._wrapped.is_acceptable(source_file, p)
+
+
+TreeVisitor.register_adapter(JavaVisitor, _TreeVisitorAsJavaVisitor)

--- a/rewrite-python/rewrite/src/rewrite/python/visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/visitor.py
@@ -28,6 +28,7 @@ from rewrite.java.visitor import JavaVisitor
 from rewrite.python.support_types import Py
 from rewrite.tree import SourceFile
 from rewrite.utils import list_map
+from rewrite.visitor import TreeVisitor
 
 if TYPE_CHECKING:
     from rewrite.python.tree import (
@@ -665,4 +666,59 @@ class PythonVisitor(JavaVisitor[P]):
             expression=self.visit_and_cast(yield_from.expression, Expression, p)
         )
         return yield_from
+
+
+class _TreeVisitorAsPythonVisitor(PythonVisitor):
+    """Adapts a generic ``TreeVisitor`` as a ``PythonVisitor``.
+
+    Returned by :meth:`TreeVisitor.adapt` when a Py LST node's ``accept``
+    is called with a non-Python visitor. The wrapper is-a ``PythonVisitor``
+    (and therefore also a ``JavaVisitor``) so language-specific dispatch
+    finds the default child-traversal implementations; ``pre_visit`` /
+    ``post_visit`` / ``default_value`` / ``is_acceptable`` plus
+    ``_cursor`` / ``_visit_count`` / ``_after_visit`` are forwarded to the
+    wrapped visitor so user-defined logic still runs against the right state.
+    """
+
+    def __init__(self, wrapped: TreeVisitor):
+        self._wrapped = wrapped
+
+    @property
+    def _cursor(self):
+        return self._wrapped._cursor
+
+    @_cursor.setter
+    def _cursor(self, value):
+        self._wrapped._cursor = value
+
+    @property
+    def _visit_count(self):
+        return self._wrapped._visit_count
+
+    @_visit_count.setter
+    def _visit_count(self, value):
+        self._wrapped._visit_count = value
+
+    @property
+    def _after_visit(self):
+        return self._wrapped._after_visit
+
+    @_after_visit.setter
+    def _after_visit(self, value):
+        self._wrapped._after_visit = value
+
+    def pre_visit(self, tree, p):
+        return self._wrapped.pre_visit(tree, p)
+
+    def post_visit(self, tree, p):
+        return self._wrapped.post_visit(tree, p)
+
+    def default_value(self, tree, p):
+        return self._wrapped.default_value(tree, p)
+
+    def is_acceptable(self, source_file, p):
+        return self._wrapped.is_acceptable(source_file, p)
+
+
+TreeVisitor.register_adapter(PythonVisitor, _TreeVisitorAsPythonVisitor)
 

--- a/rewrite-python/rewrite/src/rewrite/visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/visitor.py
@@ -95,6 +95,12 @@ class TreeVisitor(ABC, Generic[T, P]):
     _cursor: Cursor = Cursor(None, "root")
     _after_visit: Optional[List[TreeVisitor[Any, P]]] = None
 
+    # Maps a language-specific visitor base class (e.g. JavaVisitor, PythonVisitor)
+    # to a class that wraps a generic TreeVisitor as that visitor type. Populated
+    # by language modules at import time via :meth:`register_adapter`. See
+    # :meth:`adapt` for the use-case.
+    _adapter_registry: ClassVar[Dict[Type['TreeVisitor[Any, Any]'], Type['TreeVisitor[Any, Any]']]] = {}
+
     @classmethod
     def noop(cls):
         return NoopVisitor()
@@ -196,20 +202,75 @@ class TreeVisitor(ABC, Generic[T, P]):
 
         A visitor is adaptable if:
         1. It is already an instance of the target type, OR
-        2. It is a base TreeVisitor (not a language-specific visitor)
-
-        This is a simplified implementation. Full adaptation support
-        would check tree type hierarchies like Java does.
+        2. A registered adapter exists for the target type (the bare-TreeVisitor
+           case — see :meth:`adapt`), OR
+        3. The visitor is itself an adapter wrapping a generic TreeVisitor.
         """
         if isinstance(self, adapt_to):
             return True
-        # Base TreeVisitor is adaptable to any visitor type
-        # (its tree type is Tree, which is a supertype of all tree types)
-        return type(self).__mro__[1] == TreeVisitor or type(self) == TreeVisitor
+        if getattr(self, '_wrapped', None) is not None:
+            return True
+        for cls in adapt_to.__mro__:
+            if cls in TreeVisitor._adapter_registry:
+                return True
+        return False
 
     def adapt(self, tree_type, visitor_type: Type[TV]) -> TV:
-        # FIXME implement the visitor adapting
+        """Return a visitor of ``visitor_type`` that delegates to ``self``.
+
+        Language-specific LST nodes route through this when their ``accept``
+        is called with a non-language-specific visitor — e.g. ``J.accept`` does
+        ``self.accept_java(v.adapt(J, JavaVisitor), p)``. Without an adapter,
+        a bare ``TreeVisitor`` would flow into ``accept_java`` and fail with
+        ``AttributeError`` on the first language-specific dispatch (e.g.
+        ``visit_compilation_unit``), since the bare base class doesn't
+        implement those methods.
+
+        The returned adapter is-a ``visitor_type`` (so the language-specific
+        ``visit_*`` defaults are available for child traversal), but it
+        forwards ``pre_visit`` / ``post_visit`` / ``default_value`` /
+        ``is_acceptable`` and the ``_cursor`` / ``_visit_count`` /
+        ``_after_visit`` state to the wrapped visitor — so any user-defined
+        logic on the original generic visitor still runs against the right
+        cursor and observes traversal via its own ``pre_visit`` / ``post_visit``.
+
+        If ``self`` is already an instance of ``visitor_type`` (the common case
+        where the user passed a language-specific visitor), no adapter is
+        created. If ``self`` is itself an adapter wrapping some other visitor,
+        the wrapped visitor is unwrapped first so we don't stack adapters when
+        a single recipe traversal crosses language boundaries (e.g. visiting a
+        Py node from inside a JavaVisitor adapter chain).
+
+        Adapter classes are registered by each language's visitor module via
+        :meth:`register_adapter`; if no adapter is registered for the requested
+        visitor type, ``self`` is returned unchanged for backwards
+        compatibility.
+        """
+        if isinstance(self, visitor_type):
+            return cast(TV, self)
+        target: TreeVisitor = self
+        wrapped = getattr(self, '_wrapped', None)
+        if wrapped is not None:
+            target = wrapped
+            if isinstance(target, visitor_type):
+                return cast(TV, target)
+        for cls in visitor_type.__mro__:
+            adapter_cls = TreeVisitor._adapter_registry.get(cls)
+            if adapter_cls is not None:
+                return cast(TV, adapter_cls(target))
         return cast(TV, self)
+
+    @classmethod
+    def register_adapter(cls, target_visitor_type: Type['TreeVisitor[Any, Any]'],
+                         adapter_cls: Type['TreeVisitor[Any, Any]']) -> None:
+        """Register an adapter class that wraps a generic TreeVisitor as ``target_visitor_type``.
+
+        Each language module (``rewrite.java.visitor``, ``rewrite.python.visitor``,
+        ...) calls this once at import time to make its language visitor reachable
+        via :meth:`adapt`. The adapter must subclass ``target_visitor_type`` and
+        accept a single ``wrapped`` argument in its constructor.
+        """
+        cls._adapter_registry[target_visitor_type] = adapter_cls
 
 
 class NoopVisitor(TreeVisitor[Tree, P]):

--- a/rewrite-python/rewrite/tests/test_visitor_adapt.py
+++ b/rewrite-python/rewrite/tests/test_visitor_adapt.py
@@ -1,0 +1,120 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``TreeVisitor.adapt`` and the language-visitor adapters.
+
+A subclass of ``TreeVisitor`` that overrides only ``pre_visit`` / ``post_visit``
+must be usable on language-specific LST nodes (Py, J). Without the adapter
+mechanism, the LST node's ``accept`` would call language-specific dispatch
+methods (``visit_compilation_unit``, ``visit_method_declaration``, ...) that
+the bare ``TreeVisitor`` doesn't implement, raising ``AttributeError``.
+"""
+
+from dataclasses import fields
+from uuid import uuid4
+
+from rewrite import Markers, TreeVisitor
+from rewrite.java.support_types import Space
+from rewrite.markers import SearchResult
+
+
+def _empty_py_compilation_unit(*, markers: Markers = Markers.EMPTY):
+    """Construct a minimal ``Py.CompilationUnit`` for visitor tests."""
+    from rewrite.python.tree import CompilationUnit
+    cu_fields = {f.name: None for f in fields(CompilationUnit) if f.init}
+    cu_fields['_id'] = uuid4()
+    cu_fields['_markers'] = markers
+    cu_fields['_prefix'] = Space.EMPTY
+    cu_fields['_imports'] = []
+    cu_fields['_statements'] = []
+    cu_fields['_eof'] = Space.EMPTY
+    cu_fields['_source_path'] = None
+    cu_fields['_charset_name'] = None
+    cu_fields['_charset_bom_marked'] = False
+    cu_fields['_checksum'] = None
+    cu_fields['_file_attributes'] = None
+    return CompilationUnit(**cu_fields)
+
+
+class TestTreeVisitorAdapt:
+    def test_bare_tree_visitor_visits_python_compilation_unit(self):
+        """A bare ``TreeVisitor`` must be able to visit a ``Py.CompilationUnit``.
+
+        Regression: previously raised
+        ``AttributeError: '...' object has no attribute 'visit_compilation_unit'``
+        because ``TreeVisitor.adapt`` returned ``self`` and the language dispatch
+        in ``Py.accept`` flowed into ``accept_python`` with a bare visitor.
+        """
+        visited = []
+
+        class _Collector(TreeVisitor):
+            def pre_visit(self, tree, p):
+                visited.append(tree)
+                return tree
+
+        cu = _empty_py_compilation_unit()
+        result = _Collector().visit(cu, None)
+
+        assert result is cu
+        assert cu in visited
+
+    def test_pre_visit_runs_for_root_through_adapter(self):
+        """``pre_visit`` must run on the root node with the adapter in place."""
+        call_count = 0
+
+        class _Counter(TreeVisitor):
+            def pre_visit(self, tree, p):
+                nonlocal call_count
+                call_count += 1
+                return tree
+
+        _Counter().visit(_empty_py_compilation_unit(), None)
+        assert call_count == 1
+
+    def test_collect_search_result_ids_finds_marker_on_py_root(self):
+        """End-to-end: the original ``_collect_search_result_ids`` (which uses a
+        ``TreeVisitor`` subclass) must collect a ``SearchResult`` marker placed
+        on a ``Py.CompilationUnit``."""
+        from rewrite.rpc.server import _collect_search_result_ids
+
+        sr_id = uuid4()
+        markers = Markers(uuid4(), [SearchResult(sr_id, "test")])
+        cu = _empty_py_compilation_unit(markers=markers)
+
+        ids = _collect_search_result_ids(cu)
+        assert ids == {str(sr_id)}
+
+    def test_adapt_returns_self_for_already_correct_visitor_type(self):
+        """``adapt`` is a no-op when the visitor already is-a target type."""
+        from rewrite.python.visitor import PythonVisitor
+        v = PythonVisitor()
+        assert v.adapt(None, PythonVisitor) is v
+
+    def test_adapt_unwraps_existing_adapter(self):
+        """Cross-language traversal must not stack adapters: an adapter wrapping
+        a generic visitor, when re-adapted to a different visitor type, should
+        wrap the original generic visitor (not the existing adapter)."""
+        from rewrite.java.visitor import JavaVisitor
+        from rewrite.python.visitor import PythonVisitor
+
+        class _Bare(TreeVisitor):
+            pass
+
+        bare = _Bare()
+        java_adapter = bare.adapt(None, JavaVisitor)
+        # Now adapt the Java adapter to a PythonVisitor — should wrap `bare`,
+        # not `java_adapter`.
+        python_adapter = java_adapter.adapt(None, PythonVisitor)
+        assert isinstance(python_adapter, PythonVisitor)
+        assert python_adapter._wrapped is bare


### PR DESCRIPTION
## Summary

`TreeVisitor.adapt()` was stubbed in `rewrite-python` (`# FIXME implement the visitor adapting`) — it just returned `self`. That's load-bearing for correctness because each language's LST root routes its `accept(v, p)` through the adapter:

```python
class J:
    def accept(self, v, p):
        return self.accept_java(v.adapt(J, JavaVisitor), p)

class Py(J):
    def accept(self, v, p):
        return self.accept_python(v.adapt(Py, PythonVisitor), p)
```

When `v` is a bare `TreeVisitor` (or a direct subclass that overrides only `pre_visit`/`post_visit` — a common pattern for cross-language collectors), the stubbed `adapt` flowed `v` straight into `accept_java`/`accept_python`, which immediately calls language-specific dispatch:

```python
class CompilationUnit:
    def accept_python(self, v, p):
        return v.visit_compilation_unit(self, p)
```

The bare `TreeVisitor` doesn't implement `visit_compilation_unit` → `AttributeError`, wrapped in `RecipeRunException` by the visitor framework's outer `try/except` and propagated up. Reproducible failure:

```python
class _Collector(TreeVisitor):
    def pre_visit(self, tree, p):
        return tree

_Collector().visit(some_py_compilation_unit, None)
# RecipeRunException: AttributeError: '_Collector' object has no attribute 'visit_compilation_unit'
```

- This blocks any correct implementation of `_collect_search_result_ids` (and similar cross-language tree walks) from extending the bare `TreeVisitor`. #7589 worked around the symptom by replacing the visitor-based collector with a hand-rolled iterative walker; closing that PR was the right call — this is the right layer to fix it.

## Implementation

- A class-level registry on `TreeVisitor` maps each language visitor base class to a small adapter class. Each language module (`rewrite.java.visitor`, `rewrite.python.visitor`) registers its adapter at import time via `TreeVisitor.register_adapter`.

- `adapt(tree_type, visitor_type)` returns:
  - `self` if the visitor is already an instance of `visitor_type`
  - otherwise an adapter instance that is-a `visitor_type` (so the language-specific `visit_*` defaults in `JavaVisitor` / `PythonVisitor` are available for child traversal) and forwards `pre_visit` / `post_visit` / `default_value` / `is_acceptable` plus `_cursor` / `_visit_count` / `_after_visit` to the wrapped visitor — so user-defined logic on the original generic visitor still runs against the right cursor and sees every traversed node.

- When `adapt` is called on an existing adapter (e.g. cross-language traversal: a Py node visited via a `JavaVisitor` adapter chain), the wrapped visitor is unwrapped and re-wrapped in the correct adapter rather than nesting adapters.

`is_adaptable_to` is updated to match the new semantics: a visitor is adaptable to a target type if it's already an instance, or if it's an existing adapter, or if a registered adapter exists for the target type.

## Test plan

- [x] New `tests/test_visitor_adapt.py` covers:
  - The regression — a bare `TreeVisitor` subclass visiting a `Py.CompilationUnit` no longer raises
  - `pre_visit` actually fires on the visited node
  - End-to-end: `_collect_search_result_ids` (which uses a `TreeVisitor` subclass) finds a `SearchResult` marker on a `Py` root
  - `adapt` is a no-op when the visitor already is-a target type
  - `adapt` unwraps an existing adapter rather than stacking adapters
- [x] Manual smoke test against the production install path (`~/.moderne/cli/python/openrewrite/8.81.6/`) — same minimal repro that crashed before this fix now succeeds and `pre_visit` is invoked.