### PR TITLE
csharp: implement `TreeVisitor.Adapt()` on the .NET side

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
@@ -1545,3 +1545,39 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
     private RoslynFormatter.DeferredFormatVisitor<P>? _deferredFormat;
 }
+
+/// <summary>
+/// Adapts a generic <see cref="TreeVisitor{J,P}"/> as a <see cref="CSharpVisitor{P}"/>.
+/// Returned by <see cref="TreeVisitor{T,P}.Adapt"/> when a Cs node is visited by a non-CSharp
+/// visitor (including a bare <see cref="TreeVisitor{J,P}"/> or a plain <see cref="JavaVisitor{P}"/>
+/// whose switch would throw on Cs types). The wrapper IS-A CSharpVisitor so the C#-specific
+/// Accept switch runs and child traversal uses the right defaults; <see cref="Visit"/> and
+/// <see cref="TreeVisitor{T,P}.Cursor"/> are forwarded to the wrapped visitor so user-defined
+/// PreVisit / PostVisit / DefaultValue / cursor state still drive the traversal.
+/// </summary>
+internal sealed class TreeVisitorAsCSharpVisitor<P> : CSharpVisitor<P>
+{
+    private readonly TreeVisitor<J, P> _wrapped;
+
+    public TreeVisitorAsCSharpVisitor(TreeVisitor<J, P> wrapped) => _wrapped = wrapped;
+
+    public override Cursor Cursor
+    {
+        get => _wrapped.Cursor;
+        set => _wrapped.Cursor = value;
+    }
+
+    public override J? Visit(Tree? tree, P p) => _wrapped.Visit(tree, p);
+}
+
+internal static class CSharpVisitorAdapterInit
+{
+    [System.Runtime.CompilerServices.ModuleInitializer]
+    internal static void Init()
+    {
+        TreeVisitorAdapterRegistry.Register(
+            treeType: typeof(Cs),
+            openLangVisitorType: typeof(CSharpVisitor<>),
+            openAdapterType: typeof(TreeVisitorAsCSharpVisitor<>));
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/TreeVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/TreeVisitor.cs
@@ -50,10 +50,11 @@ public class TreeVisitor<T, P> : ITreeVisitor<P> where T : class, Tree
             return tree;
         return Visit(tree, p);
     }
-    public Cursor Cursor { get; set; } = new();
+    public virtual Cursor Cursor { get; set; } = new();
     private int _visitCount;
     private bool _stopAfterPreVisit;
     private List<TreeVisitor<T, P>>? _afterVisit;
+    private Dictionary<Type, TreeVisitor<T, P>>? _adapterCache;
 
     public virtual T? PreVisit(T tree, P p) => tree;
 
@@ -65,6 +66,42 @@ public class TreeVisitor<T, P> : ITreeVisitor<P> where T : class, Tree
     /// implemented via switch pattern matching on the visitor side.
     /// </summary>
     protected virtual T? Accept(T tree, P p) => tree;
+
+    /// <summary>
+    /// Returns a visitor capable of dispatching <paramref name="tree"/> to language-specific
+    /// visit methods. By default consults <see cref="TreeVisitorAdapterRegistry"/>: if a more
+    /// specific language visitor (e.g. <c>JavaVisitor&lt;P&gt;</c>, <c>CSharpVisitor&lt;P&gt;</c>)
+    /// is registered for the tree's family and <c>this</c> is not already that kind of visitor,
+    /// returns a wrapper adapter that forwards lifecycle hooks back to <c>this</c> while
+    /// providing the language-specific Accept dispatch. Otherwise returns <c>this</c>.
+    /// <para/>
+    /// Without this routing, a bare <see cref="TreeVisitor{T,P}"/> traversing a Cs/J source
+    /// would silently no-op (default <see cref="Accept"/> is identity), and a
+    /// <c>JavaVisitor&lt;P&gt;</c> traversing a Cs source would throw on the first Cs node
+    /// that its switch doesn't recognize.
+    /// </summary>
+    protected virtual TreeVisitor<T, P> Adapt(T tree)
+    {
+        var factories = TreeVisitorAdapterRegistry.Factories;
+        for (int i = 0; i < factories.Count; i++)
+        {
+            var factory = factories[i];
+            if (!factory.TreeType.IsInstanceOfType(tree)) continue;
+
+            var closedLangType = factory.OpenLangVisitorType.MakeGenericType(typeof(P));
+            if (closedLangType.IsInstanceOfType(this)) return this;
+
+            _adapterCache ??= new Dictionary<Type, TreeVisitor<T, P>>(2);
+            if (!_adapterCache.TryGetValue(closedLangType, out var cached))
+            {
+                var closedAdapterType = factory.OpenAdapterType.MakeGenericType(typeof(P));
+                cached = (TreeVisitor<T, P>)Activator.CreateInstance(closedAdapterType, this)!;
+                _adapterCache[closedLangType] = cached;
+            }
+            return cached;
+        }
+        return this;
+    }
 
     public virtual T? Visit(Tree? tree, P p)
     {
@@ -78,7 +115,7 @@ public class TreeVisitor<T, P> : ITreeVisitor<P> where T : class, Tree
         T? t = PreVisit(typed, p);
         if (!_stopAfterPreVisit)
         {
-            if (t != null) t = Accept(t, p);
+            if (t != null) t = Adapt(t).Accept(t, p);
             if (t != null) t = PostVisit(t, p);
         }
         _stopAfterPreVisit = false;
@@ -150,6 +187,49 @@ public class TreeVisitor<T, P> : ITreeVisitor<P> where T : class, Tree
         public override T? Visit(Tree? tree, P p) => tree as T;
     }
 }
+/// <summary>
+/// Registry of language-specific visitor adapters used by <see cref="TreeVisitor{T,P}.Adapt"/>.
+/// Each language module registers its <c>(treeType, openLangVisitorType, openAdapterType)</c>
+/// triple at module load time via a <see cref="System.Runtime.CompilerServices.ModuleInitializerAttribute"/>.
+/// Entries are kept sorted with the most specific tree type first so that, e.g., a Cs node
+/// matches the CSharpVisitor adapter before falling through to the JavaVisitor adapter.
+/// </summary>
+public static class TreeVisitorAdapterRegistry
+{
+    public sealed record AdapterFactory(
+        Type TreeType,
+        Type OpenLangVisitorType,
+        Type OpenAdapterType);
+
+    private static readonly List<AdapterFactory> _factories = new();
+    private static readonly object _lock = new();
+
+    public static void Register(Type treeType, Type openLangVisitorType, Type openAdapterType)
+    {
+        lock (_lock)
+        {
+            // Deduplicate in case a module initializer somehow runs twice.
+            for (int i = 0; i < _factories.Count; i++)
+            {
+                if (_factories[i].TreeType == treeType && _factories[i].OpenLangVisitorType == openLangVisitorType)
+                    return;
+            }
+
+            _factories.Add(new AdapterFactory(treeType, openLangVisitorType, openAdapterType));
+            _factories.Sort((a, b) =>
+            {
+                if (a.TreeType == b.TreeType) return 0;
+                // Most specific first: if a is a base of b, b wins → a after b.
+                if (a.TreeType.IsAssignableFrom(b.TreeType)) return 1;
+                if (b.TreeType.IsAssignableFrom(a.TreeType)) return -1;
+                return 0;
+            });
+        }
+    }
+
+    internal static IReadOnlyList<AdapterFactory> Factories => _factories;
+}
+
 public static class TreeVisitorExtensions
 {
     public static ITreeVisitor<T> Combine<T>(this ITreeVisitor<T> first, ITreeVisitor<T> second) where T : class

--- a/rewrite-csharp/csharp/OpenRewrite/Java/JavaVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/JavaVisitor.cs
@@ -1213,3 +1213,39 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithAnnotations(ListUtils.Map(node.Annotations, ann => Visit(ann, p) as Annotation));
     }
 }
+
+/// <summary>
+/// Adapts a generic <see cref="TreeVisitor{J,P}"/> as a <see cref="JavaVisitor{P}"/>.
+/// Returned by <see cref="TreeVisitor{T,P}.Adapt"/> when a J node is visited by a non-Java
+/// visitor. The wrapper IS-A JavaVisitor (so the language-specific Accept switch runs and
+/// child traversal uses JavaVisitor's defaults), but it forwards <see cref="Visit"/> and
+/// <see cref="TreeVisitor{T,P}.Cursor"/> to the wrapped visitor so that user-defined
+/// PreVisit / PostVisit / DefaultValue / cursor state on the original visitor still drive
+/// the traversal.
+/// </summary>
+internal sealed class TreeVisitorAsJavaVisitor<P> : JavaVisitor<P>
+{
+    private readonly TreeVisitor<J, P> _wrapped;
+
+    public TreeVisitorAsJavaVisitor(TreeVisitor<J, P> wrapped) => _wrapped = wrapped;
+
+    public override Cursor Cursor
+    {
+        get => _wrapped.Cursor;
+        set => _wrapped.Cursor = value;
+    }
+
+    public override J? Visit(Tree? tree, P p) => _wrapped.Visit(tree, p);
+}
+
+internal static class JavaVisitorAdapterInit
+{
+    [System.Runtime.CompilerServices.ModuleInitializer]
+    internal static void Init()
+    {
+        TreeVisitorAdapterRegistry.Register(
+            treeType: typeof(J),
+            openLangVisitorType: typeof(JavaVisitor<>),
+            openAdapterType: typeof(TreeVisitorAsJavaVisitor<>));
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Core/TreeVisitorAdaptTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Core/TreeVisitorAdaptTest.cs
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp;
+using OpenRewrite.Java;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Tests.Core;
+
+/// <summary>
+/// Verifies that <see cref="TreeVisitor{T,P}.Adapt"/> wraps a generic visitor as the right
+/// language-specific visitor before dispatching Accept. Without adaptation a bare
+/// <c>TreeVisitor&lt;J, P&gt;</c> would silently no-op (default Accept is identity) and a
+/// plain <c>JavaVisitor&lt;P&gt;</c> would throw on the first Cs node its switch doesn't
+/// recognize. Mirrors the regression fix made on the Python side in commit 96c08d1eaf.
+/// </summary>
+public class TreeVisitorAdaptTest
+{
+    private static readonly string CSharpSource = """
+        using System;
+
+        namespace MyApp
+        {
+            public class Foo
+            {
+                public int Bar(int x) => x + 1;
+            }
+        }
+        """;
+
+    /// <summary>
+    /// A bare TreeVisitor that only overrides PreVisit must descend into every node of a Cs
+    /// source file. Before the fix, the default Accept (identity) caused traversal to stop
+    /// at the root.
+    /// </summary>
+    [Fact]
+    public void BareTreeVisitorTraversesCSharpSource()
+    {
+        var cu = new CSharpParser().Parse(CSharpSource);
+
+        var collector = new CountingPreVisitor();
+        collector.Visit(cu, new ExecutionContext());
+
+        // Must descend into the namespace, class, method, parameter, body, etc.
+        // Not asserting an exact count (parser-version-dependent), but it must be > 1
+        // (more than just the CompilationUnit itself).
+        Assert.True(collector.Count > 5,
+            $"Expected bare TreeVisitor to descend into Cs nodes, only saw {collector.Count} preVisit calls");
+
+        // Must include both Cs-specific types and shared J types.
+        Assert.Contains(collector.SeenTypes, t => typeof(Cs).IsAssignableFrom(t));
+        Assert.Contains(collector.SeenTypes, t => typeof(J).IsAssignableFrom(t) && !typeof(Cs).IsAssignableFrom(t));
+    }
+
+    /// <summary>
+    /// A plain JavaVisitor visiting a Cs source file must not throw on Cs-specific nodes.
+    /// Before the fix, JavaVisitor's switch had no arm for Cs.UsingDirective /
+    /// Cs.CompilationUnit / etc. and threw "Unknown J tree type".
+    /// </summary>
+    [Fact]
+    public void JavaVisitorTraversesCSharpSourceWithoutThrowing()
+    {
+        var cu = new CSharpParser().Parse(CSharpSource);
+
+        var visitor = new MethodCountingJavaVisitor();
+        var ex = Record.Exception(() => visitor.Visit(cu, new ExecutionContext()));
+
+        Assert.Null(ex);
+        Assert.Equal(1, visitor.MethodCount);
+    }
+}
+
+file class CountingPreVisitor : TreeVisitor<J, ExecutionContext>
+{
+    public int Count { get; private set; }
+    public HashSet<System.Type> SeenTypes { get; } = new();
+
+    public override J? PreVisit(J tree, ExecutionContext p)
+    {
+        Count++;
+        SeenTypes.Add(tree.GetType());
+        return tree;
+    }
+}
+
+file class MethodCountingJavaVisitor : JavaVisitor<ExecutionContext>
+{
+    public int MethodCount { get; private set; }
+
+    public override J VisitMethodDeclaration(MethodDeclaration method, ExecutionContext p)
+    {
+        MethodCount++;
+        return base.VisitMethodDeclaration(method, p);
+    }
+}


### PR DESCRIPTION
## Summary

- Mirrors the Python fix from c89d246c70 (#7590) for the parallel .NET implementation in `rewrite-csharp/csharp/OpenRewrite/`. Two distinct failure modes existed before this change:

1. **Silent no-op:** A bare `TreeVisitor<J, P>` (or any subclass that overrides only `PreVisit` / `PostVisit` — a common pattern for cross-language collectors) traversing a parsed C# source would silently no-op past the root. The default `Accept` is identity, so traversal never descended into children. Quiet, but every per-node hook missed every node.

2. **Hard throw:** A plain `JavaVisitor<P>` traversing a Cs source would throw `InvalidOperationException("Unknown J tree type: ...")` on the first `Cs.UsingDirective` / `Cs.PropertyDeclaration` / etc. its switch doesn't recognize.

Unlike the JVM side (which inherits a real `TreeVisitor.adapt()` from `rewrite-core` backed by Quarkus Gizmo bytecode generation) and unlike the TypeScript side (which sidesteps the problem with a kind-keyed registry consulted only inside `JavaVisitor.accept`), the C# port had no adaptation mechanism at all.

## Approach

* **`TreeVisitorAdapterRegistry`** — a non-generic, lock-protected registry of `(treeType, openLangVisitorType, openAdapterType)` triples kept sorted with the most specific tree type first, so a Cs node hits the `CSharpVisitor` adapter before falling through to the `JavaVisitor` one.

* **`TreeVisitor<T, P>.Adapt(tree)`** — looks up the matching language adapter, closes the open generic with `P`, and instantiates via `Activator`. Result is cached per visitor instance keyed by the closed language-visitor type, so the wrapper allocation happens at most once per language per visitor lifetime.

* **`Visit()`** now dispatches via `Adapt(t).Accept(t, p)` instead of `Accept(t, p)`. `Cursor` is made virtual so the adapter can forward it to the wrapped visitor.

* **`TreeVisitorAsJavaVisitor<P>` / `TreeVisitorAsCSharpVisitor<P>`** — thin adapter classes that IS-A `JavaVisitor` / `CSharpVisitor` (so the language switch and child-traversal defaults are inherited), but override `Visit` to forward to the wrapped visitor (so its lifecycle — `_visitCount`, `_afterVisit`, `_stopAfterPreVisit`, `PreVisit`, `PostVisit`, `DefaultValue` — runs unchanged) and override `Cursor` to forward to wrapped state. Each language registers its triple via a `[ModuleInitializer]` that fires on assembly load, so registration is guaranteed before any `TreeVisitor<J, P>.Visit()` call regardless of which generic instantiations the user code happens to reference.

## Test plan

- [x] New `TreeVisitorAdaptTest` covers both regression modes:
  - `BareTreeVisitorTraversesCSharpSource`: a `TreeVisitor<J, ExecutionContext>` overriding only `PreVisit` descends into both Cs- and J-typed nodes of a parsed file.
  - `JavaVisitorTraversesCSharpSourceWithoutThrowing`: a `JavaVisitor<ExecutionContext>` traverses the same source without throwing on Cs nodes.
- [x] Full C# suite green: 1917 / 1917 passing locally with `RPC_TEST_SERVER_CLASSPATH` wired via `./gradlew :rewrite-csharp:rpcTestClasspath` (covers JVM↔.NET RPC integration tests too).
- [x] No changes to public API surface beyond making `Cursor` virtual and adding `Adapt` (protected virtual). Existing `JavaVisitor` / `CSharpVisitor` / `XmlVisitor` overrides of `Accept` continue to compile unchanged.