### PR TITLE
go: dispatch `*tree.Else` in `GoVisitor.Visit` so RPC sends the body

### DIFF
--- a/rewrite-go/pkg/visitor/go_visitor.go
+++ b/rewrite-go/pkg/visitor/go_visitor.go
@@ -121,6 +121,8 @@ func (v *GoVisitor) Visit(t tree.Tree, p any) tree.Tree {
 		return v.self().VisitReturn(n, p)
 	case *tree.If:
 		return v.self().VisitIf(n, p)
+	case *tree.Else:
+		return v.self().VisitElse(n, p)
 	case *tree.Assignment:
 		return v.self().VisitAssignment(n, p)
 	case *tree.MethodDeclaration:
@@ -240,6 +242,7 @@ type VisitorI interface {
 	VisitBlock(block *tree.Block, p any) tree.J
 	VisitReturn(ret *tree.Return, p any) tree.J
 	VisitIf(ifStmt *tree.If, p any) tree.J
+	VisitElse(el *tree.Else, p any) tree.J
 	VisitAssignment(assign *tree.Assignment, p any) tree.J
 	VisitMethodDeclaration(md *tree.MethodDeclaration, p any) tree.J
 	VisitFieldAccess(fa *tree.FieldAccess, p any) tree.J
@@ -378,6 +381,20 @@ func (v *GoVisitor) VisitIf(ifStmt *tree.If, p any) tree.J {
 		ifStmt.ElsePart = &ep
 	}
 	return ifStmt
+}
+
+// VisitElse handles the synthetic *tree.Else wrapper that JavaSender produces
+// for RPC parity with Java's J.If.Else. The node never appears in a parsed
+// Go AST — language-level recipes go through VisitIf instead — so the default
+// implementation simply visits the body so traversal terminates correctly.
+func (v *GoVisitor) VisitElse(el *tree.Else, p any) tree.J {
+	el = el.WithPrefix(v.self().VisitSpace(el.Prefix, p))
+	el = el.WithMarkers(v.visitMarkers(el.Markers, p))
+	body := el.Body
+	body.Element = v.self().Visit(body.Element, p).(tree.Statement)
+	body.After = v.self().VisitSpace(body.After, p)
+	el.Body = body
+	return el
 }
 
 func (v *GoVisitor) VisitAssignment(assign *tree.Assignment, p any) tree.J {

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/ParseProjectIfElseTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/ParseProjectIfElseTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.rpc;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.ParseExceptionResult;
+import org.openrewrite.SourceFile;
+import org.openrewrite.tree.ParseError;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the visitor dispatch gap on {@code *tree.Else}.
+ * Without the dispatcher entry, {@code JavaSender.VisitElse} never runs —
+ * the synthetic Else wrapper that maps Go's {@code if/else} onto Java's
+ * {@code J.If.Else} was sent through preVisit only, leaving the receive
+ * queue desynchronized for the whole parse and surfacing as
+ * {@code ClassCastException: Space cannot be cast to JRightPadded} or
+ * {@code Expected CHANGE with positions in receiveList}.
+ */
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class ParseProjectIfElseTest {
+
+    @TempDir
+    Path tempDir;
+
+    @TempDir
+    Path projectDir;
+
+    @BeforeEach
+    void before() {
+        Path binaryPath = Paths.get("build/rewrite-go-rpc").toAbsolutePath();
+        GoRewriteRpc.setFactory(GoRewriteRpc.builder()
+                .goBinaryPath(binaryPath)
+                .log(tempDir.resolve("go-rpc.log"))
+                .traceRpcMessages());
+    }
+
+    @AfterEach
+    void after() {
+        GoRewriteRpc.shutdownCurrent();
+    }
+
+    @Test
+    void ifElseInProjectFile() throws Exception {
+        write(projectDir.resolve("go.mod"), """
+                module example.com/foo
+
+                go 1.22
+                """);
+        write(projectDir.resolve("main.go"), """
+                package main
+
+                func abs(x int) int {
+                \tif x < 0 {
+                \t\treturn -x
+                \t} else {
+                \t\treturn x
+                \t}
+                }
+                """);
+
+        GoRewriteRpc rpc = GoRewriteRpc.getOrStart();
+        List<SourceFile> sources = rpc.parseProject(projectDir, new InMemoryExecutionContext())
+                .collect(Collectors.toList());
+
+        List<ParseError> parseErrors = sources.stream()
+                .filter(s -> s instanceof ParseError)
+                .map(s -> (ParseError) s)
+                .collect(Collectors.toList());
+
+        assertThat(parseErrors)
+                .as("expected zero parse errors; got: %s",
+                        parseErrors.stream()
+                                .map(pe -> pe.getSourcePath() + ": " + pe.getMarkers().findFirst(ParseExceptionResult.class)
+                                        .map(ParseExceptionResult::getMessage).orElse("(no message)"))
+                                .collect(Collectors.joining("\n")))
+                .isEmpty();
+    }
+
+    private static void write(Path path, String content) throws java.io.IOException {
+        Files.createDirectories(path.getParent());
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## Summary

`JavaSender.VisitIf` constructs a synthetic `*tree.Else` to mirror Java's `J.If.Else` on the wire, but `GoVisitor.Visit`'s type switch had no case for it. The node fell through to `default: return t`, so preVisit (id/prefix/markers) ran but `JavaSender.VisitElse` never did and the body was never sent. The receive queue desynchronized for the rest of the parse, surfacing on the Java side as either:

- `Expected CHANGE with positions in receiveList, but got ADD ...` (in `RpcReceiveQueue.receiveList` whenever a list-typed field is the first to land on the misaligned offset), or
- `ClassCastException: org.openrewrite.java.tree.Space cannot be cast to org.openrewrite.java.tree.JRightPadded` (when `JavaReceiver.visitElse` is the unlucky one that reads the next misaligned message).

The integ test `GolangParserIntegTest.ifElseStatement` was already failing on `main` for this reason; downstream the moderne-cli was hitting the same desync on every gorilla/mux file with an `if/else` past it (29 parse errors across 64 files in a 3-repo sample).

## Fix

Add the dispatch entry, the matching `VisitorI` method, and a default `GoVisitor.VisitElse` that visits prefix / markers / body so language-level traversal terminates correctly.

## Test plan

- [x] `:rewrite-go:integTest` — full suite green, including `GolangParserIntegTest.ifElseStatement` (was failing).
- [x] New regression test `ParseProjectIfElseTest.ifElseInProjectFile` — fails on the parent commit, passes here.
- [x] Downstream moderne-cli build over gorilla/mux + spf13/cobra + stretchr/testify: 0 parse errors across 60 files (was 29 / 64 before).