### PR TITLE
Renew sbt CPE false-positive suppressions to 2026-06-01

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2026-05-01Z">
+    <suppress until="2026-06-01Z">
         <notes><![CDATA[
            file name: launcher-interface-1.4.4.jar
            reason: false positive on the regex pattern of impacted modules → sbt tool is at 1.10.4 whereas this vulnerability has been patched in version 1.9.7.
@@ -8,7 +8,7 @@
         <packageUrl regex="true">^pkg:maven/org\.scala-sbt/launcher-interface@.*$</packageUrl>
         <cve>CVE-2023-46122</cve>
     </suppress>
-    <suppress until="2026-05-01Z">
+    <suppress until="2026-06-01Z">
         <notes><![CDATA[
            file name: sbinary_2.13-0.5.1.jar
            reason: false positive on the regex pattern of impacted modules → sbt tool is at 1.10.4 whereas this vulnerability has been patched in version 1.9.7.


### PR DESCRIPTION
## Summary

CVE-2023-46122 affects \`org.scala-sbt:io\` and \`sbt\` itself prior to 1.9.7, not \`org.scala-sbt:launcher-interface\` or \`org.scala-sbt:sbinary_2.13\` — OWASP matches via shared CPE. The two existing suppressions expired on 2026-05-01; renewed to \`until=\"2026-06-01Z\"\`.

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1054

## Test plan
- [x] xmllint validates suppressions.xml
- [ ] Next dependency-check scan no longer flags CVE-2023-46122 against launcher-interface / sbinary_2.13