### PR TITLE
Use application mainClass in MigrateToGradle9

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseMainClassPropertyForApplication.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseMainClassPropertyForApplication.java
@@ -17,20 +17,12 @@ package org.openrewrite.gradle.gradle9;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Parser;
-import org.openrewrite.Preconditions;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.gradle.IsBuildGradle;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaSourceFile;
-import org.openrewrite.java.tree.Space;
-import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.*;
 import org.openrewrite.kotlin.tree.K;
 
 import java.nio.file.Paths;
@@ -62,25 +54,23 @@ public class UseMainClassPropertyForApplication extends Recipe {
 
             @Override
             public J visitAssignment(J.Assignment assignment, ExecutionContext ctx) {
+                if (!isMainClassName(assignment.getVariable())) {
+                    return assignment;
+                }
                 if (getCursor().getNearestMessage(IN_APPLICATION) != null) {
                     Expression variable = assignment.getVariable();
                     if (variable instanceof J.Identifier) {
-                        J.Identifier id = (J.Identifier) variable;
-                        if ("mainClassName".equals(id.getSimpleName())) {
-                            return assignment.withVariable(id.withSimpleName("mainClass"));
-                        }
+                        return assignment.withVariable(((J.Identifier) variable).withSimpleName("mainClass"));
                     } else if (variable instanceof J.FieldAccess) {
                         J.FieldAccess fieldAccess = (J.FieldAccess) variable;
-                        if ("mainClassName".equals(fieldAccess.getSimpleName())) {
-                            return assignment.withVariable(
-                                    fieldAccess.withName(fieldAccess.getName().withSimpleName("mainClass"))
-                            );
-                        }
+                        return assignment.withVariable(
+                                fieldAccess.withName(fieldAccess.getName().withSimpleName("mainClass"))
+                        );
                     }
                     return assignment;
                 }
 
-                if (getCursor().firstEnclosing(J.Lambda.class) == null && isMainClassName(assignment.getVariable())) {
+                if (getCursor().firstEnclosing(J.Lambda.class) == null) {
                     Expression rhs = assignment.getAssignment();
                     if (rhs instanceof J.Literal && ((J.Literal) rhs).getValueSource() != null) {
                         String valueSource = ((J.Literal) rhs).getValueSource();
@@ -101,7 +91,7 @@ public class UseMainClassPropertyForApplication extends Recipe {
                     return super.visitVariableDeclarations(multiVariable, ctx);
                 }
                 J.VariableDeclarations.NamedVariable variable = variables.get(0);
-                if (!"mainClassName".equals(variable.getSimpleName())) {
+                if (!isMainClassName(variable)) {
                     return super.visitVariableDeclarations(multiVariable, ctx);
                 }
                 Expression initializer = variable.getInitializer();
@@ -115,8 +105,7 @@ public class UseMainClassPropertyForApplication extends Recipe {
             private J parseApplicationBlock(ExecutionContext ctx, String valueSource, Space prefix) {
                 String snippet = "application {\n    mainClass = " + valueSource + "\n}";
                 JavaSourceFile sourceFile = getCursor().firstEnclosing(JavaSourceFile.class);
-                boolean isKotlinDsl = sourceFile != null &&
-                        sourceFile.getSourcePath().toString().endsWith(".gradle.kts");
+                boolean isKotlinDsl = sourceFile instanceof K.CompilationUnit;
                 if (isKotlinDsl) {
                     Statement statement = GradleParser.builder().build()
                             .parseInputs(Collections.singletonList(
@@ -138,11 +127,13 @@ public class UseMainClassPropertyForApplication extends Recipe {
                         .withPrefix(prefix);
             }
 
-            private boolean isMainClassName(Expression variable) {
+            private boolean isMainClassName(Tree variable) {
                 if (variable instanceof J.Identifier) {
                     return "mainClassName".equals(((J.Identifier) variable).getSimpleName());
                 } else if (variable instanceof J.FieldAccess) {
                     return "mainClassName".equals(((J.FieldAccess) variable).getSimpleName());
+                } else if (variable instanceof J.VariableDeclarations.NamedVariable) {
+                    return "mainClassName".equals(((J.VariableDeclarations.NamedVariable) variable).getSimpleName());
                 }
                 return false;
             }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseMainClassPropertyForApplication.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseMainClassPropertyForApplication.java
@@ -18,13 +18,24 @@ package org.openrewrite.gradle.gradle9;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Parser;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.gradle.IsBuildGradle;
+import org.openrewrite.groovy.tree.G;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.kotlin.tree.K;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -32,10 +43,10 @@ public class UseMainClassPropertyForApplication extends Recipe {
 
     private static final String IN_APPLICATION = "IN_APPLICATION";
 
-    String displayName = "Use `mainClass` instead of `mainClassName` in the `application` block";
+    String displayName = "Use `application { mainClass }` instead of `mainClassName`";
 
     String description = "The `mainClassName` property on the `application` extension was deprecated in Gradle 6.4 and removed in Gradle 9.0. " +
-            "Use the `mainClass` property instead. " +
+            "Use `application { mainClass = ... }` instead. Top-level `mainClassName` assignments are wrapped in an `application` block. " +
             "See the [Gradle upgrade guide](https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html) for more information.";
 
     @Override
@@ -50,25 +61,90 @@ public class UseMainClassPropertyForApplication extends Recipe {
             }
 
             @Override
-            public J.Assignment visitAssignment(J.Assignment assignment, ExecutionContext ctx) {
-                if (getCursor().getNearestMessage(IN_APPLICATION) == null) {
+            public J visitAssignment(J.Assignment assignment, ExecutionContext ctx) {
+                if (getCursor().getNearestMessage(IN_APPLICATION) != null) {
+                    Expression variable = assignment.getVariable();
+                    if (variable instanceof J.Identifier) {
+                        J.Identifier id = (J.Identifier) variable;
+                        if ("mainClassName".equals(id.getSimpleName())) {
+                            return assignment.withVariable(id.withSimpleName("mainClass"));
+                        }
+                    } else if (variable instanceof J.FieldAccess) {
+                        J.FieldAccess fieldAccess = (J.FieldAccess) variable;
+                        if ("mainClassName".equals(fieldAccess.getSimpleName())) {
+                            return assignment.withVariable(
+                                    fieldAccess.withName(fieldAccess.getName().withSimpleName("mainClass"))
+                            );
+                        }
+                    }
                     return assignment;
                 }
-                Expression variable = assignment.getVariable();
-                if (variable instanceof J.Identifier) {
-                    J.Identifier id = (J.Identifier) variable;
-                    if ("mainClassName".equals(id.getSimpleName())) {
-                        return assignment.withVariable(id.withSimpleName("mainClass"));
-                    }
-                } else if (variable instanceof J.FieldAccess) {
-                    J.FieldAccess fieldAccess = (J.FieldAccess) variable;
-                    if ("mainClassName".equals(fieldAccess.getSimpleName())) {
-                        return assignment.withVariable(
-                                fieldAccess.withName(fieldAccess.getName().withSimpleName("mainClass"))
-                        );
+
+                if (getCursor().firstEnclosing(J.Lambda.class) == null && isMainClassName(assignment.getVariable())) {
+                    Expression rhs = assignment.getAssignment();
+                    if (rhs instanceof J.Literal && ((J.Literal) rhs).getValueSource() != null) {
+                        String valueSource = ((J.Literal) rhs).getValueSource();
+                        return parseApplicationBlock(ctx, valueSource, assignment.getPrefix());
                     }
                 }
                 return assignment;
+            }
+
+            @Override
+            public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                if (getCursor().getNearestMessage(IN_APPLICATION) != null ||
+                        getCursor().firstEnclosing(J.Lambda.class) != null) {
+                    return super.visitVariableDeclarations(multiVariable, ctx);
+                }
+                List<J.VariableDeclarations.NamedVariable> variables = multiVariable.getVariables();
+                if (variables.size() != 1) {
+                    return super.visitVariableDeclarations(multiVariable, ctx);
+                }
+                J.VariableDeclarations.NamedVariable variable = variables.get(0);
+                if (!"mainClassName".equals(variable.getSimpleName())) {
+                    return super.visitVariableDeclarations(multiVariable, ctx);
+                }
+                Expression initializer = variable.getInitializer();
+                if (!(initializer instanceof J.Literal) || ((J.Literal) initializer).getValueSource() == null) {
+                    return super.visitVariableDeclarations(multiVariable, ctx);
+                }
+                String valueSource = ((J.Literal) initializer).getValueSource();
+                return parseApplicationBlock(ctx, valueSource, multiVariable.getPrefix());
+            }
+
+            private J parseApplicationBlock(ExecutionContext ctx, String valueSource, Space prefix) {
+                String snippet = "application {\n    mainClass = " + valueSource + "\n}";
+                JavaSourceFile sourceFile = getCursor().firstEnclosing(JavaSourceFile.class);
+                boolean isKotlinDsl = sourceFile != null &&
+                        sourceFile.getSourcePath().toString().endsWith(".gradle.kts");
+                if (isKotlinDsl) {
+                    Statement statement = GradleParser.builder().build()
+                            .parseInputs(Collections.singletonList(
+                                    Parser.Input.fromString(Paths.get("build.gradle.kts"), snippet)), null, ctx)
+                            .map(K.CompilationUnit.class::cast)
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalStateException("Could not parse application block"))
+                            .getStatements()
+                            .get(0);
+                    return ((J) statement).withPrefix(prefix);
+                }
+                return ((J) GradleParser.builder().build()
+                        .parse(ctx, snippet)
+                        .map(G.CompilationUnit.class::cast)
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalStateException("Could not parse application block"))
+                        .getStatements()
+                        .get(0))
+                        .withPrefix(prefix);
+            }
+
+            private boolean isMainClassName(Expression variable) {
+                if (variable instanceof J.Identifier) {
+                    return "mainClassName".equals(((J.Identifier) variable).getSimpleName());
+                } else if (variable instanceof J.FieldAccess) {
+                    return "mainClassName".equals(((J.FieldAccess) variable).getSimpleName());
+                }
+                return false;
             }
         });
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/MigrateToGradle9Test.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/MigrateToGradle9Test.java
@@ -39,7 +39,10 @@ class MigrateToGradle9Test implements RewriteTest {
               plugins {
                   id 'java'
                   id 'jacoco'
+                  id 'application'
               }
+
+              mainClassName = "com.example.AppMain"
 
               repositories {
                   mavenCentral()
@@ -61,6 +64,11 @@ class MigrateToGradle9Test implements RewriteTest {
               plugins {
                   id 'java'
                   id 'jacoco'
+                  id 'application'
+              }
+
+              application {
+                  mainClass = "com.example.AppMain"
               }
 
               repositories {
@@ -115,7 +123,10 @@ class MigrateToGradle9Test implements RewriteTest {
             """
               plugins {
                   `java`
+                  `application`
               }
+
+              mainClassName = "com.example.AppMain"
 
               tasks.register<JavaExec>("doSomething") {
                   main = "com.example.AppMain"
@@ -124,6 +135,11 @@ class MigrateToGradle9Test implements RewriteTest {
             """
               plugins {
                   `java`
+                  `application`
+              }
+
+              application {
+                  mainClass = "com.example.AppMain"
               }
 
               tasks.register<JavaExec>("doSomething") {


### PR DESCRIPTION
## Summary

Use application mainClass in MigrateToGradle9 recipe

# Test cases
- handle build.gradle 
- handle build.gradle.kts
