### PR TITLE
Fix ConcurrentModificationException in RecipeMarketplace.Category.merge

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -87,7 +87,9 @@ public class RecipeMarketplace {
                 if (existingSubCategory != null) {
                     existingSubCategory.merge(subCategory);
                 } else {
-                    categories.add(subCategory);
+                    Category copy = new Category(subCategory.displayName, subCategory.description);
+                    copy.merge(subCategory);
+                    categories.add(copy);
                 }
             }
         }

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
@@ -463,6 +463,45 @@ class RecipeMarketplaceReaderTest {
     }
 
     @Test
+    void mergeDoesNotAliasCategoryBranches() {
+        // Regression: when the target lacks a category that the source has, merge
+        // must deep-copy the branch rather than aliasing the source's Category
+        // instance. Otherwise later mutations to the target's tree mutate the
+        // source as well, and when the source is a cached marketplace shared
+        // across requests, concurrent readers iterate while a writer mutates,
+        // producing ConcurrentModificationException.
+        RecipeMarketplace source = new RecipeMarketplaceReader().fromCsv("""
+          name,category1,category2,ecosystem,packageName
+          org.example.SourceRecipe,Inner,Outer,maven,org.example:source
+          """);
+        RecipeMarketplace target = new RecipeMarketplace();
+
+        target.getRoot().merge(source.getRoot());
+
+        RecipeMarketplace.Category sourceOuter = findCategory(source.getRoot(), "Outer");
+        RecipeMarketplace.Category targetOuter = findCategory(target.getRoot(), "Outer");
+        assertThat(targetOuter).isNotSameAs(sourceOuter);
+        assertThat(findCategory(targetOuter, "Inner")).isNotSameAs(findCategory(sourceOuter, "Inner"));
+
+        // Mutate the target by merging an overlay that overlaps the same path.
+        // If the target's branches were aliased to source, this would also mutate source.
+        RecipeMarketplace overlay = new RecipeMarketplaceReader().fromCsv("""
+          name,category1,category2,ecosystem,packageName
+          org.example.OverlayRecipe,Inner,Outer,maven,org.example:overlay
+          """);
+        target.getRoot().merge(overlay.getRoot());
+
+        assertThat(findCategory(sourceOuter, "Inner").getRecipes())
+          .as("Source category must not be mutated by changes to merge target")
+          .extracting(RecipeListing::getName)
+          .containsExactly("org.example.SourceRecipe");
+
+        assertThat(findCategory(targetOuter, "Inner").getRecipes())
+          .extracting(RecipeListing::getName)
+          .containsExactlyInAnyOrder("org.example.SourceRecipe", "org.example.OverlayRecipe");
+    }
+
+    @Test
     void installCategoriesCaseInsensitive() {
         // When installing recipes via CSV where one uses "AI" and another uses "ai"
         // in the same category position, they should land in the same category


### PR DESCRIPTION
## Summary

`RecipeMarketplace.Category.merge` aliased the source's `Category` (and its mutable `recipes` / `categories` `ArrayList`s) into the target's tree when the target lacked a matching sub-category. Subsequent mutations to the target's tree then mutated the source as well. In moderne-saas, where a cached universal-marketplace instance is shared across requests, this races: one thread iterates `category.recipes` inside `merge` while another thread's `merge` calls `recipes.remove(...) / recipes.add(...)` on the same list, producing:

```
java.util.ConcurrentModificationException
    at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1096)
    at java.base/java.util.ArrayList$Itr.next(ArrayList.java:1050)
    at org.openrewrite.marketplace.RecipeMarketplace$Category.merge(RecipeMarketplace.java:75)
    at org.openrewrite.marketplace.RecipeMarketplace$Category.merge(RecipeMarketplace.java:88)
    ...
```

Fix: when the target lacks a matching sub-category, deep-copy the branch into a fresh `Category` rooted in the target's enclosing `RecipeMarketplace` rather than adding the source's reference directly. The recipe leaf was already safe via `recipe.withMarketplace(...)`; only the category branch was aliased.

## Test plan

- [x] New `mergeDoesNotAliasCategoryBranches` regression test in `RecipeMarketplaceReaderTest` verifies the source isn't mutated when the target is mutated post-merge, and that the `Category` instances differ.
- [x] Confirmed the test fails on `main` (`Expected not same: ...$Category@...`) and passes with the fix.
- [x] Full `:rewrite-core:test --tests RecipeMarketplaceReaderTest` suite green.
