### PR TITLE
Bump s4u/maven-settings-action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       # Route Maven resolution through Moderne's Artifactory cache to avoid
       # Maven Central rate-limiting (HTTP 404 + Retry-After) under parallel
       # test load. Picked up by MavenSettingsAutoLoadingExtension at test time.
-      - uses: s4u/maven-settings-action@v3.1.0
+      - uses: s4u/maven-settings-action@v4.0.0
         with:
           mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
           servers: '[{"id": "moderne-cache", "username": "${{ secrets.ARTIFACTORY_USERNAME }}", "password": "${{ secrets.ARTIFACTORY_PASSWORD }}"}]'


### PR DESCRIPTION
## What's changed?

Minor thing, bumping the recently added `s4u/maven-settings-action` to v4.

## What's your motivation?

Get rid of the warning in GHA:
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: s4u/maven-settings-action@v3.1.0. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```