### PR TITLE
Scala: fix parsing of trailing whitespace before closing parentheses

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -352,8 +352,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             } else {
                 visit(element, p);
             }
+            visitSpace(param.getAfter(), JRightPadded.Location.METHOD_DECLARATION_PARAMETER.getAfterLocation(), p);
             if (i < paramList.size() - 1) {
-                visitSpace(param.getAfter(), JRightPadded.Location.METHOD_DECLARATION_PARAMETER.getAfterLocation(), p);
                 p.append(',');
             }
         }
@@ -485,8 +485,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             } else {
                 visit(elem, p);
             }
+            visitSpace(lp.getAfter(), JRightPadded.Location.METHOD_DECLARATION_PARAMETER.getAfterLocation(), p);
             if (j < lps.size() - 1) {
-                visitSpace(lp.getAfter(), JRightPadded.Location.METHOD_DECLARATION_PARAMETER.getAfterLocation(), p);
                 p.append(',');
             }
         }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -830,8 +830,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             List<JRightPadded<J.TypeParameter>> elements = typeParams.getPadding().getElements();
             for (int i = 0; i < elements.size(); i++) {
                 visit(elements.get(i).getElement(), p);
+                visitSpace(elements.get(i).getAfter(), Space.Location.TYPE_PARAMETER_SUFFIX, p);
                 if (i < elements.size() - 1) {
-                    visitSpace(elements.get(i).getAfter(), Space.Location.TYPE_PARAMETER_SUFFIX, p);
                     p.append(',');
                 }
             }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -4060,15 +4060,22 @@ class ScalaTreeVisitor(
         typeParams.zipWithIndex.foreach { case (tparam, idx) =>
           val jTypeParam = visitTypeParameter(tparam)
           val isLast = idx == typeParams.size - 1
-          
-          jTypeParams.add(JRightPadded.build(jTypeParam))
 
-          // Advance cursor past the comma so the next param's extractPrefix
-          // doesn't include it. The printer handles comma output.
-          if (!isLast && cursor < source.length) {
+          val afterParam: Space = if (!isLast && cursor < source.length) {
             val commaPos = source.indexOf(',', cursor)
-            if (commaPos >= 0) cursor = commaPos + 1
-          }
+            if (commaPos >= 0) {
+              val before = Space.format(source.substring(cursor, commaPos))
+              cursor = commaPos + 1
+              before
+            } else Space.EMPTY
+          } else if (isLast && cursor < source.length) {
+            // Capture whitespace between last type parameter and closing `]`
+            val closePos = source.indexOf(']', cursor)
+            if (closePos >= 0) Space.format(source.substring(cursor, closePos))
+            else Space.EMPTY
+          } else Space.EMPTY
+
+          jTypeParams.add(new JRightPadded(jTypeParam, afterParam, Markers.EMPTY))
         }
         
         // Update cursor to after closing bracket.
@@ -5059,20 +5066,29 @@ class ScalaTreeVisitor(
         cursor = cursor + bracketIdx + 1
 
         val jTypeParams = new util.ArrayList[JRightPadded[J.TypeParameter]]()
-        typeParams.foreach { tp =>
+        typeParams.zipWithIndex.foreach { case (tp, idx) =>
           val jtp = visitTypeParameter(tp)
+          val isLast = idx == typeParams.size - 1
           val afterParam = if (cursor < source.length) {
-            val s = source.substring(cursor, Math.min(cursor + 20, source.length))
-            val commaIdx = s.indexOf(',')
-            if (commaIdx >= 0) {
-              cursor = cursor + commaIdx + 1
-              Space.format(s.substring(0, commaIdx))
-            } else Space.EMPTY
+            if (!isLast) {
+              val s = source.substring(cursor, Math.min(cursor + 200, source.length))
+              val commaIdx = s.indexOf(',')
+              if (commaIdx >= 0) {
+                cursor = cursor + commaIdx + 1
+                Space.format(s.substring(0, commaIdx))
+              } else Space.EMPTY
+            } else {
+              // Capture whitespace between last type parameter and closing `]`
+              val s = source.substring(cursor, Math.min(cursor + 200, source.length))
+              val closeIdx = s.indexOf(']')
+              if (closeIdx >= 0) Space.format(s.substring(0, closeIdx))
+              else Space.EMPTY
+            }
           } else Space.EMPTY
           jTypeParams.add(new JRightPadded(jtp, afterParam, Markers.EMPTY))
         }
 
-        val afterSearch = source.substring(cursor, Math.min(cursor + 50, source.length))
+        val afterSearch = source.substring(cursor, Math.min(cursor + 200, source.length))
         val closeBracket = afterSearch.indexOf(']')
         if (closeBracket >= 0) {
           cursor = cursor + closeBracket + 1

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5106,7 +5106,18 @@ class ScalaTreeVisitor(
               beforeComma
             } else Space.EMPTY
           } else Space.EMPTY
-        } else Space.EMPTY
+        } else {
+          // Capture whitespace between last parameter and closing `)` so
+          // multi-line parameter lists with `)` on its own line round-trip.
+          val paramEnd = Math.max(0, vd.span.end - offsetAdjustment)
+          val lookupStart = Math.max(cursor, paramEnd)
+          if (lookupStart < source.length) {
+            val remaining = source.substring(lookupStart, Math.min(lookupStart + 200, source.length))
+            val closeParen = remaining.indexOf(')')
+            if (closeParen >= 0) Space.format(remaining.substring(0, closeParen))
+            else Space.EMPTY
+          } else Space.EMPTY
+        }
         jParams.add(new JRightPadded(param.asInstanceOf[J], afterParam, Markers.EMPTY))
       }
 
@@ -5152,7 +5163,18 @@ class ScalaTreeVisitor(
                 beforeComma
               } else Space.EMPTY
             } else Space.EMPTY
-          } else Space.EMPTY
+          } else {
+            // Capture whitespace between last parameter and closing `)` so
+            // multi-line parameter lists with `)` on its own line round-trip.
+            val paramEnd = Math.max(0, vd.span.end - offsetAdjustment)
+            val lookupStart = Math.max(cursor, paramEnd)
+            if (lookupStart < source.length) {
+              val remaining = source.substring(lookupStart, Math.min(lookupStart + 200, source.length))
+              val closeParen = remaining.indexOf(')')
+              if (closeParen >= 0) Space.format(remaining.substring(0, closeParen))
+              else Space.EMPTY
+            } else Space.EMPTY
+          }
           jParams.add(new JRightPadded(param.asInstanceOf[Statement], afterParam, Markers.EMPTY))
         }
         val lastParamEnd = if (firstList.nonEmpty) Math.max(0, firstList.last.span.end - offsetAdjustment) else cursor

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -114,6 +114,38 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void multilineTypeParameters() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def f[
+                      A,
+                      B
+                  ](x: A): A = x
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void multilineCurriedParameterList() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def f(a: Int)(
+                      b: Int,
+                      c: Int
+                  ): Int = a + b + c
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void multilineParameterListWithClosingParenOnOwnLine() {
         rewriteRun(
             scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -114,6 +114,22 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void multilineParameterListWithClosingParenOnOwnLine() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def add(
+                      x: Int,
+                      y: Int
+                  ): Int = x + y
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void overrideMethod() {
         rewriteRun(
             scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
@@ -235,6 +235,36 @@ class ClassDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void multilineClassTypeParameters() {
+        rewriteRun(
+            scala(
+                """
+                class Foo[
+                    A,
+                    B
+                ]
+                """
+            )
+        );
+    }
+
+    @Test
+    void multilineWithClauses() {
+        rewriteRun(
+            scala(
+                """
+                trait B
+                trait C
+                trait D
+                class A extends B
+                    with C
+                    with D
+                """
+            )
+        );
+    }
+
+    @Test
     void methodWithImplicitParameter() {
         rewriteRun(
             scala(


### PR DESCRIPTION
## What's changed?

A fix to Scala parser for whitespace just before closing parentheses in a few cases of LST elements.

## What's your motivation?

These are parser idempotency issues.