### PR TITLE
Scala: add support for parsing `export` statements

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaIsoVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaIsoVisitor.java
@@ -204,6 +204,11 @@ public class ScalaIsoVisitor<P> extends ScalaVisitor<P> {
     }
 
     @Override
+    public S.Export visitExport(S.Export export, P p) {
+        return (S.Export) super.visitExport(export, p);
+    }
+
+    @Override
     public J.InstanceOf visitInstanceOf(J.InstanceOf instanceOf, P p) {
         return (J.InstanceOf) super.visitInstanceOf(instanceOf, p);
     }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -510,6 +510,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return visitTypeAscription((S.TypeAscription) tree, p);
         } else if (tree instanceof S.TypeAlias) {
             return visitTypeAlias((S.TypeAlias) tree, p);
+        } else if (tree instanceof S.Export) {
+            return visitExport((S.Export) tree, p);
         } else if (tree instanceof S.PatternDefinition) {
             return visitPatternDefinition((S.PatternDefinition) tree, p);
         } else if (tree instanceof S.FunctionCall) {
@@ -1355,6 +1357,21 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         p.append(typeAlias.getText());
         afterSyntax(typeAlias, p);
         return typeAlias;
+    }
+
+    public J visitExport(S.Export export, PrintOutputCapture<P> p) {
+        beforeSyntax(export, Space.Location.LANGUAGE_EXTENSION, p);
+        p.append("export ");
+        Expression clause = export.getExportClause();
+        if (clause instanceof J.FieldAccess && isWildcardImport((J.FieldAccess) clause)) {
+            J.FieldAccess fa = (J.FieldAccess) clause;
+            visitFieldAccessUpToWildcard(fa, p);
+            p.append("." + fa.getName().getSimpleName());
+        } else {
+            visit(clause, p);
+        }
+        afterSyntax(export, p);
+        return export;
     }
 
     public J visitPatternDefinition(S.PatternDefinition patDef, PrintOutputCapture<P> p) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -149,6 +149,19 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         return t;
     }
 
+    public J visitExport(S.Export export, P p) {
+        S.Export e = export;
+        e = e.withPrefix(visitSpace(e.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        e = e.withMarkers(visitMarkers(e.getMarkers(), p));
+        Statement temp = (Statement) visitStatement(e, p);
+        if (!(temp instanceof S.Export)) {
+            return temp;
+        }
+        e = (S.Export) temp;
+        e = e.withExportClause(visitAndCast(e.getExportClause(), p));
+        return e;
+    }
+
     public J visitPatternDefinition(S.PatternDefinition patDef, P p) {
         S.PatternDefinition pd = patDef;
         pd = pd.withPrefix(visitSpace(pd.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -628,6 +628,67 @@ public interface S extends J {
     }
 
     /**
+     * Represents a Scala 3 {@code export} clause, which re-exports a member of a
+     * value into the enclosing scope. Export clauses were introduced in Scala 3
+     * and have no Scala 2 equivalent.
+     * <p>
+     * The {@code exportClause} is the dotted path identifying what is exported,
+     * structured the same way as {@link J.Import#getQualid()} (i.e., a
+     * {@link J.FieldAccess} whose final segment is the exported name, or
+     * {@code "*"} / {@code "_"} for wildcards).
+     * <p>
+     * Examples:
+     * <ul>
+     *   <li>{@code export A.B.c}</li>
+     *   <li>{@code export A.B.*} (canonical Scala 3 wildcard)</li>
+     *   <li>{@code export A.B._} (legacy wildcard form still accepted by the compiler)</li>
+     * </ul>
+     * Brace-selector forms ({@code export A.{x, y}}) and aliased forms
+     * ({@code export A.{x as y}}) are not yet modelled and cause the parser to
+     * raise an exception.
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    final class Export implements S, Statement {
+
+        @With @Getter @EqualsAndHashCode.Include
+        UUID id;
+
+        @With @Getter
+        Space prefix;
+
+        @With @Getter
+        Markers markers;
+
+        /**
+         * The exported path. For simple exports this is a {@link J.FieldAccess}
+         * built the same way as {@link J.Import#getQualid()}, where the final
+         * segment names the exported member (or {@code *} / {@code _} for
+         * wildcards). Typed as {@link Expression} to leave room for richer
+         * forms (named-export containers, etc.) once brace selectors are modelled.
+         */
+        @With @Getter
+        Expression exportClause;
+
+        public Export(UUID id, Space prefix, Markers markers, Expression exportClause) {
+            this.id = id;
+            this.prefix = prefix;
+            this.markers = markers;
+            this.exportClause = exportClause;
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitExport(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Statement getCoordinates() {
+            return new CoordinateBuilder.Statement(this);
+        }
+    }
+
+    /**
      * Represents a Scala pattern definition (destructuring declaration).
      * <p>
      * Examples:

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -2163,109 +2163,17 @@ class ScalaTreeVisitor(
   }
 
   private def visitImport(imp: Trees.Import[?]): J = {
-    // Check if this is a simple import (no braces) that can map to J.Import
-    if (isSimpleImport(imp)) {
-      // Extract the prefix - should only be whitespace/comments before "import"
-      val adjustedStart = Math.max(0, imp.span.start - offsetAdjustment)
-      val prefix = if (cursor < adjustedStart) {
-        val prefixText = source.substring(cursor, adjustedStart)
-        cursor = adjustedStart
-        Space.format(prefixText)
-      } else {
-        Space.EMPTY
-      }
-      
-      
-      // Set import context flag for identifier processing
-      val oldInImportContext = isInImportContext
-      isInImportContext = true
-      
-      // Save current cursor position and move it to the start of the import expression
-      // The import expression (imp.expr) should have its span starting after "import "
-      val savedCursor = cursor
-      if (imp.expr.span.exists) {
-        val exprStart = Math.max(0, imp.expr.span.start - offsetAdjustment)
-        cursor = exprStart
-      }
-      
-      // Visit the import expression to get the field access
-      val expr = visitTree(imp.expr)
-      
-      // Restore import context flag
-      isInImportContext = oldInImportContext
-      
-      // For imports, we need a FieldAccess that includes the selectors
-      // Build the qualid: for `import java.util.List`, expr=Select(Ident(java),util), selector=List
-      // For `import java.util`, expr=Ident(java), selector=util
-      var qualid: J.FieldAccess = expr match {
-        case fa: J.FieldAccess => fa
-        case id: J.Identifier if imp.selectors.nonEmpty =>
-          // Simple Ident root (e.g., `java` in `import java.util`)
-          // Build FieldAccess with the Ident as target and first selector as name
-          val selector = imp.selectors.head
-          selector match {
-            case is @ untpd.ImportSelector(sIdent: Trees.Ident[?], untpd.EmptyTree, untpd.EmptyTree) =>
-              if (cursor < source.length && source.charAt(cursor) == '.') cursor += 1
-              // For wildcard imports, read source to preserve * vs _
-              val selName = if (is.isWildcard) {
-                val adjustedEnd = Math.max(0, imp.span.end - offsetAdjustment)
-                if (adjustedEnd > 0 && adjustedEnd <= source.length && source.charAt(adjustedEnd - 1) == '*') "*" else "_"
-              } else sIdent.name.toString
-              val packagePrefix = extractFqn(imp.expr)
-              val fqn = if (packagePrefix.nonEmpty) packagePrefix + "." + selName else selName
-              val selectorType: JavaType = typeForFqn(fqn)
-              new J.FieldAccess(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-                id, JLeftPadded.build(ident(selName, Space.EMPTY, selectorType)), selectorType)
-            case _ =>
-              // Can't build valid FieldAccess
-              return visitUnknown(imp)
-          }
-        case other =>
-          return visitUnknown(imp)
-      }
-
-      // Handle selectors for multi-segment imports (e.g., `import java.util.List`)
-      // Skip if we already consumed the selector above (single Ident root case)
-      val alreadyHandledSelector = expr.isInstanceOf[J.Identifier] && imp.selectors.nonEmpty
-      if (!alreadyHandledSelector && imp.selectors.nonEmpty && imp.selectors.size == 1) {
-        val selector = imp.selectors.head
-        selector match {
-          case is @ untpd.ImportSelector(idTree: Trees.Ident[?], untpd.EmptyTree, untpd.EmptyTree) =>
-            if (cursor < source.length && source.charAt(cursor) == '.') cursor += 1
-            // For wildcard imports, use source character to preserve * vs _
-            val selectorName = if (is.isWildcard) {
-              // Read the actual wildcard char from source
-              val adjustedEnd = Math.max(0, imp.span.end - offsetAdjustment)
-              if (adjustedEnd > 0 && adjustedEnd <= source.length) {
-                val lastChar = source.charAt(adjustedEnd - 1)
-                if (lastChar == '*') "*" else "_"
-              } else idTree.name.toString
-            } else idTree.name.toString
-            val packagePrefix = extractFqn(imp.expr)
-            val fqn = if (packagePrefix.nonEmpty) packagePrefix + "." + selectorName else selectorName
-            val selectorType: JavaType = typeForFqn(fqn)
-            qualid = new J.FieldAccess(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-              qualid,
-              JLeftPadded.build(ident(selectorName, Space.EMPTY, selectorType)),
-              selectorType)
-          case _ =>
-        }
-      }
-      
-      // Update cursor to the end of the import
-      if (imp.span.exists) {
-        val adjustedEnd = Math.max(0, imp.span.end - offsetAdjustment)
-        updateCursor(adjustedEnd)
-      }
-      
-      // Create J.Import
+    if (isSimpleImportOrExport(imp, "import")) {
+      val (prefix, qualid) = buildImportOrExportQualid(imp)
+      // J.Import requires a static-import flag and supports an alias slot;
+      // Scala has neither for simple imports.
       new J.Import(
         Tree.randomId(),
         prefix,
         Markers.EMPTY,
-        JLeftPadded.build(false), // static imports are not supported in Scala
+        JLeftPadded.build(false),
         qualid,
-        null // no alias for simple imports
+        null
       )
     } else {
       // Complex imports: braces, aliases (as/=>), wildcards with braces, etc.
@@ -2313,86 +2221,16 @@ class ScalaTreeVisitor(
       )
     }
   }
-  
+
   private def visitExport(exp: Trees.Export[?]): J = {
     // Scala 3 export clauses share their AST shape with imports
-    // (Dotty: both extend `ImportOrExport` with `expr` + `selectors`).
-    // We model the supported subset (no braces, no aliases) as an S.Export
-    // whose `exportClause` is a J.FieldAccess built the same way as
-    // J.Import's qualid. Brace/alias forms are rejected by visitUnknown
-    // so the gap is caught by tests rather than silently degraded.
-    if (!isSimpleExport(exp)) {
+    // (Dotty: both extend `Trees.ImportOrExport` with `expr` + `selectors`),
+    // so we reuse the same qualid-building logic. Brace and alias forms are
+    // not yet modelled; visitUnknown throws so the gap surfaces in tests.
+    if (!isSimpleImportOrExport(exp, "export")) {
       return visitUnknown(exp)
     }
-
-    val adjustedStart = Math.max(0, exp.span.start - offsetAdjustment)
-    val prefix = if (cursor < adjustedStart) {
-      val prefixText = source.substring(cursor, adjustedStart)
-      cursor = adjustedStart
-      Space.format(prefixText)
-    } else {
-      Space.EMPTY
-    }
-
-    val oldInImportContext = isInImportContext
-    isInImportContext = true
-
-    if (exp.expr.span.exists) {
-      val exprStart = Math.max(0, exp.expr.span.start - offsetAdjustment)
-      cursor = exprStart
-    }
-
-    val expr = visitTree(exp.expr)
-    isInImportContext = oldInImportContext
-
-    var qualid: J.FieldAccess = expr match {
-      case fa: J.FieldAccess => fa
-      case id: J.Identifier if exp.selectors.nonEmpty =>
-        val selector = exp.selectors.head
-        selector match {
-          case is @ untpd.ImportSelector(sIdent: Trees.Ident[?], untpd.EmptyTree, untpd.EmptyTree) =>
-            if (cursor < source.length && source.charAt(cursor) == '.') cursor += 1
-            val selName = if (is.isWildcard) {
-              val adjustedEnd = Math.max(0, exp.span.end - offsetAdjustment)
-              if (adjustedEnd > 0 && adjustedEnd <= source.length && source.charAt(adjustedEnd - 1) == '*') "*" else "_"
-            } else sIdent.name.toString
-            new J.FieldAccess(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-              id, JLeftPadded.build(ident(selName, Space.EMPTY)), null)
-          case _ =>
-            return visitUnknown(exp)
-        }
-      case _ =>
-        return visitUnknown(exp)
-    }
-
-    // Multi-segment exports (e.g., `export A.B.c`): apply the trailing selector
-    // to the FieldAccess produced from the expression. This mirrors visitImport.
-    val alreadyHandledSelector = expr.isInstanceOf[J.Identifier] && exp.selectors.nonEmpty
-    if (!alreadyHandledSelector && exp.selectors.nonEmpty && exp.selectors.size == 1) {
-      val selector = exp.selectors.head
-      selector match {
-        case is @ untpd.ImportSelector(idTree: Trees.Ident[?], untpd.EmptyTree, untpd.EmptyTree) =>
-          if (cursor < source.length && source.charAt(cursor) == '.') cursor += 1
-          val selectorName = if (is.isWildcard) {
-            val adjustedEnd = Math.max(0, exp.span.end - offsetAdjustment)
-            if (adjustedEnd > 0 && adjustedEnd <= source.length) {
-              val lastChar = source.charAt(adjustedEnd - 1)
-              if (lastChar == '*') "*" else "_"
-            } else idTree.name.toString
-          } else idTree.name.toString
-          qualid = new J.FieldAccess(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-            qualid,
-            JLeftPadded.build(ident(selectorName, Space.EMPTY)),
-            null)
-        case _ =>
-      }
-    }
-
-    if (exp.span.exists) {
-      val adjustedEnd = Math.max(0, exp.span.end - offsetAdjustment)
-      updateCursor(adjustedEnd)
-    }
-
+    val (prefix, qualid) = buildImportOrExportQualid(exp)
     new S.Export(
       Tree.randomId(),
       prefix,
@@ -2401,45 +2239,132 @@ class ScalaTreeVisitor(
     )
   }
 
-  private def isSimpleExport(exp: Trees.Export[?]): Boolean = {
-    if (exp.span.exists) {
-      val adjustedStart = Math.max(0, exp.span.start - offsetAdjustment)
-      val adjustedEnd = Math.max(0, exp.span.end - offsetAdjustment)
-      if (adjustedStart >= 0 && adjustedEnd <= source.length && adjustedEnd > adjustedStart) {
-        val exportText = source.substring(adjustedStart, adjustedEnd)
-        // Not simple if:
-        // - has braces:  export a.{B, C}
-        // - has rename:  export a.{B as C} or export a.{B => C}
-        // - span doesn't start with `export` (continuation in a comma-separated form)
-        !exportText.contains("{") && !exportText.contains(" as ") && !exportText.contains("=>") &&
-          exportText.trim.startsWith("export")
-      } else {
-        false
-      }
+  /**
+   * Build the `J.FieldAccess` qualid for a simple import or export — i.e. one
+   * with no braces and no aliases. Both `Trees.Import` and `Trees.Export` extend
+   * `Trees.ImportOrExport`, which exposes the shared `expr` and `selectors`
+   * members the construction depends on.
+   *
+   * Returns the leading `Space` (whitespace + comments before the keyword) and
+   * the qualid. Advances the cursor past the end of the import/export. If the
+   * shape can't be modelled, raises via `visitUnknown` so the caller sees a
+   * failure rather than a degraded value.
+   */
+  private def buildImportOrExportQualid(
+    tree: Trees.ImportOrExport[?]
+  ): (Space, J.FieldAccess) = {
+    val adjustedStart = Math.max(0, tree.span.start - offsetAdjustment)
+    val prefix = if (cursor < adjustedStart) {
+      val prefixText = source.substring(cursor, adjustedStart)
+      cursor = adjustedStart
+      Space.format(prefixText)
     } else {
-      false
+      Space.EMPTY
     }
+
+    // Identifier resolution inside an import/export path differs from regular
+    // expression context (e.g. `_` becomes `*` for wildcards), so flag the
+    // visit and restore the previous value when done.
+    val oldInImportContext = isInImportContext
+    isInImportContext = true
+
+    if (tree.expr.span.exists) {
+      val exprStart = Math.max(0, tree.expr.span.start - offsetAdjustment)
+      cursor = exprStart
+    }
+
+    val expr = visitTree(tree.expr)
+    isInImportContext = oldInImportContext
+
+    // Build the qualid: for `(import|export) java.util.List`, expr is
+    // Select(Ident(java), util) and the trailing selector is `List`.
+    // For `(import|export) java.util`, expr is Ident(java) and the only
+    // selector is `util`.
+    var qualid: J.FieldAccess = expr match {
+      case fa: J.FieldAccess => fa
+      case id: J.Identifier if tree.selectors.nonEmpty =>
+        val selector = tree.selectors.head
+        selector match {
+          case is @ untpd.ImportSelector(sIdent: Trees.Ident[?], untpd.EmptyTree, untpd.EmptyTree) =>
+            if (cursor < source.length && source.charAt(cursor) == '.') cursor += 1
+            val selName = wildcardOrName(is, sIdent, tree.span)
+            val selectorType: JavaType = lookupSelectorType(tree.expr, selName)
+            new J.FieldAccess(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+              id, JLeftPadded.build(ident(selName, Space.EMPTY, selectorType)), selectorType)
+          case _ =>
+            return visitUnknown(tree)
+        }
+      case _ =>
+        return visitUnknown(tree)
+    }
+
+    // Multi-segment paths (e.g., `import java.util.List`): apply the trailing
+    // selector to the FieldAccess produced from the expression. Skipped if the
+    // single-Ident-root branch above already consumed it.
+    val alreadyHandledSelector = expr.isInstanceOf[J.Identifier] && tree.selectors.nonEmpty
+    if (!alreadyHandledSelector && tree.selectors.nonEmpty && tree.selectors.size == 1) {
+      val selector = tree.selectors.head
+      selector match {
+        case is @ untpd.ImportSelector(idTree: Trees.Ident[?], untpd.EmptyTree, untpd.EmptyTree) =>
+          if (cursor < source.length && source.charAt(cursor) == '.') cursor += 1
+          val selectorName = wildcardOrName(is, idTree, tree.span)
+          val selectorType: JavaType = lookupSelectorType(tree.expr, selectorName)
+          qualid = new J.FieldAccess(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+            qualid,
+            JLeftPadded.build(ident(selectorName, Space.EMPTY, selectorType)),
+            selectorType)
+        case _ =>
+      }
+    }
+
+    if (tree.span.exists) {
+      val adjustedEnd = Math.max(0, tree.span.end - offsetAdjustment)
+      updateCursor(adjustedEnd)
+    }
+
+    (prefix, qualid)
   }
 
-  private def isSimpleImport(imp: Trees.Import[?]): Boolean = {
-    // Check if this is a simple import without braces
-    if (imp.span.exists) {
-      val adjustedStart = Math.max(0, imp.span.start - offsetAdjustment)
-      val adjustedEnd = Math.max(0, imp.span.end - offsetAdjustment)
-      if (adjustedStart >= 0 && adjustedEnd <= source.length && adjustedEnd > adjustedStart) {
-        val importText = source.substring(adjustedStart, adjustedEnd)
-        // Not simple if:
-        // - has braces: import a.{B, C}
-        // - has rename: import a.{B as C} or import a.{B => C}
-        // - span doesn't contain "import" keyword (part of comma-separated import like `import A._, B._`)
-        !importText.contains("{") && !importText.contains(" as ") && !importText.contains("=>") &&
-          importText.trim.startsWith("import")
-      } else {
-        false
-      }
-    } else {
-      false
-    }
+  /**
+   * For a wildcard selector, read the wildcard char from source so we preserve
+   * `*` (Scala 3) vs `_` (legacy) verbatim. For a named selector, return the
+   * name as written in the AST.
+   */
+  private def wildcardOrName(
+    is: untpd.ImportSelector,
+    idTree: Trees.Ident[?],
+    span: Spans.Span
+  ): String = {
+    if (!is.isWildcard) return idTree.name.toString
+    val adjustedEnd = Math.max(0, span.end - offsetAdjustment)
+    if (adjustedEnd > 0 && adjustedEnd <= source.length && source.charAt(adjustedEnd - 1) == '*') "*" else "_"
+  }
+
+  /**
+   * Best-effort type lookup for a selector by FQN. Useful for imports
+   * (`scala.collection.mutable` resolves to a known type); for exports the
+   * selector usually names a member of a local value, so this typically
+   * returns `null` — which is the desired behavior.
+   */
+  private def lookupSelectorType(expr: Trees.Tree[?], selectorName: String): JavaType = {
+    val packagePrefix = extractFqn(expr)
+    val fqn = if (packagePrefix.nonEmpty) packagePrefix + "." + selectorName else selectorName
+    typeForFqn(fqn)
+  }
+
+  /**
+   * True for an import or export with no braces and no rename arrows, whose
+   * span starts with the given keyword (filters out continuations of
+   * comma-separated forms like `import A._, B._`).
+   */
+  private def isSimpleImportOrExport(tree: Trees.ImportOrExport[?], keyword: String): Boolean = {
+    if (!tree.span.exists) return false
+    val adjustedStart = Math.max(0, tree.span.start - offsetAdjustment)
+    val adjustedEnd = Math.max(0, tree.span.end - offsetAdjustment)
+    if (adjustedStart < 0 || adjustedEnd > source.length || adjustedEnd <= adjustedStart) return false
+    val text = source.substring(adjustedStart, adjustedEnd)
+    !text.contains("{") && !text.contains(" as ") && !text.contains("=>") &&
+      text.trim.startsWith(keyword)
   }
   
   

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -197,6 +197,7 @@ class ScalaTreeVisitor(
       case postfixOp: untpd.PostfixOp => visitPostfixOp(postfixOp)
       case parens: untpd.Parens => visitParentheses(parens)
       case imp: Trees.Import[?] => visitImport(imp)
+      case exp: Trees.Export[?] => visitExport(exp)
       case pkg: Trees.PackageDef[?] => visitPackageDef(pkg)
       case newTree: Trees.New[?] => visitNew(newTree)
       case vd: Trees.ValDef[?] => visitValDef(vd)
@@ -2313,6 +2314,113 @@ class ScalaTreeVisitor(
     }
   }
   
+  private def visitExport(exp: Trees.Export[?]): J = {
+    // Scala 3 export clauses share their AST shape with imports
+    // (Dotty: both extend `ImportOrExport` with `expr` + `selectors`).
+    // We model the supported subset (no braces, no aliases) as an S.Export
+    // whose `exportClause` is a J.FieldAccess built the same way as
+    // J.Import's qualid. Brace/alias forms are rejected by visitUnknown
+    // so the gap is caught by tests rather than silently degraded.
+    if (!isSimpleExport(exp)) {
+      return visitUnknown(exp)
+    }
+
+    val adjustedStart = Math.max(0, exp.span.start - offsetAdjustment)
+    val prefix = if (cursor < adjustedStart) {
+      val prefixText = source.substring(cursor, adjustedStart)
+      cursor = adjustedStart
+      Space.format(prefixText)
+    } else {
+      Space.EMPTY
+    }
+
+    val oldInImportContext = isInImportContext
+    isInImportContext = true
+
+    if (exp.expr.span.exists) {
+      val exprStart = Math.max(0, exp.expr.span.start - offsetAdjustment)
+      cursor = exprStart
+    }
+
+    val expr = visitTree(exp.expr)
+    isInImportContext = oldInImportContext
+
+    var qualid: J.FieldAccess = expr match {
+      case fa: J.FieldAccess => fa
+      case id: J.Identifier if exp.selectors.nonEmpty =>
+        val selector = exp.selectors.head
+        selector match {
+          case is @ untpd.ImportSelector(sIdent: Trees.Ident[?], untpd.EmptyTree, untpd.EmptyTree) =>
+            if (cursor < source.length && source.charAt(cursor) == '.') cursor += 1
+            val selName = if (is.isWildcard) {
+              val adjustedEnd = Math.max(0, exp.span.end - offsetAdjustment)
+              if (adjustedEnd > 0 && adjustedEnd <= source.length && source.charAt(adjustedEnd - 1) == '*') "*" else "_"
+            } else sIdent.name.toString
+            new J.FieldAccess(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+              id, JLeftPadded.build(ident(selName, Space.EMPTY)), null)
+          case _ =>
+            return visitUnknown(exp)
+        }
+      case _ =>
+        return visitUnknown(exp)
+    }
+
+    // Multi-segment exports (e.g., `export A.B.c`): apply the trailing selector
+    // to the FieldAccess produced from the expression. This mirrors visitImport.
+    val alreadyHandledSelector = expr.isInstanceOf[J.Identifier] && exp.selectors.nonEmpty
+    if (!alreadyHandledSelector && exp.selectors.nonEmpty && exp.selectors.size == 1) {
+      val selector = exp.selectors.head
+      selector match {
+        case is @ untpd.ImportSelector(idTree: Trees.Ident[?], untpd.EmptyTree, untpd.EmptyTree) =>
+          if (cursor < source.length && source.charAt(cursor) == '.') cursor += 1
+          val selectorName = if (is.isWildcard) {
+            val adjustedEnd = Math.max(0, exp.span.end - offsetAdjustment)
+            if (adjustedEnd > 0 && adjustedEnd <= source.length) {
+              val lastChar = source.charAt(adjustedEnd - 1)
+              if (lastChar == '*') "*" else "_"
+            } else idTree.name.toString
+          } else idTree.name.toString
+          qualid = new J.FieldAccess(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+            qualid,
+            JLeftPadded.build(ident(selectorName, Space.EMPTY)),
+            null)
+        case _ =>
+      }
+    }
+
+    if (exp.span.exists) {
+      val adjustedEnd = Math.max(0, exp.span.end - offsetAdjustment)
+      updateCursor(adjustedEnd)
+    }
+
+    new S.Export(
+      Tree.randomId(),
+      prefix,
+      Markers.EMPTY,
+      qualid
+    )
+  }
+
+  private def isSimpleExport(exp: Trees.Export[?]): Boolean = {
+    if (exp.span.exists) {
+      val adjustedStart = Math.max(0, exp.span.start - offsetAdjustment)
+      val adjustedEnd = Math.max(0, exp.span.end - offsetAdjustment)
+      if (adjustedStart >= 0 && adjustedEnd <= source.length && adjustedEnd > adjustedStart) {
+        val exportText = source.substring(adjustedStart, adjustedEnd)
+        // Not simple if:
+        // - has braces:  export a.{B, C}
+        // - has rename:  export a.{B as C} or export a.{B => C}
+        // - span doesn't start with `export` (continuation in a comma-separated form)
+        !exportText.contains("{") && !exportText.contains(" as ") && !exportText.contains("=>") &&
+          exportText.trim.startsWith("export")
+      } else {
+        false
+      }
+    } else {
+      false
+    }
+  }
+
   private def isSimpleImport(imp: Trees.Import[?]): Boolean = {
     // Check if this is a simple import without braces
     if (imp.span.exists) {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ExportTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ExportTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.scala.Assertions.scala;
+
+class ExportTest implements RewriteTest {
+
+    @Test
+    void singleExport() {
+        rewriteRun(
+          scala(
+            """
+            class C(inner: Inner) {
+              export inner.foo
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void nestedPathExport() {
+        rewriteRun(
+          scala(
+            """
+            class C(a: A) {
+              export a.b.c
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void wildcardExportStar() {
+        rewriteRun(
+          scala(
+            """
+            class C(inner: Inner) {
+              export inner.*
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void wildcardExportUnderscore() {
+        // `_` is the legacy wildcard form still accepted by the compiler;
+        // exports themselves are Scala 3 only.
+        rewriteRun(
+          scala(
+            """
+            class C(inner: Inner) {
+              export inner._
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void multipleExports() {
+        rewriteRun(
+          scala(
+            """
+            class C(a: A, b: B) {
+              export a.foo
+              export b.bar
+            }
+            """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?

Add support for a new LST element in Scala representing `export` statements.
Re-using part of the parsing logic with `import` statements handling which are similar.

## What's your motivation?

It wasn't supported yet and the parser choked on these.