### PR TITLE
Scala: fix whitespace handling around `=>`

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -212,7 +212,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                     p.append("catch {");
                 }
                 // Print case with AST whitespace
-                J.VariableDeclarations varDecl = aCatch.getParameter().getTree();
+                JRightPadded<J.VariableDeclarations> paramPadded = aCatch.getParameter().getPadding().getTree();
+                J.VariableDeclarations varDecl = paramPadded.getElement();
                 visitSpace(varDecl.getPrefix(), Space.Location.VARIABLE_DECLARATIONS_PREFIX, p);
                 p.append("case");
                 if (!varDecl.getVariables().isEmpty()) {
@@ -222,7 +223,13 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                     p.append(":");
                     visit(varDecl.getTypeExpression(), p);
                 }
-                p.append(" =>");
+                Space afterParam = paramPadded.getAfter();
+                if (afterParam.getWhitespace().isEmpty() && afterParam.getComments().isEmpty()) {
+                    p.append(' ');
+                } else {
+                    visitSpace(afterParam, Space.Location.CONTROL_PARENTHESES_PREFIX, p);
+                }
+                p.append("=>");
                 for (Statement stmt : aCatch.getBody().getStatements()) {
                     visit(stmt, p);
                 }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -223,12 +223,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                     p.append(":");
                     visit(varDecl.getTypeExpression(), p);
                 }
-                Space afterParam = paramPadded.getAfter();
-                if (afterParam.getWhitespace().isEmpty() && afterParam.getComments().isEmpty()) {
-                    p.append(' ');
-                } else {
-                    visitSpace(afterParam, Space.Location.CONTROL_PARENTHESES_PREFIX, p);
-                }
+                visitSpace(paramPadded.getAfter(), Space.Location.CONTROL_PARENTHESES_PREFIX, p);
                 p.append("=>");
                 for (Statement stmt : aCatch.getBody().getStatements()) {
                     visit(stmt, p);
@@ -275,12 +270,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             // The last label's after space is the space before "if" guard, or
             // the space before "=>" when there is no guard.
             if (li == labelPadding.size() - 1) {
-                Space afterLabel = lp.getAfter();
-                if (case_.getGuard() == null && afterLabel.getWhitespace().isEmpty() && afterLabel.getComments().isEmpty()) {
-                    p.append(' ');
-                } else {
-                    visitSpace(afterLabel, JRightPadded.Location.CASE.getAfterLocation(), p);
-                }
+                visitSpace(lp.getAfter(), JRightPadded.Location.CASE.getAfterLocation(), p);
             }
         }
         if (case_.getGuard() != null) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -265,16 +265,23 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         for (int li = 0; li < labelPadding.size(); li++) {
             JRightPadded<J> lp = labelPadding.get(li);
             visit(lp.getElement(), p);
-            // The last label's after space is the space before "if" guard (if any)
-            if (li == labelPadding.size() - 1 && case_.getGuard() != null) {
-                visitSpace(lp.getAfter(), JRightPadded.Location.CASE.getAfterLocation(), p);
+            // The last label's after space is the space before "if" guard, or
+            // the space before "=>" when there is no guard.
+            if (li == labelPadding.size() - 1) {
+                Space afterLabel = lp.getAfter();
+                if (case_.getGuard() == null && afterLabel.getWhitespace().isEmpty() && afterLabel.getComments().isEmpty()) {
+                    p.append(' ');
+                } else {
+                    visitSpace(afterLabel, JRightPadded.Location.CASE.getAfterLocation(), p);
+                }
             }
         }
         if (case_.getGuard() != null) {
             p.append("if");
             visit(case_.getGuard(), p);
+            p.append(' ');
         }
-        p.append(" =>");
+        p.append("=>");
         if (case_.getPadding().getBody() != null) {
             visit(case_.getPadding().getBody().getElement(), p);
         }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5797,6 +5797,9 @@ class ScalaTreeVisitor(
           case expr: Expression => guard = expr
           case _ =>
         }
+      } else {
+        val arrowPos = source.indexOf("=>", cursor)
+        if (arrowPos >= cursor) labelAfter = Space.format(source.substring(cursor, arrowPos))
       }
       val labels = new util.ArrayList[JRightPadded[J]]()
       labels.add(JRightPadded.build(patternJ).withAfter(labelAfter))

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5551,14 +5551,16 @@ class ScalaTreeVisitor(
           case _ => ("_", null)
         }
         updateCursor(caseDef.pat.span.end)
-        if (arrowIdx >= 0) { val a = source.indexOf("=>", cursor); if (a >= 0) cursor = a + 2 }
+        val arrowAbs = source.indexOf("=>", cursor)
+        val spaceBeforeArrow = if (arrowAbs >= cursor) Space.format(source.substring(cursor, arrowAbs)) else Space.EMPTY
+        if (arrowIdx >= 0 && arrowAbs >= 0) cursor = arrowAbs + 2
 
         val paramId = ident(paramName, Space.format(" "))
         val namedVar = new J.VariableDeclarations.NamedVariable(Tree.randomId(), Space.EMPTY, Markers.EMPTY, paramId, Collections.emptyList(), null, null)
         val varDecl = new J.VariableDeclarations(Tree.randomId(), casePrefix, Markers.EMPTY,
           Collections.emptyList(), Collections.emptyList(), paramType, null, Collections.emptyList(),
           Collections.singletonList(JRightPadded.build(namedVar)))
-        val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(varDecl))
+        val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(varDecl).withAfter(spaceBeforeArrow))
 
         val caseBody = visitTree(caseDef.body) match {
           case block: J.Block => block
@@ -5670,14 +5672,16 @@ class ScalaTreeVisitor(
           case _ => ("_", null)
         }
         updateCursor(caseDef.pat.span.end)
-        if (arrowIdx >= 0) { val a = source.indexOf("=>", cursor); if (a >= 0) cursor = a + 2 }
+        val arrowAbs = source.indexOf("=>", cursor)
+        val spaceBeforeArrow = if (arrowAbs >= cursor) Space.format(source.substring(cursor, arrowAbs)) else Space.EMPTY
+        if (arrowIdx >= 0 && arrowAbs >= 0) cursor = arrowAbs + 2
 
         val paramId = ident(paramName, Space.format(" "))
         val namedVar = new J.VariableDeclarations.NamedVariable(Tree.randomId(), Space.EMPTY, Markers.EMPTY, paramId, Collections.emptyList(), null, null)
         val varDecl = new J.VariableDeclarations(Tree.randomId(), casePrefix, Markers.EMPTY,
           Collections.emptyList(), Collections.emptyList(), paramType, null, Collections.emptyList(),
           Collections.singletonList(JRightPadded.build(namedVar)))
-        val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(varDecl))
+        val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(varDecl).withAfter(spaceBeforeArrow))
 
         val caseBody = visitTree(caseDef.body) match {
           case block: J.Block => block

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LambdaTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LambdaTest.java
@@ -177,6 +177,19 @@ class LambdaTest implements RewriteTest {
     }
 
     @Test
+    void lambdaWithExtraWhitespaceBeforeArrow() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  val f = (x: Int)   => x + 1
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void partialFunctionLiteralAsMapArgument() {
         rewriteRun(
             scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
@@ -215,6 +215,22 @@ class MatchTest implements RewriteTest {
     }
 
     @Test
+    void matchWithExtraWhitespaceBeforeArrow() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              def handle(x: Any): String = x match {
+                case "a"   => "1"
+                case _ => "0"
+              }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void matchWithLineCommentContainingIfBeforeGuard() {
         rewriteRun(
           scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
@@ -152,6 +152,24 @@ class TryTest implements RewriteTest {
     }
 
     @Test
+    void catchWithExtraWhitespaceBeforeArrow() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                def run(): Unit = try {
+                  println("risky")
+                } catch {
+                  case e: RuntimeException   => println("rt")
+                  case e: Exception          => println("ex")
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void tryWithTypedPattern() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

Fixing Scala parser to handle whitespace around `=>` better.

## What's your motivation?

It suffered from idempotency issues.