### PR TITLE
Bump default Gradle test version to 8.14.5

### DIFF
--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelBuilder.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelBuilder.java
@@ -83,7 +83,7 @@ public class OpenRewriteModelBuilder {
             gradleVersion = wrapperGradleVersion(projectDir.toPath().resolve("gradle/wrapper/gradle-wrapper.properties"));
             connector.useBuildDistribution();
         } else {
-            gradleVersion = System.getProperty("org.openrewrite.test.gradleVersion", "8.14.3");
+            gradleVersion = System.getProperty("org.openrewrite.test.gradleVersion", "8.14.5");
             connector.useGradleVersion(gradleVersion);
         }
         connector


### PR DESCRIPTION
Updates the fallback Gradle version used by `OpenRewriteModelBuilder` from 8.14.3 to 8.14.5 when no wrapper is present and the `org.openrewrite.test.gradleVersion` system property is not set.

We saw some problems with Java 25 with 8.14.3, and with Kotlin DLS with 8.14.4.
Hoping 8.14.5 fixes both to unlock Java 25 for our workflows downstream.