### PR TITLE
Scala: introduce ExpressionStatement

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaIsoVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaIsoVisitor.java
@@ -43,6 +43,11 @@ public class ScalaIsoVisitor<P> extends ScalaVisitor<P> {
     }
 
     @Override
+    public J visitExpressionStatement(S.ExpressionStatement expressionStatement, P p) {
+        return super.visitExpressionStatement(expressionStatement, p);
+    }
+
+    @Override
     public Expression visitExpression(Expression expression, P p) {
         return (Expression) super.visitExpression(expression, p);
     }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -510,6 +510,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         } else if (tree instanceof S.StatementExpression) {
             // Transparent — visit the inner statement
             return visit(((S.StatementExpression) tree).getStatement(), p);
+        } else if (tree instanceof S.ExpressionStatement) {
+            // Transparent — visit the inner expression
+            return visit(((S.ExpressionStatement) tree).getExpression(), p);
         } else if (tree instanceof S.TypeAscription) {
             return visitTypeAscription((S.TypeAscription) tree, p);
         } else if (tree instanceof S.TypeAlias) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -133,6 +133,11 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         return statementExpression.acceptScala(this, p);
     }
 
+    public J visitExpressionStatement(S.ExpressionStatement expressionStatement, P p) {
+        // Transparent — just visit the inner expression
+        return expressionStatement.acceptScala(this, p);
+    }
+
     public J visitTypeAscription(S.TypeAscription typeAscription, P p) {
         S.TypeAscription t = typeAscription;
         t = t.withPrefix(visitSpace(t.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -518,6 +518,87 @@ public interface S extends J {
     }
 
     /**
+     * Wraps an Expression to make it usable as a Statement.
+     * In Scala, expressions can appear in statement position (e.g. inside a class
+     * body or a block), and we need to model that without losing the expression
+     * type. This wrapper is transparent — prefix, markers, and coordinates all
+     * delegate to the inner expression.
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    final class ExpressionStatement implements S, Expression, Statement {
+
+        @Getter
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        @Getter
+        Expression expression;
+
+        public ExpressionStatement(UUID id, Expression expression) {
+            this.id = id;
+            this.expression = expression;
+        }
+
+        public ExpressionStatement withId(UUID id) {
+            return this.id == id ? this : new ExpressionStatement(id, expression);
+        }
+
+        public ExpressionStatement withExpression(Expression expression) {
+            return this.expression == expression ? this : new ExpressionStatement(id, expression);
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            J j = v.visit(getExpression(), p);
+            if (j instanceof ExpressionStatement) {
+                return j;
+            } else if (j instanceof Expression) {
+                return withExpression((Expression) j);
+            }
+            return j;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <J2 extends J> J2 withPrefix(Space space) {
+            return (J2) withExpression(expression.withPrefix(space));
+        }
+
+        @Override
+        public Space getPrefix() {
+            return expression.getPrefix();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <J2 extends Tree> J2 withMarkers(Markers markers) {
+            return (J2) withExpression(expression.withMarkers(markers));
+        }
+
+        @Override
+        public Markers getMarkers() {
+            return expression.getMarkers();
+        }
+
+        @Override
+        public @Nullable JavaType getType() {
+            return expression.getType();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends J> T withType(@Nullable JavaType type) {
+            return (T) withExpression(expression.withType(type));
+        }
+
+        @Override
+        public CoordinateBuilder.Statement getCoordinates() {
+            return new CoordinateBuilder.Statement(this);
+        }
+    }
+
+    /**
      * Represents Scala type ascription: {@code expr: Type}.
      * <p>
      * This is NOT a cast — it's a compile-time type annotation that narrows/widens

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -3752,10 +3752,14 @@ class ScalaTreeVisitor(
     // Visit all statements in the block
     for (i <- block.stats.indices) {
       val stat = block.stats(i)
-      val visitResult = visitTree(stat)
+      val visitResult = visitTree(stat) match {
+        case expr: Expression if !expr.isInstanceOf[Statement] =>
+          new S.ExpressionStatement(Tree.randomId(), expr)
+        case other => other
+      }
       visitResult match {
         case null => // Skip null statements (e.g., package declarations)
-        case stmt: Statement => 
+        case stmt: Statement =>
           // Extract trailing space after this statement
           val statEnd = Math.max(0, stat.span.end - offsetAdjustment)
           val nextStart = if (i < block.stats.length - 1) {
@@ -5311,11 +5315,10 @@ class ScalaTreeVisitor(
         visitTree(rhs) match {
             case block: J.Block => block
             case expr: Expression =>
-              // Ensure expression can be used as Statement in the block.
-              // S.StatementExpression now accepts J, so wrap pure Expressions.
+              // Wrap Expression in S.ExpressionStatement so it can be used as a Statement.
               val stmtExpr: Statement = expr match {
                 case s: Statement => s
-                case _ => new S.StatementExpression(Tree.randomId(), expr)
+                case _ => new S.ExpressionStatement(Tree.randomId(), expr)
               }
               val statements = new util.ArrayList[JRightPadded[Statement]]()
               statements.add(JRightPadded.build(stmtExpr))
@@ -5547,16 +5550,17 @@ class ScalaTreeVisitor(
     }
 
     // Visit the try body
+    val omitBracesMarkers = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
     val body = visitTree(parsedTry.expr) match {
       case block: J.Block => block
-      case expr: Expression =>
-        val stmts = new util.ArrayList[JRightPadded[Statement]]()
-        stmts.add(JRightPadded.build(expr.asInstanceOf[Statement]))
-        new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), stmts, Space.EMPTY)
       case stmt: Statement =>
         val stmts = new util.ArrayList[JRightPadded[Statement]]()
         stmts.add(JRightPadded.build(stmt))
-        new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), stmts, Space.EMPTY)
+        new J.Block(Tree.randomId(), Space.EMPTY, omitBracesMarkers, JRightPadded.build(false), stmts, Space.EMPTY)
+      case expr: Expression =>
+        val stmts = new util.ArrayList[JRightPadded[Statement]]()
+        stmts.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
+        new J.Block(Tree.randomId(), Space.EMPTY, omitBracesMarkers, JRightPadded.build(false), stmts, Space.EMPTY)
       case _ => visitUnknown(parsedTry)
     }
 
@@ -5621,11 +5625,11 @@ class ScalaTreeVisitor(
 
         val caseBody = visitTree(caseDef.body) match {
           case block: J.Block => block
-          case expr: Expression =>
-            val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(expr.asInstanceOf[Statement]))
-            new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), s, Space.EMPTY)
           case stmt: Statement =>
             val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(stmt))
+            new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), s, Space.EMPTY)
+          case expr: Expression =>
+            val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
             new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), s, Space.EMPTY)
           case _ => new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), new util.ArrayList(), Space.EMPTY)
         }
@@ -5655,11 +5659,15 @@ class ScalaTreeVisitor(
       val fs = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 50, source.length)) else ""
       val fi = fs.indexOf("finally"); val fSpace = if (fi > 0) Space.format(fs.substring(0, fi)) else Space.EMPTY
       if (fi >= 0) cursor = cursor + fi + 7
+      val parsedFinallyOmitBraces = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
       val fb = visitTree(parsedTry.finalizer) match {
         case block: J.Block => block
+        case stmt: Statement =>
+          val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(stmt))
+          new J.Block(Tree.randomId(), Space.EMPTY, parsedFinallyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
         case expr: Expression =>
-          val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(expr.asInstanceOf[Statement]))
-          new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), s, Space.EMPTY)
+          val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
+          new J.Block(Tree.randomId(), Space.EMPTY, parsedFinallyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
         case _ => null
       }
       if (fb != null) JLeftPadded.build(fb).withBefore(fSpace) else null
@@ -5674,16 +5682,17 @@ class ScalaTreeVisitor(
     val tryStart = Math.max(0, tryTree.span.start - offsetAdjustment)
     if (tryStart >= cursor && tryStart + 3 <= source.length) cursor = tryStart + 3
 
+    val omitBracesMarkers = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
     val body = visitTree(tryTree.expr) match {
       case block: J.Block => block
-      case expr: Expression =>
-        val stmts = new util.ArrayList[JRightPadded[Statement]]()
-        stmts.add(JRightPadded.build(expr.asInstanceOf[Statement]))
-        new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), stmts, Space.EMPTY)
       case stmt: Statement =>
         val stmts = new util.ArrayList[JRightPadded[Statement]]()
         stmts.add(JRightPadded.build(stmt))
-        new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), stmts, Space.EMPTY)
+        new J.Block(Tree.randomId(), Space.EMPTY, omitBracesMarkers, JRightPadded.build(false), stmts, Space.EMPTY)
+      case expr: Expression =>
+        val stmts = new util.ArrayList[JRightPadded[Statement]]()
+        stmts.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
+        new J.Block(Tree.randomId(), Space.EMPTY, omitBracesMarkers, JRightPadded.build(false), stmts, Space.EMPTY)
       case _ => return visitUnknown(tryTree).asInstanceOf[J.Try]
     }
 
@@ -5742,11 +5751,11 @@ class ScalaTreeVisitor(
 
         val caseBody = visitTree(caseDef.body) match {
           case block: J.Block => block
-          case expr: Expression =>
-            val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(expr.asInstanceOf[Statement]))
-            new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), s, Space.EMPTY)
           case stmt: Statement =>
             val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(stmt))
+            new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), s, Space.EMPTY)
+          case expr: Expression =>
+            val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
             new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), s, Space.EMPTY)
           case _ => new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), new util.ArrayList(), Space.EMPTY)
         }
@@ -5775,14 +5784,15 @@ class ScalaTreeVisitor(
       val fs = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 50, source.length)) else ""
       val fi = fs.indexOf("finally"); val fSpace = if (fi > 0) Space.format(fs.substring(0, fi)) else Space.EMPTY
       if (fi >= 0) cursor = cursor + fi + 7
+      val finallyOmitBraces = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
       val fb = visitTree(tryTree.finalizer) match {
         case block: J.Block => block
-        case expr: Expression =>
-          val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(expr.asInstanceOf[Statement]))
-          new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), s, Space.EMPTY)
         case stmt: Statement =>
           val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(stmt))
-          new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), s, Space.EMPTY)
+          new J.Block(Tree.randomId(), Space.EMPTY, finallyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
+        case expr: Expression =>
+          val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
+          new J.Block(Tree.randomId(), Space.EMPTY, finallyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
         case _ => null
       }
       if (fb != null) JLeftPadded.build(fb).withBefore(fSpace) else null

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -3093,6 +3093,8 @@ class ScalaTreeVisitor(
           if (stat.span.exists && !isSynth && visitedSpans.add(stat.span.start)) {
             visitTree(stat) match {
               case stmt: Statement => statements.add(JRightPadded.build(stmt))
+              case expr: Expression =>
+                statements.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
               case _ =>
             }
           }
@@ -4363,6 +4365,8 @@ class ScalaTreeVisitor(
                   case null =>
                   case stmt: Statement =>
                     statements.add(JRightPadded.build(stmt))
+                  case expr: Expression =>
+                    statements.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
                   case _ =>
                 }
               }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixOpTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixOpTest.java
@@ -85,6 +85,103 @@ class InfixOpTest implements RewriteTest {
     }
 
     @Test
+    void matchCaseWithExpression() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              val x = 1 match {
+                case 1 => 2 + 3
+                case _ => 0
+              }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void ifThenExpressionBody() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              val x = if (true) 1 + 2 else 3
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void whileBodyExpression() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              def run(): Unit = while (false) 1 + 2
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void tryWithExpressionBody() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              val x = try 1 + 2 catch { case _: Throwable => 0 }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void tryCatchCaseWithExpression() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              val x = try { 1 } catch { case _: Throwable => 1 + 2 }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void tryFinallyWithExpression() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              val x = try { 1 } finally 1 + 2
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void stringInfixAsBlockStatement() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              def run(): Int = {
+                1 + 2
+                3
+              }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void stringInfixInClassBody() {
         rewriteRun(
           scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixOpTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixOpTest.java
@@ -85,6 +85,19 @@ class InfixOpTest implements RewriteTest {
     }
 
     @Test
+    void stringInfixInClassBody() {
+        rewriteRun(
+          scala(
+            """
+            class Test {
+              "name" - "x"
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void compoundAssignPlus() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

Adding the `ExpressionStatement` wrapper LST element to Scala.
And using it in several cases.

## What's your motivation?

Parsing suffers from idempotency issues. Often swallowing silently some portions of code.