### PR TITLE
Scala: support * methods with tuple

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -4863,9 +4863,22 @@ class ScalaTreeVisitor(
       // The AST has one block, so the inner braces are lost in the round-trip
     }
 
-    // Detect parameterless methods (def name: Type = ...) — no parens in source
+    // Detect parameterless methods (def name: Type = ...) — no parens in source.
+    // Use nameSpan when available so symbolic names like `*` or `+:` are skipped
+    // correctly (otherwise the alpha-only name scan stops at the first char and
+    // mistakes the body's opening `(` for a parameter list).
     var hasParensInSource = true
-    if (adjustedStart < adjustedEnd && adjustedEnd <= source.length) {
+    if (dd.nameSpan.exists) {
+      val nameEnd = Math.max(0, dd.nameSpan.end - offsetAdjustment)
+      var i = nameEnd
+      while (i < source.length && source.charAt(i).isWhitespace) i += 1
+      if (i < source.length) {
+        val nextCh = source.charAt(i)
+        if (nextCh == ':' || nextCh == '=') {
+          hasParensInSource = false
+        }
+      }
+    } else if (adjustedStart < adjustedEnd && adjustedEnd <= source.length) {
       val defSource = source.substring(adjustedStart, adjustedEnd)
       val defIdx = defSource.indexOf("def ")
       if (defIdx >= 0) {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -173,4 +173,17 @@ class MethodDeclarationTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void symbolicNameWithTupleBody() {
+        rewriteRun(
+            scala(
+                """
+                class Foo {
+                  def * = (1, 2, 3)
+                }
+                """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fix a corner case in Scala parsing, a method with `*` as its name and tuple as implementation, e.g. `def * = (1, 2, 3)`.

## What's your motivation?

This suffers from an idempotency problem.