### PR TITLE
Scala: fix parsing of whitespace around `_.` calls

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7086,8 +7086,13 @@ class ScalaTreeVisitor(
     }.toSet
     
     if (syntheticParams.nonEmpty) {
-      // Check if the source contains actual underscore placeholders
+      // Check if the source contains actual underscore placeholders.
+      // `extractSource` advances `cursor` to the span end, which would clobber
+      // the prefix extraction below — save and restore so leading whitespace
+      // (e.g. the space after a comma in `foo(a, _.toString)`) is preserved.
+      val savedCursor = cursor
       val funcSource = extractSource(func.span)
+      cursor = savedCursor
       val hasUnderscorePlaceholder = funcSource.contains("_")
       
       // If we have synthetic params and underscore in source, it's likely a placeholder lambda

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LambdaTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LambdaTest.java
@@ -92,6 +92,19 @@ class LambdaTest implements RewriteTest {
     }
 
     @Test
+    void underscoreLambdaAsSecondArgument() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  foo(x => x.bar, _.toString)
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void lambdaWithBlock() {
         rewriteRun(
             scala(


### PR DESCRIPTION
## What's changed?

Fix Scala parser for `_.` calls and whitespace around them.

## What's your motivation?

The parser suffers from idempotency issues.