### PR TITLE
Scala: fix printer hardcoded whitespace

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -276,12 +276,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         if (case_.getGuard() != null) {
             p.append("if");
             visit(case_.getGuard(), p);
-            Space guardArrowSpace = case_.getPadding().getStatements().getBefore();
-            if (guardArrowSpace.isEmpty()) {
-                p.append(' ');
-            } else {
-                visitSpace(guardArrowSpace, Space.Location.CASE, p);
-            }
+            visitSpace(case_.getPadding().getStatements().getBefore(), Space.Location.CASE, p);
         }
         p.append("=>");
         if (case_.getPadding().getBody() != null) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -301,9 +301,6 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             }
         }
         if (!defAlreadyPrinted) {
-            if (!method.getModifiers().isEmpty()) {
-                p.append(" ");
-            }
             p.append("def");
         }
         visit(method.getName(), p);
@@ -348,9 +345,6 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 if (!varDecl.getVariables().isEmpty() &&
                     varDecl.getVariables().get(0).getPadding().getInitializer() != null) {
                     JLeftPadded<Expression> init = varDecl.getVariables().get(0).getPadding().getInitializer();
-                    if (init.getBefore().isEmpty()) {
-                        p.append(" ");
-                    }
                     visitLeftPadded("=", init, JLeftPadded.Location.VARIABLE_INITIALIZER, p);
                 }
             } else {
@@ -972,39 +966,34 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
     public J visitVariableDeclarations(J.VariableDeclarations multiVariable, PrintOutputCapture<P> p) {
         beforeSyntax(multiVariable, Space.Location.VARIABLE_DECLARATIONS_PREFIX, p);
         visit(multiVariable.getLeadingAnnotations(), p);
-        
-        // If we have annotations, ensure space after them before modifiers/val/var
-        if (!multiVariable.getLeadingAnnotations().isEmpty()) {
-            p.append(" ");
-        }
-        
+
         // Check if this is a lambda parameter - if so, don't print val/var
         boolean isLambdaParam = multiVariable.getMarkers().findFirst(
             org.openrewrite.scala.marker.LambdaParameter.class).isPresent();
-        
-        // Print modifiers, but handle Final specially since Scala uses val/var.
-        // The implicit Final modifier (keyword=null) prints as "val".
-        // An explicit "final" modifier prints normally.
-        // The "lazy" modifier is a LanguageExtension and prints via visitModifier.
-        boolean isVal = false;
-        boolean hasVisibleModifier = false;
 
+        // Print modifiers, but handle Final specially since Scala uses val/var.
+        // The implicit Final modifier (keyword=null) marks val; (keyword="given") marks given.
+        // Its prefix carries the source whitespace between the last visible modifier (or annotations)
+        // and the val/given keyword.
+        // An explicit "final" modifier prints normally.
+        boolean hasVisibleModifier = false;
         String valVarKeyword = "var";
+        Space valVarPrefix = null;
+        boolean annotationGapBridged = false;
         for (J.Modifier m : multiVariable.getModifiers()) {
-            if (m.getType() == J.Modifier.Type.Final) {
-                // Any Final modifier means this is a val (or given)
-                isVal = true;
-                if ("given".equals(m.getKeyword())) {
-                    valVarKeyword = "given";
-                } else {
+            if (m.getType() == J.Modifier.Type.Final && !"final".equals(m.getKeyword())) {
+                // Implicit Final marking val/given — capture prefix, don't visit.
+                valVarKeyword = "given".equals(m.getKeyword()) ? "given" : "val";
+                valVarPrefix = m.getPrefix();
+            } else {
+                if (m.getType() == J.Modifier.Type.Final && "final".equals(m.getKeyword())) {
+                    // Explicit "final" keyword still implies val (Scala val is implicitly final).
                     valVarKeyword = "val";
                 }
-                // Only print the modifier if it has an explicit "final" keyword
-                if ("final".equals(m.getKeyword())) {
-                    visit(m, p);
-                    hasVisibleModifier = true;
+                if (!hasVisibleModifier && !multiVariable.getLeadingAnnotations().isEmpty() && m.getPrefix().isEmpty()) {
+                    p.append(" ");
+                    annotationGapBridged = true;
                 }
-            } else {
                 visit(m, p);
                 hasVisibleModifier = true;
             }
@@ -1012,7 +1001,11 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
 
         // Print val/var/given (unless it's a lambda parameter)
         if (!isLambdaParam) {
-            if (hasVisibleModifier) {
+            if (valVarPrefix != null) {
+                visitSpace(valVarPrefix, Space.Location.MODIFIER_PREFIX, p);
+            } else if (hasVisibleModifier) {
+                p.append(" ");
+            } else if (!annotationGapBridged && !multiVariable.getLeadingAnnotations().isEmpty()) {
                 p.append(" ");
             }
             p.append(valVarKeyword);

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -276,7 +276,12 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         if (case_.getGuard() != null) {
             p.append("if");
             visit(case_.getGuard(), p);
-            p.append(' ');
+            Space guardArrowSpace = case_.getPadding().getStatements().getBefore();
+            if (guardArrowSpace.isEmpty()) {
+                p.append(' ');
+            } else {
+                visitSpace(guardArrowSpace, Space.Location.CASE, p);
+            }
         }
         p.append("=>");
         if (case_.getPadding().getBody() != null) {

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -2474,6 +2474,9 @@ class ScalaTreeVisitor(
     var hasExplicitFinal = false
     var hasExplicitLazy = false
     
+    // Track the position right after the last modifier keyword (excluding any trailing whitespace).
+    // Used later to compute beforeValVar — the whitespace between the last modifier and val/var/given.
+    var lastModifierKeywordEnd = -1
     if (adjustedStart >= 0 && adjustedEnd <= source.length && adjustedStart < adjustedEnd) {
       val sourceSnippet = source.substring(adjustedStart, adjustedEnd)
 
@@ -2498,6 +2501,7 @@ class ScalaTreeVisitor(
           keyword, J.Modifier.Type.Private, Collections.emptyList()
         ))
         modifierEndPos = leadingWs + keyLen
+        lastModifierKeywordEnd = modifierEndPos
         if (modifierEndPos < sourceSnippet.length && sourceSnippet.charAt(modifierEndPos) == ' ') modifierEndPos += 1
       } else if (trimmedSnippet.startsWith("protected")) {
         var keyword = "protected"
@@ -2512,6 +2516,7 @@ class ScalaTreeVisitor(
           keyword, J.Modifier.Type.Protected, Collections.emptyList()
         ))
         modifierEndPos = leadingWs + keyLen
+        lastModifierKeywordEnd = modifierEndPos
         if (modifierEndPos < sourceSnippet.length && sourceSnippet.charAt(modifierEndPos) == ' ') modifierEndPos += 1
       }
       
@@ -2526,27 +2531,33 @@ class ScalaTreeVisitor(
           hasExplicitFinal = true
           modifiers.add(new J.Modifier(Tree.randomId(), modSpace, Markers.EMPTY,
             "final", J.Modifier.Type.Final, Collections.emptyList()))
+          lastModifierKeywordEnd = modifierEndPos + "final".length
           modifierEndPos += "final ".length
         } else if (remaining.startsWith("lazy ")) {
           hasExplicitLazy = true
           modifiers.add(new J.Modifier(Tree.randomId(), modSpace, Markers.EMPTY,
             "lazy", J.Modifier.Type.LanguageExtension, Collections.emptyList()))
+          lastModifierKeywordEnd = modifierEndPos + "lazy".length
           modifierEndPos += "lazy ".length
         } else if (remaining.startsWith("implicit ")) {
           modifiers.add(new J.Modifier(Tree.randomId(), modSpace, Markers.EMPTY,
             "implicit", J.Modifier.Type.LanguageExtension, Collections.emptyList()))
+          lastModifierKeywordEnd = modifierEndPos + "implicit".length
           modifierEndPos += "implicit ".length
         } else if (remaining.startsWith("override ")) {
           modifiers.add(new J.Modifier(Tree.randomId(), modSpace, Markers.EMPTY,
             "override", J.Modifier.Type.LanguageExtension, Collections.emptyList()))
+          lastModifierKeywordEnd = modifierEndPos + "override".length
           modifierEndPos += "override ".length
         } else if (remaining.startsWith("abstract ")) {
           modifiers.add(new J.Modifier(Tree.randomId(), modSpace, Markers.EMPTY,
             "abstract", J.Modifier.Type.Abstract, Collections.emptyList()))
+          lastModifierKeywordEnd = modifierEndPos + "abstract".length
           modifierEndPos += "abstract ".length
         } else if (remaining.startsWith("sealed ")) {
           modifiers.add(new J.Modifier(Tree.randomId(), modSpace, Markers.EMPTY,
             "sealed", J.Modifier.Type.Sealed, Collections.emptyList()))
+          lastModifierKeywordEnd = modifierEndPos + "sealed".length
           modifierEndPos += "sealed ".length
         } else {
           scanning = false
@@ -2567,13 +2578,11 @@ class ScalaTreeVisitor(
       }
       
       if (keywordStart >= 0) {
-        // Extract space before val/var (after modifiers or annotations)
-        if (keywordStart > 0) {
-          beforeValVar = Space.format(afterModifiers.substring(0, keywordStart))
-        } else if (hasAnnotations && modifierEndPos == 0) {
-          // When we have annotations but no other modifiers, the space is already in beforeValVar
-          // since cursor is positioned after annotations
-          beforeValVar = Space.EMPTY
+        // Whitespace between the last modifier keyword (or start of snippet, if none) and val/var/given.
+        val totalKeywordPos = modifierEndPos + keywordStart
+        val gapStart = if (lastModifierKeywordEnd >= 0) lastModifierKeywordEnd else 0
+        if (gapStart < totalKeywordPos) {
+          beforeValVar = Space.format(sourceSnippet.substring(gapStart, totalKeywordPos))
         }
         
         // Move cursor past all modifiers and the keyword
@@ -2608,7 +2617,7 @@ class ScalaTreeVisitor(
       val finalKeyword = if (isGiven) "given" else null
       modifiers.add(new J.Modifier(
         Tree.randomId(),
-        if (modifiers.isEmpty) beforeValVar else Space.SINGLE_SPACE,
+        beforeValVar,
         Markers.EMPTY,
         finalKeyword,
         J.Modifier.Type.Final,
@@ -5040,11 +5049,13 @@ class ScalaTreeVisitor(
       }
     }
 
-    val (modifiers, _) = extractModifiersFromText(dd.mods, modifierText)
+    val (modifiers, lastModEnd) = extractModifiersFromText(dd.mods, modifierText)
 
-    // If annotations but no modifiers, capture the space between annotations and "def"
-    if (hasAnnotations && modifiers.isEmpty() && modifierText.nonEmpty && modifierText.trim().isEmpty) {
-      modifiers.add(new J.Modifier(Tree.randomId(), Space.format(modifierText), Markers.EMPTY,
+    // Always capture the whitespace between the last modifier (or start) and "def"
+    // as the prefix of a synthetic "def" LanguageExtension modifier.
+    if (defIndex >= 0) {
+      val defPrefixText = if (lastModEnd <= modifierText.length) modifierText.substring(lastModEnd) else ""
+      modifiers.add(new J.Modifier(Tree.randomId(), Space.format(defPrefixText), Markers.EMPTY,
         "def", J.Modifier.Type.LanguageExtension, Collections.emptyList()))
     }
 
@@ -5494,12 +5505,16 @@ class ScalaTreeVisitor(
     } else null
 
     // Handle default value
+    var initBefore: Space = Space.EMPTY
     val initializer: Expression = if (vd.rhs != untpd.EmptyTree && vd.rhs.span.exists) {
       val rhsStart = Math.max(0, vd.rhs.span.start - offsetAdjustment)
       if (cursor < rhsStart) {
         val before = source.substring(cursor, rhsStart)
         val eqIdx = before.indexOf('=')
-        if (eqIdx >= 0) cursor = cursor + eqIdx + 1
+        if (eqIdx >= 0) {
+          initBefore = Space.format(before.substring(0, eqIdx))
+          cursor = cursor + eqIdx + 1
+        }
       }
       visitTree(vd.rhs) match {
         case expr: Expression => expr
@@ -5513,7 +5528,7 @@ class ScalaTreeVisitor(
       Markers.EMPTY,
       paramName,
       Collections.emptyList(),
-      if (initializer != null) JLeftPadded.build(initializer) else null,
+      if (initializer != null) new JLeftPadded(initBefore, initializer, Markers.EMPTY) else null,
       variableTypeOfTree(vd)
     )
 

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5856,9 +5856,12 @@ class ScalaTreeVisitor(
       val patternJ = visitTree(caseDef.pat) match { case j: J => j; case _ => ident("_", Space.format(" ")) }
 
       // Handle guard: `case x if condition =>`
-      // Store space-before-if in label's after space so the printer can emit it
+      // Store space-before-if in label's after space so the printer can emit it.
+      // Store space between guard expression end and `=>` in the statements
+      // container's `before` space (matching the Java printer's convention).
       var guard: Expression = null
       var labelAfter = Space.EMPTY
+      var guardArrowSpace = Space.EMPTY
       if (!caseDef.guard.isEmpty && caseDef.guard.span.exists) {
         val ifPos = positionOfNext("if")
         if (ifPos > cursor) labelAfter = Space.format(source.substring(cursor, ifPos))
@@ -5868,6 +5871,8 @@ class ScalaTreeVisitor(
           case expr: Expression => guard = expr
           case _ =>
         }
+        val arrowPos = source.indexOf("=>", cursor)
+        if (arrowPos >= cursor) guardArrowSpace = Space.format(source.substring(cursor, arrowPos))
       } else {
         val arrowPos = source.indexOf("=>", cursor)
         if (arrowPos >= cursor) labelAfter = Space.format(source.substring(cursor, arrowPos))
@@ -5881,8 +5886,10 @@ class ScalaTreeVisitor(
       val caseBodyJ = visitTree(caseDef.body) match { case j: J => JRightPadded.build(j); case _ => null }
       updateCursor(caseDef.span.end)
 
+      val statementsContainer: JContainer[Statement] =
+        JContainer.build(guardArrowSpace, java.util.Collections.emptyList[JRightPadded[Statement]](), Markers.EMPTY)
       val jCase = new J.Case(Tree.randomId(), casePrefix, Markers.EMPTY, J.Case.Type.Rule,
-        null, null, JContainer.build(Space.EMPTY, labels, Markers.EMPTY), guard, JContainer.empty(), caseBodyJ)
+        null, null, JContainer.build(Space.EMPTY, labels, Markers.EMPTY), guard, statementsContainer, caseBodyJ)
       caseStatements.add(JRightPadded.build(jCase.asInstanceOf[Statement]))
     }
 

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -23,6 +23,45 @@ import static org.openrewrite.scala.Assertions.scala;
 class MethodDeclarationTest implements RewriteTest {
 
     @Test
+    void extraSpaceBetweenModifierAndDef() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  private   def hello(): Int = 1
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void extraSpaceBeforeParameterDefaultEquals() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def hello(x: Int   = 1): Int = x
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void noSpaceAroundParameterDefaultEquals() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def hello(x: Int=1): Int = x
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void simpleMethod() {
         rewriteRun(
             scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
@@ -23,6 +23,22 @@ import static org.openrewrite.scala.Assertions.scala;
 class MatchTest implements RewriteTest {
 
     @Test
+    void emptyCaseBodyWithGuardPreservesAlignmentBeforeArrow() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              def handle(x: Int): Unit = x match {
+                case 1 if x > 0   =>
+                case _ => println(x)
+              }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void simpleMatch() {
         rewriteRun(
           scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/VariableDeclarationsTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/VariableDeclarationsTest.java
@@ -23,6 +23,32 @@ import static org.openrewrite.scala.Assertions.scala;
 class VariableDeclarationsTest implements RewriteTest {
 
     @Test
+    void extraSpaceBetweenAnnotationAndVal() {
+        rewriteRun(
+          scala(
+            """
+            class Test {
+              @deprecated   val x = 1
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void extraSpaceBetweenModifierAndVal() {
+        rewriteRun(
+          scala(
+            """
+            class Test {
+              private   val x = 1
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void valDeclaration() {
         rewriteRun(
           scala("val x = 5")


### PR DESCRIPTION
## What's changed?

Fix several cases of the Scala parser (and printer) assuming there's always exactly one space in certain places in the syntax.

## What's your motivation?

Idempotency issues.
