### PR TITLE
Scala: fix printing missing modifiers

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -468,6 +468,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 J.VariableDeclarations vd = (J.VariableDeclarations) elem;
                 visitSpace(vd.getPrefix(), Space.Location.VARIABLE_DECLARATIONS_PREFIX, p);
                 visit(vd.getLeadingAnnotations(), p);
+                visit(vd.getModifiers(), p);
                 if (!vd.getVariables().isEmpty()) {
                     visit(vd.getVariables().get(0).getName(), p);
                 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -225,4 +225,17 @@ class MethodDeclarationTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void implicitInSecondParamList() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def apply(obj: String)(implicit c: Int): String = obj
+                }
+                """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fix Scala printer not to skip printing out modifiers in method parameters.

## What's your motivation?

Otherwise idempotency issues are observed.