### PR TITLE
Scala: support for indented syntax

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -198,10 +198,52 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
     }
 
     @Override
+    public J visitWhileLoop(J.WhileLoop whileLoop, PrintOutputCapture<P> p) {
+        if (!whileLoop.getMarkers().findFirst(IndentedSyntax.class).isPresent()) {
+            return super.visitWhileLoop(whileLoop, p);
+        }
+        // Scala 3 paren-less form: `while cond do body`
+        beforeSyntax(whileLoop, Space.Location.WHILE_PREFIX, p);
+        p.append("while");
+        J.ControlParentheses<Expression> cp = whileLoop.getCondition();
+        visitSpace(cp.getPrefix(), Space.Location.WHILE_CONDITION, p);
+        JRightPadded<Expression> condPadded = cp.getPadding().getTree();
+        visit(condPadded.getElement(), p);
+        visitSpace(condPadded.getAfter(), Space.Location.CONTROL_PARENTHESES_PREFIX, p);
+        p.append("do");
+        visit(whileLoop.getBody(), p);
+        afterSyntax(whileLoop, p);
+        return whileLoop;
+    }
+
+    @Override
+    public J visitIf(J.If iff, PrintOutputCapture<P> p) {
+        if (!iff.getMarkers().findFirst(IndentedSyntax.class).isPresent()) {
+            return super.visitIf(iff, p);
+        }
+        // Scala 3 paren-less form: `if cond then thenp [else elsep]`
+        beforeSyntax(iff, Space.Location.IF_PREFIX, p);
+        p.append("if");
+        J.ControlParentheses<Expression> cp = iff.getIfCondition();
+        visitSpace(cp.getPrefix(), Space.Location.IF_PREFIX, p);
+        JRightPadded<Expression> condPadded = cp.getPadding().getTree();
+        visit(condPadded.getElement(), p);
+        visitSpace(condPadded.getAfter(), Space.Location.CONTROL_PARENTHESES_PREFIX, p);
+        p.append("then");
+        visit(iff.getThenPart(), p);
+        if (iff.getElsePart() != null) {
+            visit(iff.getElsePart(), p);
+        }
+        afterSyntax(iff, p);
+        return iff;
+    }
+
+    @Override
     public J visitTry(J.Try tryable, PrintOutputCapture<P> p) {
         beforeSyntax(tryable, Space.Location.TRY_PREFIX, p);
         p.append("try");
         visit(tryable.getBody(), p);
+        boolean indentedCatch = tryable.getMarkers().findFirst(IndentedSyntax.class).isPresent();
         if (!tryable.getCatches().isEmpty()) {
             // Print catch block with cases from AST whitespace
             for (int i = 0; i < tryable.getCatches().size(); i++) {
@@ -209,7 +251,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 if (i == 0) {
                     // First catch — prefix is the space before "catch"
                     visitSpace(aCatch.getPrefix(), Space.Location.CATCH_PREFIX, p);
-                    p.append("catch {");
+                    p.append(indentedCatch ? "catch" : "catch {");
                 }
                 // Print case with AST whitespace
                 JRightPadded<J.VariableDeclarations> paramPadded = aCatch.getParameter().getPadding().getTree();
@@ -232,7 +274,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             // Close catch block — use end space from last catch body if available
             J.Try.Catch lastCatch = tryable.getCatches().get(tryable.getCatches().size() - 1);
             visitSpace(lastCatch.getBody().getEnd(), Space.Location.BLOCK_END, p);
-            p.append("}");
+            if (!indentedCatch) {
+                p.append("}");
+            }
         }
         if (tryable.getPadding().getFinally() != null) {
             visitSpace(tryable.getPadding().getFinally().getBefore(), Space.Location.TRY_FINALLY, p);
@@ -247,14 +291,17 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
     public J visitSwitch(J.Switch switch_, PrintOutputCapture<P> p) {
         beforeSyntax(switch_, Space.Location.SWITCH_PREFIX, p);
         visit(switch_.getSelector().getTree(), p);
-        p.append(" match {");
+        boolean indented = switch_.getMarkers().findFirst(IndentedSyntax.class).isPresent();
+        p.append(indented ? " match" : " match {");
         // Print cases directly (not via visitBlock which adds { })
         J.Block casesBlock = switch_.getCases();
         for (int i = 0; i < casesBlock.getStatements().size(); i++) {
             visit(casesBlock.getStatements().get(i), p);
         }
         visitSpace(casesBlock.getEnd(), Space.Location.BLOCK_END, p);
-        p.append("}");
+        if (!indented) {
+            p.append("}");
+        }
         afterSyntax(switch_, p);
         return switch_;
     }
@@ -1478,10 +1525,13 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         beforeSyntax(forLoop, Space.Location.LANGUAGE_EXTENSION, p);
         p.append("for");
         char open = forLoop.getOpenBracket();
+        boolean parenless = open == ' ';  // Scala 3 indented form: no '(' or '{'
         char close = open == '(' ? ')' : '}';
         JContainer<S.For.Enumerator> enums = forLoop.getPadding().getEnumerators();
         visitSpace(enums.getBefore(), Space.Location.LANGUAGE_EXTENSION, p);
-        p.append(open);
+        if (!parenless) {
+            p.append(open);
+        }
         List<JRightPadded<S.For.Enumerator>> elems = enums.getPadding().getElements();
         for (int i = 0; i < elems.size(); i++) {
             JRightPadded<S.For.Enumerator> rp = elems.get(i);
@@ -1489,14 +1539,17 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             visitSpace(rp.getAfter(), Space.Location.LANGUAGE_EXTENSION, p);
             // Print ';' separator only if both this and next element are NOT guards.
             // Scala's for-comprehensions don't separate guards with ';'.
-            if (i < elems.size() - 1) {
+            // In paren-less form, enumerators are separated by newlines (whitespace), not ';'.
+            if (i < elems.size() - 1 && !parenless) {
                 S.For.Enumerator next = elems.get(i + 1).getElement();
                 if (next.getKind() != S.For.Enumerator.Kind.Guard) {
                     p.append(';');
                 }
             }
         }
-        p.append(close);
+        if (!parenless) {
+            p.append(close);
+        }
         visitSpace(forLoop.getBeforeBody(), Space.Location.LANGUAGE_EXTENSION, p);
         if (forLoop.isYielding()) {
             p.append("yield");

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -32,7 +32,7 @@ import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeTree;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.scala.marker.BlockArgument;
-import org.openrewrite.scala.marker.IndentedBlock;
+import org.openrewrite.scala.marker.IndentedSyntax;
 import org.openrewrite.scala.marker.SObject;
 import org.openrewrite.scala.marker.Semicolon;
 import org.openrewrite.scala.marker.TypeProjection;
@@ -588,6 +588,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         beforeSyntax(pkg, Space.Location.PACKAGE_PREFIX, p);
         p.append("package");
         visit(pkg.getExpression(), p);
+        if (pkg.getMarkers().findFirst(IndentedSyntax.class).isPresent()) {
+            p.append(':');
+        }
         // Note: No semicolon in Scala package declarations
         afterSyntax(pkg, p);
         return pkg;
@@ -860,7 +863,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return block;
         }
         // Scala 3 braceless (indentation-based) blocks use `:` instead of `{}`
-        if (block.getMarkers().findFirst(IndentedBlock.class).isPresent()) {
+        if (block.getMarkers().findFirst(IndentedSyntax.class).isPresent()) {
             beforeSyntax(block, Space.Location.BLOCK_PREFIX, p);
             p.append(':');
             visitStatements(block.getPadding().getStatements(), JRightPadded.Location.BLOCK_STATEMENT, p);

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/IndentedSyntax.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/IndentedSyntax.java
@@ -20,14 +20,15 @@ import org.openrewrite.marker.Marker;
 import java.util.UUID;
 
 /**
- * Marks a {@link org.openrewrite.java.tree.J.Block} that uses Scala 3 braceless
- * (indentation-based) syntax. The block is delimited by {@code :} and indentation
- * rather than {@code {}} braces.
+ * Marks an LST element that uses Scala 3 indentation-based syntax, where the body
+ * is introduced by {@code :} and indentation rather than {@code {}} braces. Applied
+ * to a {@link org.openrewrite.java.tree.J.Block} for braceless blocks, and to a
+ * {@link org.openrewrite.java.tree.J.Package} for an indented package region.
  */
-public class IndentedBlock implements Marker {
+public class IndentedSyntax implements Marker {
     private final UUID id;
 
-    public IndentedBlock(UUID id) {
+    public IndentedSyntax(UUID id) {
         this.id = id;
     }
 
@@ -37,7 +38,7 @@ public class IndentedBlock implements Marker {
     }
 
     @Override
-    public IndentedBlock withId(UUID id) {
-        return new IndentedBlock(id);
+    public IndentedSyntax withId(UUID id) {
+        return new IndentedSyntax(id);
     }
 }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaASTConverter.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaASTConverter.scala
@@ -21,9 +21,10 @@ import org.openrewrite.Tree
 import org.openrewrite.java.internal.JavaTypeFactory
 import org.openrewrite.java.tree.*
 import org.openrewrite.marker.Markers
+import org.openrewrite.scala.marker.IndentedSyntax
 
 import java.util
-import java.util.{Collections, List as JList}
+import java.util.{Collections, List as JList, UUID}
 
 /**
  * Result of converting a Scala AST to compilation unit components.
@@ -165,18 +166,36 @@ class ScalaASTConverter {
     // This includes "package" keyword + package name
     val packageEndPos = pkgDef.pid.span.end
 
+    // Detect Scala 3 indented package syntax: `package foo.bar:` followed by an indented region.
+    // If the next non-space character after the package name is `:`, consume it and tag the
+    // J.Package with IndentedSyntax so the printer re-emits the colon.
+    val srcText = visitor.getSourceText
+    val srcOffset = visitor.getOffsetAdjustment
+    var scanIdx = packageEndPos - srcOffset
+    while (scanIdx < srcText.length && (srcText.charAt(scanIdx) == ' ' || srcText.charAt(scanIdx) == '\t')) {
+      scanIdx += 1
+    }
+    val hasIndentedColon = scanIdx < srcText.length && srcText.charAt(scanIdx) == ':'
+    val cursorAfter = if (hasIndentedColon) scanIdx + 1 + srcOffset else packageEndPos
+
     // Update the visitor's cursor to after the package declaration
     // This is crucial to prevent the package text from being included
     // in the prefix of subsequent statements
-    visitor.updateCursor(packageEndPos)
+    visitor.updateCursor(cursorAfter)
 
     // Create package expression
     val packageExpr: Expression = TypeTree.build(packageName)
 
+    val markers = if (hasIndentedColon) {
+      Markers.build(Collections.singletonList(new IndentedSyntax(UUID.randomUUID())))
+    } else {
+      Markers.EMPTY
+    }
+
     new J.Package(
       Tree.randomId(),
       prefix,
-      Markers.EMPTY,
+      markers,
       packageExpr.withPrefix(Space.build(" ", Collections.emptyList())),
       Collections.emptyList()
     )

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -3287,12 +3287,16 @@ class ScalaTreeVisitor(
 
   private def visitIf(ifTree: Trees.If[?]): J = {
     val prefix = extractPrefix(ifTree.span)
-    
-    
+
+
     // Find where the condition parentheses start
     val adjustedStart = Math.max(0, ifTree.span.start - offsetAdjustment)
     val condStart = Math.max(0, ifTree.cond.span.start - offsetAdjustment)
-    
+
+    // Detect Scala 3 `if cond then ...` (no parens). The condition is not wrapped in untpd.Parens,
+    // and there is no `(` between `if` and the condition's start position.
+    val ifIsParenless = !ifTree.cond.isInstanceOf[untpd.Parens]
+
     // Extract space before parentheses and move cursor past "if" to the condition
     var beforeParenSpace = Space.EMPTY
     if (adjustedStart < condStart && cursor <= condStart) {
@@ -3302,12 +3306,17 @@ class ScalaTreeVisitor(
       val ifIndex = between.indexOf("if")
       if (ifIndex >= 0) {
         val afterIf = ifIndex + 2
-        val remainingStr = between.substring(afterIf)
-        val parenIndex = remainingStr.indexOf('(')
-        if (parenIndex >= 0) {
-          beforeParenSpace = Space.format(remainingStr.substring(0, parenIndex))
-          // Move cursor to the opening parenthesis
-          cursor = cursor + afterIf + parenIndex
+        if (ifIsParenless) {
+          // Move cursor just past the `if` keyword; the condition's prefix will absorb the space.
+          cursor = cursor + afterIf
+        } else {
+          val remainingStr = between.substring(afterIf)
+          val parenIndex = remainingStr.indexOf('(')
+          if (parenIndex >= 0) {
+            beforeParenSpace = Space.format(remainingStr.substring(0, parenIndex))
+            // Move cursor to the opening parenthesis
+            cursor = cursor + afterIf + parenIndex
+          }
         }
       }
     }
@@ -3373,7 +3382,22 @@ class ScalaTreeVisitor(
         // For non-parenthesized conditions, just move cursor to end
         cursor = Math.max(0, ifTree.cond.span.end - offsetAdjustment)
     }
-    
+
+    // For Scala 3 `if cond then ...`, advance the cursor past the `then` keyword
+    // (which sits between the condition and the then-branch). The space before `then`
+    // is absorbed into afterCondSpace; space after is the thenp's prefix.
+    if (ifIsParenless) {
+      val thenpStart = Math.max(0, ifTree.thenp.span.start - offsetAdjustment)
+      if (cursor < thenpStart && thenpStart <= source.length) {
+        val between = source.substring(cursor, thenpStart)
+        val thenIdx = between.indexOf("then")
+        if (thenIdx >= 0) {
+          afterCondSpace = Space.format(between.substring(0, thenIdx))
+          cursor = cursor + thenIdx + 4
+        }
+      }
+    }
+
     // Visit the then branch — in Scala, any expression is valid as then-branch
     val thenPart = visitTree(ifTree.thenp) match {
       case stmt: Statement => JRightPadded.build(stmt)
@@ -3423,11 +3447,15 @@ class ScalaTreeVisitor(
     
     // Update cursor to end of the if expression
     updateCursor(ifTree.span.end)
-    
+
+    val ifMarkers = if (ifIsParenless)
+      Markers.build(Collections.singletonList(new IndentedSyntax(UUID.randomUUID())))
+    else Markers.EMPTY
+
     new J.If(
       Tree.randomId(),
       prefix,
-      Markers.EMPTY,
+      ifMarkers,
       new J.ControlParentheses(
         Tree.randomId(),
         beforeParenSpace,
@@ -3441,11 +3469,14 @@ class ScalaTreeVisitor(
   
   private def visitWhileDo(whileTree: Trees.WhileDo[?]): J = {
     val prefix = extractPrefix(whileTree.span)
-    
+
     // Find where the condition parentheses start
     val adjustedStart = Math.max(0, whileTree.span.start - offsetAdjustment)
     val condStart = Math.max(0, whileTree.cond.span.start - offsetAdjustment)
-    
+
+    // Detect Scala 3 `while cond do ...` (no parens). Same shape as `if cond then`.
+    val whileIsParenless = !whileTree.cond.isInstanceOf[untpd.Parens]
+
     // Extract space before parentheses and move cursor past "while" to the condition
     var beforeParenSpace = Space.EMPTY
     if (adjustedStart < condStart && cursor <= condStart) {
@@ -3454,12 +3485,16 @@ class ScalaTreeVisitor(
       val whileIndex = between.indexOf("while")
       if (whileIndex >= 0) {
         val afterWhile = whileIndex + 5 // "while" is 5 chars
-        val remainingStr = between.substring(afterWhile)
-        val parenIndex = remainingStr.indexOf('(')
-        if (parenIndex >= 0) {
-          beforeParenSpace = Space.format(remainingStr.substring(0, parenIndex))
-          // Move cursor to the opening parenthesis
-          cursor = cursor + afterWhile + parenIndex
+        if (whileIsParenless) {
+          cursor = cursor + afterWhile
+        } else {
+          val remainingStr = between.substring(afterWhile)
+          val parenIndex = remainingStr.indexOf('(')
+          if (parenIndex >= 0) {
+            beforeParenSpace = Space.format(remainingStr.substring(0, parenIndex))
+            // Move cursor to the opening parenthesis
+            cursor = cursor + afterWhile + parenIndex
+          }
         }
       }
     }
@@ -3521,7 +3556,20 @@ class ScalaTreeVisitor(
       case _ =>
         cursor = Math.max(0, whileTree.cond.span.end - offsetAdjustment)
     }
-    
+
+    // Scala 3 `while cond do ...` — advance the cursor past the `do` keyword.
+    if (whileIsParenless) {
+      val bodyStart = Math.max(0, whileTree.body.span.start - offsetAdjustment)
+      if (cursor < bodyStart && bodyStart <= source.length) {
+        val between = source.substring(cursor, bodyStart)
+        val doIdx = between.indexOf("do")
+        if (doIdx >= 0) {
+          afterCondSpace = Space.format(between.substring(0, doIdx))
+          cursor = cursor + doIdx + 2
+        }
+      }
+    }
+
     // Visit the body — wrap non-Statement expressions (e.g. `while (cond) ()`)
     val body = visitTree(whileTree.body) match {
       case stmt: Statement => JRightPadded.build(stmt)
@@ -3532,10 +3580,14 @@ class ScalaTreeVisitor(
     // Update cursor to end of the while loop
     updateCursor(whileTree.span.end)
 
+    val whileMarkers = if (whileIsParenless)
+      Markers.build(Collections.singletonList(new IndentedSyntax(UUID.randomUUID())))
+    else Markers.EMPTY
+
     new J.WhileLoop(
       Tree.randomId(),
       prefix,
-      Markers.EMPTY,
+      whileMarkers,
       new J.ControlParentheses(
         Tree.randomId(),
         beforeParenSpace,
@@ -5583,14 +5635,18 @@ class ScalaTreeVisitor(
 
     // Handle catch handler
     val catches = new util.ArrayList[J.Try.Catch]()
+    var catchHasBraces = true
     if (!parsedTry.handler.isEmpty && parsedTry.handler.span.exists) {
       val catchSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 50, source.length)) else ""
       val catchIdx = catchSearch.indexOf("catch")
       val catchPrefix = if (catchIdx > 0) Space.format(catchSearch.substring(0, catchIdx)) else Space.EMPTY
       if (catchIdx >= 0) cursor = cursor + catchIdx + 5
-      val braceSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 20, source.length)) else ""
+      // Scala 3 `catch case ... =>` (no braces) — only consume `{` if it appears before the first `case`.
+      val braceSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 200, source.length)) else ""
       val braceIdx = braceSearch.indexOf('{')
-      if (braceIdx >= 0) cursor = cursor + braceIdx + 1
+      val firstCaseIdx = braceSearch.indexOf("case")
+      catchHasBraces = braceIdx >= 0 && (firstCaseIdx < 0 || braceIdx < firstCaseIdx)
+      if (catchHasBraces) cursor = cursor + braceIdx + 1
 
       // The handler should be a Match tree containing the case defs
       val cases: List[Trees.CaseDef[?]] = parsedTry.handler match {
@@ -5655,7 +5711,7 @@ class ScalaTreeVisitor(
         catches.add(new J.Try.Catch(Tree.randomId(), thisCatchPrefix, Markers.EMPTY, controlParens, caseBody))
       }
       // Extract end space before closing '}'  and set it on the last catch body
-      if (cursor < source.length) {
+      if (catchHasBraces && cursor < source.length) {
         val r = source.substring(cursor, Math.min(cursor + 50, source.length))
         val ci = r.indexOf('}')
         if (ci >= 0) {
@@ -5691,7 +5747,9 @@ class ScalaTreeVisitor(
     } else null
 
     updateCursor(parsedTry.span.end)
-    new J.Try(Tree.randomId(), prefix, Markers.EMPTY, null, body, catches, finallyBlock)
+    val tryMarkers = if (catchHasBraces) Markers.EMPTY
+      else Markers.build(Collections.singletonList(new IndentedSyntax(UUID.randomUUID())))
+    new J.Try(Tree.randomId(), prefix, tryMarkers, null, body, catches, finallyBlock)
   }
 
   private def visitTryImpl(tryTree: Trees.Try[?]): J.Try = {
@@ -5714,15 +5772,19 @@ class ScalaTreeVisitor(
     }
 
     val catches = new util.ArrayList[J.Try.Catch]()
+    var catchHasBraces = true
     if (tryTree.cases.nonEmpty) {
       // Extract space before "catch" keyword — this becomes the first Catch's prefix
       val catchSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 50, source.length)) else ""
       val catchIdx = catchSearch.indexOf("catch")
       val catchPrefix = if (catchIdx > 0) Space.format(catchSearch.substring(0, catchIdx)) else Space.EMPTY
       if (catchIdx >= 0) cursor = cursor + catchIdx + 5
-      val braceSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 20, source.length)) else ""
+      // Scala 3 `catch case ... =>` (no braces) — only consume `{` if it appears before the first `case`.
+      val braceSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 200, source.length)) else ""
       val braceIdx = braceSearch.indexOf('{')
-      if (braceIdx >= 0) cursor = cursor + braceIdx + 1
+      val firstCaseIdx = braceSearch.indexOf("case")
+      catchHasBraces = braceIdx >= 0 && (firstCaseIdx < 0 || braceIdx < firstCaseIdx)
+      if (catchHasBraces) cursor = cursor + braceIdx + 1
 
       for (caseDef <- tryTree.cases) {
         val casePrefix = extractPrefix(caseDef.span)
@@ -5782,7 +5844,7 @@ class ScalaTreeVisitor(
         catches.add(new J.Try.Catch(Tree.randomId(), thisCatchPrefix, Markers.EMPTY, controlParens, caseBody))
       }
       // Extract end space before closing '}' and set it on the last catch body
-      if (cursor < source.length) {
+      if (catchHasBraces && cursor < source.length) {
         val r = source.substring(cursor, Math.min(cursor + 50, source.length))
         val ci = r.indexOf('}')
         if (ci >= 0) {
@@ -5816,7 +5878,9 @@ class ScalaTreeVisitor(
     } else null
 
     updateCursor(tryTree.span.end)
-    new J.Try(Tree.randomId(), prefix, Markers.EMPTY, null, body, catches, finallyBlock)
+    val tryMarkers = if (catchHasBraces) Markers.EMPTY
+      else Markers.build(Collections.singletonList(new IndentedSyntax(UUID.randomUUID())))
+    new J.Try(Tree.randomId(), prefix, tryMarkers, null, body, catches, finallyBlock)
   }
 
   private def visitMatchTree(matchTree: Trees.Match[?]): J = {
@@ -5853,16 +5917,22 @@ class ScalaTreeVisitor(
 
     val ms = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 30, source.length)) else ""
     val mi = ms.indexOf("match"); if (mi >= 0) cursor = cursor + mi + 5
-    val bs = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 20, source.length)) else ""
-    val bi = bs.indexOf('{'); if (bi >= 0) cursor = cursor + bi + 1
+    // Scala 3 `x match\n  case ...` has no `{` before the cases — detect that form.
+    val bs = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 200, source.length)) else ""
+    val braceIdx = bs.indexOf('{')
+    val caseIdx = bs.indexOf("case")
+    val isBraceForm = braceIdx >= 0 && (caseIdx < 0 || braceIdx < caseIdx)
+    if (isBraceForm) cursor = cursor + braceIdx + 1
 
-    val casesBlock = buildCasesBlock(matchTree)
+    val casesBlock = buildCasesBlock(matchTree, isBraceForm)
     updateCursor(matchTree.span.end)
     val selectorParens = new J.ControlParentheses[Expression](Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(selector))
-    new J.Switch(Tree.randomId(), prefix, Markers.EMPTY, selectorParens, casesBlock)
+    val markers = if (isBraceForm) Markers.EMPTY
+      else Markers.build(Collections.singletonList(new IndentedSyntax(UUID.randomUUID())))
+    new J.Switch(Tree.randomId(), prefix, markers, selectorParens, casesBlock)
   }
 
-  private def buildCasesBlock(matchTree: Trees.Match[?]): J.Block = {
+  private def buildCasesBlock(matchTree: Trees.Match[?], hasClosingBrace: Boolean = true): J.Block = {
     val caseStatements = new util.ArrayList[JRightPadded[Statement]]()
     for (caseDef <- matchTree.cases) {
       val casePrefix = extractPrefix(caseDef.span)
@@ -5903,14 +5973,16 @@ class ScalaTreeVisitor(
       caseStatements.add(JRightPadded.build(jCase.asInstanceOf[Statement]))
     }
 
-    // Extract space before closing brace of match block
+    // Extract space before closing brace of match block (or up to span end for indented form)
     val matchEnd = Math.max(0, matchTree.span.end - offsetAdjustment)
     var matchEndSpace = Space.EMPTY
     if (cursor < matchEnd && matchEnd <= source.length) {
       val remaining = source.substring(cursor, matchEnd)
-      val closeIdx = remaining.lastIndexOf('}')
-      if (closeIdx > 0) {
-        matchEndSpace = Space.format(remaining.substring(0, closeIdx))
+      if (hasClosingBrace) {
+        val closeIdx = remaining.lastIndexOf('}')
+        if (closeIdx > 0) {
+          matchEndSpace = Space.format(remaining.substring(0, closeIdx))
+        }
       }
     }
     new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), caseStatements, matchEndSpace)
@@ -6336,16 +6408,18 @@ class ScalaTreeVisitor(
   /** Common parser for ForDo (complex) and ForYield. */
   private def buildSFor(prefix: Space, enums: List[Trees.Tree[?]], body: Trees.Tree[?],
                         yielding: Boolean, spanEnd: Int): S.For = {
-    // Find opening bracket: ( or {
-    val openIdx = {
+    // Find opening bracket: ( or {. If we encounter a non-whitespace character before either,
+    // we're in the Scala 3 paren-less form (e.g. `for i <- 1 to 10 yield ...`).
+    val (openIdx, openBracket): (Int, Char) = {
       var i = cursor
-      while (i < source.length && source.charAt(i) != '(' && source.charAt(i) != '{') i += 1
-      if (i < source.length) i else -1
+      while (i < source.length && source.charAt(i).isWhitespace) i += 1
+      if (i < source.length && (source.charAt(i) == '(' || source.charAt(i) == '{')) (i, source.charAt(i))
+      else (-1, ' ')  // ' ' sentinel: no bracket (Scala 3 indented form)
     }
-    val openBracket: Char = if (openIdx >= 0) source.charAt(openIdx) else '('
+    val isParenless = openBracket == ' '
     val beforeOpen: Space = if (openIdx > cursor) Space.format(source.substring(cursor, openIdx)) else Space.EMPTY
     if (openIdx >= 0) cursor = openIdx + 1
-    val closeChar = if (openBracket == '(') ')' else '}'
+    val closeChar = if (openBracket == '(') ')' else if (openBracket == '{') '}' else ' '
 
     import scala.jdk.CollectionConverters.*
     val enumsList = enums.asJava
@@ -6353,16 +6427,30 @@ class ScalaTreeVisitor(
     var i = 0
     while (i < enumsList.size) {
       val isLast = i + 1 == enumsList.size
-      // Compute the end position of enums (close bracket position)
-      val closeIdx = source.indexOf(closeChar, cursor)
-      rpEnums.add(buildForEnumerator(enumsList.get(i), isLast, if (closeIdx >= 0) closeIdx else spanEnd))
+      // Compute the end position of enums: close bracket for paren form; for paren-less,
+      // stop at `yield` (yielding form) or body start (do form), whichever isn't a keyword.
+      val enumEnd =
+        if (isParenless) {
+          val bodyStart = Math.max(0, body.span.start - offsetAdjustment)
+          if (yielding) {
+            val yieldIdx = source.indexOf("yield", cursor)
+            if (yieldIdx >= 0 && yieldIdx < bodyStart) yieldIdx else bodyStart
+          } else bodyStart
+        }
+        else {
+          val closeIdx = source.indexOf(closeChar, cursor)
+          if (closeIdx >= 0) closeIdx else spanEnd
+        }
+      rpEnums.add(buildForEnumerator(enumsList.get(i), isLast, enumEnd))
       i += 1
     }
     val enumerators = JContainer.build(beforeOpen, rpEnums, Markers.EMPTY)
 
-    // Find closing bracket
-    val closeIdx = source.indexOf(closeChar, cursor)
-    if (closeIdx >= 0) cursor = closeIdx + 1
+    // Find closing bracket (only in paren form)
+    if (!isParenless) {
+      val closeIdx = source.indexOf(closeChar, cursor)
+      if (closeIdx >= 0) cursor = closeIdx + 1
+    }
 
     // Capture space before body / `yield`
     val bodyStart = Math.max(0, body.span.start - offsetAdjustment)

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -27,7 +27,7 @@ import org.openrewrite.java.marker.OmitParentheses
 import org.openrewrite.marker.Markers
 import org.openrewrite.scala.marker.Implicit
 import org.openrewrite.scala.marker.LambdaParameter
-import org.openrewrite.scala.marker.IndentedBlock
+import org.openrewrite.scala.marker.IndentedSyntax
 import org.openrewrite.scala.marker.OmitBraces
 import org.openrewrite.scala.marker.PackageObject
 import org.openrewrite.scala.marker.SObject
@@ -172,7 +172,11 @@ class ScalaTreeVisitor(
   }
   
   def getCursor: Int = cursor
-  
+
+  def getSourceText: String = source
+
+  def getOffsetAdjustment: Int = offsetAdjustment
+
   def updateCursor(position: Int): Unit = {
     val adjustedPosition = Math.max(0, position - offsetAdjustment)
     if (adjustedPosition > cursor && adjustedPosition <= source.length) {
@@ -3121,7 +3125,7 @@ class ScalaTreeVisitor(
         }
         
         val blockMarkers = if (isBraceless) {
-          Markers.build(Collections.singletonList(new IndentedBlock(Tree.randomId())))
+          Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId())))
         } else Markers.EMPTY
 
         new J.Block(
@@ -4397,7 +4401,7 @@ class ScalaTreeVisitor(
           } else Space.EMPTY
 
           val classBlockMarkers = if (isClassBraceless) {
-            Markers.build(Collections.singletonList(new IndentedBlock(Tree.randomId())))
+            Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId())))
           } else Markers.EMPTY
 
           new J.Block(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
@@ -178,6 +178,77 @@ class CompilationUnitTest implements RewriteTest {
     }
 
     @Test
+    void indentedIfThenElse() {
+        rewriteRun(
+          scala(
+            """
+            val x =
+              if true then
+                1
+              else
+                2
+            """
+          )
+        );
+    }
+
+    @Test
+    void indentedWhileDo() {
+        rewriteRun(
+          scala(
+            """
+            object O:
+              var i = 0
+              while i < 10 do
+                i = i + 1
+            """
+          )
+        );
+    }
+
+    @Test
+    void indentedForYield() {
+        rewriteRun(
+          scala(
+            """
+            object O:
+              val xs =
+                for i <- 1 to 10
+                yield i * 2
+            """
+          )
+        );
+    }
+
+    @Test
+    void indentedTryCatch() {
+        rewriteRun(
+          scala(
+            """
+            val x =
+              try
+                42
+              catch
+                case _: Exception => 0
+            """
+          )
+        );
+    }
+
+    @Test
+    void indentedMatch() {
+        rewriteRun(
+          scala(
+            """
+            val x = 1 match
+              case 1 => "one"
+              case _ => "other"
+            """
+          )
+        );
+    }
+
+    @Test
     void withTrailingWhitespace() {
         rewriteRun(
           scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
@@ -166,6 +166,18 @@ class CompilationUnitTest implements RewriteTest {
     }
 
     @Test
+    void indentedPackage() {
+        rewriteRun(
+          scala(
+            """
+            package com.example:
+              val x = 42
+            """
+          )
+        );
+    }
+
+    @Test
     void withTrailingWhitespace() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

Improve Scala parser support for indented (whitespace-significant) syntax.
Rename the `IndentedBlock` marker to `IndentedSyntax` as not only blocks can be indented.

## What's your motivation?

Handle a broader set of Scala programs.