### PR TITLE
AddDependency: prevent duplicate `<dependency>` when existing direct dep already satisfies the request

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -229,16 +229,15 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                     return maven;
                 }
 
-                // If the dependency is already in compile scope it will be available everywhere, no need to continue
+                // If the dependency is already on the classpath as a transitive dependency (and the recipe accepts that),
+                // no direct declaration is needed. Direct duplicates are handled by AddDependencyVisitor below.
                 Map<Scope, List<ResolvedDependency>> dependencies = getResolutionResult().getDependencies();
                 if (dependencies.get(Scope.Compile) != null) {
                     for (ResolvedDependency d : dependencies.get(Scope.Compile)) {
-                        if (hasAcceptableTransitivity(d, acc) &&
+                        if (d.isTransitive() &&
+                            hasAcceptableTransitivity(d, acc) &&
                             groupId.equals(d.getGroupId()) &&
-                            artifactId.equals(d.getArtifactId()) &&
-                            (d.isTransitive() ||
-                                    (d.isDirect() && version.equals(d.getVersion())))
-                        ) {
+                            artifactId.equals(d.getArtifactId())) {
                             return maven;
                         }
                     }
@@ -248,7 +247,8 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                 Scope resolvedScopeEnum = Scope.fromName(resolvedScope);
                 if ((resolvedScopeEnum == Scope.Provided || resolvedScopeEnum == Scope.Test) && dependencies.get(resolvedScopeEnum) != null) {
                     for (ResolvedDependency d : dependencies.get(resolvedScopeEnum)) {
-                        if (hasAcceptableTransitivity(d, acc) &&
+                        if (d.isTransitive() &&
+                                hasAcceptableTransitivity(d, acc) &&
                                 groupId.equals(d.getGroupId()) && artifactId.equals(d.getArtifactId())) {
                             return maven;
                         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
@@ -34,6 +34,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyList;
@@ -92,7 +93,12 @@ public class AddDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
             ResolvedPom resolvedPom = getResolutionResult().getPom();
             String existingGroupId = resolvedPom.getValue(tag.getChildValue("groupId").orElse(null));
             String existingArtifactId = resolvedPom.getValue(tag.getChildValue("artifactId").orElse(null));
-            if (groupId.equals(existingGroupId) && artifactId.equals(existingArtifactId)) {
+            String wantedType = type == null ? "jar" : type;
+            String existingType = tag.getChildValue("type").orElse("jar");
+            String existingClassifier = tag.getChildValue("classifier").orElse(null);
+            if (groupId.equals(existingGroupId) && artifactId.equals(existingArtifactId) &&
+                    wantedType.equals(existingType) &&
+                    Objects.equals(classifier, existingClassifier)) {
                 Scope requestedScope = Scope.fromName(scope);
                 Scope existingScope = Scope.fromName(resolvedPom.getValue(tag.getChildValue("scope").orElse(null)));
                 if (tag.getMarkers().getMarkers().stream()
@@ -123,6 +129,10 @@ public class AddDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
                                 return e.warn(tag);
                             }
                         }
+                    }
+                    if (versionToUse == null && requestedScope == existingScope) {
+                        getCursor().putMessageOnFirstEnclosing(Xml.Document.class, "doNotAlterDependency", true);
+                        return tag;
                     }
                     if (versionToUse != null) {
                         getCursor().putMessageOnFirstEnclosing(Xml.Document.class, "requestedVersionChange", true);
@@ -157,10 +167,11 @@ public class AddDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
 
         boolean requestedVersionChange = getCursor().getMessage("requestedVersionChange", false);
         Scope resolvedScope = Scope.fromName(scope);
+        String wantedType = type == null ? "jar" : type;
         Map<Scope, List<ResolvedDependency>> dependencies = getResolutionResult().getDependencies();
         if (dependencies.containsKey(resolvedScope)) {
             for (ResolvedDependency d : dependencies.get(resolvedScope)) {
-                if (d.isDirect() && groupId.equals(d.getGroupId()) && artifactId.equals(d.getArtifactId())) {
+                if (d.isDirect() && matchesCoordinate(d, wantedType)) {
                     if (requestedVersionChange) {
                         checkVersionUpdate(d.getVersion());
                     }
@@ -182,7 +193,7 @@ public class AddDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
             Scope oldScope = getCursor().getMessage("oldScope");
             if (dependencies.containsKey(oldScope)) {
                 for (ResolvedDependency d : dependencies.get(oldScope)) {
-                    if (d.isDirect() && groupId.equals(d.getGroupId()) && artifactId.equals(d.getArtifactId())) {
+                    if (d.isDirect() && matchesCoordinate(d, wantedType)) {
                         if (requestedVersionChange) {
                             checkVersionUpdate(d.getVersion());
                         }
@@ -269,6 +280,13 @@ public class AddDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
 
             return super.visitTag(tag, ctx);
         }
+    }
+
+    private boolean matchesCoordinate(ResolvedDependency d, String wantedType) {
+        return groupId.equals(d.getGroupId()) &&
+                artifactId.equals(d.getArtifactId()) &&
+                wantedType.equals(d.getType()) &&
+                Objects.equals(classifier, d.getClassifier());
     }
 
     private @Nullable String tryGetFamilyVersion() {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -2359,6 +2359,68 @@ class AddDependencyTest implements RewriteTest {
         );
     }
 
+    @Test
+    void doesNotDuplicateWhenChainedAfterChangeDependencyWithSemverSelector() {
+        rewriteRun(
+          spec -> spec.recipes(
+            new ChangeDependencyGroupIdAndArtifactId(
+              "javax.ws.rs", "javax.ws.rs-api",
+              "jakarta.ws.rs", "jakarta.ws.rs-api",
+              "3.0.x", null),
+            new AddDependency(
+              "jakarta.ws.rs", "jakarta.ws.rs-api", "3.0.x", null,
+              null, true, null, null, null, false, null, null)
+          ),
+          pomXml(
+            """
+              <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>jakarta.ws.rs</groupId>
+                              <artifactId>jakarta.ws.rs-api</artifactId>
+                              <version>3.0.0</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                      <dependency>
+                          <groupId>javax.ws.rs</groupId>
+                          <artifactId>javax.ws.rs-api</artifactId>
+                          <version>2.1.1</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>jakarta.ws.rs</groupId>
+                              <artifactId>jakarta.ws.rs-api</artifactId>
+                              <version>3.0.0</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                      <dependency>
+                          <groupId>jakarta.ws.rs</groupId>
+                          <artifactId>jakarta.ws.rs-api</artifactId>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
     private AddDependency addDependency(@SuppressWarnings("SameParameterValue") String gav) {
         return addDependency(gav, null, null, null);
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -2263,6 +2263,102 @@ class AddDependencyTest implements RewriteTest {
         );
     }
 
+    @Test
+    void doesNotDuplicateWhenManagedVersionSatisfiesSemverSelector() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:28.X", "com.google.common.math.IntMath")),
+          pomXml(
+            """
+              <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-parent</artifactId>
+                  <version>1</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>com.google.guava</groupId>
+                              <artifactId>guava</artifactId>
+                              <version>28.0-jre</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """
+          ),
+          mavenProject(
+            "server",
+            srcMainJava(
+              java(usingGuavaIntMath)
+            ),
+            pomXml(
+              """
+                <project>
+                    <parent>
+                        <groupId>com.mycompany.app</groupId>
+                        <artifactId>my-parent</artifactId>
+                        <version>1</version>
+                    </parent>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void addsWhenSameGaExistsWithDifferentClassifier() {
+        var addDep = new AddDependency("com.google.guava", "guava", "29.0-jre", null,
+          null, true, null, null, "tests", false, null, null);
+        rewriteRun(
+          spec -> spec.recipe(addDep),
+          pomXml(
+            """
+              <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.google.guava</groupId>
+                          <artifactId>guava</artifactId>
+                          <version>29.0-jre</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.google.guava</groupId>
+                          <artifactId>guava</artifactId>
+                          <version>29.0-jre</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>com.google.guava</groupId>
+                          <artifactId>guava</artifactId>
+                          <version>29.0-jre</version>
+                          <classifier>tests</classifier>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
     private AddDependency addDependency(@SuppressWarnings("SameParameterValue") String gav) {
         return addDependency(gav, null, null, null);
     }


### PR DESCRIPTION
## Problem

`AddDependency` (and the cross-build wrapper `org.openrewrite.java.dependencies.AddDependency`) can emit a duplicate `<dependency>` entry for the same `groupId:artifactId` even when one is already declared in the same scope. The dedup pre-check at [`AddDependency.java:233-245`](https://github.com/openrewrite/rewrite/blob/main/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java#L233-L245) compares the recipe's option `version` to the *resolved* version of the existing direct dependency via `String.equals`. Any non-exact-match value bypasses dedup:

- A semver selector (`3.0.x`, `28.X`, etc.) never equals a concrete resolved version literal.
- A version pin that differs from what `<dependencyManagement>` resolves to misses.
- Maven property references (`${some.version}`) miss before resolution.

A separate classifier-blind dedup elsewhere in `AddDependencyVisitor` also suppresses *legitimate* adds when a same-GA jar already exists and the recipe is targeting a different `<classifier>`.

## Fix

Move direct-dependency dedup into `AddDependencyVisitor.visitTag`, where the decision is made against the XML (always current) rather than the resolution model. When the existing `<dependency>` tag matches groupId/artifactId/type/classifier, the requested scope equals the existing scope, and any managed version satisfies the recipe's version selector, set the existing `doNotAlterDependency` cursor message and return the document unmodified. The version-update path (`requestedVersionChange` → `checkVersionUpdate`) and the scope-broadening path (`requestedScopeChange` → `ChangeDependencyScope`) are unchanged and continue to work for direct deps.

Restrict the two pre-check loops in `AddDependency.java` to **transitive-only** matches (gate on `d.isTransitive()`). Direct-dep handling flows through the visitor where scope broadening, version updates, and dedup can coexist consistently.

Also disambiguate the `visitTag` predicate and the resolution-based dedup loops in `visitDocument` by `<type>` and `<classifier>` so adding `g:a:tests` is no longer treated as a duplicate of an existing `g:a` jar.

## Tests

- **`addsWhenSameGaExistsWithDifferentClassifier`** — pom has `com.google.guava:guava:29.0-jre` jar, recipe adds `com.google.guava:guava:29.0-jre` with `<classifier>tests</classifier>`. **Verified failing pre-fix**: the existing-dep check (classifier-blind) suppressed the add; post-fix both coordinates land in the pom.
- **`doesNotDuplicateWhenManagedVersionSatisfiesSemverSelector`** — pom inherits a parent that manages `com.google.guava:guava:28.0-jre`, the dep is declared in the child without a `<version>`, recipe asks for `28.X` with `onlyIfUsing`. Forward regression coverage: in this minimal isolated form the existing resolution-based dedup catches it, so the test passes pre-fix too — it pins the `doNotAlterDependency` short-circuit as the load-bearing path now that the resolution-based dedup is no longer relied on for direct deps.
- **`doesNotDuplicateWhenChainedAfterChangeDependencyWithSemverSelector`** — mirrors the `JavaxWsToJakartaWs` recipeList shape: `ChangeDependencyGroupIdAndArtifactId` rewrites `javax.ws.rs:javax.ws.rs-api:2.1.1` → `jakarta.ws.rs:jakarta.ws.rs-api` (managed at `3.0.0`), then `AddDependency` runs with selector `3.0.x`. Also forward regression coverage: in this minimal form `<version>` is stripped (BOM-managed) and the resolution-based dedup catches the would-be duplicate. Documents the intended end-state (single managed jakarta entry) and pins the `doNotAlterDependency` short-circuit for the BOM-managed-rewrite case.

Full `:rewrite-maven:test` suite passes.

## Note on coverage

Of the three new tests, only the classifier case currently fails on `main` — the two no-duplicate tests are documenting intent and pinning the new short-circuit, not catching an actively-failing scenario. The `version.equals(d.getVersion())` defect in the `AddDependency` pre-check is real but currently masked by the visitor's lines 161-171 dedup against a fresh resolution model; the fix collapses that two-layer arrangement into a single XML-driven gate that doesn't depend on resolution-model freshness.

## Test plan

- [x] `:rewrite-maven:test` green
- [x] `addsWhenSameGaExistsWithDifferentClassifier` confirmed to fail pre-fix
- [ ] `rewrite-migrate-java` Jakarta migration tests green against this branch