### PR TITLE
rpc: cap concurrent in-flight requests via ExecutionContext

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -297,8 +297,11 @@ public class RewriteRpc {
 
         String sourceFileType = (tree instanceof SourceFile ? tree : requireNonNull(cursor).firstEnclosingOrThrow(SourceFile.class))
                 .getClass().getName();
-        VisitResponse response = send("Visit", new Visit(visitorName, sourceFileType, null,
+        Supplier<VisitResponse> doSend = () -> send("Visit", new Visit(visitorName, sourceFileType, null,
                 tree.getId().toString(), pId, cursorIds), VisitResponse.class);
+        VisitResponse response = p instanceof ExecutionContext
+                ? RewriteRpcExecutionContextView.view((ExecutionContext) p).withInFlightSlot(doSend)
+                : doSend.get();
         return response.isModified() ?
                 getObject(tree.getId().toString(), sourceFileType) :
                 tree;
@@ -314,14 +317,18 @@ public class RewriteRpc {
 
         String sourceFileType = (tree instanceof SourceFile ? tree : requireNonNull(cursor).firstEnclosingOrThrow(SourceFile.class))
                 .getClass().getName();
-        return send("BatchVisit", new BatchVisit(sourceFileType, treeId, pId, cursorIds, visitors),
+        Supplier<BatchVisitResponse> doSend = () -> send("BatchVisit",
+                new BatchVisit(sourceFileType, treeId, pId, cursorIds, visitors),
                 BatchVisitResponse.class);
+        return p instanceof ExecutionContext
+                ? RewriteRpcExecutionContextView.view((ExecutionContext) p).withInFlightSlot(doSend)
+                : doSend.get();
     }
 
     public Collection<? extends SourceFile> generate(String remoteRecipeId, ExecutionContext ctx) {
         String ctxId = maybeUnwrapExecutionContext(ctx);
-        GenerateResponse response = send("Generate", new Generate(remoteRecipeId, ctxId),
-                GenerateResponse.class);
+        GenerateResponse response = RewriteRpcExecutionContextView.view(ctx).withInFlightSlot(() ->
+                send("Generate", new Generate(remoteRecipeId, ctxId), GenerateResponse.class));
         if (!response.getIds().isEmpty()) {
             List<SourceFile> generated = new ArrayList<>(response.getIds().size());
             for (int i = 0; i < response.getIds().size(); i++) {
@@ -452,7 +459,8 @@ public class RewriteRpc {
             public boolean tryAdvance(Consumer<? super SourceFile> action) {
                 if (ids == null) {
                     // FIXME handle `TimeoutException` gracefully
-                    ids = send("Parse", new Parse(mappedInputs, relativeTo != null ? relativeTo.toString() : null), ParseResponse.class);
+                    ids = RewriteRpcExecutionContextView.view(ctx).withInFlightSlot(() ->
+                            send("Parse", new Parse(mappedInputs, relativeTo != null ? relativeTo.toString() : null), ParseResponse.class));
                     assert ids.size() == inputList.size();
                 }
 

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcExecutionContextView.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcExecutionContextView.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import org.openrewrite.DelegatingExecutionContext;
+import org.openrewrite.ExecutionContext;
+
+import java.util.concurrent.Semaphore;
+import java.util.function.Supplier;
+
+public class RewriteRpcExecutionContextView extends DelegatingExecutionContext {
+    private static final String MAX_IN_FLIGHT = "org.openrewrite.rpc.maxInFlight";
+    private static final String IN_FLIGHT_SEMAPHORE = "org.openrewrite.rpc.inFlightSemaphore";
+
+    public RewriteRpcExecutionContextView(ExecutionContext delegate) {
+        super(delegate);
+    }
+
+    public static RewriteRpcExecutionContextView view(ExecutionContext ctx) {
+        if (ctx instanceof RewriteRpcExecutionContextView) {
+            return (RewriteRpcExecutionContextView) ctx;
+        }
+        return new RewriteRpcExecutionContextView(ctx);
+    }
+
+    /**
+     * Cap on concurrent in-flight RPC requests across this run, sized to the
+     * memory headroom of the host running rewrite-rpc subprocesses. Each
+     * permit covers one actively-executing visit/parse/generate/print; idle
+     * subprocesses do not consume a permit. Default is unlimited so that
+     * out-of-the-box OpenRewrite behavior is unchanged; callers (e.g. a host
+     * that knows its own memory budget) opt in by setting an explicit cap.
+     */
+    public RewriteRpcExecutionContextView setMaxInFlight(int maxInFlight) {
+        putMessage(MAX_IN_FLIGHT, maxInFlight);
+        return this;
+    }
+
+    public int getMaxInFlight() {
+        return getMessage(MAX_IN_FLIGHT, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Run {@code work} while holding one of the in-flight RPC permits. The
+     * semaphore is created lazily on first call and shared across every
+     * thread that observes this ExecutionContext.
+     */
+    public <T> T withInFlightSlot(Supplier<T> work) {
+        Semaphore slots = computeMessageIfAbsent(IN_FLIGHT_SEMAPHORE,
+                k -> new Semaphore(getMaxInFlight()));
+        slots.acquireUninterruptibly();
+        try {
+            return work.get();
+        } finally {
+            slots.release();
+        }
+    }
+}


### PR DESCRIPTION
Adds `RewriteRpcExecutionContextView` so callers can cap how many `RewriteRpc` requests are in flight at once across a `mod run`. Each permit covers one actively-executing visit/parse/generate/batchVisit; idle subprocesses do not consume a permit.

## Motivation

When recipes fan out across a `ForkJoinPool`, `RewriteRpcProcessManager` spawns one rewrite-rpc subprocess per worker thread (`ThreadLocal`), and each subprocess (Python/JS/.NET/Go) is unbounded in memory. On a memory-constrained host running a polyglot recipe across many repos, peak active subprocesses can exhaust host RAM and take the JVM unresponsive — the failure mode that recently surfaced under `UpgradeToPython314` runs on a 16-vCPU/32-GB host.

Capping `mod run --parallel` would also throttle pure-Java recipes that don't spawn subprocesses, which is the wrong altitude for the knob — the cost is per-subprocess, but `--parallel` caps the work mix.

## Shape

`RewriteRpcExecutionContextView.view(ctx).withInFlightSlot(() -> send(...))` wraps the four heavy `RewriteRpc` methods that drive subprocess work: `visit`, `batchVisit`, `generate`, `parse`. The `Semaphore` is created lazily (atomically via `ConcurrentHashMap`-backed `computeMessageIfAbsent`) on the first acquire and shared across all threads observing the same `ExecutionContext`.

Default cap is `Integer.MAX_VALUE` — pure-Java recipes pay zero overhead, and existing callers see no behavior change unless they explicitly opt in via `setMaxInFlight(n)`.

## Why guard the request, not the spawn

Wrapping `getOrStart()` (acquire on spawn, release on shutdown) would let the first N threads hold their permits for the whole `mod run`, permanently head-of-line-blocking the other workers. Wrapping each request lets all FJP threads spawn idle subprocesses freely, but caps how many can be *actively visiting* at once. Idle interpreter footprint is small; peak active footprint is what causes OOM.
