### PR TITLE
Java: exclude leaked checkstyle Maven metadata from shadowJar

### DIFF
--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -100,4 +100,8 @@ tasks.named<ShadowJar>("shadowJar").configure {
     dependsOn(checkstyle)
     configurations = listOf(checkstyle)
     relocate("com.puppycrawl.tools.checkstyle", "org.openrewrite.tools.checkstyle")
+    // Avoid leaking the bundled checkstyle's META-INF/maven/com.puppycrawl.tools/checkstyle/
+    // metadata, which would otherwise cause tools that read pom.properties to misidentify
+    // this jar as com.puppycrawl.tools:checkstyle.
+    exclude("META-INF/maven/**")
 }


### PR DESCRIPTION
## Motivation

The `rewrite-java` shadowJar bundles the `checkstyle` dependency and relocates `com.puppycrawl.tools.checkstyle` → `org.openrewrite.tools.checkstyle`, but it does not strip the bundled `META-INF/maven/com.puppycrawl.tools/checkstyle/{pom.xml,pom.properties}` metadata. As a result the produced jar contains exactly one Maven metadata entry, and it identifies the jar as `com.puppycrawl.tools:checkstyle:9.3`:

```
$ unzip -l rewrite-java-8.82.0-SNAPSHOT.jar | grep META-INF/maven
   META-INF/maven/com.puppycrawl.tools/checkstyle/pom.xml
   META-INF/maven/com.puppycrawl.tools/checkstyle/pom.properties

$ unzip -p rewrite-java-8.82.0-SNAPSHOT.jar META-INF/maven/com.puppycrawl.tools/checkstyle/pom.properties
artifactId=checkstyle
groupId=com.puppycrawl.tools
version=9.3
```

Any tool that follows the standard Maven convention of identifying a jar by reading `META-INF/maven/<g>/<a>/pom.properties` will misidentify `rewrite-java` as `com.puppycrawl.tools:checkstyle:9.3`. This already caused a real problem downstream (a partition cache labelled with the wrong coordinates).

Other rewrite jars don't include `META-INF/maven/` at all (Gradle convention), so the simplest, lowest-risk fix is to exclude foreign Maven metadata from the shadow jar entirely.

## Summary

- Add `exclude("META-INF/maven/**")` to the `shadowJar` configuration in `rewrite-java/build.gradle.kts` so no leaked third-party Maven metadata ships in the jar.

## Test plan

- [x] `./gradlew :rewrite-java:shadowJar` builds successfully.
- [x] `unzip -l rewrite-java/build/libs/rewrite-java-*-SNAPSHOT.jar | grep META-INF/maven` returns no entries.
- [x] Relocated checkstyle classes are still bundled (`grep -c 'org/openrewrite/tools/checkstyle'` returns 1272 entries).
- [ ] Full CI green.