### PR TITLE
rpc: kill child processes at JVM exit via shutdown hook

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -71,7 +71,7 @@ public class RewriteRpcProcess extends Thread {
 
     public RewriteRpcProcess(String... command) {
         this.command = command;
-        this.setName("JavaScriptRewriteRpcProcess");
+        this.setName("RewriteRpcProcess");
         this.setDaemon(false);
     }
 
@@ -168,6 +168,13 @@ public class RewriteRpcProcess extends Thread {
             }
         }
 
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                shutdown();
+            } catch (Throwable ignored) {
+            }
+        }, "rpc-shutdown"));
+
         SimpleModule module = new SimpleModule();
         module.addSerializer(Path.class, new PathSerializer());
         module.addDeserializer(Path.class, new PathDeserializer());
@@ -191,7 +198,7 @@ public class RewriteRpcProcess extends Thread {
                 }
                 int exitCode = process.exitValue();
                 if (exitCode != 0 && exitCode != 1 && exitCode != 143) { // 143 = SIGTERM
-                    throw new RuntimeException("JavaScript Rewrite RPC process crashed with exit code: " + exitCode);
+                    throw new RuntimeException("Rewrite RPC process crashed with exit code: " + exitCode);
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RewriteRpcProcessTest {
+
+    /**
+     * Forks a JVM that spawns a long-running child via {@link RewriteRpcProcess} and
+     * exits without calling {@link RewriteRpcProcess#shutdown()}. Asserts that the
+     * spawned child is no longer alive once the forked JVM exits, confirming that
+     * the JVM-exit shutdown hook on {@code RewriteRpcProcess} actually killed it.
+     * <p>
+     * Without the hook this test fails: on Unix the orphan would be reparented to
+     * init and remain alive; on Windows it would simply continue running.
+     */
+    @Test
+    void shutdownHookKillsChildOnJvmExit() throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(
+                System.getProperty("java.home") + "/bin/java",
+                "-cp", System.getProperty("java.class.path"),
+                ForkedJvmEntryPoint.class.getName());
+        pb.redirectErrorStream(true);
+        Process forked = pb.start();
+
+        long childPid = -1;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(forked.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith("RPC_PID=")) {
+                    childPid = Long.parseLong(line.substring("RPC_PID=".length()).trim());
+                }
+            }
+        }
+        assertThat(forked.waitFor(15, TimeUnit.SECONDS))
+                .as("forked JVM should exit on its own")
+                .isTrue();
+        assertThat(childPid).as("forked JVM should have printed an RPC_PID").isPositive();
+
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (isAlive(childPid) && System.nanoTime() < deadline) {
+            //noinspection BusyWait
+            Thread.sleep(50);
+        }
+
+        boolean stillAlive = isAlive(childPid);
+        if (stillAlive) {
+            // Don't leak a stray sleep if the assertion is about to fail.
+            ProcessHandle.of(childPid).ifPresent(ProcessHandle::destroyForcibly);
+        }
+        assertThat(stillAlive)
+                .as("child PID %s should be dead after forked JVM exit (shutdown hook)", childPid)
+                .isFalse();
+    }
+
+    private static boolean isAlive(long pid) {
+        return ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false);
+    }
+
+    /**
+     * Runs in the forked JVM. Spawns a long-running child via {@link RewriteRpcProcess},
+     * prints its PID, and returns from {@code main} so the JVM exits without an explicit
+     * {@code shutdown()} call.
+     */
+    public static class ForkedJvmEntryPoint {
+        public static void main(String[] args) throws Exception {
+            RewriteRpcProcess proc = new RewriteRpcProcess("sleep", "30");
+            proc.start();
+
+            Field f = RewriteRpcProcess.class.getDeclaredField("process");
+            f.setAccessible(true);
+            Process underlying = (Process) f.get(proc);
+
+            System.out.println("RPC_PID=" + underlying.pid());
+            System.out.flush();
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

`RewriteRpcProcess.start()` now registers a per-instance JVM shutdown hook that invokes its own `shutdown()` on JVM exit.

## What's your motivation?

Prior to this change, RPC subprocesses spawned by worker threads (`ForkJoinPool.commonPool()`, `parallelStream`) were not being killed, leaving leftover `node.exe` / `python.exe` running after the JVM exited.


## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
