### PR TITLE
rpc: avoid ForkJoinPool compensation in send polling loop

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -43,8 +43,6 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -606,19 +604,27 @@ public class RewriteRpc {
             // Send the request and get the future
             CompletableFuture<JsonRpcSuccess> future = jsonRpc.send(JsonRpcRequest.newRequest(method, body));
 
-            // Poll for completion while checking if process is alive
+            // future.get(timeout) from a FJP worker triggers ManagedBlocker compensation,
+            // which spawns helper threads that can leak per-thread RewriteRpc state.
+            // Poll non-blockingly + Thread.sleep so FJP doesn't compensate.
             long totalTimeoutMs = timeout.toMillis();
-            long checkIntervalMs = 500; // Check every 500ms
+            long pollIntervalMs = 1;
+            long livenessIntervalMs = 500;
             long elapsedMs = 0;
-
+            long lastLivenessMs = 0;
             while (elapsedMs < totalTimeoutMs) {
-                try {
-                    // Try to get the result with a short timeout
-                    return future.get(checkIntervalMs, TimeUnit.MILLISECONDS).getResult(responseType);
-                } catch (TimeoutException e) {
+                JsonRpcSuccess result = future.getNow(null);
+                if (result != null) {
+                    return result.getResult(responseType);
+                }
+                if (future.isCompletedExceptionally()) {
+                    return future.get().getResult(responseType);
+                }
+                Thread.sleep(pollIntervalMs);
+                elapsedMs += pollIntervalMs;
+                if (elapsedMs - lastLivenessMs >= livenessIntervalMs) {
                     checkLiveness();
-                    elapsedMs += checkIntervalMs;
-                    // Continue waiting if process is still alive and we haven't hit total timeout
+                    lastLivenessMs = elapsedMs;
                 }
             }
 


### PR DESCRIPTION
## What's changed?

`RewriteRpc.send`'s polling loop now uses `future.getNow(null)` + `Thread.sleep(1ms)` instead of `future.get(checkIntervalMs, TimeUnit.MILLISECONDS)`. Liveness check decoupled from polling cadence and fires every 500ms.

## What's your motivation?

`future.get(long, TimeUnit)` from a `ForkJoinPool` worker goes through `CompletableFuture.Signaller.block`, which is a `ForkJoinPool.ManagedBlocker`. ManagedBlocker is the explicit hook FJP watches for and reacts to by spawning a **compensation worker** — a fresh thread added to keep parallelism while the original is parked.

That compensation worker can pick up other queued work (recipe load, printer invocations, etc.) and call `PythonRewriteRpc.getOrStart()` / `JavaScriptRewriteRpc.getOrStart()` / etc., spawning a fresh OS rpc subprocess into its `ThreadLocal`. When FJP later terminates the idle compensation worker, its TL is GC'd — but the **OS process is independent of the JVM heap and survives**. The dispatching worker's `RunTask.execute()` finally only runs `shutdownCurrent()` on the dispatching thread's TL, never on the dead compensation worker.

On a moderne-cli `mod run` against ~448 Python repos, this accumulated 127+ alive python rpc processes per long-running JVM, with each leaked rpc carrying a different past repo's log path in argv. Each compensation-worker spawn = one leaked OS process. The same mechanism applies to JS / C# / Go rpcs.

`Thread.sleep` parks the thread via `LockSupport` directly, not through ManagedBlocker, so FJP doesn't compensate. Parallelism temporarily drops by one while a worker is in `rpc.send`, which is exactly the resource-bounded behavior `--parallel` is supposed to mean.

Verified locally with a 20-repo Python LST sample running `UpgradeToPython314` at `--parallel=14`:
- Before: spawn count >> repo count under load (compensation amplification)
- After: spawn count = repo count, alive rpc count ≤ `--parallel`, no compensation worker thread names in jstack, `final_alive=0` after run.

- ## Pairs with #7616

- #7616 added a JVM-shutdown-hook on `RewriteRpcProcess` to kill child processes at JVM exit — that catches survivors at process termination. This PR prevents the leak from happening intra-run by removing its trigger.

### Checklist

- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
