### PR TITLE
rpc: install openrewrite with [profiling] extra so Python rpc can report to Pyroscope

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -740,12 +740,16 @@ public class PythonRewriteRpc extends RewriteRpc {
             try {
                 Files.createDirectories(pipPackagesPath);
 
+                // Install with the [profiling] extra so pyroscope-io is available when
+                // PYROSCOPE_SERVER_ADDRESS is set in the rpc subprocess environment. The
+                // SDK init in rewrite.rpc.server is a no-op when the env var is unset, so
+                // adding the extra costs nothing for non-profiled deployments.
                 ProcessBuilder pb = new ProcessBuilder(
                         pythonPath.toString(),
                         "-m", "pip", "install",
                         "--upgrade",
                         "--target=" + pipPackagesPath.toAbsolutePath().normalize(),
-                        "openrewrite==" + version
+                        "openrewrite[profiling]==" + version
                 );
                 pb.environment().putAll(environment);
                 pb.redirectErrorStream(true);


### PR DESCRIPTION
## What's changed?

`PythonRewriteRpc$Builder.bootstrapOpenrewrite` now installs the openrewrite Python package with the `[profiling]` extra: `openrewrite[profiling]==<version>` instead of `openrewrite==<version>`.

## What's your motivation?

- #7558 added Pyroscope SDK init to the Python rpc server (`_init_pyroscope` in `rewrite.rpc.server`), gated on `PYROSCOPE_SERVER_ADDRESS` in the subprocess environment, and made `pyroscope-io` the `[profiling]` extra in `pyproject.toml`. Without the extra installed, `_init_pyroscope` ImportError-warns and silently no-ops — so the Python rpc never reports flame graphs even when the env vars are wired through correctly.

Observed on the moderne-cli dev recipe-worker:

- Pyroscope env vars **are** set on the Python subprocess: `PYROSCOPE_SERVER_ADDRESS=https://...`, `PYROSCOPE_APPLICATION_NAME=modcli`, plus full `PYROSCOPE_LABELS` (verified via `cat /proc/<rpc-pid>/environ`).
- `pyroscope-io` is **not** installed in the python interpreter the rpc uses (`/opt/python/bin/python3.11 -c "import pyroscope"` → `ModuleNotFoundError`).
- Pyroscope dashboard shows `modcli` flame graphs from the JVM only — no `runtime=python` slice.

`bootstrapOpenrewrite` is the runtime install hook that seeds the per-version pip-packages directory used as the rpc's PYTHONPATH, so this is the right place to add the extra. Always installing the extra costs nothing for non-profiled deployments — the SDK init is gated on `PYROSCOPE_SERVER_ADDRESS` and no-ops when unset.

JS doesn't need a parallel change: `npx --package=@openrewrite/rewrite@<version>` honors `optionalDependencies` in package.json automatically. Go has the SDK as a regular dep already. C# uses CoreCLR profiler env vars only.

### Checklist

- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
