### PR TITLE
rpc: walk superclass chain in RpcVisitor.isAcceptable

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcVisitor.java
@@ -22,6 +22,8 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 class RpcVisitor extends TreeVisitor<Tree, ExecutionContext> {
     private final RewriteRpc rpc;
@@ -29,7 +31,13 @@ class RpcVisitor extends TreeVisitor<Tree, ExecutionContext> {
 
     @Override
     public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-        return rpc.getLanguages().contains(sourceFile.getClass().getName());
+        List<String> languages = rpc.getLanguages();
+        for (Class<?> c = sourceFile.getClass(); c != null; c = c.getSuperclass()) {
+            if (languages.contains(c.getName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
## What's changed?

`RpcVisitor.isAcceptable` now walks the source file's superclass chain when comparing against the language types reported by the rpc, instead of doing an exact-name match on the leaf class.

## What's your motivation?

`rpc.getLanguages()` returns canonical class names (e.g. `org.openrewrite.python.tree.Py$CompilationUnit`). When a `SourceFile` instance reaches the visitor as a *subclass* of one of those types, the original exact-name `contains` check returned false and the BatchVisit / Visit dispatch silently skipped the file. The Java side had no warning and the rpc never received a `Visit` request — recipes appeared to run cleanly with `runFilesSearched` populated but never called the rpc visitors, so every per-file outcome was "no change."

Walking the superclass chain handles the subclass case while preserving direct-instance semantics: a direct instance of the advertised type matches on the first iteration of the loop, so existing call sites behave identically.

Confirmed locally: on a Python migration recipe (`org.openrewrite.python.migrate.UpgradeToPython314`) running over a sample of 9 Python repos, pre-fix produced 0 `handle_visit` and 0 `handle_batch_visit` calls on the Python rpc side; post-fix produced ~1000 visits and ~5000 prints across the same workload.

### Checklist

- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
