### PR TITLE
Python rpc: skip SearchResult walk when visitor didn't modify (~59% faster)

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1317,8 +1317,10 @@ def handle_batch_visit(params: dict) -> dict:
         modified = after is not before
         deleted = after is None
 
-        # Diff SearchResult IDs against the running set
-        if deleted:
+        # Diff SearchResult IDs against the running set. Trees are immutable, so
+        # a visitor that returns the same reference cannot have added new
+        # SearchResults — skip the full-tree walk in that case.
+        if deleted or not modified:
             search_result_ids = []
         else:
             after_ids = _collect_search_result_ids(after)


### PR DESCRIPTION
## Summary

`handle_batch_visit` calls `_collect_search_result_ids(after)` after every visitor invocation, even when the visitor returned the same tree reference. Since trees are immutable, an unchanged tree cannot have gained new `SearchResult` markers, so the walk is pure waste.

For composite recipes that expand into many child visitors — e.g. `UpgradeToPython314` → `UpgradeToPython313` chain has ~15-20 children — most visitor invocations don't modify any given file, so most walks were redundant.

## Why it's safe

`_collect_search_result_ids` exists to track which `SearchResult` markers were added by *this* visitor, by diffing `after_ids` against the running `known_ids`. Trees in OpenRewrite are immutable; a visitor that wants to add a marker must produce a new tree reference. So `after is before` ⇒ no new markers ⇒ the diff is empty.

## Performance impact

Measured on `org.openrewrite.python.migrate.UpgradeToPython314` against `ArchiveBox/ArchiveBox` @ `c5e23d93` (228 .py files, fix=61). Single-repo run, JFR + cProfile.

| | Before | After |
|---|---:|---:|
| Wall time | **5:25 (322.7s)** | **2:19 (133.8s)** |
| `_collect_search_result_ids` calls | 16,940 | dropped from top 30 |
| `replace_if_changed` calls | 42M | 17M |
| `isinstance` calls | 99.7M | 57.7M |
| fix count | 61 | 61 |

**~59% wall-time reduction with one line of logic; same recipe outcome.**

JVM was idle during the run (1-15% jvmUser per JFR `jdk.CPULoad`); 100% of the wall time was the Python rpc subprocess. After-fix top hot path is now the legitimate visitor framework dispatch (`visit`, `visit_right_padded`, `visit_compilation_unit`).

## Test plan

- [x] Recipe outcome unchanged: `runFilesWithFixResults=61` before and after.
- [x] No new errors: `runFilesWithErrors=0` before and after.
- [ ] CI runs the existing `tests/rpc/` suite — the change is `or not modified` on a branch that already has the `deleted` short-circuit, so existing test coverage exercises both paths.
