### PR TITLE
rewrite-python: wire Preconditions.check end-to-end for RPC recipes

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcRecipe.java
@@ -47,9 +47,19 @@ public class RpcRecipe extends ScanningRecipe<Integer> {
     private final RecipeDescriptor descriptor;
     @Getter
     private final String editVisitor;
+    /**
+     * Composite of all editPreconditions resolved during PrepareRecipe. Exposed so that the
+     * BatchVisit batching path in {@link org.openrewrite.scheduling.RecipeRunCycle} can
+     * evaluate preconditions locally before adding a visitor to the batch — otherwise the
+     * batch would dispatch the visit RPC for files that the precondition would have rejected.
+     * The non-batch path uses {@link #getVisitor()}, which already wraps with
+     * {@link org.openrewrite.Preconditions#check}.
+     */
+    @Getter
     private final @Nullable TreeVisitor<?, ExecutionContext> editPreconditionVisitor;
     @Getter
     private final @Nullable String scanVisitor;
+    @Getter
     private final @Nullable TreeVisitor<?, ExecutionContext> scanPreconditionVisitor;
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -334,12 +334,28 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                     // the file as modified.
                     if (currentRpc.getLanguages().contains(src.getClass().getName())) {
                         RpcRecipe rpcRecipe = (RpcRecipe) recipe;
-                        batch.items.add(new BatchVisit.BatchVisitItem(rpcRecipe.getEditVisitor(), null));
-                        batch.recipeStacks.add(recipeStack);
-                        if (batch.originalBeforeBatch == null) {
-                            batch.originalBeforeBatch = src;
+                        // Evaluate the precondition locally before batching. The non-batch
+                        // path runs the precondition via getVisitor()'s Preconditions.check
+                        // wrapper; the batch path bypasses that wrapper because it dispatches
+                        // editVisitor names directly. Without this gate, every batched recipe
+                        // would visit every file regardless of preconditions, defeating the
+                        // optimization.
+                        TreeVisitor<?, ExecutionContext> precondition = rpcRecipe.getEditPreconditionVisitor();
+                        boolean preconditionPasses = true;
+                        if (precondition != null) {
+                            //noinspection unchecked
+                            TreeVisitor<Tree, ExecutionContext> typed =
+                                    (TreeVisitor<Tree, ExecutionContext>) precondition;
+                            preconditionPasses = typed.visit(src, ctx, rootCursor) != src;
                         }
-                        batch.rpc = currentRpc;
+                        if (preconditionPasses) {
+                            batch.items.add(new BatchVisit.BatchVisitItem(rpcRecipe.getEditVisitor(), null));
+                            batch.recipeStacks.add(recipeStack);
+                            if (batch.originalBeforeBatch == null) {
+                                batch.originalBeforeBatch = src;
+                            }
+                            batch.rpc = currentRpc;
+                        }
                     }
 
                     // If this is the last recipe in the batch, flush now

--- a/rewrite-python/rewrite/src/rewrite/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/__init__.py
@@ -24,6 +24,7 @@ from .markers import *
 from .parser import *
 from .result import *
 from .style import *
+from .preconditions import Check, Preconditions, RecipeCheck
 from .tree import Checksum, FileAttributes, SourceFile, Tree, PrintOutputCapture, PrinterFactory
 from .utils import random_id, list_find, list_map, list_map_last
 from .visitor import Cursor, TreeVisitor
@@ -62,6 +63,11 @@ __all__ = [
     'option',
     'OptionDescriptor',
     'RecipeDescriptor',
+
+    # Preconditions
+    'Check',
+    'Preconditions',
+    'RecipeCheck',
 
     # Categories and Marketplace
     'CategoryDescriptor',

--- a/rewrite-python/rewrite/src/rewrite/preconditions.py
+++ b/rewrite-python/rewrite/src/rewrite/preconditions.py
@@ -1,0 +1,185 @@
+# Copyright 2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Precondition wrappers for recipe editors and scanners.
+
+Mirrors Java's ``org.openrewrite.Preconditions``. A recipe author writes::
+
+    def editor(self) -> TreeVisitor[Any, ExecutionContext]:
+        return Preconditions.check(uses_method("array tostring()"), MyVisitor())
+
+The framework introspects the wrapper at PrepareRecipe time and emits the
+``check`` visitor's identity in the ``editPreconditions`` slot of the
+``PrepareRecipeResponse``. The Java side then evaluates the precondition
+against the local source file *before* dispatching the visit RPC, skipping
+the entire RPC round trip when the precondition does not match.
+
+When a recipe is supplied as the ``check``, its ``editor()`` is used as the
+condition visitor. ``ScanningRecipe`` is rejected because its scan phase
+needs accumulator state that a stateless precondition check cannot provide.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Union, TYPE_CHECKING, cast
+
+from rewrite.execution import DelegatingExecutionContext, ExecutionContext
+from rewrite.tree import SourceFile, Tree
+from rewrite.visitor import Cursor, TreeVisitor
+
+if TYPE_CHECKING:
+    from rewrite.recipe import Recipe
+
+
+class _DataTableSuppressingExecutionContext(DelegatingExecutionContext):
+    """Suppresses data-table writes from precondition visitors.
+
+    Mirrors Java's ``Preconditions.DataTableSuppressingExecutionContextView``.
+    Precondition visitors are typically search recipes (``HasMethod``,
+    ``HasType``) that would otherwise emit data-table rows on every file
+    they're checked against. We want to keep those rows scoped to actual
+    recipe runs, not preconditions.
+    """
+
+    def __init__(self, delegate: ExecutionContext) -> None:
+        super().__init__(delegate)
+
+
+def _suppressing(ctx: ExecutionContext) -> ExecutionContext:
+    if isinstance(ctx, _DataTableSuppressingExecutionContext):
+        return ctx
+    return _DataTableSuppressingExecutionContext(ctx)
+
+
+class Check(TreeVisitor[Tree, ExecutionContext]):
+    """Wrapper visitor that gates ``v`` on whether ``check`` mutates the tree.
+
+    Semantics mirror Java's ``Preconditions.Check``: the precondition runs
+    first; if it returns a different tree (i.e. it added a ``SearchResult``
+    marker), the wrapped visitor runs. Otherwise the wrapped visitor is
+    skipped and the original tree is returned unchanged.
+
+    For non-``SourceFile`` trees the precondition is bypassed — preconditions
+    are designed to evaluate at the root and may assume the root layout.
+
+    The framework also introspects this wrapper at PrepareRecipe time and
+    promotes ``check`` to the ``editPreconditions`` wire slot so that the
+    Java host can evaluate the precondition locally and skip the visit RPC
+    entirely. In that case the wrapped ``v`` is what runs Python-side, so
+    the ``visit`` method below is the fallback for in-process callers (tests,
+    direct invocation) and for non-RPC dispatch paths.
+    """
+
+    def __init__(
+        self,
+        check: TreeVisitor[Any, ExecutionContext],
+        v: TreeVisitor[Any, ExecutionContext],
+    ) -> None:
+        self._check = check
+        self._v = v
+
+    @property
+    def check(self) -> TreeVisitor[Any, ExecutionContext]:
+        return self._check
+
+    @property
+    def wrapped(self) -> TreeVisitor[Any, ExecutionContext]:
+        return self._v
+
+    def is_acceptable(self, source_file: SourceFile, p: ExecutionContext) -> bool:
+        return self._check.is_acceptable(source_file, p) and self._v.is_acceptable(
+            source_file, p
+        )
+
+    def visit(
+        self,
+        tree: Optional[Tree],
+        p: ExecutionContext,
+        parent: Optional[Cursor] = None,
+    ) -> Optional[Tree]:
+        if not isinstance(tree, SourceFile):
+            return self._v.visit(tree, p, parent)
+        condition_after = self._check.visit(tree, _suppressing(p), parent)
+        if condition_after is not tree:
+            return self._v.visit(tree, p, parent)
+        return tree
+
+
+class RecipeCheck(Check):
+    """A ``Check`` whose precondition visitor is a recipe's editor.
+
+    Stores the originating ``Recipe`` so the framework can resolve the
+    precondition's wire identity (the recipe's ``edit:<id>`` visitor name)
+    at PrepareRecipe time without re-running ``recipe.editor()``.
+    """
+
+    def __init__(
+        self,
+        recipe: "Recipe",
+        v: TreeVisitor[Any, ExecutionContext],
+    ) -> None:
+        # Local import: Recipe imports from rewrite.preconditions for the
+        # forward reference, so we resolve the editor at construction time.
+        from rewrite.recipe import ScanningRecipe
+
+        if isinstance(recipe, ScanningRecipe):
+            raise ValueError(
+                "ScanningRecipe is not supported as a precondition: scan-phase "
+                "recipes accumulate cross-file state, which a stateless "
+                "precondition check cannot provide."
+            )
+        super().__init__(recipe.editor(), v)
+        self._recipe = recipe
+
+    @property
+    def recipe(self) -> "Recipe":
+        return self._recipe
+
+
+class Preconditions:
+    """Static helpers for wrapping editors with precondition checks.
+
+    Usage::
+
+        from rewrite.preconditions import Preconditions
+        from rewrite.python.preconditions import uses_method
+
+        class ReplaceArrayTostring(Recipe):
+            def editor(self):
+                return Preconditions.check(
+                    uses_method("array tostring()"),
+                    self._tostring_visitor(),
+                )
+    """
+
+    @staticmethod
+    def check(
+        check: Union[TreeVisitor[Any, ExecutionContext], "Recipe"],
+        v: TreeVisitor[Any, ExecutionContext],
+    ) -> Check:
+        """Wrap ``v`` with a precondition check.
+
+        Accepts either a ``TreeVisitor`` or a ``Recipe`` for ``check``. When a
+        ``Recipe`` is supplied, its ``editor()`` is used as the precondition
+        visitor (``ScanningRecipe`` is rejected — see :class:`RecipeCheck`).
+
+        The return is always a :class:`Check` instance. Recipe-form returns a
+        :class:`RecipeCheck` so the framework can recover the originating
+        recipe at wire-serialization time.
+        """
+        from rewrite.recipe import Recipe
+
+        if isinstance(check, Recipe):
+            return RecipeCheck(check, v)
+        return Check(cast(TreeVisitor[Any, ExecutionContext], check), v)

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -602,6 +602,8 @@ def handle_reset(params: dict) -> bool:
     remote_objects.clear()
     remote_refs.clear()
     _prepared_recipes.clear()
+    _prepared_editor_overrides.clear()
+    _prepared_edit_preconditions.clear()
     _execution_contexts.clear()
     _recipe_accumulators.clear()
     _recipe_phases.clear()
@@ -1051,6 +1053,16 @@ def _serialize_value(value) -> Any:
 
 # Prepared recipes storage - maps recipe IDs to recipe instances
 _prepared_recipes: Dict[str, Any] = {}
+# Cached bare-editor visitors keyed by prepared recipe id. Populated at
+# PrepareRecipe time when recipe.editor() returns a Preconditions.check
+# wrapper: we strip the wrapper, register the precondition's wire identity
+# in editPreconditions (so the host evaluates it Java-side), and store the
+# bare editor here. When BatchVisit / Visit dispatches edit:<id> back, we
+# return this bare editor so the precondition does not double-run.
+_prepared_editor_overrides: Dict[str, Any] = {}
+# Per-recipe-edit-phase precondition wire entries collected at PrepareRecipe
+# time from a Preconditions.check(...) wrapper around recipe.editor().
+_prepared_edit_preconditions: Dict[str, List[Dict[str, Any]]] = {}
 # Execution contexts storage - maps context IDs to ExecutionContext instances
 _execution_contexts: Dict[str, Any] = {}
 # Accumulator storage for ScanningRecipes - maps recipe IDs to accumulators
@@ -1143,11 +1155,32 @@ def handle_prepare_recipe(params: dict) -> dict:
     from rewrite.recipe import ScanningRecipe
     is_scanning = isinstance(recipe, ScanningRecipe)
 
+    # Introspect recipe.editor() once at prepare time. If the recipe wrapped
+    # its editor in Preconditions.check(...), we extract the precondition's
+    # wire identity (so the Java host can evaluate it locally and skip the
+    # visit RPC for non-matching files) and cache the bare editor (so a
+    # subsequent dispatch via _instantiate_visitor returns the unwrapped
+    # editor — otherwise the precondition would also run Python-side and
+    # double the cost).
+    edit_preconditions: List[Dict[str, Any]] = list(_get_preconditions(recipe, 'edit'))
+    if not is_scanning:
+        try:
+            editor_visitor = recipe.editor()
+        except Exception:
+            editor_visitor = None
+        if editor_visitor is not None:
+            extracted = _extract_preconditions_from_editor(editor_visitor)
+            if extracted is not None:
+                bare_editor, wire_entries = extracted
+                _prepared_editor_overrides[prepared_id] = bare_editor
+                edit_preconditions.extend(wire_entries)
+    _prepared_edit_preconditions[prepared_id] = edit_preconditions
+
     response = {
         'id': prepared_id,
         'descriptor': _recipe_descriptor_to_dict(descriptor),
         'editVisitor': f'edit:{prepared_id}',
-        'editPreconditions': _get_preconditions(recipe, 'edit'),
+        'editPreconditions': edit_preconditions,
         'scanVisitor': f'scan:{prepared_id}' if is_scanning else None,
         'scanPreconditions': _get_preconditions(recipe, 'scan') if is_scanning else [],
     }
@@ -1164,15 +1197,95 @@ def handle_prepare_recipe(params: dict) -> dict:
 
 
 def _get_preconditions(recipe, phase: str) -> List[dict]:
-    """Get preconditions for a recipe phase.
+    """Baseline preconditions for a recipe phase.
 
-    For now, we add a type precondition to ensure only Python files are visited.
+    Always includes the language gate (only visit Python source files). Recipe-
+    declared preconditions from a ``Preconditions.check(...)`` wrapper around
+    ``recipe.editor()`` are added on top by ``handle_prepare_recipe`` — see
+    :func:`_extract_preconditions_from_editor`.
     """
-    # Add precondition to only visit Python source files
     return [{
         'visitorName': 'org.openrewrite.rpc.internal.FindTreesOfType',
         'visitorOptions': {'type': 'org.openrewrite.python.tree.Py'}
     }]
+
+
+def _extract_preconditions_from_editor(editor_visitor):
+    """Walk a ``Preconditions.check(...)`` wrapper chain on an editor result.
+
+    If ``editor_visitor`` is a :class:`rewrite.preconditions.Check`, returns a
+    tuple ``(bare_editor, [precondition_wire_entry, ...])`` where ``bare_editor``
+    is the innermost non-Check visitor and the wire entries describe each
+    precondition in evaluation order. Returns ``None`` if no Check wrapper
+    is present.
+
+    Each precondition wire entry has shape ``{'visitorName': str,
+    'visitorOptions': dict | None}`` matching ``PrepareRecipeResponse.Precondition``.
+
+    Supported precondition shapes:
+      * ``RecipeCheck`` — uses the wrapped recipe's wire identity
+        (``edit:<id>``) when known.
+      * ``Check`` wrapping a :class:`PreparedJavaRecipe` — uses its
+        ``edit_visitor`` directly.
+      * ``Check`` wrapping a recipe with ``java_recipe_name`` — emits the
+        Java recipe name and options for Java-side instantiation.
+
+    Anything else (a generic in-process ``TreeVisitor`` for unit tests) is
+    not propagated to the wire — those would have to round-trip back to
+    Python anyway, which defeats the point of the precondition optimization.
+    For the in-process / test path the wrapper still works because Python
+    keeps using the wrapper (no override cached); see :class:`Check.visit`.
+    """
+    from rewrite.preconditions import Check, RecipeCheck
+
+    if not isinstance(editor_visitor, Check):
+        return None
+
+    wire_entries: List[Dict[str, Any]] = []
+    inner: Any = editor_visitor
+    while isinstance(inner, Check):
+        wire = _check_wire_entry(inner)
+        if wire is None:
+            # Cannot serialize this check to the wire; abort the optimization
+            # for this editor. Returning None leaves the wrapper intact so
+            # the precondition runs Python-side as a fallback.
+            return None
+        wire_entries.append(wire)
+        inner = inner.wrapped
+    return inner, wire_entries
+
+
+def _check_wire_entry(check) -> Optional[Dict[str, Any]]:
+    """Translate a single :class:`Check` to a precondition wire entry."""
+    from rewrite.preconditions import RecipeCheck
+    from rewrite.rpc.java_recipe import PreparedJavaRecipe
+
+    if isinstance(check, RecipeCheck):
+        recipe = check.recipe
+        prepared_id = _find_prepared_id(recipe)
+        if prepared_id is not None:
+            return {'visitorName': f'edit:{prepared_id}', 'visitorOptions': None}
+        java_name = getattr(recipe, 'java_recipe_name', None)
+        if java_name is not None:
+            options = getattr(recipe, 'delegates_to_options', {})
+            return {'visitorName': java_name, 'visitorOptions': dict(options)}
+        return None
+
+    condition = check.check
+    if isinstance(condition, PreparedJavaRecipe):
+        return {'visitorName': condition.edit_visitor, 'visitorOptions': None}
+    java_name = getattr(condition, 'java_recipe_name', None)
+    if java_name is not None:
+        options = getattr(condition, 'delegates_to_options', {})
+        return {'visitorName': java_name, 'visitorOptions': dict(options)}
+    return None
+
+
+def _find_prepared_id(recipe) -> Optional[str]:
+    for prep_id, prep_recipe in _prepared_recipes.items():
+        if prep_recipe is recipe:
+            return prep_id
+    return None
 
 
 def handle_visit(params: dict) -> dict:
@@ -1401,6 +1514,13 @@ def _instantiate_visitor(visitor_name: str, ctx):
             acc = _recipe_accumulators[recipe_id]
             return recipe.editor_with_data(acc)
 
+        # If the recipe wrapped its editor in Preconditions.check(...) and we
+        # captured the bare editor at PrepareRecipe time, return it here so
+        # the precondition does not double-run on the Python side. The host
+        # has already evaluated it via the editPreconditions wire slot.
+        override = _prepared_editor_overrides.get(recipe_id)
+        if override is not None:
+            return override
         return recipe.editor()
 
     elif visitor_name.startswith('scan:'):

--- a/rewrite-python/rewrite/tests/rpc/test_preconditions_wire.py
+++ b/rewrite-python/rewrite/tests/rpc/test_preconditions_wire.py
@@ -1,0 +1,271 @@
+# Copyright 2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wire-level tests for Preconditions.check introspection at PrepareRecipe time.
+
+These exercise ``handle_prepare_recipe`` and verify it correctly extracts
+precondition wire entries from a ``Preconditions.check(...)`` wrapper around
+``recipe.editor()``, registers the bare editor in the override cache, and
+returns the wrapper-free editor on subsequent ``_instantiate_visitor`` calls.
+"""
+
+from typing import Any
+
+import pytest
+
+from rewrite import (
+    InMemoryExecutionContext,
+    Preconditions,
+    Recipe,
+    RecipeMarketplace,
+    Tree,
+    TreeVisitor,
+)
+from rewrite.marketplace import Python
+
+
+class _Identity(TreeVisitor[Tree, Any]):
+    def visit(self, tree, p, parent=None):
+        return tree
+
+
+class _BareEditor(TreeVisitor[Tree, Any]):
+    """Sentinel editor; identity is what we assert in tests."""
+
+    sentinel = "bare-editor-sentinel"
+
+
+class _PreconditionRecipe(Recipe):
+    """Recipe whose editor() returns Preconditions.check(condition_recipe, bare).
+
+    The condition is itself a recipe so we exercise the RecipeCheck path —
+    the Java side will resolve its wire identity via ``edit:<id>``.
+    """
+
+    @property
+    def name(self):
+        return "test.precondition.PreconditionRecipe"
+
+    @property
+    def display_name(self):
+        return "Precondition recipe"
+
+    @property
+    def description(self):
+        return "Wraps an editor in a precondition for testing wire serialization."
+
+    def editor(self):
+        return Preconditions.check(_ConditionRecipe(), _BareEditor())
+
+
+class _ConditionRecipe(Recipe):
+    @property
+    def name(self):
+        return "test.precondition.ConditionRecipe"
+
+    @property
+    def display_name(self):
+        return "Condition recipe"
+
+    @property
+    def description(self):
+        return "Plays the role of a search recipe used as a precondition."
+
+    def editor(self):
+        return _Identity()
+
+
+class _PlainRecipe(Recipe):
+    @property
+    def name(self):
+        return "test.precondition.PlainRecipe"
+
+    @property
+    def display_name(self):
+        return "Plain"
+
+    @property
+    def description(self):
+        return "Editor() returns a plain visitor (no Preconditions.check wrapper)."
+
+    def editor(self):
+        return _BareEditor()
+
+
+@pytest.fixture
+def isolated_server():
+    """Swap the global marketplace + state caches so tests don't leak."""
+    import rewrite.rpc.server as server
+
+    saved_marketplace = server._marketplace
+    server._marketplace = RecipeMarketplace()
+    server._prepared_recipes.clear()
+    server._prepared_editor_overrides.clear()
+    server._prepared_edit_preconditions.clear()
+    try:
+        yield server
+    finally:
+        server._marketplace = saved_marketplace
+        server._prepared_recipes.clear()
+        server._prepared_editor_overrides.clear()
+        server._prepared_edit_preconditions.clear()
+
+
+def _install(server, recipe_cls):
+    server._marketplace.install(recipe_cls, Python)
+
+
+class TestPrepareRecipeWithPreconditions:
+    def test_plain_editor_yields_only_baseline_preconditions(self, isolated_server):
+        server = isolated_server
+        _install(server, _PlainRecipe)
+
+        response = server.handle_prepare_recipe(
+            {"id": "test.precondition.PlainRecipe"}
+        )
+
+        # Only the language-gate precondition (FindTreesOfType) is expected.
+        precs = response["editPreconditions"]
+        assert len(precs) == 1
+        assert precs[0]["visitorName"] == "org.openrewrite.rpc.internal.FindTreesOfType"
+        prepared_id = response["id"]
+        # No override cached: editor() returned a plain visitor.
+        assert prepared_id not in server._prepared_editor_overrides
+
+    def test_check_wrapped_editor_emits_recipe_precondition(self, isolated_server):
+        server = isolated_server
+        _install(server, _ConditionRecipe)
+        _install(server, _PreconditionRecipe)
+
+        # PrepareRecipe the condition first so its wire identity is known
+        # when the wrapping recipe's editor() is introspected.
+        cond_resp = server.handle_prepare_recipe(
+            {"id": "test.precondition.ConditionRecipe"}
+        )
+        cond_visitor = cond_resp["editVisitor"]
+
+        # Make the same recipe instance available to RecipeCheck. The recipe
+        # constructed inside _PreconditionRecipe.editor() is a fresh instance
+        # of _ConditionRecipe; rebind the global so it matches the prepared
+        # one. We do this by storing the prepared recipe as a sentinel and
+        # making _PreconditionRecipe.editor() return Preconditions.check
+        # against that exact instance.
+        prepared_condition_recipe = server._prepared_recipes[cond_resp["id"]]
+
+        class _PreconditionRecipeUsingPrepared(Recipe):
+            @property
+            def name(self):
+                return "test.precondition.PreconditionRecipeUsingPrepared"
+
+            @property
+            def display_name(self):
+                return "Precondition recipe using prepared"
+
+            @property
+            def description(self):
+                return "Wires the precondition to a previously-prepared condition recipe."
+
+            def editor(self):
+                return Preconditions.check(prepared_condition_recipe, _BareEditor())
+
+        _install(server, _PreconditionRecipeUsingPrepared)
+
+        response = server.handle_prepare_recipe(
+            {"id": "test.precondition.PreconditionRecipeUsingPrepared"}
+        )
+
+        precs = response["editPreconditions"]
+        # Baseline language-gate + recipe precondition.
+        assert len(precs) == 2
+        # First entry is the language gate, second is the recipe-as-precondition.
+        assert precs[0]["visitorName"] == (
+            "org.openrewrite.rpc.internal.FindTreesOfType"
+        )
+        assert precs[1]["visitorName"] == cond_visitor
+
+    def test_bare_editor_is_cached_and_returned_by_instantiate(
+        self, isolated_server
+    ):
+        server = isolated_server
+        _install(server, _ConditionRecipe)
+
+        cond_resp = server.handle_prepare_recipe(
+            {"id": "test.precondition.ConditionRecipe"}
+        )
+        prepared_condition_recipe = server._prepared_recipes[cond_resp["id"]]
+
+        class _Wrapper(Recipe):
+            @property
+            def name(self):
+                return "test.precondition.Wrapper"
+
+            @property
+            def display_name(self):
+                return "Wrapper"
+
+            @property
+            def description(self):
+                return "Editor returns Preconditions.check around a bare editor."
+
+            def editor(self):
+                return Preconditions.check(prepared_condition_recipe, _BareEditor())
+
+        _install(server, _Wrapper)
+        resp = server.handle_prepare_recipe({"id": "test.precondition.Wrapper"})
+        prepared_id = resp["id"]
+
+        # The override cache holds the BARE editor (not the Check wrapper),
+        # so dispatch via _instantiate_visitor returns it directly.
+        assert prepared_id in server._prepared_editor_overrides
+        cached = server._prepared_editor_overrides[prepared_id]
+        assert isinstance(cached, _BareEditor)
+
+        ctx = InMemoryExecutionContext()
+        instantiated = server._instantiate_visitor(f"edit:{prepared_id}", ctx)
+        assert instantiated is cached
+
+    def test_check_with_unserializable_visitor_falls_back(self, isolated_server):
+        """A Check wrapping a generic TreeVisitor (no recipe identity, no
+        java_recipe_name, no PreparedJavaRecipe) cannot be propagated to the
+        wire — it would have to RPC back to Python which defeats the
+        optimization. The introspection silently leaves the wrapper intact so
+        the precondition still runs Python-side via the wrapper's visit()."""
+        server = isolated_server
+
+        class _OpaqueCheckRecipe(Recipe):
+            @property
+            def name(self):
+                return "test.precondition.OpaqueCheck"
+
+            @property
+            def display_name(self):
+                return "Opaque check"
+
+            @property
+            def description(self):
+                return "Editor wraps in a Check whose condition has no wire identity."
+
+            def editor(self):
+                return Preconditions.check(_Identity(), _BareEditor())
+
+        _install(server, _OpaqueCheckRecipe)
+        resp = server.handle_prepare_recipe(
+            {"id": "test.precondition.OpaqueCheck"}
+        )
+        prepared_id = resp["id"]
+
+        # No wire entry beyond the baseline language gate.
+        assert len(resp["editPreconditions"]) == 1
+        # No override cached — the wrapper still runs Python-side as a fallback.
+        assert prepared_id not in server._prepared_editor_overrides

--- a/rewrite-python/rewrite/tests/test_preconditions.py
+++ b/rewrite-python/rewrite/tests/test_preconditions.py
@@ -1,0 +1,226 @@
+# Copyright 2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-process tests for the Preconditions wrapper.
+
+These verify the wrapper semantics directly (no RPC). Wire-level tests for
+the PrepareRecipe introspection live in tests/rpc/test_server.py.
+"""
+
+from typing import Any, List, Optional
+
+import pytest
+
+from rewrite import (
+    Cursor,
+    InMemoryExecutionContext,
+    Preconditions,
+    Recipe,
+    SourceFile,
+    Tree,
+    TreeVisitor,
+)
+from rewrite.markers import SearchResult
+from rewrite.preconditions import Check, RecipeCheck
+
+
+class _RecordingVisitor(TreeVisitor[Tree, Any]):
+    """Returns the same tree, recording each visit."""
+
+    def __init__(self) -> None:
+        self.calls: int = 0
+
+    def visit(self, tree, p, parent=None):
+        self.calls += 1
+        return tree
+
+
+class _MarkingVisitor(TreeVisitor[Tree, Any]):
+    """Returns a sentinel different tree, simulating a precondition match."""
+
+    def __init__(self) -> None:
+        self.calls: int = 0
+        self.last_tree = None
+
+    def visit(self, tree, p, parent=None):
+        self.calls += 1
+        self.last_tree = tree
+        # Return any non-identity object so the Check sees "modified".
+        return object()
+
+
+class _StubSourceFile(SourceFile):
+    """Minimal SourceFile-like sentinel that bypasses the abstract API.
+
+    SourceFile is abstract; we only need ``isinstance`` to succeed inside
+    :meth:`Check.visit`. The Check wrapper does not call any of the abstract
+    properties, so a bare subclass is safe for these tests.
+    """
+
+    def __init__(self):
+        pass
+
+    @property
+    def id(self):
+        raise NotImplementedError
+
+    @property
+    def markers(self):
+        raise NotImplementedError
+
+    @property
+    def charset_name(self):
+        return None
+
+    @property
+    def charset_bom_marked(self):
+        return False
+
+    @property
+    def checksum(self):
+        return None
+
+    @property
+    def file_attributes(self):
+        return None
+
+    @property
+    def source_path(self):
+        return None
+
+    def is_acceptable(self, v, p):
+        return True
+
+    def printer(self, cursor):
+        raise NotImplementedError
+
+
+def _stub_source_file():
+    return _StubSourceFile.__new__(_StubSourceFile)
+
+
+def test_check_runs_editor_when_condition_marks_tree():
+    condition = _MarkingVisitor()
+    editor = _RecordingVisitor()
+
+    wrapped = Preconditions.check(condition, editor)
+    sf = _stub_source_file()
+    ctx = InMemoryExecutionContext()
+
+    result = wrapped.visit(sf, ctx)
+
+    assert condition.calls == 1
+    assert editor.calls == 1
+    # The editor returned the same tree, but the gate fired.
+    assert result is sf
+
+
+def test_check_skips_editor_when_condition_returns_identity():
+    condition = _RecordingVisitor()  # returns same tree
+    editor = _RecordingVisitor()
+
+    wrapped = Preconditions.check(condition, editor)
+    sf = _stub_source_file()
+    ctx = InMemoryExecutionContext()
+
+    result = wrapped.visit(sf, ctx)
+
+    assert condition.calls == 1
+    assert editor.calls == 0, "editor should not run when precondition is identity"
+    assert result is sf
+
+
+def test_check_passes_through_for_non_source_file():
+    """Preconditions only gate at the SourceFile root — nested trees pass through."""
+    condition = _RecordingVisitor()
+    editor = _RecordingVisitor()
+
+    wrapped = Preconditions.check(condition, editor)
+    not_a_source_file = object()
+    ctx = InMemoryExecutionContext()
+
+    wrapped.visit(not_a_source_file, ctx)
+
+    assert condition.calls == 0
+    assert editor.calls == 1
+
+
+def test_recipe_check_uses_recipe_editor_as_condition():
+    class _CheckRecipe(Recipe):
+        @property
+        def name(self):
+            return "test.recipe.Check"
+
+        @property
+        def display_name(self):
+            return "Check"
+
+        @property
+        def description(self):
+            return "Marks every file."
+
+        def editor(self):
+            return _MarkingVisitor()
+
+    editor = _RecordingVisitor()
+    wrapped = Preconditions.check(_CheckRecipe(), editor)
+
+    assert isinstance(wrapped, RecipeCheck)
+
+    sf = _stub_source_file()
+    ctx = InMemoryExecutionContext()
+    wrapped.visit(sf, ctx)
+
+    assert editor.calls == 1
+
+
+def test_recipe_check_rejects_scanning_recipe():
+    from rewrite import ScanningRecipe
+
+    class _ScanRecipe(ScanningRecipe):
+        @property
+        def name(self):
+            return "test.recipe.Scan"
+
+        @property
+        def display_name(self):
+            return "Scan"
+
+        @property
+        def description(self):
+            return "Scan."
+
+        def initial_value(self, ctx):
+            return set()
+
+    with pytest.raises(ValueError, match="ScanningRecipe is not supported"):
+        Preconditions.check(_ScanRecipe(), _RecordingVisitor())
+
+
+def test_check_is_acceptable_ands_both_legs():
+    class _Reject(TreeVisitor[Tree, Any]):
+        def is_acceptable(self, sf, p):
+            return False
+
+    accept = _RecordingVisitor()
+    reject = _Reject()
+    sf = _stub_source_file()
+    ctx = InMemoryExecutionContext()
+
+    # condition rejects -> wrapper rejects
+    assert Preconditions.check(reject, accept).is_acceptable(sf, ctx) is False
+    # editor rejects -> wrapper rejects
+    assert Preconditions.check(accept, reject).is_acceptable(sf, ctx) is False
+    # both accept -> wrapper accepts
+    assert Preconditions.check(accept, accept).is_acceptable(sf, ctx) is True


### PR DESCRIPTION
## Summary

Java's `Preconditions.check(condition, editor)` lets a recipe author skip the editor when the precondition doesn't match, and the Java host can short-circuit the visit RPC entirely when the precondition is wired through `PrepareRecipeResponse.editPreconditions`. The Python framework exposed the supporting helpers (`uses_method`, `uses_type`) but had:

- no `Preconditions.check` analog
- no recipe-author path to declare a precondition
- no introspection at PrepareRecipe time
- `_get_preconditions` was a stub that always returned just the language gate

This PR wires the full path. Recipe authors write:

```python
def editor(self):
    return Preconditions.check(uses_method("array tostring()"), MyVisitor())
```

and the Java host evaluates the precondition locally before dispatching the visit RPC for both single-recipe and composite-recipe (BatchVisit) paths.

## What changed

**rewrite-python framework:**
- New `rewrite.preconditions` module with `Preconditions`, `Check`, `RecipeCheck` mirroring the Java API. Exported from `rewrite/__init__.py`.
- `handle_prepare_recipe` now calls `recipe.editor()` once at prepare time and walks any `Check` wrapper chain to extract the precondition's wire identity. Bare editor is cached so subsequent `_instantiate_visitor` dispatch returns the unwrapped editor — otherwise the precondition would also run Python-side and double the cost.
- Supported precondition shapes: `RecipeCheck` whose recipe is already prepared (uses its `edit:<id>`), `Check` wrapping a `PreparedJavaRecipe` (uses its `edit_visitor`), and `Check` wrapping a recipe that declares `java_recipe_name`. Anything else falls back to in-process `Check.visit` (test path).

**Java side (`rewrite-core`):**
- `RpcRecipe.getEditPreconditionVisitor()` getter exposed so the batching scheduler can evaluate preconditions locally.
- `RecipeRunCycle.editSource` evaluates `RpcRecipe.editPreconditionVisitor` against the source file before adding to a BatchVisit batch and skips items whose precondition rejects the file. Without this, the BatchVisit path bypassed `Preconditions.check` because it dispatched bare `editVisitor` names.

## Tests

`tests/test_preconditions.py` (in-process semantics):
- gate runs editor when condition marks the tree
- gate skips editor when condition returns identity
- pass-through for non-`SourceFile` trees
- `RecipeCheck` rejects `ScanningRecipe`
- `is_acceptable` is the AND of both legs

`tests/rpc/test_preconditions_wire.py` (PrepareRecipe introspection):
- plain editor yields only the language-gate precondition
- `Check`-wrapped editor emits the recipe's `edit:<id>` in `editPreconditions`
- bare editor is cached in `_prepared_editor_overrides`; `_instantiate_visitor` returns it
- unserializable `Check` (generic visitor with no recipe identity) falls back without emitting wire entries — wrapper still runs Python-side as a fallback

87 passed, 5 skipped on the full rewrite-python test suite.

## Performance impact (motivation)

Profiled `UpgradeToPython314` against `ArchiveBox/ArchiveBox` (228 .py files):
- After #7620 (the prior `_collect_search_result_ids` fix): 5:25 → 2:19.
- `visit_compilation_unit` is still called **9,977 times = ~44× per file** because the composite expands into ~15 child visitors via `UpgradeToPython{313..38}`, each walking the full tree. Most of those walks are wasted on files that have zero match candidates.
- With this PR plus per-recipe preconditions in `openrewrite-migrate-python`, each child's `HasMethod`/`HasType` precondition is evaluated Java-side against `Py.CompilationUnit.TypesInUse`. Files that don't match skip the visit RPC entirely — single-recipe path goes through `Preconditions.check` in `RpcRecipe.getVisitor()`, and BatchVisit path is gated in `RecipeRunCycle.editSource`.

## Test plan

- [x] `tests/test_preconditions.py` and `tests/rpc/test_preconditions_wire.py` pass locally.
- [x] Existing rewrite-python suite (87 passed, 5 skipped) still passes.
- [ ] Java unit tests for the `RecipeRunCycle` change require a Gradle build; will verify in CI.
- [ ] End-to-end: companion PR in `openrewrite/rewrite-migrate-python` applies preconditions to a sample of recipes; will measure wall-time impact on ArchiveBox once both land.
