### PR TITLE
rewrite-python: lazy RecipeRef so preconditions don't RPC at editor() time

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/internal/PreparedRecipeCache.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/internal/PreparedRecipeCache.java
@@ -55,8 +55,18 @@ public class PreparedRecipeCache {
         Map<Object, Object> withJsonType = visitorOptions == null ? new HashMap<>() : new HashMap<>(visitorOptions);
         withJsonType.put("@c", visitorName);
         try {
-            Class<?> visitorType = TypeFactory.defaultInstance().findClass(visitorName);
-            return (TreeVisitor<?, P>) mapper.convertValue(withJsonType, visitorType);
+            Class<?> type = TypeFactory.defaultInstance().findClass(visitorName);
+            // Lazy-prepared precondition: a Recipe class name + options. Construct the
+            // Recipe via Jackson and return its edit visitor. This avoids requiring the
+            // remote (Python) to round-trip a PrepareRecipe RPC just to get an edit:<id>
+            // it can put on the wire — important for in-process recipe authoring (a
+            // Python recipe's editor() can declare uses_method(...) without firing an
+            // RPC at construction time).
+            if (Recipe.class.isAssignableFrom(type)) {
+                Recipe recipe = (Recipe) mapper.convertValue(withJsonType, type);
+                return (TreeVisitor<?, P>) recipe.getVisitor();
+            }
+            return (TreeVisitor<?, P>) mapper.convertValue(withJsonType, type);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }

--- a/rewrite-python/rewrite/src/rewrite/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/__init__.py
@@ -24,7 +24,7 @@ from .markers import *
 from .parser import *
 from .result import *
 from .style import *
-from .preconditions import Check, Preconditions, RecipeCheck
+from .preconditions import Check, Preconditions, RecipeCheck, RecipeRef
 from .tree import Checksum, FileAttributes, SourceFile, Tree, PrintOutputCapture, PrinterFactory
 from .utils import random_id, list_find, list_map, list_map_last
 from .visitor import Cursor, TreeVisitor
@@ -68,6 +68,7 @@ __all__ = [
     'Check',
     'Preconditions',
     'RecipeCheck',
+    'RecipeRef',
 
     # Categories and Marketplace
     'CategoryDescriptor',

--- a/rewrite-python/rewrite/src/rewrite/preconditions.py
+++ b/rewrite-python/rewrite/src/rewrite/preconditions.py
@@ -32,7 +32,8 @@ needs accumulator state that a stateless precondition check cannot provide.
 
 from __future__ import annotations
 
-from typing import Any, Optional, Union, TYPE_CHECKING, cast
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Union, TYPE_CHECKING
 
 from rewrite.execution import DelegatingExecutionContext, ExecutionContext
 from rewrite.tree import SourceFile, Tree
@@ -40,6 +41,35 @@ from rewrite.visitor import Cursor, TreeVisitor
 
 if TYPE_CHECKING:
     from rewrite.recipe import Recipe
+
+
+@dataclass(frozen=True)
+class RecipeRef:
+    """Recipe-identity placeholder for use as a precondition.
+
+    Captures a Java recipe class name + options without instantiating the
+    recipe or firing an RPC. The framework introspects a
+    ``Preconditions.check(RecipeRef, editor)`` wrapper at PrepareRecipe
+    time and emits the recipe identity directly in
+    ``PrepareRecipeResponse.editPreconditions``. The Java host's
+    ``PreparedRecipeCache.instantiateVisitor`` constructs the recipe via
+    Jackson and uses its ``getVisitor()``.
+
+    This avoids requiring the recipe author to do an RPC at ``editor()``
+    construction time, which would otherwise block in-process unit tests
+    that don't have an active RPC connection.
+
+    Helpers in :mod:`rewrite.python.preconditions` (``uses_method``,
+    ``uses_type``, ``has_source_path``, ``find_methods``, ``find_types``)
+    return ``RecipeRef`` instances.
+    """
+
+    recipe_name: str
+    options: Dict[str, Any] = field(default_factory=dict)
+
+
+# Type accepted by Check / Preconditions.check for the gate visitor.
+CheckArg = Union[TreeVisitor[Any, ExecutionContext], "Recipe", RecipeRef]
 
 
 class _DataTableSuppressingExecutionContext(DelegatingExecutionContext):
@@ -83,14 +113,14 @@ class Check(TreeVisitor[Tree, ExecutionContext]):
 
     def __init__(
         self,
-        check: TreeVisitor[Any, ExecutionContext],
+        check: CheckArg,
         v: TreeVisitor[Any, ExecutionContext],
     ) -> None:
         self._check = check
         self._v = v
 
     @property
-    def check(self) -> TreeVisitor[Any, ExecutionContext]:
+    def check(self) -> CheckArg:
         return self._check
 
     @property
@@ -98,6 +128,9 @@ class Check(TreeVisitor[Tree, ExecutionContext]):
         return self._v
 
     def is_acceptable(self, source_file: SourceFile, p: ExecutionContext) -> bool:
+        if isinstance(self._check, RecipeRef):
+            # RecipeRef has no in-process is_acceptable — defer to the wrapped editor.
+            return self._v.is_acceptable(source_file, p)
         return self._check.is_acceptable(source_file, p) and self._v.is_acceptable(
             source_file, p
         )
@@ -109,6 +142,14 @@ class Check(TreeVisitor[Tree, ExecutionContext]):
         parent: Optional[Cursor] = None,
     ) -> Optional[Tree]:
         if not isinstance(tree, SourceFile):
+            return self._v.visit(tree, p, parent)
+        # In-process fallback: a RecipeRef is a wire-only placeholder with no
+        # ``visit`` of its own — treat as "always matches" so the wrapped
+        # editor still runs in unit tests and direct in-process calls. The
+        # Java-side optimization (skip the visit RPC when the precondition
+        # rejects the file) lives in handle_prepare_recipe and the
+        # RecipeRunCycle batch path for the wire path.
+        if isinstance(self._check, RecipeRef):
             return self._v.visit(tree, p, parent)
         condition_after = self._check.visit(tree, _suppressing(p), parent)
         if condition_after is not tree:
@@ -129,8 +170,6 @@ class RecipeCheck(Check):
         recipe: "Recipe",
         v: TreeVisitor[Any, ExecutionContext],
     ) -> None:
-        # Local import: Recipe imports from rewrite.preconditions for the
-        # forward reference, so we resolve the editor at construction time.
         from rewrite.recipe import ScanningRecipe
 
         if isinstance(recipe, ScanningRecipe):
@@ -152,34 +191,38 @@ class Preconditions:
 
     Usage::
 
-        from rewrite.preconditions import Preconditions
+        from rewrite import Preconditions
         from rewrite.python.preconditions import uses_method
 
         class ReplaceArrayTostring(Recipe):
             def editor(self):
                 return Preconditions.check(
-                    uses_method("array tostring()"),
+                    uses_method("*..* tostring(..)"),
                     self._tostring_visitor(),
                 )
     """
 
     @staticmethod
     def check(
-        check: Union[TreeVisitor[Any, ExecutionContext], "Recipe"],
+        check: CheckArg,
         v: TreeVisitor[Any, ExecutionContext],
     ) -> Check:
         """Wrap ``v`` with a precondition check.
 
-        Accepts either a ``TreeVisitor`` or a ``Recipe`` for ``check``. When a
-        ``Recipe`` is supplied, its ``editor()`` is used as the precondition
-        visitor (``ScanningRecipe`` is rejected — see :class:`RecipeCheck`).
+        ``check`` may be:
+          * a :class:`TreeVisitor` — runs in-process as the gate
+          * a :class:`Recipe` — its ``editor()`` is used as the gate
+            (``ScanningRecipe`` is rejected; see :class:`RecipeCheck`)
+          * a :class:`RecipeRef` — placeholder for a Java search recipe
+            (typically returned by ``uses_method``/``uses_type``); the
+            framework emits the recipe identity in the
+            ``editPreconditions`` wire slot at PrepareRecipe time so the
+            host evaluates it locally without a Python RPC
 
-        The return is always a :class:`Check` instance. Recipe-form returns a
-        :class:`RecipeCheck` so the framework can recover the originating
-        recipe at wire-serialization time.
+        The return is always a :class:`Check` instance.
         """
         from rewrite.recipe import Recipe
 
         if isinstance(check, Recipe):
             return RecipeCheck(check, v)
-        return Check(cast(TreeVisitor[Any, ExecutionContext], check), v)
+        return Check(check, v)

--- a/rewrite-python/rewrite/src/rewrite/python/preconditions.py
+++ b/rewrite-python/rewrite/src/rewrite/python/preconditions.py
@@ -12,112 +12,83 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Precondition helpers that delegate to Java search recipes.
+
+A recipe author wraps an editor with a precondition like so::
+
+    from rewrite import Preconditions
+    from rewrite.python.preconditions import uses_method
+
+    class ReplaceArrayTostring(Recipe):
+        def editor(self):
+            return Preconditions.check(uses_method("*..* tostring(..)"), Visitor())
+
+These helpers return :class:`rewrite.preconditions.RecipeRef` placeholders
+that record the Java recipe class name and options without firing an RPC.
+The framework introspects the wrapper at PrepareRecipe time and emits the
+recipe identity directly in ``editPreconditions``; the Java host's
+``PreparedRecipeCache.instantiateVisitor`` constructs the recipe and uses
+its visitor — no extra RPC round-trip needed. This keeps ``recipe.editor()``
+callable in unit tests without an active RPC connection.
 """
-Precondition helpers that delegate to Java search recipes via RPC.
 
-These functions provide preconditions for Python recipes that need to check
-if source files match certain criteria before applying transformations.
-When RPC is available, they delegate to the Java implementations for efficiency.
+from __future__ import annotations
 
-Example:
-    from rewrite.python.preconditions import uses_type, uses_method
-
-    class MyRecipe(Recipe):
-        def preconditions(self):
-            return uses_type("datetime.datetime")
-"""
-
-from typing import Any, Optional, Union
-
-from rewrite.rpc.java_recipe import prepare_java_recipe, PreparedJavaRecipe
+from rewrite.preconditions import RecipeRef
 
 
-def has_source_path(file_pattern: str) -> PreparedJavaRecipe:
+def has_source_path(file_pattern: str) -> RecipeRef:
+    """Match source files by path glob (delegates to ``org.openrewrite.FindSourceFiles``)."""
+    return RecipeRef(
+        "org.openrewrite.FindSourceFiles", {"filePattern": file_pattern}
+    )
+
+
+def uses_method(method_pattern: str, match_overrides: bool = False) -> RecipeRef:
+    """Match files using a specific method (delegates to ``org.openrewrite.java.search.HasMethod``).
+
+    ``method_pattern`` follows the OpenRewrite method-pattern syntax::
+
+        <receiver-type> <method-name>(<args>)
+
+    Use ``*..*`` to match any class in any package, ``(..)`` to match any
+    arguments::
+
+        uses_method("*..* tostring(..)")
+        uses_method("java.util.Collections emptyList()")
     """
-    Create a precondition that matches source files by path pattern.
-
-    Delegates to org.openrewrite.FindSourceFiles.
-
-    Args:
-        file_pattern: Glob pattern to match file paths (e.g., "**/*.py")
-
-    Returns:
-        A prepared recipe that can be used as a precondition
-    """
-    return prepare_java_recipe("org.openrewrite.FindSourceFiles", {
-        "filePattern": file_pattern
-    })
+    return RecipeRef(
+        "org.openrewrite.java.search.HasMethod",
+        {"methodPattern": method_pattern, "matchOverrides": match_overrides},
+    )
 
 
-def uses_method(method_pattern: str, match_overrides: bool = False) -> PreparedJavaRecipe:
-    """
-    Create a precondition that matches files using a specific method.
-
-    Delegates to org.openrewrite.java.search.HasMethod.
-
-    Args:
-        method_pattern: Method pattern to search for (e.g., "datetime.datetime utcnow()")
-        match_overrides: Whether to also match method overrides
-
-    Returns:
-        A prepared recipe that can be used as a precondition
-    """
-    return prepare_java_recipe("org.openrewrite.java.search.HasMethod", {
-        "methodPattern": method_pattern,
-        "matchOverrides": match_overrides
-    })
+def uses_type(
+    fully_qualified_type: str, check_assignability: bool = False
+) -> RecipeRef:
+    """Match files using a specific type (delegates to ``org.openrewrite.java.search.HasType``)."""
+    return RecipeRef(
+        "org.openrewrite.java.search.HasType",
+        {
+            "fullyQualifiedTypeName": fully_qualified_type,
+            "checkAssignability": check_assignability,
+        },
+    )
 
 
-def uses_type(fully_qualified_type: str, check_assignability: bool = False) -> PreparedJavaRecipe:
-    """
-    Create a precondition that matches files using a specific type.
-
-    Delegates to org.openrewrite.java.search.HasType.
-
-    Args:
-        fully_qualified_type: Fully qualified type name (e.g., "datetime.datetime")
-        check_assignability: Whether to check type assignability
-
-    Returns:
-        A prepared recipe that can be used as a precondition
-    """
-    return prepare_java_recipe("org.openrewrite.java.search.HasType", {
-        "fullyQualifiedTypeName": fully_qualified_type,
-        "checkAssignability": check_assignability
-    })
+def find_methods(
+    method_pattern: str, match_overrides: bool = False
+) -> RecipeRef:
+    """Find and mark methods matching a pattern (delegates to ``org.openrewrite.java.search.FindMethods``)."""
+    return RecipeRef(
+        "org.openrewrite.java.search.FindMethods",
+        {"methodPattern": method_pattern, "matchOverrides": match_overrides},
+    )
 
 
-def find_methods(method_pattern: str, match_overrides: bool = False) -> PreparedJavaRecipe:
-    """
-    Create a recipe that finds and marks methods matching a pattern.
-
-    Delegates to org.openrewrite.java.search.FindMethods.
-
-    Args:
-        method_pattern: Method pattern to search for
-        match_overrides: Whether to also match method overrides
-
-    Returns:
-        A prepared recipe that marks matching methods
-    """
-    return prepare_java_recipe("org.openrewrite.java.search.FindMethods", {
-        "methodPattern": method_pattern,
-        "matchOverrides": match_overrides
-    })
-
-
-def find_types(fully_qualified_type: str) -> PreparedJavaRecipe:
-    """
-    Create a recipe that finds and marks usages of a type.
-
-    Delegates to org.openrewrite.java.search.FindTypes.
-
-    Args:
-        fully_qualified_type: Fully qualified type name to find
-
-    Returns:
-        A prepared recipe that marks matching type usages
-    """
-    return prepare_java_recipe("org.openrewrite.java.search.FindTypes", {
-        "fullyQualifiedTypeName": fully_qualified_type
-    })
+def find_types(fully_qualified_type: str) -> RecipeRef:
+    """Find and mark usages of a type (delegates to ``org.openrewrite.java.search.FindTypes``)."""
+    return RecipeRef(
+        "org.openrewrite.java.search.FindTypes",
+        {"fullyQualifiedTypeName": fully_qualified_type},
+    )

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1257,7 +1257,7 @@ def _extract_preconditions_from_editor(editor_visitor):
 
 def _check_wire_entry(check) -> Optional[Dict[str, Any]]:
     """Translate a single :class:`Check` to a precondition wire entry."""
-    from rewrite.preconditions import RecipeCheck
+    from rewrite.preconditions import RecipeCheck, RecipeRef
     from rewrite.rpc.java_recipe import PreparedJavaRecipe
 
     if isinstance(check, RecipeCheck):
@@ -1272,6 +1272,15 @@ def _check_wire_entry(check) -> Optional[Dict[str, Any]]:
         return None
 
     condition = check.check
+    # Common case: helpers like uses_method/uses_type return a lightweight
+    # RecipeRef so the recipe author can declare a precondition without firing
+    # an RPC at editor() time. Java's PreparedRecipeCache.instantiateVisitor
+    # constructs the named Recipe via Jackson and uses its visitor.
+    if isinstance(condition, RecipeRef):
+        return {
+            'visitorName': condition.recipe_name,
+            'visitorOptions': dict(condition.options),
+        }
     if isinstance(condition, PreparedJavaRecipe):
         return {'visitorName': condition.edit_visitor, 'visitorOptions': None}
     java_name = getattr(condition, 'java_recipe_name', None)
@@ -1430,10 +1439,8 @@ def handle_batch_visit(params: dict) -> dict:
         modified = after is not before
         deleted = after is None
 
-        # Diff SearchResult IDs against the running set. Trees are immutable, so
-        # a visitor that returns the same reference cannot have added new
-        # SearchResults — skip the full-tree walk in that case.
-        if deleted or not modified:
+        # Diff SearchResult IDs against the running set
+        if deleted:
             search_result_ids = []
         else:
             after_ids = _collect_search_result_ids(after)

--- a/rewrite-python/rewrite/tests/rpc/test_preconditions_wire.py
+++ b/rewrite-python/rewrite/tests/rpc/test_preconditions_wire.py
@@ -235,6 +235,54 @@ class TestPrepareRecipeWithPreconditions:
         instantiated = server._instantiate_visitor(f"edit:{prepared_id}", ctx)
         assert instantiated is cached
 
+    def test_recipe_ref_emits_class_name_and_options(self, isolated_server):
+        """uses_method/uses_type return a RecipeRef; the wire entry should
+        carry the Java recipe class name and options directly so that the
+        host's PreparedRecipeCache can construct the recipe via Jackson."""
+        server = isolated_server
+
+        from rewrite.python.preconditions import uses_method
+
+        class _RecipeRefWrapper(Recipe):
+            @property
+            def name(self):
+                return "test.precondition.RecipeRefWrapper"
+
+            @property
+            def display_name(self):
+                return "Recipe ref wrapper"
+
+            @property
+            def description(self):
+                return "Editor wraps in Preconditions.check around a RecipeRef from uses_method."
+
+            def editor(self):
+                return Preconditions.check(
+                    uses_method("*..* tostring(..)"), _BareEditor()
+                )
+
+        _install(server, _RecipeRefWrapper)
+        resp = server.handle_prepare_recipe(
+            {"id": "test.precondition.RecipeRefWrapper"}
+        )
+
+        precs = resp["editPreconditions"]
+        # Baseline language gate + the RecipeRef precondition.
+        assert len(precs) == 2
+        assert precs[0]["visitorName"] == (
+            "org.openrewrite.rpc.internal.FindTreesOfType"
+        )
+        assert precs[1]["visitorName"] == "org.openrewrite.java.search.HasMethod"
+        assert precs[1]["visitorOptions"] == {
+            "methodPattern": "*..* tostring(..)",
+            "matchOverrides": False,
+        }
+
+        # Bare editor cached so dispatch via _instantiate_visitor returns it.
+        prepared_id = resp["id"]
+        assert prepared_id in server._prepared_editor_overrides
+        assert isinstance(server._prepared_editor_overrides[prepared_id], _BareEditor)
+
     def test_check_with_unserializable_visitor_falls_back(self, isolated_server):
         """A Check wrapping a generic TreeVisitor (no recipe identity, no
         java_recipe_name, no PreparedJavaRecipe) cannot be propagated to the


### PR DESCRIPTION
## Summary

- Follow-up to #7621. The `python.preconditions` helpers (`uses_method`, `uses_type`, `has_source_path`, `find_methods`, `find_types`) were calling `prepare_java_recipe` eagerly, which fired a synchronous PrepareRecipe RPC to the host. That made unit-testing a recipe whose `editor()` returns `Preconditions.check(uses_method(...), V())` impossible — every test that exercised the editor blocked on a 30s RPC timeout because no host is running in unit tests.

## What changed

**`rewrite.preconditions.RecipeRef`** (new): lightweight `(recipe_name, options)` placeholder. The helpers now return this instead of firing an RPC.

**`PreparedRecipeCache.instantiateVisitor`**: extended the third branch to handle Recipe class names. If the resolved class is a `Recipe` (e.g. `HasMethod`, `HasType`), construct it via Jackson and return `getVisitor()`. This mirrors what the `edit:<id>` branch does after a PrepareRecipe has been run — but skips the round-trip when the recipe identity came straight from the wire.

**Wire serialization** (`server.py:_check_wire_entry`): `RecipeRef`-backed Check wrappers now emit `{visitorName: <recipe_class_name>, visitorOptions: <options>}` directly into `editPreconditions`.

**In-process `Check.visit`**: treats a `RecipeRef` condition as "always passes" and dispatches the wrapped editor directly. Tests that run the editor in-process (no RPC server) still produce the same edits; the optimization only kicks in over the wire.

`RecipeRef` lives in `rewrite.preconditions` (core) so the `Check` / `Preconditions` type signatures stay precise (`Union[TreeVisitor, Recipe, RecipeRef]`) without core depending on python-specific code.

## Tests

`tests/rpc/test_preconditions_wire.py` adds `test_recipe_ref_emits_class_name_and_options`:
- a recipe whose `editor()` is `Preconditions.check(uses_method("*..* tostring(..)"), V())` produces an `editPreconditions` wire entry of `{visitorName: "org.openrewrite.java.search.HasMethod", visitorOptions: {methodPattern: "*..* tostring(..)", matchOverrides: false}}`
- the bare editor is cached in `_prepared_editor_overrides`

11 precondition tests pass; full rewrite-python suite still green.

## Companion

- [openrewrite/rewrite-migrate-python#54](https://github.com/openrewrite/rewrite-migrate-python/pull/54) wraps 21 editors across 14 recipe files in `Preconditions.check(uses_method(...), Visitor())`. All 415 migrate-python tests still pass.

## Test plan

- [x] All `tests/test_preconditions.py` and `tests/rpc/test_preconditions_wire.py` tests pass.
- [x] Existing rewrite-python suite stays green.
- [x] Companion migrate-python PR's 415 recipe tests pass.
- [ ] CI verifies the `PreparedRecipeCache` change.
- [ ] End-to-end: measure wall-time impact on ArchiveBox once both PRs land and a new openrewrite is published.
