### PR TITLE
javascript: defensive Space handling in JavaScriptPrinter.visitSpace

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/print.ts
+++ b/rewrite-javascript/rewrite/src/javascript/print.ts
@@ -1815,7 +1815,16 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
         }
     }
 
-    override async visitSpace(space: J.Space, p: PrintOutputCapture): Promise<J.Space> {
+    override async visitSpace(space: J.Space | undefined, p: PrintOutputCapture): Promise<J.Space> {
+        // Recipes can mutate trees in ways that drop required Space fields (e.g. a
+        // RightPadded with `after` left undefined). The hot path is BatchVisit →
+        // print, so throwing here aborts the formatter for the whole file and the
+        // caller falls back to "essential formatting", losing Prettier output.
+        // Treat a missing Space as empty: produces correct text and keeps the
+        // recipe on the fast path.
+        if (!space) {
+            return emptySpace;
+        }
         p.append(space.whitespace!);
 
         const comments = space.comments;


### PR DESCRIPTION
## Summary

`JavaScriptPrinter.visitSpace` throws `TypeError: Cannot read properties of undefined (reading 'whitespace')` when called with a missing `J.Space`. Treat undefined as `emptySpace` instead, so the printer produces correct text and doesn't abort on partially-formed trees.

## Why

Real recipes occasionally produce trees with missing Space fields — most often a `J.RightPadded` constructed without an `after`. The current line:

```ts
p.append(space.whitespace!);
```

throws on the `undefined.whitespace` access. The error is caught upstream where the recipe falls back to "essential formatting only," skipping Prettier and emitting a stack trace plus a Cursor dump per occurrence.

Observed in production during `mod run org.openrewrite.node.migrate.upgrade-node-24` against the `ALL/Open Source/JavaScript` working set: 4-8 occurrences per affected file across several repos, each producing ~1 KB of stack noise and losing Prettier formatting for the affected subtree.

## What this changes

```ts
override async visitSpace(space: J.Space | undefined, p: PrintOutputCapture): Promise<J.Space> {
    if (!space) {
        return emptySpace;
    }
    p.append(space.whitespace!);
    ...
}
```

The Liskov-compatible parameter widening (`J.Space | undefined`) is fine — the override still accepts everything the parent declared.

## Caveat

This is a bandaid at the lowest call site. The right long-term fix is the construction site: whichever recipe builds a `J.RightPadded` with `after: undefined` should be fixed to set it to `emptySpace`. That root cause investigation is out of scope here. This PR removes the user-visible Prettier-loss / log-noise effect.

## Test plan

- [x] `tsc --noEmit -p tsconfig.build.json` passes
- [ ] Run a JS recipe known to hit the issue (e.g. upgrade-node-24 against a representative JS repo) and confirm no `Cannot read properties of undefined (reading 'whitespace')` lines in `rpc.log`