### PR TITLE
rewrite-python: restore the skip-walk-when-not-modified guard

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1439,8 +1439,10 @@ def handle_batch_visit(params: dict) -> dict:
         modified = after is not before
         deleted = after is None
 
-        # Diff SearchResult IDs against the running set
-        if deleted:
+        # Diff SearchResult IDs against the running set. When the visitor
+        # didn't modify the tree, no new SearchResult markers were added
+        # — skip the full-tree walk in that case.
+        if deleted or not modified:
             search_result_ids = []
         else:
             after_ids = _collect_search_result_ids(after)


### PR DESCRIPTION
## Summary

Restores the `or not modified` clause to `handle_batch_visit`'s SearchResult-id collection so the full-tree walk runs only when a visitor actually modified the tree.

- #7620 introduced the guard:

```python
if deleted or not modified:
    search_result_ids = []
```

- While integrating the lazy-`RecipeRef` change in #7622, the `or not modified` clause was dropped. As a result the walk fired for every visitor in a batch regardless of outcome.

## Impact

Measured on `org.openrewrite.python.migrate.UpgradeToPython314` against `ArchiveBox/ArchiveBox` (228 .py files, 61 fixes), wall time:

| Stage | Wall time |
|---|---|
- | #7620 + #7621 + #7622 (today's `main`, with the regression) | ~1m 48s |
- | #7620 + #7621 + #7622 + this fix | ~1m 14s |

That's ~31% off this benchmark, with no change to fix count (61) or files searched (228). cProfile attributes ~205s of cumulative time to `_collect_search_result_ids`; the guard takes the count of those calls back down to roughly the modified-visit count instead of every-visitor count.

## Test plan

- [x] `pytest tests/test_preconditions.py tests/rpc/` — 22 passed, 5 skipped
- [x] `mod run --recipe=org.openrewrite.python.migrate.UpgradeToPython314` on ArchiveBox produces 61 fixes (matches main)
