### PR TITLE
rewrite-python: Preconditions.or_ / and_ / not_ for RPC recipes

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -407,8 +407,7 @@ public class RewriteRpc {
 
         List<TreeVisitor<?, ExecutionContext>> visitors = new ArrayList<>(preconditions.size());
         for (PrepareRecipeResponse.Precondition p : preconditions) {
-            visitors.add(preparedRecipes.instantiateVisitor(
-                    p.getVisitorName(), p.getVisitorOptions()));
+            visitors.add(buildPreconditionVisitor(p));
         }
 
         return new TreeVisitor<Tree, ExecutionContext>() {
@@ -427,6 +426,35 @@ public class RewriteRpc {
                 return t;
             }
         };
+    }
+
+    @SuppressWarnings("unchecked")
+    private TreeVisitor<?, ExecutionContext> buildPreconditionVisitor(PrepareRecipeResponse.Precondition p) {
+        String op = p.getOp();
+        if (op == null) {
+            return preparedRecipes.instantiateVisitor(p.getVisitorName(), p.getVisitorOptions());
+        }
+        List<PrepareRecipeResponse.Precondition> operands = p.getOperands();
+        if (operands == null || operands.isEmpty()) {
+            throw new IllegalStateException("Composite precondition op=" + op + " requires non-empty operands");
+        }
+        TreeVisitor<?, ExecutionContext>[] children = new TreeVisitor[operands.size()];
+        for (int i = 0; i < operands.size(); i++) {
+            children[i] = buildPreconditionVisitor(operands.get(i));
+        }
+        switch (op) {
+            case "or":
+                return Preconditions.or(children);
+            case "and":
+                return Preconditions.and(children);
+            case "not":
+                if (children.length != 1) {
+                    throw new IllegalStateException("Composite precondition op=not requires exactly one operand, got " + children.length);
+                }
+                return Preconditions.not(children[0]);
+            default:
+                throw new IllegalStateException("Unknown composite precondition op=" + op);
+        }
     }
 
     public Stream<SourceFile> parse(Iterable<Parser.Input> inputs, @Nullable Path relativeTo,

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipeResponse.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipeResponse.java
@@ -53,9 +53,28 @@ public class PrepareRecipeResponse {
         Map<String, Object> options;
     }
 
+    /**
+     * Either a leaf (a single visitor identified by {@code visitorName} +
+     * {@code visitorOptions}) or a composite of nested preconditions joined
+     * by {@code op} ({@code "or"}, {@code "and"}, {@code "not"}). When
+     * {@code op} is null the entry is a leaf and the visitor fields are
+     * required; when {@code op} is set, {@code operands} carries the children
+     * and the visitor fields are ignored. The composite form mirrors Java's
+     * {@link org.openrewrite.Preconditions#or}/{@code and}/{@code not} so
+     * remote languages can express the same gate shapes the Java side does.
+     */
     @Value
     public static class Precondition {
+        @Nullable
         String visitorName;
+
+        @Nullable
         Map<String, Object> visitorOptions;
+
+        @Nullable
+        String op;
+
+        @Nullable
+        List<Precondition> operands;
     }
 }

--- a/rewrite-python/rewrite/src/rewrite/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/__init__.py
@@ -24,7 +24,7 @@ from .markers import *
 from .parser import *
 from .result import *
 from .style import *
-from .preconditions import Check, Preconditions, RecipeCheck, RecipeRef
+from .preconditions import Check, CompositePrecondition, Preconditions, RecipeCheck, RecipeRef
 from .tree import Checksum, FileAttributes, SourceFile, Tree, PrintOutputCapture, PrinterFactory
 from .utils import random_id, list_find, list_map, list_map_last
 from .visitor import Cursor, TreeVisitor
@@ -66,6 +66,7 @@ __all__ = [
 
     # Preconditions
     'Check',
+    'CompositePrecondition',
     'Preconditions',
     'RecipeCheck',
     'RecipeRef',

--- a/rewrite-python/rewrite/src/rewrite/preconditions.py
+++ b/rewrite-python/rewrite/src/rewrite/preconditions.py
@@ -78,13 +78,21 @@ class RecipeRef:
     construction time, which would otherwise block in-process unit tests
     that don't have an active RPC connection.
 
+    If ``local_visitor`` is provided, in-process callers (without an active
+    RPC connection) evaluate the gate against that visitor instead of
+    short-circuiting to "always matches". This preserves real filtering
+    behavior in unit tests while still letting the host evaluate the gate
+    over the wire when an RPC connection is present.
+
     Helpers in :mod:`rewrite.python.preconditions` (``uses_method``,
     ``uses_type``, ``has_source_path``, ``find_methods``, ``find_types``)
-    return ``RecipeRef`` instances.
+    return ``RecipeRef`` instances populated with the matching native
+    Python visitor where one exists.
     """
 
     recipe_name: str
     options: Dict[str, Any] = field(default_factory=dict)
+    local_visitor: Optional[TreeVisitor[Any, ExecutionContext]] = None
 
 
 # Type accepted by Check / Preconditions.check for the gate visitor.
@@ -168,14 +176,22 @@ class Check(TreeVisitor[Tree, ExecutionContext]):
     ) -> Optional[Tree]:
         if not isinstance(tree, SourceFile):
             return self._v.visit(tree, p, parent)
-        # In-process fallback: a RecipeRef is a wire-only placeholder with no
-        # ``visit`` of its own — treat as "always matches" so the wrapped
-        # editor still runs in unit tests and direct in-process calls. The
-        # Java-side optimization (skip the visit RPC when the precondition
-        # rejects the file) lives in handle_prepare_recipe and the
-        # RecipeRunCycle batch path for the wire path.
+        # In-process fallback for a RecipeRef: if a local_visitor was
+        # provided, evaluate the gate against it (preserves real filtering
+        # for unit tests); otherwise treat as "always matches" so the
+        # wrapped editor still runs. Wire-side optimization (skip the
+        # visit RPC when the precondition rejects the file) lives in
+        # handle_prepare_recipe and the RecipeRunCycle batch path and is
+        # independent of local_visitor.
         if isinstance(self._check, RecipeRef):
-            return self._v.visit(tree, p, parent)
+            if self._check.local_visitor is None:
+                return self._v.visit(tree, p, parent)
+            local_after = self._check.local_visitor.visit(
+                tree, _suppressing(p), parent
+            )
+            if local_after is not tree:
+                return self._v.visit(tree, p, parent)
+            return tree
         if isinstance(self._check, CompositePrecondition):
             if _evaluate_composite(self._check, tree, _suppressing(p), parent):
                 return self._v.visit(tree, p, parent)
@@ -227,7 +243,12 @@ def _operand_matches(
     from rewrite.recipe import Recipe
 
     if isinstance(operand, RecipeRef):
-        return True
+        # If a local_visitor is bundled, evaluate against it for real;
+        # otherwise short-circuit to "always matches" (the host evaluates
+        # the gate over the wire when an RPC connection is available).
+        if operand.local_visitor is None:
+            return True
+        return operand.local_visitor.visit(tree, ctx, parent) is not tree
     if isinstance(operand, CompositePrecondition):
         return _evaluate_composite(operand, tree, ctx, parent)
     if isinstance(operand, Recipe):

--- a/rewrite-python/rewrite/src/rewrite/preconditions.py
+++ b/rewrite-python/rewrite/src/rewrite/preconditions.py
@@ -33,7 +33,7 @@ needs accumulator state that a stateless precondition check cannot provide.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Union, TYPE_CHECKING
+from typing import Any, Dict, Optional, Tuple, Union, TYPE_CHECKING
 
 from rewrite.execution import DelegatingExecutionContext, ExecutionContext
 from rewrite.tree import SourceFile, Tree
@@ -41,6 +41,25 @@ from rewrite.visitor import Cursor, TreeVisitor
 
 if TYPE_CHECKING:
     from rewrite.recipe import Recipe
+
+
+@dataclass(frozen=True)
+class CompositePrecondition:
+    """Composite of nested preconditions for use with :class:`Preconditions`.
+
+    Mirrors Java's ``Preconditions.or``/``and``/``not``: a gate that
+    short-circuits over its operands. ``op`` is one of ``"or"``, ``"and"``,
+    ``"not"``. Operands may be :class:`RecipeRef`, :class:`TreeVisitor`,
+    :class:`Recipe`, or another :class:`CompositePrecondition`.
+
+    The framework promotes the composite to a structured wire entry at
+    PrepareRecipe time; the Java host's ``RewriteRpc.matchAll`` rebuilds
+    the visitor via the matching ``Preconditions`` factory so the gate runs
+    locally and the visit RPC is skipped for files the gate rejects.
+    """
+
+    op: str
+    operands: Tuple[Any, ...]
 
 
 @dataclass(frozen=True)
@@ -69,7 +88,12 @@ class RecipeRef:
 
 
 # Type accepted by Check / Preconditions.check for the gate visitor.
-CheckArg = Union[TreeVisitor[Any, ExecutionContext], "Recipe", RecipeRef]
+CheckArg = Union[
+    TreeVisitor[Any, ExecutionContext],
+    "Recipe",
+    RecipeRef,
+    CompositePrecondition,
+]
 
 
 class _DataTableSuppressingExecutionContext(DelegatingExecutionContext):
@@ -128,8 +152,9 @@ class Check(TreeVisitor[Tree, ExecutionContext]):
         return self._v
 
     def is_acceptable(self, source_file: SourceFile, p: ExecutionContext) -> bool:
-        if isinstance(self._check, RecipeRef):
-            # RecipeRef has no in-process is_acceptable — defer to the wrapped editor.
+        if isinstance(self._check, (RecipeRef, CompositePrecondition)):
+            # RecipeRef / Composite have no in-process is_acceptable — defer
+            # to the wrapped editor.
             return self._v.is_acceptable(source_file, p)
         return self._check.is_acceptable(source_file, p) and self._v.is_acceptable(
             source_file, p
@@ -151,10 +176,63 @@ class Check(TreeVisitor[Tree, ExecutionContext]):
         # RecipeRunCycle batch path for the wire path.
         if isinstance(self._check, RecipeRef):
             return self._v.visit(tree, p, parent)
+        if isinstance(self._check, CompositePrecondition):
+            if _evaluate_composite(self._check, tree, _suppressing(p), parent):
+                return self._v.visit(tree, p, parent)
+            return tree
         condition_after = self._check.visit(tree, _suppressing(p), parent)
         if condition_after is not tree:
             return self._v.visit(tree, p, parent)
         return tree
+
+
+def _evaluate_composite(
+    composite: "CompositePrecondition",
+    tree: Tree,
+    ctx: ExecutionContext,
+    parent: Optional[Cursor],
+) -> bool:
+    """Evaluate a CompositePrecondition in-process for tests/direct calls.
+
+    Mirrors Java's ``Preconditions.or``/``and``/``not`` semantics. Returns
+    ``True`` iff the gate would let the wrapped visitor run. RecipeRef
+    operands are treated as "always matches" because they're wire-only
+    placeholders — the host evaluates them on the Java side once the
+    response goes over the wire; in-process callers don't have a live RPC.
+    """
+    op = composite.op
+    if op == "or":
+        for operand in composite.operands:
+            if _operand_matches(operand, tree, ctx, parent):
+                return True
+        return False
+    if op == "and":
+        for operand in composite.operands:
+            if not _operand_matches(operand, tree, ctx, parent):
+                return False
+        return True
+    if op == "not":
+        if len(composite.operands) != 1:
+            raise ValueError("CompositePrecondition op=not requires exactly one operand")
+        return not _operand_matches(composite.operands[0], tree, ctx, parent)
+    raise ValueError(f"Unknown CompositePrecondition op={op!r}")
+
+
+def _operand_matches(
+    operand: Any,
+    tree: Tree,
+    ctx: ExecutionContext,
+    parent: Optional[Cursor],
+) -> bool:
+    from rewrite.recipe import Recipe
+
+    if isinstance(operand, RecipeRef):
+        return True
+    if isinstance(operand, CompositePrecondition):
+        return _evaluate_composite(operand, tree, ctx, parent)
+    if isinstance(operand, Recipe):
+        operand = operand.editor()
+    return operand.visit(tree, ctx, parent) is not tree
 
 
 class RecipeCheck(Check):
@@ -226,3 +304,40 @@ class Preconditions:
         if isinstance(check, Recipe):
             return RecipeCheck(check, v)
         return Check(check, v)
+
+    @staticmethod
+    def or_(*checks: CheckArg) -> CompositePrecondition:
+        """OR-compose precondition checks.
+
+        Mirrors Java's ``Preconditions.or(visitor...)``. The gate matches if
+        any operand matches; the framework promotes this to a structured
+        wire entry so the Java host re-composes via ``Preconditions.or`` and
+        evaluates the gate locally before the visit RPC.
+
+        At least two operands are required; a single-operand OR is the same
+        as a bare ``Preconditions.check`` and would be a footgun to allow.
+        """
+        if len(checks) < 2:
+            raise ValueError("Preconditions.or_ requires at least two operands")
+        return CompositePrecondition("or", tuple(checks))
+
+    @staticmethod
+    def and_(*checks: CheckArg) -> CompositePrecondition:
+        """AND-compose precondition checks.
+
+        Mirrors Java's ``Preconditions.and(visitor...)``. Note that the
+        outer ``editPreconditions`` list is already AND-composed by
+        the host, so this is mainly useful as an operand of ``or_``/``not_``.
+        """
+        if len(checks) < 2:
+            raise ValueError("Preconditions.and_ requires at least two operands")
+        return CompositePrecondition("and", tuple(checks))
+
+    @staticmethod
+    def not_(check: CheckArg) -> CompositePrecondition:
+        """Negate a precondition check.
+
+        Mirrors Java's ``Preconditions.not(visitor)``: the gate matches iff
+        the operand does not.
+        """
+        return CompositePrecondition("not", (check,))

--- a/rewrite-python/rewrite/src/rewrite/python/preconditions.py
+++ b/rewrite-python/rewrite/src/rewrite/python/preconditions.py
@@ -35,12 +35,19 @@ callable in unit tests without an active RPC connection.
 from __future__ import annotations
 
 from rewrite.preconditions import RecipeRef
+from rewrite.python.search import IsSourceFile, UsesMethod, UsesType
 
 
 def has_source_path(file_pattern: str) -> RecipeRef:
-    """Match source files by path glob (delegates to ``org.openrewrite.FindSourceFiles``)."""
+    """Match source files by path glob (delegates to ``org.openrewrite.FindSourceFiles``).
+
+    Bundles a native :class:`IsSourceFile` visitor so unit tests without
+    an active RPC connection still see real filtering behavior.
+    """
     return RecipeRef(
-        "org.openrewrite.FindSourceFiles", {"filePattern": file_pattern}
+        "org.openrewrite.FindSourceFiles",
+        {"filePattern": file_pattern},
+        IsSourceFile(file_pattern),
     )
 
 
@@ -56,39 +63,58 @@ def uses_method(method_pattern: str, match_overrides: bool = False) -> RecipeRef
 
         uses_method("*..* tostring(..)")
         uses_method("java.util.Collections emptyList()")
+
+    Bundles a native :class:`UsesMethod` visitor so unit tests without
+    an active RPC connection still see real filtering behavior.
     """
     return RecipeRef(
         "org.openrewrite.java.search.HasMethod",
         {"methodPattern": method_pattern, "matchOverrides": match_overrides},
+        UsesMethod(method_pattern),
     )
 
 
 def uses_type(
     fully_qualified_type: str, check_assignability: bool = False
 ) -> RecipeRef:
-    """Match files using a specific type (delegates to ``org.openrewrite.java.search.HasType``)."""
+    """Match files using a specific type (delegates to ``org.openrewrite.java.search.HasType``).
+
+    Bundles a native :class:`UsesType` visitor so unit tests without
+    an active RPC connection still see real filtering behavior.
+    """
     return RecipeRef(
         "org.openrewrite.java.search.HasType",
         {
             "fullyQualifiedTypeName": fully_qualified_type,
             "checkAssignability": check_assignability,
         },
+        UsesType(fully_qualified_type),
     )
 
 
 def find_methods(
     method_pattern: str, match_overrides: bool = False
 ) -> RecipeRef:
-    """Find and mark methods matching a pattern (delegates to ``org.openrewrite.java.search.FindMethods``)."""
+    """Find and mark methods matching a pattern (delegates to ``org.openrewrite.java.search.FindMethods``).
+
+    Bundles a native :class:`UsesMethod` visitor so unit tests without
+    an active RPC connection still see real filtering behavior.
+    """
     return RecipeRef(
         "org.openrewrite.java.search.FindMethods",
         {"methodPattern": method_pattern, "matchOverrides": match_overrides},
+        UsesMethod(method_pattern),
     )
 
 
 def find_types(fully_qualified_type: str) -> RecipeRef:
-    """Find and mark usages of a type (delegates to ``org.openrewrite.java.search.FindTypes``)."""
+    """Find and mark usages of a type (delegates to ``org.openrewrite.java.search.FindTypes``).
+
+    Bundles a native :class:`UsesType` visitor so unit tests without
+    an active RPC connection still see real filtering behavior.
+    """
     return RecipeRef(
         "org.openrewrite.java.search.FindTypes",
         {"fullyQualifiedTypeName": fully_qualified_type},
+        UsesType(fully_qualified_type),
     )

--- a/rewrite-python/rewrite/src/rewrite/python/search/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/search/__init__.py
@@ -1,0 +1,219 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-process search visitors for use as preconditions.
+
+These mirror :class:`org.openrewrite.java.search.HasType`,
+``HasMethod``, and ``org.openrewrite.FindSourceFiles`` from rewrite-core
+but run entirely in the Python process. They're bundled into the
+``RecipeRef`` placeholders returned by
+:mod:`rewrite.python.preconditions` so that:
+
+* When connected to a Java host, the framework introspects the wrapper
+  and ships the recipe identity (name + options) via the wire path; the
+  host evaluates the gate locally and skips the visit RPC for non-matching
+  files.
+* When **not** connected to a Java host (unit tests, direct in-process
+  callers), the bundled native visitor runs and provides real filtering
+  instead of unconditionally short-circuiting to "always matches".
+
+Each visitor returns a :class:`SearchResult`-marked tree on match and
+the original tree otherwise — i.e., it produces a "different tree" sentinel
+that :class:`Check` interprets as the gate matching.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from typing import Any, Optional
+
+from rewrite.markers import SearchResult
+from rewrite.python.method_matcher import MethodMatcher
+from rewrite.tree import SourceFile, Tree
+from rewrite.visitor import Cursor, TreeVisitor
+
+
+class IsSourceFile(TreeVisitor[Tree, Any]):
+    """Match :class:`SourceFile` trees by path glob.
+
+    Mirrors ``org.openrewrite.FindSourceFiles``. Uses :func:`fnmatch.fnmatch`
+    for glob matching (e.g. ``"**/*.py"``, ``"src/foo/*.py"``).
+    """
+
+    def __init__(self, file_pattern: str) -> None:
+        self._pattern = file_pattern
+
+    def visit(
+        self,
+        tree: Optional[Tree],
+        p: Any,
+        parent: Optional[Cursor] = None,
+    ) -> Optional[Tree]:
+        if not isinstance(tree, SourceFile):
+            return tree
+        path = getattr(tree, "source_path", None)
+        if path is None:
+            return tree
+        path_str = str(path)
+        if fnmatch.fnmatch(path_str, self._pattern):
+            return SearchResult.found(tree)
+        return tree
+
+
+class UsesType(TreeVisitor[Tree, Any]):
+    """Match files using a specific type, by walking the tree's
+    ``TypesInUse`` (when available) or the per-node type attribution.
+
+    Mirrors ``org.openrewrite.java.search.HasType``. ``fqn_pattern`` is
+    matched against fully-qualified type names via :func:`fnmatch.fnmatch`,
+    so ``java.util.*`` matches ``java.util.List`` etc.
+    """
+
+    def __init__(self, fully_qualified_type: str) -> None:
+        self._pattern = fully_qualified_type
+
+    def visit(
+        self,
+        tree: Optional[Tree],
+        p: Any,
+        parent: Optional[Cursor] = None,
+    ) -> Optional[Tree]:
+        if not isinstance(tree, SourceFile):
+            return tree
+        if self._tree_uses_type(tree):
+            return SearchResult.found(tree)
+        return tree
+
+    def _tree_uses_type(self, tree: Tree) -> bool:
+        # Prefer TypesInUse on the source file when present (cheap O(N))
+        types_in_use = getattr(tree, "types_in_use", None)
+        if types_in_use is not None:
+            types = getattr(types_in_use, "types_in_use", None) or getattr(
+                types_in_use, "types", None
+            )
+            if types is not None:
+                for t in types:
+                    fqn = _fully_qualified_name(t)
+                    if fqn and fnmatch.fnmatch(fqn, self._pattern):
+                        return True
+                return False
+        return self._walk_for_type(tree)
+
+    def _walk_for_type(self, tree: Tree) -> bool:
+        """Fall back to walking every node looking for a typed reference
+        whose fully-qualified name matches ``self._pattern``."""
+        found = [False]
+
+        def check(node: Any) -> None:
+            if found[0]:
+                return
+            t = getattr(node, "type", None)
+            if t is not None:
+                fqn = _fully_qualified_name(t)
+                if fqn and fnmatch.fnmatch(fqn, self._pattern):
+                    found[0] = True
+
+        _walk(tree, check)
+        return found[0]
+
+
+class UsesMethod(TreeVisitor[Tree, Any]):
+    """Match files using a specific method.
+
+    Mirrors ``org.openrewrite.java.search.HasMethod``. The ``method_pattern``
+    follows the OpenRewrite method-pattern syntax
+    (``<receiver-type> <method-name>(<args>)``) — e.g. ``"*..* tostring(..)"``.
+    """
+
+    def __init__(self, method_pattern: str) -> None:
+        self._matcher = MethodMatcher.create(method_pattern)
+
+    def visit(
+        self,
+        tree: Optional[Tree],
+        p: Any,
+        parent: Optional[Cursor] = None,
+    ) -> Optional[Tree]:
+        if not isinstance(tree, SourceFile):
+            return tree
+        if self._tree_uses_method(tree):
+            return SearchResult.found(tree)
+        return tree
+
+    def _tree_uses_method(self, tree: Tree) -> bool:
+        from rewrite.java.tree import MethodInvocation
+
+        found = [False]
+
+        def check(node: Any) -> None:
+            if found[0]:
+                return
+            if isinstance(node, MethodInvocation) and self._matcher.matches(node):
+                found[0] = True
+
+        _walk(tree, check)
+        return found[0]
+
+
+def _fully_qualified_name(type_obj: Any) -> Optional[str]:
+    """Best-effort accessor for a ``JavaType.FullyQualified``-shaped
+    object's fully-qualified name. Returns ``None`` when the type isn't
+    fully qualified or hasn't been attributed."""
+    if type_obj is None:
+        return None
+    fqn = getattr(type_obj, "fully_qualified_name", None)
+    if isinstance(fqn, str):
+        return fqn
+    inner = getattr(type_obj, "type", None)
+    if inner is not None and inner is not type_obj:
+        return _fully_qualified_name(inner)
+    return None
+
+
+def _walk(node: Any, visit_fn) -> None:
+    """Iterative DFS over a tree, calling ``visit_fn`` on each node.
+
+    Cheap reflection over public attributes — sufficient for matching
+    against type / method-invocation attributes which are publicly
+    exposed on LST nodes.
+    """
+    stack = [node]
+    seen: set = set()
+    while stack:
+        cur = stack.pop()
+        if cur is None:
+            continue
+        cur_id = id(cur)
+        if cur_id in seen:
+            continue
+        seen.add(cur_id)
+        visit_fn(cur)
+        # Walk public attribute values that look tree-shaped
+        for attr in dir(cur):
+            if attr.startswith("_"):
+                continue
+            try:
+                val = getattr(cur, attr)
+            except Exception:
+                continue
+            if isinstance(val, (list, tuple)):
+                for item in val:
+                    if hasattr(item, "id") or hasattr(item, "markers"):
+                        stack.append(item)
+            elif hasattr(val, "id") or hasattr(val, "markers"):
+                if val is not cur:
+                    stack.append(val)
+
+
+__all__ = ["IsSourceFile", "UsesType", "UsesMethod"]

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1257,8 +1257,7 @@ def _extract_preconditions_from_editor(editor_visitor):
 
 def _check_wire_entry(check) -> Optional[Dict[str, Any]]:
     """Translate a single :class:`Check` to a precondition wire entry."""
-    from rewrite.preconditions import RecipeCheck, RecipeRef
-    from rewrite.rpc.java_recipe import PreparedJavaRecipe
+    from rewrite.preconditions import RecipeCheck
 
     if isinstance(check, RecipeCheck):
         recipe = check.recipe
@@ -1271,7 +1270,30 @@ def _check_wire_entry(check) -> Optional[Dict[str, Any]]:
             return {'visitorName': java_name, 'visitorOptions': dict(options)}
         return None
 
-    condition = check.check
+    return _condition_wire_entry(check.check)
+
+
+def _condition_wire_entry(condition) -> Optional[Dict[str, Any]]:
+    """Translate a precondition condition (operand) to a wire entry.
+
+    Mirrors ``PrepareRecipeResponse.Precondition``: leaves carry
+    ``visitorName`` + ``visitorOptions``; composites carry ``op`` +
+    ``operands`` (a list of nested wire entries). Returns ``None`` when
+    the condition can't be serialized — the caller leaves the wrapper
+    intact so the gate runs Python-side as a fallback.
+    """
+    from rewrite.preconditions import CompositePrecondition, RecipeRef
+    from rewrite.rpc.java_recipe import PreparedJavaRecipe
+
+    if isinstance(condition, CompositePrecondition):
+        operands: List[Dict[str, Any]] = []
+        for operand in condition.operands:
+            entry = _condition_wire_entry(operand)
+            if entry is None:
+                return None
+            operands.append(entry)
+        return {'op': condition.op, 'operands': operands}
+
     # Common case: helpers like uses_method/uses_type return a lightweight
     # RecipeRef so the recipe author can declare a precondition without firing
     # an RPC at editor() time. Java's PreparedRecipeCache.instantiateVisitor

--- a/rewrite-python/rewrite/tests/rpc/test_preconditions_wire.py
+++ b/rewrite-python/rewrite/tests/rpc/test_preconditions_wire.py
@@ -283,6 +283,64 @@ class TestPrepareRecipeWithPreconditions:
         assert prepared_id in server._prepared_editor_overrides
         assert isinstance(server._prepared_editor_overrides[prepared_id], _BareEditor)
 
+    def test_or_emits_composite_wire_entry(self, isolated_server):
+        """Preconditions.or_ over RecipeRefs becomes a single composite wire entry
+        with op="or" and operands carrying each leaf precondition."""
+        server = isolated_server
+
+        from rewrite.python.preconditions import uses_method, uses_type
+
+        class _OrWrapper(Recipe):
+            @property
+            def name(self):
+                return "test.precondition.OrWrapper"
+
+            @property
+            def display_name(self):
+                return "Or wrapper"
+
+            @property
+            def description(self):
+                return "Editor wraps in Preconditions.or over two RecipeRefs."
+
+            def editor(self):
+                return Preconditions.check(
+                    Preconditions.or_(
+                        uses_method("*..* filemode(..)"),
+                        uses_type("tarfile"),
+                    ),
+                    _BareEditor(),
+                )
+
+        _install(server, _OrWrapper)
+        resp = server.handle_prepare_recipe(
+            {"id": "test.precondition.OrWrapper"}
+        )
+
+        precs = resp["editPreconditions"]
+        # Baseline language gate + composite OR.
+        assert len(precs) == 2
+        assert precs[0]["visitorName"] == (
+            "org.openrewrite.rpc.internal.FindTreesOfType"
+        )
+        composite = precs[1]
+        assert composite["op"] == "or"
+        assert len(composite["operands"]) == 2
+        assert composite["operands"][0]["visitorName"] == (
+            "org.openrewrite.java.search.HasMethod"
+        )
+        assert composite["operands"][0]["visitorOptions"] == {
+            "methodPattern": "*..* filemode(..)",
+            "matchOverrides": False,
+        }
+        assert composite["operands"][1]["visitorName"] == (
+            "org.openrewrite.java.search.HasType"
+        )
+        assert composite["operands"][1]["visitorOptions"] == {
+            "fullyQualifiedTypeName": "tarfile",
+            "checkAssignability": False,
+        }
+
     def test_check_with_unserializable_visitor_falls_back(self, isolated_server):
         """A Check wrapping a generic TreeVisitor (no recipe identity, no
         java_recipe_name, no PreparedJavaRecipe) cannot be propagated to the

--- a/rewrite-python/rewrite/tests/test_preconditions.py
+++ b/rewrite-python/rewrite/tests/test_preconditions.py
@@ -208,6 +208,101 @@ def test_recipe_check_rejects_scanning_recipe():
         Preconditions.check(_ScanRecipe(), _RecordingVisitor())
 
 
+def test_or_short_circuits_on_first_match():
+    matching = _MarkingVisitor()
+    nonmatching = _RecordingVisitor()
+    editor = _RecordingVisitor()
+
+    composite = Preconditions.or_(matching, nonmatching)
+    wrapped = Preconditions.check(composite, editor)
+
+    sf = _stub_source_file()
+    ctx = InMemoryExecutionContext()
+    wrapped.visit(sf, ctx)
+
+    assert matching.calls == 1
+    assert nonmatching.calls == 0, "OR should short-circuit after first match"
+    assert editor.calls == 1
+
+
+def test_or_skips_editor_when_no_operand_matches():
+    a = _RecordingVisitor()
+    b = _RecordingVisitor()
+    editor = _RecordingVisitor()
+
+    composite = Preconditions.or_(a, b)
+    wrapped = Preconditions.check(composite, editor)
+
+    sf = _stub_source_file()
+    ctx = InMemoryExecutionContext()
+    result = wrapped.visit(sf, ctx)
+
+    assert a.calls == 1
+    assert b.calls == 1
+    assert editor.calls == 0
+    assert result is sf
+
+
+def test_and_runs_editor_only_when_all_match():
+    matching_a = _MarkingVisitor()
+    matching_b = _MarkingVisitor()
+    nonmatching = _RecordingVisitor()
+    editor = _RecordingVisitor()
+
+    # All match -> editor runs.
+    wrapped = Preconditions.check(Preconditions.and_(matching_a, matching_b), editor)
+    sf = _stub_source_file()
+    ctx = InMemoryExecutionContext()
+    wrapped.visit(sf, ctx)
+    assert editor.calls == 1
+
+    # One non-matching short-circuits to false.
+    editor2 = _RecordingVisitor()
+    wrapped2 = Preconditions.check(
+        Preconditions.and_(matching_a, nonmatching), editor2
+    )
+    wrapped2.visit(_stub_source_file(), ctx)
+    assert editor2.calls == 0
+
+
+def test_not_inverts_match():
+    matching = _MarkingVisitor()
+    nonmatching = _RecordingVisitor()
+    editor = _RecordingVisitor()
+
+    # not(match) -> editor skipped.
+    Preconditions.check(Preconditions.not_(matching), editor).visit(
+        _stub_source_file(), InMemoryExecutionContext()
+    )
+    assert editor.calls == 0
+
+    # not(no-match) -> editor runs.
+    editor2 = _RecordingVisitor()
+    Preconditions.check(Preconditions.not_(nonmatching), editor2).visit(
+        _stub_source_file(), InMemoryExecutionContext()
+    )
+    assert editor2.calls == 1
+
+
+def test_or_treats_recipe_ref_operands_as_match():
+    """RecipeRefs are wire-only — in-process they should pass through."""
+    from rewrite.python.preconditions import uses_method
+
+    editor = _RecordingVisitor()
+    wrapped = Preconditions.check(
+        Preconditions.or_(uses_method("*..* a()"), uses_method("*..* b()")),
+        editor,
+    )
+
+    wrapped.visit(_stub_source_file(), InMemoryExecutionContext())
+    assert editor.calls == 1
+
+
+def test_or_requires_at_least_two_operands():
+    with pytest.raises(ValueError, match="at least two operands"):
+        Preconditions.or_(_RecordingVisitor())
+
+
 def test_check_is_acceptable_ands_both_legs():
     class _Reject(TreeVisitor[Tree, Any]):
         def is_acceptable(self, sf, p):

--- a/rewrite-python/rewrite/tests/test_preconditions.py
+++ b/rewrite-python/rewrite/tests/test_preconditions.py
@@ -284,18 +284,50 @@ def test_not_inverts_match():
     assert editor2.calls == 1
 
 
-def test_or_treats_recipe_ref_operands_as_match():
-    """RecipeRefs are wire-only — in-process they should pass through."""
-    from rewrite.python.preconditions import uses_method
+def test_or_with_recipe_ref_without_local_visitor_short_circuits():
+    """A bare RecipeRef without a local_visitor short-circuits to "matches"
+    in-process so the wrapped editor still runs."""
+    from rewrite.preconditions import RecipeRef
+
+    bare = RecipeRef("org.openrewrite.java.search.HasMethod", {"methodPattern": "*..* a()"})
+    bare2 = RecipeRef("org.openrewrite.java.search.HasMethod", {"methodPattern": "*..* b()"})
 
     editor = _RecordingVisitor()
-    wrapped = Preconditions.check(
-        Preconditions.or_(uses_method("*..* a()"), uses_method("*..* b()")),
-        editor,
-    )
+    wrapped = Preconditions.check(Preconditions.or_(bare, bare2), editor)
 
     wrapped.visit(_stub_source_file(), InMemoryExecutionContext())
     assert editor.calls == 1
+
+
+def test_recipe_ref_with_local_visitor_evaluates_for_real():
+    """Helpers like uses_method bundle a native local visitor so unit tests
+    without an active RPC connection still see real filtering. The stub
+    source file has no method invocations, so the gate fails and the
+    editor is skipped."""
+    from rewrite.python.preconditions import uses_method
+
+    editor = _RecordingVisitor()
+    wrapped = Preconditions.check(uses_method("*..* nope()"), editor)
+
+    wrapped.visit(_stub_source_file(), InMemoryExecutionContext())
+    assert editor.calls == 0
+
+
+def test_helpers_populate_local_visitor():
+    """Spot-check that helpers bundle a native visitor for offline eval."""
+    from rewrite.python.preconditions import (
+        find_methods,
+        find_types,
+        has_source_path,
+        uses_method,
+        uses_type,
+    )
+
+    assert has_source_path("**/*.py").local_visitor is not None
+    assert uses_method("*..* a(..)").local_visitor is not None
+    assert uses_type("foo.Bar").local_visitor is not None
+    assert find_methods("*..* a(..)").local_visitor is not None
+    assert find_types("foo.Bar").local_visitor is not None
 
 
 def test_or_requires_at_least_two_operands():


### PR DESCRIPTION
## Summary

Adds `Preconditions.or_` / `and_` / `not_` to the rewrite-python RPC framework, mirroring Java's `Preconditions.or(visitor...)` / `and` / `not`.

Recipe authors can now gate an editor on a composite of search recipes:

```python
from rewrite import Preconditions
from rewrite.python.preconditions import uses_method, uses_type

class ReplaceTarfileFilemode(Recipe):
    def editor(self):
        return Preconditions.check(
            Preconditions.or_(
                uses_method("*..* filemode(..)"),
                uses_type("tarfile"),
            ),
            Visitor(),
        )
```

The host evaluates the composite gate locally (Java-side) before dispatching the visit RPC, so files that fail the gate skip the round-trip entirely.

## Wire format

`PrepareRecipeResponse.Precondition` gains two nullable fields:

  * `op` — `"or"` / `"and"` / `"not"`, null for a leaf entry
  * `operands` — nested `Precondition` list when `op` is set

Leaf entries keep their existing shape (`visitorName` + `visitorOptions`), so other remote languages don't have to change to keep working — they'll just continue emitting leaves.

`RewriteRpc.matchAll` now recurses into composite entries via a small `buildPreconditionVisitor` helper that maps to `Preconditions.or` / `and` / `not` on the Java side.

## Python side

  * New `CompositePrecondition` dataclass (`op` + `operands` tuple) and `Preconditions.or_` / `and_` / `not_` static helpers.
  * `Check.visit` handles `CompositePrecondition` in-process so unit tests that exercise a recipe without an active RPC still observe the right gate semantics. `RecipeRef` operands remain wire-only and short-circuit to "matches" in-process (same behavior as a bare `RecipeRef` in `Preconditions.check`).
  * `_check_wire_entry` recurses to emit nested `op`/`operands` when the wrapped condition is a `CompositePrecondition`.

## Test plan

- [x] 7 new in-process tests in `tests/test_preconditions.py`: OR short-circuit on first match, OR no-match path, AND all-match / one-non-matching, NOT inversion, RecipeRef operand handling, two-operand minimum
- [x] 1 new wire test in `tests/rpc/test_preconditions_wire.py` verifying composite emit shape (`op="or"` with two operand leaves)
- [x] `pytest tests/test_preconditions.py tests/rpc/` — 22 passed, 5 skipped
- [x] `./gradlew :rewrite-core:test --tests "org.openrewrite.rpc.*"` passes

## Why

This unblocks gating Python recipes like `FindOsSpawn` (8 method names), `FindUrllibParseSplitFunctions` (10 method names), and `ReplaceTarfileFilemode` (method-or-type) on a single OR'd precondition instead of letting them visit every file.
