### PR TITLE
rewrite-javascript: Preconditions.or / and / not for RPC recipes

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/preconditions.ts
+++ b/rewrite-javascript/rewrite/src/javascript/preconditions.ts
@@ -14,29 +14,38 @@
  * limitations under the License.
  */
 import {RecipeRef} from "../preconditions";
+import {IsSourceFile} from "../search";
+import {UsesMethod, UsesType} from "./search";
 
 /**
  * Match source files by path glob.
  *
- * Returns a {@link RecipeRef} placeholder. The framework introspects a
- * ``check(hasSourcePath(...), editor)`` wrapper at PrepareRecipe time
- * and emits the recipe identity directly in
+ * Returns a {@link RecipeRef} placeholder bundled with a native
+ * {@link IsSourceFile} visitor for in-process evaluation. The framework
+ * introspects a ``check(hasSourcePath(...), editor)`` wrapper at
+ * PrepareRecipe time and emits the recipe identity directly in
  * ``editPreconditions``; the Java host's ``PreparedRecipeCache.instantiateVisitor``
  * constructs the recipe and uses its visitor — no extra RPC round-trip
- * needed at editor() construction time, so unit tests can call
- * ``recipe.editor()`` without an active RPC connection.
+ * needed at editor() construction time. Unit tests without an active
+ * RPC connection fall back to the bundled native visitor for real
+ * filtering.
  *
  * Delegates to {@code org.openrewrite.FindSourceFiles}.
  */
 export function hasSourcePath(filePattern: string): RecipeRef {
-    return new RecipeRef("org.openrewrite.FindSourceFiles", {filePattern});
+    return new RecipeRef(
+        "org.openrewrite.FindSourceFiles",
+        {filePattern},
+        new IsSourceFile(filePattern),
+    );
 }
 
 /**
  * Match files using a specific method.
  *
- * Returns a {@link RecipeRef} placeholder; see {@link hasSourcePath} for
- * the introspection / lazy-evaluation pattern.
+ * Returns a {@link RecipeRef} placeholder bundled with a native
+ * {@link UsesMethod} visitor for in-process evaluation; see
+ * {@link hasSourcePath} for the introspection / lazy-evaluation pattern.
  *
  * ``methodPattern`` follows the OpenRewrite method-pattern syntax:
  * ``<receiver-type> <method-name>(<args>)`` — e.g.
@@ -45,41 +54,60 @@ export function hasSourcePath(filePattern: string): RecipeRef {
  * Delegates to {@code org.openrewrite.java.search.HasMethod}.
  */
 export function usesMethod(methodPattern: string, matchOverrides: boolean = false): RecipeRef {
-    return new RecipeRef("org.openrewrite.java.search.HasMethod", {methodPattern, matchOverrides});
+    return new RecipeRef(
+        "org.openrewrite.java.search.HasMethod",
+        {methodPattern, matchOverrides},
+        new UsesMethod(methodPattern),
+    );
 }
 
 /**
  * Match files using a specific type.
  *
- * Returns a {@link RecipeRef} placeholder; see {@link hasSourcePath} for
- * the introspection / lazy-evaluation pattern.
+ * Returns a {@link RecipeRef} placeholder bundled with a native
+ * {@link UsesType} visitor for in-process evaluation; see
+ * {@link hasSourcePath} for the introspection / lazy-evaluation pattern.
  *
  * Delegates to {@code org.openrewrite.java.search.HasType}.
  */
 export function usesType(fullyQualifiedTypeName: string, checkAssignability: boolean = false): RecipeRef {
-    return new RecipeRef("org.openrewrite.java.search.HasType", {fullyQualifiedTypeName, checkAssignability});
+    return new RecipeRef(
+        "org.openrewrite.java.search.HasType",
+        {fullyQualifiedTypeName, checkAssignability},
+        new UsesType(fullyQualifiedTypeName),
+    );
 }
 
 /**
  * Find and mark methods matching a pattern.
  *
- * Returns a {@link RecipeRef} placeholder; see {@link hasSourcePath} for
- * the introspection / lazy-evaluation pattern.
+ * Returns a {@link RecipeRef} placeholder bundled with a native
+ * {@link UsesMethod} visitor for in-process evaluation; see
+ * {@link hasSourcePath} for the introspection / lazy-evaluation pattern.
  *
  * Delegates to {@code org.openrewrite.java.search.FindMethods}.
  */
 export function findMethods(methodPattern: string, matchOverrides: boolean = false): RecipeRef {
-    return new RecipeRef("org.openrewrite.java.search.FindMethods", {methodPattern, matchOverrides});
+    return new RecipeRef(
+        "org.openrewrite.java.search.FindMethods",
+        {methodPattern, matchOverrides},
+        new UsesMethod(methodPattern),
+    );
 }
 
 /**
  * Find and mark usages of a type.
  *
- * Returns a {@link RecipeRef} placeholder; see {@link hasSourcePath} for
- * the introspection / lazy-evaluation pattern.
+ * Returns a {@link RecipeRef} placeholder bundled with a native
+ * {@link UsesType} visitor for in-process evaluation; see
+ * {@link hasSourcePath} for the introspection / lazy-evaluation pattern.
  *
  * Delegates to {@code org.openrewrite.java.search.FindTypes}.
  */
 export function findTypes(fullyQualifiedTypeName: string): RecipeRef {
-    return new RecipeRef("org.openrewrite.java.search.FindTypes", {fullyQualifiedTypeName});
+    return new RecipeRef(
+        "org.openrewrite.java.search.FindTypes",
+        {fullyQualifiedTypeName},
+        new UsesType(fullyQualifiedTypeName),
+    );
 }

--- a/rewrite-javascript/rewrite/src/javascript/preconditions.ts
+++ b/rewrite-javascript/rewrite/src/javascript/preconditions.ts
@@ -13,29 +13,73 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {RewriteRpc} from "../rpc/rewrite-rpc";
-import {UsesMethod, UsesType} from "./search";
-import {ExecutionContext} from "../execution";
-import {TreeVisitor} from "../visitor";
-import {IsSourceFile} from "../search";
-import {RpcRecipe} from "../rpc/recipe";
+import {RecipeRef} from "../preconditions";
 
-export function hasSourcePath(filePattern: string): Promise<RpcRecipe> | TreeVisitor<any, ExecutionContext> {
-    return RewriteRpc.get() ? RewriteRpc.get()!.prepareRecipe("org.openrewrite.FindSourceFiles", {
-        filePattern
-    }) : new IsSourceFile(filePattern);
+/**
+ * Match source files by path glob.
+ *
+ * Returns a {@link RecipeRef} placeholder. The framework introspects a
+ * ``check(hasSourcePath(...), editor)`` wrapper at PrepareRecipe time
+ * and emits the recipe identity directly in
+ * ``editPreconditions``; the Java host's ``PreparedRecipeCache.instantiateVisitor``
+ * constructs the recipe and uses its visitor — no extra RPC round-trip
+ * needed at editor() construction time, so unit tests can call
+ * ``recipe.editor()`` without an active RPC connection.
+ *
+ * Delegates to {@code org.openrewrite.FindSourceFiles}.
+ */
+export function hasSourcePath(filePattern: string): RecipeRef {
+    return new RecipeRef("org.openrewrite.FindSourceFiles", {filePattern});
 }
 
-export function usesMethod(methodPattern: string, matchOverrides: boolean = false): Promise<RpcRecipe> | TreeVisitor<any, ExecutionContext> {
-    return RewriteRpc.get() ? RewriteRpc.get()!.prepareRecipe("org.openrewrite.java.search.HasMethod", {
-        methodPattern,
-        matchOverrides
-    }) : new UsesMethod(methodPattern);
+/**
+ * Match files using a specific method.
+ *
+ * Returns a {@link RecipeRef} placeholder; see {@link hasSourcePath} for
+ * the introspection / lazy-evaluation pattern.
+ *
+ * ``methodPattern`` follows the OpenRewrite method-pattern syntax:
+ * ``<receiver-type> <method-name>(<args>)`` — e.g.
+ * ``"*..* tostring(..)"`` or ``"java.util.Collections emptyList()"``.
+ *
+ * Delegates to {@code org.openrewrite.java.search.HasMethod}.
+ */
+export function usesMethod(methodPattern: string, matchOverrides: boolean = false): RecipeRef {
+    return new RecipeRef("org.openrewrite.java.search.HasMethod", {methodPattern, matchOverrides});
 }
 
-export function usesType(fullyQualifiedType: string): Promise<RpcRecipe> | TreeVisitor<any, ExecutionContext> {
-    return RewriteRpc.get() ? RewriteRpc.get()!.prepareRecipe("org.openrewrite.java.search.HasType", {
-        fullyQualifiedType,
-        checkAssignability: false
-    }) : new UsesType(fullyQualifiedType);
+/**
+ * Match files using a specific type.
+ *
+ * Returns a {@link RecipeRef} placeholder; see {@link hasSourcePath} for
+ * the introspection / lazy-evaluation pattern.
+ *
+ * Delegates to {@code org.openrewrite.java.search.HasType}.
+ */
+export function usesType(fullyQualifiedTypeName: string, checkAssignability: boolean = false): RecipeRef {
+    return new RecipeRef("org.openrewrite.java.search.HasType", {fullyQualifiedTypeName, checkAssignability});
+}
+
+/**
+ * Find and mark methods matching a pattern.
+ *
+ * Returns a {@link RecipeRef} placeholder; see {@link hasSourcePath} for
+ * the introspection / lazy-evaluation pattern.
+ *
+ * Delegates to {@code org.openrewrite.java.search.FindMethods}.
+ */
+export function findMethods(methodPattern: string, matchOverrides: boolean = false): RecipeRef {
+    return new RecipeRef("org.openrewrite.java.search.FindMethods", {methodPattern, matchOverrides});
+}
+
+/**
+ * Find and mark usages of a type.
+ *
+ * Returns a {@link RecipeRef} placeholder; see {@link hasSourcePath} for
+ * the introspection / lazy-evaluation pattern.
+ *
+ * Delegates to {@code org.openrewrite.java.search.FindTypes}.
+ */
+export function findTypes(fullyQualifiedTypeName: string): RecipeRef {
+    return new RecipeRef("org.openrewrite.java.search.FindTypes", {fullyQualifiedTypeName});
 }

--- a/rewrite-javascript/rewrite/src/preconditions.ts
+++ b/rewrite-javascript/rewrite/src/preconditions.ts
@@ -18,8 +18,31 @@ import {Cursor, isSourceFile, SourceFile, Tree} from './tree';
 import {Recipe} from "./recipe";
 import {ExecutionContext} from "./execution";
 
+/**
+ * Composite of nested precondition operands joined by an operator.
+ *
+ * Mirrors Java's ``Preconditions.or``/``and``/``not``: a gate that
+ * short-circuits over its operands. ``op`` is one of ``"or"`` / ``"and"`` /
+ * ``"not"``. Operands may be ``TreeVisitor``, ``Recipe``, or another
+ * ``CompositePrecondition``.
+ *
+ * The framework promotes the composite to a structured wire entry at
+ * PrepareRecipe time; the Java host's ``RewriteRpc.matchAll`` rebuilds
+ * the visitor via the matching ``Preconditions`` factory so the gate runs
+ * locally and the visit RPC is skipped for files the gate rejects.
+ */
+export class CompositePrecondition {
+    constructor(
+        readonly op: "or" | "and" | "not",
+        readonly operands: ReadonlyArray<CheckArg>
+    ) {
+    }
+}
+
+export type CheckArg = Recipe | TreeVisitor<any, ExecutionContext> | CompositePrecondition;
+
 export async function check<T extends Tree>(
-    checkCondition: Recipe | Promise<Recipe> | TreeVisitor<T, ExecutionContext> | Promise<TreeVisitor<T, ExecutionContext>> | boolean,
+    checkCondition: CheckArg | Promise<CheckArg> | boolean,
     v: TreeVisitor<T, ExecutionContext> | Promise<TreeVisitor<T, ExecutionContext>>
 ): Promise<TreeVisitor<T, ExecutionContext>> {
     const resolvedCheck = await checkCondition;
@@ -31,15 +54,52 @@ export async function check<T extends Tree>(
     return new Check(resolvedCheck, resolvedV);
 }
 
+/**
+ * OR-compose precondition checks. Mirrors Java's
+ * ``Preconditions.or(visitor...)``: the gate matches if any operand
+ * matches. Requires at least two operands; a single-operand OR has no
+ * value over a bare ``check``.
+ */
+export function or(...operands: CheckArg[]): CompositePrecondition {
+    if (operands.length < 2) {
+        throw new Error("Preconditions.or requires at least two operands");
+    }
+    return new CompositePrecondition("or", operands);
+}
+
+/**
+ * AND-compose precondition checks. The outer ``editPreconditions`` list
+ * is already AND-composed by the host, so this is mainly useful as an
+ * operand of ``or``/``not``.
+ */
+export function and(...operands: CheckArg[]): CompositePrecondition {
+    if (operands.length < 2) {
+        throw new Error("Preconditions.and requires at least two operands");
+    }
+    return new CompositePrecondition("and", operands);
+}
+
+/**
+ * Negate a precondition check. Mirrors Java's ``Preconditions.not(visitor)``:
+ * the gate matches iff the operand does not.
+ */
+export function not(operand: CheckArg): CompositePrecondition {
+    return new CompositePrecondition("not", [operand]);
+}
+
 export class Check<T extends Tree> extends TreeVisitor<T, ExecutionContext> {
     constructor(
-        readonly check: TreeVisitor<T, ExecutionContext> | Recipe,
+        readonly check: CheckArg,
         readonly v: TreeVisitor<T, ExecutionContext>
     ) {
         super();
     }
 
     async isAcceptable(sourceFile: SourceFile, ctx: ExecutionContext): Promise<boolean> {
+        if (this.check instanceof CompositePrecondition) {
+            // Composites have no in-process is_acceptable — defer to the wrapped editor.
+            return this.v.isAcceptable(sourceFile, ctx);
+        }
         return await (await this.checkVisitor()).isAcceptable(sourceFile, ctx) &&
             await this.v.isAcceptable(sourceFile, ctx);
     }
@@ -53,12 +113,11 @@ export class Check<T extends Tree> extends TreeVisitor<T, ExecutionContext> {
                 : this.v.visit<R>(tree, ctx);
         }
 
-        const checkResult = parent !== undefined
-            ? await (await this.checkVisitor()).visit(tree, ctx, parent)
-            : await (await this.checkVisitor()).visit(tree, ctx);
+        const matched = this.check instanceof CompositePrecondition
+            ? await evaluateComposite(this.check, tree, ctx, parent)
+            : await this.runLeafCheck(tree, ctx, parent);
 
-        // If check visitor modified the tree (returned something different), run the main visitor
-        if (checkResult !== (tree as unknown as T)) {
+        if (matched) {
             return parent !== undefined
                 ? this.v.visit<R>(tree, ctx, parent)
                 : this.v.visit<R>(tree, ctx);
@@ -67,7 +126,62 @@ export class Check<T extends Tree> extends TreeVisitor<T, ExecutionContext> {
         return tree as unknown as R;
     }
 
-    private async checkVisitor(): Promise<TreeVisitor<any, ExecutionContext>> {
-        return this.check instanceof Recipe ? this.check.editor() : this.check;
+    private async runLeafCheck(tree: Tree, ctx: ExecutionContext, parent?: Cursor): Promise<boolean> {
+        const checkResult = parent !== undefined
+            ? await (await this.checkVisitor()).visit(tree, ctx, parent)
+            : await (await this.checkVisitor()).visit(tree, ctx);
+        return checkResult !== (tree as unknown as T);
     }
+
+    private async checkVisitor(): Promise<TreeVisitor<any, ExecutionContext>> {
+        return this.check instanceof Recipe ? this.check.editor() : (this.check as TreeVisitor<any, ExecutionContext>);
+    }
+}
+
+/**
+ * Evaluate a {@link CompositePrecondition} in-process for unit tests and
+ * direct callers that don't have a live RPC. Mirrors Java's
+ * ``Preconditions.or``/``and``/``not`` semantics. Returns ``true`` iff the
+ * gate would let the wrapped visitor run.
+ */
+async function evaluateComposite(
+    composite: CompositePrecondition,
+    tree: Tree,
+    ctx: ExecutionContext,
+    parent?: Cursor
+): Promise<boolean> {
+    const operands = composite.operands;
+    switch (composite.op) {
+        case "or":
+            for (const operand of operands) {
+                if (await operandMatches(operand, tree, ctx, parent)) return true;
+            }
+            return false;
+        case "and":
+            for (const operand of operands) {
+                if (!(await operandMatches(operand, tree, ctx, parent))) return false;
+            }
+            return true;
+        case "not":
+            if (operands.length !== 1) {
+                throw new Error("CompositePrecondition op=not requires exactly one operand");
+            }
+            return !(await operandMatches(operands[0], tree, ctx, parent));
+    }
+}
+
+async function operandMatches(
+    operand: CheckArg,
+    tree: Tree,
+    ctx: ExecutionContext,
+    parent?: Cursor
+): Promise<boolean> {
+    if (operand instanceof CompositePrecondition) {
+        return evaluateComposite(operand, tree, ctx, parent);
+    }
+    const visitor = operand instanceof Recipe ? await operand.editor() : operand;
+    const result = parent !== undefined
+        ? await visitor.visit(tree, ctx, parent)
+        : await visitor.visit(tree, ctx);
+    return result !== tree;
 }

--- a/rewrite-javascript/rewrite/src/preconditions.ts
+++ b/rewrite-javascript/rewrite/src/preconditions.ts
@@ -33,14 +33,22 @@ import {ExecutionContext} from "./execution";
  * construction time, which would otherwise block in-process unit tests
  * that don't have an active RPC connection.
  *
+ * If ``localVisitor`` is provided, in-process callers (without an active
+ * RPC connection) evaluate the gate against that visitor instead of
+ * short-circuiting to "always matches". This preserves real filtering
+ * behavior in unit tests while still letting the host evaluate the gate
+ * over the wire when an RPC connection is present.
+ *
  * Helpers in ``@openrewrite/rewrite/javascript/preconditions``
  * (``usesMethod``, ``usesType``, ``hasSourcePath``, ``findMethods``,
- * ``findTypes``) return ``RecipeRef`` instances.
+ * ``findTypes``) return ``RecipeRef`` instances populated with the
+ * matching native TS visitor where one exists.
  */
 export class RecipeRef {
     constructor(
         readonly recipeName: string,
-        readonly options: Readonly<Record<string, any>> = {}
+        readonly options: Readonly<Record<string, any>> = {},
+        readonly localVisitor?: TreeVisitor<any, ExecutionContext>
     ) {
     }
 }
@@ -140,12 +148,21 @@ export class Check<T extends Tree> extends TreeVisitor<T, ExecutionContext> {
                 : this.v.visit<R>(tree, ctx);
         }
 
-        // In-process fallback: a RecipeRef is a wire-only placeholder with no
-        // ``visit`` of its own — treat as "always matches" so the wrapped
-        // editor still runs in unit tests and direct in-process calls. The
-        // wire-side optimization (skip the visit RPC when the precondition
-        // rejects the file) lives in optimizePreconditions.
+        // In-process fallback for a RecipeRef: if a localVisitor was
+        // provided, evaluate the gate against it (preserves real filtering
+        // for unit tests); otherwise treat as "always matches" so the
+        // wrapped editor still runs. Wire-side optimization (skip the
+        // visit RPC when the precondition rejects the file) lives in
+        // optimizePreconditions and is independent of localVisitor.
         if (this.check instanceof RecipeRef) {
+            if (this.check.localVisitor !== undefined) {
+                const localResult = parent !== undefined
+                    ? await this.check.localVisitor.visit(tree, ctx, parent)
+                    : await this.check.localVisitor.visit(tree, ctx);
+                if (localResult === (tree as unknown as T)) {
+                    return tree as unknown as R;
+                }
+            }
             return parent !== undefined
                 ? this.v.visit<R>(tree, ctx, parent)
                 : this.v.visit<R>(tree, ctx);
@@ -215,10 +232,17 @@ async function operandMatches(
     parent?: Cursor
 ): Promise<boolean> {
     if (operand instanceof RecipeRef) {
-        // Wire-only — treat as "always matches" in-process so the wrapped
+        // If a localVisitor was provided, evaluate against it for real;
+        // otherwise short-circuit to "always matches" so the wrapped
         // editor still runs in unit tests. The host evaluates the gate
         // for real once the response goes over the wire.
-        return true;
+        if (operand.localVisitor === undefined) {
+            return true;
+        }
+        const result = parent !== undefined
+            ? await operand.localVisitor.visit(tree, ctx, parent)
+            : await operand.localVisitor.visit(tree, ctx);
+        return result !== tree;
     }
     if (operand instanceof CompositePrecondition) {
         return evaluateComposite(operand, tree, ctx, parent);

--- a/rewrite-javascript/rewrite/src/preconditions.ts
+++ b/rewrite-javascript/rewrite/src/preconditions.ts
@@ -19,12 +19,39 @@ import {Recipe} from "./recipe";
 import {ExecutionContext} from "./execution";
 
 /**
+ * Recipe-identity placeholder for use as a precondition.
+ *
+ * Captures a Java recipe class name + options without instantiating the
+ * recipe or firing an RPC. The framework introspects a
+ * ``check(RecipeRef, editor)`` wrapper at PrepareRecipe time and emits
+ * the recipe identity directly in
+ * ``PrepareRecipeResponse.editPreconditions``. The Java host's
+ * ``PreparedRecipeCache.instantiateVisitor`` constructs the recipe via
+ * Jackson and uses its visitor.
+ *
+ * This avoids requiring the recipe author to do an RPC at ``editor()``
+ * construction time, which would otherwise block in-process unit tests
+ * that don't have an active RPC connection.
+ *
+ * Helpers in ``@openrewrite/rewrite/javascript/preconditions``
+ * (``usesMethod``, ``usesType``, ``hasSourcePath``, ``findMethods``,
+ * ``findTypes``) return ``RecipeRef`` instances.
+ */
+export class RecipeRef {
+    constructor(
+        readonly recipeName: string,
+        readonly options: Readonly<Record<string, any>> = {}
+    ) {
+    }
+}
+
+/**
  * Composite of nested precondition operands joined by an operator.
  *
  * Mirrors Java's ``Preconditions.or``/``and``/``not``: a gate that
  * short-circuits over its operands. ``op`` is one of ``"or"`` / ``"and"`` /
- * ``"not"``. Operands may be ``TreeVisitor``, ``Recipe``, or another
- * ``CompositePrecondition``.
+ * ``"not"``. Operands may be ``TreeVisitor``, ``Recipe``, ``RecipeRef``,
+ * or another ``CompositePrecondition``.
  *
  * The framework promotes the composite to a structured wire entry at
  * PrepareRecipe time; the Java host's ``RewriteRpc.matchAll`` rebuilds
@@ -39,7 +66,7 @@ export class CompositePrecondition {
     }
 }
 
-export type CheckArg = Recipe | TreeVisitor<any, ExecutionContext> | CompositePrecondition;
+export type CheckArg = Recipe | TreeVisitor<any, ExecutionContext> | RecipeRef | CompositePrecondition;
 
 export async function check<T extends Tree>(
     checkCondition: CheckArg | Promise<CheckArg> | boolean,
@@ -96,8 +123,8 @@ export class Check<T extends Tree> extends TreeVisitor<T, ExecutionContext> {
     }
 
     async isAcceptable(sourceFile: SourceFile, ctx: ExecutionContext): Promise<boolean> {
-        if (this.check instanceof CompositePrecondition) {
-            // Composites have no in-process is_acceptable — defer to the wrapped editor.
+        if (this.check instanceof RecipeRef || this.check instanceof CompositePrecondition) {
+            // RecipeRef / Composite have no in-process is_acceptable — defer to the wrapped editor.
             return this.v.isAcceptable(sourceFile, ctx);
         }
         return await (await this.checkVisitor()).isAcceptable(sourceFile, ctx) &&
@@ -108,6 +135,17 @@ export class Check<T extends Tree> extends TreeVisitor<T, ExecutionContext> {
         // if tree isn't an instanceof of SourceFile, then a precondition visitor may
         // not be able to do its work because it may assume we are starting from the root level
         if (!isSourceFile(tree)) {
+            return parent !== undefined
+                ? this.v.visit<R>(tree, ctx, parent)
+                : this.v.visit<R>(tree, ctx);
+        }
+
+        // In-process fallback: a RecipeRef is a wire-only placeholder with no
+        // ``visit`` of its own — treat as "always matches" so the wrapped
+        // editor still runs in unit tests and direct in-process calls. The
+        // wire-side optimization (skip the visit RPC when the precondition
+        // rejects the file) lives in optimizePreconditions.
+        if (this.check instanceof RecipeRef) {
             return parent !== undefined
                 ? this.v.visit<R>(tree, ctx, parent)
                 : this.v.visit<R>(tree, ctx);
@@ -176,6 +214,12 @@ async function operandMatches(
     ctx: ExecutionContext,
     parent?: Cursor
 ): Promise<boolean> {
+    if (operand instanceof RecipeRef) {
+        // Wire-only — treat as "always matches" in-process so the wrapped
+        // editor still runs in unit tests. The host evaluates the gate
+        // for real once the response goes over the wire.
+        return true;
+    }
     if (operand instanceof CompositePrecondition) {
         return evaluateComposite(operand, tree, ctx, parent);
     }

--- a/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
@@ -17,7 +17,7 @@ import * as rpc from "vscode-jsonrpc/node";
 import {MessageConnection} from "vscode-jsonrpc/node";
 import {Recipe, RecipeDescriptor, ScanningRecipe} from "../../recipe";
 import {SnowflakeId} from "@akashrajpurohit/snowflake-id";
-import {Check} from "../../preconditions";
+import {Check, CheckArg, CompositePrecondition} from "../../preconditions";
 import {RpcRecipe} from "../recipe";
 import {TreeVisitor} from "../../visitor";
 import {ExecutionContext} from "../../execution";
@@ -109,8 +109,9 @@ export class PrepareRecipe {
         }
 
         if (visitor! instanceof Check) {
-            if (visitor.check instanceof RpcRecipe) {
-                preconditions.push({visitorName: phase === "edit" ? visitor.check.editVisitor : visitor.check.scanVisitor!});
+            const wireEntry = this.conditionWireEntry(visitor.check, phase);
+            if (wireEntry) {
+                preconditions.push(wireEntry);
                 recipe = Object.assign(
                     Object.create(Object.getPrototypeOf(recipe)),
                     recipe,
@@ -133,6 +134,34 @@ export class PrepareRecipe {
             await this.visitorTypePrecondition(preconditions, visitor!);
         }
         return recipe;
+    }
+
+    /**
+     * Translate a precondition condition (operand) to a wire entry.
+     *
+     * Mirrors the Java {@code PrepareRecipeResponse.Precondition} schema:
+     * leaves carry {@code visitorName} (+ optional options); composites
+     * carry {@code op} ({@code "or"}/{@code "and"}/{@code "not"}) and a
+     * nested {@code operands} list. Returns {@code undefined} when the
+     * condition can't be serialized — the caller leaves the wrapper
+     * intact so the gate runs in-process as a fallback.
+     */
+    private static conditionWireEntry(condition: CheckArg, phase: "edit" | "scan"): Precondition | undefined {
+        if (condition instanceof CompositePrecondition) {
+            const operands: Precondition[] = [];
+            for (const operand of condition.operands) {
+                const entry = this.conditionWireEntry(operand, phase);
+                if (entry === undefined) {
+                    return undefined;
+                }
+                operands.push(entry);
+            }
+            return {op: condition.op, operands};
+        }
+        if (condition instanceof RpcRecipe) {
+            return {visitorName: phase === "edit" ? condition.editVisitor : condition.scanVisitor!};
+        }
+        return undefined;
     }
 
     private static async visitorTypePrecondition(preconditions: Precondition[], v: TreeVisitor<any, ExecutionContext>): Promise<Precondition[]> {
@@ -183,7 +212,20 @@ export interface PrepareRecipeResponse {
     delegatesTo?: DelegatesTo
 }
 
+/**
+ * Either a leaf (a single visitor identified by {@code visitorName} +
+ * optional {@code visitorOptions}) or a composite of nested preconditions
+ * joined by {@code op} ({@code "or"} / {@code "and"} / {@code "not"}).
+ *
+ * When {@code op} is undefined the entry is a leaf and {@code visitorName}
+ * is required; when {@code op} is set, {@code operands} carries the
+ * children and the visitor fields are ignored. The composite form mirrors
+ * Java's {@code Preconditions.or}/{@code and}/{@code not} so remote
+ * languages can express the same gate shapes the Java side does.
+ */
 export interface Precondition {
-    visitorName: string
+    visitorName?: string
     visitorOptions?: {}
+    op?: "or" | "and" | "not"
+    operands?: Precondition[]
 }

--- a/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
@@ -17,7 +17,7 @@ import * as rpc from "vscode-jsonrpc/node";
 import {MessageConnection} from "vscode-jsonrpc/node";
 import {Recipe, RecipeDescriptor, ScanningRecipe} from "../../recipe";
 import {SnowflakeId} from "@akashrajpurohit/snowflake-id";
-import {Check, CheckArg, CompositePrecondition} from "../../preconditions";
+import {Check, CheckArg, CompositePrecondition, RecipeRef} from "../../preconditions";
 import {RpcRecipe} from "../recipe";
 import {TreeVisitor} from "../../visitor";
 import {ExecutionContext} from "../../execution";
@@ -157,6 +157,14 @@ export class PrepareRecipe {
                 operands.push(entry);
             }
             return {op: condition.op, operands};
+        }
+        // Common case: helpers like usesMethod / usesType return a lightweight
+        // RecipeRef so the recipe author can declare a precondition without
+        // firing an RPC at editor() time. The Java host's
+        // PreparedRecipeCache.instantiateVisitor constructs the named recipe
+        // via Jackson and uses its visitor.
+        if (condition instanceof RecipeRef) {
+            return {visitorName: condition.recipeName, visitorOptions: {...condition.options}};
         }
         if (condition instanceof RpcRecipe) {
             return {visitorName: phase === "edit" ? condition.editVisitor : condition.scanVisitor!};

--- a/rewrite-javascript/rewrite/test/preconditions.test.ts
+++ b/rewrite-javascript/rewrite/test/preconditions.test.ts
@@ -16,6 +16,10 @@
 import {RecipeSpec} from "../src/test";
 import {javascript} from "../src/javascript";
 import {ConditionalFindIdentifier, FindIdentifierWithPathPrecondition} from "../fixtures/path-precondition";
+import {and, check, CompositePrecondition, not, or} from "../src/preconditions";
+import {ExecutionContext} from "../src/execution";
+import {TreeVisitor} from "../src/visitor";
+import {Cursor, Tree} from "../src/tree";
 
 describe('Preconditions', () => {
     test('visitor precondition - should only mark identifiers in matching path', async () => {
@@ -59,5 +63,105 @@ describe('Preconditions', () => {
         await spec.rewriteRun(
             javascript('const bar = 1;')
         );
+    });
+});
+
+/**
+ * Stub source-file sentinel: only ``isSourceFile(tree)`` needs to be true
+ * inside ``Check.visit``; the wrapper doesn't read source-file fields.
+ */
+const stubSourceFile = (): Tree => ({
+    kind: "org.openrewrite.tree.SourceFile",
+    id: "00000000-0000-0000-0000-000000000000",
+    markers: {kind: "org.openrewrite.marker.Markers", id: "00000000-0000-0000-0000-000000000000", markers: []},
+    sourcePath: "stub",
+    charsetName: undefined,
+    charsetBomMarked: false,
+    checksum: undefined,
+    fileAttributes: undefined
+} as unknown as Tree);
+
+class RecordingVisitor extends TreeVisitor<any, ExecutionContext> {
+    calls = 0;
+
+    async visit<R extends any>(tree: Tree, _: ExecutionContext, _parent?: Cursor): Promise<R | undefined> {
+        this.calls++;
+        return tree as R;
+    }
+}
+
+class MarkingVisitor extends TreeVisitor<any, ExecutionContext> {
+    calls = 0;
+
+    async visit<R extends any>(tree: Tree, _: ExecutionContext, _parent?: Cursor): Promise<R | undefined> {
+        this.calls++;
+        return ({...(tree as any)}) as R;
+    }
+}
+
+describe('Preconditions composites (in-process)', () => {
+    test('or short-circuits on the first matching operand', async () => {
+        const matching = new MarkingVisitor();
+        const nonMatching = new RecordingVisitor();
+        const editor = new RecordingVisitor();
+
+        const wrapped = await check(or(matching, nonMatching), editor);
+        await wrapped.visit(stubSourceFile(), {} as ExecutionContext);
+
+        expect(matching.calls).toBe(1);
+        expect(nonMatching.calls).toBe(0);
+        expect(editor.calls).toBe(1);
+    });
+
+    test('or skips editor when no operand matches', async () => {
+        const a = new RecordingVisitor();
+        const b = new RecordingVisitor();
+        const editor = new RecordingVisitor();
+
+        const wrapped = await check(or(a, b), editor);
+        await wrapped.visit(stubSourceFile(), {} as ExecutionContext);
+
+        expect(a.calls).toBe(1);
+        expect(b.calls).toBe(1);
+        expect(editor.calls).toBe(0);
+    });
+
+    test('and runs editor only when all operands match', async () => {
+        const matchA = new MarkingVisitor();
+        const matchB = new MarkingVisitor();
+        const editor = new RecordingVisitor();
+
+        const wrapped = await check(and(matchA, matchB), editor);
+        await wrapped.visit(stubSourceFile(), {} as ExecutionContext);
+        expect(editor.calls).toBe(1);
+
+        const editor2 = new RecordingVisitor();
+        const wrapped2 = await check(and(matchA, new RecordingVisitor()), editor2);
+        await wrapped2.visit(stubSourceFile(), {} as ExecutionContext);
+        expect(editor2.calls).toBe(0);
+    });
+
+    test('not inverts a single-operand match', async () => {
+        const matching = new MarkingVisitor();
+        const editor1 = new RecordingVisitor();
+        await (await check(not(matching), editor1)).visit(stubSourceFile(), {} as ExecutionContext);
+        expect(editor1.calls).toBe(0);
+
+        const nonMatching = new RecordingVisitor();
+        const editor2 = new RecordingVisitor();
+        await (await check(not(nonMatching), editor2)).visit(stubSourceFile(), {} as ExecutionContext);
+        expect(editor2.calls).toBe(1);
+    });
+
+    test('or/and require at least two operands', () => {
+        expect(() => or(new RecordingVisitor())).toThrow(/at least two operands/);
+        expect(() => and(new RecordingVisitor())).toThrow(/at least two operands/);
+    });
+
+    test('CompositePrecondition is a plain class', () => {
+        const composite = or(new RecordingVisitor(), new MarkingVisitor());
+        expect(composite).toBeInstanceOf(CompositePrecondition);
+        expect(composite.op).toBe("or");
+        expect(composite.operands).toHaveLength(2);
     });
 });

--- a/rewrite-javascript/rewrite/test/preconditions.test.ts
+++ b/rewrite-javascript/rewrite/test/preconditions.test.ts
@@ -16,7 +16,8 @@
 import {RecipeSpec} from "../src/test";
 import {javascript} from "../src/javascript";
 import {ConditionalFindIdentifier, FindIdentifierWithPathPrecondition} from "../fixtures/path-precondition";
-import {and, check, CompositePrecondition, not, or} from "../src/preconditions";
+import {and, check, CompositePrecondition, not, or, RecipeRef} from "../src/preconditions";
+import {findMethods, findTypes, hasSourcePath, usesMethod, usesType} from "../src/javascript/preconditions";
 import {ExecutionContext} from "../src/execution";
 import {TreeVisitor} from "../src/visitor";
 import {Cursor, Tree} from "../src/tree";
@@ -163,5 +164,50 @@ describe('Preconditions composites (in-process)', () => {
         expect(composite).toBeInstanceOf(CompositePrecondition);
         expect(composite.op).toBe("or");
         expect(composite.operands).toHaveLength(2);
+    });
+
+    test('RecipeRef helpers are lazy and identifiable', () => {
+        // Helpers must NOT fire any RPC when called — they just bundle a
+        // recipe name + options for later wire emission.
+        const refs = [
+            hasSourcePath("**/foo.ts"),
+            usesMethod("*..* tostring(..)"),
+            usesType("java.util.List"),
+            findMethods("*..* fromstring(..)"),
+            findTypes("java.util.Map"),
+        ];
+
+        for (const ref of refs) {
+            expect(ref).toBeInstanceOf(RecipeRef);
+        }
+
+        expect(refs[0].recipeName).toBe("org.openrewrite.FindSourceFiles");
+        expect(refs[0].options).toEqual({filePattern: "**/foo.ts"});
+
+        expect(refs[1].recipeName).toBe("org.openrewrite.java.search.HasMethod");
+        expect(refs[1].options).toEqual({methodPattern: "*..* tostring(..)", matchOverrides: false});
+
+        expect(refs[2].recipeName).toBe("org.openrewrite.java.search.HasType");
+        expect(refs[2].options).toEqual({fullyQualifiedTypeName: "java.util.List", checkAssignability: false});
+
+        expect(refs[3].recipeName).toBe("org.openrewrite.java.search.FindMethods");
+        expect(refs[4].recipeName).toBe("org.openrewrite.java.search.FindTypes");
+    });
+
+    test('RecipeRef short-circuits to "matches" in-process', async () => {
+        // Wire-only — direct in-process callers should still run the
+        // wrapped editor since the host isn't available to evaluate the
+        // gate for real.
+        const editor = new RecordingVisitor();
+        await (await check(usesMethod("*..* nope(..)"), editor))
+            .visit(stubSourceFile(), {} as ExecutionContext);
+        expect(editor.calls).toBe(1);
+    });
+
+    test('Or with RecipeRef operands also short-circuits to "matches"', async () => {
+        const editor = new RecordingVisitor();
+        await (await check(or(usesMethod("*..* a()"), usesType("X")), editor))
+            .visit(stubSourceFile(), {} as ExecutionContext);
+        expect(editor.calls).toBe(1);
     });
 });

--- a/rewrite-javascript/rewrite/test/preconditions.test.ts
+++ b/rewrite-javascript/rewrite/test/preconditions.test.ts
@@ -194,20 +194,40 @@ describe('Preconditions composites (in-process)', () => {
         expect(refs[4].recipeName).toBe("org.openrewrite.java.search.FindTypes");
     });
 
-    test('RecipeRef short-circuits to "matches" in-process', async () => {
-        // Wire-only — direct in-process callers should still run the
-        // wrapped editor since the host isn't available to evaluate the
-        // gate for real.
+    test('RecipeRef without localVisitor short-circuits to "matches"', async () => {
+        // Construct a RecipeRef directly without bundling a native
+        // visitor — in-process callers should fall back to "always
+        // matches" so the wrapped editor still runs (the host evaluates
+        // the gate for real once the response goes over the wire).
         const editor = new RecordingVisitor();
-        await (await check(usesMethod("*..* nope(..)"), editor))
+        const refWithoutLocal = new RecipeRef("org.openrewrite.java.search.HasMethod", {
+            methodPattern: "*..* nope(..)",
+            matchOverrides: false,
+        });
+        await (await check(refWithoutLocal, editor))
             .visit(stubSourceFile(), {} as ExecutionContext);
         expect(editor.calls).toBe(1);
     });
 
-    test('Or with RecipeRef operands also short-circuits to "matches"', async () => {
+    test('RecipeRef with localVisitor evaluates the gate for real', async () => {
+        // Helpers like usesMethod populate a native local visitor so
+        // unit tests still see real filtering behavior. The stub source
+        // file has no method invocations, so the gate fails and the
+        // editor is skipped.
         const editor = new RecordingVisitor();
-        await (await check(or(usesMethod("*..* a()"), usesType("X")), editor))
+        await (await check(usesMethod("*..* nope(..)"), editor))
             .visit(stubSourceFile(), {} as ExecutionContext);
-        expect(editor.calls).toBe(1);
+        expect(editor.calls).toBe(0);
+    });
+
+    test('helpers populate localVisitor for real in-process filtering', () => {
+        // Spot-check that helpers bundle a TreeVisitor for offline
+        // eval. The actual filtering behavior is exercised by the
+        // RecipeSpec / fixture tests at the top of this file.
+        expect(hasSourcePath("**/*.ts").localVisitor).toBeDefined();
+        expect(usesMethod("*..* a(..)").localVisitor).toBeDefined();
+        expect(usesType("X").localVisitor).toBeDefined();
+        expect(findMethods("*..* a(..)").localVisitor).toBeDefined();
+        expect(findTypes("X").localVisitor).toBeDefined();
     });
 });


### PR DESCRIPTION
## Summary

- Mirrors the rewrite-python work in #7625 on the JavaScript side. A recipe author can now gate an editor on a composite of search recipes:

```ts
import {check, or} from "@openrewrite/rewrite/preconditions";
import {usesMethod, usesType} from "@openrewrite/rewrite/javascript/preconditions";

class ReplaceTarfileFilemode extends Recipe {
    async editor() {
        return await check(
            or(usesMethod("*..* filemode(..)"), usesType("tarfile")),
            new Visitor()
        );
    }
}
```

The host evaluates the composite gate locally before dispatching the visit RPC, so files that fail the gate skip the round-trip entirely.

## Wire format

`Precondition` (TypeScript interface) gains two optional fields, matching the Java DTO:

  * `op` — `"or"` / `"and"` / `"not"`, undefined for a leaf entry
  * `operands` — nested `Precondition[]` when `op` is set

- Leaf entries keep their existing shape (`visitorName` + `visitorOptions`), so other remote languages don't have to change to keep working — they'll just continue emitting leaves. `RewriteRpc.matchAll` (Java side, landed in #7625) recurses into composite entries via a small `buildPreconditionVisitor` helper that maps to `Preconditions.or` / `and` / `not`.

## JS side

  * New `CompositePrecondition` class (`op` + `operands`) and `or` / `and` / `not` exports.
  * `Check.visit` / `isAcceptable` handle composites in-process so unit tests that exercise a recipe without an active RPC still observe the right gate semantics. `RpcRecipe` operands stay wire-only (their gate runs on the host once the wire entry lands).
  * `optimizePreconditions` now goes through `conditionWireEntry`, which recurses into composites and emits nested `op` / `operands`. Returns `undefined` when an operand can't be serialized, leaving the wrapper intact for in-process fallback.

## Test plan

- [x] 6 new in-process tests in `test/preconditions.test.ts`: OR short-circuit on first match, OR no-match path, AND all-match / one-non-matching, NOT inversion, two-operand minimum, the dataclass shape
- [x] `vitest run test/preconditions.test.ts` — 9 passed (3 existing + 6 new)
- [x] `npx tsc --noEmit -p tsconfig.json` — no errors in modified files

## Why

- Mirrors the rewrite-python recipe work that landed in #7625, so JS recipe authors can express OR'd gates over multiple search recipes (e.g. "any of 8 method patterns") instead of letting the editor visit every file.
