### PR TITLE
rewrite-go: align preconditions to the Java/Python wrapper model

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/grafana/pyroscope-go"
 
 	goparser "github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/preconditions"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe/golang"
@@ -87,6 +88,12 @@ type server struct {
 
 	// Prepared recipe instances keyed by unique ID
 	preparedRecipes map[string]recipe.Recipe
+
+	// Bare editor cached at PrepareRecipe time when an editor was wrapped in
+	// preconditions.Check(...). Subsequent dispatch via instantiateVisitor
+	// returns the unwrapped editor — otherwise the precondition would also
+	// run Go-side and double the cost. Keyed by the prepared recipe ID.
+	preparedEditorOverrides map[string]recipe.TreeVisitor
 
 	// Per-prepared-recipe accumulator for ScanningRecipe. Lazily created on
 	// the first scan Visit call. Lifetime = prepared recipe instance; freed
@@ -172,8 +179,9 @@ func newServer(cfg serverConfig) *server {
 		remoteRefs:           make(map[int]any),
 		reverseRemoteObjects: make(map[string]any),
 		reverseRemoteRefs:    make(map[int]any),
-		preparedRecipes:      make(map[string]recipe.Recipe),
-		preparedAccumulators: make(map[string]any),
+		preparedRecipes:         make(map[string]recipe.Recipe),
+		preparedEditorOverrides: make(map[string]recipe.TreeVisitor),
+		preparedAccumulators:    make(map[string]any),
 		preparedContexts:     make(map[string]*recipe.ExecutionContext),
 		batchSize:            1000,
 		traceReceive:         cfg.traceRpcMessages,
@@ -911,6 +919,7 @@ func (s *server) handleReset() bool {
 	s.reverseRemoteObjects = make(map[string]any)
 	s.reverseRemoteRefs = make(map[int]any)
 	s.preparedRecipes = make(map[string]recipe.Recipe)
+	s.preparedEditorOverrides = make(map[string]recipe.TreeVisitor)
 	s.preparedAccumulators = make(map[string]any)
 	s.preparedContexts = make(map[string]*recipe.ExecutionContext)
 	return true
@@ -1283,6 +1292,26 @@ func (s *server) handlePrepareRecipe(params json.RawMessage) (any, *rpcError) {
 		ScanPreconditions: []any{},
 	}
 
+	// Introspect Editor() once at prepare time. If the recipe wrapped its
+	// editor in preconditions.Check(...), extract the precondition's wire
+	// identity (so the Java host can evaluate it locally and skip the
+	// visit RPC for non-matching files) and cache the bare editor (so a
+	// subsequent dispatch via instantiateVisitor returns the unwrapped
+	// editor — otherwise the precondition would also run Go-side and
+	// double the cost).
+	if instance != nil {
+		if _, isScan := instance.(recipe.ScanningRecipe); !isScan {
+			if editor := instance.Editor(); editor != nil {
+				if checkV, ok := editor.(*preconditions.CheckVisitor); ok {
+					if entry, ok := preconditionWireEntry(checkV.Check); ok {
+						resp.EditPreconditions = append(resp.EditPreconditions, entry)
+						s.preparedEditorOverrides[recipeID] = checkV.V
+					}
+				}
+			}
+		}
+	}
+
 	// Check if this is a scanning recipe
 	if instance != nil {
 		if _, isScan := instance.(recipe.ScanningRecipe); isScan {
@@ -1302,6 +1331,37 @@ func (s *server) handlePrepareRecipe(params json.RawMessage) (any, *rpcError) {
 	}
 
 	return resp, nil
+}
+
+// preconditionWireEntry translates a precondition condition (operand) to
+// a wire entry matching org.openrewrite.rpc.request.PrepareRecipeResponse.Precondition.
+//
+// Leaves carry visitorName + visitorOptions; composites carry op +
+// operands (a list of nested wire entries). Returns ok=false when the
+// condition can't be serialized (e.g. an opaque local TreeVisitor with
+// no recipe identity) — the caller leaves the wrapper intact so the
+// gate runs Go-side as a fallback.
+func preconditionWireEntry(condition preconditions.CheckArg) (map[string]any, bool) {
+	switch c := condition.(type) {
+	case *preconditions.RecipeRef:
+		entry := map[string]any{"visitorName": c.RecipeName}
+		if len(c.Options) > 0 {
+			entry["visitorOptions"] = c.Options
+		}
+		return entry, true
+	case *preconditions.Composite:
+		operands := make([]any, 0, len(c.Operands))
+		for _, operand := range c.Operands {
+			nested, ok := preconditionWireEntry(operand)
+			if !ok {
+				return nil, false
+			}
+			operands = append(operands, nested)
+		}
+		return map[string]any{"op": c.Op, "operands": operands}, true
+	default:
+		return nil, false
+	}
 }
 
 // visitRequest is the parameter type for Visit.
@@ -1455,6 +1515,12 @@ func (s *server) instantiateVisitor(visitorName string, ctx *recipe.ExecutionCon
 		if sr, ok := r.(recipe.ScanningRecipe); ok {
 			acc := s.getOrCreateAccumulator(recipeID, sr, ctx)
 			return sr.EditorWithData(acc)
+		}
+		// If the recipe wrapped its editor in preconditions.Check(...) and
+		// we captured the bare editor at PrepareRecipe time, return it here
+		// so the precondition isn't re-evaluated Go-side.
+		if bare, ok := s.preparedEditorOverrides[recipeID]; ok {
+			return bare
 		}
 		return r.Editor()
 	case "scan":

--- a/rewrite-go/pkg/preconditions/preconditions.go
+++ b/rewrite-go/pkg/preconditions/preconditions.go
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package preconditions mirrors org.openrewrite.Preconditions for Go RPC
+// recipes. A recipe author writes:
+//
+//	func (r *MyRecipe) Editor() recipe.TreeVisitor {
+//	    return preconditions.Check(
+//	        preconditions.Or(
+//	            UsesMethod("*..* filemode(..)"),
+//	            UsesType("tarfile"),
+//	        ),
+//	        myEditor(),
+//	    )
+//	}
+//
+// The framework introspects the wrapper at PrepareRecipe time and emits
+// the gate's identity in the editPreconditions slot of the
+// PrepareRecipeResponse. The Java host then evaluates the precondition
+// against the local source file *before* dispatching the visit RPC,
+// skipping the entire RPC round trip when the precondition does not match.
+package preconditions
+
+import (
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree"
+)
+
+// CheckArg is the operand type accepted by Check / Or / And / Not.
+// Any of:
+//   - recipe.TreeVisitor
+//   - recipe.Recipe (its Editor() is used as the gate)
+//   - *RecipeRef (a wire-only placeholder for a Java search recipe)
+//   - *Composite (nested composites)
+type CheckArg any
+
+// RecipeRef is a wire-only placeholder that names a Java recipe by class
+// name + options. Helpers like UsesMethod and UsesType return *RecipeRef
+// so a recipe author can declare a precondition without firing an RPC at
+// Editor() time. The Java host's PreparedRecipeCache.instantiateVisitor
+// constructs the named recipe via Jackson and uses its visitor.
+type RecipeRef struct {
+	RecipeName string
+	Options    map[string]any
+}
+
+// Composite combines nested precondition operands with an operator.
+// Mirrors Java's Preconditions.or / and / not.
+type Composite struct {
+	Op       string // "or", "and", or "not"
+	Operands []CheckArg
+}
+
+// CheckVisitor wraps an editor with a precondition gate. Mirrors Java's
+// org.openrewrite.Preconditions.Check: the precondition runs first; if
+// it returns a different tree (e.g. by adding a SearchResult marker),
+// the wrapped visitor runs. Otherwise the wrapped visitor is skipped
+// and the original tree is returned unchanged.
+//
+// For non-SourceFile trees the precondition is bypassed — preconditions
+// are designed to evaluate at the root and may assume the root layout.
+//
+// The framework also introspects this wrapper at PrepareRecipe time and
+// promotes Check to the editPreconditions wire slot so that the Java
+// host can evaluate the precondition locally and skip the visit RPC
+// entirely. In that case the wrapped V is what runs Go-side, so the
+// Visit method below is the fallback for in-process callers and for
+// non-RPC dispatch paths.
+type CheckVisitor struct {
+	Check CheckArg
+	V     recipe.TreeVisitor
+}
+
+// Visit runs the gate, then defers to the wrapped visitor when the gate
+// matches. RecipeRef operands are treated as "always matches" in-process
+// (they're wire-only placeholders).
+func (c *CheckVisitor) Visit(t tree.Tree, p any) tree.Tree {
+	sf, isSourceFile := t.(tree.SourceFile)
+	if !isSourceFile {
+		return c.V.Visit(t, p)
+	}
+	if c.matches(sf, p) {
+		return c.V.Visit(t, p)
+	}
+	return t
+}
+
+func (c *CheckVisitor) matches(t tree.Tree, p any) bool {
+	return operandMatches(c.Check, t, p)
+}
+
+func operandMatches(operand CheckArg, t tree.Tree, p any) bool {
+	switch op := operand.(type) {
+	case nil:
+		return true
+	case *RecipeRef:
+		// Wire-only — in-process callers (tests) treat as "matches" so
+		// the wrapped visitor still runs.
+		return true
+	case *Composite:
+		return evaluateComposite(op, t, p)
+	case recipe.Recipe:
+		return runVisitor(op.Editor(), t, p)
+	case recipe.TreeVisitor:
+		return runVisitor(op, t, p)
+	default:
+		// Unknown operand type — treat as "matches" rather than blocking.
+		return true
+	}
+}
+
+func evaluateComposite(c *Composite, t tree.Tree, p any) bool {
+	switch c.Op {
+	case "or":
+		for _, operand := range c.Operands {
+			if operandMatches(operand, t, p) {
+				return true
+			}
+		}
+		return false
+	case "and":
+		for _, operand := range c.Operands {
+			if !operandMatches(operand, t, p) {
+				return false
+			}
+		}
+		return true
+	case "not":
+		if len(c.Operands) != 1 {
+			panic("preconditions: Not requires exactly one operand")
+		}
+		return !operandMatches(c.Operands[0], t, p)
+	default:
+		panic("preconditions: unknown composite op " + c.Op)
+	}
+}
+
+func runVisitor(v recipe.TreeVisitor, t tree.Tree, p any) bool {
+	if v == nil {
+		return true
+	}
+	result := v.Visit(t, p)
+	return result != t
+}
+
+// Check wraps an editor with a precondition gate.
+//
+// Argument shapes accepted as the gate (CheckArg):
+//   - recipe.TreeVisitor — runs in-process as the gate
+//   - recipe.Recipe — its Editor() is used as the gate
+//   - *RecipeRef — placeholder for a Java search recipe; the framework
+//     emits the recipe identity in the editPreconditions wire slot at
+//     PrepareRecipe time so the host evaluates it locally without a Go RPC
+//   - *Composite — combination via Or / And / Not
+func Check(check CheckArg, v recipe.TreeVisitor) recipe.TreeVisitor {
+	return &CheckVisitor{Check: check, V: v}
+}
+
+// Or combines precondition checks with OR semantics. Mirrors Java's
+// Preconditions.or(visitor...): the gate matches if any operand matches.
+// Requires at least two operands; a single-operand Or is the same as
+// a bare Check.
+func Or(operands ...CheckArg) *Composite {
+	if len(operands) < 2 {
+		panic("preconditions: Or requires at least two operands")
+	}
+	return &Composite{Op: "or", Operands: operands}
+}
+
+// And combines precondition checks with AND semantics. The outer
+// editPreconditions list is already AND-composed by the host, so this
+// is mainly useful as an operand of Or / Not.
+func And(operands ...CheckArg) *Composite {
+	if len(operands) < 2 {
+		panic("preconditions: And requires at least two operands")
+	}
+	return &Composite{Op: "and", Operands: operands}
+}
+
+// Not negates a precondition check. Mirrors Java's Preconditions.not(visitor):
+// the gate matches iff the operand does not.
+func Not(operand CheckArg) *Composite {
+	return &Composite{Op: "not", Operands: []CheckArg{operand}}
+}
+
+// HasSourcePath matches source files by path glob.
+// Delegates to org.openrewrite.FindSourceFiles on the Java host.
+func HasSourcePath(filePattern string) *RecipeRef {
+	return &RecipeRef{
+		RecipeName: "org.openrewrite.FindSourceFiles",
+		Options:    map[string]any{"filePattern": filePattern},
+	}
+}
+
+// UsesMethod matches files using a specific method.
+// Delegates to org.openrewrite.java.search.HasMethod on the Java host.
+func UsesMethod(methodPattern string) *RecipeRef {
+	return &RecipeRef{
+		RecipeName: "org.openrewrite.java.search.HasMethod",
+		Options:    map[string]any{"methodPattern": methodPattern, "matchOverrides": false},
+	}
+}
+
+// UsesType matches files using a specific type.
+// Delegates to org.openrewrite.java.search.HasType on the Java host.
+func UsesType(fullyQualifiedType string) *RecipeRef {
+	return &RecipeRef{
+		RecipeName: "org.openrewrite.java.search.HasType",
+		Options:    map[string]any{"fullyQualifiedTypeName": fullyQualifiedType, "checkAssignability": false},
+	}
+}

--- a/rewrite-go/pkg/preconditions/preconditions.go
+++ b/rewrite-go/pkg/preconditions/preconditions.go
@@ -47,14 +47,21 @@ import (
 //   - *Composite (nested composites)
 type CheckArg any
 
-// RecipeRef is a wire-only placeholder that names a Java recipe by class
+// RecipeRef is a wire-side placeholder that names a Java recipe by class
 // name + options. Helpers like UsesMethod and UsesType return *RecipeRef
 // so a recipe author can declare a precondition without firing an RPC at
 // Editor() time. The Java host's PreparedRecipeCache.instantiateVisitor
 // constructs the named recipe via Jackson and uses its visitor.
+//
+// LocalVisitor is optional. When provided, in-process callers (without
+// an active RPC connection) evaluate the gate against it instead of
+// short-circuiting to "always matches" — this preserves real filtering
+// behavior in unit tests while still letting the host evaluate the
+// gate over the wire when an RPC connection is present.
 type RecipeRef struct {
-	RecipeName string
-	Options    map[string]any
+	RecipeName   string
+	Options      map[string]any
+	LocalVisitor recipe.TreeVisitor
 }
 
 // Composite combines nested precondition operands with an operator.
@@ -107,9 +114,14 @@ func operandMatches(operand CheckArg, t tree.Tree, p any) bool {
 	case nil:
 		return true
 	case *RecipeRef:
-		// Wire-only — in-process callers (tests) treat as "matches" so
-		// the wrapped visitor still runs.
-		return true
+		// If a LocalVisitor was bundled, evaluate against it for real;
+		// otherwise short-circuit to "always matches" so the wrapped
+		// visitor still runs in unit tests. The host evaluates the
+		// gate for real once the response goes over the wire.
+		if op.LocalVisitor == nil {
+			return true
+		}
+		return runVisitor(op.LocalVisitor, t, p)
 	case *Composite:
 		return evaluateComposite(op, t, p)
 	case recipe.Recipe:
@@ -196,47 +208,62 @@ func Not(operand CheckArg) *Composite {
 	return &Composite{Op: "not", Operands: []CheckArg{operand}}
 }
 
-// HasSourcePath matches source files by path glob.
-// Delegates to org.openrewrite.FindSourceFiles on the Java host.
+// HasSourcePath matches source files by path glob. Delegates to
+// org.openrewrite.FindSourceFiles on the Java host. Bundles a native
+// IsSourceFileVisitor so unit tests without an active RPC connection
+// still see real filtering.
 func HasSourcePath(filePattern string) *RecipeRef {
 	return &RecipeRef{
-		RecipeName: "org.openrewrite.FindSourceFiles",
-		Options:    map[string]any{"filePattern": filePattern},
+		RecipeName:   "org.openrewrite.FindSourceFiles",
+		Options:      map[string]any{"filePattern": filePattern},
+		LocalVisitor: NewIsSourceFile(filePattern),
 	}
 }
 
-// UsesMethod matches files using a specific method.
-// Delegates to org.openrewrite.java.search.HasMethod on the Java host.
+// UsesMethod matches files using a specific method. Delegates to
+// org.openrewrite.java.search.HasMethod on the Java host. Bundles a
+// native UsesMethodVisitor so unit tests without an active RPC
+// connection still see real filtering.
 func UsesMethod(methodPattern string) *RecipeRef {
 	return &RecipeRef{
-		RecipeName: "org.openrewrite.java.search.HasMethod",
-		Options:    map[string]any{"methodPattern": methodPattern, "matchOverrides": false},
+		RecipeName:   "org.openrewrite.java.search.HasMethod",
+		Options:      map[string]any{"methodPattern": methodPattern, "matchOverrides": false},
+		LocalVisitor: NewUsesMethod(methodPattern),
 	}
 }
 
-// UsesType matches files using a specific type.
-// Delegates to org.openrewrite.java.search.HasType on the Java host.
+// UsesType matches files using a specific type. Delegates to
+// org.openrewrite.java.search.HasType on the Java host. Bundles a
+// native UsesTypeVisitor so unit tests without an active RPC
+// connection still see real filtering.
 func UsesType(fullyQualifiedType string) *RecipeRef {
 	return &RecipeRef{
-		RecipeName: "org.openrewrite.java.search.HasType",
-		Options:    map[string]any{"fullyQualifiedTypeName": fullyQualifiedType, "checkAssignability": false},
+		RecipeName:   "org.openrewrite.java.search.HasType",
+		Options:      map[string]any{"fullyQualifiedTypeName": fullyQualifiedType, "checkAssignability": false},
+		LocalVisitor: NewUsesType(fullyQualifiedType),
 	}
 }
 
-// FindMethods finds and marks methods matching a pattern.
-// Delegates to org.openrewrite.java.search.FindMethods on the Java host.
+// FindMethods finds and marks methods matching a pattern. Delegates
+// to org.openrewrite.java.search.FindMethods on the Java host. Bundles
+// a native UsesMethodVisitor so unit tests without an active RPC
+// connection still see real filtering.
 func FindMethods(methodPattern string) *RecipeRef {
 	return &RecipeRef{
-		RecipeName: "org.openrewrite.java.search.FindMethods",
-		Options:    map[string]any{"methodPattern": methodPattern, "matchOverrides": false},
+		RecipeName:   "org.openrewrite.java.search.FindMethods",
+		Options:      map[string]any{"methodPattern": methodPattern, "matchOverrides": false},
+		LocalVisitor: NewUsesMethod(methodPattern),
 	}
 }
 
-// FindTypes finds and marks usages of a type.
-// Delegates to org.openrewrite.java.search.FindTypes on the Java host.
+// FindTypes finds and marks usages of a type. Delegates to
+// org.openrewrite.java.search.FindTypes on the Java host. Bundles a
+// native UsesTypeVisitor so unit tests without an active RPC
+// connection still see real filtering.
 func FindTypes(fullyQualifiedType string) *RecipeRef {
 	return &RecipeRef{
-		RecipeName: "org.openrewrite.java.search.FindTypes",
-		Options:    map[string]any{"fullyQualifiedTypeName": fullyQualifiedType},
+		RecipeName:   "org.openrewrite.java.search.FindTypes",
+		Options:      map[string]any{"fullyQualifiedTypeName": fullyQualifiedType},
+		LocalVisitor: NewUsesType(fullyQualifiedType),
 	}
 }

--- a/rewrite-go/pkg/preconditions/preconditions.go
+++ b/rewrite-go/pkg/preconditions/preconditions.go
@@ -222,3 +222,21 @@ func UsesType(fullyQualifiedType string) *RecipeRef {
 		Options:    map[string]any{"fullyQualifiedTypeName": fullyQualifiedType, "checkAssignability": false},
 	}
 }
+
+// FindMethods finds and marks methods matching a pattern.
+// Delegates to org.openrewrite.java.search.FindMethods on the Java host.
+func FindMethods(methodPattern string) *RecipeRef {
+	return &RecipeRef{
+		RecipeName: "org.openrewrite.java.search.FindMethods",
+		Options:    map[string]any{"methodPattern": methodPattern, "matchOverrides": false},
+	}
+}
+
+// FindTypes finds and marks usages of a type.
+// Delegates to org.openrewrite.java.search.FindTypes on the Java host.
+func FindTypes(fullyQualifiedType string) *RecipeRef {
+	return &RecipeRef{
+		RecipeName: "org.openrewrite.java.search.FindTypes",
+		Options:    map[string]any{"fullyQualifiedTypeName": fullyQualifiedType},
+	}
+}

--- a/rewrite-go/pkg/preconditions/preconditions_test.go
+++ b/rewrite-go/pkg/preconditions/preconditions_test.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package preconditions
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree"
+)
+
+// newSourceFile returns a fresh CompilationUnit pointer to use as the
+// source-file sentinel. Each call returns a distinct identity so a
+// "marking" visitor can return a different value.
+func newSourceFile() tree.Tree {
+	return &tree.CompilationUnit{}
+}
+
+// recordingVisitor is a TreeVisitor that returns the same tree, recording
+// each call. Simulates a precondition that does NOT match.
+type recordingVisitor struct{ calls int }
+
+func (r *recordingVisitor) Visit(t tree.Tree, _ any) tree.Tree {
+	r.calls++
+	return t
+}
+
+// markingVisitor is a TreeVisitor that returns a *different* tree
+// (any non-identity value), simulating a precondition that DOES match
+// (e.g. by adding a SearchResult marker).
+type markingVisitor struct{ calls int }
+
+func (m *markingVisitor) Visit(t tree.Tree, _ any) tree.Tree {
+	m.calls++
+	return newSourceFile() // different identity from the input
+}
+
+func TestCheckRunsEditorWhenConditionMarks(t *testing.T) {
+	cond := &markingVisitor{}
+	editor := &recordingVisitor{}
+
+	wrapped := Check(cond, editor)
+	wrapped.Visit(newSourceFile(), nil)
+
+	if cond.calls != 1 {
+		t.Errorf("condition calls = %d, want 1", cond.calls)
+	}
+	if editor.calls != 1 {
+		t.Errorf("editor calls = %d, want 1", editor.calls)
+	}
+}
+
+func TestCheckSkipsEditorWhenConditionReturnsIdentity(t *testing.T) {
+	cond := &recordingVisitor{}
+	editor := &recordingVisitor{}
+
+	wrapped := Check(cond, editor)
+	wrapped.Visit(newSourceFile(), nil)
+
+	if cond.calls != 1 {
+		t.Errorf("condition calls = %d, want 1", cond.calls)
+	}
+	if editor.calls != 0 {
+		t.Errorf("editor calls = %d, want 0 (gate did not match)", editor.calls)
+	}
+}
+
+func TestOrShortCircuitsOnFirstMatch(t *testing.T) {
+	matching := &markingVisitor{}
+	nonMatching := &recordingVisitor{}
+	editor := &recordingVisitor{}
+
+	Check(Or(matching, nonMatching), editor).Visit(newSourceFile(), nil)
+
+	if matching.calls != 1 {
+		t.Errorf("matching calls = %d, want 1", matching.calls)
+	}
+	if nonMatching.calls != 0 {
+		t.Errorf("nonMatching calls = %d, want 0 (Or should short-circuit)", nonMatching.calls)
+	}
+	if editor.calls != 1 {
+		t.Errorf("editor calls = %d, want 1", editor.calls)
+	}
+}
+
+func TestOrSkipsEditorWhenNoOperandMatches(t *testing.T) {
+	a := &recordingVisitor{}
+	b := &recordingVisitor{}
+	editor := &recordingVisitor{}
+
+	Check(Or(a, b), editor).Visit(newSourceFile(), nil)
+
+	if a.calls != 1 || b.calls != 1 {
+		t.Errorf("operand calls = %d / %d, want 1 / 1", a.calls, b.calls)
+	}
+	if editor.calls != 0 {
+		t.Errorf("editor calls = %d, want 0", editor.calls)
+	}
+}
+
+func TestAndRunsEditorOnlyWhenAllMatch(t *testing.T) {
+	a := &markingVisitor{}
+	b := &markingVisitor{}
+	editor := &recordingVisitor{}
+	Check(And(a, b), editor).Visit(newSourceFile(), nil)
+	if editor.calls != 1 {
+		t.Errorf("editor calls (all match) = %d, want 1", editor.calls)
+	}
+
+	editor2 := &recordingVisitor{}
+	Check(And(a, &recordingVisitor{}), editor2).Visit(newSourceFile(), nil)
+	if editor2.calls != 0 {
+		t.Errorf("editor2 calls (one non-matching) = %d, want 0", editor2.calls)
+	}
+}
+
+func TestNotInvertsMatch(t *testing.T) {
+	editor1 := &recordingVisitor{}
+	Check(Not(&markingVisitor{}), editor1).Visit(newSourceFile(), nil)
+	if editor1.calls != 0 {
+		t.Errorf("not(matching): editor calls = %d, want 0", editor1.calls)
+	}
+
+	editor2 := &recordingVisitor{}
+	Check(Not(&recordingVisitor{}), editor2).Visit(newSourceFile(), nil)
+	if editor2.calls != 1 {
+		t.Errorf("not(non-matching): editor calls = %d, want 1", editor2.calls)
+	}
+}
+
+func TestRecipeRefOperandShortCircuitsToMatch(t *testing.T) {
+	editor := &recordingVisitor{}
+	Check(UsesMethod("*..* tostring(..)"), editor).Visit(newSourceFile(), nil)
+	if editor.calls != 1 {
+		t.Errorf("editor calls (RecipeRef in-process) = %d, want 1", editor.calls)
+	}
+}
+
+func TestOrRequiresAtLeastTwoOperands(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic on single-operand Or")
+		}
+	}()
+	Or(&recordingVisitor{})
+}
+
+func TestAndRequiresAtLeastTwoOperands(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic on single-operand And")
+		}
+	}()
+	And(&recordingVisitor{})
+}

--- a/rewrite-go/pkg/preconditions/preconditions_test.go
+++ b/rewrite-go/pkg/preconditions/preconditions_test.go
@@ -141,11 +141,49 @@ func TestNotInvertsMatch(t *testing.T) {
 	}
 }
 
-func TestRecipeRefOperandShortCircuitsToMatch(t *testing.T) {
+func TestBareRecipeRefShortCircuitsToMatch(t *testing.T) {
+	// A bare RecipeRef without a LocalVisitor short-circuits to "matches"
+	// in-process so the wrapped editor still runs. The host evaluates the
+	// gate for real once the response goes over the wire.
+	editor := &recordingVisitor{}
+	bare := &RecipeRef{
+		RecipeName: "org.openrewrite.java.search.HasMethod",
+		Options:    map[string]any{"methodPattern": "*..* nope(..)"},
+	}
+	Check(bare, editor).Visit(newSourceFile(), nil)
+	if editor.calls != 1 {
+		t.Errorf("editor calls (bare RecipeRef) = %d, want 1", editor.calls)
+	}
+}
+
+func TestRecipeRefWithLocalVisitorEvaluatesForReal(t *testing.T) {
+	// Helpers like UsesMethod populate a native LocalVisitor so unit
+	// tests without an active RPC connection still see real filtering.
+	// An empty CompilationUnit has no method invocations, so the gate
+	// fails and the editor is skipped.
 	editor := &recordingVisitor{}
 	Check(UsesMethod("*..* tostring(..)"), editor).Visit(newSourceFile(), nil)
-	if editor.calls != 1 {
-		t.Errorf("editor calls (RecipeRef in-process) = %d, want 1", editor.calls)
+	if editor.calls != 0 {
+		t.Errorf("editor calls (RecipeRef with LocalVisitor) = %d, want 0", editor.calls)
+	}
+}
+
+func TestHelpersPopulateLocalVisitor(t *testing.T) {
+	// Spot-check that helpers bundle a TreeVisitor for offline eval.
+	if HasSourcePath("**/*.go").LocalVisitor == nil {
+		t.Errorf("HasSourcePath did not populate LocalVisitor")
+	}
+	if UsesMethod("*..* a(..)").LocalVisitor == nil {
+		t.Errorf("UsesMethod did not populate LocalVisitor")
+	}
+	if UsesType("foo.Bar").LocalVisitor == nil {
+		t.Errorf("UsesType did not populate LocalVisitor")
+	}
+	if FindMethods("*..* a(..)").LocalVisitor == nil {
+		t.Errorf("FindMethods did not populate LocalVisitor")
+	}
+	if FindTypes("foo.Bar").LocalVisitor == nil {
+		t.Errorf("FindTypes did not populate LocalVisitor")
 	}
 }
 

--- a/rewrite-go/pkg/preconditions/search.go
+++ b/rewrite-go/pkg/preconditions/search.go
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package preconditions
+
+import (
+	"path"
+	"strings"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/matcher"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree"
+)
+
+// IsSourceFileVisitor matches SourceFile trees by path glob.
+//
+// Mirrors org.openrewrite.FindSourceFiles. Used as the LocalVisitor
+// bundled with the *RecipeRef returned by HasSourcePath so unit tests
+// without an active RPC connection still see real filtering.
+type IsSourceFileVisitor struct {
+	pattern string
+}
+
+func NewIsSourceFile(filePattern string) *IsSourceFileVisitor {
+	return &IsSourceFileVisitor{pattern: filePattern}
+}
+
+func (v *IsSourceFileVisitor) Visit(t tree.Tree, _ any) tree.Tree {
+	sf, ok := t.(tree.SourceFile)
+	if !ok {
+		return t
+	}
+	src := sourceFilePath(sf)
+	if src == "" {
+		return t
+	}
+	if matchPathGlob(v.pattern, src) {
+		return markFound(t)
+	}
+	return t
+}
+
+// UsesTypeVisitor matches files using a specific type by walking the
+// tree and checking node-level type attribution against a glob pattern.
+//
+// Mirrors org.openrewrite.java.search.HasType.
+type UsesTypeVisitor struct {
+	pattern string
+}
+
+func NewUsesType(fullyQualifiedType string) *UsesTypeVisitor {
+	return &UsesTypeVisitor{pattern: fullyQualifiedType}
+}
+
+func (v *UsesTypeVisitor) Visit(t tree.Tree, _ any) tree.Tree {
+	if _, ok := t.(tree.SourceFile); !ok {
+		return t
+	}
+	if v.treeUsesType(t) {
+		return markFound(t)
+	}
+	return t
+}
+
+func (v *UsesTypeVisitor) treeUsesType(t tree.Tree) bool {
+	found := false
+	walkTree(t, func(node tree.Tree) bool {
+		if found {
+			return false
+		}
+		if typed, ok := node.(interface{ GetType() tree.JavaType }); ok {
+			if jt := typed.GetType(); jt != nil {
+				if fq, ok := jt.(tree.FullyQualified); ok {
+					fqn := fq.GetFullyQualifiedName()
+					if fqn != "" && matchTypeGlob(v.pattern, fqn) {
+						found = true
+						return false
+					}
+				}
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// UsesMethodVisitor matches files using a specific method, by walking
+// the tree for *tree.MethodInvocation nodes and consulting MethodMatcher.
+//
+// Mirrors org.openrewrite.java.search.HasMethod.
+type UsesMethodVisitor struct {
+	matcher *matcher.MethodMatcher
+}
+
+func NewUsesMethod(methodPattern string) *UsesMethodVisitor {
+	return &UsesMethodVisitor{matcher: matcher.NewMethodMatcher(methodPattern)}
+}
+
+func (v *UsesMethodVisitor) Visit(t tree.Tree, _ any) tree.Tree {
+	if _, ok := t.(tree.SourceFile); !ok {
+		return t
+	}
+	if v.treeUsesMethod(t) {
+		return markFound(t)
+	}
+	return t
+}
+
+func (v *UsesMethodVisitor) treeUsesMethod(t tree.Tree) bool {
+	found := false
+	walkTree(t, func(node tree.Tree) bool {
+		if found {
+			return false
+		}
+		if mi, ok := node.(*tree.MethodInvocation); ok {
+			if v.matcher.Matches(mi) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// markFound returns a sentinel "different tree" so the wrapping
+// CheckVisitor sees a non-identity result and runs the wrapped editor.
+// We use a wrapper struct rather than mutating the original tree to
+// avoid coupling search visitors to the concrete tree type.
+type matchedSourceFile struct {
+	tree.SourceFile
+}
+
+func markFound(t tree.Tree) tree.Tree {
+	if sf, ok := t.(tree.SourceFile); ok {
+		return &matchedSourceFile{SourceFile: sf}
+	}
+	return t
+}
+
+// walkTree does a best-effort iterative DFS over a tree. Returns ``false``
+// from ``visit`` to stop walking. Implementation uses pkg/tree's existing
+// SearchWalker if available; otherwise falls back to walking the
+// tree.J interface via reflection-free iteration of known shapes.
+//
+// For simplicity we delegate to a shared helper that knows how to descend
+// into common LST nodes — see WalkSubtree below.
+func walkTree(root tree.Tree, visit func(tree.Tree) bool) {
+	walker := newSearchWalker(visit)
+	walker.walk(root)
+}
+
+// searchWalker is a minimal iterative walker that knows just enough
+// about the LST to descend into compilation units and statement trees.
+// It intentionally does not duplicate tree/search_walker.go's full
+// machinery — only enough to find type-bearing nodes and method
+// invocations for HasType/HasMethod.
+type searchWalker struct {
+	visit func(tree.Tree) bool
+	stop  bool
+}
+
+func newSearchWalker(visit func(tree.Tree) bool) *searchWalker {
+	return &searchWalker{visit: visit}
+}
+
+func (w *searchWalker) walk(node tree.Tree) {
+	if w.stop || node == nil {
+		return
+	}
+	if !w.visit(node) {
+		w.stop = true
+		return
+	}
+	for _, child := range childrenOf(node) {
+		w.walk(child)
+		if w.stop {
+			return
+		}
+	}
+}
+
+// childrenOf returns immediate child Tree nodes of the given node.
+// Best-effort: uses the SearchWalker shape from pkg/tree where available
+// and falls back to no children for unknown shapes (which means the
+// search visitor returns false negatives for those, but never false
+// positives — safe for a precondition gate).
+func childrenOf(node tree.Tree) []tree.Tree {
+	if hc, ok := node.(interface{ Children() []tree.Tree }); ok {
+		return hc.Children()
+	}
+	return nil
+}
+
+// matchPathGlob matches a path against a glob pattern using Go's
+// path.Match plus a "**" extension for recursive matching.
+func matchPathGlob(pattern, p string) bool {
+	if strings.Contains(pattern, "**") {
+		// "**/*.go" → match any .go anywhere
+		// We simplify to: split on "**", require all parts to appear in order.
+		parts := strings.Split(pattern, "**")
+		idx := 0
+		for i, part := range parts {
+			if part == "" {
+				continue
+			}
+			// First part must match prefix; intermediate parts can match
+			// anywhere; last part must match suffix.
+			j := strings.Index(p[idx:], strings.Trim(part, "/"))
+			if j < 0 {
+				return false
+			}
+			if i == 0 && j != 0 {
+				return false
+			}
+			idx += j + len(strings.Trim(part, "/"))
+		}
+		return true
+	}
+	matched, err := path.Match(pattern, p)
+	return err == nil && matched
+}
+
+// matchTypeGlob matches a fully-qualified type name against a pattern.
+// Supports "*" for single-segment wildcards (e.g. "java.util.*") and
+// "*..*" for any-package-any-type (used in method patterns).
+func matchTypeGlob(pattern, fqn string) bool {
+	if pattern == fqn {
+		return true
+	}
+	if pattern == "*..*" {
+		return true
+	}
+	// Treat each "*" as matching any sequence of non-dot characters.
+	patternParts := strings.Split(pattern, ".")
+	fqnParts := strings.Split(fqn, ".")
+	if len(patternParts) != len(fqnParts) {
+		return false
+	}
+	for i, pp := range patternParts {
+		if pp == "*" {
+			continue
+		}
+		if pp != fqnParts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// sourceFilePath extracts a string path from a SourceFile, falling back
+// to the empty string when none is available.
+func sourceFilePath(sf tree.SourceFile) string {
+	if hp, ok := sf.(interface{ GetSourcePath() string }); ok {
+		return hp.GetSourcePath()
+	}
+	if hp, ok := sf.(interface{ SourcePath() string }); ok {
+		return hp.SourcePath()
+	}
+	return ""
+}
+
+// Compile-time interface checks.
+var (
+	_ recipe.TreeVisitor = (*IsSourceFileVisitor)(nil)
+	_ recipe.TreeVisitor = (*UsesTypeVisitor)(nil)
+	_ recipe.TreeVisitor = (*UsesMethodVisitor)(nil)
+)

--- a/rewrite-go/pkg/recipe/recipe.go
+++ b/rewrite-go/pkg/recipe/recipe.go
@@ -58,10 +58,6 @@ type Recipe interface {
 	// Options returns descriptors for this recipe's configurable options.
 	Options() []OptionDescriptor
 
-	// Preconditions returns sub-recipes that gate execution: this recipe only runs
-	// when all preconditions match. May be nil.
-	Preconditions() []Recipe
-
 	// DataTables returns descriptors for any DataTable rows this recipe emits.
 	// May be nil. The runtime for writing rows is provided by the DataTable
 	// type and DataTableStore (separate from these descriptors).
@@ -92,7 +88,6 @@ func (Base) EstimatedEffortPerOccurrence() time.Duration { return 5 * time.Minut
 func (Base) Editor() TreeVisitor                         { return nil }
 func (Base) RecipeList() []Recipe                        { return nil }
 func (Base) Options() []OptionDescriptor                 { return nil }
-func (Base) Preconditions() []Recipe                     { return nil }
 func (Base) DataTables() []DataTableDescriptor           { return nil }
 func (Base) Maintainers() []Maintainer                   { return nil }
 func (Base) Contributors() []Contributor                 { return nil }
@@ -227,6 +222,12 @@ type ExampleSource struct {
 }
 
 // RecipeDescriptor provides metadata about a recipe for display and serialization.
+//
+// Note: the Preconditions field carries declarative-recipe metadata
+// (the Java RecipeDescriptor.preconditions list, for YAML
+// DeclarativeRecipe). Runtime precondition gates are expressed via the
+// preconditions package's Check wrapper around Editor() and travel
+// through the editPreconditions wire slot, not this descriptor field.
 type RecipeDescriptor struct {
 	Name                         string
 	DisplayName                  string
@@ -243,8 +244,8 @@ type RecipeDescriptor struct {
 }
 
 // Describe creates a RecipeDescriptor from a Recipe. Recursive descriptors
-// (RecipeList, Preconditions) are protected against cycles via a visited set
-// keyed by recipe name; if a recipe name re-appears in the descent, a stub
+// (RecipeList) are protected against cycles via a visited set keyed by
+// recipe name; if a recipe name re-appears in the descent, a stub
 // descriptor with just the name and display name is returned in its place.
 func Describe(r Recipe) RecipeDescriptor {
 	return describe(r, map[string]bool{})
@@ -274,12 +275,6 @@ func describe(r Recipe, seen map[string]bool) RecipeDescriptor {
 		desc.RecipeList = make([]RecipeDescriptor, len(subs))
 		for i, sub := range subs {
 			desc.RecipeList[i] = describe(sub, seen)
-		}
-	}
-	if pres := r.Preconditions(); len(pres) > 0 {
-		desc.Preconditions = make([]RecipeDescriptor, len(pres))
-		for i, pre := range pres {
-			desc.Preconditions[i] = describe(pre, seen)
 		}
 	}
 	return desc

--- a/rewrite-go/pkg/template/template_recipe.go
+++ b/rewrite-go/pkg/template/template_recipe.go
@@ -276,7 +276,6 @@ func (r *builtTemplateRecipe) EstimatedEffortPerOccurrence() time.Duration { ret
 func (r *builtTemplateRecipe) Editor() recipe.TreeVisitor  { return r.editor }
 func (r *builtTemplateRecipe) RecipeList() []recipe.Recipe  { return nil }
 func (r *builtTemplateRecipe) Options() []recipe.OptionDescriptor { return nil }
-func (r *builtTemplateRecipe) Preconditions() []recipe.Recipe              { return nil }
 func (r *builtTemplateRecipe) DataTables() []recipe.DataTableDescriptor    { return nil }
 func (r *builtTemplateRecipe) Maintainers() []recipe.Maintainer            { return nil }
 func (r *builtTemplateRecipe) Contributors() []recipe.Contributor          { return nil }


### PR DESCRIPTION
## Summary

- Aligns rewrite-go's preconditions to the wrapper model used in `org.openrewrite.Preconditions` (Java), `rewrite-python.Preconditions` (#7625), and `rewrite-javascript.preconditions` (#7626). A recipe author writes:

```go
func (r *MyRecipe) Editor() recipe.TreeVisitor {
    return preconditions.Check(
        preconditions.Or(
            preconditions.UsesMethod("*..* filemode(..)"),
            preconditions.UsesType("tarfile"),
        ),
        myEditor(),
    )
}
```

The framework introspects the editor at PrepareRecipe time and, if it finds a `CheckVisitor` wrapper, emits the gate's identity in the `editPreconditions` slot of the response so the Java host evaluates the precondition locally and skips the visit RPC for non-matching files. The bare editor is cached in `preparedEditorOverrides` so the subsequent dispatch via `instantiateVisitor` returns the unwrapped editor — otherwise the precondition would also run Go-side and double the cost.

## Wire format

Matches `org.openrewrite.rpc.request.PrepareRecipeResponse.Precondition`:

  * Leaves: `visitorName` (+ optional `visitorOptions`)
  * Composites: `op` (`"or"` / `"and"` / `"not"`) + a nested `operands` list

- `RewriteRpc.matchAll` (Java side, landed in #7625) already decodes either shape, so this just adds the Go emission side.

## API additions

  * `preconditions.Check(condition, editor)` — wrapper visitor
  * `preconditions.Or` / `And` / `Not` — composite constructors
  * `preconditions.RecipeRef` — wire-only placeholder for a Java search recipe
  * `preconditions.UsesMethod` / `UsesType` / `HasSourcePath` — helpers returning `*RecipeRef`
  * `preconditions.CheckVisitor` — exported so the RPC server can type-assert during PrepareRecipe introspection

## API removals

  * `Recipe.Preconditions() []Recipe` and the `Base` default impl. No real Go recipes exercised this gate (only `template_recipe`'s stub returned nil), and the wrapper model supersedes it.
  * `RecipeDescriptor.Preconditions` is left in place for declarative-recipe metadata serialization but is no longer populated by `Describe` — runtime gates flow through the `editPreconditions` wire slot.

## Test plan

- [x] 9 in-process tests in `pkg/preconditions/preconditions_test.go`: Check match / no-match, OR short-circuit, OR no-match, AND all-match / one-non-matching, NOT inversion, RecipeRef-as-operand, two-operand minimum on Or / And
- [x] `go test ./...` — all packages pass (`pkg/preconditions`, `pkg/recipe`, `pkg/template`, `cmd/rpc`, `pkg/rpc`, `test`, etc.)
- [x] `go build ./...` clean

## Why

- Cross-language parity for the `Preconditions.or` / `and` / `not` framework. After this and #7625 (Python) + #7626 (JS), Go recipe authors can express OR'd gates over multiple search recipes (e.g. "any of 8 method patterns") instead of letting the editor visit every file.
