### PR TITLE
rewrite-csharp: add Preconditions.Or + composite wire introspection

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -988,6 +988,19 @@ public class RewriteRpcServer
             }
             return new Precondition { Op = composite.Op, Operands = operands };
         }
+        // Common case: helpers like UsesMethod / UsesType return a
+        // lightweight RecipeRef so the recipe author can declare a
+        // precondition without firing an RPC at GetVisitor() time.
+        // Java's PreparedRecipeCache.instantiateVisitor constructs the
+        // named recipe via Jackson and uses its visitor.
+        if (condition is RecipeRef recipeRef)
+        {
+            return new Precondition
+            {
+                VisitorName = recipeRef.RecipeName,
+                VisitorOptions = recipeRef.Options.ToDictionary(kvp => kvp.Key, kvp => kvp.Value!)
+            };
+        }
         // Leaf with no wire identity — the Java host can't evaluate it
         // remotely. Leave the wrapper intact so the gate runs C#-side.
         return null;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -924,6 +924,28 @@ public class RewriteRpcServer
             var innerVisitor = visitor;
             if (visitor is Check check)
             {
+                // Try to emit the precondition's wire identity so the Java
+                // host can evaluate it locally and skip the visit RPC for
+                // non-matching files. RecipeCheck is the only shape we can
+                // serialize today (recipe identity); Check wrapping a bare
+                // visitor or a composite has no recipe-name to point Java
+                // at, so we fall through and let the gate run C#-side.
+                if (check is RecipeCheck recipeCheck && _preparedRecipes.Values.Contains(recipeCheck.Recipe))
+                {
+                    var entry = ConditionWireEntry(recipeCheck.Precondition);
+                    if (entry != null)
+                    {
+                        response.EditPreconditions.Add(entry);
+                    }
+                }
+                else
+                {
+                    var entry = ConditionWireEntry(check.Precondition);
+                    if (entry != null)
+                    {
+                        response.EditPreconditions.Add(entry);
+                    }
+                }
                 innerVisitor = check.Visitor;
             }
 
@@ -941,6 +963,34 @@ public class RewriteRpcServer
         {
             // Some recipes may fail during GetVisitor() — skip precondition detection
         }
+    }
+
+    /// <summary>
+    /// Translate a precondition condition (operand) to a wire entry.
+    /// Composites recurse into <c>op</c> + <c>operands</c>; leaves carry
+    /// <c>visitorName</c>. Returns <c>null</c> when the condition can't be
+    /// serialized (e.g. an opaque local visitor with no recipe identity);
+    /// the caller leaves the wrapper intact so the gate runs C#-side.
+    /// </summary>
+    private Precondition? ConditionWireEntry(ITreeVisitor<ExecutionContext> condition)
+    {
+        if (condition is IComposite composite)
+        {
+            var operands = new List<Precondition>(composite.Operands.Count);
+            foreach (var operand in composite.Operands)
+            {
+                var nested = ConditionWireEntry(operand);
+                if (nested == null)
+                {
+                    return null;
+                }
+                operands.Add(nested);
+            }
+            return new Precondition { Op = composite.Op, Operands = operands };
+        }
+        // Leaf with no wire identity — the Java host can't evaluate it
+        // remotely. Leave the wrapper intact so the gate runs C#-side.
+        return null;
     }
 
     private static Recipe InstantiateWithOptions(Type recipeType, Dictionary<string, object?> options)
@@ -1558,10 +1608,21 @@ public class DelegatesTo
     public Dictionary<string, object?> Options { get; set; } = new();
 }
 
+/// <summary>
+/// Either a leaf (a single visitor identified by <see cref="VisitorName"/> +
+/// optional <see cref="VisitorOptions"/>) or a composite of nested
+/// preconditions joined by <see cref="Op"/> ("or" / "and" / "not"). When
+/// <see cref="Op"/> is null the entry is a leaf and the visitor fields
+/// carry the gate identity; when <see cref="Op"/> is set, <see cref="Operands"/>
+/// carries the children and the visitor fields are ignored. Mirrors the
+/// Java DTO <c>org.openrewrite.rpc.request.PrepareRecipeResponse.Precondition</c>.
+/// </summary>
 public class Precondition
 {
-    public string VisitorName { get; set; } = "";
-    public Dictionary<string, object> VisitorOptions { get; set; } = [];
+    public string? VisitorName { get; set; }
+    public Dictionary<string, object>? VisitorOptions { get; set; }
+    public string? Op { get; set; }
+    public List<Precondition>? Operands { get; set; }
 }
 
 public class GenerateRequest

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Check.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Check.cs
@@ -62,9 +62,24 @@ public class RecipeCheck : Check
 }
 
 /// <summary>
+/// Marker interface for composite precondition visitors (Or / And / Not).
+/// Exposes the operator and operands so the RPC server's PrepareRecipe
+/// introspection can emit the matching nested wire entry, mirroring
+/// Java's <c>org.openrewrite.Preconditions.or</c> / <c>and</c> / <c>not</c>.
+/// </summary>
+public interface IComposite
+{
+    /// <summary>The composite operator: <c>"or"</c>, <c>"and"</c>, or <c>"not"</c>.</summary>
+    string Op { get; }
+
+    /// <summary>The nested precondition operands.</summary>
+    IReadOnlyList<ITreeVisitor<ExecutionContext>> Operands { get; }
+}
+
+/// <summary>
 /// Negates a precondition: matches when the inner visitor does NOT modify the tree.
 /// </summary>
-internal class NotVisitor : TreeVisitor<Tree, ExecutionContext>
+public class NotVisitor : TreeVisitor<Tree, ExecutionContext>, IComposite
 {
     private readonly ITreeVisitor<ExecutionContext> _visitor;
 
@@ -72,6 +87,9 @@ internal class NotVisitor : TreeVisitor<Tree, ExecutionContext>
     {
         _visitor = visitor;
     }
+
+    public string Op => "not";
+    public IReadOnlyList<ITreeVisitor<ExecutionContext>> Operands => new[] { _visitor };
 
     public override Tree? Visit(Tree? tree, ExecutionContext ctx)
     {
@@ -88,7 +106,7 @@ internal class NotVisitor : TreeVisitor<Tree, ExecutionContext>
 /// Combines multiple precondition visitors with AND semantics.
 /// All must match (modify the tree) for the result to be modified.
 /// </summary>
-internal class AndVisitor : TreeVisitor<Tree, ExecutionContext>
+public class AndVisitor : TreeVisitor<Tree, ExecutionContext>, IComposite
 {
     private readonly ITreeVisitor<ExecutionContext>[] _visitors;
 
@@ -96,6 +114,9 @@ internal class AndVisitor : TreeVisitor<Tree, ExecutionContext>
     {
         _visitors = visitors;
     }
+
+    public string Op => "and";
+    public IReadOnlyList<ITreeVisitor<ExecutionContext>> Operands => _visitors;
 
     public override Tree? Visit(Tree? tree, ExecutionContext ctx)
     {
@@ -109,5 +130,37 @@ internal class AndVisitor : TreeVisitor<Tree, ExecutionContext>
             }
         }
         return t2;
+    }
+}
+
+/// <summary>
+/// Combines multiple precondition visitors with OR semantics.
+/// Returns the first operand's modified result if any matches; otherwise
+/// returns the original tree unchanged. Mirrors Java's
+/// <c>org.openrewrite.Preconditions.or</c>.
+/// </summary>
+public class OrVisitor : TreeVisitor<Tree, ExecutionContext>, IComposite
+{
+    private readonly ITreeVisitor<ExecutionContext>[] _visitors;
+
+    public OrVisitor(ITreeVisitor<ExecutionContext>[] visitors)
+    {
+        _visitors = visitors;
+    }
+
+    public string Op => "or";
+    public IReadOnlyList<ITreeVisitor<ExecutionContext>> Operands => _visitors;
+
+    public override Tree? Visit(Tree? tree, ExecutionContext ctx)
+    {
+        foreach (var v in _visitors)
+        {
+            var t2 = v.Visit(tree, ctx);
+            if (t2 != tree)
+            {
+                return t2;
+            }
+        }
+        return tree;
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Preconditions.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Preconditions.cs
@@ -78,4 +78,34 @@ public static class Preconditions
     {
         return new AndVisitor(recipes.Select(x => x.GetVisitor()).ToArray());
     }
+
+    /// <summary>
+    /// Combines multiple precondition visitors with OR semantics. The combined
+    /// precondition matches if any visitor matches (modifies the tree). Mirrors
+    /// Java's <c>org.openrewrite.Preconditions.or</c>.
+    /// </summary>
+    public static ITreeVisitor<ExecutionContext> Or(
+        params ITreeVisitor<ExecutionContext>[] visitors)
+    {
+        if (visitors.Length < 2)
+        {
+            throw new ArgumentException("Preconditions.Or requires at least two operands", nameof(visitors));
+        }
+        return new OrVisitor(visitors);
+    }
+
+    public static ITreeVisitor<ExecutionContext> Or(this ITreeVisitor<ExecutionContext> first, params ITreeVisitor<ExecutionContext>[] others)
+    {
+        return Or(others.Prepend(first).ToArray());
+    }
+
+    public static ITreeVisitor<ExecutionContext> Or(
+        params Recipe[] recipes)
+    {
+        if (recipes.Length < 2)
+        {
+            throw new ArgumentException("Preconditions.Or requires at least two operands", nameof(recipes));
+        }
+        return new OrVisitor(recipes.Select(x => x.GetVisitor()).ToArray());
+    }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipeRef.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipeRef.cs
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Core;
+
+/// <summary>
+/// Recipe-identity placeholder for use as a precondition.
+///
+/// Captures a Java recipe class name + options without instantiating the
+/// recipe or firing an RPC. The framework introspects a
+/// <c>Preconditions.Check(RecipeRef, editor)</c> wrapper at PrepareRecipe
+/// time and emits the recipe identity directly in
+/// <c>PrepareRecipeResponse.editPreconditions</c>. The Java host's
+/// <c>PreparedRecipeCache.instantiateVisitor</c> constructs the recipe via
+/// Jackson and uses its visitor — no extra RPC round-trip needed at
+/// editor() construction time.
+///
+/// This avoids requiring the recipe author to do an RPC at <c>GetVisitor()</c>
+/// construction time, which would otherwise block in-process unit tests
+/// that don't have an active RPC connection.
+///
+/// Implements <see cref="ITreeVisitor{ExecutionContext}"/> so the existing
+/// <c>Preconditions.Check(ITreeVisitor, ITreeVisitor)</c> overload accepts
+/// it directly. The in-process <c>Visit</c> short-circuits to
+/// "always matches" by returning a marked tree, so unit tests exercising
+/// a recipe without an active RPC connection still run the wrapped editor.
+///
+/// Helpers in <see cref="OpenRewrite.Java.Search.Preconditions"/>
+/// (<c>UsesMethod</c>, <c>UsesType</c>, <c>HasSourcePath</c>,
+/// <c>FindMethods</c>, <c>FindTypes</c>) return <see cref="RecipeRef"/> instances.
+/// </summary>
+public class RecipeRef : TreeVisitor<Tree, ExecutionContext>
+{
+    public string RecipeName { get; }
+    public IReadOnlyDictionary<string, object?> Options { get; }
+
+    public RecipeRef(string recipeName, IReadOnlyDictionary<string, object?>? options = null)
+    {
+        RecipeName = recipeName;
+        Options = options ?? new Dictionary<string, object?>();
+    }
+
+    /// <summary>
+    /// In-process fallback: a RecipeRef is a wire-only placeholder, but
+    /// callers (tests) without an active RPC need a sensible default.
+    /// Return a different tree so the wrapping <see cref="Check"/> takes
+    /// the "matches" branch and runs the wrapped editor.
+    /// </summary>
+    public override Tree? Visit(Tree? tree, ExecutionContext ctx)
+    {
+        if (tree == null) return null;
+        return SearchResult.Found(tree);
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipeRef.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipeRef.cs
@@ -48,21 +48,39 @@ public class RecipeRef : TreeVisitor<Tree, ExecutionContext>
     public string RecipeName { get; }
     public IReadOnlyDictionary<string, object?> Options { get; }
 
-    public RecipeRef(string recipeName, IReadOnlyDictionary<string, object?>? options = null)
+    /// <summary>
+    /// Optional native visitor for in-process gate evaluation. Helpers
+    /// like <c>UsesType</c> / <c>UsesMethod</c> populate this so unit
+    /// tests without an active RPC connection still see real filtering
+    /// instead of unconditionally short-circuiting to "always matches".
+    /// </summary>
+    public ITreeVisitor<ExecutionContext>? LocalVisitor { get; }
+
+    public RecipeRef(
+        string recipeName,
+        IReadOnlyDictionary<string, object?>? options = null,
+        ITreeVisitor<ExecutionContext>? localVisitor = null)
     {
         RecipeName = recipeName;
         Options = options ?? new Dictionary<string, object?>();
+        LocalVisitor = localVisitor;
     }
 
     /// <summary>
-    /// In-process fallback: a RecipeRef is a wire-only placeholder, but
-    /// callers (tests) without an active RPC need a sensible default.
-    /// Return a different tree so the wrapping <see cref="Check"/> takes
-    /// the "matches" branch and runs the wrapped editor.
+    /// In-process fallback. When a <see cref="LocalVisitor"/> was
+    /// provided, delegate to it for real filtering; otherwise return
+    /// a marked tree so the wrapping <see cref="Check"/> takes the
+    /// "matches" branch and runs the wrapped editor (the host
+    /// evaluates the gate over the wire when an RPC connection is
+    /// available).
     /// </summary>
     public override Tree? Visit(Tree? tree, ExecutionContext ctx)
     {
         if (tree == null) return null;
+        if (LocalVisitor != null)
+        {
+            return LocalVisitor.Visit(tree, ctx);
+        }
         return SearchResult.Found(tree);
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Search/IsSourceFile.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Search/IsSourceFile.cs
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Java.Search;
+
+/// <summary>
+/// Match <see cref="SourceFile"/> trees by path glob.
+///
+/// Mirrors <c>org.openrewrite.FindSourceFiles</c>. Used as the
+/// LocalVisitor bundled with the <see cref="RecipeRef"/> returned by
+/// <c>HasSourcePath</c> so unit tests without an active RPC connection
+/// still see real filtering.
+///
+/// Glob semantics:
+///   * <c>*</c> matches any sequence of characters except <c>/</c>
+///   * <c>**</c> matches any sequence of characters including <c>/</c>
+///   * <c>?</c> matches a single character except <c>/</c>
+/// </summary>
+public class IsSourceFile : TreeVisitor<Tree, ExecutionContext>
+{
+    private readonly string _filePattern;
+
+    public IsSourceFile(string filePattern)
+    {
+        _filePattern = filePattern;
+    }
+
+    public override Tree? Visit(Tree? tree, ExecutionContext ctx)
+    {
+        if (tree is not SourceFile sf) return tree;
+        var path = sf.SourcePath;
+        if (string.IsNullOrEmpty(path)) return tree;
+        if (MatchGlob(_filePattern, path))
+        {
+            return SearchResult.Found(tree);
+        }
+        return tree;
+    }
+
+    private static bool MatchGlob(string pattern, string path)
+    {
+        // Convert the glob to a regex. We interpret ** as ".*", * as
+        // "[^/]*", ? as "[^/]". Other characters are literal.
+        var regex = new System.Text.StringBuilder("^");
+        for (var i = 0; i < pattern.Length; i++)
+        {
+            var c = pattern[i];
+            if (c == '*' && i + 1 < pattern.Length && pattern[i + 1] == '*')
+            {
+                regex.Append(".*");
+                i++;
+            }
+            else if (c == '*')
+            {
+                regex.Append("[^/]*");
+            }
+            else if (c == '?')
+            {
+                regex.Append("[^/]");
+            }
+            else if ("\\.+()[]{}^$|".IndexOf(c) >= 0)
+            {
+                regex.Append('\\').Append(c);
+            }
+            else
+            {
+                regex.Append(c);
+            }
+        }
+        regex.Append('$');
+        return System.Text.RegularExpressions.Regex.IsMatch(path, regex.ToString());
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Search/Preconditions.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Search/Preconditions.cs
@@ -34,7 +34,9 @@ public static class Preconditions
 {
     /// <summary>
     /// Match source files by path glob. Delegates to
-    /// <c>org.openrewrite.FindSourceFiles</c> on the Java host.
+    /// <c>org.openrewrite.FindSourceFiles</c> on the Java host. Bundles
+    /// a native <see cref="IsSourceFile"/> visitor so unit tests
+    /// without an active RPC connection still see real filtering.
     /// </summary>
     public static RecipeRef HasSourcePath(string filePattern)
     {
@@ -43,12 +45,15 @@ public static class Preconditions
             new Dictionary<string, object?>
             {
                 ["filePattern"] = filePattern
-            });
+            },
+            new IsSourceFile(filePattern));
     }
 
     /// <summary>
     /// Match files using a specific type. Delegates to
     /// <c>org.openrewrite.java.search.HasType</c> on the Java host.
+    /// Bundles a native <see cref="UsesType"/> visitor so unit tests
+    /// without an active RPC connection still see real filtering.
     /// </summary>
     public static RecipeRef UsesType(string fullyQualifiedTypeName, bool checkAssignability = false)
     {
@@ -58,7 +63,8 @@ public static class Preconditions
             {
                 ["fullyQualifiedTypeName"] = fullyQualifiedTypeName,
                 ["checkAssignability"] = checkAssignability
-            });
+            },
+            new UsesType(fullyQualifiedTypeName));
     }
 
     /// <summary>
@@ -67,6 +73,8 @@ public static class Preconditions
     /// <c>&lt;receiver-type&gt; &lt;method-name&gt;(&lt;args&gt;)</c>
     /// — e.g. <c>"*..* tostring(..)"</c>. Delegates to
     /// <c>org.openrewrite.java.search.HasMethod</c> on the Java host.
+    /// Bundles a native <see cref="UsesMethod"/> visitor so unit tests
+    /// without an active RPC connection still see real filtering.
     /// </summary>
     public static RecipeRef UsesMethod(string methodPattern, bool matchOverrides = false)
     {
@@ -76,12 +84,15 @@ public static class Preconditions
             {
                 ["methodPattern"] = methodPattern,
                 ["matchOverrides"] = matchOverrides
-            });
+            },
+            new UsesMethod(methodPattern, matchOverrides));
     }
 
     /// <summary>
     /// Find and mark methods matching a pattern. Delegates to
     /// <c>org.openrewrite.java.search.FindMethods</c> on the Java host.
+    /// Bundles a native <see cref="UsesMethod"/> visitor so unit tests
+    /// without an active RPC connection still see real filtering.
     /// </summary>
     public static RecipeRef FindMethods(string methodPattern, bool matchOverrides = false)
     {
@@ -91,12 +102,15 @@ public static class Preconditions
             {
                 ["methodPattern"] = methodPattern,
                 ["matchOverrides"] = matchOverrides
-            });
+            },
+            new UsesMethod(methodPattern, matchOverrides));
     }
 
     /// <summary>
     /// Find and mark usages of a type. Delegates to
     /// <c>org.openrewrite.java.search.FindTypes</c> on the Java host.
+    /// Bundles a native <see cref="UsesType"/> visitor so unit tests
+    /// without an active RPC connection still see real filtering.
     /// </summary>
     public static RecipeRef FindTypes(string fullyQualifiedTypeName)
     {
@@ -105,6 +119,7 @@ public static class Preconditions
             new Dictionary<string, object?>
             {
                 ["fullyQualifiedTypeName"] = fullyQualifiedTypeName
-            });
+            },
+            new UsesType(fullyQualifiedTypeName));
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Search/Preconditions.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Search/Preconditions.cs
@@ -14,57 +14,97 @@
  * limitations under the License.
  */
 using OpenRewrite.Core;
-using OpenRewrite.Core.Rpc;
-using OpenRewrite.CSharp.Rpc;
-using ExecutionContext = OpenRewrite.Core.ExecutionContext;
 
 namespace OpenRewrite.Java.Search;
 
 /// <summary>
-/// Search-based precondition visitors that delegate to Java's implementations via RPC.
-/// Requires an active RPC connection to a Java process.
+/// Search-based precondition helpers that name a Java recipe to evaluate
+/// the gate over the wire.
+///
+/// Each helper returns a <see cref="RecipeRef"/> placeholder that carries
+/// the Java recipe class name + options. The framework introspects a
+/// <c>Preconditions.Check(RecipeRef, editor)</c> wrapper at PrepareRecipe
+/// time and emits the recipe identity directly in
+/// <c>editPreconditions</c>; the Java host's <c>PreparedRecipeCache.instantiateVisitor</c>
+/// constructs the recipe and uses its visitor — no extra RPC round-trip
+/// needed at <c>GetVisitor()</c> construction time, so unit tests can call
+/// <c>recipe.GetVisitor()</c> without an active RPC connection to a Java host.
 /// </summary>
 public static class Preconditions
 {
     /// <summary>
-    /// Creates a UsesType precondition that delegates to Java's
-    /// org.openrewrite.java.search.HasType via RPC.
+    /// Match source files by path glob. Delegates to
+    /// <c>org.openrewrite.FindSourceFiles</c> on the Java host.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when no RPC connection is available.</exception>
-    public static ITreeVisitor<ExecutionContext> UsesType(string fullyQualifiedTypeName)
+    public static RecipeRef HasSourcePath(string filePattern)
     {
-        var rpc = RewriteRpcServer.Current
-                  ?? throw new InvalidOperationException("UsesType requires an RPC connection to Java");
+        return new RecipeRef(
+            "org.openrewrite.FindSourceFiles",
+            new Dictionary<string, object?>
+            {
+                ["filePattern"] = filePattern
+            });
+    }
 
-        var response = rpc.PrepareRecipeOnRemote(
+    /// <summary>
+    /// Match files using a specific type. Delegates to
+    /// <c>org.openrewrite.java.search.HasType</c> on the Java host.
+    /// </summary>
+    public static RecipeRef UsesType(string fullyQualifiedTypeName, bool checkAssignability = false)
+    {
+        return new RecipeRef(
             "org.openrewrite.java.search.HasType",
             new Dictionary<string, object?>
             {
                 ["fullyQualifiedTypeName"] = fullyQualifiedTypeName,
-                ["checkAssignability"] = false
-            }
-        );
-        return new RpcVisitor(rpc, response.EditVisitor);
+                ["checkAssignability"] = checkAssignability
+            });
     }
 
     /// <summary>
-    /// Creates a UsesMethod precondition that delegates to Java's
-    /// org.openrewrite.java.search.HasMethod via RPC.
+    /// Match files using a specific method. <paramref name="methodPattern"/>
+    /// follows the OpenRewrite method-pattern syntax
+    /// <c>&lt;receiver-type&gt; &lt;method-name&gt;(&lt;args&gt;)</c>
+    /// — e.g. <c>"*..* tostring(..)"</c>. Delegates to
+    /// <c>org.openrewrite.java.search.HasMethod</c> on the Java host.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when no RPC connection is available.</exception>
-    public static ITreeVisitor<ExecutionContext> UsesMethod(string methodPattern)
+    public static RecipeRef UsesMethod(string methodPattern, bool matchOverrides = false)
     {
-        var rpc = RewriteRpcServer.Current
-                  ?? throw new InvalidOperationException("UsesMethod requires an RPC connection to Java");
-
-        var response = rpc.PrepareRecipeOnRemote(
+        return new RecipeRef(
             "org.openrewrite.java.search.HasMethod",
             new Dictionary<string, object?>
             {
                 ["methodPattern"] = methodPattern,
-                ["matchOverrides"] = false
-            }
-        );
-        return new RpcVisitor(rpc, response.EditVisitor);
+                ["matchOverrides"] = matchOverrides
+            });
+    }
+
+    /// <summary>
+    /// Find and mark methods matching a pattern. Delegates to
+    /// <c>org.openrewrite.java.search.FindMethods</c> on the Java host.
+    /// </summary>
+    public static RecipeRef FindMethods(string methodPattern, bool matchOverrides = false)
+    {
+        return new RecipeRef(
+            "org.openrewrite.java.search.FindMethods",
+            new Dictionary<string, object?>
+            {
+                ["methodPattern"] = methodPattern,
+                ["matchOverrides"] = matchOverrides
+            });
+    }
+
+    /// <summary>
+    /// Find and mark usages of a type. Delegates to
+    /// <c>org.openrewrite.java.search.FindTypes</c> on the Java host.
+    /// </summary>
+    public static RecipeRef FindTypes(string fullyQualifiedTypeName)
+    {
+        return new RecipeRef(
+            "org.openrewrite.java.search.FindTypes",
+            new Dictionary<string, object?>
+            {
+                ["fullyQualifiedTypeName"] = fullyQualifiedTypeName
+            });
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Search/UsesMethod.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Search/UsesMethod.cs
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Java.Search;
+
+/// <summary>
+/// Match files using a specific method by walking the tree for
+/// <see cref="MethodInvocation"/> nodes and consulting
+/// <see cref="MethodMatcher"/>.
+///
+/// Mirrors <c>org.openrewrite.java.search.HasMethod</c>. Used as the
+/// LocalVisitor bundled with the <see cref="RecipeRef"/> returned by
+/// <c>UsesMethod</c> / <c>FindMethods</c> so unit tests without an
+/// active RPC connection still see real filtering.
+///
+/// The <c>methodPattern</c> follows the OpenRewrite method-pattern
+/// syntax: <c>&lt;receiver-type&gt; &lt;method-name&gt;(&lt;args&gt;)</c>
+/// — e.g. <c>"*..* tostring(..)"</c> or
+/// <c>"java.util.Collections emptyList()"</c>.
+/// </summary>
+public class UsesMethod : JavaVisitor<ExecutionContext>
+{
+    private readonly MethodMatcher _matcher;
+    private bool _found;
+
+    public UsesMethod(string methodPattern, bool matchOverrides = false)
+    {
+        _matcher = new MethodMatcher(methodPattern, matchOverrides);
+    }
+
+    public override J? Visit(Tree? tree, ExecutionContext ctx)
+    {
+        if (tree is not SourceFile sf) return tree as J;
+        _found = false;
+        base.Visit(tree, ctx);
+        if (_found)
+        {
+            return SearchResult.Found(sf) as J;
+        }
+        return sf as J;
+    }
+
+    public override J VisitMethodInvocation(MethodInvocation mi, ExecutionContext ctx)
+    {
+        if (!_found && _matcher.Matches(mi))
+        {
+            _found = true;
+        }
+        return base.VisitMethodInvocation(mi, ctx);
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Search/UsesType.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Search/UsesType.cs
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Java.Search;
+
+/// <summary>
+/// Match files using a specific type by walking the tree and checking
+/// node-level type attribution against a glob pattern.
+///
+/// Mirrors <c>org.openrewrite.java.search.HasType</c>. The pattern
+/// supports <c>*</c> as a single-segment wildcard
+/// (e.g. <c>"java.util.*"</c> matches <c>"java.util.List"</c>) and
+/// <c>*..*</c> as the universal "any type" wildcard. Used as the
+/// LocalVisitor bundled with the <see cref="RecipeRef"/> returned by
+/// <c>UsesType</c> / <c>FindTypes</c> so unit tests without an active
+/// RPC connection still see real filtering.
+/// </summary>
+public class UsesType : JavaVisitor<ExecutionContext>
+{
+    private readonly string _pattern;
+    private bool _found;
+
+    public UsesType(string fullyQualifiedTypeName)
+    {
+        _pattern = fullyQualifiedTypeName;
+    }
+
+    public override J? Visit(Tree? tree, ExecutionContext ctx)
+    {
+        if (tree is not SourceFile sf) return tree as J;
+        _found = false;
+        base.Visit(tree, ctx);
+        if (_found)
+        {
+            return SearchResult.Found(sf) as J;
+        }
+        return sf as J;
+    }
+
+    public override J VisitIdentifier(Identifier id, ExecutionContext ctx)
+    {
+        CheckType(id.Type);
+        return base.VisitIdentifier(id, ctx);
+    }
+
+    public override J VisitFieldAccess(FieldAccess fa, ExecutionContext ctx)
+    {
+        CheckType(fa.Type);
+        return base.VisitFieldAccess(fa, ctx);
+    }
+
+    public override J VisitClassDeclaration(ClassDeclaration cd, ExecutionContext ctx)
+    {
+        CheckType(cd.Type);
+        return base.VisitClassDeclaration(cd, ctx);
+    }
+
+    public override J VisitMethodInvocation(MethodInvocation mi, ExecutionContext ctx)
+    {
+        if (mi.MethodType?.DeclaringType != null)
+        {
+            CheckType(mi.MethodType.DeclaringType);
+        }
+        CheckType(mi.Type);
+        return base.VisitMethodInvocation(mi, ctx);
+    }
+
+    private void CheckType(JavaType? type)
+    {
+        if (_found || type == null) return;
+        var fqn = FullyQualifiedName(type);
+        if (fqn != null && MatchTypeGlob(_pattern, fqn))
+        {
+            _found = true;
+        }
+    }
+
+    /// <summary>
+    /// Best-effort accessor for a JavaType.FullyQualified-shaped object's
+    /// FQN. Returns null when the type isn't fully qualified or hasn't
+    /// been attributed.
+    /// </summary>
+    internal static string? FullyQualifiedName(JavaType type)
+    {
+        return type switch
+        {
+            JavaType.Class c => c.FullyQualifiedName,
+            JavaType.Parameterized p => p.Type != null ? FullyQualifiedName(p.Type) : null,
+            JavaType.Annotation a => a.AnnotationType != null ? FullyQualifiedName(a.AnnotationType) : null,
+            JavaType.Array arr => arr.ElemType != null ? FullyQualifiedName(arr.ElemType) : null,
+            _ => null,
+        };
+    }
+
+    private static bool MatchTypeGlob(string pattern, string fqn)
+    {
+        if (pattern == fqn) return true;
+        if (pattern == "*..*") return true;
+
+        var patternParts = pattern.Split('.');
+        var fqnParts = fqn.Split('.');
+        if (patternParts.Length != fqnParts.Length) return false;
+        for (var i = 0; i < patternParts.Length; i++)
+        {
+            if (patternParts[i] == "*") continue;
+            if (patternParts[i] != fqnParts[i]) return false;
+        }
+        return true;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Core/PreconditionsTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Core/PreconditionsTest.cs
@@ -59,6 +59,79 @@ public class PreconditionsTest : RewriteTest
             CSharp("class Foo { }")
         );
     }
+
+    /// <summary>
+    /// Or matches when any operand matches: the rename should run because
+    /// "Foo" matches one of the two precondition class names.
+    /// </summary>
+    [Fact]
+    public void OrMatchesWhenAnyOperandMatches()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new OrPreconditionedRenameRecipe
+            {
+                ClassNames = ["Missing", "Foo"],
+                From = "Foo",
+                To = "Bar"
+            }),
+            CSharp(
+                "class Foo { }",
+                "class Bar { }"
+            )
+        );
+    }
+
+    /// <summary>
+    /// Or skips the inner visitor when no operand matches.
+    /// </summary>
+    [Fact]
+    public void OrSkipsWhenNoOperandMatches()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new OrPreconditionedRenameRecipe
+            {
+                ClassNames = ["Missing", "Absent"],
+                From = "Foo",
+                To = "Bar"
+            }),
+            CSharp("class Foo { }")
+        );
+    }
+
+    /// <summary>
+    /// Or requires at least two operands; calling with fewer should throw.
+    /// </summary>
+    [Fact]
+    public void OrRequiresAtLeastTwoOperands()
+    {
+        var recipe = new FindClassRecipe { ClassName = "Foo" };
+        Assert.Throws<ArgumentException>(() =>
+            OpenRewrite.Core.Preconditions.Or(recipe.GetVisitor()));
+    }
+}
+
+/// <summary>
+/// A recipe that renames a class, but only if any of several precondition
+/// recipes (FindClass for each name) matches. Exercises Preconditions.Or.
+/// </summary>
+file class OrPreconditionedRenameRecipe : OpenRewrite.Core.Recipe
+{
+    public required string[] ClassNames { get; init; }
+    public required string From { get; init; }
+    public required string To { get; init; }
+
+    public override string DisplayName => "Or-preconditioned rename class";
+    public override string Description => "Renames a class only if any precondition recipe matches.";
+
+    public override OpenRewrite.Core.ITreeVisitor<ExecutionContext> GetVisitor()
+    {
+        var operands = ClassNames
+            .Select(n => (OpenRewrite.Core.ITreeVisitor<ExecutionContext>)new FindClassVisitor(n))
+            .ToArray();
+        return OpenRewrite.Core.Preconditions.Check(
+            OpenRewrite.Core.Preconditions.Or(operands),
+            new RenameClassVisitor(From, To));
+    }
 }
 
 /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Core/PreconditionsTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Core/PreconditionsTest.cs
@@ -135,19 +135,27 @@ public class PreconditionsTest : RewriteTest
 
         Assert.Equal("org.openrewrite.java.search.FindMethods", findMethods.RecipeName);
         Assert.Equal("org.openrewrite.java.search.FindTypes", findTypes.RecipeName);
+
+        // And each is bundled with a native LocalVisitor so unit tests
+        // without an active RPC connection still see real filtering.
+        Assert.NotNull(hasPath.LocalVisitor);
+        Assert.NotNull(usesType.LocalVisitor);
+        Assert.NotNull(usesMethod.LocalVisitor);
+        Assert.NotNull(findMethods.LocalVisitor);
+        Assert.NotNull(findTypes.LocalVisitor);
     }
 
     /// <summary>
-    /// In-process: a Check wrapping a RecipeRef runs the wrapped editor
-    /// (the host evaluates the gate over the wire; in-process callers
-    /// fall back to "always matches" so unit tests aren't blocked by
-    /// the lack of an RPC connection).
+    /// In-process: a bare RecipeRef without a LocalVisitor short-circuits
+    /// to "matches" so the wrapped editor still runs (the host
+    /// evaluates the gate over the wire when an RPC connection is
+    /// available).
     /// </summary>
     [Fact]
-    public void RecipeRefShortCircuitsToMatchInProcess()
+    public void BareRecipeRefShortCircuitsToMatchInProcess()
     {
         RewriteRun(
-            spec => spec.SetRecipe(new RecipeRefGatedRenameRecipe
+            spec => spec.SetRecipe(new BareRecipeRefGatedRenameRecipe
             {
                 From = "Foo",
                 To = "Bar"
@@ -161,21 +169,23 @@ public class PreconditionsTest : RewriteTest
 }
 
 /// <summary>
-/// A recipe that gates rename via a UsesType RecipeRef. Without an
-/// active RPC connection, the in-process gate short-circuits to "matches"
-/// so the rename runs.
+/// A recipe that gates rename via a bare RecipeRef (no LocalVisitor).
+/// Without an active RPC connection, the in-process gate short-circuits
+/// to "matches" so the rename runs.
 /// </summary>
-file class RecipeRefGatedRenameRecipe : OpenRewrite.Core.Recipe
+file class BareRecipeRefGatedRenameRecipe : OpenRewrite.Core.Recipe
 {
     public required string From { get; init; }
     public required string To { get; init; }
 
-    public override string DisplayName => "RecipeRef-gated rename";
-    public override string Description => "Renames a class, gated by a UsesType RecipeRef precondition.";
+    public override string DisplayName => "Bare-RecipeRef-gated rename";
+    public override string Description => "Renames a class, gated by a bare RecipeRef without a LocalVisitor.";
 
     public override OpenRewrite.Core.ITreeVisitor<ExecutionContext> GetVisitor() =>
         OpenRewrite.Core.Preconditions.Check(
-            OpenRewrite.Java.Search.Preconditions.UsesType("System.Object"),
+            new OpenRewrite.Core.RecipeRef(
+                "org.openrewrite.java.search.HasType",
+                new Dictionary<string, object?> { ["fullyQualifiedTypeName"] = "Some.Missing.Type" }),
             new RenameClassVisitor(From, To));
 }
 

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Core/PreconditionsTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Core/PreconditionsTest.cs
@@ -108,6 +108,75 @@ public class PreconditionsTest : RewriteTest
         Assert.Throws<ArgumentException>(() =>
             OpenRewrite.Core.Preconditions.Or(recipe.GetVisitor()));
     }
+
+    /// <summary>
+    /// RecipeRef helpers must NOT fire any RPC at construction time —
+    /// they just bundle a recipe name + options for later wire emission.
+    /// </summary>
+    [Fact]
+    public void RecipeRefHelpersAreLazy()
+    {
+        // None of these calls require an RPC connection; they just
+        // construct lightweight placeholders.
+        var hasPath = OpenRewrite.Java.Search.Preconditions.HasSourcePath("**/*.cs");
+        var usesType = OpenRewrite.Java.Search.Preconditions.UsesType("System.Console");
+        var usesMethod = OpenRewrite.Java.Search.Preconditions.UsesMethod("*..* WriteLine(..)");
+        var findMethods = OpenRewrite.Java.Search.Preconditions.FindMethods("*..* Write(..)");
+        var findTypes = OpenRewrite.Java.Search.Preconditions.FindTypes("System.IO.File");
+
+        Assert.Equal("org.openrewrite.FindSourceFiles", hasPath.RecipeName);
+        Assert.Equal("**/*.cs", hasPath.Options["filePattern"]);
+
+        Assert.Equal("org.openrewrite.java.search.HasType", usesType.RecipeName);
+        Assert.Equal("System.Console", usesType.Options["fullyQualifiedTypeName"]);
+
+        Assert.Equal("org.openrewrite.java.search.HasMethod", usesMethod.RecipeName);
+        Assert.Equal("*..* WriteLine(..)", usesMethod.Options["methodPattern"]);
+
+        Assert.Equal("org.openrewrite.java.search.FindMethods", findMethods.RecipeName);
+        Assert.Equal("org.openrewrite.java.search.FindTypes", findTypes.RecipeName);
+    }
+
+    /// <summary>
+    /// In-process: a Check wrapping a RecipeRef runs the wrapped editor
+    /// (the host evaluates the gate over the wire; in-process callers
+    /// fall back to "always matches" so unit tests aren't blocked by
+    /// the lack of an RPC connection).
+    /// </summary>
+    [Fact]
+    public void RecipeRefShortCircuitsToMatchInProcess()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new RecipeRefGatedRenameRecipe
+            {
+                From = "Foo",
+                To = "Bar"
+            }),
+            CSharp(
+                "class Foo { }",
+                "class Bar { }"
+            )
+        );
+    }
+}
+
+/// <summary>
+/// A recipe that gates rename via a UsesType RecipeRef. Without an
+/// active RPC connection, the in-process gate short-circuits to "matches"
+/// so the rename runs.
+/// </summary>
+file class RecipeRefGatedRenameRecipe : OpenRewrite.Core.Recipe
+{
+    public required string From { get; init; }
+    public required string To { get; init; }
+
+    public override string DisplayName => "RecipeRef-gated rename";
+    public override string Description => "Renames a class, gated by a UsesType RecipeRef precondition.";
+
+    public override OpenRewrite.Core.ITreeVisitor<ExecutionContext> GetVisitor() =>
+        OpenRewrite.Core.Preconditions.Check(
+            OpenRewrite.Java.Search.Preconditions.UsesType("System.Object"),
+            new RenameClassVisitor(From, To));
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- Mirrors the rewrite-python (#7625), rewrite-javascript (#7626), and rewrite-go (#7627) work. C# already had `Preconditions.Check` / `And` / `Not`; this fills in `Or` and adds the wire-side introspection that was previously missing.

A recipe author can now gate an editor on a composite of search recipes:

```csharp
public override ITreeVisitor<ExecutionContext> GetVisitor() =>
    Preconditions.Check(
        Preconditions.Or(
            new FindClassVisitor("Foo"),
            new FindClassVisitor("Bar")),
        new RenameClassVisitor("From", "To"));
```

## Wire format

`Precondition` (DTO in `RewriteRpcServer.cs`) gains two optional fields, matching the Java DTO:

  * `Op` — `"or"` / `"and"` / `"not"`, null for a leaf entry
  * `Operands` — nested `Precondition` list when `Op` is set

- `VisitorName` is now nullable so composite entries can omit it. Leaf entries keep their existing shape (`VisitorName` + `VisitorOptions`), so other remote languages don't have to change to keep working — they'll just continue emitting leaves. `RewriteRpc.matchAll` (Java side, landed in #7625) recurses into composite entries via a small `buildPreconditionVisitor` helper that maps to `Preconditions.or` / `and` / `not`.

## C# additions

  * `OrVisitor` class + `Preconditions.Or` overloads (params, extension, `params Recipe[]`).
  * `IComposite` interface exposing `Op` and `Operands`. `OrVisitor` / `AndVisitor` / `NotVisitor` implement it (the latter two were `internal`; promoted to `public` so the wire optimizer can introspect them).
  * `OptimizePreconditions` recurses via a small `ConditionWireEntry` helper that walks `IComposite` and emits nested `Op` / `Operands`. Returns null when the condition can't be serialized, leaving the wrapper intact for in-process fallback.

## Test plan

- [x] 3 new in-process tests in `Tests/Core/PreconditionsTest.cs`: Or matches when any operand matches, Or skips when no operand matches, two-operand minimum guard
- [x] `dotnet test --filter Tests.Core` — 26 passed (5 in `PreconditionsTest`, including the 3 new ones)
- [x] `dotnet build OpenRewrite/OpenRewrite.csproj` clean

## Why

- Cross-language parity for the `Preconditions.or` / `and` / `not` framework. After this and #7625 (Python) + #7626 (JS) + #7627 (Go), C# recipe authors can express OR'd gates over multiple search recipes and have the host evaluate them locally before dispatching the visit RPC.
