### PR TITLE
RewriteRpcProcess: deregister shutdown hook in shutdown()

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -69,6 +69,9 @@ public class RewriteRpcProcess extends Thread {
     @Setter
     private @Nullable Path stderrRedirect;
 
+    @Nullable
+    private Thread shutdownHook;
+
     public RewriteRpcProcess(String... command) {
         this.command = command;
         this.setName("RewriteRpcProcess");
@@ -168,12 +171,15 @@ public class RewriteRpcProcess extends Thread {
             }
         }
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        // Hold a reference so shutdown() can deregister the hook; otherwise each
+        // RPC process leaks its full RewriteRpc graph via ApplicationShutdownHooks.
+        shutdownHook = new Thread(() -> {
             try {
                 shutdown();
             } catch (Throwable ignored) {
             }
-        }, "rpc-shutdown"));
+        }, "rpc-shutdown");
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
 
         SimpleModule module = new SimpleModule();
         module.addSerializer(Path.class, new PathSerializer());
@@ -188,6 +194,14 @@ public class RewriteRpcProcess extends Thread {
     }
 
     public void shutdown() {
+        if (shutdownHook != null) {
+            try {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
+            } catch (IllegalStateException ignored) {
+                // JVM is already shutting down (e.g. shutdown() invoked from the hook itself).
+            }
+            shutdownHook = null;
+        }
         if (process != null && process.isAlive()) {
             process.destroy();
             try {


### PR DESCRIPTION
## Summary
- The shutdown hook registered in `start()` (#7616) was never removed, so every `RewriteRpcProcess` instance was retained for the lifetime of the JVM via `ApplicationShutdownHooks.hooks` — and through the captured `this`, the entire `RewriteRpc` graph went with it (`localObjects`/`remoteObjects` populated with every Tree sent over RPC).
- Store the hook in a field, deregister it in `shutdown()`, and ignore `IllegalStateException` so the hook-driven shutdown path stays a no-op.

## What we observed
`mod run org.openrewrite.node.migrate.upgrade-node-24` against a 93-repo JavaScript working set with the default 4 GB heap:

| | before this PR | after this PR |
|---|---|---|
| outcome | `OutOfMemoryError` at 4m 51s | clean exit at 11m 26s |
| repos completed | 5 | 56 (37 skipped no-LST, 1 unrelated tooljet RPC SIGABRT) |
| UUIDs at ~5 min | 18.7M (after 4 repos) | 10.8M (after 23 repos) |

Eclipse MAT on the OOM heap dump showed 11 leaked `rpc-shutdown` Threads dominating 2.73 GB — 64% of heap — each retaining one `RewriteRpcProcess` and its parent `RewriteRpc`.

## Test plan
- [x] `:rewrite-core:test --tests RewriteRpcProcessTest` passes (the JVM-exit cleanup test from #7616 still verifies the hook fires when the process is abandoned).
- [x] Validated end-to-end: full `mod run` workload that previously OOM'd now completes on the same -Xmx4g.