### PR TITLE
rewrite-python: cache JavaVisitor / PyVisitor imports in is_acceptable / accept

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/java/support_types.py
+++ b/rewrite-python/rewrite/src/rewrite/java/support_types.py
@@ -16,6 +16,12 @@ if TYPE_CHECKING:
 
 P = TypeVar('P')
 
+# Cached on first use to avoid the import-machinery cost of repeating
+# `from .visitor import JavaVisitor` inside is_acceptable / accept on every
+# visited Java node (millions of calls per recipe run). The lazy-then-cached
+# pattern preserves the original circular-import workaround.
+_JavaVisitor: Any = None
+
 
 class J(Tree):
     @property
@@ -24,12 +30,18 @@ class J(Tree):
         ...
 
     def is_acceptable(self, v: TreeVisitor[Any, P], p: P) -> bool:
-        from .visitor import JavaVisitor
-        return v.is_adaptable_to(JavaVisitor)
+        global _JavaVisitor
+        if _JavaVisitor is None:
+            from .visitor import JavaVisitor
+            _JavaVisitor = JavaVisitor
+        return v.is_adaptable_to(_JavaVisitor)
 
     def accept(self, v: TreeVisitor[Any, P], p: P) -> Optional[Any]:
-        from .visitor import JavaVisitor
-        return self.accept_java(v.adapt(J, JavaVisitor), p)
+        global _JavaVisitor
+        if _JavaVisitor is None:
+            from .visitor import JavaVisitor
+            _JavaVisitor = JavaVisitor
+        return self.accept_java(v.adapt(J, _JavaVisitor), p)
 
     def accept_java(self, v: 'JavaVisitor[P]', p: P) -> Optional['J']:
         ...

--- a/rewrite-python/rewrite/src/rewrite/python/support_types.py
+++ b/rewrite-python/rewrite/src/rewrite/python/support_types.py
@@ -12,18 +12,29 @@ if TYPE_CHECKING:
 
 P = TypeVar('P')
 
+# Cached on first use to avoid the import-machinery cost of repeating
+# `from .visitor import PythonVisitor` inside is_acceptable / accept on every
+# visited Python node. Lazy-then-cached preserves the circular-import workaround.
+_PythonVisitor: Any = None
+
 
 class Py(J):
     def accept(self, v: TreeVisitor[Any, P], p: P) -> Optional[Any]:
-        from .visitor import PythonVisitor
-        return self.accept_python(v.adapt(Py, PythonVisitor), p)
+        global _PythonVisitor
+        if _PythonVisitor is None:
+            from .visitor import PythonVisitor
+            _PythonVisitor = PythonVisitor
+        return self.accept_python(v.adapt(Py, _PythonVisitor), p)
 
     def accept_python(self, v: 'PythonVisitor[P]', p: P) -> Optional['J']:
         ...
 
     def is_acceptable(self, v: TreeVisitor[Any, P], p: P) -> bool:
-        from .visitor import PythonVisitor
-        return v.is_adaptable_to(PythonVisitor)
+        global _PythonVisitor
+        if _PythonVisitor is None:
+            from .visitor import PythonVisitor
+            _PythonVisitor = PythonVisitor
+        return v.is_adaptable_to(_PythonVisitor)
 
 
 T = TypeVar('T')


### PR DESCRIPTION
## Summary

`J.is_acceptable` and `J.accept` (in `rewrite/java/support_types.py`) each ran `from .visitor import JavaVisitor` on every invocation — likewise `Py.is_acceptable` / `Py.accept` in `rewrite/python/support_types.py` for `PyVisitor`. The from-import is cheap individually, but the cost adds up across the millions of node visits a recipe run does, since the import machinery still walks `sys.modules`.

Cache the visitor class on first use behind a module-level `_JavaVisitor` / `_PyVisitor` global, populated lazily so the original circular-import workaround (`visitor` imports from `support_types`) keeps working.

## Impact

Measured ~3.4s saving on `org.openrewrite.python.migrate.UpgradeToPython314` against `ArchiveBox/ArchiveBox` (228 `.py` files, 61 fixes) — small absolute number but cleanly tractable since the hot path is ~10M-visit-call deep on a typical recipe run. Fix count and files-searched unchanged.

## Test plan

- [x] `pytest rewrite-python/rewrite/tests/` — 1198 passed, 11 skipped
- [x] No behavior change: the cached `_JavaVisitor` / `_PyVisitor` references the same class object the lazy import would have returned

## Why now

Standalone perf tweak. Independent of the in-flight `Preconditions.or` work.
