### PR TITLE
rewrite-python: Unknown declaring-type for unattributed method calls + public SearchResult.found

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/markers.py
+++ b/rewrite-python/rewrite/src/rewrite/markers.py
@@ -111,6 +111,27 @@ class SearchResult(Marker):
         desc = self._description or ""
         return comment_wrapper(f"({desc})" if desc else "")
 
+    @staticmethod
+    def found(tree: Any, description: Optional[str] = None) -> Any:
+        """Add a :class:`SearchResult` marker to ``tree``.
+
+        Mirrors Java's ``org.openrewrite.marker.SearchResult.found(tree)``:
+        returns a new tree (different identity from the input) carrying a
+        fresh :class:`SearchResult` marker. Returns ``None`` unchanged so
+        callers can safely chain through nullable trees.
+
+        Used by search recipes and search-as-precondition visitors to
+        signal "this tree matched"; the wrapping :class:`Check` interprets
+        the identity flip as the gate matching.
+        """
+        if tree is None:
+            return None
+        current = tree.markers
+        new_markers = Markers(
+            current.id, list(current.markers) + [SearchResult(random_id(), description)]
+        )
+        return tree.replace(_markers=new_markers)
+
 
 class Markup(Marker, ABC):
     """

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -941,19 +941,41 @@ class PythonTypeMapping:
         names = [f"arg{i}" for i in range(len(param_types))]
         return names, param_types
 
-    def _get_declaring_type(self, node: ast.Call) -> Optional[JavaType.FullyQualified]:
-        """Get the declaring type (class/module) for a method call."""
+    def _get_declaring_type(self, node: ast.Call) -> JavaType.FullyQualified:
+        """Get the declaring type (class/module) for a method call.
+
+        Always returns a non-null FullyQualified — falls back to
+        :data:`_UNKNOWN` (a shared ``JavaType.Unknown`` singleton) when
+        Ty can't resolve the receiver and AST inference doesn't yield a
+        recognizable type. This keeps ``JavaType.Method.declaring_type``
+        non-null for every method invocation, which is what
+        ``org.openrewrite.java.search.HasMethod`` / ``UsesMethod`` /
+        ``MethodMatcher`` expect: those gates accept ``JavaType.Unknown``
+        receivers under wildcard patterns (``*..*``) but reject method
+        types whose declaring type is null.
+
+        Without this, a precondition like
+        ``Preconditions.check(uses_method("*..* tostring(..)"), V())``
+        was failing on unattributed Python sources (e.g. test fixtures
+        that don't import the receiver type), because the host's
+        wire-side HasMethod gate could not find a matching method use
+        in ``TypesInUse``.
+        """
         if isinstance(node.func, ast.Attribute):
             receiver = node.func.value
 
             # For chained calls like "hello".upper().split(), the receiver is a Call
             if isinstance(receiver, ast.Call):
-                return self._get_call_return_type(receiver)
+                resolved = self._get_call_return_type(receiver)
+                if resolved is not None:
+                    return resolved
 
             # Try to look up receiver type in ty-types index
             type_id = self._lookup_type_id(receiver)
             if type_id is not None:
-                return self._resolve_declaring_type(type_id)
+                resolved = self._resolve_declaring_type(type_id)
+                if resolved is not None:
+                    return resolved
 
         elif isinstance(node.func, ast.Name):
             # For function calls, look up the function name
@@ -976,7 +998,8 @@ class PythonTypeMapping:
                         if module_name and module_name != 'builtins':
                             return self._create_class_type(module_name)
 
-        return self._infer_declaring_type_from_ast(node)
+        inferred = self._infer_declaring_type_from_ast(node)
+        return inferred if inferred is not None else _UNKNOWN
 
     def _resolve_declaring_type(self, type_id: int) -> Optional[JavaType.FullyQualified]:
         """Resolve a type ID to a declaring type, maximizing object reuse.


### PR DESCRIPTION
## Summary

- Two paired changes that together unblock `Preconditions.check(uses_method(...), V())` gates from failing wire-side evaluation when Python sources lack receiver-type attribution (e.g. unit-test fixtures that don't import the receiver). The motivating regression: rewrite-migrate-python#54's recipe wraps were silently no-op'ing for inputs like `my_array.tostring()` once the wire-side `HasMethod` gate became active.

### type_mapping

`PythonTypeMapping._get_declaring_type` previously returned `None` when Ty couldn't resolve the receiver and AST inference didn't yield a recognizable type. That left `JavaType.Method._declaring_type` as `None` for method invocations like `my_array.tostring()` in unattributed sources. The Python `MethodMatcher.matches` explicitly returns `False` when `method_type.declaring_type is None`, so the in-process `UsesMethod` gate fails — and on the wire path `TypesInUse.hasMethodUse` can't reliably match the method either.

Now `_get_declaring_type` returns a non-null `FullyQualified` in every case — falling back to the shared `_UNKNOWN` singleton — so `HasMethod` / `UsesMethod` precondition gates work against unattributed code. The function signature changes from `Optional[JavaType.FullyQualified]` to `JavaType.FullyQualified` to document the new invariant. The intermediate resolution paths (Ty type-id lookup, attribute chain inference) that previously returned None now fall through to the Unknown fallback rather than short-circuiting.

### SearchResult.found

- Adds a public `SearchResult.found(tree, description=None)` static factory mirroring Java's `org.openrewrite.marker.SearchResult.found`. Returns a new tree carrying a fresh `SearchResult` marker — the canonical "different tree" sentinel that `Check` / `CompositePrecondition` interpret as the gate matching. The native `rewrite/python/search/{IsSourceFile,UsesType,UsesMethod}` visitors (added in #7625) were already calling `SearchResult.found(tree)`, which silently AttributeError'd at runtime because the helper didn't exist; this fixes that.

- ## Impact on rewrite-migrate-python#54

Locally I rebuilt rewrite-migrate-python's full test suite against this branch's editable install:

| Before | After |
|---|---|
| 12 failing (`test_array_deprecations`, `test_cgi_parse_deprecations`, `test_html_parser_deprecations`, …) | All 415 passing |

- (One more recipe-level fix in #54 was also needed — `ReplaceReTemplate` was gating on `uses_method` but matches both method and field-access forms of `re.template` / `re.TEMPLATE` — that's a small follow-up commit on the recipe side.)

## Test plan

- [x] `pytest rewrite-python/rewrite/tests/` — 1198 passed, 11 skipped
- [x] Direct unit verification: `PythonTypeMapping().method_invocation_type(ast.parse("data = my_array.tostring()").body[0].value).declaring_type is _UNKNOWN` ✓
- [x] rewrite-migrate-python full suite against an editable install — 415 passed
