### PR TITLE
rewrite-csharp: fix UsesType/UsesMethod local visitor traversal

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/Java/Search/UsesMethod.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Search/UsesMethod.cs
@@ -46,14 +46,17 @@ public class UsesMethod : JavaVisitor<ExecutionContext>
 
     public override J? Visit(Tree? tree, ExecutionContext ctx)
     {
-        if (tree is not SourceFile sf) return tree as J;
-        _found = false;
-        base.Visit(tree, ctx);
-        if (_found)
+        if (tree is SourceFile sf)
         {
-            return SearchResult.Found(sf) as J;
+            _found = false;
+            base.Visit(tree, ctx);
+            if (_found)
+            {
+                return SearchResult.Found(sf) as J;
+            }
+            return sf as J;
         }
-        return sf as J;
+        return base.Visit(tree, ctx);
     }
 
     public override J VisitMethodInvocation(MethodInvocation mi, ExecutionContext ctx)

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Search/UsesType.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Search/UsesType.cs
@@ -42,14 +42,17 @@ public class UsesType : JavaVisitor<ExecutionContext>
 
     public override J? Visit(Tree? tree, ExecutionContext ctx)
     {
-        if (tree is not SourceFile sf) return tree as J;
-        _found = false;
-        base.Visit(tree, ctx);
-        if (_found)
+        if (tree is SourceFile sf)
         {
-            return SearchResult.Found(sf) as J;
+            _found = false;
+            base.Visit(tree, ctx);
+            if (_found)
+            {
+                return SearchResult.Found(sf) as J;
+            }
+            return sf as J;
         }
-        return sf as J;
+        return base.Visit(tree, ctx);
     }
 
     public override J VisitIdentifier(Identifier id, ExecutionContext ctx)


### PR DESCRIPTION
## Summary

- Fixes the failing `PreconditionsCheckTest.PreconditionMatchesAndVisitorRuns` test that's been breaking the main branch since #7628.

- The local `UsesType` / `UsesMethod` visitors added in #7628 overrode `Visit(Tree?, P)` to short-circuit non-`SourceFile` trees:

```csharp
if (tree is not SourceFile sf) return tree as J;
```

When `Check.Visit` dispatches the precondition over a C# source, the CSharpVisitor adapter walks the tree and forwards each child back through `_wrapped.Visit(child)` — i.e. back into this same override. Because children aren't `SourceFile`, the override returned immediately without descending, so `_found` never got set on `Console.WriteLine(...)`, the precondition reported no match, and the inner editor was skipped.

Fix: fall through to `base.Visit(tree, ctx)` for non-`SourceFile` trees so the adapter's child dispatches recurse properly.

## Test plan

- [x] `dotnet test --filter PreconditionsCheckTest` — 3/3 pass (was 1 failing on main)
- [x] `dotnet test --filter Tests.Core.PreconditionsTest` — 7/7 pass (no regression in in-process tests that don't exercise traversal)
- [x] Build is green