### PR TITLE
rewrite-maven: route tests through the Maven settings mirror

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsAutoLoadingExtension.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsAutoLoadingExtension.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.tree.MavenRepository.MAVEN_LOCAL_DEFAULT;
+
+/**
+ * Loads {@code ~/.m2/settings.xml} (and {@code $M2_HOME/conf/settings.xml}) into the
+ * default {@link ExecutionContext} for every {@link RewriteTest} in this module, so a
+ * configured Maven mirror or repository is honored by recipes that resolve artifacts.
+ * Auto-registered via {@code META-INF/services/org.junit.jupiter.api.extension.Extension}.
+ * Tests that construct their own {@link ExecutionContext} and bypass {@code rewriteRun()}
+ * should opt in explicitly via {@link MavenSettings#readMavenSettingsFromDisk(ExecutionContext)}.
+ */
+public class MavenSettingsAutoLoadingExtension implements BeforeAllCallback {
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        RewriteTest.defaultExecutionContextCustomizers.putIfAbsent(
+                MavenSettingsAutoLoadingExtension.class,
+                MavenSettingsAutoLoadingExtension::loadMavenSettings);
+    }
+
+    private static void loadMavenSettings(ExecutionContext ctx) {
+        MavenExecutionContextView mctx = MavenExecutionContextView.view(ctx);
+        boolean nothingConfigured = mctx.getSettings() == null &&
+                                    mctx.getLocalRepository().equals(MAVEN_LOCAL_DEFAULT) &&
+                                    mctx.getRepositories().isEmpty() &&
+                                    mctx.getActiveProfiles().isEmpty() &&
+                                    mctx.getMirrors().isEmpty();
+        if (nothingConfigured) {
+            mctx.setMavenSettings(MavenSettings.readMavenSettingsFromDisk(mctx));
+        }
+    }
+}

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/cache/LocalMavenArtifactCacheTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/cache/LocalMavenArtifactCacheTest.java
@@ -21,7 +21,9 @@ import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.SourceFile;
+import org.openrewrite.maven.MavenExecutionContextView;
 import org.openrewrite.maven.MavenParser;
+import org.openrewrite.maven.MavenSettings;
 import org.openrewrite.maven.tree.*;
 
 import java.io.ByteArrayInputStream;
@@ -154,6 +156,7 @@ class LocalMavenArtifactCacheTest {
 
     private static ResolvedDependency findDependency() {
         ExecutionContext ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
+        MavenExecutionContextView.view(ctx).setMavenSettings(MavenSettings.readMavenSettingsFromDisk(ctx));
         ResolvedGroupArtifactVersion recipeGav = new ResolvedGroupArtifactVersion(
           "https://repo1.maven.org/maven2",
           "org.openrewrite.recipe",

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -205,6 +205,7 @@ class MavenPomDownloaderTest implements RewriteTest {
         @Test
         void onlyAccessRequiredRepositories() throws Exception {
             var ctx = MavenExecutionContextView.view(this.ctx);
+            ctx.setMavenSettings(MavenSettings.readMavenSettingsFromDisk(ctx));
             // Avoid actually trying to reach the made-up https://internalartifactrepository.yourorg.com
             for (MavenRepository repository : ctx.getRepositories()) {
                 repository.setKnownToExist(true);
@@ -253,6 +254,9 @@ class MavenPomDownloaderTest implements RewriteTest {
         @Test
         void mirrorsOverrideRepositoriesInPom() {
             var ctx = MavenExecutionContextView.view(this.ctx);
+            // normalizeRepository probes the mirror over HTTP; the class-level 250ms timeout
+            // is too aggressive under suite load and causes the probe to return null.
+            HttpSenderExecutionContextView.view(this.ctx).setHttpSender(new HttpUrlConnectionSender());
             ctx.setMavenSettings(MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"),
               //language=xml
               """
@@ -1122,6 +1126,7 @@ class MavenPomDownloaderTest implements RewriteTest {
 
         @Test
         void canResolveDifferentVersionOfProjectPom() {
+            MavenExecutionContextView.view(ctx).setMavenSettings(MavenSettings.readMavenSettingsFromDisk(ctx));
             var gav = new GroupArtifactVersion("org.springframework.boot", "spring-boot-starter-parent", "3.0.0");
 
             Path pomPath = Path.of("pom.xml");
@@ -1586,7 +1591,9 @@ class MavenPomDownloaderTest implements RewriteTest {
 
     @Test
     void resolveDependencies() throws Exception {
-        var doc = (Xml.Document) MavenParser.builder().build().parse("""
+        var ctx = new InMemoryExecutionContext();
+        MavenExecutionContextView.view(ctx).setMavenSettings(MavenSettings.readMavenSettingsFromDisk(ctx));
+        var doc = (Xml.Document) MavenParser.builder().build().parse(ctx, """
           <project>
               <parent>
                   <groupId>org.springframework.boot</groupId>
@@ -1606,7 +1613,6 @@ class MavenPomDownloaderTest implements RewriteTest {
               </dependencies>
           </project>
           """).toList().getFirst();
-        var ctx = new InMemoryExecutionContext();
         MavenResolutionResult resolutionResult = doc.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow()
           .resolveDependencies(new MavenPomDownloader(emptyMap(), ctx, null, null), ctx);
         List<ResolvedDependency> deps = resolutionResult.getDependencies().get(Scope.Compile);
@@ -1619,7 +1625,9 @@ class MavenPomDownloaderTest implements RewriteTest {
         // `azure-spring-data-cosmos` brings in `azure-core-http-netty`, which uses property `<boring-ssl-classifier/>`
         // https://repo1.maven.org/maven2/com/azure/azure-spring-data-cosmos/3.45.0/azure-spring-data-cosmos-3.45.0.pom
         // https://repo1.maven.org/maven2/com/azure/azure-core-http-netty/1.16.2/azure-core-http-netty-1.16.2.pom
-        var doc = (Xml.Document) MavenParser.builder().build().parse("""
+        var ctx = new InMemoryExecutionContext();
+        MavenExecutionContextView.view(ctx).setMavenSettings(MavenSettings.readMavenSettingsFromDisk(ctx));
+        var doc = (Xml.Document) MavenParser.builder().build().parse(ctx, """
           <project>
               <groupId>com.example</groupId>
               <artifactId>demo</artifactId>
@@ -1636,7 +1644,6 @@ class MavenPomDownloaderTest implements RewriteTest {
               </dependencies>
           </project>
           """).toList().getFirst();
-        var ctx = new InMemoryExecutionContext();
         MavenResolutionResult resolutionResult = doc.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow()
           .resolveDependencies(new MavenPomDownloader(emptyMap(), ctx, null, null), ctx);
         List<ResolvedDependency> deps = resolutionResult.getDependencies().get(Scope.Compile);

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReaderTest.java
@@ -31,6 +31,7 @@ import org.openrewrite.marketplace.RecipeClassLoader;
 import org.openrewrite.marketplace.RecipeListing;
 import org.openrewrite.marketplace.RecipeMarketplace;
 import org.openrewrite.maven.MavenExecutionContextView;
+import org.openrewrite.maven.MavenSettings;
 import org.openrewrite.maven.cache.LocalMavenArtifactCache;
 import org.openrewrite.maven.utilities.MavenArtifactDownloader;
 
@@ -55,7 +56,9 @@ class MavenRecipeBundleReaderTest {
     void setUp() {
         InMemoryExecutionContext ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
         HttpSenderExecutionContextView.view(ctx).setHttpSender(new HttpUrlConnectionSender());
-        MavenExecutionContextView.view(ctx).setAddCentralRepository(true);
+        MavenExecutionContextView.view(ctx)
+                .setAddCentralRepository(true)
+                .setMavenSettings(MavenSettings.readMavenSettingsFromDisk(ctx));
 
         LocalMavenArtifactCache artifactCache = new LocalMavenArtifactCache(tempDir.resolve("artifacts"));
         MavenArtifactDownloader downloader = new MavenArtifactDownloader(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/marketplace/MavenRecipeMarketplaceGeneratorTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/marketplace/MavenRecipeMarketplaceGeneratorTest.java
@@ -24,6 +24,7 @@ import org.openrewrite.marketplace.RecipeClassLoader;
 import org.openrewrite.marketplace.RecipeListing;
 import org.openrewrite.marketplace.RecipeMarketplace;
 import org.openrewrite.maven.MavenExecutionContextView;
+import org.openrewrite.maven.MavenSettings;
 import org.openrewrite.maven.cache.LocalMavenArtifactCache;
 import org.openrewrite.maven.tree.GroupArtifact;
 import org.openrewrite.maven.utilities.MavenArtifactDownloader;
@@ -80,6 +81,7 @@ class MavenRecipeMarketplaceGeneratorTest {
         HttpSenderExecutionContextView.view(ctx).setHttpSender(new HttpUrlConnectionSender());
         MavenExecutionContextView mavenCtx = MavenExecutionContextView.view(ctx);
         mavenCtx.setAddCentralRepository(true);
+        mavenCtx.setMavenSettings(MavenSettings.readMavenSettingsFromDisk(ctx));
 
         LocalMavenArtifactCache artifactCache = new LocalMavenArtifactCache(tempDir.resolve("artifacts"));
         MavenArtifactDownloader downloader = new MavenArtifactDownloader(
@@ -153,6 +155,7 @@ class MavenRecipeMarketplaceGeneratorTest {
         HttpSenderExecutionContextView.view(ctx).setHttpSender(new HttpUrlConnectionSender());
         MavenExecutionContextView mavenCtx = MavenExecutionContextView.view(ctx);
         mavenCtx.setAddCentralRepository(true);
+        mavenCtx.setMavenSettings(MavenSettings.readMavenSettingsFromDisk(ctx));
 
         LocalMavenArtifactCache artifactCache = new LocalMavenArtifactCache(tempDir.resolve("artifacts"));
         MavenArtifactDownloader downloader = new MavenArtifactDownloader(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindRepositoryOrderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindRepositoryOrderTest.java
@@ -35,7 +35,7 @@ class FindRepositoryOrderTest implements RewriteTest {
     @Test
     void findRepositoryOrder() {
         var ctx = MavenExecutionContextView.view(new InMemoryExecutionContext());
-        ctx.setMavenSettings(MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"),
+        MavenSettings testSettings = MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"),
           //language=xml
           """
             <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
@@ -60,7 +60,9 @@ class FindRepositoryOrderTest implements RewriteTest {
                 </profiles>
             </settings>
             """
-        ), ctx));
+        ), ctx);
+        // Merge in user/install settings so any configured mirror (e.g. CI's moderne-cache) still applies.
+        ctx.setMavenSettings(testSettings.merge(MavenSettings.readMavenSettingsFromDisk(ctx)));
 
         rewriteRun(
           spec -> spec

--- a/rewrite-maven/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/rewrite-maven/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.openrewrite.maven.MavenSettingsAutoLoadingExtension


### PR DESCRIPTION
## Summary
- Add `MavenSettingsAutoLoadingExtension` (+ JUnit `META-INF/services` registration) so every `RewriteTest` in `rewrite-maven` loads `~/.m2/settings.xml` into the default `ExecutionContext` — mirroring what `rewrite-gradle` already does. In CI this routes Maven resolution through `moderne-cache-3` instead of Cloudflare-fronted Central, which has been returning 404 + Retry-After under rate limits.
- Tests that build their own `InMemoryExecutionContext` and bypass `rewriteRun()` (e.g. `MavenPomDownloaderTest.resolveDependencies`, `MavenRecipeBundleReaderTest.setUp`, `MavenRecipeMarketplaceGeneratorTest`, `LocalMavenArtifactCacheTest.findDependency`) opt in explicitly via `MavenSettings.readMavenSettingsFromDisk(ctx)`. `FindRepositoryOrderTest` merges its hand-crafted settings with the on-disk ones so the test's profile still wins but any CI-configured mirror still applies.
- `MavenPomDownloaderTest.mirrorsOverrideRepositoriesInPom` now uses a default-timeout `HttpUrlConnectionSender` instead of the class-level 250 ms one. The 250 ms is intentionally aggressive for the surrounding fast-fail tests, but under suite load this one test's mirror probe was timing out and returning null.

## Test plan
- [x] `./gradlew :rewrite-maven:test` — passes locally (with a `~/.m2/settings.xml` that mirrors `*` to `artifactory.moderne.ninja/.../moderne-cache-3`)
- [ ] CI green on this branch — should see the 28 previously-failing tests from run 25616076143 (`MavenRecipeBundleReaderTest`, `MavenRecipeMarketplaceGeneratorTest`, `LocalMavenArtifactCacheTest`, `FindRepositoryOrderTest`, `MavenPomDownloaderTest.resolveDependencies` / `emptyClassifierPropertyInIntermediatePom` / `onlyAccessRequiredRepositories` / `canResolveDifferentVersionOfProjectPom`) pass via the mirror

## Known not-fixed
The `UpdateMavenWrapperTest` failures from the same CI run are **not** addressed here. Those go through `rewriteRun()` so this PR's extension does load settings into the ctx, and metadata fetches via `MavenPomDownloader` now go through the mirror — but the wrapper JAR/distribution download bypasses Maven settings entirely (`MavenWrapper.create()` builds a `Remote` from the un-mirrored repository URI, then downloads via raw `HttpSender` with no mirror translation or server credential lookup). Fixing that needs a source-side change in `MavenWrapper`, not a test change, so it's intentionally out of scope here.