### PR TITLE
Scala: fix parsing of optional semicolon in for loops

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -1531,14 +1531,10 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             JRightPadded<S.For.Enumerator> rp = elems.get(i);
             visit(rp.getElement(), p);
             visitSpace(rp.getAfter(), Space.Location.LANGUAGE_EXTENSION, p);
-            // Print ';' separator only if both this and next element are NOT guards.
-            // Scala's for-comprehensions don't separate guards with ';'.
-            // In paren-less form, enumerators are separated by newlines (whitespace), not ';'.
-            if (i < elems.size() - 1 && !parenless) {
-                S.For.Enumerator next = elems.get(i + 1).getElement();
-                if (next.getKind() != S.For.Enumerator.Kind.Guard) {
-                    p.append(';');
-                }
+            // An explicit ';' separator is preserved via a Semicolon marker on the
+            // JRightPadded. Newline-separated generators have no marker and no ';'.
+            if (rp.getMarkers().findFirst(Semicolon.class).isPresent()) {
+                p.append(';');
             }
         }
         if (!parenless) {

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -6403,13 +6403,28 @@ class ScalaTreeVisitor(
         s"For enumerator rhs did not produce an Expression: ${rhsTree.getClass.getSimpleName}")
     }
 
-    // Determine the after-space (before `;` separator or, for the last enumerator,
-    // before the closing bracket). For an enumerator followed by a guard, there is
-    // no `;` in the source — the guard's prefix captures the whitespace.
+    // Determine the after-space and whether an explicit `;` separator was present.
+    // Scala for-comprehensions allow `;` between generators, but newline-separated
+    // generators have no `;`. Track this via the Semicolon marker so the printer
+    // can round-trip correctly.
+    var rpMarkers: Markers = Markers.EMPTY
     val after: Space = if (!isLast) {
-      val sep = source.indexOf(';', cursor)
-      if (sep >= 0 && sep < closeBracketPos) {
+      // Look for `;` before any non-whitespace char and before the next enumerator.
+      // If only whitespace separates this enumerator from the next, there was no `;`.
+      val sep = {
+        var idx = -1
+        var j = cursor
+        while (idx < 0 && j < closeBracketPos) {
+          val c = source.charAt(j)
+          if (c == ';') idx = j
+          else if (!c.isWhitespace) j = closeBracketPos // stop scanning
+          else j += 1
+        }
+        idx
+      }
+      if (sep >= 0) {
         val s = if (sep > cursor) Space.format(source.substring(cursor, sep)) else Space.EMPTY
+        rpMarkers = Markers.EMPTY.add(new Semicolon(UUID.randomUUID()))
         cursor = sep + 1
         s
       } else Space.EMPTY
@@ -6424,7 +6439,7 @@ class ScalaTreeVisitor(
 
     val enumerator = new S.For.Enumerator(Tree.randomId(), enumPrefix, Markers.EMPTY,
       kind, lhs, beforeOp, rhs)
-    JRightPadded.build(enumerator).withAfter(after)
+    new JRightPadded(enumerator, after, rpMarkers)
   }
 
   /** Common parser for ForDo (complex) and ForYield. */

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/Scala2CompatTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/Scala2CompatTest.java
@@ -1136,4 +1136,22 @@ class Scala2CompatTest implements RewriteTest {
             }
         }
     }
+
+    @Test
+    void forComprehensionWithBlockBody() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  for {
+                    _ <- Some(1)
+                    field <- Some(2)
+                  } {
+                    println(field)
+                  }
+                }
+                """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fix parsing of optional semicolon in `for` loops. And the variant of it without a semicolon, but a newline in between, e.g.
```scala
                  for {
                    _ <- Some(1)
                    field <- Some(2)
                  }
```

## What's your motivation?

They suffer from idempotency issues.