### PR TITLE
Speed up Tree.randomId() with ThreadLocalRandom

### DIFF
--- a/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/core/TreeRandomIdBenchmark.java
+++ b/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/core/TreeRandomIdBenchmark.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.core;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.Tree;
+
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+public class TreeRandomIdBenchmark {
+
+    @Benchmark
+    @Threads(1)
+    public void uuidRandomUUID_singleThread(Blackhole bh) {
+        bh.consume(UUID.randomUUID());
+    }
+
+    @Benchmark
+    @Threads(8)
+    public void uuidRandomUUID_multiThread(Blackhole bh) {
+        bh.consume(UUID.randomUUID());
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void treeRandomId_singleThread(Blackhole bh) {
+        bh.consume(Tree.randomId());
+    }
+
+    @Benchmark
+    @Threads(8)
+    public void treeRandomId_multiThread(Blackhole bh) {
+        bh.consume(Tree.randomId());
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void inlineThreadLocalRandom_singleThread(Blackhole bh) {
+        ThreadLocalRandom r = ThreadLocalRandom.current();
+        long msb = (r.nextLong() & 0xffffffffffff0fffL) | 0x0000000000004000L;
+        long lsb = (r.nextLong() & 0x3fffffffffffffffL) | 0x8000000000000000L;
+        bh.consume(new UUID(msb, lsb));
+    }
+
+    @Benchmark
+    @Threads(8)
+    public void inlineThreadLocalRandom_multiThread(Blackhole bh) {
+        ThreadLocalRandom r = ThreadLocalRandom.current();
+        long msb = (r.nextLong() & 0xffffffffffff0fffL) | 0x0000000000004000L;
+        long lsb = (r.nextLong() & 0x3fffffffffffffffL) | 0x8000000000000000L;
+        bh.consume(new UUID(msb, lsb));
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(TreeRandomIdBenchmark.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/core/package-info.java
+++ b/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/core/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.openrewrite.benchmarks.core;
+
+import org.jspecify.annotations.NullMarked;

--- a/rewrite-core/src/main/java/org/openrewrite/Tree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Tree.java
@@ -23,13 +23,16 @@ import org.openrewrite.marker.Markers;
 import org.openrewrite.quark.Quark;
 
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@c", include = JsonTypeInfo.As.PROPERTY)
 public interface Tree {
 
     static UUID randomId() {
-        //noinspection ConstantConditions
-        return UUID.randomUUID();
+        ThreadLocalRandom r = ThreadLocalRandom.current();
+        long msb = (r.nextLong() & 0xffffffffffff0fffL) | 0x0000000000004000L; // version 4
+        long lsb = (r.nextLong() & 0x3fffffffffffffffL) | 0x8000000000000000L; // variant IETF
+        return new UUID(msb, lsb);
     }
 
     /**

--- a/rewrite-core/src/test/java/org/openrewrite/TreeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/TreeTest.java
@@ -26,6 +26,14 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.text.PlainText;
 
 import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.UnaryOperator;
 
 import static java.util.Objects.requireNonNull;
@@ -34,6 +42,56 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.openrewrite.test.SourceSpecs.text;
 
 class TreeTest implements RewriteTest {
+
+    @Test
+    void randomIdReturnsUuidV4WithIetfVariant() {
+        for (int i = 0; i < 1000; i++) {
+            UUID id = Tree.randomId();
+            assertThat(id.version()).isEqualTo(4);
+            assertThat(id.variant()).isEqualTo(2); // IETF (RFC 4122)
+        }
+    }
+
+    @Test
+    void randomIdProducesNoDuplicatesAcrossManyCalls() {
+        int n = 1_000_000;
+        Set<UUID> seen = new HashSet<>(n);
+        for (int i = 0; i < n; i++) {
+            seen.add(Tree.randomId());
+        }
+        assertThat(seen).hasSize(n);
+    }
+
+    @Test
+    void randomIdIsUniqueAcrossThreads() throws InterruptedException {
+        int threads = 16;
+        int perThread = 100_000;
+        Set<UUID> ids = ConcurrentHashMap.newKeySet(threads * perThread);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        try {
+            for (int t = 0; t < threads; t++) {
+                pool.submit(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < perThread; i++) {
+                            ids.add(Tree.randomId());
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertThat(done.await(60, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            pool.shutdownNow();
+        }
+        assertThat(ids).hasSize(threads * perThread);
+    }
 
     @Test
     void customMarkerPrinting() {


### PR DESCRIPTION
## Motivation

`Tree.randomId()` previously delegated to `UUID.randomUUID()`, which reads from a shared `SecureRandom` instance. On macOS and Linux this runs SHA-1 over `/dev/urandom` output, and the shared instance contends across threads — a real concern for OpenRewrite since recipe visitors run on a ForkJoinPool.

JFR profiling of a real recipe run (the AssertJ migration over this repository) attributed roughly **1.5-2% of recipe CPU** to `randomId()` and its downstream `SecureRandom` / SHA path:

- Direct `Tree.randomId()` frames: ~75 samples
- `ByteArrayAccess.i2bBig` (SHA inside `SecureRandom`): ~51 samples
- Plus `SecureRandom.nextBytes`, `NativePRNG.engineNextBytes`, `MessageDigest.digest` deeper in stacks

Tree IDs are **process-local identity tokens**, not cryptographic secrets — they only need to be collision-resistant within a JVM session. `ThreadLocalRandom` is the right fit: ~50ns per UUID, no thread contention, JDK built-in.

## Examples

```java
static UUID randomId() {
    ThreadLocalRandom r = ThreadLocalRandom.current();
    long msb = (r.nextLong() & 0xffffffffffff0fffL) | 0x0000000000004000L; // version 4
    long lsb = (r.nextLong() & 0x3fffffffffffffffL) | 0x8000000000000000L; // variant IETF
    return new UUID(msb, lsb);
}
```

The bit masking matches what `UUID.randomUUID()` does internally to produce an RFC 4122 §4.4 version-4 UUID: clear version bits + set to 4, clear variant bits + set to IETF. The returned `java.util.UUID` is observationally indistinguishable from the previous implementation — same type, same `toString()` format, same equality/hashCode behavior. This changes the *implementation* of `Tree.randomId()`, not its *contract*.

## Benchmark

`TreeRandomIdBenchmark` (JMH, throughput, ops/µs — higher is better) on this machine:

| Benchmark                                | Threads | Score (ops/µs) | Alloc/op |
| ---------------------------------------- | ------- | -------------- | -------- |
| `UUID.randomUUID()` (baseline)           | 1       | 4.05           | 128 B    |
| `Tree.randomId()` (new)                  | 1       | 140.71         | 32 B     |
| `ThreadLocalRandom` inlined (sanity)     | 1       | 165.36         | 32 B     |
| `UUID.randomUUID()` (baseline)           | 8       | 2.12           | 128 B    |
| `Tree.randomId()` (new)                  | 8       | 311.83         | 32 B     |
| `ThreadLocalRandom` inlined (sanity)     | 8       | 515.12         | 32 B     |

Single-threaded: ~**35×** faster. Eight threads: ~**147×** faster — the bigger jump reflects how the old code contends on the shared `SecureRandom`, while the new code uses per-thread state. Allocation per call drops from 128 B (extra `byte[]` from `SecureRandom`) to 32 B (just the `UUID` object).

## Summary

- Replace `UUID.randomUUID()` inside `Tree.randomId()` with a `ThreadLocalRandom`-backed UUIDv4 generator
- Add `TreeTest` cases covering UUIDv4 format compliance, single-threaded uniqueness across 1,000,000 calls, and concurrent uniqueness across 16 threads × 100,000 calls
- Add `TreeRandomIdBenchmark` under `rewrite-benchmarks` comparing `UUID.randomUUID()`, the new `Tree.randomId()`, and an inlined `ThreadLocalRandom` baseline, at 1 and 8 threads
- No other call sites of `UUID.randomUUID()` are touched (e.g., `HttpSender` multipart boundaries remain on the cryptographic source)

## Test plan

- [x] `./gradlew :rewrite-core:check` passes
- [x] `TreeTest.randomIdReturnsUuidV4WithIetfVariant` asserts `version() == 4` and `variant() == 2` (IETF / RFC 4122) over 1,000 generated IDs
- [x] `TreeTest.randomIdProducesNoDuplicatesAcrossManyCalls` generates 1,000,000 IDs into a `HashSet` and asserts no collisions
- [x] `TreeTest.randomIdIsUniqueAcrossThreads` generates 16 × 100,000 IDs concurrently into a `ConcurrentHashMap` keyset and asserts no collisions
- [x] `TreeRandomIdBenchmark` run end-to-end; results captured above