### PR TITLE
Scala: fix parsing for postfix operator syntax

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -671,26 +671,42 @@ class ScalaTreeVisitor(
         )
         
       case _ =>
-        // Other postfix operators - treat as unary for now
+        // Scala postfix call `obj op` is equivalent to `obj.op` — model it as a
+        // J.MethodInvocation with no arguments and the InfixNotation marker so the
+        // printer emits `<select> <name>` rather than `<select>.<name>()`.
         val prefix = extractPrefix(postfixOp.span)
-        
-        val expr = visitTree(postfixOp.od) match {
+
+        val selectExpr = visitTree(postfixOp.od) match {
           case e: Expression => e
           case j: J => new S.StatementExpression(Tree.randomId(), j)
           case _ => return visitUnknown(postfixOp)
         }
 
-        // For postfix operators, we need to determine the operator type
-        // Currently only handling as PostDecrement (as a placeholder)
-        val operator = J.Unary.Type.PostDecrement // This is a placeholder
-        
-        new J.Unary(
+        val opName = postfixOp.op.name.toString
+        val odEnd = Math.max(0, postfixOp.od.span.end - offsetAdjustment)
+        val opStart = Math.max(0, postfixOp.op.span.start - offsetAdjustment)
+        val namePrefix = if (odEnd < opStart && odEnd >= 0 && opStart <= source.length) {
+          Space.format(source.substring(odEnd, opStart))
+        } else {
+          Space.format(" ")
+        }
+
+        updateCursor(postfixOp.span.end)
+
+        val name = ident(opName, namePrefix, typeFor(postfixOp.op.span))
+
+        val markersList = new util.ArrayList[org.openrewrite.marker.Marker]()
+        markersList.add(InfixNotation.create())
+
+        new J.MethodInvocation(
           Tree.randomId(),
           prefix,
-          Markers.EMPTY,
-          JLeftPadded.build(operator).withBefore(Space.EMPTY),
-          expr,
-          JavaType.Primitive.Boolean
+          Markers.build(markersList),
+          JRightPadded.build(selectExpr),
+          null,
+          name,
+          JContainer.build(Space.EMPTY, new util.ArrayList[JRightPadded[Expression]](), Markers.EMPTY),
+          methodTypeFor(postfixOp.span)
         )
     }
   }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixTest.java
@@ -37,6 +37,20 @@ class InfixTest implements RewriteTest {
     }
 
     @Test
+    void postfixChainInsideBlock() {
+        rewriteRun(
+          scala(
+            """
+            import scala.language.postfixOps
+            val r = {
+              x must not beNull
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void namedInfixMax() {
         rewriteRun(
           scala("val x = 1 max 2")

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.scala.tree;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
@@ -33,20 +34,6 @@ class InfixTest implements RewriteTest {
     void namedInfix() {
         rewriteRun(
           scala("val x = list map func")
-        );
-    }
-
-    @Test
-    void postfixChainInsideBlock() {
-        rewriteRun(
-          scala(
-            """
-            import scala.language.postfixOps
-            val r = {
-              x must not beNull
-            }
-            """
-          )
         );
     }
 
@@ -142,5 +129,167 @@ class InfixTest implements RewriteTest {
             })
           )
         );
+    }
+
+    @Nested
+    class Postfix implements RewriteTest {
+
+        @Test
+        void chainInsideBlock() {
+            rewriteRun(
+              scala(
+                """
+                import scala.language.postfixOps
+                val r = {
+                  x must not beNull
+                }
+                """
+              )
+            );
+        }
+
+        @Test
+        void simple() {
+            rewriteRun(
+              scala(
+                """
+                import scala.language.postfixOps
+                val r = x foo
+                """
+              )
+            );
+        }
+
+        @Test
+        void onLiteral() {
+            rewriteRun(
+              scala(
+                """
+                import scala.language.postfixOps
+                val r = 5 toString
+                """
+              )
+            );
+        }
+
+        @Test
+        void onParenthesizedExpression() {
+            rewriteRun(
+              scala(
+                """
+                import scala.language.postfixOps
+                val r = (1 + 2) toString
+                """
+              )
+            );
+        }
+
+        @Test
+        void onMethodCall() {
+            rewriteRun(
+              scala(
+                """
+                import scala.language.postfixOps
+                val r = List(1, 2, 3).head toString
+                """
+              )
+            );
+        }
+
+        @Test
+        void asMiddleStatement() {
+            rewriteRun(
+              scala(
+                """
+                import scala.language.postfixOps
+                val r = {
+                  x foo
+                  y bar
+                  z
+                }
+                """
+              )
+            );
+        }
+
+        @Test
+        void insideMethodBody() {
+            rewriteRun(
+              scala(
+                """
+                import scala.language.postfixOps
+                object Test {
+                  def run() = {
+                    val x = 1
+                    x must not beNull
+                  }
+                }
+                """
+              )
+            );
+        }
+
+        @Test
+        void withSemicolon() {
+            rewriteRun(
+              scala(
+                """
+                import scala.language.postfixOps
+                val r = { x foo; y }
+                """
+              )
+            );
+        }
+
+        @Test
+        void inIfBranch() {
+            rewriteRun(
+              scala(
+                """
+                import scala.language.postfixOps
+                val r = if (true) x foo else y bar
+                """
+              )
+            );
+        }
+
+        @Test
+        void inMatchCase() {
+            rewriteRun(
+              scala(
+                """
+                import scala.language.postfixOps
+                val r = x match {
+                  case 1 => y foo
+                  case _ => z bar
+                }
+                """
+              )
+            );
+        }
+
+        @Test
+        void asLastInBlockNoNewline() {
+            rewriteRun(
+              scala(
+                """
+                import scala.language.postfixOps
+                val r = { x foo }
+                """
+              )
+            );
+        }
+
+        @Test
+        void inForYield() {
+            rewriteRun(
+              scala(
+                """
+                import scala.language.postfixOps
+                val r = for (i <- List(1)) yield i toString
+                """
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
## What's changed?

Fix parsing of Scala postfix operator syntax expressions, e.g. `x must not beNull`

## What's your motivation?

They suffer from idempotency issues.