### PR TITLE
Scala: fix parsing of braced packages

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -33,6 +33,7 @@ import org.openrewrite.java.tree.TypeTree;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.scala.marker.BlockArgument;
 import org.openrewrite.scala.marker.IndentedSyntax;
+import org.openrewrite.scala.marker.PackageBraces;
 import org.openrewrite.scala.marker.SObject;
 import org.openrewrite.scala.marker.Semicolon;
 import org.openrewrite.scala.marker.TypeProjection;
@@ -43,6 +44,7 @@ import org.openrewrite.scala.marker.UnderscorePlaceholderLambda;
 import org.openrewrite.scala.tree.S;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * ScalaPrinter is responsible for converting the Scala LST back to source code.
@@ -620,6 +622,14 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             visit(statement, p);
         }
 
+        if (scu.getPackageDeclaration() != null) {
+            Optional<PackageBraces> braces = scu.getPackageDeclaration().getMarkers().findFirst(PackageBraces.class);
+            if (braces.isPresent()) {
+                p.append(braces.get().afterBody());
+                p.append('}');
+            }
+        }
+
         visitSpace(scu.getEof(), Space.Location.COMPILATION_UNIT_EOF, p);
         afterSyntax(scu, p);
         return scu;
@@ -632,6 +642,11 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         visit(pkg.getExpression(), p);
         if (pkg.getMarkers().findFirst(IndentedSyntax.class).isPresent()) {
             p.append(':');
+        }
+        Optional<PackageBraces> braces = pkg.getMarkers().findFirst(PackageBraces.class);
+        if (braces.isPresent()) {
+            p.append(braces.get().beforeBrace());
+            p.append('{');
         }
         // Note: No semicolon in Scala package declarations
         afterSyntax(pkg, p);

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaASTConverter.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaASTConverter.scala
@@ -21,7 +21,7 @@ import org.openrewrite.Tree
 import org.openrewrite.java.internal.JavaTypeFactory
 import org.openrewrite.java.tree.*
 import org.openrewrite.marker.Markers
-import org.openrewrite.scala.marker.IndentedSyntax
+import org.openrewrite.scala.marker.{IndentedSyntax, PackageBraces}
 
 import java.util
 import java.util.{Collections, List as JList, UUID}
@@ -124,6 +124,27 @@ class ScalaASTConverter {
               case other =>
             }
         }
+
+        // For braced package syntax, consume the closing `}` so it doesn't leak into
+        // EOF whitespace, and record the space before it on the marker for re-emission.
+        if (packageDecl != null) {
+          val bracesMarker = packageDecl.getMarkers.findFirst(classOf[PackageBraces])
+          if (bracesMarker.isPresent) {
+            val srcText = visitor.getSourceText
+            val srcOffset = visitor.getOffsetAdjustment
+            val startIdx = visitor.getCursor - srcOffset
+            var i = startIdx
+            while (i < srcText.length && srcText.charAt(i) != '}') {
+              i += 1
+            }
+            if (i < srcText.length && srcText.charAt(i) == '}') {
+              val afterBody = srcText.substring(startIdx, i)
+              val updated = bracesMarker.get.copy(afterBody = afterBody)
+              packageDecl = packageDecl.withMarkers(packageDecl.getMarkers.computeByType(updated, (_: PackageBraces, n: PackageBraces) => n))
+              visitor.updateCursor(i + 1 + srcOffset)
+            }
+          }
+        }
       case imp: Trees.Import[?] =>
         // Top-level import - simple ones as J.Import, complex ones as statements
         val converted = visitor.visitTree(imp)
@@ -166,17 +187,22 @@ class ScalaASTConverter {
     // This includes "package" keyword + package name
     val packageEndPos = pkgDef.pid.span.end
 
-    // Detect Scala 3 indented package syntax: `package foo.bar:` followed by an indented region.
-    // If the next non-space character after the package name is `:`, consume it and tag the
-    // J.Package with IndentedSyntax so the printer re-emits the colon.
+    // Detect Scala 3 indented package syntax: `package foo.bar:` followed by an indented region,
+    // or braced package syntax: `package foo.bar { ... }`. In each case consume the delimiter
+    // and tag the J.Package with the appropriate marker so the printer re-emits it.
     val srcText = visitor.getSourceText
     val srcOffset = visitor.getOffsetAdjustment
-    var scanIdx = packageEndPos - srcOffset
+    val scanStart = packageEndPos - srcOffset
+    var scanIdx = scanStart
     while (scanIdx < srcText.length && (srcText.charAt(scanIdx) == ' ' || srcText.charAt(scanIdx) == '\t')) {
       scanIdx += 1
     }
-    val hasIndentedColon = scanIdx < srcText.length && srcText.charAt(scanIdx) == ':'
-    val cursorAfter = if (hasIndentedColon) scanIdx + 1 + srcOffset else packageEndPos
+    val nextChar = if (scanIdx < srcText.length) srcText.charAt(scanIdx) else 0.toChar
+    val hasIndentedColon = nextChar == ':'
+    val hasBraces = nextChar == '{'
+    val cursorAfter =
+      if (hasIndentedColon || hasBraces) scanIdx + 1 + srcOffset
+      else packageEndPos
 
     // Update the visitor's cursor to after the package declaration
     // This is crucial to prevent the package text from being included
@@ -188,6 +214,9 @@ class ScalaASTConverter {
 
     val markers = if (hasIndentedColon) {
       Markers.build(Collections.singletonList(new IndentedSyntax(UUID.randomUUID())))
+    } else if (hasBraces) {
+      val beforeBrace = srcText.substring(scanStart, scanIdx)
+      Markers.build(Collections.singletonList(PackageBraces(UUID.randomUUID(), beforeBrace, "")))
     } else {
       Markers.EMPTY
     }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/marker/ScalaMarkers.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/marker/ScalaMarkers.scala
@@ -83,3 +83,17 @@ case class Curried(id: UUID) extends Marker {
   override def getId(): UUID = id
   override def withId[M <: Marker](newId: UUID): M = copy(id = newId).asInstanceOf[M]
 }
+
+/**
+ * Marks a `J.Package` that uses Scala's braced package syntax:
+ * `package foo.bar { ... }`. The printer uses this to re-emit the
+ * opening brace after the package name. The closing brace is preserved
+ * in the compilation unit's EOF whitespace.
+ *
+ * @param beforeBrace whitespace between the package name and the opening brace
+ * @param afterBody whitespace between the last statement and the closing brace
+ */
+case class PackageBraces(id: UUID, beforeBrace: String, afterBody: String) extends Marker {
+  override def getId(): UUID = id
+  override def withId[M <: Marker](newId: UUID): M = copy(id = newId).asInstanceOf[M]
+}

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
@@ -166,6 +166,19 @@ class CompilationUnitTest implements RewriteTest {
     }
 
     @Test
+    void packageWithBraces() {
+        rewriteRun(
+          scala(
+            """
+            package foo.bar {
+              val x = 42
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void indentedPackage() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

Fix Scala parser to handle braced package definitions.

## What's your motivation?

They suffer from idempotency issues.