### PR TITLE
Fix NPE in ChangeManagedDependencyGroupIdAndArtifactId for deserialized Pom

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
@@ -30,6 +30,7 @@ import org.openrewrite.xml.tree.Xml;
 
 import java.util.*;
 
+import static java.util.Collections.emptySet;
 import static java.util.Collections.max;
 import static java.util.stream.Collectors.toSet;
 import static org.openrewrite.Validated.test;
@@ -214,10 +215,15 @@ public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
                 }
             }
 
+            @SuppressWarnings("ConstantConditions")
             private Set<String> getSafeVersionPlaceholdersToChange(String groupId, String artifactId, ExecutionContext ctx) {
                 MavenResolutionResult result = getResolutionResult();
                 final ResolvedPom resolvedPom = result.getPom();
                 Pom requestedPom = resolvedPom.getRequested();
+                // Pom fields default to emptyList() via @Builder.Default, but deserialization can leave them null
+                if (requestedPom.getDependencyManagement() == null) {
+                    return emptySet();
+                }
                 Set<String> relevantProperties = requestedPom.getDependencyManagement().stream()
                         .filter(md -> isProperty(md.getVersion()) &&
                                 matchesGlob(resolvedPom.getValue(md.getGroupId()), groupId) &&


### PR DESCRIPTION
## Summary
- `getSafeVersionPlaceholdersToChange` threw an NPE at line 221 when `requestedPom.getDependencyManagement()` returned null.
- Although the field is declared `@Builder.Default = emptyList()`, deserialization can bypass the builder and leave it null (same diagnosis as the comment in `MavenDependencyPropertyUsageOverlap.java:43`).
- Added a null guard returning `emptySet()`, matching the existing precedent. `@SuppressWarnings("ConstantConditions")` is added because IntelliJ's static analysis cannot see the deserialization path — same approach already used on `resolveSemverVersion` in this file.

## Test plan
- [x] `./gradlew :rewrite-maven:test --tests "*ChangeManagedDependencyGroupIdAndArtifactIdTest"` passes
- [ ] Consider adding a regression test exercising a deserialized Pom with null `dependencyManagement`