### PR TITLE
Scala: add support for non-standard space around method return type

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -434,6 +434,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         }
 
         if (method.getReturnTypeExpression() != null) {
+            method.getReturnTypeExpression().getMarkers()
+                    .findFirst(org.openrewrite.scala.marker.ReturnTypeColonPrefix.class)
+                    .ifPresent(m -> visitSpace(m.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
             p.append(':');
             visit(method.getReturnTypeExpression(), p);
         }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/ReturnTypeColonPrefix.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/ReturnTypeColonPrefix.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Stores the whitespace that appears between the method signature (name or parameter list)
+ * and the {@code :} of an explicit return type annotation in Scala, e.g. the space in
+ * {@code def foo : Int = 5}. Attached to the method's return type expression.
+ * The space after the colon is stored in the return type expression's own prefix.
+ */
+@Value
+@With
+public class ReturnTypeColonPrefix implements Marker {
+    UUID id;
+    Space prefix;
+
+    public static ReturnTypeColonPrefix create(Space prefix) {
+        return new ReturnTypeColonPrefix(Tree.randomId(), prefix);
+    }
+}

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5415,11 +5415,18 @@ class ScalaTreeVisitor(
 
         // Only use the type if there's a colon BEFORE the equals sign (explicit type annotation)
         if (colonIdx >= 0 && (equalsIdx < 0 || colonIdx < equalsIdx)) {
+          val beforeColon = Space.format(betweenText.substring(0, colonIdx))
           cursor = cursor + colonIdx + 1
-          visitTree(tpt) match {
+          val visited = visitTree(tpt) match {
             case tt: TypeTree => tt
             case id: J.Identifier => id
             case _ => null
+          }
+          if (visited != null && beforeColon != Space.EMPTY) {
+            visited.withMarkers(visited.getMarkers.addIfAbsent(
+              org.openrewrite.scala.marker.ReturnTypeColonPrefix.create(beforeColon))).asInstanceOf[TypeTree]
+          } else {
+            visited
           }
         } else {
           null // Inferred type — not written in source

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -37,6 +37,32 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void extraSpaceBeforeReturnTypeColon() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def foo : Int = 5
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void extraSpaceBeforeReturnTypeColonWithParens() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def foo()  :  Int = 5
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void extraSpaceBeforeParameterDefaultEquals() {
         rewriteRun(
             scala(


### PR DESCRIPTION
## What's changed?

Fix Scala parser/printer for non-standard whitespace around method's return type, e.g. `def foo : Int = 5`. Notice the extra space after colon.

## What's your motivation?

It suffers from idempotency issues.