### PR TITLE
rpc: allow sharing the in-flight Semaphore across ExecutionContexts

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcExecutionContextView.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcExecutionContextView.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.rpc;
 
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.DelegatingExecutionContext;
 import org.openrewrite.ExecutionContext;
 
@@ -22,7 +23,6 @@ import java.util.concurrent.Semaphore;
 import java.util.function.Supplier;
 
 public class RewriteRpcExecutionContextView extends DelegatingExecutionContext {
-    private static final String MAX_IN_FLIGHT = "org.openrewrite.rpc.maxInFlight";
     private static final String IN_FLIGHT_SEMAPHORE = "org.openrewrite.rpc.inFlightSemaphore";
 
     public RewriteRpcExecutionContextView(ExecutionContext delegate) {
@@ -37,30 +37,56 @@ public class RewriteRpcExecutionContextView extends DelegatingExecutionContext {
     }
 
     /**
-     * Cap on concurrent in-flight RPC requests across this run, sized to the
-     * memory headroom of the host running rewrite-rpc subprocesses. Each
+     * Install a {@link Semaphore} that caps the number of concurrent in-flight
+     * rewrite-rpc requests this {@link ExecutionContext} participates in. Each
      * permit covers one actively-executing visit/parse/generate/print; idle
-     * subprocesses do not consume a permit. Default is unlimited so that
-     * out-of-the-box OpenRewrite behavior is unchanged; callers (e.g. a host
-     * that knows its own memory budget) opt in by setting an explicit cap.
+     * subprocesses do not consume a permit.
+     * <p>
+     * Pass the <strong>same</strong> {@code Semaphore} instance into multiple
+     * {@code ExecutionContext}s (e.g. one per parallel recipe-run task) to
+     * give them a single shared concurrency budget. This is the intended way
+     * to enforce a host-wide cap when many independent {@code ExecutionContext}s
+     * exist on the same JVM.
+     * <p>
+     * If no semaphore is installed, in-flight calls are unbounded — the
+     * out-of-the-box OpenRewrite default.
      */
-    public RewriteRpcExecutionContextView setMaxInFlight(int maxInFlight) {
-        putMessage(MAX_IN_FLIGHT, maxInFlight);
+    public RewriteRpcExecutionContextView setInFlightSemaphore(Semaphore inFlightSemaphore) {
+        putMessage(IN_FLIGHT_SEMAPHORE, inFlightSemaphore);
         return this;
     }
 
-    public int getMaxInFlight() {
-        return getMessage(MAX_IN_FLIGHT, Integer.MAX_VALUE);
+    public @Nullable Semaphore getInFlightSemaphore() {
+        return getMessage(IN_FLIGHT_SEMAPHORE);
     }
 
     /**
-     * Run {@code work} while holding one of the in-flight RPC permits. The
-     * semaphore is created lazily on first call and shared across every
-     * thread that observes this ExecutionContext.
+     * Convenience for the single-context case: install a fresh {@code Semaphore}
+     * with the given number of permits. The semaphore is created here and is
+     * scoped to this {@code ExecutionContext} only; child contexts that view
+     * the same delegate share it, but a separately-constructed
+     * {@code InMemoryExecutionContext} elsewhere does <em>not</em>.
+     * <p>
+     * For a host-wide cap spanning multiple parallel runs, construct one
+     * {@code Semaphore} yourself at the orchestrator level and install it
+     * via {@link #setInFlightSemaphore(Semaphore)} on every participating
+     * context.
+     */
+    public RewriteRpcExecutionContextView setMaxInFlight(int permits) {
+        return setInFlightSemaphore(new Semaphore(permits));
+    }
+
+    /**
+     * Run {@code work} while holding one in-flight RPC permit, if a semaphore
+     * has been installed via {@link #setInFlightSemaphore(Semaphore)} or
+     * {@link #setMaxInFlight(int)}. If none is installed, {@code work} runs
+     * without throttling.
      */
     public <T> T withInFlightSlot(Supplier<T> work) {
-        Semaphore slots = computeMessageIfAbsent(IN_FLIGHT_SEMAPHORE,
-                k -> new Semaphore(getMaxInFlight()));
+        Semaphore slots = getInFlightSemaphore();
+        if (slots == null) {
+            return work.get();
+        }
         slots.acquireUninterruptibly();
         try {
             return work.get();

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcExecutionContextViewTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcExecutionContextViewTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RewriteRpcExecutionContextViewTest {
+
+    @Test
+    void noSemaphoreInstalled_runsWithoutThrottling() {
+        ExecutionContext ctx = new InMemoryExecutionContext();
+        Integer result = RewriteRpcExecutionContextView.view(ctx).withInFlightSlot(() -> 42);
+        assertThat(result).isEqualTo(42);
+        assertThat(RewriteRpcExecutionContextView.view(ctx).getInFlightSemaphore()).isNull();
+    }
+
+    @Test
+    void setMaxInFlight_installsFreshSemaphore() {
+        ExecutionContext ctx = new InMemoryExecutionContext();
+        RewriteRpcExecutionContextView.view(ctx).setMaxInFlight(4);
+        Semaphore s = RewriteRpcExecutionContextView.view(ctx).getInFlightSemaphore();
+        assertThat(s).isNotNull();
+        assertThat(s.availablePermits()).isEqualTo(4);
+    }
+
+    @Test
+    void perCtxSemaphores_doNotShareAcrossIndependentContexts() {
+        ExecutionContext ctxA = new InMemoryExecutionContext();
+        ExecutionContext ctxB = new InMemoryExecutionContext();
+        RewriteRpcExecutionContextView.view(ctxA).setMaxInFlight(2);
+        RewriteRpcExecutionContextView.view(ctxB).setMaxInFlight(2);
+
+        assertThat(RewriteRpcExecutionContextView.view(ctxA).getInFlightSemaphore())
+                .isNotSameAs(RewriteRpcExecutionContextView.view(ctxB).getInFlightSemaphore());
+    }
+
+    @Test
+    void sharedSemaphore_caps_concurrencyAcross_independentContexts() throws InterruptedException {
+        // The shared-semaphore path: one Semaphore installed into multiple ExecutionContexts.
+        // No matter how many contexts/threads call withInFlightSlot concurrently, only
+        // {permits} of them can be inside the work block at once.
+        Semaphore shared = new Semaphore(2);
+
+        int contexts = 8;
+        ExecutionContext[] ctxs = new ExecutionContext[contexts];
+        for (int i = 0; i < contexts; i++) {
+            ctxs[i] = new InMemoryExecutionContext();
+            RewriteRpcExecutionContextView.view(ctxs[i]).setInFlightSemaphore(shared);
+        }
+
+        AtomicInteger concurrentInside = new AtomicInteger();
+        AtomicInteger maxConcurrentObserved = new AtomicInteger();
+        CountDownLatch allDone = new CountDownLatch(contexts);
+
+        for (int i = 0; i < contexts; i++) {
+            final int idx = i;
+            new Thread(() -> {
+                try {
+                    RewriteRpcExecutionContextView.view(ctxs[idx]).withInFlightSlot(() -> {
+                        int now = concurrentInside.incrementAndGet();
+                        maxConcurrentObserved.accumulateAndGet(now, Math::max);
+                        try {
+                            Thread.sleep(50);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        concurrentInside.decrementAndGet();
+                        return null;
+                    });
+                } finally {
+                    allDone.countDown();
+                }
+            }, "in-flight-" + i).start();
+        }
+
+        assertThat(allDone.await(10, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+        assertThat(maxConcurrentObserved.get()).isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    void permitIsReleased_onException() {
+        Semaphore shared = new Semaphore(1);
+        ExecutionContext ctx = new InMemoryExecutionContext();
+        RewriteRpcExecutionContextView.view(ctx).setInFlightSemaphore(shared);
+
+        assertThat(shared.availablePermits()).isEqualTo(1);
+        try {
+            RewriteRpcExecutionContextView.view(ctx).withInFlightSlot(() -> {
+                throw new RuntimeException("boom");
+            });
+        } catch (RuntimeException expected) {
+            // Permit must still be released so a wedged work block doesn't
+            // permanently consume slots from the shared budget.
+        }
+        assertThat(shared.availablePermits()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Summary

- `setMaxInFlight(int)` from #7614 stored an int on the `ExecutionContext` and lazily built the `Semaphore` inside `withInFlightSlot`. Each independent `ExecutionContext` therefore ended up with its own `Semaphore`, so the cap was per-ctx, not host-wide.
- Add `setInFlightSemaphore(Semaphore)` so callers that want a true host-wide cap can construct one `Semaphore` once at the orchestrator level and install the same instance on every participating context (e.g. one per repo task running in parallel).
- Keep `setMaxInFlight(int)` as a single-ctx convenience but document that it is **not** host-wide.
- `withInFlightSlot` is unthrottled when no `Semaphore` is installed, matching the prior "unbounded by default" baseline.

This unblocks Moderne's `mod run` and the SaaS recipe-worker from honoring a true process-wide rewrite-rpc concurrency cap; the wiring on those sides is in follow-up PRs.

## Test plan

- [x] New `RewriteRpcExecutionContextViewTest` covers: no-op default, fresh-Semaphore-from-`setMaxInFlight`, per-ctx isolation (the misuse pattern callers hit today), true sharing across many ctx/threads, permit release on exception.
- [x] `./gradlew :rewrite-core:test --tests '*Rpc*'` green locally.
