### PR TITLE
Scala: fix parsing of non-standard whitespace

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -41,6 +41,8 @@ import org.openrewrite.scala.marker.ScalaForLoop;
 import org.openrewrite.scala.marker.TypeAscription;
 import org.openrewrite.scala.marker.PartialFunctionLiteral;
 import org.openrewrite.scala.marker.UnderscorePlaceholderLambda;
+import org.openrewrite.scala.marker.ValVarKeyword;
+import org.openrewrite.scala.marker.PackageSemicolon;
 import org.openrewrite.scala.tree.S;
 
 import java.util.List;
@@ -253,7 +255,11 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 if (i == 0) {
                     // First catch — prefix is the space before "catch"
                     visitSpace(aCatch.getPrefix(), Space.Location.CATCH_PREFIX, p);
-                    p.append(indentedCatch ? "catch" : "catch {");
+                    p.append("catch");
+                    if (!indentedCatch) {
+                        visitSpace(aCatch.getParameter().getPrefix(), Space.Location.CONTROL_PARENTHESES_PREFIX, p);
+                        p.append("{");
+                    }
                 }
                 // Print case with AST whitespace
                 JRightPadded<J.VariableDeclarations> paramPadded = aCatch.getParameter().getPadding().getTree();
@@ -292,9 +298,15 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
     @Override
     public J visitSwitch(J.Switch switch_, PrintOutputCapture<P> p) {
         beforeSyntax(switch_, Space.Location.SWITCH_PREFIX, p);
-        visit(switch_.getSelector().getTree(), p);
+        JRightPadded<Expression> selector = switch_.getSelector().getPadding().getTree();
+        visit(selector.getElement(), p);
+        visitSpace(selector.getAfter(), Space.Location.CONTROL_PARENTHESES_PREFIX, p);
+        p.append("match");
         boolean indented = switch_.getMarkers().findFirst(IndentedSyntax.class).isPresent();
-        p.append(indented ? " match" : " match {");
+        if (!indented) {
+            visitSpace(switch_.getCases().getPrefix(), Space.Location.BLOCK_PREFIX, p);
+            p.append("{");
+        }
         // Print cases directly (not via visitBlock which adds { })
         J.Block casesBlock = switch_.getCases();
         for (int i = 0; i < casesBlock.getStatements().size(); i++) {
@@ -384,11 +396,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                     // The colon and space between name and type in Scala parameter syntax
                     // Type prefix from parser may or may not include the space
                     TypeTree typeExpr = varDecl.getTypeExpression();
-                    if (typeExpr.getPrefix().isEmpty()) {
-                        p.append(": ");
-                    } else {
-                        p.append(":");
-                    }
+                    p.append(":");
                     visit(typeExpr, p);
                 }
                 if (!varDecl.getVariables().isEmpty() &&
@@ -449,7 +457,10 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 boolean procedureSyntax = method.getMarkers().findFirst(
                         org.openrewrite.scala.marker.OmitBraces.class).isPresent();
                 if (!procedureSyntax) {
-                    p.append(" =");
+                    Space beforeEquals = actualBody instanceof J.Block ?
+                            ((J.Block) actualBody).getPrefix() : Space.SINGLE_SPACE;
+                    visitSpace(beforeEquals, Space.Location.BLOCK_PREFIX, p);
+                    p.append("=");
                 }
                 // If body is OmitBraces block with single statement, print just the statement
                 if (actualBody instanceof J.Block) {
@@ -473,7 +484,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             boolean omitBodyBraces = body.getMarkers().findFirst(
                     org.openrewrite.scala.marker.OmitBraces.class).isPresent();
             if (!procedureSyntax) {
-                p.append(" =");
+                visitSpace(body.getPrefix(), Space.Location.BLOCK_PREFIX, p);
+                p.append("=");
             }
             if (omitBodyBraces && body.getStatements().size() == 1) {
                 visit(body.getStatements().get(0), p);
@@ -523,11 +535,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 }
                 if (vd.getTypeExpression() != null) {
                     TypeTree te = vd.getTypeExpression();
-                    if (te.getPrefix().isEmpty()) {
-                        p.append(": ");
-                    } else {
-                        p.append(":");
-                    }
+                    p.append(":");
                     visit(te, p);
                 }
             } else {
@@ -594,16 +602,19 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
 
         if (scu.getPackageDeclaration() != null) {
             visit(scu.getPackageDeclaration(), p);
+            boolean packageEndsWithSemicolon = scu.getPackageDeclaration().getMarkers().findFirst(PackageSemicolon.class).isPresent();
             // In Scala, package declarations are followed by a newline
             // Check if the next element has a newline in its prefix, if not add one
-            if (!scu.getImports().isEmpty()) {
+            if (!packageEndsWithSemicolon && !scu.getImports().isEmpty()) {
                 J.Import firstImport = scu.getImports().get(0);
-                if (!firstImport.getPrefix().getWhitespace().startsWith("\n")) {
+                String firstImportPrefix = firstImport.getPrefix().getWhitespace();
+                if (!firstImportPrefix.startsWith("\n") && !firstImportPrefix.startsWith(";")) {
                     p.append("\n");
                 }
-            } else if (!scu.getStatements().isEmpty()) {
+            } else if (!packageEndsWithSemicolon && !scu.getStatements().isEmpty()) {
                 Statement firstStatement = scu.getStatements().get(0);
-                if (!firstStatement.getPrefix().getWhitespace().startsWith("\n")) {
+                String firstStatementPrefix = firstStatement.getPrefix().getWhitespace();
+                if (!firstStatementPrefix.startsWith("\n") && !firstStatementPrefix.startsWith(";")) {
                     p.append("\n");
                 }
             }
@@ -648,6 +659,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             p.append(braces.get().beforeBrace());
             p.append('{');
         }
+        if (pkg.getMarkers().findFirst(PackageSemicolon.class).isPresent()) {
+            p.append(';');
+        }
         // Note: No semicolon in Scala package declarations
         afterSyntax(pkg, p);
         return pkg;
@@ -670,14 +684,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         } else {
             visit(qualid, p);
         }
-        
-        // Handle aliases if present (for future use)
-        if (import_.getAlias() != null) {
-            p.append(" => ");
-            visit(import_.getAlias(), p);
-        }
-        
-        // Note: No semicolon in Scala import declarations
+
         afterSyntax(import_, p);
         return import_;
     }
@@ -809,11 +816,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                         }
                         if (varDecl.getTypeExpression() != null) {
                             TypeTree typeExpr = varDecl.getTypeExpression();
-                            if (typeExpr.getPrefix().isEmpty()) {
-                                p.append(": ");
-                            } else {
-                                p.append(":");
-                            }
+                            p.append(":");
                             visit(typeExpr, p);
                         }
                         if (!varDecl.getVariables().isEmpty() &&
@@ -1081,6 +1084,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         boolean hasVisibleModifier = false;
         String valVarKeyword = "var";
         Space valVarPrefix = null;
+        Optional<ValVarKeyword> valVarKeywordMarker = multiVariable.getMarkers().findFirst(ValVarKeyword.class);
         boolean annotationGapBridged = false;
         for (J.Modifier m : multiVariable.getModifiers()) {
             if (m.getType() == J.Modifier.Type.Final && !"final".equals(m.getKeyword())) {
@@ -1105,6 +1109,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         if (!isLambdaParam) {
             if (valVarPrefix != null) {
                 visitSpace(valVarPrefix, Space.Location.MODIFIER_PREFIX, p);
+            } else if (valVarKeywordMarker.isPresent()) {
+                p.append(valVarKeywordMarker.get().beforeKeyword());
             } else if (hasVisibleModifier) {
                 p.append(" ");
             } else if (!annotationGapBridged && !multiVariable.getLeadingAnnotations().isEmpty()) {
@@ -1561,7 +1567,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         beforeSyntax(ext, Space.Location.LANGUAGE_EXTENSION, p);
         p.append("extension");
         JContainer<Statement> params = ext.getPadding().getParameters();
-        visitSpace(params.getBefore(), Space.Location.LANGUAGE_EXTENSION, p);
+        p.append(params.getBefore().getWhitespace());
         p.append('(');
         List<JRightPadded<Statement>> paramList = params.getPadding().getElements();
         for (int i = 0; i < paramList.size(); i++) {
@@ -1577,11 +1583,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 }
                 if (varDecl.getTypeExpression() != null) {
                     TypeTree typeExpr = varDecl.getTypeExpression();
-                    if (typeExpr.getPrefix().isEmpty()) {
-                        p.append(": ");
-                    } else {
-                        p.append(":");
-                    }
+                    p.append(":");
                     visit(typeExpr, p);
                 }
                 if (!varDecl.getVariables().isEmpty() &&

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaASTConverter.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaASTConverter.scala
@@ -21,7 +21,7 @@ import org.openrewrite.Tree
 import org.openrewrite.java.internal.JavaTypeFactory
 import org.openrewrite.java.tree.*
 import org.openrewrite.marker.Markers
-import org.openrewrite.scala.marker.{IndentedSyntax, PackageBraces}
+import org.openrewrite.scala.marker.{IndentedSyntax, PackageBraces, PackageSemicolon}
 
 import java.util
 import java.util.{Collections, List as JList, UUID}
@@ -200,8 +200,9 @@ class ScalaASTConverter {
     val nextChar = if (scanIdx < srcText.length) srcText.charAt(scanIdx) else 0.toChar
     val hasIndentedColon = nextChar == ':'
     val hasBraces = nextChar == '{'
+    val hasSemicolon = nextChar == ';'
     val cursorAfter =
-      if (hasIndentedColon || hasBraces) scanIdx + 1 + srcOffset
+      if (hasIndentedColon || hasBraces || hasSemicolon) scanIdx + 1 + srcOffset
       else packageEndPos
 
     // Update the visitor's cursor to after the package declaration
@@ -212,14 +213,17 @@ class ScalaASTConverter {
     // Create package expression
     val packageExpr: Expression = TypeTree.build(packageName)
 
-    val markers = if (hasIndentedColon) {
-      Markers.build(Collections.singletonList(new IndentedSyntax(UUID.randomUUID())))
+    val markerList = new util.ArrayList[org.openrewrite.marker.Marker]()
+    if (hasIndentedColon) {
+      markerList.add(new IndentedSyntax(UUID.randomUUID()))
     } else if (hasBraces) {
       val beforeBrace = srcText.substring(scanStart, scanIdx)
-      Markers.build(Collections.singletonList(PackageBraces(UUID.randomUUID(), beforeBrace, "")))
-    } else {
-      Markers.EMPTY
+      markerList.add(PackageBraces(UUID.randomUUID(), beforeBrace, ""))
     }
+    if (hasSemicolon) {
+      markerList.add(PackageSemicolon(UUID.randomUUID()))
+    }
+    val markers = if (markerList.isEmpty) Markers.EMPTY else Markers.build(markerList)
 
     new J.Package(
       Tree.randomId(),

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -42,6 +42,7 @@ import org.openrewrite.scala.marker.PartialFunctionLiteral
 import org.openrewrite.scala.marker.Curried
 import org.openrewrite.scala.marker.InfixNotation
 import org.openrewrite.scala.marker.RightAssociative
+import org.openrewrite.scala.marker.ValVarKeyword
 import org.openrewrite.scala.tree.S
 
 import java.util
@@ -2212,12 +2213,15 @@ class ScalaTreeVisitor(
         )
       }
 
-      // sourceText starts with "import " - strip that for the qualid
-      val qualidText = sourceText.substring("import ".length)
+      val afterImportStart = "import".length
+      val afterImport = sourceText.substring(afterImportStart)
+      val qualidStart = afterImport.indexWhere(ch => !Character.isWhitespace(ch))
+      val qualidPrefix = if (qualidStart > 1) Space.format(afterImport.substring(1, qualidStart)) else Space.EMPTY
+      val qualidText = if (qualidStart >= 0) afterImport.substring(qualidStart) else ""
 
       // Wrap in FieldAccess with Empty target (required by J.Import).
       val qualid = new J.FieldAccess(
-        Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+        Tree.randomId(), qualidPrefix, Markers.EMPTY,
         new J.Empty(Tree.randomId(), Space.EMPTY, Markers.EMPTY),
         JLeftPadded.build(ident(qualidText)),
         null
@@ -2276,16 +2280,19 @@ class ScalaTreeVisitor(
       Space.EMPTY
     }
 
+    val keyword =
+      if (adjustedStart + "import".length <= source.length && source.startsWith("import", adjustedStart)) "import"
+      else "export"
+    cursor = Math.max(cursor, adjustedStart + keyword.length)
+    if (cursor < source.length && Character.isWhitespace(source.charAt(cursor))) {
+      cursor += 1
+    }
+
     // Identifier resolution inside an import/export path differs from regular
     // expression context (e.g. `_` becomes `*` for wildcards), so flag the
     // visit and restore the previous value when done.
     val oldInImportContext = isInImportContext
     isInImportContext = true
-
-    if (tree.expr.span.exists) {
-      val exprStart = Math.max(0, tree.expr.span.start - offsetAdjustment)
-      cursor = exprStart
-    }
 
     val expr = visitTree(tree.expr)
     isInImportContext = oldInImportContext
@@ -2499,6 +2506,7 @@ class ScalaTreeVisitor(
     
     // Extract source to find modifier keywords and val/var
     var valVarKeyword = ""
+    var beforeValVarRaw = ""
     var beforeValVar = Space.EMPTY
     var afterValVar = Space.EMPTY
     val modifiers = new util.ArrayList[J.Modifier]()
@@ -2527,8 +2535,9 @@ class ScalaTreeVisitor(
           val cb = afterKw.indexOf(']')
           if (cb >= 0) { keyword = "private" + afterKw.substring(0, cb + 1); keyLen = keyword.length }
         }
+        val modPrefix = if (leadingWs > 0) Space.format(sourceSnippet.substring(0, leadingWs)) else Space.EMPTY
         modifiers.add(new J.Modifier(
-          Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+          Tree.randomId(), modPrefix, Markers.EMPTY,
           keyword, J.Modifier.Type.Private, Collections.emptyList()
         ))
         modifierEndPos = leadingWs + keyLen
@@ -2542,8 +2551,9 @@ class ScalaTreeVisitor(
           val cb = afterKw.indexOf(']')
           if (cb >= 0) { keyword = "protected" + afterKw.substring(0, cb + 1); keyLen = keyword.length }
         }
+        val modPrefix = if (leadingWs > 0) Space.format(sourceSnippet.substring(0, leadingWs)) else Space.EMPTY
         modifiers.add(new J.Modifier(
-          Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+          Tree.randomId(), modPrefix, Markers.EMPTY,
           keyword, J.Modifier.Type.Protected, Collections.emptyList()
         ))
         modifierEndPos = leadingWs + keyLen
@@ -2613,7 +2623,8 @@ class ScalaTreeVisitor(
         val totalKeywordPos = modifierEndPos + keywordStart
         val gapStart = if (lastModifierKeywordEnd >= 0) lastModifierKeywordEnd else 0
         if (gapStart < totalKeywordPos) {
-          beforeValVar = Space.format(sourceSnippet.substring(gapStart, totalKeywordPos))
+          beforeValVarRaw = sourceSnippet.substring(gapStart, totalKeywordPos)
+          beforeValVar = Space.format(beforeValVarRaw)
         }
         
         // Move cursor past all modifiers and the keyword
@@ -2860,10 +2871,15 @@ class ScalaTreeVisitor(
     // even though it's syntactically attached to each variable
     // Use the varargs field (unused in Scala) to store space before colon
     val varargs: Space = if (beforeColon != Space.EMPTY) beforeColon else null
+    val variableMarkers =
+      if (beforeValVarRaw.nonEmpty)
+        Markers.build(Collections.singletonList(ValVarKeyword(UUID.randomUUID(), beforeValVarRaw)))
+      else Markers.EMPTY
+
     new J.VariableDeclarations(
       Tree.randomId(),
       prefix,
-      Markers.EMPTY,
+      variableMarkers,
       leadingAnnotations,
       modifiers,
       typeExpression,
@@ -5435,10 +5451,14 @@ class ScalaTreeVisitor(
         reparseProcedureBody(dd)
       case rhs if rhs != untpd.EmptyTree && rhs.span.exists =>
         val rhsStart = Math.max(0, rhs.span.start - offsetAdjustment)
+        var beforeEquals = Space.EMPTY
         if (!isProcedureSyntax && cursor < rhsStart && rhsStart <= source.length) {
           val beforeBody = source.substring(cursor, rhsStart)
           val equalsIdx = beforeBody.indexOf('=')
-          if (equalsIdx >= 0) cursor = cursor + equalsIdx + 1
+          if (equalsIdx >= 0) {
+            beforeEquals = Space.format(beforeBody.substring(0, equalsIdx))
+            cursor = cursor + equalsIdx + 1
+          }
         }
         visitTree(rhs) match {
             case block: J.Block => block
@@ -5450,13 +5470,13 @@ class ScalaTreeVisitor(
               }
               val statements = new util.ArrayList[JRightPadded[Statement]]()
               statements.add(JRightPadded.build(stmtExpr))
-              new J.Block(Tree.randomId(), Space.EMPTY,
+              new J.Block(Tree.randomId(), beforeEquals,
                 Markers.build(Collections.singletonList(new org.openrewrite.scala.marker.OmitBraces(Tree.randomId()))),
                 JRightPadded.build(false), statements, Space.EMPTY)
             case stmt: Statement =>
               val statements = new util.ArrayList[JRightPadded[Statement]]()
               statements.add(JRightPadded.build(stmt))
-              new J.Block(Tree.randomId(), Space.EMPTY,
+              new J.Block(Tree.randomId(), beforeEquals,
                 Markers.build(Collections.singletonList(new org.openrewrite.scala.marker.OmitBraces(Tree.randomId()))),
                 JRightPadded.build(false), statements, Space.EMPTY)
             case _ => null
@@ -5809,7 +5829,7 @@ class ScalaTreeVisitor(
     }
 
     // Handle catch handler
-    val catches = new util.ArrayList[J.Try.Catch]()
+      val catches = new util.ArrayList[J.Try.Catch]()
     var catchHasBraces = true
     if (!parsedTry.handler.isEmpty && parsedTry.handler.span.exists) {
       val catchSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 50, source.length)) else ""
@@ -5821,6 +5841,7 @@ class ScalaTreeVisitor(
       val braceIdx = braceSearch.indexOf('{')
       val firstCaseIdx = braceSearch.indexOf("case")
       catchHasBraces = braceIdx >= 0 && (firstCaseIdx < 0 || braceIdx < firstCaseIdx)
+      val catchBraceSpace = if (catchHasBraces && braceIdx > 0) Space.format(braceSearch.substring(0, braceIdx)) else Space.EMPTY
       if (catchHasBraces) cursor = cursor + braceIdx + 1
 
       // The handler should be a Match tree containing the case defs
@@ -5869,7 +5890,8 @@ class ScalaTreeVisitor(
         val varDecl = new J.VariableDeclarations(Tree.randomId(), casePrefix, Markers.EMPTY,
           Collections.emptyList(), Collections.emptyList(), paramType, null, Collections.emptyList(),
           Collections.singletonList(JRightPadded.build(namedVar)))
-        val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(varDecl).withAfter(spaceBeforeArrow))
+        val controlPrefix = if (catches.isEmpty) catchBraceSpace else Space.EMPTY
+        val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), controlPrefix, Markers.EMPTY, JRightPadded.build(varDecl).withAfter(spaceBeforeArrow))
 
         val caseBody = visitTree(caseDef.body) match {
           case block: J.Block => block
@@ -5959,6 +5981,7 @@ class ScalaTreeVisitor(
       val braceIdx = braceSearch.indexOf('{')
       val firstCaseIdx = braceSearch.indexOf("case")
       catchHasBraces = braceIdx >= 0 && (firstCaseIdx < 0 || braceIdx < firstCaseIdx)
+      val catchBraceSpace = if (catchHasBraces && braceIdx > 0) Space.format(braceSearch.substring(0, braceIdx)) else Space.EMPTY
       if (catchHasBraces) cursor = cursor + braceIdx + 1
 
       for (caseDef <- tryTree.cases) {
@@ -6001,7 +6024,8 @@ class ScalaTreeVisitor(
         val varDecl = new J.VariableDeclarations(Tree.randomId(), casePrefix, Markers.EMPTY,
           Collections.emptyList(), Collections.emptyList(), paramType, null, Collections.emptyList(),
           Collections.singletonList(JRightPadded.build(namedVar)))
-        val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(varDecl).withAfter(spaceBeforeArrow))
+        val controlPrefix = if (catches.isEmpty) catchBraceSpace else Space.EMPTY
+        val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), controlPrefix, Markers.EMPTY, JRightPadded.build(varDecl).withAfter(spaceBeforeArrow))
 
         val caseBody = visitTree(caseDef.body) match {
           case block: J.Block => block
@@ -6091,17 +6115,20 @@ class ScalaTreeVisitor(
     }
 
     val ms = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 30, source.length)) else ""
-    val mi = ms.indexOf("match"); if (mi >= 0) cursor = cursor + mi + 5
+    val mi = ms.indexOf("match")
+    val matchKeywordSpace = if (mi > 0) Space.format(ms.substring(0, mi)) else Space.EMPTY
+    if (mi >= 0) cursor = cursor + mi + 5
     // Scala 3 `x match\n  case ...` has no `{` before the cases — detect that form.
     val bs = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 200, source.length)) else ""
     val braceIdx = bs.indexOf('{')
     val caseIdx = bs.indexOf("case")
     val isBraceForm = braceIdx >= 0 && (caseIdx < 0 || braceIdx < caseIdx)
+    val matchBraceSpace = if (isBraceForm && braceIdx > 0) Space.format(bs.substring(0, braceIdx)) else Space.EMPTY
     if (isBraceForm) cursor = cursor + braceIdx + 1
 
-    val casesBlock = buildCasesBlock(matchTree, isBraceForm)
+    val casesBlock = buildCasesBlock(matchTree, isBraceForm).withPrefix(matchBraceSpace)
     updateCursor(matchTree.span.end)
-    val selectorParens = new J.ControlParentheses[Expression](Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(selector))
+    val selectorParens = new J.ControlParentheses[Expression](Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(selector).withAfter(matchKeywordSpace))
     val markers = if (isBraceForm) Markers.EMPTY
       else Markers.build(Collections.singletonList(new IndentedSyntax(UUID.randomUUID())))
     new J.Switch(Tree.randomId(), prefix, markers, selectorParens, casesBlock)
@@ -6444,13 +6471,13 @@ class ScalaTreeVisitor(
   private def visitExtMethods(ext: untpd.ExtMethods): S.ExtensionMethods = {
     // Scala 3 extension method block: `extension (x: T) { def ... }`
     val prefix = extractPrefix(ext.span)
-    // Advance past "extension" keyword
-    val extKwIdx = source.indexOf("extension", cursor)
-    if (extKwIdx >= 0) cursor = extKwIdx + "extension".length
-
-    // Find opening paren for parameters
-    val parenIdx = source.indexOf('(', cursor)
-    val beforeParen = if (parenIdx > cursor) Space.format(source.substring(cursor, parenIdx)) else Space.EMPTY
+    val adjustedStart = Math.max(0, ext.span.start - offsetAdjustment)
+    val searchStart = Math.max(0, Math.min(cursor, adjustedStart) - "extension".length)
+    val parenIdx = source.indexOf('(', searchStart)
+    val extKwIdx = if (parenIdx >= 0) source.lastIndexOf("extension", parenIdx) else source.indexOf("extension", cursor)
+    val keywordEnd = if (extKwIdx >= 0) extKwIdx + "extension".length else cursor
+    cursor = keywordEnd
+    val beforeParen = if (parenIdx > keywordEnd) Space.format(source.substring(keywordEnd, parenIdx)) else Space.EMPTY
     if (parenIdx >= 0) cursor = parenIdx + 1
 
     // Visit parameters from first parameter clause

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/marker/ScalaMarkers.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/marker/ScalaMarkers.scala
@@ -85,6 +85,15 @@ case class Curried(id: UUID) extends Marker {
 }
 
 /**
+ * Carries the source text between the last annotation/modifier and the
+ * `val`/`var`/`given` keyword for Scala variable declarations.
+ */
+case class ValVarKeyword(id: UUID, beforeKeyword: String) extends Marker {
+  override def getId(): UUID = id
+  override def withId[M <: Marker](newId: UUID): M = copy(id = newId).asInstanceOf[M]
+}
+
+/**
  * Marks a `J.Package` that uses Scala's braced package syntax:
  * `package foo.bar { ... }`. The printer uses this to re-emit the
  * opening brace after the package name. The closing brace is preserved
@@ -94,6 +103,15 @@ case class Curried(id: UUID) extends Marker {
  * @param afterBody whitespace between the last statement and the closing brace
  */
 case class PackageBraces(id: UUID, beforeBrace: String, afterBody: String) extends Marker {
+  override def getId(): UUID = id
+  override def withId[M <: Marker](newId: UUID): M = copy(id = newId).asInstanceOf[M]
+}
+
+/**
+ * Marks a package declaration followed by an explicit semicolon:
+ * `package foo;class Bar`.
+ */
+case class PackageSemicolon(id: UUID) extends Marker {
   override def getId(): UUID = id
   override def withId[M <: Marker](newId: UUID): M = copy(id = newId).asInstanceOf[M]
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -76,6 +76,46 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void methodParameterTypeNoSpaceAfterColon() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def foo(x:Int) = x
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void methodExtraSpaceBeforeEquals() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def foo()  = 1
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void methodNewlineBeforeEquals() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def foo()
+                    = 1
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void methodWithParameters() {
         rewriteRun(
             scala(
@@ -186,6 +226,32 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void curriedMethodExtraSpaceBeforeEquals() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def add(x: Int)(y: Int)  = x + y
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void curriedMethodParameterTypeNoSpaceAfterColon() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def add(x:Int)(y:Int) = x + y
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void multilineParameterListWithClosingParenOnOwnLine() {
         rewriteRun(
             scala(
@@ -276,6 +342,19 @@ class MethodDeclarationTest implements RewriteTest {
                     """
                     extension   (x: Int) {
                       def foo = x + 1
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void extensionParameterTypeNoSpaceAfterColon() {
+            rewriteRun(
+                scala(
+                    """
+                    extension (x:Int) {
+                      def doubled = x * 2
                     }
                     """
                 )

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
@@ -58,6 +58,17 @@ class ClassDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void classConstructorParameterTypeNoSpaceAfterColon() {
+        rewriteRun(
+            scala(
+                """
+                class Foo(x:Int)
+                """
+            )
+        );
+    }
+
+    @Test
     void classWithMultipleParameters() {
         rewriteRun(
             scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
@@ -23,6 +23,28 @@ import static org.openrewrite.scala.Assertions.scala;
 class CompilationUnitTest implements RewriteTest {
 
     @Test
+    void packageWithSemicolonBeforeImport() {
+        rewriteRun(
+          scala(
+            """
+            package foo;import bar.X
+            """
+          )
+        );
+    }
+
+    @Test
+    void packageWithSemicolonBeforeStatement() {
+        rewriteRun(
+          scala(
+            """
+            package foo;class Bar
+            """
+          )
+        );
+    }
+
+    @Test
     void emptyFile() {
         rewriteRun(
           scala("")

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ExportTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ExportTest.java
@@ -36,6 +36,19 @@ class ExportTest implements RewriteTest {
     }
 
     @Test
+    void exportExtraSpaceAfterKeyword() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              export  Foo.x
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void nestedPathExport() {
         rewriteRun(
           scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ImportTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ImportTest.java
@@ -32,6 +32,17 @@ class ImportTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void importExtraSpaceAfterKeyword() {
+        rewriteRun(
+          scala(
+            """
+            import  scala.collection.mutable
+            """
+          )
+        );
+    }
     
     @Test
     void singleImportNoNewline() {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
@@ -55,6 +55,36 @@ class MatchTest implements RewriteTest {
     }
 
     @Test
+    void matchExtraSpaceBeforeKeyword() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              val r = 1  match {
+                case _ => 0
+              }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void matchExtraSpaceBeforeBrace() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              val r = 1 match  {
+                case _ => 0
+              }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void matchWithGuard() {
         rewriteRun(
           scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
@@ -40,6 +40,36 @@ class TryTest implements RewriteTest {
     }
 
     @Test
+    void tryCatchExtraSpaceBeforeBrace() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                try { 1 } catch  {
+                  case _: Exception => 2
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void tryCatchCommentBeforeBrace() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                try { 1 } catch /* note */ {
+                  case _: Exception => 2
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void tryWithFinally() {
         rewriteRun(
           scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/VariableDeclarationsTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/VariableDeclarationsTest.java
@@ -36,12 +36,66 @@ class VariableDeclarationsTest implements RewriteTest {
     }
 
     @Test
+    void annotationNewlineBeforeModifier() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              @deprecated
+              private var x = 1
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void extraSpaceBetweenModifierAndVal() {
         rewriteRun(
           scala(
             """
             class Test {
               private   val x = 1
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void modifierExtraSpaceBeforeVar() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              private  var x = 1
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void annotationExtraSpaceBeforeVar() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              @deprecated  var x = 1
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void annotationNewlineBeforeVar() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              @deprecated
+              var x = 1
             }
             """
           )


### PR DESCRIPTION
## What's changed?

Fix Scala parser and printer to handle the cases of non-standard (eg. 2 spaces) whitespace around various LST elements.

## What's your motivation?

They fail from idepomtency issues.