### PR TITLE
Update server configuration in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: s4u/maven-settings-action@v4.0.0
         with:
           mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
-          servers: '[{"id": "moderne-cache", "username": "${{ secrets.ARTIFACTORY_USERNAME }}", "password": "${{ secrets.ARTIFACTORY_PASSWORD }}"}]'
+          servers: ${{ secrets.ARTIFACTORY_USERNAME != '' && format('[{{"id":"moderne-cache","username":"{0}","password":"{1}"}}]', secrets.ARTIFACTORY_USERNAME, secrets.ARTIFACTORY_PASSWORD) || '[]' }}
 
       - uses: openrewrite/gh-automation/.github/actions/build@main
         env:


### PR DESCRIPTION
Enable fork repos to also run using the artifactory-cache

We still use the mirror, but do not add the servers as we do not have the secrets available on forks. This will use no-auth access on our cache, which should also work. 