### PR TITLE
rpc: exit JS server when parent connection closes

### DIFF
--- a/rewrite-javascript/rewrite/src/rpc/server.ts
+++ b/rewrite-javascript/rewrite/src/rpc/server.ts
@@ -80,39 +80,37 @@ async function main() {
 
     const options = program.opts() as ProgramOptions;
 
+    let recipeCleanup: (() => Promise<void>) | undefined;
     let recipeInstallDir: string;
     if (!options.recipeInstallDir) {
-        let recipeCleanup: () => Promise<void>;
-
-        async function setupRecipeDir() {
-            const {path, cleanup} = await dir({unsafeCleanup: true});
-            recipeCleanup = cleanup;
-            return path;
-        }
-
-        // Register cleanup on exit
-        process.on('SIGINT', async () => {
-            if (recipeCleanup) {
-                await recipeCleanup();
-            }
-            // Clean up old dependency workspaces (older than 24 hours)
-            DependencyWorkspace.cleanupOldWorkspaces();
-            process.exit(0);
-        });
-
-        process.on('SIGTERM', async () => {
-            if (recipeCleanup) {
-                await recipeCleanup();
-            }
-            // Clean up old dependency workspaces (older than 24 hours)
-            DependencyWorkspace.cleanupOldWorkspaces();
-            process.exit(0);
-        });
-
-        recipeInstallDir = await setupRecipeDir();
+        const {path, cleanup} = await dir({unsafeCleanup: true});
+        recipeCleanup = cleanup;
+        recipeInstallDir = path;
     } else {
         recipeInstallDir = options.recipeInstallDir;
     }
+
+    // Single graceful-shutdown path used by SIGINT, SIGTERM, and connection
+    // close. The connection-close path is what catches parent SIGKILL: when
+    // the host JVM is killed, our stdin closes, vscode-jsonrpc fires onClose,
+    // and we exit. Without it, Pyroscope (or any other ref-holder) can keep
+    // the event loop alive and orphan this process.
+    let shuttingDown = false;
+    const shutdown = async () => {
+        if (shuttingDown) return;
+        shuttingDown = true;
+        try {
+            if (recipeCleanup) {
+                await recipeCleanup();
+            }
+            DependencyWorkspace.cleanupOldWorkspaces();
+        } finally {
+            process.exit(0);
+        }
+    };
+
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
 
     const log = options.logFile ? fs.createWriteStream(options.logFile, {flags: 'a'}) : undefined;
     const logger: rpc.Logger = {
@@ -148,6 +146,7 @@ async function main() {
 
     connection.onClose(() => {
         logger.info(`connection closed`);
+        void shutdown();
     })
 
     connection.onDispose(() => {


### PR DESCRIPTION
## Summary
- When the host JVM is SIGKILLed, its shutdown hook never runs and `RewriteRpcProcess.shutdown()` never invokes `process.destroy()` on spawned RPC subprocesses. The Python (stdin EOF → break), Go (`io.EOF` → break), and C# (`JsonRpc.Completion`) servers all exit naturally in that case; the JS server did not, because `connection.onClose` only logged — and Pyroscope (or any other event-loop ref-holder) kept the Node process alive, orphaning it on the host.
- Converge SIGINT, SIGTERM, and `connection.onClose` on a single `shutdown()` (with a re-entry guard) that performs temp-dir + workspace cleanup and exits with code 0. This closes the orphan-on-parent-SIGKILL hazard while keeping the existing signal-handler cleanup behavior.

## Test plan
- [ ] `npm run typecheck` passes
- [ ] Spawn the JS RPC server, SIGKILL the parent (or close its stdin), confirm the JS process exits within a second instead of lingering
- [ ] Verify recipe temp dir cleanup still runs on SIGINT/SIGTERM