### PR TITLE
Maven dependency recipes: dedup against XML, not resolution model

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
@@ -130,6 +130,13 @@ public class AddDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
                             }
                         }
                     }
+                    // If the managed version is already higher than anything in the recipe's selector range,
+                    // the BOM provides a superset of what AddDependency was asking for. Leave the existing
+                    // dep alone rather than scheduling a downgrade.
+                    if (versionToUse != null && managedVersion != null &&
+                            new Version(managedVersion).compareTo(new Version(versionToUse)) > 0) {
+                        versionToUse = null;
+                    }
                     if (versionToUse == null && requestedScope == existingScope) {
                         getCursor().putMessageOnFirstEnclosing(Xml.Document.class, "doNotAlterDependency", true);
                         return tag;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -266,7 +266,11 @@ public class ChangeDependencyGroupIdAndArtifactId extends ScanningRecipe<ChangeD
 
             @Override
             public Xml visitDocument(Xml.Document document, ExecutionContext ctx) {
-                isNewDependencyPresent = checkIfNewDependencyPresent(newGroupId, newArtifactId, newVersion);
+                // The XML is the source of truth and is always current. The resolution model can lag
+                // across recipes when UpdateMavenModel afterVisits haven't drained, so consult the XML
+                // first to decide whether the new GA is already present as a direct dep.
+                isNewDependencyPresent = isNewDependencyTagInXml(document, newGroupId, newArtifactId) ||
+                        checkIfNewDependencyPresent(newGroupId, newArtifactId, newVersion);
                 safeVersionPlaceholdersToChange = getSafeVersionPlaceholdersToChange(oldGroupId, oldArtifactId, ctx);
                 if (configuredToChangeManagedDependency) {
                     doAfterVisit(new ChangeManagedDependencyGroupIdAndArtifactId(
@@ -421,6 +425,31 @@ public class ChangeDependencyGroupIdAndArtifactId extends ScanningRecipe<ChangeD
                         .filter(ResolvedDependency::isDirect)
                         .anyMatch(rd -> version == null ||
                                 versionComparator != null && versionComparator.compare(null, version, rd.getVersion()) <= 0);
+            }
+
+            private boolean isNewDependencyTagInXml(Xml.Document document, @Nullable String groupId, @Nullable String artifactId) {
+                if (groupId == null || artifactId == null) {
+                    return false;
+                }
+                return document.getRoot().getChild("dependencies")
+                        .map(deps -> deps.getChildren("dependency").stream()
+                                .anyMatch(d -> groupId.equals(d.getChildValue("groupId").orElse(null)) &&
+                                        artifactId.equals(d.getChildValue("artifactId").orElse(null)) &&
+                                        isTagVersionAcceptable(d)))
+                        .orElse(false);
+            }
+
+            // Mirrors the version check in checkIfNewDependencyPresent: an explicit declared version must
+            // satisfy the recipe's newVersion selector; an absent/empty version (BOM-managed) is accepted.
+            private boolean isTagVersionAcceptable(Xml.Tag dep) {
+                if (newVersion == null) {
+                    return true;
+                }
+                String depVersion = dep.getChildValue("version").orElse(null);
+                if (depVersion == null || depVersion.isEmpty()) {
+                    return true;
+                }
+                return versionComparator != null && versionComparator.compare(null, newVersion, depVersion) <= 0;
             }
 
             private boolean isDependencyManaged(Scope scope, String groupId, String artifactId) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -2264,6 +2264,57 @@ class AddDependencyTest implements RewriteTest {
     }
 
     @Test
+    void doesNotDuplicateWhenManagedVersionExceedsSemverSelector() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:28.X", "com.google.common.math.IntMath")),
+          pomXml(
+            """
+              <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-parent</artifactId>
+                  <version>1</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>com.google.guava</groupId>
+                              <artifactId>guava</artifactId>
+                              <version>33.5.0-jre</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """
+          ),
+          mavenProject(
+            "server",
+            srcMainJava(
+              java(usingGuavaIntMath)
+            ),
+            pomXml(
+              """
+                <project>
+                    <parent>
+                        <groupId>com.mycompany.app</groupId>
+                        <artifactId>my-parent</artifactId>
+                        <version>1</version>
+                    </parent>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
     void doesNotDuplicateWhenManagedVersionSatisfiesSemverSelector() {
         rewriteRun(
           spec -> spec.recipe(addDependency("com.google.guava:guava:28.X", "com.google.common.math.IntMath")),

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -532,6 +532,73 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
     }
 
     @Test
+    void shouldNotAddNewIfManagedNewAlreadyPresentWithSemverSelector() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
+            "javax.activation",
+            "javax.activation-api",
+            "jakarta.activation",
+            "jakarta.activation-api",
+            "1.0.x",
+            null
+          )),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>jakarta.activation</groupId>
+                              <artifactId>jakarta.activation-api</artifactId>
+                              <version>1.2.1</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                      <dependency>
+                          <groupId>javax.activation</groupId>
+                          <artifactId>javax.activation-api</artifactId>
+                          <version>1.2.0</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>jakarta.activation</groupId>
+                          <artifactId>jakarta.activation-api</artifactId>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>jakarta.activation</groupId>
+                              <artifactId>jakarta.activation-api</artifactId>
+                              <version>1.2.1</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                      <dependency>
+                          <groupId>jakarta.activation</groupId>
+                          <artifactId>jakarta.activation-api</artifactId>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     void changeManagedDependencyArtifactId() {
         rewriteRun(
           spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(


### PR DESCRIPTION
## Problem

Two Maven dependency recipes — `AddDependency` and `ChangeDependencyGroupIdAndArtifactId` — make dedup decisions based on `getResolutionResult().getDependencies()` and `findDependencies(...)`. The resolution model is fresh under OSS `RecipeScheduler` (queued `UpdateMavenModel` afterVisits drain between recipes), but can lag in environments where:

- An alternate scheduler doesn't propagate `doAfterVisit` between recipes the same way.
- Some private/internal deps fail to fully resolve, leaving the model partial.
- Recipes are invoked separately (rather than chained inside a composite's `recipeList`) and there's no enforced drain between invocations.

Under any of these, the dedup checks return false negatives even though the XML clearly already contains a direct `<dependency>` for the coordinate in question. The recipes then either insert a duplicate `<dependency>` or rewrite the old tag in place alongside an existing new tag, producing an invalid pom (Maven rejects duplicate `groupId:artifactId:type:classifier`).

## Changes

### 1. `AddDependencyVisitor.visitTag` — short-circuit when managed version exceeds selector

When the BOM-managed version of an existing direct dep is *strictly higher* than anything in the recipe's selector range, the BOM provides a superset of what `AddDependency` was asking for. Today the visitor still computes `versionToUse` from the selector, sets `requestedVersionChange`, and falls through to the resolution-based dedup at lines 161-171 of `visitDocument` — which depends on the resolution model being fresh.

Short-circuit earlier: when `managedVersion > versionToUse`, zero `versionToUse` so the existing `doNotAlterDependency` path fires.

```java
if (versionToUse != null && managedVersion != null &&
        new Version(managedVersion).compareTo(new Version(versionToUse)) > 0) {
    versionToUse = null;
}
```

### 2. `ChangeDependencyGroupIdAndArtifactId` — XML-based dedup check

`checkIfNewDependencyPresent` reads `findDependencies(...)` from the resolution model and asks whether the new GA is direct. If the model is stale, this returns false even when the XML has the GA. ChangeDependency then rewrites the old tag in place, producing a duplicate.

Add an XML-based check (`isNewDependencyTagInXml`) that walks the document's `<dependencies>` looking for a tag with the new groupId/artifactId. The XML is always current, regardless of resolution-model state. OR the result with the existing model-based check.

```java
isNewDependencyPresent = isNewDependencyTagInXml(document, newGroupId, newArtifactId) ||
        checkIfNewDependencyPresent(newGroupId, newArtifactId, newVersion);
```

The XML check applies the **same version semantics** as the model-based check: an explicit `<version>` must satisfy the recipe's `newVersion` selector; an absent/empty `<version>` (BOM-managed) is accepted. Behavior for cases where the existing entry is at a different explicit version is preserved (notably `shouldAddNewIfDependencyAlreadyExistsInOlderVersion`, the existing test for issue #4514).

## Tests

- **`AddDependencyTest.doesNotDuplicateWhenManagedVersionExceedsSemverSelector`** — parent pom manages `com.google.guava:guava:33.5.0-jre`, child has a versionless `guava` dep, recipe runs `AddDependency` with selector `28.X`. Pom unchanged.

- **`ChangeDependencyGroupIdAndArtifactIdTest.shouldNotAddNewIfManagedNewAlreadyPresentWithSemverSelector`** — pom has direct `javax.activation:javax.activation-api:1.2.0`, direct versionless `jakarta.activation:jakarta.activation-api`, managed at `1.2.1` via `<dependencyManagement>`. Recipe runs with selector `1.0.x` (which doesn't satisfy the managed `1.2.1`, exercising the version-coupled fall-through path that the XML check now catches). Asserts javax removed, single jakarta entry remains.

Existing tests (notably `shouldAddNewIfDependencyAlreadyExistsInOlderVersion` for issue #4514) continue to pass — the version-aware XML check preserves their behavior.

## Relationship to #7613

This PR continues the work from #7613, which added a `doNotAlterDependency` short-circuit in `AddDependencyVisitor.visitTag` when no version action is needed. That fix only covered the *version-satisfies* case (`versionToUse == null`). The current PR extends to the *version-exceeds* case (`versionToUse != null` because selector doesn't satisfy the managed version, but the managed version is higher), and also extends the same XML-as-source-of-truth pattern to `ChangeDependencyGroupIdAndArtifactId`.

## Test plan

- [x] `:rewrite-maven:test` targeted dedup tests green
- [x] New regression tests added for both files
- [ ] Empirical validation under environments where the resolution-model-based dedup is known to miss