### PR TITLE
Gradle: handle null resolved versions in UpgradePluginVersion (consolidates #7658)

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
@@ -168,9 +168,11 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                         String versionVariableName = gStringValue.getTree().toString();
                         String resolvedPluginVersion = new DependencyVersionSelector(metadataFailures, gradleProject, gradleSettings)
                                 .select(new GroupArtifact(pluginId, pluginId + ".gradle.plugin"), "classpath", newVersion, versionPattern, ctx);
+                        if (resolvedPluginVersion == null) {
+                            return m;
+                        }
 
                         acc.versionPropNameToPluginId.put(versionVariableName, pluginId);
-                        assert resolvedPluginVersion != null;
                         acc.pluginIdToNewVersion.put(pluginId, resolvedPluginVersion);
                     } else if (versionArgs.get(0) instanceof J.Identifier) {
                         J.Identifier identifier = (J.Identifier) versionArgs.get(0);
@@ -183,6 +185,9 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                         } else {
                             resolvedPluginVersion = new DependencyVersionSelector(metadataFailures, gradleProject, gradleSettings)
                                     .select(new GroupArtifact(pluginId, pluginId + ".gradle.plugin"), "classpath", newVersion, versionPattern, ctx);
+                        }
+                        if (resolvedPluginVersion == null) {
+                            return m;
                         }
 
                         acc.versionPropNameToPluginId.put(versionVariableName, pluginId);
@@ -212,6 +217,9 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                     String pluginId = acc.versionPropNameToPluginId.get(entry.getKey());
                     if (!StringUtils.isBlank(newVersion)) {
                         String resolvedVersion = acc.pluginIdToNewVersion.get(pluginId);
+                        if (resolvedVersion == null || StringUtils.isBlank(currentVersion)) {
+                            return entry;
+                        }
                         VersionComparator versionComparator = Semver.validate(newVersion, versionPattern).getValue();
                         if (versionComparator == null) {
                             return entry;

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
@@ -305,6 +305,49 @@ class UpgradePluginVersionTest implements RewriteTest {
     }
 
     @Test
+    void unresolvableNewVersionWithInterpolatedVersionDoesNotThrow() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion("org.openrewrite.rewrite", "999.x", null)),
+          buildGradle(
+            """
+              plugins {
+                  id 'org.openrewrite.rewrite' version "$rewriteVersion"
+              }
+              """
+          ),
+          properties(
+            """
+              rewriteVersion=5.40.0
+              """,
+            spec -> spec.path("gradle.properties")
+          )
+        );
+    }
+
+    @Test
+    void unresolvableNewVersionWithIdentifierVersionDoesNotThrow() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion("org.openrewrite.rewrite", "999.x", null)),
+          settingsGradle(
+            """
+              pluginManagement {
+                  plugins {
+                      String rewriteVersion = '5.40.0'
+                      id 'org.openrewrite.rewrite' version rewriteVersion
+                  }
+              }
+              """
+          ),
+          properties(
+            """
+              rewriteVersion=
+              """,
+            spec -> spec.path("gradle.properties")
+          )
+        );
+    }
+
+    @Test
     void defaultsToLatestRelease() {
         rewriteRun(
           spec -> spec.recipe(new UpgradePluginVersion("org.openrewrite.rewrite", null, null)),


### PR DESCRIPTION
## Motivation

`UpgradePluginVersion` was crashing in the wild on the 2026-05-11 Moderne flagship "Spring Boot 4.0 best practices" run (run id `aNeLGnYR4`) with `java.lang.AssertionError: null` from `UpgradePluginVersion.java:173`.

The root cause is shared with #7658: `DependencyVersionSelector.select(...)` is `@Nullable` by contract — it returns `null` whenever no version in the plugin's Maven metadata satisfies the comparator, or when exotic versions trigger an internal `IllegalStateException` that's mapped to `null`. The scanner had three branches that each treated the same nullable contract differently:

| Branch (plugin version shape) | Pre-fix handling | Surface symptom |
| --- | --- | --- |
| Literal: `id 'foo' version '1.2.3'` | `select(GAV, …)` result passed through; the upgrade visitor short-circuits on null at line 305-307. | Safe. |
| GString: `id 'foo' version "$prop"` | Bare `assert resolvedPluginVersion != null`. | `AssertionError: null` at `:173`. **Reported.** |
| Identifier: `id 'foo' version someIdent` | Put `null` into `pluginIdToNewVersion`; downstream `visitEntry` called `VersionComparator.upgrade(currentVersion, singletonList(null))`, which NPEs inside `Pattern.matcher` in `VersionComparator.checkVersion`. | NPE — same scenario [#7658](https://github.com/openrewrite/rewrite/pull/7658) addressed. |

One rule covers both: when the selector returns `null`, leave the build script unchanged and do not pollute the accumulator. Plus a defensive guard in `visitEntry` for the blank-`currentVersion` edge case (empty values in `gradle.properties`).

## Examples

Previously crashed; now leaves both files unchanged:

```groovy
// build.gradle
plugins {
    id 'org.openrewrite.rewrite' version "$rewriteVersion"
}
```

```properties
# gradle.properties
rewriteVersion=5.40.0
```

Previously NPEd; now leaves both files unchanged:

```groovy
// settings.gradle
pluginManagement {
    plugins {
        String rewriteVersion = '5.40.0'
        id 'org.openrewrite.rewrite' version rewriteVersion
    }
}
```

```properties
# gradle.properties
rewriteVersion=
```

## Summary

- Replace the bare `assert` in the GString branch with an early `return m;` when the selector can't resolve a new version.
- Add the same guard to the Identifier branch so no `null` is ever recorded in `pluginIdToNewVersion`.
- Defensively skip `visitEntry` when the resolved version is `null` or the current version is blank.
- Add tests `unresolvableNewVersionWithInterpolatedVersionDoesNotThrow` and `unresolvableNewVersionWithIdentifierVersionDoesNotThrow`.

Consolidates #7658, which can be closed once this lands.

## Test plan

- [x] `./gradlew :rewrite-gradle:test --tests "org.openrewrite.gradle.plugins.UpgradePluginVersionTest.unresolvableNewVersionWithInterpolatedVersionDoesNotThrow"` passes.
- [x] `./gradlew :rewrite-gradle:test --tests "org.openrewrite.gradle.plugins.UpgradePluginVersionTest.unresolvableNewVersionWithIdentifierVersionDoesNotThrow"` passes.
- [x] Both new tests reproduce the original failures (`AssertionError` at `:173` and NPE in `VersionComparator.checkVersion`, respectively) on `main`.
- [x] Two unrelated tests (`springBootPluginsAreDependencyManagedVersionAware`, `doesNotPinPropertyManagedVersions`) are flaking locally due to Maven Central HTTP 429 rate limiting; they also fail on baseline without these changes.