### PR TITLE
Avoid SIOOBE in `RemoveImport` when type has no package

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveImportTest.java
@@ -965,4 +965,20 @@ class RemoveImportTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://app.moderne.io/recipe-runs/qBYPkMYl0")
+    @Test
+    void doesNotCrashWhenTypeHasNoPackage() {
+        rewriteRun(
+          spec -> spec.recipe(removeImport("Foo")),
+          java(
+            """
+              import static java.util.Collections.*;
+
+              class A {
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
@@ -134,7 +134,7 @@ public class RemoveImport<P> extends JavaIsoVisitor<P> {
                         spaceForNextImport.set(import_.getPrefix());
                         return null;
                     } else if ("*".equals(imported) && (TypeUtils.fullyQualifiedNamesAreEqual(typeName, type) ||
-                            TypeUtils.fullyQualifiedNamesAreEqual(typeName + type.substring(type.lastIndexOf('.')), type))) {
+                            !owner.isEmpty() && TypeUtils.fullyQualifiedNamesAreEqual(typeName, owner))) {
                         if (methodsAndFieldsUsed.isEmpty() && otherMethodsAndFieldsInTypeUsed.isEmpty()) {
                             spaceForNextImport.set(import_.getPrefix());
                             return null;


### PR DESCRIPTION
## Motivation

Running the Moderne flagship **Java best practices** recipe (run [`qBYPkMYl0`](https://app.moderne.io/recipe-runs/qBYPkMYl0)) against `spring-projects/spring-session-data-mongodb` and `spring-projects/spring-session-data-mongodb-examples` consistently failed three files with:

```
java.lang.StringIndexOutOfBoundsException: begin -1, end 9, length 9
  java.base/java.lang.String.substring(String.java:2709)
  org.openrewrite.java.RemoveImport.lambda$preVisit$0(RemoveImport.java:137)
  org.openrewrite.internal.ListUtils.flatMap(ListUtils.java:357)
  org.openrewrite.java.RemoveImport.preVisit(RemoveImport.java:118)
```

The crash was triggered by `org.openrewrite.java.migrate.lang.var.UseVarForGenericMethodInvocations` calling `maybeRemoveImport(vd.getType())`. The static `*`-import branch in `RemoveImport.preVisit` then evaluated

```java
TypeUtils.fullyQualifiedNamesAreEqual(typeName + type.substring(type.lastIndexOf('.')), type)
```

against each `import static foo.Bar.*` declaration. If the supplied `type` contained no `.` (e.g. an unqualified or partially attributed type), `lastIndexOf` returned `-1` and `substring(-1)` blew up.

## Summary

- `RemoveImport.preVisit` no longer calls `substring(lastIndexOf('.'))` on the target type. It uses the precomputed `owner` field instead, which the constructor already derives safely via `Math.max(0, lastIndexOf('.'))`.
- The new expression is semantically equivalent for every dotted FQN — `typeName + "." + lastSegment(type)` matches `type` iff `typeName` matches `owner` — and naturally evaluates to `false` (rather than throwing) when the target type has no owner.

## Test plan

- [x] Added `RemoveImportTest.doesNotCrashWhenTypeHasNoPackage` reproducing the same `RemoveImport.java:137` stack trace and proving it fails before the fix.
- [x] `./gradlew :rewrite-java-test:test` (full suite, including all existing `RemoveImportTest` cases) passes after the fix.