### PR TITLE
UpgradePluginVersion: avoid NPE when no upgrade is available

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
@@ -212,6 +212,9 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                     String pluginId = acc.versionPropNameToPluginId.get(entry.getKey());
                     if (!StringUtils.isBlank(newVersion)) {
                         String resolvedVersion = acc.pluginIdToNewVersion.get(pluginId);
+                        if (resolvedVersion == null || StringUtils.isBlank(currentVersion)) {
+                            return entry;
+                        }
                         VersionComparator versionComparator = Semver.validate(newVersion, versionPattern).getValue();
                         if (versionComparator == null) {
                             return entry;

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
@@ -535,6 +535,29 @@ class UpgradePluginVersionTest implements RewriteTest {
     }
 
     @Test
+    void doesNotNpeWhenNoUpgradeAvailable() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion("org.openrewrite.rewrite", "999.x", null)),
+          settingsGradle(
+            """
+              pluginManagement {
+                  plugins {
+                      String rewriteVersion = '5.40.0'
+                      id 'org.openrewrite.rewrite' version rewriteVersion
+                  }
+              }
+              """
+          ),
+          properties(
+            """
+              rewriteVersion=
+              """,
+            spec -> spec.path("gradle.properties")
+          )
+        );
+    }
+
+    @Test
     void doesNotPinPropertyManagedVersions() {
         rewriteRun(
           spec -> spec


### PR DESCRIPTION
## Motivation

`UpgradePluginVersion` crashed with a `NullPointerException` inside `VersionComparator.checkVersion` when scanning a `gradle.properties` file whose key is referenced by a `plugins { id(...).version(...) }` block but where the scanner could not resolve any new version for the plugin (so the cached resolved version was `null`). The properties visitor handed that `null` to `VersionComparator.upgrade`, which forwarded it into `Pattern.matcher(...)` and blew up:

```
java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null
  java.base/java.util.regex.Pattern.matcher(Pattern.java:1145)
  org.openrewrite.semver.VersionComparator.checkVersion(VersionComparator.java:60)
  org.openrewrite.semver.LatestRelease.isValid(LatestRelease.java:36)
  org.openrewrite.semver.XRange.isValid(XRange.java:51)
  org.openrewrite.semver.VersionComparator.upgrade(VersionComparator.java:46)
  org.openrewrite.gradle.plugins.UpgradePluginVersion$2.visitEntry(UpgradePluginVersion.java:220)
```

Observed in the 2026-05-11 Moderne flagship "Spring Boot 4.0 best practices" run (`aNeLGnYR4`).

## Summary

- Guard `UpgradePluginVersion`'s properties visitor against a `null` resolved version (the "no upgrade applicable" signal from the scanner) and against a blank current version, leaving the entry unchanged in either case.
- Add a `RewriteTest` reproducing the trace, using a non-resolvable `newVersion` (`999.x`) and a referenced `gradle.properties` key.

## Test plan

- [x] `./gradlew :rewrite-gradle:test --tests org.openrewrite.gradle.plugins.UpgradePluginVersionTest` (new test fails before the fix with the exact `checkVersion:60` NPE; all tests pass after).