### PR TITLE
Gradle `AddDependency`: skip unknown configurations instead of NPE

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleConfigurationFilter.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleConfigurationFilter.java
@@ -24,8 +24,6 @@ import org.openrewrite.maven.tree.GroupArtifact;
 import java.util.HashSet;
 import java.util.Set;
 
-import static java.util.Objects.requireNonNull;
-
 @RequiredArgsConstructor
 class GradleConfigurationFilter {
     private final GradleProject gradleProject;
@@ -36,7 +34,10 @@ class GradleConfigurationFilter {
     public void removeTransitiveConfigurations() {
         Set<String> tmpConfigurations = new HashSet<>(filteredConfigurations);
         for (String tmpConfiguration : tmpConfigurations) {
-            GradleDependencyConfiguration gdc = requireNonNull(gradleProject.getConfiguration(tmpConfiguration));
+            GradleDependencyConfiguration gdc = gradleProject.getConfiguration(tmpConfiguration);
+            if (gdc == null) {
+                continue;
+            }
             for (GradleDependencyConfiguration transitive : gradleProject.configurationsExtendingFrom(gdc, true)) {
                 filteredConfigurations.remove(transitive.getName());
             }
@@ -56,7 +57,10 @@ class GradleConfigurationFilter {
     public void removeConfigurationsContainingTransitiveDependency(GroupArtifact dependency) {
         Set<String> tmpConfigurations = new HashSet<>(filteredConfigurations);
         for (String tmpConfiguration : tmpConfigurations) {
-            GradleDependencyConfiguration gdc = requireNonNull(gradleProject.getConfiguration(tmpConfiguration));
+            GradleDependencyConfiguration gdc = gradleProject.getConfiguration(tmpConfiguration);
+            if (gdc == null) {
+                continue;
+            }
             for (GradleDependencyConfiguration transitive : gradleProject.configurationsExtendingFrom(gdc, true)) {
                 if (transitive.findResolvedDependency(dependency.getGroupId(), dependency.getArtifactId()) != null) {
                     filteredConfigurations.remove(tmpConfiguration);

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -2061,6 +2061,58 @@ class AddDependencyTest implements RewriteTest {
     }
 
 
+    @Test
+    void doesNotThrowWhenScannedConfigurationUnknownToGradleProject() {
+        // When the scanner sees a Java file marked with a source set whose corresponding
+        // `<sourceSet>Implementation` configuration is not present in the GradleProject marker
+        // (e.g. the script doesn't declare that source set, or the GradleProject was built from
+        // a script that failed to evaluate fully), the resulting `resolvedConfigurations` mixes
+        // known and unknown configuration names. The filter must not NPE on the unknown ones.
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", "com.google.common.math.IntMath")),
+          mavenProject("project",
+            srcMainJava(
+              java(usingGuavaIntMath),
+              java(
+                """
+                  import com.google.common.math.IntMath;
+                  public class B {
+                      boolean getMap() {
+                          return IntMath.isPrime(5);
+                      }
+                  }
+                  """,
+                sourceSpecs -> sourceSet(sourceSpecs, "integrationTest")
+              )
+            ),
+            buildGradle(
+              """
+                plugins {
+                    id "java-library"
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    implementation "com.google.guava:guava:29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
     private AddDependency addDependency(@SuppressWarnings("SameParameterValue") String gav) {
         return addDependency(gav, null, null);
     }


### PR DESCRIPTION
## Motivation

`AddDependency.getVisitor` decides whether to apply configuration
filtering based on whether *any* scanned configuration is known to the
`GradleProject` marker:

```java
boolean configurationKnown = resolvedConfigurations.stream()
        .anyMatch(c -> gp.getConfiguration(c) != null);
if (configurationKnown) {
    GradleConfigurationFilter gradleConfigurationFilter = new GradleConfigurationFilter(gp, resolvedConfigurations);
    gradleConfigurationFilter.removeTransitiveConfigurations();
    // ...
}
```

But `GradleConfigurationFilter.removeTransitiveConfigurations` then
iterated *every* configuration in the filtered set and used
`Objects.requireNonNull(gradleProject.getConfiguration(name))`. When the
scanner had collected a mix of known and unknown configuration names —
e.g. `{implementation, integrationTestImplementation}` against a
`GradleProject` that only declares `implementation` — the unknown name
triggered an NPE deep inside the recipe.

This surfaced in the 2026-05-11 Moderne flagship "Spring Boot 4.0 best
practices" run (recipe run `aNeLGnYR4`) against `Netflix/Raigad` and
two other repositories where the parsed `GradleProject` marker did not
carry every configuration the scanner derived from Java source-set
markers.

Stack trace:

```
java.lang.NullPointerException
  java.base/java.util.Objects.requireNonNull(Objects.java:209)
  org.openrewrite.gradle.GradleConfigurationFilter.removeTransitiveConfigurations(GradleConfigurationFilter.java:39)
  org.openrewrite.gradle.AddDependency$2.visit(AddDependency.java:251)
  ...
```

## Summary

- `GradleConfigurationFilter.removeTransitiveConfigurations` and
  `removeConfigurationsContainingTransitiveDependency` now skip
  configurations not known to the `GradleProject` instead of
  `requireNonNull`-ing the lookup. This matches the existing behavior
  of `removeConfigurationsContainingDependency`.
- The `Objects.requireNonNull` static import is no longer needed.
- Adds a regression test that reproduces the production stack trace by
  combining a Java file in the `main` source set with a Java file
  marked for a custom `integrationTest` source set whose
  `integrationTestImplementation` configuration is not present in the
  `GradleProject` marker.

## Test plan

- [x] New test `AddDependencyTest.doesNotThrowWhenScannedConfigurationUnknownToGradleProject` reproduces the production NPE on `main` (verified by running it against the unmodified `GradleConfigurationFilter`) and passes after the fix.
- [x] Full `./gradlew :rewrite-gradle:test --tests AddDependencyTest` passes locally.