### PR TITLE
Gradle: skip cleanly when synthetic dependency template fails to parse

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/AddDependencyVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/AddDependencyVisitor.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
+import org.openrewrite.DelegatingExecutionContext;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Tree;
 import org.openrewrite.gradle.GradleParser;
@@ -46,6 +47,7 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -99,9 +101,10 @@ public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
                     if (!hasDependenciesBlock(g.getStatements())) {
                         Cursor parent = getCursor();
                         setCursor(new Cursor(parent, g));
-                        J.MethodInvocation dependencies = dependenciesDeclaration(ctx)
-                                .withPrefix(Space.format("\n\n"));
-                        cu = g.withStatements(ListUtils.concat(g.getStatements(), dependencies));
+                        J.MethodInvocation dependencies = dependenciesDeclaration(ctx);
+                        if (dependencies != null) {
+                            cu = g.withStatements(ListUtils.concat(g.getStatements(), dependencies.withPrefix(Space.format("\n\n"))));
+                        }
                         setCursor(parent);
                     }
                 }
@@ -119,9 +122,13 @@ public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
             if (!hasDependenciesBlock(b.getStatements())) {
                 Cursor parent = getCursor().dropParentUntil(value -> value instanceof J.MethodInvocation || value == Cursor.ROOT_VALUE);
                 Space prefix = b.getStatements().isEmpty() ? Space.format("\n") : Space.format("\n\n");
+                J.MethodInvocation declaration = dependenciesDeclaration(ctx);
+                if (declaration == null) {
+                    return b;
+                }
                 Statement dependencies = parent.isRoot() ?
-                        dependenciesDeclaration(ctx).withPrefix(prefix) :
-                        autoFormat(dependenciesDeclaration(ctx).withPrefix(prefix), ctx, getCursor());
+                        declaration.withPrefix(prefix) :
+                        autoFormat(declaration.withPrefix(prefix), ctx, getCursor());
                 return b.withStatements(ListUtils.concat(b.getStatements(), dependencies));
             }
         }
@@ -151,6 +158,9 @@ public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
                     J.Lambda lambda = (J.Lambda) arg;
                     J.Block body = (J.Block) lambda.getBody();
                     J.MethodInvocation addDependencyInvocation = dependencyDeclaration(body, ctx, new Cursor(new Cursor(getCursor(), lambda), body));
+                    if (addDependencyInvocation == null) {
+                        return arg;
+                    }
                     InsertDependencyComparator dependencyComparator = new InsertDependencyComparator(body.getStatements(), addDependencyInvocation);
 
                     List<Statement> statements = new ArrayList<>(body.getStatements());
@@ -332,58 +342,92 @@ public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
         return false;
     }
 
-    private J.MethodInvocation dependenciesDeclaration(ExecutionContext ctx) {
+    private J.@Nullable MethodInvocation dependenciesDeclaration(ExecutionContext ctx) {
         String template = templateDependencies();
-        return (J.MethodInvocation) cache(getCursor(), new ContextFreeCacheKey(template, isKotlinDsl, J.MethodInvocation.class), () -> {
+        List<J.MethodInvocation> cached = cache(getCursor(), new ContextFreeCacheKey(template, isKotlinDsl, J.MethodInvocation.class), () -> {
             Boolean requirePrintEqualsInput = ctx.getMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT);
             try {
-                J.MethodInvocation dependencies;
                 ctx.putMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, false);
+                ExecutionContext parseCtx = silentParseCtx(ctx);
+                J.MethodInvocation dependencies;
                 if (isKotlinDsl) {
-                    dependencies = (J.MethodInvocation) ((J.Block) GRADLE_PARSER.parseInputs(singletonList(new GradleParser.Input(Paths.get("build.gradle.kts"), () -> new ByteArrayInputStream(template.getBytes(StandardCharsets.UTF_8)))), null, ctx)
-                            .findFirst()
+                    K.CompilationUnit parsed = GRADLE_PARSER.parseInputs(singletonList(new GradleParser.Input(Paths.get("build.gradle.kts"), () -> new ByteArrayInputStream(template.getBytes(StandardCharsets.UTF_8)))), null, parseCtx)
+                            .filter(K.CompilationUnit.class::isInstance)
                             .map(K.CompilationUnit.class::cast)
-                            .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"))
-                            .getStatements().get(0)).getStatements().get(0);
-                } else {
-                    dependencies = (J.MethodInvocation) GRADLE_PARSER.parse(ctx, template)
                             .findFirst()
+                            .orElse(null);
+                    if (parsed == null) {
+                        return emptyList();
+                    }
+                    dependencies = (J.MethodInvocation) ((J.Block) parsed.getStatements().get(0)).getStatements().get(0);
+                } else {
+                    G.CompilationUnit parsed = GRADLE_PARSER.parse(parseCtx, template)
+                            .filter(G.CompilationUnit.class::isInstance)
                             .map(G.CompilationUnit.class::cast)
-                            .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"))
-                            .getStatements().get(0);
+                            .findFirst()
+                            .orElse(null);
+                    if (parsed == null) {
+                        return emptyList();
+                    }
+                    dependencies = (J.MethodInvocation) parsed.getStatements().get(0);
                 }
                 return singletonList(dependencies);
             } finally {
                 ctx.putMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, requirePrintEqualsInput);
             }
-        }).get(0);
+        });
+        return cached.isEmpty() ? null : (J.MethodInvocation) cached.get(0);
     }
 
-    private J.MethodInvocation dependencyDeclaration(J.Block body, ExecutionContext ctx, Cursor cursor) {
+    private J.@Nullable MethodInvocation dependencyDeclaration(J.Block body, ExecutionContext ctx, Cursor cursor) {
         String template = templateDependency(body);
-        return (J.MethodInvocation) autoFormat(cache(cursor, new ContextFreeCacheKey(template, isKotlinDsl, J.MethodInvocation.class), () -> {
+        List<J.MethodInvocation> cached = cache(cursor, new ContextFreeCacheKey(template, isKotlinDsl, J.MethodInvocation.class), () -> {
             Boolean requirePrintEqualsInput = ctx.getMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT);
             try {
-                J.MethodInvocation dependency;
                 ctx.putMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, false);
+                ExecutionContext parseCtx = silentParseCtx(ctx);
+                J.MethodInvocation dependency;
                 if (isKotlinDsl) {
-                    dependency = (J.MethodInvocation) ((J.Block) GRADLE_PARSER.parseInputs(singletonList(new GradleParser.Input(Paths.get("build.gradle.kts"), () -> new ByteArrayInputStream(template.getBytes(StandardCharsets.UTF_8)))), null, ctx)
-                            .findFirst()
+                    K.CompilationUnit parsed = GRADLE_PARSER.parseInputs(singletonList(new GradleParser.Input(Paths.get("build.gradle.kts"), () -> new ByteArrayInputStream(template.getBytes(StandardCharsets.UTF_8)))), null, parseCtx)
+                            .filter(K.CompilationUnit.class::isInstance)
                             .map(K.CompilationUnit.class::cast)
-                            .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"))
-                            .getStatements().get(0)).getStatements().get(0);
-                } else {
-                    dependency = (J.MethodInvocation) GRADLE_PARSER.parse(ctx, template)
                             .findFirst()
+                            .orElse(null);
+                    if (parsed == null) {
+                        return emptyList();
+                    }
+                    dependency = (J.MethodInvocation) ((J.Block) parsed.getStatements().get(0)).getStatements().get(0);
+                } else {
+                    G.CompilationUnit parsed = GRADLE_PARSER.parse(parseCtx, template)
+                            .filter(G.CompilationUnit.class::isInstance)
                             .map(G.CompilationUnit.class::cast)
-                            .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"))
-                            .getStatements().get(0);
+                            .findFirst()
+                            .orElse(null);
+                    if (parsed == null) {
+                        return emptyList();
+                    }
+                    dependency = (J.MethodInvocation) parsed.getStatements().get(0);
                 }
                 return singletonList(dependency.withPrefix(Space.format("\n")));
             } finally {
                 ctx.putMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, requirePrintEqualsInput);
             }
-        }).get(0), ctx, cursor);
+        });
+        return cached.isEmpty() ? null : (J.MethodInvocation) autoFormat(cached.get(0), ctx, cursor);
+    }
+
+    private static ExecutionContext silentParseCtx(ExecutionContext ctx) {
+        return new DelegatingExecutionContext(ctx) {
+            @Override
+            public Consumer<Throwable> getOnError() {
+                // The visitor parses its own synthetic build.gradle template. Surfacing a parse
+                // failure here would crash the recipe on the user's source file even though the
+                // failure is internal — instead the calling code treats the empty result as a
+                // signal to skip this insertion.
+                return t -> {
+                };
+            }
+        };
     }
 
     private String templateDependencies() {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -2061,6 +2061,58 @@ class AddDependencyTest implements RewriteTest {
     }
 
 
+    @Test
+    void doesNotThrowWhenSyntheticTemplateFailsToParse() {
+        // A double-quote in the groupId produces an unparseable synthetic template,
+        // e.g.: `implementation "g"id:lib"`. The Groovy parser returns a ParseError,
+        // which previously caused a ClassCastException when the visitor blindly cast
+        // the parse result to G.CompilationUnit. The visitor must skip the file instead.
+        var addDep = new AddDependency("g\"id", "lib", null, null, "implementation", null, null, null, null, null);
+        rewriteRun(
+          spec -> spec.recipe(addDep),
+          mavenProject("project",
+            buildGradle(
+              //language=groovy
+              """
+                plugins {
+                    id "java-library"
+                }
+                repositories {
+                    mavenCentral()
+                }
+                dependencies {
+                    implementation "com.google.guava:guava:29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void doesNotThrowWhenSyntheticDependenciesBlockTemplateFailsToParse() {
+        // Same defensive check, but on the path that runs when no `dependencies { }`
+        // block exists yet — `dependenciesDeclaration` builds an entire block from the
+        // template, which also has to tolerate a ParseError.
+        var addDep = new AddDependency("g\"id", "lib", null, null, "implementation", null, null, null, null, null);
+        rewriteRun(
+          spec -> spec.recipe(addDep),
+          mavenProject("project",
+            buildGradle(
+              //language=groovy
+              """
+                plugins {
+                    id "java-library"
+                }
+                repositories {
+                    mavenCentral()
+                }
+                """
+            )
+          )
+        );
+    }
+
     private AddDependency addDependency(@SuppressWarnings("SameParameterValue") String gav) {
         return addDependency(gav, null, null);
     }


### PR DESCRIPTION
## Motivation

While running the flagship Moderne "Java best practices" recipe (run id `qBYPkMYl0`) against `nebula-plugins/gradle-resolution-rules-plugin/build.gradle`, `AddDependencyVisitor` crashed with:

```
java.lang.ClassCastException: Cannot cast org.openrewrite.tree.ParseError to org.openrewrite.groovy.tree.G$CompilationUnit
  java.base/java.lang.Class.cast(Class.java:3892)
  java.base/java.util.Optional.map(Optional.java:260)
  org.openrewrite.gradle.internal.AddDependencyVisitor.lambda$dependencyDeclaration$13(AddDependencyVisitor.java:378)
  ...
```

`AddDependencyVisitor.dependencyDeclaration` (and the sibling `dependenciesDeclaration`) builds a synthetic build script snippet from the recipe inputs, runs it through `GradleParser`, and casts the first result to `G.CompilationUnit` (or `K.CompilationUnit` for Kotlin DSL). When the synthetic template happens to be unparseable, the parser returns a `ParseError` and the blind `Optional.map(Class::cast)` crashes the whole recipe on that source file. The expected behaviour is to simply skip the insertion and leave the source unchanged.

## Summary

- Filter the parser stream to the expected `CompilationUnit` type before casting in both `dependencyDeclaration` and `dependenciesDeclaration`; treat an empty result as a signal to skip the insertion.
- Wrap the `ExecutionContext` used for the internal parse in a `DelegatingExecutionContext` whose `onError` is a no-op. The visitor's synthetic-template parse is an implementation detail; failures there should not be re-reported to the caller's `ExecutionContext` (which in test contexts throws an `AssertionError`).
- Update callers (`visit`, `visitBlock`, `visitMethodInvocation`) to handle a null declaration by leaving the source unchanged.

This PR is intentionally scoped to `AddDependencyVisitor` — the site surfaced by the stack trace. The same pattern (`GRADLE_PARSER.parse(...).findFirst().map(<CU>.class::cast)`) appears in `UpgradeTransitiveDependencyVersion`, `EnableDevelocityBuildCache`, `DependencyConstraintToRule`, `MigrateGradleEnterpriseToDevelocity`, `AddDevelocityGradlePlugin`, and `AddSettingsPluginRepository`; those can be hardened separately.

## Test plan

- [x] New tests in `AddDependencyTest` covering both the `dependencyDeclaration` path (build script already has a `dependencies { }` block) and the `dependenciesDeclaration` path (no `dependencies { }` block yet); both use a `groupId` containing a literal `"` to produce an unparseable synthetic template.
- [x] Both tests fail before the fix (the first throws via line 377 in the new line numbers, the second via line 350) and pass after.
- [x] `./gradlew :rewrite-gradle:test --tests "org.openrewrite.gradle.AddDependencyTest"` — the remaining failures are all `HTTP 429` from Maven Central rate-limiting and are unrelated to this change.
- [x] Verified the recipe no longer throws on the actual `nebula-plugins/gradle-resolution-rules-plugin/build.gradle` contents.