### PR TITLE
Tolerate methods without an enclosing class in RemoveMethodThrows + handle Kotlin @Throws

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodThrows.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodThrows.java
@@ -21,13 +21,20 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.search.DeclaresMethod;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
 public class RemoveMethodThrows extends Recipe {
 
+    private static final String KOTLIN_THROWS_FQN = "kotlin.jvm.Throws";
+    private static final String ANNOTATION_REMOVED_KEY = "kotlinThrowsAnnotationRemoved";
 
     @Option(displayName = "Method pattern",
             description = MethodMatcher.METHOD_PATTERN_INVOCATIONS_DESCRIPTION,
@@ -62,22 +69,63 @@ public class RemoveMethodThrows extends Recipe {
                     @Override
                     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                         J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
-                        J.ClassDeclaration cd = getCursor().firstEnclosing(J.ClassDeclaration.class);
-                        if (cd == null) {
-                            // Top-level Kotlin functions have no enclosing class; their `@Throws` is an
-                            // annotation, not a throws clause, so there is nothing to remove here.
+                        // Close the gap if the dropped `@Throws` was the only leading annotation.
+                        J.Annotation removedAnnotation = getCursor().pollMessage(ANNOTATION_REMOVED_KEY);
+                        List<J.Annotation> originalAnnotations = method.getLeadingAnnotations();
+                        if (removedAnnotation != null && originalAnnotations.size() == 1 &&
+                                originalAnnotations.get(0) == removedAnnotation) {
+                            m = collapseBlankLineLeftByRemovedAnnotation(m);
+                        }
+                        if (!matchesMethod(m) || m.getThrows() == null) {
                             return m;
                         }
-                        if (methodMatcher.matches(m, cd) && m.getThrows() != null) {
-                            return m.withThrows(ListUtils.map(m.getThrows(), nt -> {
-                                if (typeMatcher.matches(nt.getType())) {
-                                    maybeRemoveImport(nt.getType().toString());
+                        return m.withThrows(ListUtils.map(m.getThrows(), nt -> {
+                            if (typeMatcher.matches(nt.getType())) {
+                                maybeRemoveImport(nt.getType().toString());
+                                return null;
+                            }
+                            return nt;
+                        }));
+                    }
+
+                    @Override
+                    public J.@Nullable Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                        J.Annotation a = super.visitAnnotation(annotation, ctx);
+                        if (!TypeUtils.isOfClassType(a.getType(), KOTLIN_THROWS_FQN) || a.getArguments() == null) {
+                            return a;
+                        }
+                        J.MethodDeclaration enclosing = getCursor().firstEnclosing(J.MethodDeclaration.class);
+                        if (enclosing == null || !matchesMethod(enclosing)) {
+                            return a;
+                        }
+                        List<Expression> originalArgs = a.getArguments();
+                        List<Expression> remaining = ListUtils.map(originalArgs, arg -> {
+                            if (arg instanceof J.MemberReference) {
+                                JavaType referenced = ((J.MemberReference) arg).getContaining().getType();
+                                if (referenced != null && typeMatcher.matches(referenced)) {
+                                    maybeRemoveImport(referenced.toString());
                                     return null;
                                 }
-                                return nt;
-                            }));
+                            }
+                            return arg;
+                        });
+                        if (remaining == null || remaining.isEmpty()) {
+                            // Signal parent method for blank-line cleanup.
+                            getCursor().dropParentUntil(J.MethodDeclaration.class::isInstance)
+                                    .putMessage(ANNOTATION_REMOVED_KEY, annotation);
+                            //noinspection DataFlowIssue
+                            return null;
                         }
-                        return m;
+                        if (remaining.size() == originalArgs.size()) {
+                            return a;
+                        }
+                        // If the first argument was removed, the new first argument carries the prefix
+                        // it had after the comma (e.g. " ") — adopt the original first arg's prefix
+                        // so we don't end up with `( foo`.
+                        if (originalArgs.get(0) != remaining.get(0)) {
+                            remaining.set(0, remaining.get(0).withPrefix(originalArgs.get(0).getPrefix()));
+                        }
+                        return a.withArguments(remaining);
                     }
 
                     @Override
@@ -88,6 +136,44 @@ public class RemoveMethodThrows extends Recipe {
                             return mt.withThrownExceptions(ListUtils.filter(mt.getThrownExceptions(), te -> !typeMatcher.matches(te)));
                         }
                         return jt;
+                    }
+
+                    private boolean matchesMethod(J.MethodDeclaration m) {
+                        // Top-level Kotlin functions have no enclosing class; fall back to matching by
+                        // the method's declaring type from its type attribution.
+                        J.ClassDeclaration cd = getCursor().firstEnclosing(J.ClassDeclaration.class);
+                        return cd != null ? methodMatcher.matches(m, cd) : methodMatcher.matches(m.getMethodType());
+                    }
+
+                    /**
+                     * Mirrors {@link RemoveAnnotationVisitor}'s blank-line cleanup, adapted for Kotlin:
+                     * skip empty-prefix modifiers (the synthetic {@code final} sits at index 0 with no
+                     * whitespace, while {@code fun} sits later with the actual line-leading whitespace),
+                     * and for top-level functions also clear the method's own prefix.
+                     */
+                    private J.MethodDeclaration collapseBlankLineLeftByRemovedAnnotation(J.MethodDeclaration m) {
+                        boolean topLevel = getCursor().firstEnclosing(J.ClassDeclaration.class) == null;
+                        if (!m.getPrefix().getWhitespace().isEmpty()) {
+                            m = m.withPrefix(m.getPrefix().withWhitespace(""));
+                            if (!topLevel) {
+                                return m;
+                            }
+                        }
+                        for (int i = 0; i < m.getModifiers().size(); i++) {
+                            J.Modifier mod = m.getModifiers().get(i);
+                            if (!mod.getPrefix().getWhitespace().isEmpty()) {
+                                List<J.Modifier> mods = new ArrayList<>(m.getModifiers());
+                                mods.set(i, mod.withPrefix(mod.getPrefix().withWhitespace("")));
+                                return m.withModifiers(mods);
+                            }
+                        }
+                        if (m.getReturnTypeExpression() != null && !m.getReturnTypeExpression().getPrefix().getWhitespace().isEmpty()) {
+                            return m.withReturnTypeExpression(m.getReturnTypeExpression().withPrefix(m.getReturnTypeExpression().getPrefix().withWhitespace("")));
+                        }
+                        if (!m.getName().getPrefix().getWhitespace().isEmpty()) {
+                            return m.withName(m.getName().withPrefix(m.getName().getPrefix().withWhitespace("")));
+                        }
+                        return m;
                     }
                 }
         );

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodThrows.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodThrows.java
@@ -62,7 +62,12 @@ public class RemoveMethodThrows extends Recipe {
                     @Override
                     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                         J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
-                        J.ClassDeclaration cd = getCursor().firstEnclosingOrThrow(J.ClassDeclaration.class);
+                        J.ClassDeclaration cd = getCursor().firstEnclosing(J.ClassDeclaration.class);
+                        if (cd == null) {
+                            // Top-level Kotlin functions have no enclosing class; their `@Throws` is an
+                            // annotation, not a throws clause, so there is nothing to remove here.
+                            return m;
+                        }
                         if (methodMatcher.matches(m, cd) && m.getThrows() != null) {
                             return m.withThrows(ListUtils.map(m.getThrows(), nt -> {
                                 if (typeMatcher.matches(nt.getType())) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodThrows.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodThrows.java
@@ -35,6 +35,7 @@ public class RemoveMethodThrows extends Recipe {
 
     private static final String KOTLIN_THROWS_FQN = "kotlin.jvm.Throws";
     private static final String ANNOTATION_REMOVED_KEY = "kotlinThrowsAnnotationRemoved";
+    private static final String METHOD_MATCHES_KEY = "methodMatches";
 
     @Option(displayName = "Method pattern",
             description = MethodMatcher.METHOD_PATTERN_INVOCATIONS_DESCRIPTION,
@@ -68,15 +69,20 @@ public class RemoveMethodThrows extends Recipe {
         return Preconditions.check(new DeclaresMethod<>(methodMatcher), new JavaIsoVisitor<ExecutionContext>() {
                     @Override
                     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                        J.ClassDeclaration enclosingClass = getCursor().firstEnclosing(J.ClassDeclaration.class);
+                        boolean matches = enclosingClass != null ?
+                                methodMatcher.matches(method, enclosingClass) :
+                                methodMatcher.matches(method.getMethodType());
+                        getCursor().putMessage(METHOD_MATCHES_KEY, matches);
+
                         J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
-                        // Close the gap if the dropped `@Throws` was the only leading annotation.
                         J.Annotation removedAnnotation = getCursor().pollMessage(ANNOTATION_REMOVED_KEY);
                         List<J.Annotation> originalAnnotations = method.getLeadingAnnotations();
                         if (removedAnnotation != null && originalAnnotations.size() == 1 &&
                                 originalAnnotations.get(0) == removedAnnotation) {
-                            m = collapseBlankLineLeftByRemovedAnnotation(m);
+                            m = collapseBlankLineLeftByRemovedAnnotation(m, enclosingClass == null);
                         }
-                        if (!matchesMethod(m) || m.getThrows() == null) {
+                        if (!matches || m.getThrows() == null) {
                             return m;
                         }
                         return m.withThrows(ListUtils.map(m.getThrows(), nt -> {
@@ -94,8 +100,7 @@ public class RemoveMethodThrows extends Recipe {
                         if (!TypeUtils.isOfClassType(a.getType(), KOTLIN_THROWS_FQN) || a.getArguments() == null) {
                             return a;
                         }
-                        J.MethodDeclaration enclosing = getCursor().firstEnclosing(J.MethodDeclaration.class);
-                        if (enclosing == null || !matchesMethod(enclosing)) {
+                        if (!Boolean.TRUE.equals(getCursor().getNearestMessage(METHOD_MATCHES_KEY))) {
                             return a;
                         }
                         List<Expression> originalArgs = a.getArguments();
@@ -110,7 +115,6 @@ public class RemoveMethodThrows extends Recipe {
                             return arg;
                         });
                         if (remaining == null || remaining.isEmpty()) {
-                            // Signal parent method for blank-line cleanup.
                             getCursor().dropParentUntil(J.MethodDeclaration.class::isInstance)
                                     .putMessage(ANNOTATION_REMOVED_KEY, annotation);
                             //noinspection DataFlowIssue
@@ -138,31 +142,24 @@ public class RemoveMethodThrows extends Recipe {
                         return jt;
                     }
 
-                    private boolean matchesMethod(J.MethodDeclaration m) {
-                        // Top-level Kotlin functions have no enclosing class; fall back to matching by
-                        // the method's declaring type from its type attribution.
-                        J.ClassDeclaration cd = getCursor().firstEnclosing(J.ClassDeclaration.class);
-                        return cd != null ? methodMatcher.matches(m, cd) : methodMatcher.matches(m.getMethodType());
-                    }
-
                     /**
                      * Mirrors {@link RemoveAnnotationVisitor}'s blank-line cleanup, adapted for Kotlin:
                      * skip empty-prefix modifiers (the synthetic {@code final} sits at index 0 with no
                      * whitespace, while {@code fun} sits later with the actual line-leading whitespace),
                      * and for top-level functions also clear the method's own prefix.
                      */
-                    private J.MethodDeclaration collapseBlankLineLeftByRemovedAnnotation(J.MethodDeclaration m) {
-                        boolean topLevel = getCursor().firstEnclosing(J.ClassDeclaration.class) == null;
+                    private J.MethodDeclaration collapseBlankLineLeftByRemovedAnnotation(J.MethodDeclaration m, boolean topLevel) {
                         if (!m.getPrefix().getWhitespace().isEmpty()) {
                             m = m.withPrefix(m.getPrefix().withWhitespace(""));
                             if (!topLevel) {
                                 return m;
                             }
                         }
-                        for (int i = 0; i < m.getModifiers().size(); i++) {
-                            J.Modifier mod = m.getModifiers().get(i);
+                        List<J.Modifier> modifiers = m.getModifiers();
+                        for (int i = 0; i < modifiers.size(); i++) {
+                            J.Modifier mod = modifiers.get(i);
                             if (!mod.getPrefix().getWhitespace().isEmpty()) {
-                                List<J.Modifier> mods = new ArrayList<>(m.getModifiers());
+                                List<J.Modifier> mods = new ArrayList<>(modifiers);
                                 mods.set(i, mod.withPrefix(mod.getPrefix().withWhitespace("")));
                                 return m.withModifiers(mods);
                             }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/RemoveMethodThrowsTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/RemoveMethodThrowsTest.java
@@ -71,7 +71,7 @@ class RemoveMethodThrowsTest implements RewriteTest {
     }
 
     @Test
-    void classWrappedFunctionWithThrowsAnnotation() {
+    void removeSoleExceptionFromThrowsAnnotation() {
         rewriteRun(
           kotlin(
             """
@@ -79,6 +79,70 @@ class RemoveMethodThrowsTest implements RewriteTest {
 
               class Foo {
                   @Throws(IOException::class)
+                  fun foo() {
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  fun foo() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeOneExceptionFromMultiThrowsAnnotation() {
+        rewriteRun(
+          kotlin(
+            """
+              import java.io.IOException
+
+              class Foo {
+                  @Throws(IOException::class, RuntimeException::class)
+                  fun foo() {
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  @Throws(RuntimeException::class)
+                  fun foo() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeThrowsAnnotationFromTopLevelFunction() {
+        rewriteRun(
+          kotlin(
+            """
+              import java.io.IOException
+
+              @Throws(IOException::class)
+              fun foo() {
+              }
+              """,
+            """
+              fun foo() {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void leaveUnrelatedThrowsAnnotationUntouched() {
+        rewriteRun(
+          kotlin(
+            """
+              class Foo {
+                  @Throws(RuntimeException::class)
                   fun foo() {
                   }
               }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/RemoveMethodThrowsTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/RemoveMethodThrowsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.RemoveMethodThrows;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class RemoveMethodThrowsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveMethodThrows("* foo(..)", true, "java.io.IOException"));
+    }
+
+    @Test
+    void classWrappedFunction() {
+        rewriteRun(
+          kotlin(
+            """
+              class Foo {
+                  fun foo() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void topLevelFunctionDoesNotCrash() {
+        rewriteRun(
+          kotlin(
+            """
+              fun foo() {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void topLevelExtensionFunction() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveMethodThrows("* toBar(..)", true, "java.io.IOException")),
+          kotlin(
+            """
+              class Foo
+              class Bar(val x: Int)
+
+              fun Foo.toBar() = Bar(1)
+              """
+          )
+        );
+    }
+
+    @Test
+    void classWrappedFunctionWithThrowsAnnotation() {
+        rewriteRun(
+          kotlin(
+            """
+              import java.io.IOException
+
+              class Foo {
+                  @Throws(IOException::class)
+                  fun foo() {
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `RemoveMethodThrows` previously crashed with `IllegalStateException: Expected to find enclosing ClassDeclaration` when applied to a Kotlin LST that contained top-level `fun` declarations (including extension functions like `fun Foo.bar() = …`). Top-level Kotlin functions are direct children of `K.CompilationUnit` with no enclosing `J.ClassDeclaration`, but `RemoveMethodThrows.java:65` called `firstEnclosingOrThrow(J.ClassDeclaration.class)`.
- The recipe also did nothing for Kotlin source that uses `@Throws(IOException::class, …)` instead of a `throws` clause — these annotations were never inspected.

## What changed

- **Tolerate missing enclosing class.** Switched to `firstEnclosing(...)` and added a fallback to `methodMatcher.matches(JavaType.Method)` so top-level Kotlin `fun` declarations match by their declaring type from type attribution.
- **Strip matching `@kotlin.jvm.Throws` arguments.** Added an annotation visitor that walks `@Throws(...)` argument `J.MemberReference`s, removes ones whose containing type matches the exception pattern, drops the annotation when none remain, and adopts the original first-arg prefix when a non-first arg becomes the new first.
- **Collapse the blank line left by a fully-removed sole annotation.** Mirrors `RemoveAnnotationVisitor`'s cursor-message + parent-cleanup pattern, with two Kotlin-aware tweaks documented inline: skip empty-prefix modifiers (Kotlin's synthetic `final` sits at index 0 with no whitespace while `fun` carries the line-leading whitespace), and for top-level functions also clear the method's own prefix.

## Tests

New `rewrite-kotlin/src/test/java/org/openrewrite/kotlin/RemoveMethodThrowsTest.java` covers:
- top-level function: no crash, no change when no throws to remove
- top-level extension function: same
- class-wrapped function with `throws` clause sanity case
- `@Throws(IOException::class)` sole-exception → annotation removed, blank line collapsed
- `@Throws(IOException::class, RuntimeException::class)` → only matching arg removed
- Top-level `@Throws(IOException::class)` → annotation removed at column zero
- Unrelated `@Throws(RuntimeException::class)` left untouched

Existing `:rewrite-java:RemoveMethodThrowsTest` continues to pass — no behavior change for Java code.

- Reported via https://github.com/moderneinc/customer-requests/issues/2222.

## Test plan

- [ ] \`./gradlew :rewrite-java:test :rewrite-kotlin:test\`