### PR TITLE
Kotlin: fix multi-dollar string interpolation with template entries

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -280,7 +280,12 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
         p.append(delimiter);
 
         visit(stringTemplate.getStrings(), p);
-        p.append(delimiter);
+        // Strip any leading multi-dollar interpolation prefix from the closing delimiter.
+        int dollarCount = 0;
+        while (dollarCount < delimiter.length() && delimiter.charAt(dollarCount) == '$') {
+            dollarCount++;
+        }
+        p.append(delimiter.substring(dollarCount));
 
         afterSyntax(stringTemplate, p);
         return stringTemplate;
@@ -303,10 +308,24 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
     @Override
     public J visitStringTemplateExpression(K.StringTemplate.Expression expression, PrintOutputCapture<P> p) {
         beforeSyntax(expression, KSpace.Location.STRING_TEMPLATE_PREFIX, p);
+        // The interpolation marker matches the enclosing string's multi-dollar prefix length (default 1).
+        K.StringTemplate enclosing = getCursor().firstEnclosing(K.StringTemplate.class);
+        int dollarCount = 1;
+        if (enclosing != null) {
+            String enclosingDelimiter = enclosing.getDelimiter();
+            int leading = 0;
+            while (leading < enclosingDelimiter.length() && enclosingDelimiter.charAt(leading) == '$') {
+                leading++;
+            }
+            if (leading > 0) {
+                dollarCount = leading;
+            }
+        }
+        for (int i = 0; i < dollarCount; i++) {
+            p.append('$');
+        }
         if (expression.isEnclosedInBraces()) {
-            p.append("${");
-        } else {
-            p.append("$");
+            p.append('{');
         }
         visit(expression.getTree(), p);
         if (expression.isEnclosedInBraces()) {

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -3098,7 +3098,16 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 x instanceof KtSimpleNameStringTemplateEntry);
 
         if (hasStringTemplateEntry) {
-            String delimiter = expression.getFirstChild().getText();
+            PsiElement openQuote;
+            String prefix;
+            if (expression.getInterpolationPrefix() == null) {
+                openQuote = expression.getFirstChild();
+                prefix = "";
+            } else {
+                openQuote = expression.getFirstChild().getNextSibling();
+                prefix = expression.getInterpolationPrefix().getInterpolationPrefix();
+            }
+            String delimiter = prefix + openQuote.getText();
             List<J> values = new ArrayList<>(entries.length);
 
             for (KtStringTemplateEntry entry : entries) {

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinParserTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinParserTest.java
@@ -74,4 +74,68 @@ class KotlinParserTest implements RewriteTest {
         );
     }
 
+    @Test
+    void multiDollarStringInterpolationWithBlockExpression() {
+        rewriteRun(
+          kotlin(
+            """
+              val name = "World"
+              val x = $$"Hello $${name}!"
+              """
+          )
+        );
+    }
+
+    @Test
+    void multiDollarStringInterpolationWithSimpleName() {
+        rewriteRun(
+          kotlin(
+            """
+              val name = "World"
+              val x = $$"Hello $$name!"
+              """
+          )
+        );
+    }
+
+    @Test
+    void multiDollarStringInterpolationLiteralDollarBeforeInterpolation() {
+        rewriteRun(
+          kotlin(
+            """
+              val name = "World"
+              val x = $$"$$${name}"
+              """
+          )
+        );
+    }
+
+    @Test
+    void multiDollarStringInterpolationTwoBlocksWithLiteralDollarBetween() {
+        // Mirrors the pattern in KotlinTypeSignatureBuilder.kt that originally
+        // triggered the parse failure: a multi-dollar string with two block
+        // interpolations separated by a literal '$' (the JVM-style Outer$Inner FQN).
+        rewriteRun(
+          kotlin(
+            """
+              val outer = "java.lang.Object"
+              val inner = "Entry"
+              val fqn = $$"$${outer}$$${inner}"
+              """
+          )
+        );
+    }
+
+    @Test
+    void tripleDollarStringInterpolation() {
+        rewriteRun(
+          kotlin(
+            """
+              val name = "World"
+              val x = $$$"Hello $$$name!"
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## Motivation

- [#7090](https://github.com/openrewrite/rewrite/pull/7090) added support for Kotlin 2.1 multi-dollar string interpolation, but only covered the case where the string has no real template entries (i.e., the `J.Literal` branch of `visitStringTemplateExpression`). When the prefix-quoted string actually contains an interpolation — e.g. `$$"$${name}"` — the parser captured the prefix (`$$`) as the delimiter instead of `prefix + openQuote` (`$$"`), and the printer always emitted a single `$` before each interpolation. The result was a non-print-idempotent LST: parsing `$$"Hello $${name}!"` and printing it back produced `$$Hello ${name}!$$`, and any file using that syntax (including this repo's own `KotlinTypeSignatureBuilder.kt`) failed to parse.

## Examples

These now round-trip correctly:

```kotlin
val x = $$"Hello $${name}!"           // block-expression interpolation
val x = $$"Hello $$name!"             // simple-name interpolation
val x = $$"$$${name}"                 // literal `$` followed by interpolation
val x = $$"$${a}$$${b}"               // pattern from KotlinTypeSignatureBuilder
val x = $$$"Hello $$$name!"           // triple-dollar prefix
```

## Summary

- Parser (`KotlinTreeParserVisitor`): when the template has interpolation entries, capture `prefix + openQuote.getText()` as the `K.StringTemplate` delimiter (e.g. `$$"`).
- Printer (`KotlinPrinter#visitStringTemplate`): strip leading `$` characters from the delimiter when printing the closing quote.
- Printer (`KotlinPrinter#visitStringTemplateExpression`): emit N dollar signs (where N is the prefix length on the enclosing `K.StringTemplate`, defaulting to 1) before `{` or before the simple-name identifier.

## Test plan

- [x] Five new tests in `KotlinParserTest` covering block-expression interpolation, simple-name interpolation, literal-`$`-before-interpolation, the exact `Outer\$Inner` pattern from `KotlinTypeSignatureBuilder.kt`, and a triple-dollar prefix variant.
- [x] All existing `rewrite-kotlin` `tree/*` tests pass (51 test files, 0 failures).