### PR TITLE
Kotlin: handle ConeTypeVariableType in type signature builder

### DIFF
--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -286,6 +286,13 @@ class KotlinTypeMapping(
                 ""
             }
 
+            is ConeTypeVariableType -> {
+                // Inference type variable — use the constructor's debug name (typically
+                // the original type parameter's identifier) rather than the verbose
+                // `TypeVariable(...)` form from `toString()`.
+                type.typeConstructor.name.asString()
+            }
+
             else -> {
                 type.toString()
             }

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.fir.resolve.calls.FirSyntheticFunctionSymbol
 import org.jetbrains.kotlin.fir.resolve.inference.ConeTypeParameterBasedTypeVariable
 import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.resolve.toSymbol
+import org.jetbrains.kotlin.fir.symbols.ConeTypeParameterLookupTag
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.*
 import org.jetbrains.kotlin.fir.types.*
@@ -257,6 +258,19 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession, private val
                 sig.append(boundSigs)
                 sig.append("}")
                 sig.toString()
+            }
+
+            is ConeTypeVariableType -> {
+                // Inference type variable. Surfaces in scenarios like a callable
+                // reference to a generic method whose type argument hasn't been
+                // fixed yet (e.g. `buildList { forEach(::add) }`). Recover the
+                // original type parameter when available; fall back to a wildcard.
+                val original = type.typeConstructor.originalTypeParameter
+                if (original is ConeTypeParameterLookupTag) {
+                    signature(original.typeParameterSymbol.fir)
+                } else {
+                    "Generic{?}"
+                }
             }
 
             else -> throw UnsupportedOperationException("Unsupported ConeTypeProjection ${type.javaClass.name}")

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/MemberReferenceTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/MemberReferenceTest.java
@@ -17,9 +17,15 @@ package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.kotlin.KotlinIsoVisitor;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class MemberReferenceTest implements RewriteTest {
@@ -137,6 +143,50 @@ class MemberReferenceTest implements RewriteTest {
                   s.none( CharSequence  ?   :: isNullOrBlank)
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void callableReferenceToBuildListAdd() {
+        // Inside `buildList { ... }`, the receiver is `MutableList<E>` where E is
+        // a type variable being inferred. A callable reference to its `add` method
+        // exposes a `ConeTypeVariableType` parameter — which the type signature
+        // builder must handle (rather than throwing UnsupportedOperationException).
+        //
+        // We additionally assert that the recovered parameter type is the original
+        // `E` type parameter (a `GenericTypeVariable`), confirming the
+        // `ConeTypeParameterLookupTag` recovery path is taken — not the
+        // `Generic{?}` wildcard fallback.
+        AtomicBoolean asserted = new AtomicBoolean();
+        rewriteRun(
+          kotlin(
+            """
+              fun build() = buildList {
+                  listOf(1, 2, 3).forEach(::add)
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                new KotlinIsoVisitor<Integer>() {
+                    @Override
+                    public J.MemberReference visitMemberReference(J.MemberReference ref, Integer p) {
+                        JavaType.Method methodType = ref.getMethodType();
+                        assertThat(methodType).isNotNull();
+                        assertThat(methodType.getName()).isEqualTo("add");
+                        assertThat(methodType.getParameterTypes()).hasSize(1);
+                        JavaType paramType = methodType.getParameterTypes().get(0);
+                        assertThat(paramType)
+                          .as("Parameter type should be the recovered type parameter, not a wildcard")
+                          .isInstanceOf(JavaType.GenericTypeVariable.class);
+                        assertThat(((JavaType.GenericTypeVariable) paramType).getName())
+                          .as("Recovered type parameter name should be 'E' (from MutableList<E>)")
+                          .isEqualTo("E");
+                        asserted.set(true);
+                        return super.visitMemberReference(ref, p);
+                    }
+                }.visit(cu, 0);
+                assertThat(asserted).as("MemberReference for ::add should be present").isTrue();
+            })
           )
         );
     }


### PR DESCRIPTION
## Motivation

`KotlinTypeSignatureBuilder.coneTypeProjectionSignature` threw `UnsupportedOperationException: Unsupported ConeTypeProjection ...ConeTypeVariableType` for inference type variables surfaced by callable references to generic methods. The most concise repro:

```kotlin
fun build() = buildList {
    listOf(1, 2, 3).forEach(::add)
}
```

Inside `buildList { ... }` the lambda's receiver is `MutableList<E>` where `E` is an inference type variable. The callable reference `::add` exposes the parameter type as a `ConeTypeVariableType`, which the signature builder didn't recognize, causing the surrounding expression to surface as `J.Unknown`. The same pattern in this repo's own `KotlinTypeMapping.kt` is what surfaced this during a recent recipe run.

## Examples

Before, parsing this snippet failed with `UnsupportedOperationException` and produced `J.Unknown`:

```kotlin
fun build() = buildList {
    listOf(1, 2, 3).forEach(::add)
}
```

After, parsing succeeds and `J.MemberReference`'s method type carries the recovered type parameter:

```
methodType.getName()                  == "add"
methodType.getParameterTypes()[0]     is JavaType.GenericTypeVariable
((GenericTypeVariable) parameterType).getName() == "E"
```

## Summary

- `KotlinTypeSignatureBuilder.coneTypeProjectionSignature`: add a `ConeTypeVariableType` case. When the type variable's constructor carries a `ConeTypeParameterLookupTag`, reuse the existing `ConeTypeParameterType` path so the parameter type maps to the original `GenericTypeVariable`. Otherwise fall back to `Generic{?}` — same shape as `ConeStarProjection` / `ConeCapturedType`.
- `KotlinTypeMapping.coneTypeProjectionType`: extract the generic's display name from the type variable constructor's debug name (typically the original type parameter's identifier) rather than the verbose `toString()` form.

## Test plan

- [x] New test `MemberReferenceTest#callableReferenceToBuildListAdd` triggers the failure mode and additionally asserts that the recovered parameter type is a `GenericTypeVariable` named `E` — proving the `ConeTypeParameterLookupTag` recovery path is exercised, not just the `Generic{?}` fallback.
- [x] All existing `rewrite-kotlin` tests in `tree/*` continue to pass.