### PR TITLE
Throw clearer error when annotation arguments template fails to parse

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -79,6 +79,11 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                 } else if (loc == ANNOTATION_ARGUMENTS && mode == JavaCoordinates.Mode.REPLACEMENT &&
                            isScope(annotation)) {
                     List<J.Annotation> gen = unsubstitute(templateParser.parseAnnotations(getCursor(), "@Example(" + substitutedTemplate + ")"));
+                    if (gen.isEmpty()) {
+                        throw new IllegalStateException("Unable to parse annotation arguments from template: \n" +
+                                                        substitutedTemplate +
+                                                        "\nUse JavaTemplate.Builder.doBeforeParseTemplate() to see what stub is being generated and include it in any bug report.");
+                    }
                     return annotation.withArguments(gen.get(0).getArguments());
                 }
 


### PR DESCRIPTION
## Summary
- Adds an empty-list guard in `JavaTemplateJavaExtension#visitAnnotation` for the `ANNOTATION_ARGUMENTS` REPLACEMENT branch, mirroring the existing guard in the `ANNOTATION_PREFIX` branch.
- Converts an opaque `IndexOutOfBoundsException: Index 0 out of bounds for length 0` into an `IllegalStateException` with diagnostic guidance.

- Fixes #7664.

## Test plan
- [ ] `./gradlew :rewrite-java:compileJava` succeeds
- [ ] Existing `JavaTemplate` annotation tests still pass

No regression test is included: the originating Kotlin scenario could not be reduced to a reliably reproducing test against the current main; the change is defensive and improves only the error message on a path that was already broken.