### PR TITLE
Scala: stop leaking Dotty diagnostics to stderr

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/internal/ScalaCompilerContext.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/internal/ScalaCompilerContext.java
@@ -20,7 +20,10 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.ParseWarning;
 import org.openrewrite.Parser;
 import org.openrewrite.Tree;
+import org.openrewrite.scala.ScalaParser;
 import org.openrewrite.scheduling.WorkingDirectoryExecutionContextView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.*;
@@ -31,14 +34,18 @@ import java.util.stream.Collectors;
  * This class delegates to the Scala bridge for compiler interaction.
  */
 public class ScalaCompilerContext {
+    private static final Logger logger = LoggerFactory.getLogger(ScalaParser.class);
+
     private final ScalaCompilerBridge bridge;
     private final ExecutionContext executionContext;
+    private final boolean logCompilationWarningsAndErrors;
     private final List<String> classpathStrings;
 
     public ScalaCompilerContext(@Nullable Collection<Path> classpath,
                                 boolean logCompilationWarningsAndErrors,
                                 ExecutionContext executionContext) {
         this.executionContext = executionContext;
+        this.logCompilationWarningsAndErrors = logCompilationWarningsAndErrors;
         this.bridge = new ScalaCompilerBridge();
 
         // Convert classpath paths to strings for the Scala bridge
@@ -63,8 +70,11 @@ public class ScalaCompilerContext {
         List<ParseWarning> warnings = new ArrayList<>();
         for (int i = 0; i < result.warnings().size(); i++) {
             ScalaWarning w = result.warnings().get(i);
-            warnings.add(new ParseWarning(Tree.randomId(),
-                    input.getPath().toString() + " at line " + w.line() + ":" + w.column() + " " + w.message()));
+            String formatted = input.getPath() + " at line " + w.line() + ":" + w.column() + " " + w.message();
+            warnings.add(new ParseWarning(Tree.randomId(), formatted));
+            if (logCompilationWarningsAndErrors) {
+                logger.warn(formatted);
+            }
         }
 
         return new ParseResult(result, warnings);
@@ -116,8 +126,11 @@ public class ScalaCompilerContext {
                 ScalaWarning w = result.warnings().get(i);
                 Parser.Input input = inputsByPath.get(path);
                 String location = (input != null ? input.getPath().toString() : path);
-                warnings.add(new ParseWarning(Tree.randomId(),
-                        location + " at line " + w.line() + ":" + w.column() + " " + w.message()));
+                String formatted = location + " at line " + w.line() + ":" + w.column() + " " + w.message();
+                warnings.add(new ParseWarning(Tree.randomId(), formatted));
+                if (logCompilationWarningsAndErrors) {
+                    logger.warn(formatted);
+                }
             }
 
             results.put(path, new ParseResult(result, warnings));

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
@@ -21,7 +21,7 @@ import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Phases
 import dotty.tools.dotc.parsing.Parsers
 import dotty.tools.dotc.util.SourceFile
-import dotty.tools.dotc.reporting.{Diagnostic, Reporter, StoreReporter}
+import dotty.tools.dotc.reporting.{Diagnostic, StoreReporter}
 import dotty.tools.dotc.{CompilationUnit, Run, Compiler, Driver}
 import dotty.tools.dotc.config.ScalaSettings
 
@@ -57,11 +57,15 @@ class ScalaCompilerBridge {
     val driver = new ParsingDriver()
     val baseCtx: Context = driver.getInitialContext
 
+    // Buffer diagnostics in-memory so they don't leak to stderr via Dotty's default ConsoleReporter.
+    val storeReporter = new StoreReporter(null)
+
     // Configure source version, output directory, and classpath.
     given ctx: Context = {
       val fresh = baseCtx.fresh
       // Accept both Scala 2 and Scala 3 syntax (including indentation-based).
       fresh.setSetting(fresh.settings.source, "3.6-migration")
+      fresh.setReporter(storeReporter)
       // Send compiler output to a designated dir so .class files don't pollute cwd.
       if (outputDir != null) {
         fresh.setSetting(fresh.settings.outputDir, dotty.tools.io.AbstractFile.getDirectory(outputDir))
@@ -152,7 +156,36 @@ class ScalaCompilerBridge {
         // Batch compilation failed entirely; all units keep typedTree=None
     }
 
+    // Drain buffered diagnostics into per-source `warnings` lists so callers
+    // can surface them as ParseWarning markers (and optionally log them).
+    val drained = storeReporter.removeBufferedMessages
+    if (drained.nonEmpty) {
+      val byPath = drained.groupBy(diagnosticSourcePath)
+      val rIter = results.entrySet().iterator()
+      while (rIter.hasNext) {
+        val e = rIter.next()
+        byPath.get(e.getKey).foreach { diags =>
+          val ws = e.getValue.warnings
+          diags.foreach(d => ws.add(toScalaWarning(d)))
+        }
+      }
+    }
+
     results
+  }
+
+  private def diagnosticSourcePath(d: Diagnostic): String =
+    if (d.pos.exists && d.pos.source != null) d.pos.source.path else ""
+
+  private def toScalaWarning(d: Diagnostic): ScalaWarning = {
+    val (line, column) =
+      if (d.pos.exists) (d.pos.line + 1, d.pos.column + 1) else (0, 0)
+    val level = d.level match {
+      case 2 => "error"
+      case 1 => "warning"
+      case _ => "info"
+    }
+    ScalaWarning(d.message, line, column, level)
   }
 
   /**
@@ -160,14 +193,15 @@ class ScalaCompilerBridge {
    * Retained for backward compatibility.
    */
   def parse(path: String, content: String): ScalaParseResult = {
-    // Create a custom reporter to collect warnings
-    val warnings = new ListBuffer[ScalaWarning]()
+    // Buffer diagnostics in-memory so they don't leak to stderr via Dotty's default ConsoleReporter.
+    val storeReporter = new StoreReporter(null)
 
     // Create our custom driver and get a proper context with Scala 2 compat
     val driver = new ParsingDriver()
     given Context = {
       val fresh = driver.getInitialContext.fresh
       fresh.setSetting(fresh.settings.source, "3.6-migration")
+      fresh.setReporter(storeReporter)
       fresh
     }
 
@@ -194,9 +228,10 @@ class ScalaCompilerBridge {
       tree
     }
 
-    // Convert warnings to Java list
+    // Drain buffered diagnostics from the reporter so they're surfaced to the caller
+    // instead of being silently dropped (or, with the default reporter, printed to stderr).
     val javaWarnings = new ArrayList[ScalaWarning]()
-    warnings.foreach(javaWarnings.add)
+    storeReporter.removeBufferedMessages.foreach(d => javaWarnings.add(toScalaWarning(d)))
 
     ScalaParseResult(finalTree, None, javaWarnings, needsUnwrap, ctx)
   }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaParserDiagnosticsTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaParserDiagnosticsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ParseWarning;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.scala.tree.S;
+import org.openrewrite.tree.ParseError;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScalaParserDiagnosticsTest {
+
+    // Snippet whose match case is unreachable (the wildcard subsumes the literal),
+    // which Dotty reports as a `Match case Unreachable Warning` during type-checking.
+    private static final String SNIPPET_WITH_WARNING =
+            "object Diag {\n" +
+            "  def x(i: Int): Int = i match {\n" +
+            "    case _ => 0\n" +
+            "    case 1 => 1\n" +
+            "  }\n" +
+            "}\n";
+
+    @Test
+    void diagnosticsDoNotLeakToStderr() {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        try {
+            System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+
+            ScalaParser parser = ScalaParser.builder().classpath(JavaParser.runtimeClasspath()).build();
+            List<SourceFile> parsed = parser.parse(SNIPPET_WITH_WARNING).collect(Collectors.toList());
+
+            assertThat(parsed).hasSize(1);
+            assertThat(parsed.get(0)).isNotInstanceOf(ParseError.class);
+        } finally {
+            System.setErr(originalErr);
+        }
+
+        assertThat(captured.toString(StandardCharsets.UTF_8))
+                .as("Dotty diagnostics must not leak to stderr from ScalaParser")
+                .isEmpty();
+    }
+
+    @Test
+    void warningsAreSurfacedAsMarkers() {
+        ScalaParser parser = ScalaParser.builder().classpath(JavaParser.runtimeClasspath()).build();
+        List<SourceFile> parsed = parser.parse(SNIPPET_WITH_WARNING).collect(Collectors.toList());
+
+        assertThat(parsed).hasSize(1);
+        SourceFile cu = parsed.get(0);
+        assertThat(cu).isInstanceOf(S.CompilationUnit.class);
+
+        List<ParseWarning> warnings = cu.getMarkers().findAll(ParseWarning.class);
+        assertThat(warnings)
+                .as("Dotty diagnostics should be surfaced on the LST as ParseWarning markers")
+                .isNotEmpty();
+        assertThat(warnings).anyMatch(w -> w.getMessage().toLowerCase().contains("unreachable"));
+    }
+}


### PR DESCRIPTION
## Motivation

When the Moderne CLI runs prebuild on a repo that contains Scala sources, the rewrite-scala parser invokes Dotty in-process via `ScalaCompilerBridge`. The bridge never installs a `Reporter` on the Dotty `Context`, so Dotty falls back to its default `ConsoleReporter` and pipes warnings/errors straight to `System.err`. The result is dozens of `[E030]` / `[E121]` / non-local-return warnings interleaved with the CLI's own output, with no way for the caller to silence or capture them.

The Java (8/11/17/21/25), Groovy, and Kotlin parsers all follow the same convention: diagnostics are collected internally, suppressed by default, and only logged when the caller opts in via `logCompilationWarningsAndErrors(true)` — at which point they go through SLF4J so the caller's logging configuration decides where they land. The Scala parser already exposed the `logCompilationWarningsAndErrors` builder method, but the value was accepted and then dropped on the floor. This brings rewrite-scala into line.

## Summary

- `ScalaCompilerBridge` now installs a `StoreReporter` on the Dotty `Context` in both `compileAll` and `parse`, so diagnostics no longer reach `System.err`.
- Buffered diagnostics are drained post-compilation, grouped by source path, and converted to `ScalaWarning` entries on the corresponding `ScalaParseResult.warnings` list (a field that was previously created but never populated).
- `ScalaCompilerContext` now actually stores `logCompilationWarningsAndErrors`. When enabled, the per-file diagnostic strings already being built for `ParseWarning` markers are additionally logged at `WARN` via `LoggerFactory.getLogger(ScalaParser.class)`, mirroring the Groovy parser.

| `logCompilationWarningsAndErrors` | stderr | SLF4J | `ParseWarning` markers on LST |
|---|---|---|---|
| `false` (default) | silent | nothing | yes |
| `true` | silent | logs at WARN | yes |

## Test plan

- [x] New `ScalaParserDiagnosticsTest`:
  - [x] `diagnosticsDoNotLeakToStderr` — wraps a parse in `System.setErr(...)` and asserts the captured stream is empty.
  - [x] `warningsAreSurfacedAsMarkers` — parses a snippet with an unreachable match case and asserts a `ParseWarning` marker is attached with "unreachable" in the message.
- [x] Full `:rewrite-scala:test` suite passes.

## Out of scope

- The unreachable-case warnings inside `ScalaTreeVisitor.scala` are real dead code (per `rewrite-scala/CLAUDE.md`'s "nothing should map to J.Unknown" rule). They deserve a separate cleanup pass.
- The Kotlin parser still routes diagnostics to `System.err` rather than SLF4J when `logCompilationWarningsAndErrors=true`. Same root cause, also a separate cleanup.