### PR TITLE
Kotlin: don't leak dependsOn into the parse-error stream

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -182,7 +182,9 @@ public class KotlinParser implements Parser {
             compilerCus = parse(acceptedInputs, disposable, pctx);
         } catch (Throwable t) {
             disposable.dispose();
-            return acceptedInputs.stream().map(input -> ParseError.build(this, input, relativeTo, ctx, t));
+            return acceptedInputs.stream()
+                    .filter(input -> !dependsOnPaths.contains(input.getRelativePath(relativeTo)))
+                    .map(input -> ParseError.build(this, input, relativeTo, ctx, t));
         }
 
         FirSession firSession = compilerCus.getFirSession();

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinParserTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinParserTest.java
@@ -17,10 +17,20 @@ package org.openrewrite.kotlin;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
 import org.openrewrite.test.RewriteTest;
 
+import java.io.ByteArrayInputStream;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class KotlinParserTest implements RewriteTest {
@@ -61,6 +71,45 @@ class KotlinParserTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void dependsOnDoesNotLeakAsParseErrorWhenParseThrows() {
+        KotlinParser parser = KotlinParser.builder()
+          .dependsOn(
+            """
+              package foo.bar
+
+              class MyClass
+              """
+          )
+          .build();
+
+        // An input whose source supplier throws on its first call forces KotlinParser#parse
+        // to fail before any per-CU processing, exercising the catch block in parseInputs.
+        // Subsequent calls return an empty stream so ParseError.build can still capture the input.
+        AtomicInteger callCount = new AtomicInteger();
+        Parser.Input throwingInput = new Parser.Input(
+          Paths.get("Bad.kt"),
+          null,
+          () -> {
+              if (callCount.getAndIncrement() == 0) {
+                  throw new RuntimeException("intentional parse failure");
+              }
+              return new ByteArrayInputStream(new byte[0]);
+          },
+          true
+        );
+
+        List<SourceFile> results = parser
+          .parseInputs(singletonList(throwingInput), null, new InMemoryExecutionContext(t -> {
+          }))
+          .collect(Collectors.toList());
+
+        // dependsOn must not leak into the returned stream on the error path
+        assertThat(results)
+          .extracting(SourceFile::getSourcePath)
+          .containsExactly(Paths.get("Bad.kt"));
     }
 
     @Test


### PR DESCRIPTION
## Motivation

`KotlinParser#parseInputs` leaks `dependsOn` synthetic inputs into the returned `Stream<SourceFile>` whenever `parse(...)` throws. On the success path, dependsOn entries are filtered out by source path before the stream is returned (`KotlinParser.java:222`). On the error path, the `catch` block builds a `ParseError` for **every** accepted input — including the synthetic dependsOn stubs — and returns them unfiltered.

This surfaces as a real downstream bug. `rewrite-gradle`'s `GradleParser` feeds a stub via `.dependsOn(KTS_BUILD_STUBS)` to seed `.gradle.kts` receiver functions. `KotlinParser.determinePath` names that stub `org/gradle/api/<System.nanoTime()>.kt` (no class declaration → nanoTime fallback). When parsing a `.gradle.kts` with a misconfigured buildscript classpath causes `parse` to throw, those stubs leak all the way up to moderne-cli, which then tries to digest a non-existent `org/gradle/api/<nanoTime>.kt` file and crashes `BuildJob.aggregateManifestCsv` with `NoSuchFileException`.

The Java parser keeps dependsOn out of the returned stream by design — see `ReloadableJava25Parser#compileDependencies`, which parses dependsOn in a separate pass purely for the symbol-table side effect, so `parseInputs` never sees them. The Kotlin frontend needs all sources in a single parse session for FIR resolution, so it can't trivially copy that structure, but the **invariant** is the same: dependsOn must never appear in the returned stream, regardless of error/success.

## Summary

- Apply the existing `dependsOnPaths` filter on the error path of `KotlinParser#parseInputs`, mirroring the success-path filter that already runs on line 222.
- Add a regression test that constructs a user input whose source supplier throws, forcing `parse` to fail, and asserts the returned stream contains only the user input — not the dependsOn stub.

## Test plan

- [x] New test `dependsOnDoesNotLeakAsParseErrorWhenParseThrows` fails on `main` (returns `[foo/bar/MyClass.kt, Bad.kt]`, expects `[Bad.kt]`).
- [x] New test passes with the fix applied.
- [x] Existing `KotlinParserTest` tests continue to pass.