### PR TITLE
Delegate org.openrewrite.semver classes to parent in RecipeClassLoader

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
@@ -69,6 +69,7 @@ public class RecipeClassLoader extends URLClassLoader {
             "org.openrewrite.internal",
             "org.openrewrite.marker",
             "org.openrewrite.scheduling",
+            "org.openrewrite.semver",
             "org.openrewrite.style",
             "org.openrewrite.template",
             "org.openrewrite.trait",


### PR DESCRIPTION
## Summary

Fixes a `java.lang.LinkageError: loader constraint violation` thrown from `DependencyTreeWalker.walkRecursive` whenever a recipe whose runtime closure includes `rewrite-core`/`rewrite-maven` reaches `DependencyMatcher`. Reported against Moderne CLI 4.2.1 while running prethink recipes; the call chain that surfaced it is `GenerateSecurityConfig` → `DependencyInsight` → `DependencyTreeWalker`.

`org.openrewrite.semver.*` (`DependencyMatcher`, `LatestRelease`, `Semver`, …) are stable rewrite-core API types that flow across the recipe classloader boundary. They were missing from `PARENT_DELEGATED_PREFIXES`, so the child `RecipeClassLoader` was defining its own copy from the recipe-side jar while the parent had already defined one from the CLI/worker classpath. When `DependencyTreeWalker`'s method signature referenced `DependencyMatcher`, the JVM's loader-constraint check failed.

Adding `"org.openrewrite.semver"` to the prefix list forces both loaders to use the same `Class` instance, matching the pattern already used for `org.openrewrite.config`, `org.openrewrite.internal`, `org.openrewrite.marker`, etc.

## Test plan

- [x] `./gradlew :rewrite-core:test --tests "org.openrewrite.marketplace.RecipeClassLoaderTest"` passes
- [ ] Customer (Moderne CLI 4.2.1 + prethink recipes) verifies the LinkageError no longer occurs once the new `rewrite-core` ships in a CLI build