### PR TITLE
Stop closing recipe classloaders on CachingMavenRecipeBundleResolver close

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/CachingMavenRecipeBundleResolver.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/CachingMavenRecipeBundleResolver.java
@@ -25,15 +25,36 @@ import org.openrewrite.maven.utilities.MavenArtifactDownloader;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Deduplicates {@link MavenRecipeBundleResolver} instances per package coordinate so that
+ * repeated {@link #resolve(RecipeBundle)} calls for the same package share one reader
+ * (and therefore one {@link org.openrewrite.marketplace.RecipeClassLoader}).
+ * <p>
+ * <strong>Lifetime of handed-out readers.</strong> The readers (and the
+ * {@link org.openrewrite.marketplace.RecipeClassLoader}s they own) returned by
+ * {@link #resolve(RecipeBundle)} are intended to outlive this resolver. Once a {@link Recipe}
+ * has been prepared from a reader, the JVM's class cache contains classes defined by that
+ * classloader, and any later {@code getResourceAsStream}/inner-class load against those
+ * classes requires the classloader's {@code URLClassPath} jar handles to remain open.
+ * <p>
+ * For that reason {@link #close()} only clears the deduplication cache. It does <em>not</em>
+ * close the cached inner {@link MavenRecipeBundleResolver}s -- doing so would close their
+ * readers, which would close the underlying {@code URLClassLoader}s while consumers still
+ * hold references. The visible failure mode is inner-class {@code NoClassDefFoundError} and
+ * silently-null {@code getResourceAsStream} returns on a classloader that {@code ==} identity
+ * confirms is still alive (see
+ * <a href="https://github.com/moderneinc/customer-requests/issues/2346">customer-requests#2346</a>).
+ * <p>
+ * Consumers that need deterministic cleanup must close the {@link RecipeBundleReader}s they
+ * retain (or rely on JVM exit for one-shot processes).
+ */
 @RequiredArgsConstructor
 public class CachingMavenRecipeBundleResolver implements RecipeBundleResolver {
     private final ExecutionContext ctx;
     private final MavenArtifactDownloader downloader;
     private final RecipeClassLoaderFactory classLoaderFactory;
-    private final Map<String, ResolverEntry> resolverCache = new HashMap<>();
+    private final Map<String, MavenRecipeBundleResolver> resolverCache = new HashMap<>();
 
     @Override
     public String getEcosystem() {
@@ -42,11 +63,7 @@ public class CachingMavenRecipeBundleResolver implements RecipeBundleResolver {
 
     @Override
     public RecipeBundleReader resolve(RecipeBundle bundle) {
-        try (RecipeBundleResolver resolver = resolverFor(bundle)) {
-            return resolver.resolve(bundle);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        return resolverFor(bundle).resolve(bundle);
     }
 
     private String resolverKey(RecipeBundle bundle) {
@@ -54,82 +71,24 @@ public class CachingMavenRecipeBundleResolver implements RecipeBundleResolver {
     }
 
     public synchronized RecipeBundleResolver resolverFor(RecipeBundle bundle) {
-        String key = resolverKey(bundle);
-        ResolverEntry entry = resolverCache.get(key);
-        if (entry != null && !entry.evicted) {
-            if (Objects.equals(entry.bundle.getVersion(), bundle.getVersion())) {
-                return entry.createProxyResolver();
-            }
-
-            entry.markEvicted();
-        }
-
-        entry = new ResolverEntry(bundle, new MavenRecipeBundleResolver(ctx, downloader, classLoaderFactory));
-        resolverCache.put(key, entry);
-        return entry.createProxyResolver();
+        // Deduplicate by package coordinate only. A version comparison here used to evict
+        // the cached entry whenever a caller passed a fresh RecipeBundle still on the
+        // requested version (e.g., "0.5.9-SNAPSHOT") while the cached entry had been
+        // mutated to the dated snapshot ("0.5.9-20260512.123000") by the first resolve.
+        // That eviction destructively closed the prior reader's classloader -- which was
+        // still in use by Recipe instances cached upstream. We accept that a second
+        // resolve with a different version returns the first resolver's reader; callers
+        // that need version pinning resolve into separate resolverKey()s (different
+        // packageNames) already.
+        return resolverCache.computeIfAbsent(resolverKey(bundle),
+                k -> new MavenRecipeBundleResolver(ctx, downloader, classLoaderFactory));
     }
 
     @Override
-    public void close() throws Exception {
-        Exception deferredException = null;
-        for (Map.Entry<String, ResolverEntry> entry : resolverCache.entrySet()) {
-            try {
-                ResolverEntry resolverEntry = entry.getValue();
-                resolverEntry.resolver.close();
-                if (resolverEntry.leases.get() > 0) {
-                    throw new IllegalStateException("Apparent resolver leak detected");
-                }
-            } catch (Exception e) {
-                if (deferredException == null) {
-                    deferredException = e;
-                }
-            }
-        }
-        if (deferredException != null) {
-            throw deferredException;
-        }
-    }
-
-    @RequiredArgsConstructor
-    private static class ResolverEntry {
-        private final RecipeBundle bundle;
-        private final RecipeBundleResolver resolver;
-        private final AtomicInteger leases = new AtomicInteger();
-        private boolean evicted;
-
-        private synchronized void markEvicted() {
-            evicted = true;
-            if (leases.get() == 0) {
-                try {
-                    resolver.close();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        }
-
-        RecipeBundleResolver createProxyResolver() {
-            leases.incrementAndGet();
-            return new RecipeBundleResolver() {
-                @Override
-                public String getEcosystem() {
-                    return resolver.getEcosystem();
-                }
-
-                @Override
-                public RecipeBundleReader resolve(RecipeBundle bundle) {
-                    return resolver.resolve(bundle);
-                }
-
-                @Override
-                public void close() throws Exception {
-                    synchronized (ResolverEntry.this) {
-                        if (leases.decrementAndGet() == 0 && evicted) {
-                            resolver.close();
-                        }
-                    }
-                }
-            };
-        }
+    public void close() {
+        // Intentionally a no-op. Cached resolvers own readers/classloaders that may be
+        // retained externally and must outlive this resolver. See the class-level javadoc.
+        // Consumers responsible for deterministic cleanup must close their retained
+        // RecipeBundleReader instances directly.
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/marketplace/CachingMavenRecipeBundleResolverTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/marketplace/CachingMavenRecipeBundleResolverTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.marketplace;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.HttpSenderExecutionContextView;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
+import org.openrewrite.ipc.http.HttpUrlConnectionSender;
+import org.openrewrite.marketplace.RecipeBundle;
+import org.openrewrite.marketplace.RecipeBundleReader;
+import org.openrewrite.marketplace.RecipeClassLoader;
+import org.openrewrite.marketplace.RecipeListing;
+import org.openrewrite.maven.MavenExecutionContextView;
+import org.openrewrite.maven.MavenSettings;
+import org.openrewrite.maven.cache.LocalMavenArtifactCache;
+import org.openrewrite.maven.utilities.MavenArtifactDownloader;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CachingMavenRecipeBundleResolverTest {
+
+    @TempDir
+    Path tempDir;
+
+    InMemoryExecutionContext ctx;
+    MavenArtifactDownloader downloader;
+
+    @BeforeEach
+    void setUp() {
+        ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
+        HttpSenderExecutionContextView.view(ctx).setHttpSender(new HttpUrlConnectionSender());
+        MavenExecutionContextView.view(ctx)
+                .setAddCentralRepository(true)
+                .setMavenSettings(MavenSettings.readMavenSettingsFromDisk(ctx));
+
+        LocalMavenArtifactCache artifactCache = new LocalMavenArtifactCache(tempDir.resolve("artifacts"));
+        downloader = new MavenArtifactDownloader(
+                artifactCache,
+                null,
+                new HttpUrlConnectionSender(),
+                Throwable::printStackTrace
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2346")
+    @Test
+    void closeDoesNotCloseHandedOutClassLoaders() throws Exception {
+        AtomicReference<TrackingRecipeClassLoader> classLoaderRef = new AtomicReference<>();
+        CachingMavenRecipeBundleResolver resolver = new CachingMavenRecipeBundleResolver(
+                ctx, downloader, (recipeJar, classpath) -> {
+            TrackingRecipeClassLoader cl = new TrackingRecipeClassLoader(recipeJar, classpath);
+            classLoaderRef.set(cl);
+            return cl;
+        });
+
+        RecipeBundle bundle = new RecipeBundle(
+                "maven", "org.openrewrite:rewrite-core", "8.70.0", null, null);
+
+        RecipeBundleReader reader = resolver.resolve(bundle);
+        // Force classloader creation by preparing any one recipe.
+        RecipeListing first = reader.read().getAllRecipes().iterator().next();
+        reader.prepare(first, null);
+
+        TrackingRecipeClassLoader cl = classLoaderRef.get();
+        assertThat(cl)
+                .as("classLoaderFactory should have been invoked once prepare() ran")
+                .isNotNull();
+        assertThat(cl.closeCount).isZero();
+
+        resolver.close();
+
+        assertThat(cl.closeCount)
+                .as("Classloaders handed out by the resolver must outlive resolver.close() -- " +
+                    "Recipe instances cached upstream (e.g. RunTask.RECIPE_CACHE) retain them, " +
+                    "and closing the URLClassPath silently breaks getResourceAsStream/inner-class loads.")
+                .isZero();
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2346")
+    @Test
+    void resolveWithFreshBundleForSamePackageReusesCachedReader() {
+        CachingMavenRecipeBundleResolver resolver = new CachingMavenRecipeBundleResolver(
+                ctx, downloader, RecipeClassLoader::new);
+
+        RecipeBundle first = new RecipeBundle(
+                "maven", "org.openrewrite:rewrite-core", "8.70.0", null, null);
+        RecipeBundleReader r1 = resolver.resolve(first);
+        r1.read();
+
+        // A fresh RecipeBundle instance for the same package must reuse the cached
+        // reader. The prior implementation compared bundle.getVersion() against the
+        // (possibly mutated) cached entry and evicted-and-closed the prior reader on
+        // any mismatch -- destroying classloaders still in use by Recipe instances
+        // cached upstream.
+        RecipeBundle freshSameCoordinate = new RecipeBundle(
+                "maven", "org.openrewrite:rewrite-core", "8.70.0", null, null);
+        RecipeBundleReader r2 = resolver.resolve(freshSameCoordinate);
+
+        assertThat(r2).isSameAs(r1);
+    }
+
+    private static class TrackingRecipeClassLoader extends RecipeClassLoader {
+        int closeCount;
+
+        TrackingRecipeClassLoader(Path recipeJar, List<Path> classpath) {
+            super(recipeJar, classpath);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCount++;
+            super.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`CachingMavenRecipeBundleResolver` hands out `RecipeBundleReader` instances whose `RecipeClassLoader`s are retained externally. Once a `Recipe` has been prepared, the JVM's class cache contains classes defined by that classloader, and any later `getResourceAsStream` / inner-class load against those classes requires the classloader's `URLClassPath` jar handles to remain open.

Two close paths in the prior implementation closed those handles while consumers still held the classloader:

- 1. **`close()` cascade.** Added by #7277 to fix Windows CI file-handle leaks, this iterated every cached `MavenRecipeBundleResolver` and called `close()` on it, transitively closing the reader and its `URLClassLoader`.
2. **`resolverFor()` version eviction.** Compared the cached entry's `bundle.getVersion()` against the incoming bundle's and called `markEvicted()` on mismatch, also closing the inner resolver/reader/classloader. Because `MavenRecipeBundleResolver.resolve()` mutates the input bundle's `version` to the dated snapshot after resolution, any fresh `RecipeBundle` still on the requested `-SNAPSHOT` version mismatches the cached entry and triggers eviction. The RPC `PrepareRecipe` handler routinely passes such fresh bundles back through the resolvers.

The visible symptom is inner-class `NoClassDefFoundError` on a classloader whose `==` identity is unchanged but whose `URLClassPath` has been closed: `findResource` returns null silently; `loadClass` falls back to parent which doesn't have the recipe class; calling code sees `NCDFE` on `new InnerClass()`. Reproduced against `rewrite-prethink` (jtokkit `cl100k_base.tiktoken` null → `ComprehendCodeTokenCounter\$CharCountTokenizer` NCDFE) and `rewrite-static-analysis` (`FinalClassVisitor\$FinalizingVisitor` NCDFE).

- See moderneinc/customer-requests#2346.

## Changes

- Drop the lease/proxy/eviction machinery from `CachingMavenRecipeBundleResolver`. The cache is now a plain package-coordinate `computeIfAbsent`.
- `close()` is a no-op with a class-level javadoc explaining the ownership-transfer semantics. Consumers that need deterministic cleanup must close the `RecipeBundleReader`s they retain (or rely on JVM exit for one-shot processes like `mod`).
- Effectively reverts the destructive part of #7277. The CI file-handle leak it addressed is the responsibility of test code that retained `RecipeBundleReader` instances without closing them.

## Reproducer

New `CachingMavenRecipeBundleResolverTest.closeDoesNotCloseHandedOutClassLoaders` instruments a `TrackingRecipeClassLoader` and asserts \`closeCount == 0\` after \`resolver.close()\`. Verified the test fails against the prior implementation (\`closeCount == 1\`) and passes after this change.

## Companion fix

A defense-in-depth no-op override of `CliRecipeClassLoader.close()` will land in moderne-cli alongside the bom bump, so any other close path we have not yet identified cannot regress the symptom. `mod` is one-shot; the OS reclaims jar handles at JVM exit.

## Test plan

- [x] \`./gradlew :rewrite-maven:test --tests "org.openrewrite.maven.marketplace.*"\` passes
- [x] New reproducer test fails on \`origin/main\` (closeCount was 1) and passes after this change