### PR TITLE
Track resolved repository URLs per recipe bundle

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeBundleReader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeBundleReader.java
@@ -18,7 +18,9 @@ package org.openrewrite.marketplace;
 import org.openrewrite.Recipe;
 import org.openrewrite.config.RecipeDescriptor;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 public interface RecipeBundleReader extends AutoCloseable {
     RecipeBundle getBundle();
@@ -28,6 +30,16 @@ public interface RecipeBundleReader extends AutoCloseable {
     RecipeDescriptor describe(RecipeListing listing);
 
     Recipe prepare(RecipeListing listing, Map<String, Object> options);
+
+    /**
+     * Repository URLs the resolver touched while resolving this bundle, including any
+     * transitive dependencies. URLs are returned in the form the underlying tool reported
+     * them; callers that need a canonical form should normalize after receiving. May
+     * return an empty set when the implementation has no remote source to report.
+     */
+    default Set<String> getResolvedFromRepositories() {
+        return Collections.emptySet();
+    }
 
     default void close() throws Exception {
         // no-op

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -542,7 +542,7 @@ public class RewriteRpcServer
     {
         var beforeCount = _marketplace.AllRecipes().Count;
         string? version = null;
-        var resolvedRepositories = new HashSet<string>();
+        var resolvedFromRepositories = new HashSet<string>();
 
         if (request.Recipes is string path)
         {
@@ -575,25 +575,46 @@ public class RewriteRpcServer
                 if (version != null)
                     args += $" --version {version}";
 
-                // Per-install scratch dir for NUGET_PACKAGES so restore actually fetches
-                // (warm caches silently suppress the "Installed ... from ..." lines we parse).
-                var scratchPackages = Path.Combine(Path.GetDirectoryName(csprojPath)!, "nuget-packages");
-                Directory.CreateDirectory(scratchPackages);
-                var dotnetEnv = new Dictionary<string, string> { ["NUGET_PACKAGES"] = scratchPackages };
+                // Let `dotnet add package` use the user's default NuGet cache;
+                // its restore output is not the one we parse.
+                RunDotnet(args);
 
-                RunDotnet(args, env: dotnetEnv);
-
-                // Explicit restore with verbosity normal so NuGet emits per-source install lines.
-                var restoreStdout = RunDotnet(
-                    $"restore \"{csprojPath}\" --verbosity normal", env: dotnetEnv);
-                foreach (var feedUrl in ParseInstalledFromUrls(restoreStdout))
+                // For the capture pass we point NuGet at a per-install scratch
+                // directory and force a fresh restore (--force --no-cache) so the
+                // packages are re-fetched and NuGet emits the
+                // "Installed <id> <version> from <url>" lines we parse. Without
+                // this, a warm global cache silently suppresses every line. The
+                // scratch directory is discarded after parsing.
+                var scratchPackages = Path.Combine(Path.GetDirectoryName(csprojPath)!, "nuget-packages-capture");
+                try
                 {
-                    resolvedRepositories.Add(feedUrl);
+                    Directory.CreateDirectory(scratchPackages);
+                    var restoreStdout = RunDotnet(
+                        $"restore \"{csprojPath}\" --packages \"{scratchPackages}\" --force --no-cache --verbosity normal");
+                    foreach (var feedUrl in ParseInstalledFromUrls(restoreStdout))
+                    {
+                        resolvedFromRepositories.Add(feedUrl);
+                    }
+                }
+                finally
+                {
+                    try
+                    {
+                        if (Directory.Exists(scratchPackages))
+                        {
+                            Directory.Delete(scratchPackages, recursive: true);
+                        }
+                    }
+                    catch (IOException ex)
+                    {
+                        Log.Warning("Failed to clean up NuGet capture scratch directory {Dir}: {Error}",
+                            scratchPackages, ex.Message);
+                    }
                 }
 
                 version = ResolveVersionFromCsproj(csprojPath, packageName);
 
-                var assemblies = PublishAndLoadPlugin(csprojPath, packageName, dotnetEnv);
+                var assemblies = PublishAndLoadPlugin(csprojPath, packageName);
                 foreach (var assembly in assemblies)
                 {
                     CheckVersionCompatibility(assembly);
@@ -611,7 +632,7 @@ public class RewriteRpcServer
         {
             RecipesInstalled = afterCount - beforeCount,
             Version = version,
-            ResolvedRepositories = resolvedRepositories.Count == 0 ? null : resolvedRepositories.ToList()
+            ResolvedFromRepositories = resolvedFromRepositories.Count == 0 ? null : resolvedFromRepositories.ToList()
         });
     }
 
@@ -623,9 +644,12 @@ public class RewriteRpcServer
     internal static IEnumerable<string> ParseInstalledFromUrls(string restoreOutput)
     {
         // Example line:
-        //   Installed Newtonsoft.Json 13.0.3 from https://api.nuget.org/v3/index.json with content hash ABC=
+        //   Installed Newtonsoft.Json 13.0.3 from https://api.nuget.org/v3/index.json to /scratch/... with content hash ABC=.
+        // The "to <path>" segment is optional on some NuGet versions, so allow it
+        // to be absent for older clients (NuGet 5.9.0+ added the source URL; the
+        // "to <path>" segment was added later).
         var pattern = new Regex(
-            @"Installed\s+\S+\s+\S+\s+from\s+(?<url>\S+?)\s+with content hash",
+            @"Installed\s+\S+\s+\S+\s+from\s+(?<url>\S+?)\s+(?:to\s+\S+\s+)?with content hash",
             RegexOptions.CultureInvariant);
         foreach (Match m in pattern.Matches(restoreOutput))
         {
@@ -704,7 +728,7 @@ public class RewriteRpcServer
         return csprojPath;
     }
 
-    private static string RunDotnet(string arguments, IDictionary<string, string>? env = null)
+    private static string RunDotnet(string arguments)
     {
         var psi = new ProcessStartInfo("dotnet", arguments)
         {
@@ -713,13 +737,6 @@ public class RewriteRpcServer
             UseShellExecute = false,
             CreateNoWindow = true
         };
-        if (env != null)
-        {
-            foreach (var (k, v) in env)
-            {
-                psi.Environment[k] = v;
-            }
-        }
 
         using var process = System.Diagnostics.Process.Start(psi)
                             ?? throw new InvalidOperationException("Failed to start dotnet process");
@@ -758,13 +775,12 @@ public class RewriteRpcServer
     /// name, we scan all non-host DLLs in the publish output for <see cref="IRecipeActivator"/>
     /// implementations.
     /// </summary>
-    private List<Assembly> PublishAndLoadPlugin(string csprojPath, string packageName,
-        IDictionary<string, string>? env = null)
+    private List<Assembly> PublishAndLoadPlugin(string csprojPath, string packageName)
     {
         var projectDir = Path.GetDirectoryName(csprojPath)!;
         var publishDir = Path.Combine(projectDir, "publish");
 
-        RunDotnet($"publish \"{csprojPath}\" -c Release -o \"{publishDir}\"", env);
+        RunDotnet($"publish \"{csprojPath}\" -c Release -o \"{publishDir}\"");
 
         // Use the Recipes.deps.json (from the temp project) for the dependency resolver
         var depsJson = Path.Combine(publishDir, "Recipes.deps.json");
@@ -1642,7 +1658,7 @@ public class InstallRecipesResponse
 {
     public int RecipesInstalled { get; set; }
     public string? Version { get; set; }
-    public List<string>? ResolvedRepositories { get; set; }
+    public List<string>? ResolvedFromRepositories { get; set; }
 }
 
 public class PrepareRecipeRequest

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -17,6 +17,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Loader;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -541,6 +542,7 @@ public class RewriteRpcServer
     {
         var beforeCount = _marketplace.AllRecipes().Count;
         string? version = null;
+        var resolvedRepositories = new HashSet<string>();
 
         if (request.Recipes is string path)
         {
@@ -567,16 +569,31 @@ public class RewriteRpcServer
             }
             else
             {
-                // NuGet package download via dotnet CLI
+                // NuGet package download via dotnet CLI.
                 var csprojPath = EnsureRecipesProject();
                 var args = $"add \"{csprojPath}\" package {packageName}";
                 if (version != null)
                     args += $" --version {version}";
-                RunDotnet(args);
+
+                // Per-install scratch dir for NUGET_PACKAGES so restore actually fetches
+                // (warm caches silently suppress the "Installed ... from ..." lines we parse).
+                var scratchPackages = Path.Combine(Path.GetDirectoryName(csprojPath)!, "nuget-packages");
+                Directory.CreateDirectory(scratchPackages);
+                var dotnetEnv = new Dictionary<string, string> { ["NUGET_PACKAGES"] = scratchPackages };
+
+                RunDotnet(args, env: dotnetEnv);
+
+                // Explicit restore with verbosity normal so NuGet emits per-source install lines.
+                var restoreStdout = RunDotnet(
+                    $"restore \"{csprojPath}\" --verbosity normal", env: dotnetEnv);
+                foreach (var feedUrl in ParseInstalledFromUrls(restoreStdout))
+                {
+                    resolvedRepositories.Add(feedUrl);
+                }
 
                 version = ResolveVersionFromCsproj(csprojPath, packageName);
 
-                var assemblies = PublishAndLoadPlugin(csprojPath, packageName);
+                var assemblies = PublishAndLoadPlugin(csprojPath, packageName, dotnetEnv);
                 foreach (var assembly in assemblies)
                 {
                     CheckVersionCompatibility(assembly);
@@ -593,8 +610,27 @@ public class RewriteRpcServer
         return Task.FromResult(new InstallRecipesResponse
         {
             RecipesInstalled = afterCount - beforeCount,
-            Version = version
+            Version = version,
+            ResolvedRepositories = resolvedRepositories.Count == 0 ? null : resolvedRepositories.ToList()
         });
+    }
+
+    /// <summary>
+    /// Parses the "Installed &lt;id&gt; &lt;version&gt; from &lt;url&gt; with content hash &lt;h&gt;"
+    /// lines that <c>dotnet restore --verbosity normal</c> emits (NuGet 5.9+). Returns the
+    /// unique set of source feed URLs. Lines that don't match are skipped.
+    /// </summary>
+    internal static IEnumerable<string> ParseInstalledFromUrls(string restoreOutput)
+    {
+        // Example line:
+        //   Installed Newtonsoft.Json 13.0.3 from https://api.nuget.org/v3/index.json with content hash ABC=
+        var pattern = new Regex(
+            @"Installed\s+\S+\s+\S+\s+from\s+(?<url>\S+?)\s+with content hash",
+            RegexOptions.CultureInvariant);
+        foreach (Match m in pattern.Matches(restoreOutput))
+        {
+            yield return m.Groups["url"].Value;
+        }
     }
 
     private void ActivateAssembly(Assembly assembly)
@@ -668,7 +704,7 @@ public class RewriteRpcServer
         return csprojPath;
     }
 
-    private static void RunDotnet(string arguments)
+    private static string RunDotnet(string arguments, IDictionary<string, string>? env = null)
     {
         var psi = new ProcessStartInfo("dotnet", arguments)
         {
@@ -677,6 +713,13 @@ public class RewriteRpcServer
             UseShellExecute = false,
             CreateNoWindow = true
         };
+        if (env != null)
+        {
+            foreach (var (k, v) in env)
+            {
+                psi.Environment[k] = v;
+            }
+        }
 
         using var process = System.Diagnostics.Process.Start(psi)
                             ?? throw new InvalidOperationException("Failed to start dotnet process");
@@ -690,6 +733,8 @@ public class RewriteRpcServer
             throw new InvalidOperationException(
                 $"dotnet {arguments} failed (exit code {process.ExitCode}):\n{stderr}\n{stdout}");
         }
+
+        return stdout;
     }
 
     private static string ResolveVersionFromCsproj(string csprojPath, string packageName)
@@ -713,12 +758,13 @@ public class RewriteRpcServer
     /// name, we scan all non-host DLLs in the publish output for <see cref="IRecipeActivator"/>
     /// implementations.
     /// </summary>
-    private List<Assembly> PublishAndLoadPlugin(string csprojPath, string packageName)
+    private List<Assembly> PublishAndLoadPlugin(string csprojPath, string packageName,
+        IDictionary<string, string>? env = null)
     {
         var projectDir = Path.GetDirectoryName(csprojPath)!;
         var publishDir = Path.Combine(projectDir, "publish");
 
-        RunDotnet($"publish \"{csprojPath}\" -c Release -o \"{publishDir}\"");
+        RunDotnet($"publish \"{csprojPath}\" -c Release -o \"{publishDir}\"", env);
 
         // Use the Recipes.deps.json (from the temp project) for the dependency resolver
         var depsJson = Path.Combine(publishDir, "Recipes.deps.json");
@@ -1596,6 +1642,7 @@ public class InstallRecipesResponse
 {
     public int RecipesInstalled { get; set; }
     public string? Version { get; set; }
+    public List<string>? ResolvedRepositories { get; set; }
 }
 
 public class PrepareRecipeRequest

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Rpc/InstallRecipesParseTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Rpc/InstallRecipesParseTests.cs
@@ -40,6 +40,18 @@ public class InstallRecipesParseTests
     }
 
     [Fact]
+    public void ExtractsUrlWhenRestoreEmitsToPathBetweenSourceAndContentHash()
+    {
+        // Newer dotnet emits "from <url> to <local-path> with content hash <h>"
+        var output = "         Installed OpenRewrite.CodeQuality 0.1.0 from https://api.nuget.org/v3/index.json to /tmp/scratch/openrewrite.codequality/0.1.0 with content hash JlLi==.";
+
+        var urls = RewriteRpcServer.ParseInstalledFromUrls(output).ToList();
+
+        Assert.Single(urls);
+        Assert.Equal("https://api.nuget.org/v3/index.json", urls[0]);
+    }
+
+    [Fact]
     public void ExtractsInternalArtifactoryFeed()
     {
         var output = "Installed Internal.Pkg 1.0.0 from https://internal.example.com/artifactory/api/nuget/v3/nuget-virtual/index.json with content hash X=.";

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/Rpc/InstallRecipesParseTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/Rpc/InstallRecipesParseTests.cs
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.CSharp.Rpc;
+
+namespace OpenRewrite.Tests.Rpc;
+
+/// <summary>
+/// Unit tests for RewriteRpcServer.ParseInstalledFromUrls, which extracts NuGet
+/// source feed URLs from "Installed ... from ... with content hash ..." lines
+/// emitted by `dotnet restore --verbosity normal`.
+/// </summary>
+public class InstallRecipesParseTests
+{
+    [Fact]
+    public void ExtractsNugetOrgUrl()
+    {
+        var output = """
+            Restoring packages for /tmp/Recipes.csproj...
+              Installed Newtonsoft.Json 13.0.3 from https://api.nuget.org/v3/index.json with content hash ABC=.
+              Installed Microsoft.Extensions.Logging 8.0.0 from https://api.nuget.org/v3/index.json with content hash DEF=.
+            """;
+
+        var urls = RewriteRpcServer.ParseInstalledFromUrls(output).ToList();
+
+        Assert.Equal(2, urls.Count);
+        Assert.All(urls, u => Assert.Equal("https://api.nuget.org/v3/index.json", u));
+    }
+
+    [Fact]
+    public void ExtractsInternalArtifactoryFeed()
+    {
+        var output = "Installed Internal.Pkg 1.0.0 from https://internal.example.com/artifactory/api/nuget/v3/nuget-virtual/index.json with content hash X=.";
+
+        var urls = RewriteRpcServer.ParseInstalledFromUrls(output).ToList();
+
+        Assert.Single(urls);
+        Assert.Equal(
+            "https://internal.example.com/artifactory/api/nuget/v3/nuget-virtual/index.json",
+            urls[0]);
+    }
+
+    [Fact]
+    public void ReturnsEmptyForOutputWithoutInstalledLines()
+    {
+        Assert.Empty(RewriteRpcServer.ParseInstalledFromUrls(""));
+        Assert.Empty(RewriteRpcServer.ParseInstalledFromUrls("Restoring packages for /tmp/Recipes.csproj..."));
+    }
+}

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleReader.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleReader.java
@@ -20,17 +20,24 @@ import lombok.RequiredArgsConstructor;
 import org.openrewrite.Recipe;
 import org.openrewrite.config.RecipeDescriptor;
 import org.openrewrite.csharp.rpc.CSharpRewriteRpc;
+import org.openrewrite.csharp.rpc.InstallRecipesResponse;
 import org.openrewrite.marketplace.RecipeBundle;
 import org.openrewrite.marketplace.RecipeBundleReader;
 import org.openrewrite.marketplace.RecipeListing;
 import org.openrewrite.marketplace.RecipeMarketplace;
 
 import java.util.Map;
+import java.util.Set;
 
 @RequiredArgsConstructor
 public class NuGetRecipeBundleReader implements RecipeBundleReader {
     private final @Getter RecipeBundle bundle;
     private final CSharpRewriteRpc rpc;
+    private final InstallRecipesResponse installResponse;
+
+    public NuGetRecipeBundleReader(RecipeBundle bundle, CSharpRewriteRpc rpc) {
+        this(bundle, rpc, new InstallRecipesResponse(0, null, null));
+    }
 
     @Override
     public RecipeMarketplace read() {
@@ -45,5 +52,10 @@ public class NuGetRecipeBundleReader implements RecipeBundleReader {
     @Override
     public Recipe prepare(RecipeListing listing, Map<String, Object> options) {
         return rpc.prepareRecipe(listing.getName(), options);
+    }
+
+    @Override
+    public Set<String> getResolvedFromRepositories() {
+        return installResponse.resolvedFromRepositoriesOrEmpty();
     }
 }

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleResolver.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleResolver.java
@@ -47,6 +47,6 @@ public class NuGetRecipeBundleResolver implements RecipeBundleResolver {
         if (response.getVersion() != null) {
             bundle.setVersion(response.getVersion());
         }
-        return new NuGetRecipeBundleReader(bundle, rpc);
+        return new NuGetRecipeBundleReader(bundle, rpc, response);
     }
 }

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/InstallRecipesResponse.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/InstallRecipesResponse.java
@@ -18,8 +18,23 @@ package org.openrewrite.csharp.rpc;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Collections;
+import java.util.Set;
+
 @Value
 public class InstallRecipesResponse {
     int recipesInstalled;
     @Nullable String version;
+    /**
+     * NuGet feed URLs that {@code dotnet restore} pulled packages from while
+     * installing this bundle and its transitive closure. Derived from the
+     * "Installed &lt;id&gt; &lt;version&gt; from &lt;url&gt;" lines that NuGet 5.9+ emits at
+     * {@code --verbosity normal}. URLs are the source feed URLs (e.g. an
+     * {@code index.json}), not the blob URLs of the package files themselves.
+     */
+    @Nullable Set<String> resolvedFromRepositories;
+
+    public Set<String> resolvedFromRepositoriesOrEmpty() {
+        return resolvedFromRepositories == null ? Collections.emptySet() : resolvedFromRepositories;
+    }
 }

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleReaderTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleReaderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.marketplace;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.csharp.rpc.InstallRecipesResponse;
+import org.openrewrite.marketplace.RecipeBundle;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NuGetRecipeBundleReaderTest {
+
+    private static final RecipeBundle BUNDLE =
+            new RecipeBundle("nuget", "OpenRewrite.CodeQuality", "0.1.0", "0.1.0", null);
+
+    @Test
+    void returnsFeedsFromInstallResponse() {
+        Set<String> repos = new LinkedHashSet<>();
+        repos.add("https://api.nuget.org/v3/index.json");
+        repos.add("https://internal.example.com/artifactory/api/nuget/v3/nuget-virtual/index.json");
+
+        NuGetRecipeBundleReader reader = new NuGetRecipeBundleReader(
+                BUNDLE, null, new InstallRecipesResponse(1, "0.1.0", repos));
+
+        assertThat(reader.getResolvedFromRepositories()).containsExactlyInAnyOrderElementsOf(repos);
+    }
+
+    @Test
+    void returnsEmptySetWhenResponseHasNullRepositories() {
+        NuGetRecipeBundleReader reader = new NuGetRecipeBundleReader(
+                BUNDLE, null, new InstallRecipesResponse(1, "0.1.0", null));
+
+        assertThat(reader.getResolvedFromRepositories()).isEmpty();
+    }
+
+    @Test
+    void returnsEmptySetForTwoArgConstructor() {
+        // The 2-arg convenience constructor is used by call sites that don't have an
+        // install response handy. It must return an empty set rather than throwing.
+        NuGetRecipeBundleReader reader = new NuGetRecipeBundleReader(BUNDLE, null);
+
+        assertThat(reader.getResolvedFromRepositories()).isEmpty();
+    }
+}

--- a/rewrite-javascript/rewrite/src/rpc/request/install-recipes.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/install-recipes.ts
@@ -25,6 +25,51 @@ import {getPlatformCommand} from "../../shell-utils";
 export interface InstallRecipesResponse {
     recipesInstalled: number
     version?: string
+    /**
+     * Registry base URLs that npm fetched packages from while installing the bundle
+     * and its transitive closure. Derived from the `resolved` field of each entry in
+     * the resulting package-lock.json. Empty for local-path installs.
+     */
+    resolvedFromRepositories?: string[]
+}
+
+/**
+ * Read package-lock.json from `installDir` and derive the set of unique registry base
+ * URLs that served the installed packages. Returns undefined if the lockfile is absent
+ * or unreadable; an empty array if it is present but has no `resolved` URLs.
+ */
+export function collectResolvedFromRepositories(installDir: string, logger?: rpc.Logger): string[] | undefined {
+    const lockfilePath = path.join(installDir, "package-lock.json");
+    if (!fs.existsSync(lockfilePath)) {
+        return undefined;
+    }
+    let lock: any;
+    try {
+        lock = JSON.parse(fs.readFileSync(lockfilePath, "utf8"));
+    } catch (e: any) {
+        if (logger) {
+            logger.warn(`Failed to parse ${lockfilePath}: ${e?.message ?? e}`);
+        }
+        return undefined;
+    }
+
+    const bases = new Set<string>();
+    const packages = lock.packages ?? {};
+    for (const [key, value] of Object.entries(packages) as [string, any][]) {
+        if (!value || typeof value.resolved !== "string") continue;
+        const resolved = value.resolved as string;
+        // Only consider tarball URLs; skip git+https, file:, link:, etc.
+        if (!/^https?:\/\//.test(resolved)) continue;
+        const idx = resolved.lastIndexOf("/-/");
+        if (idx < 0) continue; // unrecognized shape, skip
+        const head = resolved.substring(0, idx); // "<base>/<pkgName>"
+        const pkgName = key.replace(/^.*node_modules\//, "");
+        if (!pkgName) continue;
+        if (head.endsWith("/" + pkgName)) {
+            bases.add(head.substring(0, head.length - pkgName.length - 1));
+        }
+    }
+    return Array.from(bases);
 }
 
 /**
@@ -150,9 +195,16 @@ export class InstallRecipes {
                         throw new Error(`${recipesName} does not export an 'activate' function`);
                     }
 
+                    let resolvedFromRepositories: string[] | undefined;
+                    if (typeof request.recipes === "object") {
+                        const absoluteInstallDir = path.isAbsolute(installDir) ? installDir : path.join(process.cwd(), installDir);
+                        resolvedFromRepositories = collectResolvedFromRepositories(absoluteInstallDir, logger);
+                    }
+
                     return {
                         recipesInstalled: marketplace.allRecipes().length - beforeInstall,
-                        version: installedVersion
+                        version: installedVersion,
+                        resolvedFromRepositories
                     };
                 }
             )

--- a/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
@@ -17,7 +17,7 @@ import {withDir} from "tmp-promise";
 import * as fs from "fs";
 import * as path from "path";
 import {RecipeMarketplace} from "../../src";
-import {InstallRecipes, InstallRecipesResponse} from "../../src/rpc/request/install-recipes";
+import {collectResolvedFromRepositories, InstallRecipes, InstallRecipesResponse} from "../../src/rpc/request/install-recipes";
 
 describe("InstallRecipes", () => {
 
@@ -148,6 +148,80 @@ describe("InstallRecipes", () => {
                 // then
                 expect(response.recipesInstalled).toBe(3);
                 expect(marketplace.allRecipes().length).toBe(3);
+            }, {unsafeCleanup: true});
+        });
+    });
+
+    describe("collectResolvedFromRepositories", () => {
+
+        test("returns undefined when no package-lock.json is present", async () => {
+            await withDir(async (dir) => {
+                expect(collectResolvedFromRepositories(dir.path)).toBeUndefined();
+            }, {unsafeCleanup: true});
+        });
+
+        test("derives the registry base from npm tarball URLs", async () => {
+            await withDir(async (dir) => {
+                const lockfile = {
+                    packages: {
+                        "": {name: "openrewrite-recipes", version: "1.0.0"},
+                        "node_modules/lodash": {
+                            version: "4.17.21",
+                            resolved: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+                        },
+                        "node_modules/@openrewrite/recipes-nodejs": {
+                            version: "0.40.0",
+                            resolved: "https://registry.npmjs.org/@openrewrite/recipes-nodejs/-/recipes-nodejs-0.40.0.tgz"
+                        }
+                    }
+                };
+                fs.writeFileSync(path.join(dir.path, "package-lock.json"), JSON.stringify(lockfile));
+
+                const repos = collectResolvedFromRepositories(dir.path);
+                expect(repos).toEqual(["https://registry.npmjs.org"]);
+            }, {unsafeCleanup: true});
+        });
+
+        test("preserves the path of internal registries (Artifactory virtual repos)", async () => {
+            await withDir(async (dir) => {
+                const lockfile = {
+                    packages: {
+                        "node_modules/internal-tool": {
+                            version: "1.0.0",
+                            resolved: "https://internal.example.com/artifactory/api/npm/npm-virtual/internal-tool/-/internal-tool-1.0.0.tgz"
+                        }
+                    }
+                };
+                fs.writeFileSync(path.join(dir.path, "package-lock.json"), JSON.stringify(lockfile));
+
+                const repos = collectResolvedFromRepositories(dir.path);
+                expect(repos).toEqual(["https://internal.example.com/artifactory/api/npm/npm-virtual"]);
+            }, {unsafeCleanup: true});
+        });
+
+        test("skips entries without a resolved URL or with non-tarball shapes", async () => {
+            await withDir(async (dir) => {
+                const lockfile = {
+                    packages: {
+                        "node_modules/local-link": {version: "1.0.0", link: true},
+                        "node_modules/git-dep": {version: "1.0.0", resolved: "git+https://github.com/foo/bar.git#abc"},
+                        "node_modules/file-dep": {version: "1.0.0", resolved: "file:../bar"},
+                        "node_modules/ok": {
+                            version: "1.0.0",
+                            resolved: "https://registry.npmjs.org/ok/-/ok-1.0.0.tgz"
+                        }
+                    }
+                };
+                fs.writeFileSync(path.join(dir.path, "package-lock.json"), JSON.stringify(lockfile));
+
+                expect(collectResolvedFromRepositories(dir.path)).toEqual(["https://registry.npmjs.org"]);
+            }, {unsafeCleanup: true});
+        });
+
+        test("returns an empty array when the lockfile has no resolved URLs", async () => {
+            await withDir(async (dir) => {
+                fs.writeFileSync(path.join(dir.path, "package-lock.json"), JSON.stringify({packages: {"": {}}}));
+                expect(collectResolvedFromRepositories(dir.path)).toEqual([]);
             }, {unsafeCleanup: true});
         });
     });

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleReader.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleReader.java
@@ -19,6 +19,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.openrewrite.Recipe;
 import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.javascript.rpc.InstallRecipesResponse;
 import org.openrewrite.javascript.rpc.JavaScriptRewriteRpc;
 import org.openrewrite.marketplace.RecipeBundle;
 import org.openrewrite.marketplace.RecipeBundleReader;
@@ -26,11 +27,17 @@ import org.openrewrite.marketplace.RecipeListing;
 import org.openrewrite.marketplace.RecipeMarketplace;
 
 import java.util.Map;
+import java.util.Set;
 
 @RequiredArgsConstructor
 public class NpmRecipeBundleReader implements RecipeBundleReader {
     private final @Getter RecipeBundle bundle;
     private final JavaScriptRewriteRpc rpc;
+    private final InstallRecipesResponse installResponse;
+
+    public NpmRecipeBundleReader(RecipeBundle bundle, JavaScriptRewriteRpc rpc) {
+        this(bundle, rpc, new InstallRecipesResponse(0, null, null));
+    }
 
     @Override
     public RecipeMarketplace read() {
@@ -45,5 +52,10 @@ public class NpmRecipeBundleReader implements RecipeBundleReader {
     @Override
     public Recipe prepare(RecipeListing listing, Map<String, Object> options) {
         return rpc.prepareRecipe(listing.getName(), options);
+    }
+
+    @Override
+    public Set<String> getResolvedFromRepositories() {
+        return installResponse.resolvedFromRepositoriesOrEmpty();
     }
 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleResolver.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleResolver.java
@@ -47,6 +47,6 @@ public class NpmRecipeBundleResolver implements RecipeBundleResolver {
         if (response.getVersion() != null) {
             bundle.setVersion(response.getVersion());
         }
-        return new NpmRecipeBundleReader(bundle, rpc);
+        return new NpmRecipeBundleReader(bundle, rpc, response);
     }
 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/InstallRecipesResponse.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/InstallRecipesResponse.java
@@ -18,8 +18,23 @@ package org.openrewrite.javascript.rpc;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Collections;
+import java.util.Set;
+
 @Value
 public class InstallRecipesResponse {
     int recipesInstalled;
     @Nullable String version;
+    /**
+     * Registry URLs that {@code npm install} touched while installing this bundle and
+     * its transitive closure. Derived from the {@code resolved} field of each entry in
+     * the resulting {@code package-lock.json}. URLs are returned as the worker observed
+     * them (e.g. {@code https://registry.npmjs.org}); normalization is the caller's
+     * responsibility.
+     */
+    @Nullable Set<String> resolvedFromRepositories;
+
+    public Set<String> resolvedFromRepositoriesOrEmpty() {
+        return resolvedFromRepositories == null ? Collections.emptySet() : resolvedFromRepositories;
+    }
 }

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleReaderTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleReaderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript.marketplace;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.javascript.rpc.InstallRecipesResponse;
+import org.openrewrite.marketplace.RecipeBundle;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NpmRecipeBundleReaderTest {
+
+    private static final RecipeBundle BUNDLE =
+            new RecipeBundle("npm", "@openrewrite/recipes-nodejs", "0.44.1", "0.44.1", null);
+
+    @Test
+    void returnsRegistriesFromInstallResponse() {
+        Set<String> repos = new LinkedHashSet<>();
+        repos.add("https://registry.npmjs.org");
+        repos.add("https://internal.example.com/artifactory/api/npm/npm-virtual");
+
+        NpmRecipeBundleReader reader = new NpmRecipeBundleReader(
+                BUNDLE, null, new InstallRecipesResponse(1, "0.44.1", repos));
+
+        assertThat(reader.getResolvedFromRepositories()).containsExactlyInAnyOrderElementsOf(repos);
+    }
+
+    @Test
+    void returnsEmptySetWhenResponseHasNullRepositories() {
+        NpmRecipeBundleReader reader = new NpmRecipeBundleReader(
+                BUNDLE, null, new InstallRecipesResponse(1, "0.44.1", null));
+
+        assertThat(reader.getResolvedFromRepositories()).isEmpty();
+    }
+
+    @Test
+    void returnsEmptySetForTwoArgConstructor() {
+        // The 2-arg convenience constructor is used by call sites that don't have an
+        // install response handy (e.g. tests, legacy code paths). It must return an
+        // empty set rather than throwing.
+        NpmRecipeBundleReader reader = new NpmRecipeBundleReader(BUNDLE, null);
+
+        assertThat(reader.getResolvedFromRepositories()).isEmpty();
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReader.java
@@ -31,9 +31,11 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -126,6 +128,18 @@ public class MavenRecipeBundleReader implements RecipeBundleReader {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @Override
+    public Set<String> getResolvedFromRepositories() {
+        Set<String> repos = new LinkedHashSet<>();
+        for (ResolvedDependency d : mrr.getDependencies().get(Scope.Runtime)) {
+            MavenRepository repo = d.getRepository();
+            if (repo != null) {
+                repos.add(repo.getUri());
+            }
+        }
+        return repos;
     }
 
     @Override

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReaderTest.java
@@ -138,6 +138,18 @@ class MavenRecipeBundleReaderTest {
     }
 
     @Test
+    void getResolvedFromRepositoriesReportsMavenCentral() {
+        // Metadata resolution (and therefore per-dependency repository attribution)
+        // completes inside resolver.resolve() via MavenParser.parse(); reader.read()
+        // would only trigger JAR downloads and is not needed here.
+        RecipeBundleReader reader = resolver.resolve(REWRITE_CORE_BUNDLE);
+
+        assertThat(reader.getResolvedFromRepositories())
+                .as("rewrite-core resolves through Maven Central, so its URI must appear")
+                .anyMatch(uri -> uri.contains("repo.maven.apache.org") || uri.contains("repo1.maven.org"));
+    }
+
+    @Test
     void canReadRecipesFromDirectory() throws Exception {
         MavenRecipeBundleReader reader = (MavenRecipeBundleReader) resolver.resolve(REWRITE_CORE_BUNDLE);
 

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -665,24 +665,85 @@ def _is_package_installed(package_name: str, version: Optional[str]) -> bool:
     return version is None or installed == version
 
 
-def _pip_install_recipe_package(package_name: str, version: Optional[str], target_dir: Path) -> None:
+def _pip_install_recipe_package(
+    package_name: str, version: Optional[str], target_dir: Path
+) -> Set[str]:
+    """Install the requested package + closure into target_dir.
+
+    Returns the set of unique origins (scheme://host) that pip downloaded from
+    while installing. Origins are derived from the install report (PEP 658
+    --report flag, pip 22.2+). When the running pip is too old or the report
+    cannot be parsed, an empty set is returned and a warning is logged; the
+    install itself still succeeds.
+    """
     import importlib
     import subprocess
 
     target_dir.mkdir(parents=True, exist_ok=True)
     spec = f"{package_name}=={version}" if version else package_name
-    cmd = [sys.executable, "-m", "pip", "install", "--target", str(target_dir), spec]
-    logger.info(f"pip install: {' '.join(cmd)}")
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"pip install failed for {spec} (target={target_dir}):\n{result.stderr}"
-        )
 
-    target_str = str(target_dir.resolve())
-    if target_str not in sys.path:
-        sys.path.insert(0, target_str)
-    importlib.invalidate_caches()
+    with tempfile.NamedTemporaryFile(
+        mode="r", suffix=".json", prefix="pip-report-", delete=False
+    ) as report_handle:
+        report_path = report_handle.name
+
+    try:
+        cmd = [
+            sys.executable, "-m", "pip", "install",
+            "--target", str(target_dir),
+            "--report", report_path,
+            spec,
+        ]
+        logger.info(f"pip install: {' '.join(cmd)}")
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"pip install failed for {spec} (target={target_dir}):\n{result.stderr}"
+            )
+
+        target_str = str(target_dir.resolve())
+        if target_str not in sys.path:
+            sys.path.insert(0, target_str)
+        importlib.invalidate_caches()
+
+        return _parse_pip_install_report(report_path)
+    finally:
+        try:
+            os.unlink(report_path)
+        except OSError:
+            pass
+
+
+def _parse_pip_install_report(report_path: str) -> Set[str]:
+    """Read a pip install --report JSON file and return the unique download origins.
+
+    Each entry's download_info.url is reduced to its scheme://host origin. Local
+    file:// URLs and entries without an http(s) download are skipped. This is a
+    deliberate simplification: pip's download URL (e.g. files.pythonhosted.org for
+    PyPI) is often served from a CDN host that differs from the configured index
+    URL (pypi.org/simple), so any finer-grained path matching would be misleading.
+    The saas-side comparator is expected to compare pip URLs by host.
+    """
+    from urllib.parse import urlparse
+
+    try:
+        with open(report_path, "r") as f:
+            report = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning(f"Could not parse pip install report at {report_path}: {e}")
+        return set()
+
+    origins: Set[str] = set()
+    for entry in report.get("install", []) or []:
+        download_info = entry.get("download_info") or {}
+        url = download_info.get("url")
+        if not isinstance(url, str):
+            continue
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            continue
+        origins.add(f"{parsed.scheme}://{parsed.netloc}")
+    return origins
 
 
 def handle_install_recipes(params: dict) -> dict:
@@ -717,6 +778,7 @@ def handle_install_recipes(params: dict) -> dict:
     installed_version = None
     package_name: Optional[str] = None
     recipes_added = 0
+    resolved_from_repositories: Set[str] = set()
 
     if isinstance(recipes, str):
         # Local file path - package should already be installed by caller
@@ -741,7 +803,7 @@ def handle_install_recipes(params: dict) -> dict:
             raise ValueError("Package name is required")
 
         if _recipe_install_dir is not None and not _is_package_installed(package_name, version):
-            _pip_install_recipe_package(package_name, version, _recipe_install_dir)
+            resolved_from_repositories = _pip_install_recipe_package(package_name, version, _recipe_install_dir)
 
         logger.info(f"Activating recipes package: {package_name}")
 
@@ -776,6 +838,7 @@ def handle_install_recipes(params: dict) -> dict:
         'recipesInstalled': recipes_added,
         'version': installed_version,
         'recipes': package_rows,
+        'resolvedFromRepositories': sorted(resolved_from_repositories),
     }
 
 

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -48,6 +48,7 @@ def test_handle_parse_preserves_empty_text(tmp_path, monkeypatch):
 
 
 def test_pip_install_recipe_package_shape(tmp_path, monkeypatch):
+    import json
     import rewrite.rpc.server as server
     import subprocess
 
@@ -61,21 +62,51 @@ def test_pip_install_recipe_package_shape(tmp_path, monkeypatch):
 
     def fake_run(cmd, capture_output=False, text=False):
         captured["cmd"] = cmd
+        # Simulate pip honoring --report by writing a minimal install report.
+        report_path = cmd[cmd.index("--report") + 1]
+        with open(report_path, "w") as f:
+            json.dump({
+                "install": [
+                    {"download_info": {"url": "https://files.pythonhosted.org/packages/aa/bb/foo-1.0-py3-none-any.whl"}},
+                    {"download_info": {"url": "https://internal.example.com/artifactory/api/pypi/pypi/simple/foo/foo-1.0.tar.gz"}},
+                    {"download_info": {"url": "file:///local/wheel.whl"}},
+                ]
+            }, f)
         return FakeCompletedProcess()
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    server._pip_install_recipe_package(
+    repos = server._pip_install_recipe_package(
         "openrewrite-recipes-python", "1.2.3", install_dir
     )
 
     assert install_dir.exists()
-    assert captured["cmd"][1:] == [
-        "-m", "pip", "install",
-        "--target", str(install_dir),
-        "openrewrite-recipes-python==1.2.3",
-    ]
+    assert captured["cmd"][1] == "-m"
+    assert captured["cmd"][2:5] == ["pip", "install", "--target"]
+    assert captured["cmd"][5] == str(install_dir)
+    assert "--report" in captured["cmd"]
+    assert captured["cmd"][-1] == "openrewrite-recipes-python==1.2.3"
     assert str(install_dir.resolve()) in __import__("sys").path
+    # Local file:// download skipped; http(s) downloads reduced to origin.
+    assert repos == {
+        "https://files.pythonhosted.org",
+        "https://internal.example.com",
+    }
+
+
+def test_parse_pip_install_report_handles_missing_or_malformed_file(tmp_path):
+    import rewrite.rpc.server as server
+
+    missing = tmp_path / "does-not-exist.json"
+    assert server._parse_pip_install_report(str(missing)) == set()
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{not valid json")
+    assert server._parse_pip_install_report(str(malformed)) == set()
+
+    empty_install = tmp_path / "empty.json"
+    empty_install.write_text("{}")
+    assert server._parse_pip_install_report(str(empty_install)) == set()
 
 
 def test_recipe_descriptor_to_dict_emits_all_collection_keys():

--- a/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleReader.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleReader.java
@@ -28,6 +28,7 @@ import org.openrewrite.marketplace.RecipeMarketplace;
 import org.openrewrite.rpc.request.GetMarketplaceResponse;
 
 import java.util.Map;
+import java.util.Set;
 
 @RequiredArgsConstructor
 public class PipRecipeBundleReader implements RecipeBundleReader {
@@ -56,5 +57,10 @@ public class PipRecipeBundleReader implements RecipeBundleReader {
     @Override
     public Recipe prepare(RecipeListing listing, Map<String, Object> options) {
         return rpc.prepareRecipe(listing.getName(), options);
+    }
+
+    @Override
+    public Set<String> getResolvedFromRepositories() {
+        return installResponse.resolvedFromRepositoriesOrEmpty();
     }
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/InstallRecipesResponse.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/InstallRecipesResponse.java
@@ -21,6 +21,7 @@ import org.openrewrite.rpc.request.GetMarketplaceResponse;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Response to an {@code InstallRecipes} RPC request.
@@ -40,8 +41,20 @@ public class InstallRecipesResponse {
     int recipesInstalled;
     @Nullable String version;
     @Nullable List<GetMarketplaceResponse.Row> recipes;
+    /**
+     * Index URLs that pip fetched distributions from while installing this bundle and
+     * its transitive closure. Derived from the {@code download_info.url} of each entry
+     * in {@code pip install --report -} output, stripped down to the index base.
+     * URLs are returned as the worker observed them; normalization is the caller's
+     * responsibility.
+     */
+    @Nullable Set<String> resolvedFromRepositories;
 
     public List<GetMarketplaceResponse.Row> recipesOrEmpty() {
         return recipes == null ? Collections.emptyList() : recipes;
+    }
+
+    public Set<String> resolvedFromRepositoriesOrEmpty() {
+        return resolvedFromRepositories == null ? Collections.emptySet() : resolvedFromRepositories;
     }
 }

--- a/rewrite-python/src/test/java/org/openrewrite/python/marketplace/PipRecipeBundleReaderTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/marketplace/PipRecipeBundleReaderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.marketplace;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.marketplace.RecipeBundle;
+import org.openrewrite.python.rpc.InstallRecipesResponse;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PipRecipeBundleReaderTest {
+
+    private static final RecipeBundle BUNDLE =
+            new RecipeBundle("pip", "openrewrite-static-analysis", "0.2.0", "0.2.0", null);
+
+    @Test
+    void returnsIndexesFromInstallResponse() {
+        Set<String> repos = new LinkedHashSet<>();
+        repos.add("https://files.pythonhosted.org");
+        repos.add("https://internal.example.com");
+
+        PipRecipeBundleReader reader = new PipRecipeBundleReader(
+                BUNDLE, null, new InstallRecipesResponse(1, "0.2.0", null, repos));
+
+        assertThat(reader.getResolvedFromRepositories()).containsExactlyInAnyOrderElementsOf(repos);
+    }
+
+    @Test
+    void returnsEmptySetWhenResponseHasNullRepositories() {
+        PipRecipeBundleReader reader = new PipRecipeBundleReader(
+                BUNDLE, null, new InstallRecipesResponse(1, "0.2.0", null, null));
+
+        assertThat(reader.getResolvedFromRepositories()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Problem

The recipe-marketplace platform installs recipe bundles from a configured list of artifact repositories, but has no record of which repository URLs the resolver actually fetched from. When a repo is removed from config, the platform can't tell which previously-installed bundles are now broken. To fix it on the platform side, we need that information from the rewrite resolvers.

## Solution

Adds `RecipeBundleReader.getResolvedFromRepositories()` with a default-empty implementation, plus per-ecosystem overrides:

* **Maven**: walks `MavenResolutionResult.getDependencies()` and reads each `ResolvedDependency.getRepository().getUri()`.
* **npm** (TS worker): parses `package-lock.json` after install, strips each `resolved` tarball URL down to the registry base.
* **pip** (Python worker): adds `--report <tempfile>` to `pip install`, reduces each `download_info.url` to its `scheme://host` origin.
* **NuGet** (C# worker): runs an explicit `dotnet restore --packages <fresh-scratch> --force --no-cache --verbosity normal` and parses the `Installed ... from <url>` log lines.

URLs are returned as the underlying tool reported them; normalization is a platform-side concern.

The CLI-side consumer is moderneinc/moderne-cli#3849.

## Test plan

- [x] Unit tests for each reader and each worker-side parser.
- [x] End-to-end install of a real recipe package through the patched mod CLI for all four ecosystems (Maven on host; npm/pip/NuGet each in a dedicated docker image). Sidecar JSON written by the CLI contained the expected source URL for every install.