### PR TITLE
Add .NET Framework version primitives for legacy csproj and config files

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetFrameworkVersion.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetFrameworkVersion.cs
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.Xml;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.CSharp.Recipes;
+
+/// <summary>
+/// Changes the .NET Framework version in legacy (non-SDK) .csproj files and matching app.config entries.
+/// Updates &lt;TargetFrameworkVersion&gt; in legacy csproj and the sku version inside
+/// &lt;supportedRuntime&gt; in app.config. For SDK-style .csproj &lt;TargetFramework&gt; / &lt;TargetFrameworks&gt;
+/// elements, use ChangeDotNetTargetFramework instead.
+/// </summary>
+public class ChangeDotNetFrameworkVersion : Recipe
+{
+    public override string DisplayName => "Change .NET Framework version";
+
+    public override string Description =>
+        "Changes the `<TargetFrameworkVersion>` value in legacy .csproj files and the version " +
+        "inside `<supportedRuntime sku>` in app.config files. For SDK-style csproj files, use " +
+        "`ChangeDotNetTargetFramework` to update `<TargetFramework>` / `<TargetFrameworks>` instead.";
+
+    [Option(DisplayName = "Old version",
+        Description = "The .NET Framework version to replace (e.g., v4.7.2). The leading 'v' is optional.",
+        Example = "v4.7.2")]
+    public string OldVersion { get; set; } = "";
+
+    [Option(DisplayName = "New version",
+        Description = "The .NET Framework version to use instead (e.g., v4.8). The leading 'v' is optional.",
+        Example = "v4.8")]
+    public string NewVersion { get; set; } = "";
+
+    public override ITreeVisitor<ExecutionContext> GetVisitor() =>
+        new ChangeDotNetFrameworkVersionVisitor(OldVersion, NewVersion);
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetFrameworkVersionVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetFrameworkVersionVisitor.cs
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.Xml;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.CSharp.Recipes;
+
+/// <summary>
+/// Visitor that changes the .NET Framework version in legacy .csproj &lt;TargetFrameworkVersion&gt;
+/// elements and in app.config &lt;supportedRuntime sku=...&gt; attributes.
+/// </summary>
+public class ChangeDotNetFrameworkVersionVisitor(string oldVersion, string newVersion) : XmlVisitor<ExecutionContext>
+{
+    // ".NETFramework,Version=v4.7.2" — the prefix that precedes the version inside the sku attribute.
+    private const string SkuVersionPrefix = ".NETFramework,Version=";
+
+    private readonly string _oldCanonical = Canonicalize(oldVersion);
+    private readonly string _newCanonical = Canonicalize(newVersion);
+
+    private bool _modified;
+
+    public override Xml.Xml VisitDocument(Document document, ExecutionContext ctx)
+    {
+        _modified = false;
+        var d = (Document)base.VisitDocument(document, ctx);
+        if (_modified && d.Markers.FindFirst<MSBuildProject>() != null)
+            DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+        return d;
+    }
+
+    public override Xml.Xml VisitTag(Tag tag, ExecutionContext ctx)
+    {
+        var t = (Tag)base.VisitTag(tag, ctx);
+
+        // Legacy csproj: <TargetFrameworkVersion>v4.x.y</TargetFrameworkVersion>
+        if (t.Name == "TargetFrameworkVersion")
+        {
+            var value = t.GetValue();
+            if (value != null && Canonicalize(value) == _oldCanonical)
+            {
+                _modified = true;
+                DoAfterVisit(new ChangeTagValueVisitor<ExecutionContext>(t, _newCanonical));
+            }
+            return t;
+        }
+
+        // app.config: <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.x.y" />
+        if (t.Name == "supportedRuntime")
+        {
+            var sku = t.GetAttributeValue("sku");
+            if (sku != null)
+            {
+                var idx = sku.IndexOf(SkuVersionPrefix, StringComparison.Ordinal);
+                if (idx >= 0)
+                {
+                    var versionStart = idx + SkuVersionPrefix.Length;
+                    var versionPart = sku[versionStart..];
+                    if (Canonicalize(versionPart) == _oldCanonical)
+                    {
+                        _modified = true;
+                        var newSku = sku[..versionStart] + _newCanonical;
+                        return t.ChangeAttribute("sku", newSku);
+                    }
+                }
+            }
+        }
+
+        return t;
+    }
+
+    // Accept "v4.7.2" or "4.7.2" interchangeably. Canonical form has the leading 'v'.
+    private static string Canonicalize(string version)
+    {
+        var trimmed = version.Trim();
+        if (trimmed.Length == 0) return trimmed;
+        return trimmed[0] is 'v' or 'V' ? "v" + trimmed[1..] : "v" + trimmed;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeWebConfigTargetFramework.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeWebConfigTargetFramework.cs
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.Xml;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.CSharp.Recipes;
+
+/// <summary>
+/// Changes the targetFramework attribute on &lt;httpRuntime&gt; and &lt;compilation&gt; elements
+/// in web.config and app.config files. These attributes determine ASP.NET runtime
+/// quirks-mode behavior independently of the binary TFM.
+/// </summary>
+public class ChangeWebConfigTargetFramework : Recipe
+{
+    public override string DisplayName => "Change web.config target framework";
+
+    public override string Description =>
+        "Changes the `targetFramework` attribute on `<httpRuntime>` and `<compilation>` elements " +
+        "in web.config and app.config. These attributes control ASP.NET quirks-mode behavior and " +
+        "are distinct from the binary TFM in the .csproj file.";
+
+    [Option(DisplayName = "Old version",
+        Description = "The .NET Framework version to replace (e.g., 4.7.2). The leading 'v' is optional.",
+        Example = "4.7.2")]
+    public string OldVersion { get; set; } = "";
+
+    [Option(DisplayName = "New version",
+        Description = "The .NET Framework version to use instead (e.g., 4.8). The leading 'v' is optional.",
+        Example = "4.8")]
+    public string NewVersion { get; set; } = "";
+
+    public override ITreeVisitor<ExecutionContext> GetVisitor() =>
+        new ChangeWebConfigTargetFrameworkVisitor(OldVersion, NewVersion);
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeWebConfigTargetFrameworkVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeWebConfigTargetFrameworkVisitor.cs
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.Xml;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.CSharp.Recipes;
+
+/// <summary>
+/// Visitor that changes the targetFramework attribute on &lt;httpRuntime&gt; and
+/// &lt;compilation&gt; elements in web.config and app.config files.
+/// </summary>
+public class ChangeWebConfigTargetFrameworkVisitor(string oldVersion, string newVersion) : XmlVisitor<ExecutionContext>
+{
+    private readonly string _oldCanonical = Canonicalize(oldVersion);
+    private readonly string _newCanonical = Canonicalize(newVersion);
+
+    public override Xml.Xml VisitTag(Tag tag, ExecutionContext ctx)
+    {
+        var t = (Tag)base.VisitTag(tag, ctx);
+
+        if (t.Name == "httpRuntime" || t.Name == "compilation")
+        {
+            var current = t.GetAttributeValue("targetFramework");
+            if (current != null && Canonicalize(current) == _oldCanonical)
+                return t.ChangeAttribute("targetFramework", _newCanonical);
+        }
+
+        return t;
+    }
+
+    // Strips a leading 'v' / 'V' so "4.7.2" and "v4.7.2" both match the no-prefix
+    // form used in web.config / app.config attribute values.
+    private static string Canonicalize(string version)
+    {
+        var trimmed = version.Trim();
+        if (trimmed.Length == 0) return trimmed;
+        return trimmed[0] is 'v' or 'V' ? trimmed[1..] : trimmed;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveAppContextSwitch.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveAppContextSwitch.cs
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.Xml;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.CSharp.Recipes;
+
+/// <summary>
+/// Removes a named switch from &lt;AppContextSwitchOverrides&gt; in app.config and web.config.
+/// If removing the switch leaves the value empty, the entire element (and any newly-empty
+/// ancestor like &lt;runtime&gt;) is removed.
+/// </summary>
+public class RemoveAppContextSwitch : Recipe
+{
+    public override string DisplayName => "Remove an AppContext switch";
+
+    public override string Description =>
+        "Removes a single named switch from `<AppContextSwitchOverrides value=\"...\" />` in " +
+        "app.config / web.config files. The value attribute is a semicolon-separated list of " +
+        "`Switch.Name=value` pairs; only the entry matching the supplied switch name is removed. " +
+        "If the value becomes empty, the element and any newly-empty ancestor element are removed.";
+
+    [Option(DisplayName = "Switch name",
+        Description = "The fully-qualified switch name to remove (e.g., Switch.System.Net.DontEnableSchUseStrongCrypto).",
+        Example = "Switch.System.Net.DontEnableSchUseStrongCrypto")]
+    public string SwitchName { get; set; } = "";
+
+    public override ITreeVisitor<ExecutionContext> GetVisitor() =>
+        new RemoveAppContextSwitchVisitor(SwitchName);
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveAppContextSwitchVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveAppContextSwitchVisitor.cs
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.Xml;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.CSharp.Recipes;
+
+/// <summary>
+/// Visitor that removes a single named switch from the value attribute of
+/// &lt;AppContextSwitchOverrides&gt; in app.config / web.config.
+/// </summary>
+public class RemoveAppContextSwitchVisitor(string switchName) : XmlVisitor<ExecutionContext>
+{
+    public override Xml.Xml VisitTag(Tag tag, ExecutionContext ctx)
+    {
+        var t = (Tag)base.VisitTag(tag, ctx);
+
+        if (t.Name != "AppContextSwitchOverrides")
+            return t;
+
+        var value = t.GetAttributeValue("value");
+        if (value == null)
+            return t;
+
+        var (newValue, removed) = StripSwitch(value, switchName);
+        if (!removed)
+            return t;
+
+        if (newValue.Length == 0)
+        {
+            DoAfterVisit(new RemoveContentVisitor<ExecutionContext>(t, true, false));
+            return t;
+        }
+
+        return t.ChangeAttribute("value", newValue);
+    }
+
+    // Returns the value with the named switch removed, plus a flag indicating whether
+    // a removal actually happened. Switch names are matched exactly (case-sensitive),
+    // ignoring whitespace around tokens.
+    private static (string Value, bool Removed) StripSwitch(string value, string targetName)
+    {
+        var entries = value.Split(';');
+        var kept = new List<string>(entries.Length);
+        var removed = false;
+
+        foreach (var entry in entries)
+        {
+            var trimmed = entry.Trim();
+            if (trimmed.Length == 0) continue;
+
+            var eq = trimmed.IndexOf('=');
+            var name = eq >= 0 ? trimmed[..eq].Trim() : trimmed;
+
+            if (name == targetName)
+            {
+                removed = true;
+                continue;
+            }
+
+            kept.Add(trimmed);
+        }
+
+        return (string.Join(";", kept), removed);
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/Recipes/ChangeDotNetFrameworkVersionTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/Recipes/ChangeDotNetFrameworkVersionTests.cs
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp.Recipes;
+using OpenRewrite.Test;
+
+namespace OpenRewrite.Tests.CSharp.Recipes;
+
+public class ChangeDotNetFrameworkVersionTests(RpcFixture fixture) : RpcRewriteTest(fixture)
+{
+    private static SourceSpec AppConfig(string before, string? after = null, string sourcePath = "app.config") =>
+        new(before, after, sourcePath, "org.openrewrite.xml.tree.Xml$Document");
+
+    [Fact]
+    public void ChangeLegacyCsprojTargetFrameworkVersion()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeDotNetFrameworkVersion
+            {
+                OldVersion = "v4.7.2",
+                NewVersion = "v4.8"
+            }),
+            CsProj(
+                """
+                <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+                  </PropertyGroup>
+                </Project>
+                """,
+                """
+                <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+                  </PropertyGroup>
+                </Project>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void ChangeAppConfigSupportedRuntimeSku()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeDotNetFrameworkVersion
+            {
+                OldVersion = "v4.7.2",
+                NewVersion = "v4.8"
+            }),
+            AppConfig(
+                """
+                <configuration>
+                  <startup>
+                    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+                  </startup>
+                </configuration>
+                """,
+                """
+                <configuration>
+                  <startup>
+                    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+                  </startup>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void AcceptsVersionWithoutVPrefix()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeDotNetFrameworkVersion
+            {
+                OldVersion = "4.7.2",
+                NewVersion = "4.8"
+            }),
+            CsProj(
+                """
+                <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+                  </PropertyGroup>
+                </Project>
+                """,
+                """
+                <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+                  </PropertyGroup>
+                </Project>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void ChangesBothCsprojAndAppConfigInSingleRun()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeDotNetFrameworkVersion
+            {
+                OldVersion = "v4.6.2",
+                NewVersion = "v4.7.2"
+            }),
+            CsProj(
+                """
+                <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+                  </PropertyGroup>
+                </Project>
+                """,
+                """
+                <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+                  </PropertyGroup>
+                </Project>
+                """
+            ),
+            AppConfig(
+                """
+                <configuration>
+                  <startup>
+                    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+                  </startup>
+                </configuration>
+                """,
+                """
+                <configuration>
+                  <startup>
+                    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+                  </startup>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void NoChangeWhenVersionDoesNotMatch()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeDotNetFrameworkVersion
+            {
+                OldVersion = "v4.6.2",
+                NewVersion = "v4.8"
+            }),
+            CsProj(
+                """
+                <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+                  </PropertyGroup>
+                </Project>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void NoChangeWhenSupportedRuntimeMissing()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeDotNetFrameworkVersion
+            {
+                OldVersion = "v4.7.2",
+                NewVersion = "v4.8"
+            }),
+            AppConfig(
+                """
+                <configuration>
+                  <appSettings>
+                    <add key="foo" value="bar" />
+                  </appSettings>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void IgnoresSdkStyleTargetFrameworkElement()
+    {
+        // SDK-style csproj uses <TargetFramework>net472</TargetFramework>.
+        // This recipe deliberately does not touch it; ChangeDotNetTargetFramework owns that.
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeDotNetFrameworkVersion
+            {
+                OldVersion = "v4.7.2",
+                NewVersion = "v4.8"
+            }),
+            CsProj(
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net472</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void IgnoresUnrelatedSkuValuesInSupportedRuntime()
+    {
+        // Only sku entries with the .NETFramework,Version= prefix should match.
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeDotNetFrameworkVersion
+            {
+                OldVersion = "v4.7.2",
+                NewVersion = "v4.8"
+            }),
+            AppConfig(
+                """
+                <configuration>
+                  <startup>
+                    <supportedRuntime version="v4.0" sku="Client" />
+                  </startup>
+                </configuration>
+                """
+            )
+        );
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/Recipes/ChangeWebConfigTargetFrameworkTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/Recipes/ChangeWebConfigTargetFrameworkTests.cs
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp.Recipes;
+using OpenRewrite.Test;
+
+namespace OpenRewrite.Tests.CSharp.Recipes;
+
+public class ChangeWebConfigTargetFrameworkTests(RpcFixture fixture) : RpcRewriteTest(fixture)
+{
+    private static SourceSpec WebConfig(string before, string? after = null, string sourcePath = "web.config") =>
+        new(before, after, sourcePath, "org.openrewrite.xml.tree.Xml$Document");
+
+    private static SourceSpec AppConfig(string before, string? after = null, string sourcePath = "app.config") =>
+        new(before, after, sourcePath, "org.openrewrite.xml.tree.Xml$Document");
+
+    [Fact]
+    public void ChangeHttpRuntimeTargetFramework()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeWebConfigTargetFramework
+            {
+                OldVersion = "4.7.2",
+                NewVersion = "4.8"
+            }),
+            WebConfig(
+                """
+                <configuration>
+                  <system.web>
+                    <httpRuntime targetFramework="4.7.2" />
+                  </system.web>
+                </configuration>
+                """,
+                """
+                <configuration>
+                  <system.web>
+                    <httpRuntime targetFramework="4.8" />
+                  </system.web>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void ChangeCompilationTargetFramework()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeWebConfigTargetFramework
+            {
+                OldVersion = "4.7.2",
+                NewVersion = "4.8"
+            }),
+            WebConfig(
+                """
+                <configuration>
+                  <system.web>
+                    <compilation targetFramework="4.7.2" debug="true" />
+                  </system.web>
+                </configuration>
+                """,
+                """
+                <configuration>
+                  <system.web>
+                    <compilation targetFramework="4.8" debug="true" />
+                  </system.web>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void ChangeBothHttpRuntimeAndCompilationInOneRun()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeWebConfigTargetFramework
+            {
+                OldVersion = "4.6.2",
+                NewVersion = "4.7.2"
+            }),
+            WebConfig(
+                """
+                <configuration>
+                  <system.web>
+                    <compilation targetFramework="4.6.2" debug="true" />
+                    <httpRuntime targetFramework="4.6.2" />
+                  </system.web>
+                </configuration>
+                """,
+                """
+                <configuration>
+                  <system.web>
+                    <compilation targetFramework="4.7.2" debug="true" />
+                    <httpRuntime targetFramework="4.7.2" />
+                  </system.web>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void AcceptsVersionWithVPrefix()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeWebConfigTargetFramework
+            {
+                OldVersion = "v4.7.2",
+                NewVersion = "v4.8"
+            }),
+            WebConfig(
+                """
+                <configuration>
+                  <system.web>
+                    <httpRuntime targetFramework="4.7.2" />
+                  </system.web>
+                </configuration>
+                """,
+                """
+                <configuration>
+                  <system.web>
+                    <httpRuntime targetFramework="4.8" />
+                  </system.web>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void AlsoAppliesToAppConfig()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeWebConfigTargetFramework
+            {
+                OldVersion = "4.7.2",
+                NewVersion = "4.8"
+            }),
+            AppConfig(
+                """
+                <configuration>
+                  <system.web>
+                    <httpRuntime targetFramework="4.7.2" />
+                  </system.web>
+                </configuration>
+                """,
+                """
+                <configuration>
+                  <system.web>
+                    <httpRuntime targetFramework="4.8" />
+                  </system.web>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void NoChangeWhenVersionDoesNotMatch()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeWebConfigTargetFramework
+            {
+                OldVersion = "4.6.2",
+                NewVersion = "4.8"
+            }),
+            WebConfig(
+                """
+                <configuration>
+                  <system.web>
+                    <httpRuntime targetFramework="4.7.2" />
+                  </system.web>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void NoChangeWhenAttributeAbsent()
+    {
+        // <httpRuntime> without a targetFramework attribute (uses runtime default).
+        RewriteRun(
+            spec => spec.SetRecipe(new ChangeWebConfigTargetFramework
+            {
+                OldVersion = "4.7.2",
+                NewVersion = "4.8"
+            }),
+            WebConfig(
+                """
+                <configuration>
+                  <system.web>
+                    <httpRuntime maxRequestLength="4096" />
+                  </system.web>
+                </configuration>
+                """
+            )
+        );
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/Recipes/RemoveAppContextSwitchTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Tests/CSharp/Recipes/RemoveAppContextSwitchTests.cs
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp.Recipes;
+using OpenRewrite.Test;
+
+namespace OpenRewrite.Tests.CSharp.Recipes;
+
+public class RemoveAppContextSwitchTests(RpcFixture fixture) : RpcRewriteTest(fixture)
+{
+    private static SourceSpec AppConfig(string before, string? after = null, string sourcePath = "app.config") =>
+        new(before, after, sourcePath, "org.openrewrite.xml.tree.Xml$Document");
+
+    [Fact]
+    public void RemoveSwitchFromMultiSwitchValue()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new RemoveAppContextSwitch
+            {
+                SwitchName = "Switch.System.Net.DontEnableSchUseStrongCrypto"
+            }),
+            AppConfig(
+                """
+                <configuration>
+                  <runtime>
+                    <AppContextSwitchOverrides value="Switch.System.Net.DontEnableSchUseStrongCrypto=true;Switch.Other=false" />
+                  </runtime>
+                </configuration>
+                """,
+                """
+                <configuration>
+                  <runtime>
+                    <AppContextSwitchOverrides value="Switch.Other=false" />
+                  </runtime>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void RemoveLastSwitchDropsElementAndEmptyAncestor()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new RemoveAppContextSwitch
+            {
+                SwitchName = "Switch.System.Net.DontEnableSchUseStrongCrypto"
+            }),
+            AppConfig(
+                """
+                <configuration>
+                  <runtime>
+                    <AppContextSwitchOverrides value="Switch.System.Net.DontEnableSchUseStrongCrypto=true" />
+                  </runtime>
+                </configuration>
+                """,
+                """
+                <configuration/>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void RemoveLastSwitchKeepsAncestorWithOtherChildren()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new RemoveAppContextSwitch
+            {
+                SwitchName = "Switch.System.Net.DontEnableSchUseStrongCrypto"
+            }),
+            AppConfig(
+                """
+                <configuration>
+                  <runtime>
+                    <AppContextSwitchOverrides value="Switch.System.Net.DontEnableSchUseStrongCrypto=true" />
+                    <gcServer enabled="true" />
+                  </runtime>
+                </configuration>
+                """,
+                """
+                <configuration>
+                  <runtime>
+                    <gcServer enabled="true" />
+                  </runtime>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void NoChangeWhenSwitchAbsent()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new RemoveAppContextSwitch
+            {
+                SwitchName = "Switch.NotPresent"
+            }),
+            AppConfig(
+                """
+                <configuration>
+                  <runtime>
+                    <AppContextSwitchOverrides value="Switch.System.Net.DontEnableSchUseStrongCrypto=true;Switch.Other=false" />
+                  </runtime>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void TolerantOfWhitespaceAroundSwitchEntries()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new RemoveAppContextSwitch
+            {
+                SwitchName = "Switch.System.Net.DontEnableSchUseStrongCrypto"
+            }),
+            AppConfig(
+                """
+                <configuration>
+                  <runtime>
+                    <AppContextSwitchOverrides value=" Switch.System.Net.DontEnableSchUseStrongCrypto = true ;  Switch.Other=false " />
+                  </runtime>
+                </configuration>
+                """,
+                """
+                <configuration>
+                  <runtime>
+                    <AppContextSwitchOverrides value="Switch.Other=false" />
+                  </runtime>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void DoesNotMatchSwitchByPrefix()
+    {
+        // Switch.Foo should not match Switch.FooBar.
+        RewriteRun(
+            spec => spec.SetRecipe(new RemoveAppContextSwitch
+            {
+                SwitchName = "Switch.Foo"
+            }),
+            AppConfig(
+                """
+                <configuration>
+                  <runtime>
+                    <AppContextSwitchOverrides value="Switch.FooBar=true" />
+                  </runtime>
+                </configuration>
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void HandlesValuelessSwitchEntries()
+    {
+        // Tolerate degenerate entries with no '=value' part.
+        RewriteRun(
+            spec => spec.SetRecipe(new RemoveAppContextSwitch
+            {
+                SwitchName = "Switch.Stray"
+            }),
+            AppConfig(
+                """
+                <configuration>
+                  <runtime>
+                    <AppContextSwitchOverrides value="Switch.Keep=true;Switch.Stray" />
+                  </runtime>
+                </configuration>
+                """,
+                """
+                <configuration>
+                  <runtime>
+                    <AppContextSwitchOverrides value="Switch.Keep=true" />
+                  </runtime>
+                </configuration>
+                """
+            )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds three primitives to `rewrite-csharp` that handle the .NET Framework 4.x file shapes `ChangeDotNetTargetFramework` does not touch — legacy non-SDK csproj `<TargetFrameworkVersion>`, app.config / web.config configuration sections, and AppContext switch overrides. These are foundational for upcoming in-place .NET Framework 4.x version-upgrade composite recipes in `recipes-csharp`.

## What's added

- **`ChangeDotNetFrameworkVersion`** — updates `<TargetFrameworkVersion>v4.x.y</TargetFrameworkVersion>` in legacy csproj and the version inside `<supportedRuntime sku=".NETFramework,Version=v4.x.y" />` in app.config. Deliberately does not touch SDK-style `<TargetFramework>` / `<TargetFrameworks>` — that remains the domain of `ChangeDotNetTargetFramework`.
- **`ChangeWebConfigTargetFramework`** — updates the `targetFramework` attribute on `<httpRuntime>` and `<compilation>` elements in web.config / app.config. These attributes control ASP.NET quirks-mode behavior and are distinct from the binary TFM in the csproj.
- **`RemoveAppContextSwitch`** — strips a single named switch from the semicolon-delimited `value` attribute of `<AppContextSwitchOverrides>`. Removes the element (and any newly-empty ancestor) when no switches remain. Tolerates whitespace in the value list.

All three accept either v-prefixed (`v4.7.2`) or unprefixed (`4.7.2`) version inputs and normalize internally to whichever canonical form their target file format expects.

## Test plan

- [x] 22 new tests across the three primitives, exercising the file shapes in isolation
- [x] Full `rewrite-csharp` test suite: 1944/1944 pass — no regressions
- [x] End-to-end validation in a downstream recipe set: composite recipes that chain all three primitives across .csproj, app.config, and web.config inputs in a single recipe run produce the expected output