### PR TITLE
RPC: enable CPU time collection in Pyroscope wall profiler for JS

### DIFF
--- a/rewrite-javascript/rewrite/src/rpc/server.ts
+++ b/rewrite-javascript/rewrite/src/rpc/server.ts
@@ -57,6 +57,9 @@ function initPyroscope(logger: rpc.Logger): any {
         appName: process.env.PYROSCOPE_APPLICATION_NAME || 'modcli',
         serverAddress: server,
         tags,
+        wall: {
+            collectCpuTime: true,
+        },
     });
     Pyroscope.start();
     return Pyroscope;


### PR DESCRIPTION
## What's changed?

- Somewhat a continuation of #7673.
Adding the CPU time collection to Pyroscope configuration in JavaScript RPC.

## What's your motivation?

Have better data for JS profiling in production.