### PR TITLE
Scala: fix missing print out of type arguments

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -1302,6 +1302,11 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 visit(method.getName(), p);
             }
 
+            // Type arguments: `intercept[T] { ... }` or `list.foreach[T] { ... }`
+            if (method.getTypeParameters() != null && !method.getTypeParameters().isEmpty()) {
+                visitContainer("[", method.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, ",", "]", p);
+            }
+
             // Print the block argument — it's typically an S.StatementExpression(J.Block)
             // The J.Block contains the lambda. visitBlock prints the { } braces.
             if (method.getArguments() != null) {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TypeApplyTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TypeApplyTest.java
@@ -116,6 +116,21 @@ class TypeApplyTest implements RewriteTest {
     }
 
     @Test
+    void typeApplyWithBlockArgument() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                intercept[IllegalArgumentException] {
+                  foo()
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void typeApplyWithChainedSelect() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

Fix Scala printer not to skip printing out type parameters in one of the cases.

## What's your motivation?

Otherwise it's not idempotent.