### PR TITLE
Scala: another bunch of parser fixes for extra whitespace

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -467,8 +467,12 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 boolean procedureSyntax = method.getMarkers().findFirst(
                         org.openrewrite.scala.marker.OmitBraces.class).isPresent();
                 if (!procedureSyntax) {
-                    Space beforeEquals = actualBody instanceof J.Block ?
-                            ((J.Block) actualBody).getPrefix() : Space.SINGLE_SPACE;
+                    final J finalActualBody = actualBody;
+                    Space beforeEquals = method.getMarkers()
+                            .findFirst(org.openrewrite.scala.marker.MethodBodyEqualsPrefix.class)
+                            .map(org.openrewrite.scala.marker.MethodBodyEqualsPrefix::getPrefix)
+                            .orElseGet(() -> finalActualBody instanceof J.Block ?
+                                    ((J.Block) finalActualBody).getPrefix() : Space.SINGLE_SPACE);
                     visitSpace(beforeEquals, Space.Location.BLOCK_PREFIX, p);
                     p.append("=");
                 }
@@ -494,7 +498,11 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             boolean omitBodyBraces = body.getMarkers().findFirst(
                     org.openrewrite.scala.marker.OmitBraces.class).isPresent();
             if (!procedureSyntax) {
-                visitSpace(body.getPrefix(), Space.Location.BLOCK_PREFIX, p);
+                Space beforeEquals = method.getMarkers()
+                        .findFirst(org.openrewrite.scala.marker.MethodBodyEqualsPrefix.class)
+                        .map(org.openrewrite.scala.marker.MethodBodyEqualsPrefix::getPrefix)
+                        .orElse(body.getPrefix());
+                visitSpace(beforeEquals, Space.Location.BLOCK_PREFIX, p);
                 p.append("=");
             }
             if (omitBodyBraces && body.getStatements().size() == 1) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -826,6 +826,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                         }
                         if (varDecl.getTypeExpression() != null) {
                             TypeTree typeExpr = varDecl.getTypeExpression();
+                            if (varDecl.getVarargs() != null) {
+                                visitSpace(varDecl.getVarargs(), Space.Location.VARARGS, p);
+                            }
                             p.append(":");
                             visit(typeExpr, p);
                         }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -1041,6 +1041,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
     public J visitTypeAscription(S.TypeAscription typeAscription, PrintOutputCapture<P> p) {
         beforeSyntax(typeAscription, Space.Location.LANGUAGE_EXTENSION, p);
         visit(typeAscription.getExpression(), p);
+        typeAscription.getMarkers()
+                .findFirst(org.openrewrite.scala.marker.TypeAscriptionColonPrefix.class)
+                .ifPresent(m -> visitSpace(m.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
         p.append(':');
         visit(typeAscription.getTypeTree(), p);
         afterSyntax(typeAscription, p);

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -270,6 +270,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                     visit(varDecl.getVariables().get(0).getName(), p);
                 }
                 if (varDecl.getTypeExpression() != null) {
+                    if (varDecl.getVarargs() != null) {
+                        visitSpace(varDecl.getVarargs(), Space.Location.VARARGS, p);
+                    }
                     p.append(":");
                     visit(varDecl.getTypeExpression(), p);
                 }
@@ -403,6 +406,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                     // The colon and space between name and type in Scala parameter syntax
                     // Type prefix from parser may or may not include the space
                     TypeTree typeExpr = varDecl.getTypeExpression();
+                    if (varDecl.getVarargs() != null) {
+                        visitSpace(varDecl.getVarargs(), Space.Location.VARARGS, p);
+                    }
                     p.append(":");
                     visit(typeExpr, p);
                 }
@@ -553,6 +559,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 }
                 if (vd.getTypeExpression() != null) {
                     TypeTree te = vd.getTypeExpression();
+                    if (vd.getVarargs() != null) {
+                        visitSpace(vd.getVarargs(), Space.Location.VARARGS, p);
+                    }
                     p.append(":");
                     visit(te, p);
                 }
@@ -1612,6 +1621,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 }
                 if (varDecl.getTypeExpression() != null) {
                     TypeTree typeExpr = varDecl.getTypeExpression();
+                    if (varDecl.getVarargs() != null) {
+                        visitSpace(varDecl.getVarargs(), Space.Location.VARARGS, p);
+                    }
                     p.append(":");
                     visit(typeExpr, p);
                 }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/MethodBodyEqualsPrefix.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/MethodBodyEqualsPrefix.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Stores the whitespace between a method signature and the {@code =} that
+ * introduces its body, e.g. the space in {@code def f(): Unit ={ }}. Attached
+ * to the {@link org.openrewrite.java.tree.J.MethodDeclaration}. The space after
+ * the {@code =} is stored as the body block's prefix.
+ */
+@Value
+@With
+public class MethodBodyEqualsPrefix implements Marker {
+    UUID id;
+    Space prefix;
+
+    public static MethodBodyEqualsPrefix create(Space prefix) {
+        return new MethodBodyEqualsPrefix(Tree.randomId(), prefix);
+    }
+}

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/TypeAscriptionColonPrefix.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/TypeAscriptionColonPrefix.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Stores the whitespace between an expression and the {@code :} of a Scala type
+ * ascription, e.g. the space in {@code (x : Int)}. Attached to the
+ * {@link org.openrewrite.scala.tree.S.TypeAscription}. The space after the colon is
+ * stored as the type tree's prefix.
+ */
+@Value
+@With
+public class TypeAscriptionColonPrefix implements Marker {
+    UUID id;
+    Space prefix;
+
+    public static TypeAscriptionColonPrefix create(Space prefix) {
+        return new TypeAscriptionColonPrefix(Tree.randomId(), prefix);
+    }
+}

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -424,6 +424,7 @@ class ScalaTreeVisitor(
         }
         val select = asExpression(visitTree(app.fun))
         val openIdx = source.indexOf('(', cursor)
+        val argContainerPrefix = if (openIdx > cursor) Space.format(source, cursor, openIdx) else Space.EMPTY
         if (openIdx >= 0) cursor = openIdx + 1
         val args = new util.ArrayList[JRightPadded[Expression]]()
         for (i <- app.args.indices) {
@@ -450,7 +451,7 @@ class ScalaTreeVisitor(
         new J.MethodInvocation(Tree.randomId(), prefix,
           Markers.build(Collections.singletonList(FunctionApplication.create())),
           JRightPadded.build(select), null, nameId,
-          JContainer.build(Space.EMPTY, args, Markers.EMPTY), mt)
+          JContainer.build(argContainerPrefix, args, Markers.EMPTY), mt)
     }
   }
 

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5616,11 +5616,13 @@ class ScalaTreeVisitor(
 
     // Type ascription `: Type`
     val paramEnd = Math.max(0, vd.span.end - offsetAdjustment)
+    var beforeColon: Space = Space.EMPTY
     val typeExpr: TypeTree = if (vd.tpt != untpd.EmptyTree && vd.tpt.span.exists) {
       val colonSearchEnd = Math.min(paramEnd, source.length)
       val between = if (cursor < colonSearchEnd) source.substring(cursor, colonSearchEnd) else ""
       val colonIdx = between.indexOf(':')
       if (colonIdx >= 0) {
+        if (colonIdx > 0) beforeColon = Space.format(between.substring(0, colonIdx))
         cursor = cursor + colonIdx + 1
         val res = visitTree(vd.tpt) match {
           case tt: TypeTree => tt
@@ -5669,7 +5671,7 @@ class ScalaTreeVisitor(
       paramAnnotations,
       paramModifiers,
       typeExpr,
-      null,
+      if (beforeColon != Space.EMPTY) beforeColon else null,
       Collections.emptyList(),
       Collections.singletonList(JRightPadded.build(variable))
     )
@@ -5739,10 +5741,14 @@ class ScalaTreeVisitor(
       cursor = Math.max(cursor, paramNameEnd)
     }
 
+    var beforeColon: Space = Space.EMPTY
     val typeExpr: TypeTree = if (hasExplicitType && vd.tpt != untpd.EmptyTree) {
       val colonSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 30, source.length)) else ""
       val colonIdx = colonSearch.indexOf(':')
-      if (colonIdx >= 0) cursor = cursor + colonIdx + 1
+      if (colonIdx >= 0) {
+        if (colonIdx > 0) beforeColon = Space.format(colonSearch.substring(0, colonIdx))
+        cursor = cursor + colonIdx + 1
+      }
 
       val result = if (vd.tpt.isInstanceOf[untpd.Function]) {
         // Function types (Int => Int) — create identifier from source text
@@ -5805,7 +5811,7 @@ class ScalaTreeVisitor(
       paramAnnotations,
       paramModifiers,
       typeExpr,
-      null,
+      if (beforeColon != Space.EMPTY) beforeColon else null,
       Collections.emptyList(),
       Collections.singletonList(JRightPadded.build(variable))
     )

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7239,6 +7239,13 @@ class ScalaTreeVisitor(
           if (cb.span.exists) updateCursor(cb.span.end)
           if (!boundList.isEmpty) JContainer.build(Space.EMPTY, boundList, Markers.EMPTY) else null
         } else if (cxBoundsList.nonEmpty) {
+          // Capture the space between the type-param name and the first `:` so the printer
+          // can re-emit it. The JContainer.before is the space before `:` (see ScalaPrinter).
+          val cbEnd = if (cb.span.exists) Math.max(0, cb.span.end - offsetAdjustment) else source.length
+          val colonIdx = if (cursor < cbEnd) source.indexOf(':', cursor) else -1
+          val beforeColon: Space = if (colonIdx > cursor && colonIdx < cbEnd) {
+            Space.format(source, cursor, colonIdx)
+          } else Space.EMPTY
           val boundList = new util.ArrayList[JRightPadded[TypeTree]]()
           // For each context bound, extract the bound type name
           cxBoundsList.foreach { cxBound =>
@@ -7260,7 +7267,7 @@ class ScalaTreeVisitor(
             updateCursor(cb.span.end)
           }
           // The JContainer.before space is printed BEFORE the `:` by the printer.
-          JContainer.build(Space.EMPTY, boundList, Markers.EMPTY)
+          JContainer.build(beforeColon, boundList, Markers.EMPTY)
         } else null
 
       case tb: Trees.TypeBoundsTree[?] if !tb.hi.isEmpty || !tb.lo.isEmpty =>
@@ -7361,8 +7368,9 @@ class ScalaTreeVisitor(
               return visitUnknown(typed)
           }
 
-          // Find the colon between expression and type
-          val colonSpace = {
+          // Find the colon between expression and type. Capture the space BEFORE the colon
+          // separately from the space AFTER the colon (which becomes the type tree's prefix).
+          val beforeColon: Space = {
             val tptStart = Math.max(0, typed.tpt.span.start - offsetAdjustment)
             if (tptStart > cursor) {
               val between = source.substring(cursor, tptStart)
@@ -7378,7 +7386,7 @@ class ScalaTreeVisitor(
             }
           }
 
-          // Visit the type tree
+          // Visit the type tree — its natural prefix is the space AFTER the colon.
           val typeTree = visitTree(typed.tpt) match {
             case tt: TypeTree => tt
             case id: J.Identifier => id.asInstanceOf[TypeTree]
@@ -7389,14 +7397,16 @@ class ScalaTreeVisitor(
 
           updateCursor(typed.span.end)
 
-          // The colon space becomes the type tree's prefix
-          val typedTypeTree = if (colonSpace != Space.EMPTY) typeTree.withPrefix(colonSpace) else typeTree
+          val markers = if (beforeColon != Space.EMPTY) {
+            Markers.build(Collections.singletonList(
+              org.openrewrite.scala.marker.TypeAscriptionColonPrefix.create(beforeColon)))
+          } else Markers.EMPTY
           new S.TypeAscription(
             Tree.randomId(),
             prefix,
-            Markers.EMPTY,
+            markers,
             expr,
-            typedTypeTree,
+            typeTree,
             typeFor(typed.span)
           )
         } catch {

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5459,6 +5459,7 @@ class ScalaTreeVisitor(
     }
 
     // Handle method body
+    var beforeEqualsSpace: Space = Space.EMPTY
     val body: J.Block = dd.rhs match {
       case rhs if isProcedureSyntax && rhs.span.isSynthetic =>
         // Procedure syntax: Scala 3 parser replaces body with `_root_.scala.Predef.???`.
@@ -5475,6 +5476,7 @@ class ScalaTreeVisitor(
             cursor = cursor + equalsIdx + 1
           }
         }
+        beforeEqualsSpace = beforeEquals
         visitTree(rhs) match {
             case block: J.Block => block
             case expr: Expression =>
@@ -5542,6 +5544,9 @@ class ScalaTreeVisitor(
     }
     if (isCurried) {
       markerList.add(new Curried(Tree.randomId()))
+    }
+    if (beforeEqualsSpace != Space.EMPTY) {
+      markerList.add(org.openrewrite.scala.marker.MethodBodyEqualsPrefix.create(beforeEqualsSpace))
     }
     val methodMarkers = if (!markerList.isEmpty) Markers.build(markerList) else Markers.EMPTY
 

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -740,6 +740,7 @@ class ScalaTreeVisitor(
     } else false
 
     val args = new util.ArrayList[JRightPadded[Expression]]()
+    var argContainerPrefix = Space.EMPTY
     val markers = new util.ArrayList[org.openrewrite.marker.Marker]()
     import org.openrewrite.scala.marker.FunctionApplication
     markers.add(FunctionApplication.create())
@@ -762,6 +763,9 @@ class ScalaTreeVisitor(
       // Normal parenthesized arguments: Seq(1, 2)
       val parenPos = positionOfNext("(")
       if (parenPos >= 0) {
+        if (parenPos > cursor) {
+          argContainerPrefix = Space.format(source, cursor, parenPos)
+        }
         cursor = parenPos + 1
       }
 
@@ -805,7 +809,7 @@ class ScalaTreeVisitor(
       JRightPadded.build(select),
       null, // typeParameters
       methodName,
-      JContainer.build(Space.EMPTY, args, Markers.EMPTY),
+      JContainer.build(argContainerPrefix, args, Markers.EMPTY),
       methodTypeOfTree(app)
     )
   }
@@ -1023,7 +1027,7 @@ class ScalaTreeVisitor(
       pos < source.length && source.charAt(pos) == '{'
     } else false
 
-    val argContainerPrefix = Space.EMPTY
+    var argContainerPrefix = Space.EMPTY
     val args = new util.ArrayList[JRightPadded[Expression]]()
 
     if (isBlockArg) {
@@ -1044,6 +1048,9 @@ class ScalaTreeVisitor(
       if (app.args.nonEmpty) {
         val parenPos = positionOfNext("(")
         if (parenPos >= 0) {
+          if (parenPos > cursor) {
+            argContainerPrefix = Space.format(source, cursor, parenPos)
+          }
           cursor = parenPos + 1
         }
       }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -2436,23 +2436,28 @@ class ScalaTreeVisitor(
     } else {
       // With a type, we need a full variable declaration
       val name = ident(displayName)
-      
+
       // Extract the type
       val sourceText = extractSource(vd.span)
       val colonIdx = sourceText.indexOf(':')
+      val nameLen = displayName.length
+      val nameEnd = sourceText.indexOf(displayName)
+      val beforeColon: Space = if (colonIdx > 0 && nameEnd >= 0 && nameEnd + nameLen <= colonIdx) {
+        Space.format(sourceText.substring(nameEnd + nameLen, colonIdx))
+      } else Space.EMPTY
       val typeSpace = if (colonIdx >= 0 && colonIdx + 1 < sourceText.length) {
         Space.format(sourceText.substring(colonIdx + 1).takeWhile(_.isWhitespace))
       } else {
         Space.SINGLE_SPACE
       }
-      
+
       val typeExpr: TypeTree = visitTree(vd.tpt) match {
         case tt: TypeTree => tt.withPrefix(typeSpace)
         case id: J.Identifier => id.withPrefix(typeSpace)
         case unknown: J.Unknown => unknown.withPrefix(typeSpace)  // Handle J.Unknown types
         case _ => null
       }
-      
+
       // Create the variable
       val variable = new J.VariableDeclarations.NamedVariable(
         Tree.randomId(),
@@ -2463,7 +2468,7 @@ class ScalaTreeVisitor(
         null,
         null
       )
-      
+
       // Create the variable declarations with a marker to indicate it's a lambda parameter
       import org.openrewrite.scala.marker.LambdaParameter
       new J.VariableDeclarations(
@@ -2473,7 +2478,7 @@ class ScalaTreeVisitor(
         Collections.emptyList(), // no annotations
         Collections.emptyList(), // no modifiers
         typeExpr,
-        null,
+        if (beforeColon != Space.EMPTY) beforeColon else null,
         Collections.emptyList(),
         Collections.singletonList(JRightPadded.build(variable))
       )
@@ -5905,6 +5910,17 @@ class ScalaTreeVisitor(
             (patSource, null)
           case _ => ("_", null)
         }
+        // Capture the whitespace between the param name and `:` (e.g. `e : Exception`).
+        val beforeColon: Space = if (paramType != null && caseDef.pat.span.exists) {
+          val patStart = Math.max(0, caseDef.pat.span.start - offsetAdjustment)
+          val patEnd = Math.max(0, caseDef.pat.span.end - offsetAdjustment)
+          val patSrc = if (patStart < patEnd && patEnd <= source.length) source.substring(patStart, patEnd) else ""
+          val colonAt = patSrc.indexOf(':')
+          val nameAt = if (paramName.nonEmpty) patSrc.indexOf(paramName) else -1
+          if (colonAt > 0 && nameAt >= 0 && nameAt + paramName.length <= colonAt) {
+            Space.format(patSrc.substring(nameAt + paramName.length, colonAt))
+          } else Space.EMPTY
+        } else Space.EMPTY
         updateCursor(caseDef.pat.span.end)
         val arrowAbs = source.indexOf("=>", cursor)
         val spaceBeforeArrow = if (arrowAbs >= cursor) Space.format(source, cursor, arrowAbs) else Space.EMPTY
@@ -5913,7 +5929,9 @@ class ScalaTreeVisitor(
         val paramId = ident(paramName, Space.format(" "))
         val namedVar = new J.VariableDeclarations.NamedVariable(Tree.randomId(), Space.EMPTY, Markers.EMPTY, paramId, Collections.emptyList(), null, null)
         val varDecl = new J.VariableDeclarations(Tree.randomId(), casePrefix, Markers.EMPTY,
-          Collections.emptyList(), Collections.emptyList(), paramType, null, Collections.emptyList(),
+          Collections.emptyList(), Collections.emptyList(), paramType,
+          if (beforeColon != Space.EMPTY) beforeColon else null,
+          Collections.emptyList(),
           Collections.singletonList(JRightPadded.build(namedVar)))
         val controlPrefix = if (catches.isEmpty) catchBraceSpace else Space.EMPTY
         val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), controlPrefix, Markers.EMPTY, JRightPadded.build(varDecl).withAfter(spaceBeforeArrow))
@@ -6037,6 +6055,17 @@ class ScalaTreeVisitor(
             (patSource, null)
           case _ => ("_", null)
         }
+        // Capture the whitespace between the param name and `:` (e.g. `e : Exception`).
+        val beforeColon: Space = if (paramType != null && caseDef.pat.span.exists) {
+          val patStart = Math.max(0, caseDef.pat.span.start - offsetAdjustment)
+          val patEnd = Math.max(0, caseDef.pat.span.end - offsetAdjustment)
+          val patSrc = if (patStart < patEnd && patEnd <= source.length) source.substring(patStart, patEnd) else ""
+          val colonAt = patSrc.indexOf(':')
+          val nameAt = if (paramName.nonEmpty) patSrc.indexOf(paramName) else -1
+          if (colonAt > 0 && nameAt >= 0 && nameAt + paramName.length <= colonAt) {
+            Space.format(patSrc.substring(nameAt + paramName.length, colonAt))
+          } else Space.EMPTY
+        } else Space.EMPTY
         updateCursor(caseDef.pat.span.end)
         val arrowAbs = source.indexOf("=>", cursor)
         val spaceBeforeArrow = if (arrowAbs >= cursor) Space.format(source, cursor, arrowAbs) else Space.EMPTY
@@ -6045,7 +6074,9 @@ class ScalaTreeVisitor(
         val paramId = ident(paramName, Space.format(" "))
         val namedVar = new J.VariableDeclarations.NamedVariable(Tree.randomId(), Space.EMPTY, Markers.EMPTY, paramId, Collections.emptyList(), null, null)
         val varDecl = new J.VariableDeclarations(Tree.randomId(), casePrefix, Markers.EMPTY,
-          Collections.emptyList(), Collections.emptyList(), paramType, null, Collections.emptyList(),
+          Collections.emptyList(), Collections.emptyList(), paramType,
+          if (beforeColon != Space.EMPTY) beforeColon else null,
+          Collections.emptyList(),
           Collections.singletonList(JRightPadded.build(namedVar)))
         val controlPrefix = if (catches.isEmpty) catchBraceSpace else Space.EMPTY
         val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), controlPrefix, Markers.EMPTY, JRightPadded.build(varDecl).withAfter(spaceBeforeArrow))

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -387,4 +387,30 @@ class MethodDeclarationTest implements RewriteTest {
             );
         }
     }
+
+    @Test
+    void parameterlessDef() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def foo: Int = 1
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void parameterlessDefInTrait() {
+        rewriteRun(
+            scala(
+                """
+                trait T {
+                  def bar: String
+                }
+                """
+            )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -413,4 +413,9 @@ class MethodDeclarationTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void spaceBeforeEqualsWithNoSpaceAfter() {
+        rewriteRun(scala("def f(): Unit ={ }"));
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -418,4 +418,9 @@ class MethodDeclarationTest implements RewriteTest {
     void spaceBeforeEqualsWithNoSpaceAfter() {
         rewriteRun(scala("def f(): Unit ={ }"));
     }
+
+    @Test
+    void spaceBeforeColonOnMethodParameter() {
+        rewriteRun(scala("def f(map : Int): Int = 1"));
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
@@ -363,4 +363,15 @@ class ClassDeclarationTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void typeParamContextBoundWithSpaceBeforeColon() {
+        rewriteRun(
+            scala(
+                """
+                case class Foo[T : Encoder]()
+                """
+            )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
@@ -352,4 +352,15 @@ class ClassDeclarationTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void paramNameEndingInUnderscore() {
+        rewriteRun(
+            scala(
+                """
+                class Foo(tag_ : String)
+                """
+            )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixTest.java
@@ -66,9 +66,18 @@ class InfixTest implements RewriteTest {
     }
 
     @Test
-    void rightAssocWithExtraWhitespace() {
+    void extraSpace() {
         rewriteRun(
-          scala("val xs = 1  ::  Nil")
+          scala(
+            """
+            import scala.language.postfixOps
+            object Test {
+              val rightAssoc = 1  ::  Nil
+              val binary = 1  +  2
+              val postfix = List(1, 2)  reverse
+            }
+            """
+          )
         );
     }
 
@@ -291,5 +300,6 @@ class InfixTest implements RewriteTest {
               )
             );
         }
+
     }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LambdaTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LambdaTest.java
@@ -315,4 +315,9 @@ class LambdaTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void spaceBeforeColonOnLambdaParameter() {
+        rewriteRun(scala("val f = (x : Int) => x"));
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
@@ -271,13 +271,23 @@ class MethodInvocationTest implements RewriteTest {
     }
 
     @Test
-    void whitespaceBeforeArgumentList() {
+    void extraSpace() {
         rewriteRun(
           scala(
             """
-              val m = Map (
-                "a" -> 1
-              )
+              object Test {
+                def f(a: Int)(b: Int): Int = a + b
+                def fBlock(a: Int)(g: Int => Int): Int = g(a)
+                def fType[T](x: T): T = x
+
+                val m = Map (
+                  "a" -> 1
+                )
+                val lambda = ((x: Int) => x + 1) (5)
+                val blockArg = fBlock(1)  { x => x + 1 }
+                val curried = f(1) (2)
+                val typeApplied = fType[Int] (5)
+              }
               """
           )
         );

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
@@ -269,4 +269,17 @@ class MethodInvocationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void whitespaceBeforeArgumentList() {
+        rewriteRun(
+          scala(
+            """
+              val m = Map (
+                "a" -> 1
+              )
+              """
+          )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/NewClassTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/NewClassTest.java
@@ -210,4 +210,20 @@ class NewClassTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void mixinWithExtraSpaceAroundWith() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              trait A
+              trait B
+              trait C
+              val x = new A  with  B  with  C {}
+            }
+            """
+          )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
@@ -280,12 +280,23 @@ class TryTest implements RewriteTest {
                 } catch {
                   case _: IllegalArgumentException | _: IllegalStateException => 
                     println("illegal argument or state")
-                  case e: Throwable => 
+                  case e: Throwable =>
                     println(s"unexpected error: ${e.getMessage}")
                 }
               }
               """
           )
         );
+    }
+
+    @Test
+    void spaceBeforeColonOnCatchParameter() {
+        rewriteRun(scala(
+            """
+            object T {
+              try { 1 } catch { case e : Exception => 2 }
+            }
+            """
+        ));
     }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TypeAscriptionTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TypeAscriptionTest.java
@@ -61,4 +61,11 @@ class TypeAscriptionTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void spaceBeforeColon() {
+        rewriteRun(
+            scala("val r = (1 : Int)")
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/VariableDeclarationsTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/VariableDeclarationsTest.java
@@ -191,4 +191,18 @@ class VariableDeclarationsTest implements RewriteTest {
           scala("var x: Int = _")
         );
     }
+
+    @Test
+    void tuplePatternWithExtraSpace() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              val pair = (1, 2)
+              val (a, b) = pair
+            }
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

A pack of fixes for Scala parser with the common denominator of extra whitespace handling.

## What's your motivation?

Fix idempotency issues.