### PR TITLE
Scala: S.FunctionType

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -595,6 +595,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return visitAnnotatedExpression((S.AnnotatedExpression) tree, p);
         } else if (tree instanceof S.RefinedType) {
             return visitRefinedType((S.RefinedType) tree, p);
+        } else if (tree instanceof S.FunctionType) {
+            return visitFunctionType((S.FunctionType) tree, p);
         } else if (tree instanceof S.Macro) {
             return visitMacro((S.Macro) tree, p);
         } else if (tree instanceof S.ExtensionMethods) {
@@ -1544,6 +1546,33 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         visit(annotatedExpression.getAnnotation(), p);
         afterSyntax(annotatedExpression, p);
         return annotatedExpression;
+    }
+
+    public J visitFunctionType(S.FunctionType functionType, PrintOutputCapture<P> p) {
+        beforeSyntax(functionType, Space.Location.LANGUAGE_EXTENSION, p);
+        JContainer<TypeTree> params = functionType.getPadding().getParameters();
+        visitSpace(params.getBefore(), Space.Location.LANGUAGE_EXTENSION, p);
+        if (functionType.isParenthesized()) {
+            p.append('(');
+        }
+        List<JRightPadded<TypeTree>> elements = params.getPadding().getElements();
+        for (int i = 0; i < elements.size(); i++) {
+            JRightPadded<TypeTree> element = elements.get(i);
+            visit(element.getElement(), p);
+            visitSpace(element.getAfter(), Space.Location.LANGUAGE_EXTENSION, p);
+            if (i < elements.size() - 1) {
+                p.append(',');
+            }
+        }
+        if (functionType.isParenthesized()) {
+            p.append(')');
+        }
+        JLeftPadded<TypeTree> rt = functionType.getPadding().getReturnType();
+        visitSpace(rt.getBefore(), Space.Location.LANGUAGE_EXTENSION, p);
+        p.append("=>");
+        visit(rt.getElement(), p);
+        afterSyntax(functionType, p);
+        return functionType;
     }
 
     public J visitRefinedType(S.RefinedType refinedType, PrintOutputCapture<P> p) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -22,6 +22,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JContainer;
+import org.openrewrite.java.tree.JLeftPadded;
 import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
@@ -221,6 +222,15 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         a = a.withBeforeColon(visitSpace(a.getBeforeColon(), Space.Location.LANGUAGE_EXTENSION, p));
         a = a.withAnnotation(visitAndCast(a.getAnnotation(), p));
         return a;
+    }
+
+    public J visitFunctionType(S.FunctionType functionType, P p) {
+        S.FunctionType f = functionType;
+        f = f.withPrefix(visitSpace(f.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        f = f.withMarkers(visitMarkers(f.getMarkers(), p));
+        f = f.getPadding().withParameters(visitContainer(f.getPadding().getParameters(), JContainer.Location.LANGUAGE_EXTENSION, p));
+        f = f.getPadding().withReturnType(visitLeftPadded(f.getPadding().getReturnType(), JLeftPadded.Location.LANGUAGE_EXTENSION, p));
+        return f;
     }
 
     public J visitRefinedType(S.RefinedType refinedType, P p) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -1565,4 +1565,126 @@ public interface S extends J {
             }
         }
     }
+
+    /**
+     * Represents a Scala function type: {@code Int => Int}, {@code (Int, String) => Boolean},
+     * or {@code () => Unit}. Modeled as a {@link TypeTree} so it is usable anywhere a type is
+     * expected (return type, parameter type, val type ascription).
+     *
+     * <p>The {@code parenthesized} flag distinguishes the single-arg {@code Int => Int}
+     * (unparenthesized) form from {@code (Int) => Int} and from zero-arg or multi-arg forms,
+     * which always require parentheses.
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class FunctionType implements S, TypeTree, Expression {
+
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @With @Getter @EqualsAndHashCode.Include
+        UUID id;
+
+        @With @Getter
+        Space prefix;
+
+        @With @Getter
+        Markers markers;
+
+        /**
+         * Whether the parameter list is surrounded by parentheses. {@code false} only for the
+         * single-arg form {@code Int => Int}; always {@code true} for {@code ()}, {@code (Int)},
+         * and {@code (Int, ...)}.
+         */
+        @With @Getter
+        boolean parenthesized;
+
+        /**
+         * The parameter types. The container's before-space is the space before {@code (}
+         * when parenthesized, or {@code Space.EMPTY} otherwise.
+         */
+        JContainer<TypeTree> parameters;
+
+        /**
+         * The return type. The padding's before-space is the whitespace immediately before
+         * {@code =>}; the return TypeTree's own prefix carries the space after {@code =>}.
+         */
+        JLeftPadded<TypeTree> returnType;
+
+        @With @Getter
+        @Nullable
+        JavaType type;
+
+        public static FunctionType build(UUID id, Space prefix, Markers markers, boolean parenthesized,
+                                         JContainer<TypeTree> parameters, JLeftPadded<TypeTree> returnType,
+                                         @Nullable JavaType type) {
+            return new FunctionType(null, id, prefix, markers, parenthesized, parameters, returnType, type);
+        }
+
+        public List<TypeTree> getParameters() {
+            return parameters.getElements();
+        }
+
+        public FunctionType withParameters(List<TypeTree> parameters) {
+            return getPadding().withParameters(JContainer.withElements(this.parameters, parameters));
+        }
+
+        public TypeTree getReturnType() {
+            return returnType.getElement();
+        }
+
+        public FunctionType withReturnType(TypeTree returnType) {
+            return getPadding().withReturnType(JLeftPadded.withElement(this.returnType, returnType));
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitFunctionType(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final FunctionType t;
+
+            public JContainer<TypeTree> getParameters() {
+                return t.parameters;
+            }
+
+            public FunctionType withParameters(JContainer<TypeTree> parameters) {
+                return t.parameters == parameters ? t :
+                        new FunctionType(null, t.id, t.prefix, t.markers, t.parenthesized, parameters, t.returnType, t.type);
+            }
+
+            public JLeftPadded<TypeTree> getReturnType() {
+                return t.returnType;
+            }
+
+            public FunctionType withReturnType(JLeftPadded<TypeTree> returnType) {
+                return t.returnType == returnType ? t :
+                        new FunctionType(null, t.id, t.prefix, t.markers, t.parenthesized, t.parameters, returnType, t.type);
+            }
+        }
+    }
 }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5429,15 +5429,17 @@ class ScalaTreeVisitor(
         val colonIdx = betweenText.indexOf(':')
         val equalsIdx = betweenText.indexOf('=')
 
-        // Only use the type if there's a colon BEFORE the equals sign (explicit type annotation)
-        if (colonIdx >= 0 && (equalsIdx < 0 || colonIdx < equalsIdx)) {
+        // Only use the type if there's a colon BEFORE the equals sign (explicit type annotation).
+        // For function types like `Int => Int`, the first `=` belongs to the `=>` arrow, not the
+        // body assignment — guard against picking that up as the body separator.
+        val arrowIdx = betweenText.indexOf("=>")
+        val bodyEqualsIdx = if (equalsIdx == arrowIdx && arrowIdx >= 0) {
+          betweenText.indexOf('=', arrowIdx + 2)
+        } else equalsIdx
+        if (colonIdx >= 0 && (bodyEqualsIdx < 0 || colonIdx < bodyEqualsIdx)) {
           val beforeColon = Space.format(betweenText.substring(0, colonIdx))
           cursor = cursor + colonIdx + 1
-          val visited = visitTree(tpt) match {
-            case tt: TypeTree => tt
-            case id: J.Identifier => id
-            case _ => null
-          }
+          val visited = visitTypeTree(tpt)
           if (visited != null && beforeColon != Space.EMPTY) {
             visited.withMarkers(visited.getMarkers.addIfAbsent(
               org.openrewrite.scala.marker.ReturnTypeColonPrefix.create(beforeColon))).asInstanceOf[TypeTree]
@@ -5736,24 +5738,7 @@ class ScalaTreeVisitor(
       val colonIdx = colonSearch.indexOf(':')
       if (colonIdx >= 0) cursor = cursor + colonIdx + 1
 
-      val result = if (vd.tpt.isInstanceOf[untpd.Function]) {
-        // Function types (Int => Int) — create identifier from source text
-        val typeStart = Math.max(0, vd.tpt.span.start - offsetAdjustment)
-        val typeEnd = Math.max(0, vd.tpt.span.end - offsetAdjustment)
-        val typePrefix = if (cursor < typeStart && typeStart <= source.length) {
-          Space.format(source, cursor, typeStart)
-        } else Space.EMPTY
-        val typeText = if (typeStart < typeEnd && typeEnd <= source.length) {
-          source.substring(typeStart, typeEnd)
-        } else "Any"
-        ident(typeText, typePrefix)
-      } else {
-        visitTree(vd.tpt) match {
-          case tt: TypeTree => tt
-          case id: J.Identifier => id
-          case _ => null
-        }
-      }
+      val result = visitTypeTree(vd.tpt)
       if (vd.tpt.span.exists) {
         updateCursor(vd.tpt.span.end)
       }
@@ -6777,6 +6762,132 @@ class ScalaTreeVisitor(
    */
   private def visitSyntheticTypeTree(tt: Trees.TypeTree[?]): J =
     new J.Empty(Tree.randomId(), Space.EMPTY, Markers.EMPTY)
+
+  /**
+   * Visit a tree in a type position and return a `TypeTree`. Handles `untpd.Function` in a
+   * type context (e.g. `Int => Int` as a return type or val type ascription) by building an
+   * `S.FunctionType`. For other tree shapes, delegates to `visitTree` and accepts any result
+   * that is already a `TypeTree`.
+   */
+  private def visitTypeTree(tpt: Trees.Tree[?]): TypeTree = tpt match {
+    case f: untpd.Function => visitFunctionType(f)
+    case _ =>
+      visitTree(tpt) match {
+        case tt: TypeTree => tt
+        case id: J.Identifier => id
+        case _ => null
+      }
+  }
+
+  /**
+   * Build an `S.FunctionType` for an `untpd.Function` node used in a type position
+   * (e.g. `Int => Int`, `(Int, String) => Boolean`, `() => Unit`). Each function-type
+   * argument is itself a synthetic `ValDef` whose `tpt` carries the actual parameter
+   * type and source span.
+   */
+  private def visitFunctionType(func: untpd.Function): S.FunctionType = {
+    val funcStart = Math.max(0, func.span.start - offsetAdjustment)
+    val funcEnd = Math.max(0, func.span.end - offsetAdjustment)
+    val prefix = if (cursor < funcStart && funcStart <= source.length) {
+      Space.format(source, cursor, funcStart)
+    } else Space.EMPTY
+    cursor = Math.max(cursor, funcStart)
+
+    val funcSource = if (funcStart < funcEnd && funcEnd <= source.length) {
+      source.substring(funcStart, funcEnd)
+    } else ""
+
+    // Find the arrow within the function-type source.
+    val relArrowIdx = funcSource.indexOf("=>")
+    val arrowAbs = if (relArrowIdx >= 0) funcStart + relArrowIdx else funcEnd
+
+    // Detect whether the parameter list is parenthesized. A single unnamed param like
+    // `Int => Int` is unparenthesized; everything else (`()`, `(Int)`, `(Int, Long)`)
+    // uses parentheses.
+    val headTrimmed = funcSource.dropWhile(Character.isWhitespace)
+    val parenthesized = headTrimmed.startsWith("(")
+
+    val containerBefore = if (parenthesized) {
+      val openParenAbs = funcStart + funcSource.indexOf('(')
+      val before = if (cursor < openParenAbs) Space.format(source, cursor, openParenAbs) else Space.EMPTY
+      cursor = openParenAbs + 1
+      before
+    } else Space.EMPTY
+
+    val paramElements = new util.ArrayList[JRightPadded[TypeTree]]()
+    val params = func.args
+    val closeParenAbs = if (parenthesized) {
+      // Find the matching `)` before the arrow.
+      val rel = funcSource.lastIndexOf(')', if (relArrowIdx >= 0) relArrowIdx - 1 else funcSource.length - 1)
+      if (rel >= 0) funcStart + rel else arrowAbs
+    } else arrowAbs
+
+    for (i <- params.indices) {
+      val param = params(i)
+      // For a function *type*, each arg ValDef carries the type in `tpt`.
+      val paramTpt: Trees.Tree[?] = param match {
+        case vd: Trees.ValDef[?] if vd.tpt != untpd.EmptyTree => vd.tpt
+        case other => other
+      }
+      val paramType = visitTypeTree(paramTpt)
+      val isLast = i == params.size - 1
+      val afterSpace: Space = if (!isLast) {
+        // Find the comma separating this param from the next.
+        val nextStart = Math.max(0, params(i + 1).span.start - offsetAdjustment)
+        if (cursor < nextStart && nextStart <= source.length) {
+          val between = source.substring(cursor, nextStart)
+          val commaIdx = between.indexOf(',')
+          if (commaIdx >= 0) {
+            val space = Space.format(between.substring(0, commaIdx))
+            cursor = cursor + commaIdx + 1
+            space
+          } else Space.EMPTY
+        } else Space.EMPTY
+      } else if (parenthesized) {
+        // Last param in parens: capture space up to `)`.
+        if (cursor < closeParenAbs && closeParenAbs <= source.length) {
+          Space.format(source, cursor, closeParenAbs)
+        } else Space.EMPTY
+      } else {
+        // Unparen single-arg form: param has no separator; the space before `=>`
+        // belongs to the return-type padding, not the param's after-space.
+        Space.EMPTY
+      }
+      paramElements.add(JRightPadded.build(paramType).withAfter(afterSpace))
+    }
+
+    if (parenthesized) {
+      cursor = closeParenAbs + 1
+    }
+
+    val parameters = JContainer.build(containerBefore, paramElements, Markers.EMPTY)
+
+    // Space immediately before `=>`.
+    val beforeArrow = if (cursor < arrowAbs && arrowAbs <= source.length) {
+      Space.format(source, cursor, arrowAbs)
+    } else Space.EMPTY
+
+    // Move past the arrow.
+    if (arrowAbs >= cursor) {
+      cursor = arrowAbs + 2
+    }
+
+    // The return type's own prefix (extracted by visitTree) will carry the space
+    // immediately after `=>`.
+    val returnType = visitTypeTree(func.body)
+
+    if (funcEnd > cursor) cursor = funcEnd
+
+    S.FunctionType.build(
+      Tree.randomId(),
+      prefix,
+      Markers.EMPTY,
+      parenthesized,
+      parameters,
+      new JLeftPadded(beforeArrow, returnType, Markers.EMPTY),
+      typeOfTree(func)
+    )
+  }
 
   /**
    * Returns `true` when the raw-name slice starting at `rawNameStart` (the first non-backtick

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -320,6 +320,22 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void functionTypes() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def make1(): Int => Int = x => x + 1
+                  def make2(): () => Int = () => 42
+                  def make3(): (Int, String) => Boolean = (i, s) => s.length == i
+                  def apply(f: Int => Int, x: Int): Int = f(x)
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void implicitInSecondParamList() {
         rewriteRun(
             scala(


### PR DESCRIPTION
## What's changed?

Introducing `FunctionType` to Scala LSTs.

## What's your motivation?

This is to model types like `Int => Int`.