### PR TITLE
Support parsing Python 2.7 source through the existing parser pipeline

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -459,6 +459,12 @@ public class RewriteRpc {
 
     public Stream<SourceFile> parse(Iterable<Parser.Input> inputs, @Nullable Path relativeTo,
                                     Parser parser, String sourceFileType, ExecutionContext ctx) {
+        return parse(inputs, relativeTo, parser, sourceFileType, ctx, null);
+    }
+
+    public Stream<SourceFile> parse(Iterable<Parser.Input> inputs, @Nullable Path relativeTo,
+                                    Parser parser, String sourceFileType, ExecutionContext ctx,
+                                    @Nullable Map<String, String> options) {
         List<Parser.Input> inputList = new ArrayList<>();
         List<Parse.Input> mappedInputs = new ArrayList<>();
         for (Parser.Input input : inputs) {
@@ -486,7 +492,7 @@ public class RewriteRpc {
                 if (ids == null) {
                     // FIXME handle `TimeoutException` gracefully
                     ids = RewriteRpcExecutionContextView.view(ctx).withInFlightSlot(() ->
-                            send("Parse", new Parse(mappedInputs, relativeTo != null ? relativeTo.toString() : null), ParseResponse.class));
+                            send("Parse", new Parse(mappedInputs, relativeTo != null ? relativeTo.toString() : null, options), ParseResponse.class));
                     assert ids.size() == inputList.size();
                 }
 

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/Parse.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/Parse.java
@@ -42,6 +42,15 @@ public class Parse implements RpcRequest {
     @Nullable
     String relativeTo;
 
+    /**
+     * Optional, parser-specific options forwarded to the RPC server. The handler
+     * interprets keys it recognizes and silently ignores the rest. Older clients
+     * that do not send this field deserialize to {@code null}, in which case the
+     * handler falls back to its process-wide defaults.
+     */
+    @Nullable
+    Map<String, String> options;
+
     @Value
     public static class Input {
         @Nullable

--- a/rewrite-python/rewrite/src/rewrite/python/_py2_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_py2_parser_visitor.py
@@ -24,7 +24,11 @@ from rewrite import random_id, Markers
 from rewrite.java import Space, JRightPadded, JLeftPadded, JContainer, JavaType
 from rewrite.java import tree as j
 from rewrite.python import tree as py
-from rewrite.python.markers import PrintSyntax, ExecSyntax, Quoted
+from rewrite.python.markers import (
+    PrintSyntax, ExecSyntax, Quoted, KeywordArguments,
+    TupleExceptClause, LegacyNotEqual, RaiseTuple,
+)
+from rewrite.java.markers import OmitParentheses, TrailingComma
 
 
 class Py2ParserVisitor:
@@ -92,23 +96,81 @@ class Py2ParserVisitor:
         return cu
 
     def _convert_module(self, module: parso_tree.Module) -> List[JRightPadded]:
-        """Convert a parso Module to a list of LST statements."""
-        statements = []
+        """Convert a parso Module to a list of LST statements, preserving
+        newlines so the printer can round-trip the source.
 
-        for child in module.children:
-            stmt = self._convert_node(child)
-            if stmt is not None:
-                statements.append(self._pad_statement(stmt))
-
-        # If empty, add an Empty element
+        parso emits newline leaves between top-level statements. We thread
+        each one onto the *trailing* :class:`JRightPadded.after` of the
+        statement that owns it (which is how the printer expects to find them).
+        """
+        statements = self._convert_stmt_block_children(module.children)
         if not statements:
             statements.append(JRightPadded(
                 j.Empty(random_id(), Space.EMPTY, Markers.EMPTY),
                 Space.EMPTY,
                 Markers.EMPTY
             ))
-
         return statements
+
+    def _convert_stmt_block_children(self, children) -> list:
+        """Walk a list of parso suite/module children into JRightPadded
+        statement entries with correct newline placement.
+
+        - Leading-newline leaves accumulate onto the *prefix* of the next
+          statement (so the printer's per-statement prefix emits ``\\n<indent>``
+          before each line).
+        - A simple_stmt's trailing newline is captured as the resulting
+          statement's :attr:`JRightPadded.after` so the printer terminates
+          each line correctly.
+        """
+        statements = []
+        pending_prefix = ''
+        for child in children:
+            ctype = getattr(child, 'type', None)
+            if isinstance(child, parso_tree.PythonLeaf):
+                if ctype in ('newline', 'indent', 'dedent'):
+                    pending_prefix += getattr(child, 'value', '')
+                    continue
+                if ctype == 'endmarker':
+                    # endmarker.prefix is captured by _trailing_whitespace;
+                    # nothing to add to the statement list.
+                    continue
+            stmt = self._convert_node(child)
+            if stmt is None:
+                continue
+            if pending_prefix:
+                stmt = self._prepend_prefix(stmt, pending_prefix)
+                pending_prefix = ''
+            after = Space.EMPTY
+            if ctype == 'simple_stmt' and child.children:
+                last = child.children[-1]
+                if (isinstance(last, parso_tree.PythonLeaf)
+                        and getattr(last, 'type', None) == 'newline'):
+                    # parso stores trailing comments on the newline leaf's
+                    # ``prefix`` (e.g. ``"  # comment"``) while the newline
+                    # character itself is the leaf's ``value``. Concatenate
+                    # both so the printer reproduces the trailing comment.
+                    after = Space([], last.prefix + last.value)
+            statements.append(JRightPadded(stmt, after, Markers.EMPTY))
+        # Any leftover newline gets attached as trailing-after on the last
+        # statement, so the file's terminal `\n` round-trips.
+        if pending_prefix and statements:
+            last = statements[-1]
+            combined = (last.after.whitespace if last.after else '') + pending_prefix
+            statements[-1] = JRightPadded(last.element, Space([], combined), last.markers)
+        return statements
+
+    @staticmethod
+    def _prepend_prefix(stmt, leading: str):
+        """Prepend a whitespace string to a node's prefix, when possible."""
+        if not hasattr(stmt, 'prefix'):
+            return stmt
+        existing = stmt.prefix.whitespace if stmt.prefix is not None else ''
+        new_prefix = Space([], leading + existing)
+        try:
+            return stmt.replace(_prefix=new_prefix)
+        except (TypeError, AttributeError):
+            return stmt
 
     def _convert_node(self, node) -> Optional[j.J]:
         """Convert a parso node to an LST node.
@@ -136,8 +198,14 @@ class Py2ParserVisitor:
             'break_stmt': self._convert_break_stmt,
             'continue_stmt': self._convert_continue_stmt,
             'return_stmt': self._convert_return_stmt,
+            'raise_stmt': self._convert_raise_stmt,
+            'assert_stmt': self._convert_assert_stmt,
+            'del_stmt': self._convert_del_stmt,
+            'global_stmt': self._convert_global_stmt,
+            'yield_expr': self._convert_yield_expr,
             'funcdef': self._convert_funcdef,
             'classdef': self._convert_classdef,
+            'decorated': self._convert_decorated,
             'if_stmt': self._convert_if_stmt,
             'while_stmt': self._convert_while_stmt,
             'for_stmt': self._convert_for_stmt,
@@ -158,6 +226,9 @@ class Py2ParserVisitor:
             'arith_expr': self._convert_arith_expr,
             'term': self._convert_term,
             'factor': self._convert_factor,
+            'lambdef': self._convert_lambdef,
+            'old_lambdef': self._convert_lambdef,
+            'strings': self._convert_strings,
         }
 
         converter = converters.get(node_type)
@@ -174,7 +245,33 @@ class Py2ParserVisitor:
         # parso 0.7.x uses lowercase type names (e.g. 'name', 'number')
         leaf_type = leaf.type.upper()  # ty: ignore[unresolved-attribute]  # parso leaf.type is always str
 
-        if leaf_type == 'NAME' or leaf_type == 'KEYWORD':
+        if leaf_type == 'KEYWORD':
+            # Bare statement-keywords occur inside suites when the keyword
+            # has no operands (e.g. `pass`, `break`, `continue`, `raise`,
+            # `yield`). They are routed here rather than through their
+            # `*_stmt` nodes because parso elides the wrapper for these
+            # trivial forms.
+            if leaf.value == 'pass':
+                return py.Pass(random_id(), prefix, Markers.EMPTY)
+            if leaf.value == 'break':
+                return j.Break(random_id(), prefix, Markers.EMPTY, None)
+            if leaf.value == 'continue':
+                return j.Continue(random_id(), prefix, Markers.EMPTY, None)
+            if leaf.value == 'raise':
+                return j.Throw(random_id(), prefix, Markers.EMPTY,
+                               j.Empty(random_id(), Space.EMPTY, Markers.EMPTY))
+            if leaf.value == 'return':
+                return j.Return(random_id(), prefix, Markers.EMPTY, None)
+            if leaf.value == 'yield':
+                yield_ = j.Yield(random_id(), prefix, Markers.EMPTY, False,
+                                 j.Empty(random_id(), Space.EMPTY, Markers.EMPTY))
+                return py.StatementExpression(random_id(), yield_)
+            # Generic keyword used in an expression position (e.g. `True`,
+            # `False`, `None`) — falls through to identifier shape.
+            return j.Identifier(
+                random_id(), prefix, Markers.EMPTY, [], leaf.value, None, None,
+            )
+        if leaf_type == 'NAME':
             return j.Identifier(
                 random_id(),
                 prefix,
@@ -380,33 +477,57 @@ class Py2ParserVisitor:
         return None
 
     def _convert_expr_stmt(self, node) -> Optional[j.J]:
-        """Convert an expression statement."""
+        """Convert an expression statement.
+
+        Handles:
+        * Bare expression (``f(x)``)
+        * Simple assignment (``a = b``); chained ``a = b = c`` not yet covered.
+        * Augmented assignment (``x += 1`` and the rest of the ``_aug_assign_map``).
+        """
         if len(node.children) == 1:
             # Simple expression
             expr = self._convert_node(node.children[0])
             if expr:
                 return py.ExpressionStatement(random_id(), expr)
-        elif len(node.children) >= 3 and hasattr(node.children[1], 'value') and node.children[1].value == '=':
-            # Assignment: lhs = rhs
-            lhs = self._convert_node(node.children[0])
-            eq_prefix = self._parse_space(node.children[1].prefix)
-            rhs = self._convert_node(node.children[2])
-            if lhs and rhs:
-                return j.Assignment(
-                    random_id(),
-                    Space.EMPTY,
-                    Markers.EMPTY,
-                    lhs,
-                    JLeftPadded(eq_prefix, rhs, Markers.EMPTY),
-                    None  # type
-                )
-        # TODO: Handle augmented assignments
+        elif len(node.children) >= 5 and self._is_chained_assign(node.children):
+            return self._build_chained_assignment(node.children)
+        elif len(node.children) == 3 and hasattr(node.children[1], 'value'):
+            op_value = node.children[1].value
+            if op_value == '=':
+                lhs = self._convert_node(node.children[0])
+                eq_prefix = self._parse_space(node.children[1].prefix)
+                rhs = self._convert_node(node.children[2])
+                if lhs and rhs:
+                    return j.Assignment(
+                        random_id(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        lhs,
+                        JLeftPadded(eq_prefix, rhs, Markers.EMPTY),
+                        None  # type
+                    )
+            else:
+                aug_type = self._aug_assign_map().get(op_value)
+                if aug_type is not None:
+                    lhs = self._convert_node(node.children[0])
+                    op_prefix = self._parse_space(node.children[1].prefix)
+                    rhs = self._convert_node(node.children[2])
+                    if lhs and rhs:
+                        return j.AssignmentOperation(
+                            random_id(),
+                            Space.EMPTY,
+                            Markers.EMPTY,
+                            lhs,
+                            JLeftPadded(op_prefix, aug_type, Markers.EMPTY),
+                            rhs,
+                            None,  # type
+                        )
         return self._convert_generic(node)
 
-    def _convert_pass_stmt(self, node) -> j.Empty:
+    def _convert_pass_stmt(self, node) -> py.Pass:
         """Convert pass statement."""
         prefix = self._parse_space(node.children[0].prefix)
-        return j.Empty(random_id(), prefix, Markers.EMPTY)
+        return py.Pass(random_id(), prefix, Markers.EMPTY)
 
     def _convert_break_stmt(self, node) -> j.Break:
         """Convert break statement."""
@@ -426,59 +547,1385 @@ class Py2ParserVisitor:
             expr = self._convert_node(node.children[1])
         return j.Return(random_id(), prefix, Markers.EMPTY, expr)
 
-    def _convert_funcdef(self, node) -> j.MethodDeclaration:
-        """Convert function definition."""
-        # TODO: Implement full function parsing
-        prefix = self._parse_space(node.children[0].prefix)
-        return self._placeholder_method(prefix, "funcdef")
+    @staticmethod
+    def _is_chained_assign(children) -> bool:
+        """True when an ``expr_stmt`` is shaped as ``a = b = ... = expr`` —
+        i.e. an alternating ``[target, '=', target, '=', ..., '=', value]``
+        sequence with at least two ``=`` operators."""
+        eq_count = sum(1 for c in children if getattr(c, 'value', None) == '=')
+        return eq_count >= 2
 
-    def _convert_classdef(self, node) -> j.ClassDeclaration:
-        """Convert class definition."""
-        # TODO: Implement full class parsing
-        prefix = self._parse_space(node.children[0].prefix)
-        return self._placeholder_class(prefix, "classdef")
+    def _build_chained_assignment(self, children) -> Optional[j.J]:
+        """Convert ``a = b = c`` into :class:`py.ChainedAssignment`."""
+        variables = []
+        i = 0
+        while i + 2 < len(children):
+            target = self._convert_node(children[i])
+            eq = children[i + 1]
+            if target is None or getattr(eq, 'value', None) != '=':
+                return None
+            variables.append(JRightPadded(target, self._parse_space(eq.prefix), Markers.EMPTY))
+            i += 2
+        value = self._convert_node(children[-1])
+        if value is None:
+            return None
+        return py.ChainedAssignment(
+            random_id(), Space.EMPTY, Markers.EMPTY,
+            variables, value, None,
+        )
 
-    def _convert_if_stmt(self, node) -> j.If:
-        """Convert if statement."""
-        # TODO: Implement full if parsing
-        prefix = self._parse_space(node.children[0].prefix)
-        return self._placeholder_if(prefix)
+    def _convert_raise_stmt(self, node) -> Optional[j.J]:
+        """Convert ``raise`` / ``raise E`` / ``raise E, v[, tb]`` (Py2 form).
 
-    def _convert_while_stmt(self, node) -> j.WhileLoop:
-        """Convert while statement."""
-        # TODO: Implement full while parsing
-        prefix = self._parse_space(node.children[0].prefix)
-        return self._placeholder_while(prefix)
+        The Py2 multi-argument form is wrapped in a :class:`py.CollectionLiteral`
+        of kind ``TUPLE`` tagged with :class:`RaiseTuple`, so the printer can
+        emit the legacy ``raise E, v[, tb]`` syntax without the tuple parens.
+        """
+        children = node.children
+        prefix = self._parse_space(children[0].prefix)
+        if len(children) == 1:
+            return j.Throw(random_id(), prefix, Markers.EMPTY,
+                           j.Empty(random_id(), Space.EMPTY, Markers.EMPTY))
+        if len(children) == 2:
+            exc = self._convert_node(children[1])
+            if exc is None:
+                return self._convert_generic(node)
+            return j.Throw(random_id(), prefix, Markers.EMPTY, exc)
+        # Py2 multi-arg `raise E, v[, tb]`. The remaining children are
+        # `[exception, ',', value, (',', tb)?]`.
+        items = self._pad_comma_list(children[1:], Space.EMPTY)
+        if items is None:
+            return self._convert_generic(node)
+        tuple_lit = py.CollectionLiteral(
+            random_id(), Space.EMPTY, Markers.EMPTY,
+            py.CollectionLiteral.Kind.TUPLE,
+            JContainer(Space.EMPTY, items, Markers.EMPTY),
+            None,
+        )
+        return j.Throw(
+            random_id(), prefix,
+            Markers.build(random_id(), [RaiseTuple(random_id())]),
+            tuple_lit,
+        )
 
-    def _convert_for_stmt(self, node) -> j.ForEachLoop:
-        """Convert for statement."""
-        # TODO: Implement full for parsing
-        prefix = self._parse_space(node.children[0].prefix)
-        return self._placeholder_for(prefix)
+    def _convert_assert_stmt(self, node) -> Optional[j.J]:
+        """Convert ``assert expr`` and ``assert expr, msg``."""
+        children = node.children
+        prefix = self._parse_space(children[0].prefix)
+        if len(children) < 2:
+            return self._convert_generic(node)
+        condition = self._convert_node(children[1])
+        if condition is None:
+            return self._convert_generic(node)
+        detail = None
+        if len(children) >= 4 and getattr(children[2], 'value', None) == ',':
+            msg = self._convert_node(children[3])
+            if msg is None:
+                return self._convert_generic(node)
+            detail = JLeftPadded(self._parse_space(children[2].prefix), msg, Markers.EMPTY)
+        return j.Assert(random_id(), prefix, Markers.EMPTY, condition, detail)
 
-    def _convert_try_stmt(self, node) -> j.Try:
-        """Convert try statement."""
-        # TODO: Implement full try parsing
-        prefix = self._parse_space(node.children[0].prefix)
-        return self._placeholder_try(prefix)
+    def _convert_del_stmt(self, node) -> Optional[j.J]:
+        """Convert ``del a`` / ``del a, b``."""
+        children = node.children
+        prefix = self._parse_space(children[0].prefix)
+        if len(children) < 2:
+            return self._convert_generic(node)
+        target_node = children[1]
+        targets = []
+        if getattr(target_node, 'type', None) == 'exprlist':
+            items = target_node.children
+            i = 0
+            while i < len(items):
+                item = items[i]
+                if getattr(item, 'value', None) == ',':
+                    i += 1
+                    continue
+                expr = self._convert_node(item)
+                if expr is None:
+                    return self._convert_generic(node)
+                if i + 1 < len(items) and getattr(items[i + 1], 'value', None) == ',':
+                    comma = items[i + 1]
+                    targets.append(JRightPadded(expr, self._parse_space(comma.prefix), Markers.EMPTY))
+                    i += 2
+                else:
+                    targets.append(JRightPadded(expr, Space.EMPTY, Markers.EMPTY))
+                    i += 1
+        else:
+            expr = self._convert_node(target_node)
+            if expr is None:
+                return self._convert_generic(node)
+            targets = [JRightPadded(expr, Space.EMPTY, Markers.EMPTY)]
+        return py.Del(random_id(), prefix, Markers.EMPTY, targets)
 
-    def _convert_with_stmt(self, node) -> j.Try:
-        """Convert with statement (maps to Try with resources)."""
-        # TODO: Implement full with parsing
-        prefix = self._parse_space(node.children[0].prefix)
-        return self._placeholder_try(prefix)
+    def _convert_global_stmt(self, node) -> Optional[j.J]:
+        """Convert ``global a`` / ``global a, b`` to :class:`py.VariableScope`."""
+        children = node.children
+        prefix = self._parse_space(children[0].prefix)
+        names = []
+        i = 1
+        while i < len(children):
+            child = children[i]
+            if getattr(child, 'value', None) == ',':
+                i += 1
+                continue
+            if not hasattr(child, 'value'):
+                return self._convert_generic(node)
+            ident = j.Identifier(random_id(),
+                                 self._parse_space(child.prefix),
+                                 Markers.EMPTY, [], child.value, None, None)
+            if i + 1 < len(children) and getattr(children[i + 1], 'value', None) == ',':
+                comma = children[i + 1]
+                names.append(JRightPadded(ident, self._parse_space(comma.prefix), Markers.EMPTY))
+                i += 2
+            else:
+                names.append(JRightPadded(ident, Space.EMPTY, Markers.EMPTY))
+                i += 1
+        return py.VariableScope(random_id(), prefix, Markers.EMPTY,
+                                py.VariableScope.Kind.GLOBAL, names)
 
-    def _convert_import_name(self, node) -> j.Import:
-        """Convert import statement."""
-        # TODO: Implement full import parsing
-        prefix = self._parse_space(node.children[0].prefix)
-        return self._placeholder_import(prefix)
+    def _convert_yield_expr(self, node) -> Optional[j.J]:
+        """Convert ``yield`` / ``yield expr`` / ``yield x, y``.
 
-    def _convert_import_from(self, node) -> j.Import:
-        """Convert from-import statement."""
-        # TODO: Implement full from-import parsing
-        prefix = self._parse_space(node.children[0].prefix)
-        return self._placeholder_import(prefix)
+        Wraps a :class:`j.Yield` in :class:`py.StatementExpression` so that
+        it can act as a statement when it appears at the top of a
+        ``simple_stmt`` body.
+        """
+        children = node.children
+        prefix = self._parse_space(children[0].prefix)
+        value = None
+        if len(children) >= 2:
+            value = self._convert_node(children[1])
+            if value is None:
+                return self._convert_generic(node)
+        else:
+            value = j.Empty(random_id(), Space.EMPTY, Markers.EMPTY)
+        yield_ = j.Yield(random_id(), prefix, Markers.EMPTY, False, value)
+        return py.StatementExpression(random_id(), yield_)
+
+    def _convert_decorated(self, node) -> Optional[j.J]:
+        """Convert a parso ``decorated`` wrapper around a ``funcdef`` (or
+        ``classdef``).
+
+        Each decorator becomes a :class:`j.Annotation`. The outer prefix of
+        the resulting statement is the whitespace before the first ``@``;
+        every decorator after the first has its prefix set to the newline /
+        indentation between decorators.
+        """
+        children = node.children
+        if len(children) < 2:
+            return self._convert_generic(node)
+
+        # parso emits a single decorator as a direct child, but groups
+        # multiple decorators inside a `decorators` wrapper node.
+        decorator_nodes = []
+        body_idx = 0
+        if getattr(children[0], 'type', None) == 'decorators':
+            decorator_nodes = list(children[0].children)
+            body_idx = 1
+        else:
+            while body_idx < len(children) and getattr(children[body_idx], 'type', None) == 'decorator':
+                decorator_nodes.append(children[body_idx])
+                body_idx += 1
+
+        annotations = []
+        outer_prefix = None
+        trailing = ''  # accumulator of newlines emitted between decorators
+        for dec_node in decorator_nodes:
+            ann = self._convert_decorator(dec_node)
+            if ann is None:
+                return self._convert_generic(node)
+            # Prepend any pending newline-between-decorators to this
+            # annotation's prefix so the printer reproduces line breaks.
+            if trailing:
+                existing = ann.prefix.whitespace if ann.prefix else ''
+                ann = ann.replace(_prefix=Space([], trailing + existing))
+                trailing = ''
+            if outer_prefix is None:
+                outer_prefix = ann.prefix
+                # The first annotation now carries the outer prefix, so the
+                # printer would double-print it. Clear it on the annotation.
+                annotations.append(ann.replace(_prefix=Space.EMPTY))
+            else:
+                annotations.append(ann)
+            # parso emits the trailing newline as the decorator's last
+            # child. Capture it so it can land on the next annotation /
+            # def-modifier prefix.
+            if dec_node.children:
+                last = dec_node.children[-1]
+                if (isinstance(last, parso_tree.PythonLeaf)
+                        and getattr(last, 'type', None) == 'newline'):
+                    trailing += last.value
+
+        body = children[body_idx] if body_idx < len(children) else None
+        if body is None:
+            return self._convert_generic(node)
+
+        if getattr(body, 'type', None) == 'funcdef':
+            return self._convert_funcdef(body, leading_annotations=annotations,
+                                         outer_prefix=outer_prefix,
+                                         extra_modifier_prefix=trailing)
+        if getattr(body, 'type', None) == 'classdef':
+            return self._convert_classdef(body, leading_annotations=annotations,
+                                          outer_prefix=outer_prefix,
+                                          extra_modifier_prefix=trailing)
+        return self._convert_generic(node)
+
+    def _convert_decorator(self, decorator_node) -> Optional[j.Annotation]:
+        """Convert a parso ``decorator`` node.
+
+        Grammar: ``decorator: '@' dotted_name [ '(' [arglist] ')' ] NEWLINE``.
+        """
+        children = decorator_node.children
+        if len(children) < 2:
+            return None
+        at_leaf = children[0]
+        name_node = children[1]
+        prefix = self._parse_space(at_leaf.prefix)
+
+        # The decorator name slot expects a NameTree. For a single NAME we
+        # use a bare :class:`j.Identifier` (so the printer doesn't emit a
+        # leading dot); dotted names go through ``_build_qualid``.
+        if isinstance(name_node, parso_tree.PythonLeaf):
+            annotation_type = j.Identifier(
+                random_id(),
+                self._parse_space(name_node.prefix),
+                Markers.EMPTY, [], name_node.value, None, None,
+            )
+        else:
+            annotation_type = self._build_qualid(name_node)
+            if annotation_type is None:
+                return None
+
+        args = None
+        if len(children) >= 3 and getattr(children[2], 'value', None) == '(':
+            # Decorator call: collect args between '(' and ')'.
+            open_paren = children[2]
+            close_paren_idx = None
+            for k in range(3, len(children)):
+                if getattr(children[k], 'value', None) == ')':
+                    close_paren_idx = k
+                    break
+            if close_paren_idx is not None:
+                inner = children[3:close_paren_idx]
+                close_paren = children[close_paren_idx]
+                args = self._convert_call_args(inner, close_paren,
+                                               self._parse_space(open_paren.prefix))
+
+        return j.Annotation(
+            random_id(),
+            prefix,
+            Markers.EMPTY,
+            annotation_type,
+            args,
+        )
+
+    def _convert_funcdef(self, node, leading_annotations=None, outer_prefix=None,
+                          extra_modifier_prefix='') -> Optional[j.J]:
+        """Convert a function definition.
+
+        parso shape: ``[def, NAME, parameters, ':', suite]``.
+
+        Argument types currently handled: positional (with or without
+        defaults), ``*args``, ``**kw``. Annotations and ``->`` return types
+        don't exist in Py2 and are not handled.
+
+        ``leading_annotations`` / ``outer_prefix`` are supplied by the
+        ``decorated`` wrapper so the decorators precede the bare-def's prefix
+        consistently.
+        """
+        children = node.children
+        if len(children) < 5:
+            return self._convert_generic(node)
+        def_kw, name_leaf, params_node, colon, suite_node = children[0:5]
+
+        # The `def` keyword's prefix is the space immediately before it. When
+        # we're called from the decorated wrapper, the wrapper carries the
+        # outer prefix (the whitespace before the first '@') and the def_kw
+        # prefix is just the space between the last decorator and 'def'.
+        def_prefix = self._parse_space(def_kw.prefix)
+        prefix = outer_prefix if outer_prefix is not None else def_prefix
+        modifier_prefix = Space.EMPTY if outer_prefix is not None else Space.EMPTY
+        # When no decorators, the bare `def` keyword carries no leading-of-def
+        # space (it's already on MethodDeclaration.prefix). When there are
+        # decorators, the wrapper supplies the outer prefix and the def_kw's
+        # parso prefix becomes the modifier prefix (space between decorator
+        # newline and 'def').
+        if outer_prefix is not None:
+            modifier_prefix = def_prefix
+        if extra_modifier_prefix:
+            existing = modifier_prefix.whitespace if modifier_prefix is not None else ''
+            modifier_prefix = Space([], extra_modifier_prefix + existing)
+
+        modifiers = [j.Modifier(
+            random_id(),
+            modifier_prefix,
+            Markers.EMPTY,
+            'def',
+            j.Modifier.Type.Default,
+            [],
+        )]
+
+        name_ident = j.Identifier(
+            random_id(),
+            self._parse_space(name_leaf.prefix),
+            Markers.EMPTY, [], name_leaf.value, None, None,
+        )
+
+        params_container = self._convert_parameters(params_node)
+        if params_container is None:
+            return self._convert_generic(node)
+
+        body = self._convert_suite_to_block(suite_node, self._parse_space(colon.prefix))
+
+        return j.MethodDeclaration(
+            random_id(),
+            prefix,
+            Markers.EMPTY,
+            leading_annotations or [],
+            modifiers,
+            None,  # type_parameters
+            None,  # return_type_expression (Py2 has none)
+            [],    # name_annotations
+            name_ident,
+            params_container,
+            None,  # throws
+            body,
+            None,  # default_value
+            None,  # method_type
+        )
+
+    def _convert_parameters(self, params_node) -> Optional[JContainer]:
+        """Convert a parso ``parameters`` node to a parameter ``JContainer``.
+
+        Each parso ``param`` becomes a :class:`j.VariableDeclarations`
+        whose single ``NamedVariable`` carries the parameter name and
+        (when present) its default value. ``*args`` populates the
+        ``varargs`` slot; ``**kw`` is marked with the
+        :class:`KeywordArguments` marker so the printer emits ``**``.
+        """
+        children = params_node.children
+        if len(children) < 2:
+            return None
+        open_paren = children[0]
+        close_paren = children[-1]
+        param_nodes = children[1:-1]
+        leading = self._parse_space(open_paren.prefix)
+
+        if not param_nodes:
+            empty = j.Empty(random_id(), self._parse_space(close_paren.prefix), Markers.EMPTY)
+            return JContainer(leading, [JRightPadded(empty, Space.EMPTY, Markers.EMPTY)], Markers.EMPTY)
+
+        padded_params = []
+        for i, p in enumerate(param_nodes):
+            converted = self._convert_param(p)
+            if converted is None:
+                return None
+            is_last = (i == len(param_nodes) - 1)
+            # parso `param` nodes carry their own trailing comma when not the
+            # last; use it for the JRightPadded.after. For the final param,
+            # use the space before `)`.
+            after = self._extract_param_trailing_space(p)
+            if is_last and after == Space.EMPTY:
+                after = self._parse_space(close_paren.prefix)
+            padded_params.append(JRightPadded(converted, after, Markers.EMPTY))
+
+        return JContainer(leading, padded_params, Markers.EMPTY)
+
+    @staticmethod
+    def _extract_param_trailing_space(param_node) -> Space:
+        """Return the space attached to a trailing comma inside a parso
+        ``param`` node, or :attr:`Space.EMPTY` when there is no trailing
+        comma. The comma itself is consumed implicitly by the printer."""
+        last = param_node.children[-1]
+        if getattr(last, 'value', None) == ',':
+            # The space-before-comma belongs to the comma's own prefix; that
+            # becomes the JRightPadded.after on this parameter.
+            return Py2ParserVisitor._static_parse_space(last.prefix)
+        return Space.EMPTY
+
+    @staticmethod
+    def _static_parse_space(text: str) -> Space:
+        if not text:
+            return Space.EMPTY
+        return Space([], text)
+
+    def _convert_param(self, param_node) -> Optional[j.VariableDeclarations]:
+        """Convert one parso ``param`` node to :class:`j.VariableDeclarations`.
+
+        Shapes handled:
+        * ``NAME``                  — positional
+        * ``NAME = expr``           — positional with default
+        * ``'*' NAME``              — vararg
+        * ``'**' NAME``             — kwargs
+        Any trailing comma is consumed in :meth:`_extract_param_trailing_space`.
+        """
+        children = list(param_node.children)
+        # Strip trailing comma if present — it's handled by the caller.
+        if children and getattr(children[-1], 'value', None) == ',':
+            children = children[:-1]
+        if not children:
+            return None
+
+        markers = Markers.EMPTY
+        varargs_space: Optional[Space] = None
+        prefix = Space.EMPTY
+
+        first = children[0]
+        if getattr(first, 'value', None) == '*':
+            prefix = self._parse_space(first.prefix)
+            # The varargs slot stores the space immediately after `*`
+            # (parso captures that as the next leaf's prefix).
+            if len(children) >= 2:
+                varargs_space = self._parse_space(children[1].prefix)
+            name_leaf = children[1] if len(children) >= 2 else None
+            rest = children[2:]
+        elif getattr(first, 'value', None) == '**':
+            prefix = self._parse_space(first.prefix)
+            markers = Markers.build(random_id(), [KeywordArguments(random_id())])
+            # `**` consumes the leading prefix; the name's parso prefix is the
+            # space between `**` and the name (typically empty).
+            name_leaf = children[1] if len(children) >= 2 else None
+            rest = children[2:]
+        else:
+            prefix = self._parse_space(first.prefix)
+            name_leaf = first
+            rest = children[1:]
+
+        if name_leaf is None or not hasattr(name_leaf, 'value'):
+            return None
+
+        # For *args/**kw the name's leading whitespace is captured in
+        # varargs_space (vararg) or carried to the name prefix (kwargs).
+        # For positional params, the prefix has already been consumed.
+        name_prefix = Space.EMPTY
+        if markers != Markers.EMPTY:  # kwargs
+            name_prefix = self._parse_space(name_leaf.prefix)
+        name_ident = j.Identifier(
+            random_id(),
+            name_prefix,
+            Markers.EMPTY, [], name_leaf.value, None, None,
+        )
+
+        initializer = None
+        if len(rest) >= 2 and getattr(rest[0], 'value', None) == '=':
+            eq_leaf = rest[0]
+            default_value = self._convert_node(rest[1])
+            if default_value is None:
+                return None
+            initializer = JLeftPadded(
+                self._parse_space(eq_leaf.prefix),
+                default_value,
+                Markers.EMPTY,
+            )
+
+        named_var = j.VariableDeclarations.NamedVariable(
+            random_id(),
+            Space.EMPTY,
+            Markers.EMPTY,
+            name_ident,
+            [],          # dimensions_after_name
+            initializer,
+            None,        # variable_type
+        )
+        return j.VariableDeclarations(
+            random_id(),
+            prefix,
+            markers,
+            [],          # leading_annotations
+            [],          # modifiers
+            None,        # type_expression
+            varargs_space,
+            [],          # dimensions_before_name
+            [JRightPadded(named_var, Space.EMPTY, Markers.EMPTY)],
+        )
+
+    def _convert_classdef(self, node, leading_annotations=None, outer_prefix=None,
+                           extra_modifier_prefix='') -> Optional[j.J]:
+        """Convert a class definition.
+
+        Grammar:
+            classdef: 'class' NAME ['(' [testlist] ')'] ':' suite
+
+        The Py2-only old-style class form (``class Foo:`` with no parens)
+        is preserved as ``implements=None`` and round-trips through the
+        printer based on that distinction (vs. ``implements=JContainer(...)``
+        for ``class Foo():`` or ``class Foo(Base):``).
+        """
+        children = node.children
+        if len(children) < 4:
+            return self._convert_generic(node)
+
+        class_kw = children[0]
+        name_leaf = children[1]
+        class_prefix = self._parse_space(class_kw.prefix)
+        prefix = outer_prefix if outer_prefix is not None else class_prefix
+        kind_prefix = class_prefix if outer_prefix is not None else Space.EMPTY
+        if extra_modifier_prefix:
+            existing = kind_prefix.whitespace if kind_prefix is not None else ''
+            kind_prefix = Space([], extra_modifier_prefix + existing)
+
+        name_ident = j.Identifier(
+            random_id(),
+            self._parse_space(name_leaf.prefix),
+            Markers.EMPTY, [], name_leaf.value, None, None,
+        )
+
+        # Skip the name to find the optional `(...)` bases list, then `:`.
+        idx = 2
+        interfaces = None
+        if idx < len(children) and getattr(children[idx], 'value', None) == '(':
+            open_paren = children[idx]
+            close_idx = idx + 1
+            while close_idx < len(children) and getattr(children[close_idx], 'value', None) != ')':
+                close_idx += 1
+            if close_idx >= len(children):
+                return self._convert_generic(node)
+            close_paren = children[close_idx]
+            inside = children[idx + 1:close_idx]
+            leading = self._parse_space(open_paren.prefix)
+            interfaces = self._convert_class_bases(inside, close_paren, leading)
+            idx = close_idx + 1
+
+        if idx >= len(children) or getattr(children[idx], 'value', None) != ':':
+            return self._convert_generic(node)
+        colon = children[idx]
+        suite_node = children[idx + 1] if idx + 1 < len(children) else None
+        if suite_node is None:
+            return self._convert_generic(node)
+
+        body = self._convert_suite_to_block(suite_node, self._parse_space(colon.prefix))
+
+        kind = j.ClassDeclaration.Kind(
+            random_id(), kind_prefix, Markers.EMPTY,
+            [], j.ClassDeclaration.Kind.Type.Class,
+        )
+        return j.ClassDeclaration(
+            random_id(),
+            prefix,
+            Markers.EMPTY,
+            leading_annotations or [],
+            [],
+            kind,
+            name_ident,
+            None,   # type_parameters
+            None,   # primary_constructor
+            None,   # extends
+            interfaces,
+            None,   # permits
+            body,
+            None,   # type
+        )
+
+    def _convert_class_bases(self, inside, close_paren, leading) -> JContainer:
+        """Convert the contents between ``(`` and ``)`` of a class header."""
+        before_close = self._parse_space(close_paren.prefix)
+        if not inside:
+            empty = j.Empty(random_id(), before_close, Markers.EMPTY)
+            return JContainer(leading,
+                              [JRightPadded(empty, Space.EMPTY, Markers.EMPTY)],
+                              Markers.EMPTY)
+        # `class Foo(Base):` — one base node; `class Foo(A, B):` — testlist.
+        if len(inside) == 1 and getattr(inside[0], 'type', None) == 'testlist':
+            items = inside[0].children
+        else:
+            items = inside
+        result = []
+        i = 0
+        while i < len(items):
+            child = items[i]
+            if getattr(child, 'value', None) == ',':
+                i += 1
+                continue
+            base = self._convert_node(child)
+            if base is None:
+                # Unknown shape — bail to a single Empty so we don't drop
+                # any tokens.
+                empty = j.Empty(random_id(), before_close, Markers.EMPTY)
+                return JContainer(leading,
+                                  [JRightPadded(empty, Space.EMPTY, Markers.EMPTY)],
+                                  Markers.EMPTY)
+            if i + 1 < len(items) and getattr(items[i + 1], 'value', None) == ',':
+                comma = items[i + 1]
+                result.append(JRightPadded(base, self._parse_space(comma.prefix), Markers.EMPTY))
+                i += 2
+            else:
+                result.append(JRightPadded(base, before_close, Markers.EMPTY))
+                i += 1
+        return JContainer(leading, result, Markers.EMPTY)
+
+    def _convert_if_stmt(self, node) -> Optional[j.J]:
+        """Convert ``if`` / ``elif`` / ``else`` chain.
+
+        Parso emits a flat list
+        ``[if, test, :, suite, (elif, test, :, suite)*, (else, :, suite)?]``.
+        We render each ``elif`` as a nested :class:`j.If` inside the parent's
+        :class:`j.If.Else` slot, matching the Py3 visitor convention.
+        """
+        result = self._build_if_chain(node.children, 0)
+        if result is None:
+            return self._convert_generic(node)
+        return result
+
+    def _build_if_chain(self, children, start) -> Optional[j.If]:
+        if start + 3 >= len(children):
+            return None
+        kw = children[start]
+        test_node = children[start + 1]
+        colon = children[start + 2]
+        suite_node = children[start + 3]
+
+        prefix = self._parse_space(kw.prefix)
+        test_expr = self._convert_node(test_node)
+        if test_expr is None:
+            return None
+
+        condition = j.ControlParentheses(
+            random_id(),
+            Space.EMPTY,
+            Markers.EMPTY,
+            JRightPadded(test_expr, Space.EMPTY, Markers.EMPTY),
+        )
+        body = self._convert_suite_to_block(suite_node, self._parse_space(colon.prefix))
+        then_part = JRightPadded(body, Space.EMPTY, Markers.EMPTY)
+
+        elze = None
+        idx = start + 4
+        if idx < len(children):
+            tail_kw = children[idx]
+            tail_val = getattr(tail_kw, 'value', None)
+            if tail_val == 'elif':
+                nested = self._build_if_chain(children, idx)
+                if nested is None:
+                    return None
+                # Inner If's prefix already holds the space before 'elif'; we
+                # wrap it bare and keep j.If.Else.prefix as Space.EMPTY so the
+                # printer doesn't double-print the gap.
+                elze = j.If.Else(
+                    random_id(),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    JRightPadded(nested, Space.EMPTY, Markers.EMPTY),
+                )
+            elif tail_val == 'else':
+                else_colon = children[idx + 1]
+                else_suite = children[idx + 2]
+                else_block = self._convert_suite_to_block(else_suite, self._parse_space(else_colon.prefix))
+                elze = j.If.Else(
+                    random_id(),
+                    self._parse_space(tail_kw.prefix),
+                    Markers.EMPTY,
+                    JRightPadded(else_block, Space.EMPTY, Markers.EMPTY),
+                )
+
+        return j.If(
+            random_id(), prefix, Markers.EMPTY,
+            condition, then_part, elze,
+        )
+
+    def _convert_while_stmt(self, node) -> Optional[j.J]:
+        """Convert ``while expr: suite [else: suite]``."""
+        children = node.children
+        if len(children) < 4:
+            return self._convert_generic(node)
+        while_kw, test_node, colon, suite_node = children[0:4]
+        prefix = self._parse_space(while_kw.prefix)
+
+        test_expr = self._convert_node(test_node)
+        if test_expr is None:
+            return self._convert_generic(node)
+
+        condition = j.ControlParentheses(
+            random_id(), Space.EMPTY, Markers.EMPTY,
+            JRightPadded(test_expr, Space.EMPTY, Markers.EMPTY),
+        )
+        body = self._convert_suite_to_block(suite_node, self._parse_space(colon.prefix))
+        loop = j.WhileLoop(
+            random_id(), prefix, Markers.EMPTY,
+            condition,
+            JRightPadded(body, Space.EMPTY, Markers.EMPTY),
+        )
+        return self._maybe_wrap_else(loop, children, 4)
+
+    def _convert_for_stmt(self, node) -> Optional[j.J]:
+        """Convert ``for target in iterable: suite [else: suite]``.
+
+        Single-name and tuple-destructure (``for i, j in ...``) targets
+        are both supported; the destructure form is wrapped in a
+        :class:`py.CollectionLiteral` of kind ``TUPLE``.
+        """
+        children = node.children
+        if len(children) < 6:
+            return self._convert_generic(node)
+        for_kw, target_node, in_kw, iter_node, colon, suite_node = children[0:6]
+
+        prefix = self._parse_space(for_kw.prefix)
+        if getattr(target_node, 'type', None) == 'exprlist':
+            items = self._pad_comma_list(target_node.children, Space.EMPTY)
+            if items is None:
+                return self._convert_generic(node)
+            target = py.CollectionLiteral(
+                random_id(), Space.EMPTY, Markers.EMPTY,
+                py.CollectionLiteral.Kind.TUPLE,
+                JContainer(Space.EMPTY, items, Markers.EMPTY),
+                None,
+            )
+        else:
+            target = self._convert_node(target_node)
+        iterable = self._convert_node(iter_node)
+        if target is None or iterable is None:
+            return self._convert_generic(node)
+
+        target_stmt = py.ExpressionStatement(random_id(), target)
+        control = j.ForEachLoop.Control(
+            random_id(), Space.EMPTY, Markers.EMPTY,
+            JRightPadded(target_stmt, self._parse_space(in_kw.prefix), Markers.EMPTY),
+            JRightPadded(iterable, Space.EMPTY, Markers.EMPTY),
+        )
+        body = self._convert_suite_to_block(suite_node, self._parse_space(colon.prefix))
+        loop = j.ForEachLoop(
+            random_id(), prefix, Markers.EMPTY,
+            control, JRightPadded(body, Space.EMPTY, Markers.EMPTY),
+        )
+        return self._maybe_wrap_else(loop, children, 6)
+
+    def _maybe_wrap_else(self, loop, children, idx) -> j.J:
+        """Wrap a while/for loop in :class:`py.TrailingElseWrapper` when a
+        trailing ``else:`` clause is present in the parso children."""
+        if idx >= len(children) or getattr(children[idx], 'value', None) != 'else':
+            return loop
+        else_kw = children[idx]
+        else_colon = children[idx + 1]
+        else_suite = children[idx + 2]
+        else_block = self._convert_suite_to_block(
+            else_suite, self._parse_space(else_colon.prefix),
+        )
+        return py.TrailingElseWrapper(
+            random_id(),
+            loop.prefix,
+            Markers.EMPTY,
+            loop.replace(_prefix=Space.EMPTY),
+            JLeftPadded(self._parse_space(else_kw.prefix), else_block, Markers.EMPTY),
+        )
+
+    def _convert_suite_to_block(self, suite_node, block_prefix) -> j.Block:
+        """Convert a parso ``suite`` to a :class:`j.Block`, threading
+        newlines onto statement prefixes / trailing-padding so the printer
+        can faithfully reproduce the original line layout.
+        """
+        statements = self._convert_stmt_block_children(suite_node.children)
+        return j.Block(
+            random_id(),
+            block_prefix,
+            Markers.EMPTY,
+            JRightPadded(False, Space.EMPTY, Markers.EMPTY),  # not static
+            statements,
+            Space.EMPTY,
+        )
+
+    def _convert_try_stmt(self, node) -> Optional[j.J]:
+        """Convert ``try`` / ``except`` / ``else`` / ``finally`` blocks.
+
+        Both Py3 (``except E as e:``) and Py2 (``except E, e:``) catch forms
+        are accepted; the Py2 form is marked with
+        :class:`TupleExceptClause` so a future printer change can emit the
+        legacy syntax.
+        """
+        children = node.children
+        if len(children) < 4:
+            return self._convert_generic(node)
+        try_kw = children[0]
+        try_colon = children[1]
+        try_suite = children[2]
+        prefix = self._parse_space(try_kw.prefix)
+        body = self._convert_suite_to_block(try_suite, self._parse_space(try_colon.prefix))
+
+        catches = []
+        else_block = None
+        finally_block = None
+
+        i = 3
+        while i < len(children):
+            current = children[i]
+            ctype = getattr(current, 'type', None)
+            cval = getattr(current, 'value', None)
+            if ctype == 'except_clause':
+                # except_clause + ':' + suite
+                except_clause = current
+                if i + 2 >= len(children):
+                    return self._convert_generic(node)
+                colon = children[i + 1]
+                suite = children[i + 2]
+                catch = self._build_catch(except_clause, colon, suite)
+                if catch is None:
+                    return self._convert_generic(node)
+                catches.append(catch)
+                i += 3
+            elif cval == 'except':
+                # Bare `except:` (no except_clause wrapper).
+                if i + 2 >= len(children):
+                    return self._convert_generic(node)
+                colon = children[i + 1]
+                suite = children[i + 2]
+                catch = self._build_bare_catch(current, colon, suite)
+                if catch is None:
+                    return self._convert_generic(node)
+                catches.append(catch)
+                i += 3
+            elif cval == 'else':
+                if i + 2 >= len(children):
+                    return self._convert_generic(node)
+                colon = children[i + 1]
+                suite = children[i + 2]
+                else_block = JLeftPadded(
+                    self._parse_space(current.prefix),
+                    self._convert_suite_to_block(suite, self._parse_space(colon.prefix)),
+                    Markers.EMPTY,
+                )
+                i += 3
+            elif cval == 'finally':
+                if i + 2 >= len(children):
+                    return self._convert_generic(node)
+                colon = children[i + 1]
+                suite = children[i + 2]
+                finally_block = JLeftPadded(
+                    self._parse_space(current.prefix),
+                    self._convert_suite_to_block(suite, self._parse_space(colon.prefix)),
+                    Markers.EMPTY,
+                )
+                i += 3
+            else:
+                # Unrecognized — bail out cleanly.
+                return self._convert_generic(node)
+
+        try_ = j.Try(
+            random_id(), prefix, Markers.EMPTY,
+            None,  # resources
+            body, catches, finally_block,
+        )
+        if else_block is None:
+            return try_
+        return py.TrailingElseWrapper(
+            random_id(), try_.prefix, Markers.EMPTY,
+            try_.replace(_prefix=Space.EMPTY),
+            else_block,
+        )
+
+    def _build_bare_catch(self, except_kw, colon, suite) -> Optional[j.Try.Catch]:
+        """Build a catch for the bare ``except:`` form (no exception type)."""
+        prefix = self._parse_space(except_kw.prefix)
+        empty_type = py.ExceptionType(
+            random_id(), Space.EMPTY, Markers.EMPTY,
+            None, False,
+            j.Empty(random_id(), Space.EMPTY, Markers.EMPTY),
+        )
+        empty_name = j.Identifier(random_id(), Space.EMPTY, Markers.EMPTY, [], '', None, None)
+        named = j.VariableDeclarations.NamedVariable(
+            random_id(), Space.EMPTY, Markers.EMPTY, empty_name, [], None, None,
+        )
+        var_decl = j.VariableDeclarations(
+            random_id(), Space.EMPTY, Markers.EMPTY,
+            [], [], empty_type, None, [],
+            [JRightPadded(named, Space.EMPTY, Markers.EMPTY)],
+        )
+        return j.Try.Catch(
+            random_id(), prefix, Markers.EMPTY,
+            j.ControlParentheses(
+                random_id(), Space.EMPTY, Markers.EMPTY,
+                JRightPadded(var_decl, Space.EMPTY, Markers.EMPTY),
+            ),
+            self._convert_suite_to_block(suite, self._parse_space(colon.prefix)),
+        )
+
+    def _build_catch(self, except_clause, colon, suite) -> Optional[j.Try.Catch]:
+        """Build a catch from a parso ``except_clause`` node + ':' + suite."""
+        ec_children = except_clause.children
+        except_kw = ec_children[0]
+        prefix = self._parse_space(except_kw.prefix)
+
+        # except_clause shapes:
+        #   ['except']                         (handled separately above)
+        #   ['except', type]
+        #   ['except', type, 'as', name]
+        #   ['except', type, ',', name]        ← Py2 form
+        type_node = ec_children[1]
+        type_expr = self._convert_node(type_node)
+        if type_expr is None:
+            return None
+        exception_type = py.ExceptionType(
+            random_id(), Space.EMPTY, Markers.EMPTY,
+            None, False, type_expr,
+        )
+
+        name_ident = j.Identifier(random_id(), Space.EMPTY, Markers.EMPTY, [], '', None, None)
+        before_as = Space.EMPTY
+        catch_markers = Markers.EMPTY
+        if len(ec_children) >= 4:
+            sep = ec_children[2]
+            name_leaf = ec_children[3]
+            before_as = self._parse_space(sep.prefix)
+            sep_val = getattr(sep, 'value', None)
+            if sep_val == ',':
+                catch_markers = Markers.build(random_id(), [TupleExceptClause(random_id())])
+            # Otherwise it's `as` — the Py3-style form.
+            if hasattr(name_leaf, 'value'):
+                name_ident = j.Identifier(
+                    random_id(),
+                    self._parse_space(name_leaf.prefix),
+                    Markers.EMPTY, [], name_leaf.value, None, None,
+                )
+
+        named = j.VariableDeclarations.NamedVariable(
+            random_id(), Space.EMPTY, Markers.EMPTY, name_ident, [], None, None,
+        )
+        var_decl = j.VariableDeclarations(
+            random_id(), Space.EMPTY, Markers.EMPTY,
+            [], [], exception_type, None, [],
+            [JRightPadded(named, before_as, Markers.EMPTY)],
+        )
+        return j.Try.Catch(
+            random_id(), prefix, catch_markers,
+            j.ControlParentheses(
+                random_id(), Space.EMPTY, Markers.EMPTY,
+                JRightPadded(var_decl, Space.EMPTY, Markers.EMPTY),
+            ),
+            self._convert_suite_to_block(suite, self._parse_space(colon.prefix)),
+        )
+
+    def _convert_with_stmt(self, node) -> Optional[j.J]:
+        """Convert ``with`` statements.
+
+        Grammar:
+            with_stmt: 'with' with_item (',' with_item)* ':' suite
+            with_item: test ['as' expr]
+        """
+        children = node.children
+        if len(children) < 4:
+            return self._convert_generic(node)
+        with_kw = children[0]
+        prefix = self._parse_space(with_kw.prefix)
+
+        # Find the ':' that ends the head.
+        colon_idx = None
+        for k in range(1, len(children)):
+            if getattr(children[k], 'value', None) == ':' and isinstance(children[k], parso_tree.PythonLeaf):
+                colon_idx = k
+                break
+        if colon_idx is None:
+            return self._convert_generic(node)
+        colon = children[colon_idx]
+        suite_node = children[colon_idx + 1] if colon_idx + 1 < len(children) else None
+        if suite_node is None:
+            return self._convert_generic(node)
+
+        # Collect items (with_item or bare expression) separated by commas.
+        items_children = children[1:colon_idx]
+        resources = []
+        i = 0
+        while i < len(items_children):
+            child = items_children[i]
+            if getattr(child, 'value', None) == ',':
+                i += 1
+                continue
+            # Capture the leading whitespace of this item (space between
+            # ``with``/``,`` and the first leaf) so it can go on the
+            # Resource.prefix — the printer emits each resource's prefix
+            # after the comma it follows.
+            first_leaf = (child if isinstance(child, parso_tree.PythonLeaf)
+                          else (child.children[0] if getattr(child, 'children', None) else None))
+            item_leading = (self._parse_space(first_leaf.prefix)
+                            if first_leaf is not None and hasattr(first_leaf, 'prefix')
+                            else Space.EMPTY)
+            resource = self._build_with_resource(child, is_first=False)
+            if resource is None:
+                return self._convert_generic(node)
+            resource = resource.replace(_prefix=item_leading)
+            after = Space.EMPTY
+            if i + 1 < len(items_children) and getattr(items_children[i + 1], 'value', None) == ',':
+                comma = items_children[i + 1]
+                after = self._parse_space(comma.prefix)
+                i += 2
+            else:
+                i += 1
+            resources.append(JRightPadded(resource, after, Markers.EMPTY))
+
+        if not resources:
+            return self._convert_generic(node)
+
+        body = self._convert_suite_to_block(suite_node, self._parse_space(colon.prefix))
+        # Each Resource carries its own leading whitespace on .prefix; the
+        # container's leading slot stays empty, and OmitParentheses tells
+        # the printer to skip the ``(...)`` wrapping.
+        return j.Try(
+            random_id(), prefix, Markers.EMPTY,
+            JContainer(Space.EMPTY, resources,
+                       Markers.build(random_id(), [OmitParentheses(random_id())])),
+            body, [], None,
+        )
+
+    def _build_with_resource(self, item, is_first) -> Optional[j.Try.Resource]:
+        """Convert a parso ``with_item`` (or bare expression) to :class:`j.Try.Resource`.
+
+        The printer's ``with``-statement branch (in :meth:`visit_try`) walks
+        the inner ``j.Assignment`` directly (printing ``ctx as target``), so
+        we use that shape rather than wrapping in a :class:`py.ExpressionTypeTree`.
+        Bare expressions (``with foo:``) are wrapped to satisfy the TypedTree
+        contract.
+        """
+        if getattr(item, 'type', None) == 'with_item':
+            ctx_node = item.children[0]
+            as_kw = item.children[1]
+            target_leaf = item.children[2]
+            ctx_expr = self._convert_node(ctx_node)
+            target = self._convert_node(target_leaf)
+            if ctx_expr is None or target is None:
+                return None
+            # Strip the leading whitespace from the ctx_expr — it is
+            # captured separately (on JContainer.before for the first item
+            # or on JRightPadded.after of the preceding item). Leaving it
+            # in place produces a double space in the printer output.
+            ctx_expr = self._strip_leading_space(ctx_expr)
+            var = j.Assignment(
+                random_id(), Space.EMPTY, Markers.EMPTY,
+                target,
+                JLeftPadded(self._parse_space(as_kw.prefix), ctx_expr, Markers.EMPTY),
+                None,
+            )
+        else:
+            expr = self._convert_node(item)
+            if expr is None:
+                return None
+            expr = self._strip_leading_space(expr)
+            var = py.ExpressionTypeTree(random_id(), Space.EMPTY, Markers.EMPTY, expr)
+        return j.Try.Resource(random_id(), Space.EMPTY, Markers.EMPTY, var, False)
+
+    @staticmethod
+    def _strip_leading_space(node):
+        """Return ``node`` with its outer prefix reset to :attr:`Space.EMPTY`.
+
+        Used when the caller has already captured the leading whitespace on
+        a different LST slot (e.g. a ``JContainer.before``) and would
+        otherwise emit a duplicated space at print time.
+        """
+        if not hasattr(node, 'prefix') or node.prefix == Space.EMPTY:
+            return node
+        try:
+            return node.replace(_prefix=Space.EMPTY)
+        except (TypeError, AttributeError):
+            return node
+
+    def _convert_import_name(self, node) -> Optional[j.J]:
+        """Convert ``import x``, ``import x.y``, ``import x as y``, ``import a, b``.
+
+        Single-name imports produce a bare :class:`j.Import` to match the Py3
+        visitor convention; multi-name forms wrap in :class:`py.MultiImport`
+        with ``from_=None``.
+        """
+        keyword = node.children[0]  # 'import'
+        prefix = self._parse_space(keyword.prefix)
+        rest = node.children[1:]
+        if len(rest) != 1:
+            return self._convert_generic(node)
+        target = rest[0]
+
+        if getattr(target, 'type', None) == 'dotted_as_names':
+            imports = self._imports_from_as_names(target.children)
+            if imports is None:
+                return self._convert_generic(node)
+            # The first import's qualid carries the space between 'import'
+            # and the first name; the JContainer's leading space is EMPTY.
+            return py.MultiImport(
+                random_id(),
+                prefix,
+                Markers.EMPTY,
+                None,  # from_
+                False,  # parenthesized
+                JContainer(Space.EMPTY, imports, Markers.EMPTY),
+            )
+
+        imp = self._build_one_import(target)
+        if imp is None:
+            return self._convert_generic(node)
+        return j.Import(
+            random_id(),
+            prefix,
+            Markers.EMPTY,
+            imp.padding.static,
+            imp.qualid,
+            imp.padding.alias,
+        )
+
+    def _convert_import_from(self, node) -> Optional[j.J]:
+        """Convert ``from M import X``, ``from M import X, Y``,
+        ``from M import (X, Y)``, ``from M import *``, and relative
+        ``from . import X`` / ``from .pkg import X`` forms.
+
+        Always produces :class:`py.MultiImport`; the ``from_`` slot carries
+        the module reference.
+        """
+        children = node.children
+        # children[0] is 'from'. Find the 'import' keyword's index.
+        prefix = self._parse_space(children[0].prefix)
+        import_idx = next(
+            (i for i, c in enumerate(children)
+             if getattr(c, 'type', None) == 'keyword' and getattr(c, 'value', None) == 'import'),
+            -1,
+        )
+        if import_idx < 1:
+            return self._convert_generic(node)
+
+        module_children = children[1:import_idx]
+        import_kw = children[import_idx]
+        after_import = children[import_idx + 1:]
+
+        from_tree = self._build_from_module(module_children)
+        if from_tree is None:
+            return self._convert_generic(node)
+
+        # JRightPadded.after holds the space between the module ref and 'import'.
+        from_padded = JRightPadded(from_tree, self._parse_space(import_kw.prefix), Markers.EMPTY)
+
+        # Parse the right-hand-side names. Two parenthesized forms exist:
+        # `(a, b)` (list_in_parens) and bare names.
+        parenthesized = False
+        names_leading = Space.EMPTY
+        close_paren = None
+        rhs = after_import
+        if rhs and getattr(rhs[0], 'value', None) == '(':
+            parenthesized = True
+            open_paren = rhs[0]
+            close_paren = rhs[-1] if getattr(rhs[-1], 'value', None) == ')' else None
+            names_leading = self._parse_space(open_paren.prefix)
+            rhs = rhs[1:-1] if close_paren else rhs[1:]
+        # For the non-parenthesized form, the leading whitespace is
+        # preserved on the inner Identifier inside each import's qualid
+        # (set by ``_build_qualid``). Leaving ``names_leading`` empty
+        # avoids double-emitting that space.
+
+        if len(rhs) == 1 and getattr(rhs[0], 'value', None) == '*':
+            star = rhs[0]
+            star_qualid = j.FieldAccess(
+                random_id(),
+                self._parse_space(star.prefix),
+                Markers.EMPTY,
+                j.Empty(random_id(), Space.EMPTY, Markers.EMPTY),
+                JLeftPadded(
+                    Space.EMPTY,
+                    j.Identifier(random_id(), Space.EMPTY, Markers.EMPTY, [], '*', None, None),
+                    Markers.EMPTY,
+                ),
+                None,
+            )
+            imports = [JRightPadded(
+                j.Import(
+                    random_id(), Space.EMPTY, Markers.EMPTY,
+                    JLeftPadded(Space.EMPTY, False, Markers.EMPTY),
+                    star_qualid, None,
+                ),
+                Space.EMPTY,
+                Markers.EMPTY,
+            )]
+        elif len(rhs) == 1 and getattr(rhs[0], 'type', None) == 'import_as_names':
+            imports = self._imports_from_as_names(rhs[0].children)
+            if imports is None:
+                return self._convert_generic(node)
+        elif len(rhs) >= 1:
+            # Single import name (with or without `as`), flat in the children.
+            imports = self._imports_from_as_names(rhs)
+            if imports is None:
+                return self._convert_generic(node)
+        else:
+            return self._convert_generic(node)
+
+        # When parenthesized, the last import's `after` covers space before `)`.
+        if parenthesized and close_paren is not None and imports:
+            last = imports[-1]
+            imports[-1] = JRightPadded(last.element, self._parse_space(close_paren.prefix), last.markers)
+
+        return py.MultiImport(
+            random_id(),
+            prefix,
+            Markers.EMPTY,
+            from_padded,
+            parenthesized,
+            JContainer(names_leading, imports, Markers.EMPTY),
+        )
+
+    def _imports_from_as_names(self, items) -> Optional[list]:
+        """Walk a flat ``[item, ',', item, ',', ...]`` list of import items
+        (each either a NAME / dotted_name or a dotted_as_name / import_as_name)
+        into ``JRightPadded[j.Import]`` entries."""
+        out = []
+        i = 0
+        while i < len(items):
+            child = items[i]
+            if getattr(child, 'value', None) == ',':
+                i += 1
+                continue
+            imp = self._build_one_import(child)
+            if imp is None:
+                return None
+            if i + 1 < len(items) and getattr(items[i + 1], 'value', None) == ',':
+                comma = items[i + 1]
+                out.append(JRightPadded(imp, self._parse_space(comma.prefix), Markers.EMPTY))
+                i += 2
+            else:
+                out.append(JRightPadded(imp, Space.EMPTY, Markers.EMPTY))
+                i += 1
+        return out
+
+    def _build_one_import(self, target) -> Optional[j.Import]:
+        """Build a ``j.Import`` for a single import item.
+
+        Accepts:
+        * a NAME leaf — ``import os``
+        * a ``dotted_name`` node — ``import os.path``
+        * a ``dotted_as_name`` node — ``import os as o``
+        * an ``import_as_name`` node — ``X as Y`` inside a ``from`` clause
+        """
+        alias = None
+        if getattr(target, 'type', None) in ('dotted_as_name', 'import_as_name'):
+            inner_name = target.children[0]
+            as_kw = target.children[1]
+            alias_leaf = target.children[2]
+            alias_ident = j.Identifier(
+                random_id(),
+                self._parse_space(alias_leaf.prefix),
+                Markers.EMPTY, [], alias_leaf.value, None, None,
+            )
+            alias = JLeftPadded(self._parse_space(as_kw.prefix), alias_ident, Markers.EMPTY)
+            target = inner_name
+
+        qualid = self._build_qualid(target)
+        if qualid is None:
+            return None
+        return j.Import(
+            random_id(),
+            Space.EMPTY,
+            Markers.EMPTY,
+            JLeftPadded(Space.EMPTY, False, Markers.EMPTY),
+            qualid,
+            alias,
+        )
+
+    def _build_qualid(self, node_or_leaf) -> Optional[j.FieldAccess]:
+        """Build a :class:`j.FieldAccess` for an :class:`j.Import.qualid`.
+
+        For a single bare name, returns ``FieldAccess(target=Empty, name)``
+        which the import printer special-cases (it emits just the name,
+        not ``.name``). For dotted names, returns a left-associative chain
+        whose leftmost target is a bare :class:`j.Identifier` (not an
+        Empty-target FieldAccess) so a regular FieldAccess print walks
+        produce ``a.b.c`` without a stray leading dot.
+        """
+        if isinstance(node_or_leaf, parso_tree.PythonLeaf):
+            # The Identifier carries the parso prefix so that both the
+            # standalone ``j.Import`` printer branch (which would otherwise
+            # consume the FieldAccess's outer prefix) and the
+            # ``py.MultiImport`` printer branch (which skips the FieldAccess
+            # prefix and only renders the name) reproduce the whitespace
+            # before the name.
+            ident = j.Identifier(
+                random_id(),
+                self._parse_space(node_or_leaf.prefix),
+                Markers.EMPTY, [],
+                node_or_leaf.value, None, None,
+            )
+            return j.FieldAccess(
+                random_id(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                j.Empty(random_id(), Space.EMPTY, Markers.EMPTY),
+                JLeftPadded(Space.EMPTY, ident, Markers.EMPTY),
+                None,
+            )
+
+        if getattr(node_or_leaf, 'type', None) != 'dotted_name':
+            return None
+
+        children = node_or_leaf.children
+        first = children[0]
+        if not isinstance(first, parso_tree.PythonLeaf):
+            return None
+        # Leftmost element is a bare Identifier carrying the prefix of the
+        # whole dotted chain.
+        leftmost: j.J = j.Identifier(
+            random_id(),
+            self._parse_space(first.prefix),
+            Markers.EMPTY, [], first.value, None, None,
+        )
+        i = 1
+        while i + 1 <= len(children) - 1:
+            dot = children[i]
+            name_leaf = children[i + 1]
+            name_ident = j.Identifier(
+                random_id(),
+                self._parse_space(name_leaf.prefix),
+                Markers.EMPTY, [], name_leaf.value, None, None,
+            )
+            leftmost = j.FieldAccess(
+                random_id(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                leftmost,
+                JLeftPadded(self._parse_space(dot.prefix), name_ident, Markers.EMPTY),
+                None,
+            )
+            i += 2
+        return leftmost
+
+    def _build_from_module(self, items) -> Optional[j.J]:
+        """Construct the module reference between ``from`` and ``import``.
+
+        Forms handled (matching the Py3 visitor's convention of folding
+        leading dots into the textual name):
+        * ``[name]``                  → :class:`j.FieldAccess` wrapping the name
+        * ``[dotted_name]``           → :class:`j.FieldAccess` chain
+        * ``[. . ... ]`` (pure dots)  → :class:`j.Identifier` whose value is the dots
+        * ``[. . pkg]`` (mixed)       → :class:`j.Identifier` whose value is ``..pkg``
+        """
+        if not items:
+            return None
+
+        dot_count = 0
+        idx = 0
+        while idx < len(items) and getattr(items[idx], 'value', None) == '.':
+            dot_count += 1
+            idx += 1
+
+        if dot_count == 0:
+            target = items[0]
+            # Single NAME → bare :class:`j.Identifier`; dotted → :class:`j.FieldAccess`.
+            # The printer renders the former cleanly while the latter chains dots.
+            if isinstance(target, parso_tree.PythonLeaf):
+                return j.Identifier(
+                    random_id(),
+                    self._parse_space(target.prefix),
+                    Markers.EMPTY, [], target.value, None, None,
+                )
+            return self._build_qualid(target)
+
+        first_dot = items[0]
+        prefix = self._parse_space(first_dot.prefix)
+        rest = items[idx:]
+        if not rest:
+            text = '.' * dot_count
+        else:
+            # Mixed dot+name forms (e.g. ``from .pkg.sub import X``). We
+            # collect the textual form to preserve round-trip without
+            # inventing a new LST shape for "relative dotted name".
+            parts = []
+            for c in rest:
+                if isinstance(c, parso_tree.PythonLeaf):
+                    parts.append(c.value)
+                elif getattr(c, 'type', None) == 'dotted_name':
+                    parts.append(c.get_code(include_prefix=False))
+                else:
+                    parts.append(c.get_code(include_prefix=False))
+            text = '.' * dot_count + ''.join(parts)
+        return j.Identifier(
+            random_id(), prefix, Markers.EMPTY, [], text, None, None,
+        )
 
     def _convert_suite(self, node) -> j.Block:
         """Convert a suite (block of statements)."""
@@ -497,7 +1944,17 @@ class Py2ParserVisitor:
         )
 
     def _convert_atom(self, node) -> Optional[j.J]:
-        """Convert an atom (basic expression)."""
+        """Convert an atom (basic expression).
+
+        Handles:
+        * Single-child passthrough (NAME/NUMBER/STRING).
+        * Backtick repr ``` `expr` ``` (Python 2 only) — already covered.
+        * Parenthesized single expression ``(expr)`` → :class:`j.Parentheses`.
+
+        Not yet handled (TODO): tuples ``(a, b)``, list ``[...]``, dict ``{k:v}``,
+        set ``{...}``, and generator expressions. These fall through to the
+        generic ``<atom>`` placeholder.
+        """
         if len(node.children) == 1:
             return self._convert_node(node.children[0])
 
@@ -520,78 +1977,908 @@ class Py2ParserVisitor:
                 JavaType.Primitive.String
             )
 
-        # TODO: Handle parenthesized expressions, list/dict literals, etc.
+        # Paren / bracket / brace forms.
+        first_v = getattr(node.children[0], 'value', None)
+        last_v = getattr(node.children[-1], 'value', None)
+        if first_v == '[' and last_v == ']':
+            return self._convert_list_atom(node)
+        if first_v == '{' and last_v == '}':
+            return self._convert_braced_atom(node)
+        if first_v == '(' and last_v == ')':
+            return self._convert_paren_atom(node)
+
         return self._convert_generic(node)
+
+    def _convert_paren_atom(self, node) -> Optional[j.J]:
+        """Convert ``(...)`` atom: parenthesized expression, empty tuple, or tuple literal."""
+        open_paren = node.children[0]
+        close_paren = node.children[-1]
+        leading = self._parse_space(open_paren.prefix)
+        before_close = self._parse_space(close_paren.prefix)
+
+        if len(node.children) == 2:
+            # Empty tuple `()`.
+            empty = j.Empty(random_id(), before_close, Markers.EMPTY)
+            return py.CollectionLiteral(
+                random_id(), leading, Markers.EMPTY,
+                py.CollectionLiteral.Kind.TUPLE,
+                JContainer(Space.EMPTY, [JRightPadded(empty, Space.EMPTY, Markers.EMPTY)], Markers.EMPTY),
+                None,
+            )
+
+        inner = node.children[1]
+        # Single non-tuple expression → Parentheses.
+        if getattr(inner, 'type', None) not in ('testlist_comp', 'testlist'):
+            inner_expr = self._convert_node(inner)
+            if inner_expr is None:
+                return None
+            return j.Parentheses(
+                random_id(), leading, Markers.EMPTY,
+                JRightPadded(inner_expr, before_close, Markers.EMPTY),
+            )
+
+        # `(expr for x in xs)` — generator expression.
+        if getattr(inner, 'type', None) == 'testlist_comp' and self._is_comprehension(inner.children):
+            return self._build_listcomp(inner, leading, before_close,
+                                        py.ComprehensionExpression.Kind.GENERATOR)
+        # Tuple. testlist_comp here is the comma-separated, non-comprehension form.
+        items = self._pad_comma_list(inner.children, before_close)
+        if items is None:
+            return None
+        # `(x,)` (1-element tuple) is still a tuple; the trailing comma is
+        # preserved in the JRightPadded.after of the lone element.
+        return py.CollectionLiteral(
+            random_id(), leading, Markers.EMPTY,
+            py.CollectionLiteral.Kind.TUPLE,
+            JContainer(Space.EMPTY, items, Markers.EMPTY),
+            None,
+        )
+
+    def _convert_list_atom(self, node) -> Optional[j.J]:
+        """Convert ``[...]`` atom — list literal (comprehensions deferred)."""
+        open_b = node.children[0]
+        close_b = node.children[-1]
+        leading = self._parse_space(open_b.prefix)
+        before_close = self._parse_space(close_b.prefix)
+
+        if len(node.children) == 2:
+            empty = j.Empty(random_id(), before_close, Markers.EMPTY)
+            return py.CollectionLiteral(
+                random_id(), leading, Markers.EMPTY,
+                py.CollectionLiteral.Kind.LIST,
+                JContainer(Space.EMPTY, [JRightPadded(empty, Space.EMPTY, Markers.EMPTY)], Markers.EMPTY),
+                None,
+            )
+        inner = node.children[1]
+        if getattr(inner, 'type', None) == 'testlist_comp' and self._is_comprehension(inner.children):
+            return self._build_listcomp(inner, leading, before_close,
+                                        py.ComprehensionExpression.Kind.LIST)
+        item_nodes = inner.children if getattr(inner, 'type', None) == 'testlist_comp' else [inner]
+        items = self._pad_comma_list(item_nodes, before_close)
+        if items is None:
+            return None
+        return py.CollectionLiteral(
+            random_id(), leading, Markers.EMPTY,
+            py.CollectionLiteral.Kind.LIST,
+            JContainer(Space.EMPTY, items, Markers.EMPTY),
+            None,
+        )
+
+    def _build_listcomp(self, testlist_comp, leading, suffix, kind) -> Optional[j.J]:
+        """Build a list/set/generator comprehension from a ``testlist_comp``."""
+        children = testlist_comp.children
+        if len(children) < 2:
+            return None
+        result_expr = self._convert_node(children[0])
+        if result_expr is None:
+            return None
+        return self._build_comprehension(kind, result_expr, children[1],
+                                         leading, suffix)
+
+    def _convert_braced_atom(self, node) -> Optional[j.J]:
+        """Convert ``{...}`` atom — dict, set, or empty dict.
+
+        Empty ``{}`` is a dict literal (Python convention).
+        ``{1: 2}`` → dict (look for ``:`` separator).
+        ``{1, 2}`` → set.
+        """
+        open_b = node.children[0]
+        close_b = node.children[-1]
+        leading = self._parse_space(open_b.prefix)
+        before_close = self._parse_space(close_b.prefix)
+
+        if len(node.children) == 2:
+            empty = j.Empty(random_id(), before_close, Markers.EMPTY)
+            return py.DictLiteral(
+                random_id(), leading, Markers.EMPTY,
+                JContainer(Space.EMPTY, [JRightPadded(empty, Space.EMPTY, Markers.EMPTY)], Markers.EMPTY),
+                None,
+            )
+
+        inner = node.children[1]
+        if getattr(inner, 'type', None) != 'dictorsetmaker':
+            # Single element set like `{x}`.
+            elem = self._convert_node(inner)
+            if elem is None:
+                return None
+            return py.CollectionLiteral(
+                random_id(), leading, Markers.EMPTY,
+                py.CollectionLiteral.Kind.SET,
+                JContainer(Space.EMPTY, [JRightPadded(elem, before_close, Markers.EMPTY)], Markers.EMPTY),
+                None,
+            )
+
+        kids = inner.children
+        if self._is_comprehension(kids):
+            # Either ``{x for x in xs}`` (set comp) or ``{k: v for k, v in d}`` (dict comp).
+            has_colon = any(getattr(c, 'value', None) == ':' for c in kids)
+            if has_colon:
+                # Find the colon, the value is between colon and the comp_for.
+                colon_idx = next(i for i, c in enumerate(kids)
+                                 if getattr(c, 'value', None) == ':')
+                key = self._convert_node(kids[0])
+                value = self._convert_node(kids[colon_idx + 1])
+                comp_for_idx = next(i for i, c in enumerate(kids)
+                                    if getattr(c, 'type', None) in ('comp_for', 'sync_comp_for'))
+                if key is None or value is None:
+                    return None
+                key_padded = JRightPadded(key, self._parse_space(kids[colon_idx].prefix), Markers.EMPTY)
+                result = py.KeyValue(random_id(), Space.EMPTY, Markers.EMPTY,
+                                     key_padded, value, None)
+                return self._build_comprehension(
+                    py.ComprehensionExpression.Kind.DICT,
+                    result, kids[comp_for_idx], leading, before_close,
+                )
+            # set comprehension
+            result_expr = self._convert_node(kids[0])
+            if result_expr is None:
+                return None
+            return self._build_comprehension(
+                py.ComprehensionExpression.Kind.SET,
+                result_expr, kids[1], leading, before_close,
+            )
+        # Decide dict vs. set by presence of a top-level ':'.
+        is_dict = any(getattr(c, 'value', None) == ':' for c in kids)
+        if is_dict:
+            entries = self._build_dict_entries(kids, before_close)
+            if entries is None:
+                return None
+            return py.DictLiteral(
+                random_id(), leading, Markers.EMPTY,
+                JContainer(Space.EMPTY, entries, Markers.EMPTY),
+                None,
+            )
+        items = self._pad_comma_list(kids, before_close)
+        if items is None:
+            return None
+        return py.CollectionLiteral(
+            random_id(), leading, Markers.EMPTY,
+            py.CollectionLiteral.Kind.SET,
+            JContainer(Space.EMPTY, items, Markers.EMPTY),
+            None,
+        )
+
+    @staticmethod
+    def _is_comprehension(children) -> bool:
+        """True if a ``testlist_comp`` / ``dictorsetmaker`` child list
+        contains a ``(sync_)comp_for`` clause — i.e. it's a comprehension or
+        generator rather than a plain literal."""
+        return any(getattr(c, 'type', None) in ('comp_for', 'sync_comp_for') for c in children)
+
+    def _build_comprehension(self, kind, result, clause_children, leading, suffix) -> Optional[j.J]:
+        """Build a :class:`py.ComprehensionExpression`.
+
+        ``result`` is the LST node for the value expression that precedes
+        the ``for`` clauses (or a KeyValue for dict comps).
+        ``clause_children`` is the parso ``sync_comp_for`` node's children.
+        """
+        clauses = self._parse_comp_clauses(clause_children)
+        if clauses is None:
+            return None
+        return py.ComprehensionExpression(
+            random_id(), leading, Markers.EMPTY,
+            kind, result, clauses, suffix, None,
+        )
+
+    def _parse_comp_clauses(self, node) -> Optional[list]:
+        """Walk a (chain of) ``(sync_)comp_for`` / ``comp_if`` nodes into
+        :class:`py.ComprehensionExpression.Clause` entries.
+
+        Grammar:
+            sync_comp_for: 'for' exprlist 'in' or_test [comp_iter]
+            comp_iter:     comp_for | comp_if
+            comp_if:       'if' test_nocond [comp_iter]
+        Each ``for`` boundary begins a new Clause; ``if`` clauses are
+        attached as conditions on the most recent Clause.
+        """
+        clauses: list = []
+        conditions: list = []
+        current = node
+
+        def stash_clause(for_kw, target_node, in_kw, iterable_node):
+            if getattr(target_node, 'type', None) == 'exprlist':
+                tuple_items = self._pad_comma_list(target_node.children, Space.EMPTY)
+                if tuple_items is None:
+                    return False
+                target = py.CollectionLiteral(
+                    random_id(), Space.EMPTY, Markers.EMPTY,
+                    py.CollectionLiteral.Kind.TUPLE,
+                    JContainer(Space.EMPTY, tuple_items, Markers.EMPTY),
+                    None,
+                )
+            else:
+                target = self._convert_node(target_node)
+            iterable = self._convert_node(iterable_node)
+            if target is None or iterable is None:
+                return False
+            clause = py.ComprehensionExpression.Clause(
+                random_id(),
+                self._parse_space(for_kw.prefix),
+                Markers.EMPTY,
+                None,  # async
+                target,
+                JLeftPadded(self._parse_space(in_kw.prefix), iterable, Markers.EMPTY),
+                conditions or None,
+            )
+            clauses.append(clause)
+            return True
+
+        while current is not None:
+            ctype = getattr(current, 'type', None)
+            if ctype in ('comp_for', 'sync_comp_for'):
+                children = current.children
+                if len(children) < 4:
+                    return None
+                for_kw = children[0]
+                target_node = children[1]
+                in_kw = children[2]
+                iter_node = children[3]
+                conditions = []
+                if not stash_clause(for_kw, target_node, in_kw, iter_node):
+                    return None
+                current = children[4] if len(children) > 4 else None
+            elif ctype == 'comp_if':
+                children = current.children
+                if len(children) < 2:
+                    return None
+                if_kw = children[0]
+                cond_node = children[1]
+                cond_expr = self._convert_node(cond_node)
+                if cond_expr is None:
+                    return None
+                condition = py.ComprehensionExpression.Condition(
+                    random_id(),
+                    self._parse_space(if_kw.prefix),
+                    Markers.EMPTY,
+                    cond_expr,
+                )
+                # Attach to most-recent clause
+                last = clauses[-1]
+                new_conds = list(last.conditions or []) + [condition]
+                clauses[-1] = py.ComprehensionExpression.Clause(
+                    random_id(), last.prefix, last.markers,
+                    None, last.iterator_variable,
+                    JLeftPadded(last.padding.iterated_list.before,
+                                last.padding.iterated_list.element,
+                                last.padding.iterated_list.markers),
+                    new_conds,
+                )
+                current = children[2] if len(children) > 2 else None
+            else:
+                # Unknown node — bail out so the caller falls back.
+                return None
+
+        return clauses
+
+    def _pad_comma_list(self, items, before_close) -> Optional[list]:
+        """Turn a ``[item, ',', item, ',', ...]`` flat parso list into
+        :class:`JRightPadded` entries.
+
+        A trailing comma — present in ``(1, 2,)``, ``[1, 2,]``, etc. — is
+        recorded via the :class:`TrailingComma` marker on the last element
+        with its ``suffix`` carrying the whitespace between the comma and
+        the closing delimiter, so the printer round-trips both the comma
+        and the whitespace exactly.
+        """
+        result = []
+        i = 0
+        while i < len(items):
+            child = items[i]
+            if getattr(child, 'value', None) == ',':
+                i += 1
+                continue
+            expr = self._convert_node(child)
+            if expr is None:
+                return None
+            if i + 1 < len(items) and getattr(items[i + 1], 'value', None) == ',':
+                comma = items[i + 1]
+                comma_prefix = self._parse_space(comma.prefix)
+                if i + 2 >= len(items):
+                    # Trailing comma at the very end of the list.
+                    result.append(JRightPadded(
+                        expr, comma_prefix,
+                        Markers.build(random_id(), [TrailingComma(random_id(), before_close)]),
+                    ))
+                else:
+                    result.append(JRightPadded(expr, comma_prefix, Markers.EMPTY))
+                i += 2
+            else:
+                result.append(JRightPadded(expr, before_close, Markers.EMPTY))
+                i += 1
+        return result
+
+    def _build_dict_entries(self, kids, before_close) -> Optional[list]:
+        """Walk a ``dictorsetmaker`` list for the dict case:
+        ``[key, ':', value, ',', key, ':', value, ...]`` (optional trailing comma).
+
+        Trailing commas are recorded via the :class:`TrailingComma` marker
+        on the last entry, with the suffix carrying the whitespace before
+        the closing ``}`` — mirroring the convention used by
+        :meth:`_pad_comma_list` so the printer round-trips both shapes
+        consistently.
+        """
+        entries = []
+        i = 0
+        while i < len(kids):
+            k = kids[i]
+            if getattr(k, 'value', None) == ',':
+                i += 1
+                continue
+            key = self._convert_node(k)
+            if key is None or i + 2 >= len(kids):
+                return None
+            colon = kids[i + 1]
+            if getattr(colon, 'value', None) != ':':
+                return None
+            value = self._convert_node(kids[i + 2])
+            if value is None:
+                return None
+            key_padded = JRightPadded(key, self._parse_space(colon.prefix), Markers.EMPTY)
+            entry = py.KeyValue(random_id(), Space.EMPTY, Markers.EMPTY,
+                                key_padded, value, None)
+            i += 3
+            if i < len(kids) and getattr(kids[i], 'value', None) == ',':
+                comma = kids[i]
+                comma_prefix = self._parse_space(comma.prefix)
+                i += 1
+                if i >= len(kids):
+                    entries.append(JRightPadded(
+                        entry, comma_prefix,
+                        Markers.build(random_id(), [TrailingComma(random_id(), before_close)]),
+                    ))
+                else:
+                    entries.append(JRightPadded(entry, comma_prefix, Markers.EMPTY))
+            else:
+                entries.append(JRightPadded(entry, before_close, Markers.EMPTY))
+        return entries
 
     def _convert_power(self, node) -> Optional[j.J]:
-        """Convert a power expression."""
+        """Convert a power expression.
+
+        Grammar:
+            power: atom trailer* ['**' factor]
+            trailer: '(' [arglist] ')' | '[' subscriptlist ']' | '.' NAME
+
+        Trailers are applied left-to-right to the atom. A trailing ``**``
+        wraps the result in a right-associative ``py.Binary(Power)``.
+        """
         if len(node.children) == 1:
             return self._convert_node(node.children[0])
-        # TODO: Handle ** operator, attribute access, function calls
-        return self._convert_generic(node)
+
+        children = node.children
+
+        # Detect trailing `'**' factor` — it's always the last two children.
+        pow_idx = -1
+        if len(children) >= 3 and getattr(children[-2], 'value', None) == '**':
+            pow_idx = len(children) - 2
+        trailer_end = pow_idx if pow_idx >= 0 else len(children)
+
+        # Start with the atom (which may carry leading whitespace as its prefix).
+        current = self._convert_node(children[0])
+        if current is None:
+            return self._convert_generic(node)
+
+        for i in range(1, trailer_end):
+            trailer = children[i]
+            applied = self._apply_trailer(current, trailer)
+            if applied is None:
+                return self._convert_generic(node)
+            current = applied
+
+        if pow_idx >= 0:
+            op_leaf = children[pow_idx]
+            rhs = self._convert_node(children[pow_idx + 1])
+            if rhs is None:
+                return self._convert_generic(node)
+            current = py.Binary(
+                random_id(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                current,
+                JLeftPadded(self._parse_space(op_leaf.prefix), py.Binary.Type.Power, Markers.EMPTY),
+                None,  # negation slot (unused)
+                rhs,
+                None,
+            )
+
+        return current
+
+    def _apply_trailer(self, base, trailer) -> Optional[j.J]:
+        """Apply one parso ``trailer`` node to ``base``.
+
+        Trailer shapes:
+            ``'.' NAME``                → :class:`j.FieldAccess`
+            ``'(' [arglist] ')'``       → :class:`j.MethodInvocation`
+            ``'[' subscriptlist ']'``   → :class:`j.ArrayAccess`
+        """
+        op_leaf = trailer.children[0]
+        op_value = getattr(op_leaf, 'value', None)
+
+        if op_value == '.':
+            # '.' NAME
+            name_leaf = trailer.children[1]
+            name_ident = self._convert_node(name_leaf)
+            if not isinstance(name_ident, j.Identifier):
+                return None
+            return j.FieldAccess(
+                random_id(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                base,
+                JLeftPadded(self._parse_space(op_leaf.prefix), name_ident, Markers.EMPTY),
+                None,  # type
+            )
+
+        if op_value == '(':
+            close_paren = trailer.children[-1]
+            inner = trailer.children[1:-1]
+            args = self._convert_call_args(inner, close_paren, self._parse_space(op_leaf.prefix))
+            if args is None:
+                return None
+            # Re-shape the base into MethodInvocation form. When the base is
+            # a FieldAccess we pull it apart so the method name and select are
+            # explicit on the invocation node.
+            if isinstance(base, j.FieldAccess):
+                select_after = base.padding.name.before
+                return j.MethodInvocation(
+                    random_id(),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    JRightPadded(base.target, select_after, Markers.EMPTY),
+                    None,
+                    base.name,
+                    args,
+                    None,
+                )
+            if isinstance(base, j.Identifier):
+                return j.MethodInvocation(
+                    random_id(),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    None,
+                    None,
+                    base,
+                    args,
+                    None,
+                )
+            # Call on an arbitrary expression result, e.g. ``f()()``.
+            return j.MethodInvocation(
+                random_id(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                JRightPadded(base, Space.EMPTY, Markers.EMPTY),
+                None,
+                j.Identifier(random_id(), Space.EMPTY, Markers.EMPTY, [], "", None, None),
+                args,
+                None,
+            )
+
+        if op_value == '[':
+            close_bracket = trailer.children[-1]
+            inner = trailer.children[1] if len(trailer.children) == 3 else None
+            if inner is None:
+                return None
+            if getattr(inner, 'type', None) == 'subscript':
+                index = self._convert_slice(inner)
+            elif getattr(inner, 'type', None) == 'subscriptlist':
+                # Multi-element subscript ``a[i, j]`` — render as a tuple.
+                items = self._pad_comma_list(inner.children, Space.EMPTY)
+                if items is None:
+                    return None
+                index = py.CollectionLiteral(
+                    random_id(), Space.EMPTY, Markers.EMPTY,
+                    py.CollectionLiteral.Kind.TUPLE,
+                    JContainer(Space.EMPTY, items, Markers.EMPTY),
+                    None,
+                )
+            else:
+                index = self._convert_node(inner)
+            if index is None:
+                return None
+            return j.ArrayAccess(
+                random_id(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                base,
+                j.ArrayDimension(
+                    random_id(),
+                    self._parse_space(op_leaf.prefix),
+                    Markers.EMPTY,
+                    JRightPadded(index, self._parse_space(close_bracket.prefix), Markers.EMPTY),
+                ),
+                None,
+            )
+
+        return None
+
+    def _convert_slice(self, subscript_node) -> Optional[j.J]:
+        """Convert a parso ``subscript`` (start[:stop[:step]]) to :class:`py.Slice`.
+
+        Each component is optional; absent components produce ``None`` slots.
+        ``a[::2]`` parses as ``[':', sliceop[':', 2]]`` — no start and no stop.
+        """
+        children = subscript_node.children
+        start = None
+        stop = None
+        step = None
+        idx = 0
+        # Parse optional start (any non-':' child before the first ':').
+        if idx < len(children) and getattr(children[idx], 'value', None) != ':':
+            expr = self._convert_node(children[idx])
+            if expr is None:
+                return None
+            start = JRightPadded(expr, Space.EMPTY, Markers.EMPTY)
+            idx += 1
+        # First ':'.
+        if idx >= len(children) or getattr(children[idx], 'value', None) != ':':
+            return None
+        idx += 1
+        # Optional stop.
+        if idx < len(children) and getattr(children[idx], 'value', None) != ':' \
+                and getattr(children[idx], 'type', None) != 'sliceop':
+            expr = self._convert_node(children[idx])
+            if expr is None:
+                return None
+            stop = JRightPadded(expr, Space.EMPTY, Markers.EMPTY)
+            idx += 1
+        # Optional sliceop = [':' [expr]].
+        if idx < len(children) and getattr(children[idx], 'type', None) == 'sliceop':
+            sop = children[idx]
+            if len(sop.children) >= 2:
+                expr = self._convert_node(sop.children[1])
+                if expr is None:
+                    return None
+                step = JRightPadded(expr, Space.EMPTY, Markers.EMPTY)
+        return py.Slice(random_id(), Space.EMPTY, Markers.EMPTY, start, stop, step)
+
+    def _convert_call_args(self, inner, close_paren, leading_space) -> Optional[JContainer]:
+        """Build the JContainer holding a function call's arguments.
+
+        ``inner`` is the list of parso children between ``(`` and ``)``;
+        ``close_paren`` is the ``)`` leaf (used to capture the space before it);
+        ``leading_space`` is the space before the ``(``.
+
+        Argument forms currently handled: positional expressions. Not yet
+        handled: keyword arguments (``f(a=1)``), star/double-star unpacking
+        (``f(*xs, **kw)``), generator-expression call argument (``f(x for x in xs)``).
+        """
+        before_close = self._parse_space(close_paren.prefix)
+
+        # Unwrap arglist if present.
+        if len(inner) == 1 and getattr(inner[0], 'type', None) == 'arglist':
+            items = list(inner[0].children)
+        else:
+            items = list(inner)
+
+        if not items:
+            empty = j.Empty(random_id(), before_close, Markers.EMPTY)
+            return JContainer(
+                leading_space,
+                [JRightPadded(empty, Space.EMPTY, Markers.EMPTY)],
+                Markers.EMPTY,
+            )
+
+        args = []
+        i = 0
+        while i < len(items):
+            child = items[i]
+            cval = getattr(child, 'value', None)
+            if cval == ',':
+                # Stray comma — skip (e.g. trailing comma after last arg).
+                i += 1
+                continue
+            if cval == '*' and i + 1 < len(items):
+                # ``*xs`` unpack
+                star_leaf = child
+                inner = self._convert_node(items[i + 1])
+                if inner is None:
+                    return None
+                arg = py.Star(
+                    random_id(),
+                    self._parse_space(star_leaf.prefix),
+                    Markers.EMPTY,
+                    py.Star.Kind.LIST,
+                    inner,
+                    None,
+                )
+                i += 2
+            elif cval == '**' and i + 1 < len(items):
+                # ``**kw`` unpack
+                star_leaf = child
+                inner = self._convert_node(items[i + 1])
+                if inner is None:
+                    return None
+                arg = py.Star(
+                    random_id(),
+                    self._parse_space(star_leaf.prefix),
+                    Markers.EMPTY,
+                    py.Star.Kind.DICT,
+                    inner,
+                    None,
+                )
+                i += 2
+            elif getattr(child, 'type', None) == 'argument':
+                arg = self._convert_argument(child)
+                if arg is None:
+                    return None
+                i += 1
+            else:
+                arg = self._convert_node(child)
+                if arg is None:
+                    return None
+                i += 1
+            if i < len(items) and getattr(items[i], 'value', None) == ',':
+                comma = items[i]
+                comma_prefix = self._parse_space(comma.prefix)
+                i += 1
+                # A comma that lands at the very end of the items list is a
+                # trailing comma (``foo(a, b,)``). We record it via the
+                # :class:`TrailingComma` marker whose suffix carries the
+                # whitespace between the comma and ``)`` so round-trip is
+                # byte-exact.
+                if i >= len(items):
+                    args.append(JRightPadded(
+                        arg, comma_prefix,
+                        Markers.build(random_id(), [TrailingComma(random_id(), before_close)]),
+                    ))
+                else:
+                    args.append(JRightPadded(arg, comma_prefix, Markers.EMPTY))
+            else:
+                args.append(JRightPadded(arg, before_close, Markers.EMPTY))
+
+        return JContainer(leading_space, args, Markers.EMPTY)
+
+    def _convert_argument(self, arg_node) -> Optional[j.J]:
+        """Convert a parso ``argument`` node.
+
+        Shapes:
+        * ``NAME '=' test``           → :class:`py.NamedArgument` (keyword arg)
+        * ``test (sync_)comp_for``    → generator expression as call arg
+        """
+        children = arg_node.children
+        if len(children) >= 3 and getattr(children[1], 'value', None) == '=':
+            name_leaf = children[0]
+            if not hasattr(name_leaf, 'value'):
+                return None
+            name_ident = j.Identifier(
+                random_id(),
+                self._parse_space(name_leaf.prefix),
+                Markers.EMPTY, [], name_leaf.value, None, None,
+            )
+            value = self._convert_node(children[2])
+            if value is None:
+                return None
+            return py.NamedArgument(
+                random_id(), Space.EMPTY, Markers.EMPTY,
+                name_ident,
+                JLeftPadded(self._parse_space(children[1].prefix), value, Markers.EMPTY),
+                None,
+            )
+        # Generator-expression argument: ``test (sync_)comp_for ...``.
+        if (len(children) >= 2 and
+                getattr(children[1], 'type', None) in ('comp_for', 'sync_comp_for')):
+            result_expr = self._convert_node(children[0])
+            if result_expr is None:
+                return None
+            return self._build_comprehension(
+                py.ComprehensionExpression.Kind.GENERATOR,
+                result_expr, children[1], Space.EMPTY, Space.EMPTY,
+            )
+        return None
 
     def _convert_testlist(self, node) -> Optional[j.J]:
-        """Convert a testlist (comma-separated expressions)."""
+        """Convert a ``testlist`` (comma-separated expressions).
+
+        A multi-child testlist is a tuple (e.g. ``return a, b`` returns a
+        tuple, ``a, b = 1, 2`` unpacks a tuple). The result is a
+        :class:`py.CollectionLiteral` of kind ``TUPLE`` whose elements
+        container carries the ``OmitParentheses`` marker — testlists in
+        source never wear parentheses; tuple atoms ``(a, b)`` go through
+        :meth:`_convert_paren_atom` and *do* keep them.
+        """
         if len(node.children) == 1:
             return self._convert_node(node.children[0])
-        # TODO: Handle tuples
-        return self._convert_generic(node)
+        items = self._pad_comma_list(node.children, Space.EMPTY)
+        if items is None:
+            return self._convert_generic(node)
+        return py.CollectionLiteral(
+            random_id(), Space.EMPTY, Markers.EMPTY,
+            py.CollectionLiteral.Kind.TUPLE,
+            JContainer(Space.EMPTY, items,
+                       Markers.build(random_id(), [OmitParentheses(random_id())])),
+            None,
+        )
 
     def _convert_test(self, node) -> Optional[j.J]:
-        """Convert a test expression."""
+        """Convert a test expression.
+
+        Handles the ternary form ``a if b else c`` (parso shape
+        ``[a, 'if', b, 'else', c]``) into :class:`j.Ternary`. Note that
+        :class:`j.Ternary` stores its condition first, then the
+        true / false parts — but Python's source order is
+        true-part / condition / false-part, so the printer reverses again.
+        """
         if len(node.children) == 1:
             return self._convert_node(node.children[0])
-        # TODO: Handle ternary expressions
+        if (len(node.children) == 5
+                and getattr(node.children[1], 'value', None) == 'if'
+                and getattr(node.children[3], 'value', None) == 'else'):
+            true_node, if_kw, cond_node, else_kw, false_node = node.children
+            true_part = self._convert_node(true_node)
+            condition = self._convert_node(cond_node)
+            false_part = self._convert_node(false_node)
+            if true_part is None or condition is None or false_part is None:
+                return self._convert_generic(node)
+            return j.Ternary(
+                random_id(), Space.EMPTY, Markers.EMPTY,
+                condition,
+                JLeftPadded(self._parse_space(if_kw.prefix), true_part, Markers.EMPTY),
+                JLeftPadded(self._parse_space(else_kw.prefix), false_part, Markers.EMPTY),
+                None,
+            )
         return self._convert_generic(node)
+
+    def _convert_strings(self, node) -> Optional[j.J]:
+        """Convert implicit string concatenation (``"a" "b"``).
+
+        parso wraps adjacent string literals in a ``strings`` node. We
+        emit a single :class:`j.Literal` whose ``value_source`` preserves
+        the inter-piece whitespace verbatim so the printer reproduces the
+        original layout.
+        """
+        pieces = [c for c in node.children if isinstance(c, parso_tree.PythonLeaf)
+                  and c.type == 'string']
+        if not pieces:
+            return None
+        outer_prefix = self._parse_space(pieces[0].prefix)
+        value_source = pieces[0].value + ''.join(p.prefix + p.value for p in pieces[1:])
+        markers = Markers.build(random_id(), [Quoted(random_id(), self._detect_quote_style(pieces[0].value))])
+        return j.Literal(
+            random_id(),
+            outer_prefix,
+            markers,
+            value_source,
+            value_source,
+            None,
+            JavaType.Primitive.String,
+        )
 
     def _convert_or_test(self, node) -> Optional[j.J]:
-        """Convert an or_test expression."""
+        """Convert an or_test expression (``a or b or c``)."""
         if len(node.children) == 1:
             return self._convert_node(node.children[0])
-        # TODO: Handle 'or' operator
-        return self._convert_generic(node)
+        return self._fold_binary(node.children) or self._convert_generic(node)
 
     def _convert_and_test(self, node) -> Optional[j.J]:
-        """Convert an and_test expression."""
+        """Convert an and_test expression (``a and b and c``)."""
         if len(node.children) == 1:
             return self._convert_node(node.children[0])
-        # TODO: Handle 'and' operator
-        return self._convert_generic(node)
+        return self._fold_binary(node.children) or self._convert_generic(node)
 
     def _convert_not_test(self, node) -> Optional[j.J]:
-        """Convert a not_test expression."""
+        """Convert a not_test expression (``not x``)."""
         if len(node.children) == 1:
             return self._convert_node(node.children[0])
-        # TODO: Handle 'not' operator
-        return self._convert_generic(node)
+        # not_test: 'not' not_test
+        return self._convert_unary(node.children[0], node.children[1])
 
     def _convert_comparison(self, node) -> Optional[j.J]:
-        """Convert a comparison expression."""
+        """Convert a comparison expression (``a < b <= c``).
+
+        Two-token Py2 operators (``not in``, ``is not``) are not yet handled;
+        callers fall back to the generic placeholder for those.
+        """
         if len(node.children) == 1:
             return self._convert_node(node.children[0])
-        # TODO: Handle comparison operators
-        return self._convert_generic(node)
+        return self._fold_binary(node.children) or self._convert_generic(node)
 
     def _convert_arith_expr(self, node) -> Optional[j.J]:
-        """Convert an arithmetic expression."""
+        """Convert an arithmetic expression (``a + b - c``)."""
         if len(node.children) == 1:
             return self._convert_node(node.children[0])
-        # TODO: Handle + and - operators
-        return self._convert_generic(node)
+        return self._fold_binary(node.children) or self._convert_generic(node)
 
     def _convert_term(self, node) -> Optional[j.J]:
-        """Convert a term expression."""
+        """Convert a term expression (``a * b / c % d``)."""
         if len(node.children) == 1:
             return self._convert_node(node.children[0])
-        # TODO: Handle *, /, //, % operators
-        return self._convert_generic(node)
+        return self._fold_binary(node.children) or self._convert_generic(node)
 
     def _convert_factor(self, node) -> Optional[j.J]:
-        """Convert a factor expression."""
+        """Convert a factor expression (``-x``, ``+x``, ``~x``)."""
         if len(node.children) == 1:
             return self._convert_node(node.children[0])
-        # TODO: Handle unary +, -, ~ operators
-        return self._convert_generic(node)
+        # factor: ('+'|'-'|'~') factor
+        return self._convert_unary(node.children[0], node.children[1])
+
+    def _convert_lambdef(self, node) -> Optional[j.J]:
+        """Convert ``lambda [params]: expr``.
+
+        Grammar:
+            lambdef: 'lambda' [varargslist] ':' test
+        Parameter shapes mirror funcdef's ``param`` form (positional,
+        default, ``*args``, ``**kw``).
+        """
+        children = list(node.children)
+        if len(children) < 3:
+            return self._convert_generic(node)
+        lambda_kw = children[0]
+        prefix = self._parse_space(lambda_kw.prefix)
+
+        colon_idx = next((i for i, c in enumerate(children)
+                          if getattr(c, 'value', None) == ':'), -1)
+        if colon_idx < 1:
+            return self._convert_generic(node)
+        colon = children[colon_idx]
+        body_node = children[colon_idx + 1] if colon_idx + 1 < len(children) else None
+        if body_node is None:
+            return self._convert_generic(node)
+
+        param_nodes = children[1:colon_idx]
+        params_padded = []
+        if not param_nodes:
+            empty = j.Empty(random_id(), Space.EMPTY, Markers.EMPTY)
+            params_padded = [JRightPadded(empty, Space.EMPTY, Markers.EMPTY)]
+        else:
+            for i, p in enumerate(param_nodes):
+                if getattr(p, 'value', None) == ',':
+                    continue
+                if getattr(p, 'type', None) == 'param':
+                    converted = self._convert_param(p)
+                    after = self._extract_param_trailing_space(p)
+                else:
+                    # Lone NAME leaf (parso sometimes emits this form in
+                    # old_lambdef contexts).
+                    if not hasattr(p, 'value'):
+                        return self._convert_generic(node)
+                    ident = j.Identifier(random_id(),
+                                         self._parse_space(p.prefix),
+                                         Markers.EMPTY, [], p.value, None, None)
+                    named = j.VariableDeclarations.NamedVariable(
+                        random_id(), Space.EMPTY, Markers.EMPTY, ident, [], None, None,
+                    )
+                    converted = j.VariableDeclarations(
+                        random_id(), Space.EMPTY, Markers.EMPTY,
+                        [], [], None, None, [],
+                        [JRightPadded(named, Space.EMPTY, Markers.EMPTY)],
+                    )
+                    after = Space.EMPTY
+                if converted is None:
+                    return self._convert_generic(node)
+                params_padded.append(JRightPadded(converted, after, Markers.EMPTY))
+
+        body = self._convert_node(body_node)
+        if body is None:
+            return self._convert_generic(node)
+
+        return j.Lambda(
+            random_id(), prefix, Markers.EMPTY,
+            j.Lambda.Parameters(random_id(), Space.EMPTY, Markers.EMPTY,
+                                False, params_padded),
+            self._parse_space(colon.prefix),  # arrow Space — for lambda it's the space before `:`
+            body,
+            None,  # type
+        )
 
     def _convert_generic(self, node) -> Optional[j.J]:
         """Generic conversion for unhandled node types.
@@ -654,6 +2941,180 @@ class Py2ParserVisitor:
             return JavaType.Primitive.Long
         else:
             return JavaType.Primitive.Int
+
+    # --- Expression folding helpers ---
+
+    # parso augmented-assignment operator text -> j.AssignmentOperation.Type
+    @staticmethod
+    def _aug_assign_map():
+        return {
+            '+=':  j.AssignmentOperation.Type.Addition,
+            '-=':  j.AssignmentOperation.Type.Subtraction,
+            '*=':  j.AssignmentOperation.Type.Multiplication,
+            '/=':  j.AssignmentOperation.Type.Division,
+            '%=':  j.AssignmentOperation.Type.Modulo,
+            '&=':  j.AssignmentOperation.Type.BitAnd,
+            '|=':  j.AssignmentOperation.Type.BitOr,
+            '^=':  j.AssignmentOperation.Type.BitXor,
+            '<<=': j.AssignmentOperation.Type.LeftShift,
+            '>>=': j.AssignmentOperation.Type.RightShift,
+            '**=': j.AssignmentOperation.Type.Exponentiation,
+            '//=': j.AssignmentOperation.Type.FloorDivision,
+            '@=':  j.AssignmentOperation.Type.MatrixMultiplication,
+        }
+
+    # parso operator text -> (Binary class, Type enum value).
+    # `j.Binary` is used when the operator maps directly to Java semantics;
+    # `py.Binary` is used for Python-specific operators (FloorDivision, Power,
+    # In/Is, MatrixMultiplication) that the printer renders differently.
+    @staticmethod
+    def _bin_op_map():
+        return {
+            '+':   (j.Binary, j.Binary.Type.Addition),
+            '-':   (j.Binary, j.Binary.Type.Subtraction),
+            '*':   (j.Binary, j.Binary.Type.Multiplication),
+            '/':   (j.Binary, j.Binary.Type.Division),
+            '%':   (j.Binary, j.Binary.Type.Modulo),
+            '|':   (j.Binary, j.Binary.Type.BitOr),
+            '&':   (j.Binary, j.Binary.Type.BitAnd),
+            '^':   (j.Binary, j.Binary.Type.BitXor),
+            '<<':  (j.Binary, j.Binary.Type.LeftShift),
+            '>>':  (j.Binary, j.Binary.Type.RightShift),
+            '<':   (j.Binary, j.Binary.Type.LessThan),
+            '<=':  (j.Binary, j.Binary.Type.LessThanOrEqual),
+            '>':   (j.Binary, j.Binary.Type.GreaterThan),
+            '>=':  (j.Binary, j.Binary.Type.GreaterThanOrEqual),
+            '==':  (j.Binary, j.Binary.Type.Equal),
+            '!=':  (j.Binary, j.Binary.Type.NotEqual),
+            '<>':  (j.Binary, j.Binary.Type.NotEqual),  # Py2 spelling; tagged via marker
+            'and': (j.Binary, j.Binary.Type.And),
+            'or':  (j.Binary, j.Binary.Type.Or),
+            '//':  (py.Binary, py.Binary.Type.FloorDivision),
+            '**':  (py.Binary, py.Binary.Type.Power),
+            '@':   (py.Binary, py.Binary.Type.MatrixMultiplication),
+            'in':  (py.Binary, py.Binary.Type.In),
+            'is':  (py.Binary, py.Binary.Type.Is),
+            # TODO: '<>' (Py2 not-equal) requires a LegacyNotEqual marker + printer support.
+            # TODO: 'not in' / 'is not' are two-token operators; need lookahead in the fold.
+        }
+
+    # parso unary-operator text -> j.Unary.Type
+    @staticmethod
+    def _unary_op_map():
+        return {
+            '+':   j.Unary.Type.Positive,
+            '-':   j.Unary.Type.Negative,
+            '~':   j.Unary.Type.Complement,
+            'not': j.Unary.Type.Not,
+        }
+
+    def _fold_binary(self, children) -> Optional[j.J]:
+        """Fold parso's flat ``[lhs, op, rhs, op, rhs, ...]`` children into a
+        left-associative ``j.Binary`` / ``py.Binary`` chain.
+
+        Operators may be:
+        * a single token (``+``, ``and``, ``==``, etc.)
+        * a parso ``comp_op`` node carrying a two-token form
+          (``not in``, ``is not``) — handled via the ``py.Binary`` negation
+          slot.
+
+        Returns ``None`` if any operator is unrecognized; the caller falls
+        back to a generic placeholder rather than dropping operator info.
+        """
+        bin_map = self._bin_op_map()
+        left = self._convert_node(children[0])
+        if left is None:
+            return None
+        i = 1
+        while i + 1 < len(children):
+            op_leaf = children[i]
+            rhs_node = children[i + 1]
+            # Two-token operator wrapped in a `comp_op` node.
+            if getattr(op_leaf, 'type', None) == 'comp_op':
+                op_kids = op_leaf.children
+                if len(op_kids) == 2:
+                    first = op_kids[0].value
+                    second = op_kids[1].value
+                    if first == 'not' and second == 'in':
+                        op_type = py.Binary.Type.NotIn
+                    elif first == 'is' and second == 'not':
+                        op_type = py.Binary.Type.IsNot
+                    else:
+                        return None
+                    op_padded = JLeftPadded(
+                        self._parse_space(op_kids[0].prefix),
+                        op_type,
+                        Markers.EMPTY,
+                    )
+                    negation = self._parse_space(op_kids[1].prefix)
+                    rhs = self._convert_node(rhs_node)
+                    if rhs is None:
+                        return None
+                    left = py.Binary(
+                        random_id(), Space.EMPTY, Markers.EMPTY,
+                        left, op_padded, negation, rhs, None,
+                    )
+                    i += 2
+                    continue
+                return None
+
+            op_text = getattr(op_leaf, 'value', None)
+            mapping = bin_map.get(op_text)
+            if mapping is None:
+                return None
+            cls, op_type = mapping
+            op_padded = JLeftPadded(
+                self._parse_space(op_leaf.prefix),
+                op_type,
+                Markers.EMPTY,
+            )
+            rhs = self._convert_node(rhs_node)
+            if rhs is None:
+                return None
+            node_markers = Markers.EMPTY
+            if op_text == '<>':
+                node_markers = Markers.build(random_id(), [LegacyNotEqual(random_id())])
+            if cls is py.Binary:
+                left = py.Binary(
+                    random_id(),
+                    Space.EMPTY,
+                    node_markers,
+                    left,
+                    op_padded,
+                    None,  # negation slot for `not in` / `is not` (unused here)
+                    rhs,
+                    None,  # type — left blank; type attribution happens later
+                )
+            else:
+                left = j.Binary(
+                    random_id(),
+                    Space.EMPTY,
+                    node_markers,
+                    left,
+                    op_padded,
+                    rhs,
+                    None,
+                )
+            i += 2
+        return left
+
+    def _convert_unary(self, op_leaf, operand_node) -> Optional[j.J]:
+        """Build a ``j.Unary`` from a ``[op_leaf, operand]`` parso pair."""
+        op_text = getattr(op_leaf, 'value', None)
+        op_type = self._unary_op_map().get(op_text)
+        if op_type is None:
+            return None
+        operand = self._convert_node(operand_node)
+        if operand is None:
+            return None
+        return j.Unary(
+            random_id(),
+            self._parse_space(op_leaf.prefix),
+            Markers.EMPTY,
+            JLeftPadded(Space.EMPTY, op_type, Markers.EMPTY),
+            operand,
+            None,
+        )
 
     # --- Placeholder methods for complex constructs ---
 

--- a/rewrite-python/rewrite/src/rewrite/python/_py2_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_py2_parser_visitor.py
@@ -14,7 +14,7 @@ Key differences from the Python 3 ParserVisitor:
 """
 
 from pathlib import Path
-from typing import Optional, List
+from typing import Optional, List, Tuple
 from uuid import UUID
 
 import parso
@@ -22,13 +22,14 @@ from parso.python import tree as parso_tree
 
 from rewrite import random_id, Markers
 from rewrite.java import Space, JRightPadded, JLeftPadded, JContainer, JavaType
+from rewrite.java.support_types import TextComment
 from rewrite.java import tree as j
 from rewrite.python import tree as py
 from rewrite.python.markers import (
     PrintSyntax, ExecSyntax, Quoted, KeywordArguments,
     TupleExceptClause, LegacyNotEqual, RaiseTuple,
 )
-from rewrite.java.markers import OmitParentheses, TrailingComma
+from rewrite.java.markers import OmitParentheses, Semicolon, TrailingComma
 
 
 class Py2ParserVisitor:
@@ -76,7 +77,13 @@ class Py2ParserVisitor:
             A Py.CompilationUnit representing the parsed source code.
         """
         # Convert parso tree to LST statements
-        statements = self._convert_module(self._tree)
+        statements, end_ws = self._convert_module(self._tree)
+
+        # Combine block end-whitespace (from trailing ``;`` lines) with
+        # the file's terminal whitespace recovered from the endmarker.
+        trailing = self._trailing_whitespace()
+        if end_ws is not Space.EMPTY:
+            trailing = Space([], end_ws.whitespace + trailing.whitespace)
 
         # Build CompilationUnit
         cu = py.CompilationUnit(
@@ -88,40 +95,41 @@ class Py2ParserVisitor:
             None,  # charset_name
             self._bom_marked,
             None,  # checksum
-            [],    # imports (TODO: extract from statements)
+            [],    # imports — Python imports live in `statements`, like the Py3 parser
             statements,
-            self._trailing_whitespace()
+            trailing,
         )
 
         return cu
 
-    def _convert_module(self, module: parso_tree.Module) -> List[JRightPadded]:
+    def _convert_module(self, module: parso_tree.Module) -> Tuple[List[JRightPadded], Space]:
         """Convert a parso Module to a list of LST statements, preserving
         newlines so the printer can round-trip the source.
 
         parso emits newline leaves between top-level statements. We thread
         each one onto the *trailing* :class:`JRightPadded.after` of the
-        statement that owns it (which is how the printer expects to find them).
+        statement that owns it (which is how the printer expects to find
+        them). Returns the statement list plus any leftover end-whitespace
+        that must be appended to ``cu.eof`` (e.g. the ``\\n`` after a
+        trailing ``;`` line).
         """
-        statements = self._convert_stmt_block_children(module.children)
+        statements, end_ws = self._convert_stmt_block_children(module.children)
         if not statements:
             statements.append(JRightPadded(
                 j.Empty(random_id(), Space.EMPTY, Markers.EMPTY),
                 Space.EMPTY,
                 Markers.EMPTY
             ))
-        return statements
+        return statements, end_ws
 
-    def _convert_stmt_block_children(self, children) -> list:
-        """Walk a list of parso suite/module children into JRightPadded
-        statement entries with correct newline placement.
+    def _convert_stmt_block_children(self, children) -> Tuple[list, Space]:
+        """Walk parso suite/module children into ``JRightPadded`` statements.
 
-        - Leading-newline leaves accumulate onto the *prefix* of the next
-          statement (so the printer's per-statement prefix emits ``\\n<indent>``
-          before each line).
-        - A simple_stmt's trailing newline is captured as the resulting
-          statement's :attr:`JRightPadded.after` so the printer terminates
-          each line correctly.
+        Newlines between statements live on the next statement's prefix.
+        When a line ends with a trailing ``;``, the trailing newline can't
+        live in ``JRightPadded.after`` (the printer renders ``.after``
+        *before* markers); the helper returns it so the surrounding
+        ``cu.eof`` or ``block.end`` slot absorbs it instead.
         """
         statements = []
         pending_prefix = ''
@@ -132,43 +140,52 @@ class Py2ParserVisitor:
                     pending_prefix += getattr(child, 'value', '')
                     continue
                 if ctype == 'endmarker':
-                    # endmarker.prefix is captured by _trailing_whitespace;
-                    # nothing to add to the statement list.
+                    # endmarker.prefix is captured by _trailing_whitespace.
                     continue
+            if ctype == 'simple_stmt':
+                padded, trail = self._convert_simple_stmt_padded(child)
+                if padded and pending_prefix:
+                    padded[0] = padded[0].replace(
+                        element=self._prepend_prefix(padded[0].element, pending_prefix),
+                    )
+                    pending_prefix = ''
+                statements.extend(padded)
+                pending_prefix += trail
+                continue
             stmt = self._convert_node(child)
             if stmt is None:
                 continue
             if pending_prefix:
                 stmt = self._prepend_prefix(stmt, pending_prefix)
                 pending_prefix = ''
-            after = Space.EMPTY
-            if ctype == 'simple_stmt' and child.children:
-                last = child.children[-1]
-                if (isinstance(last, parso_tree.PythonLeaf)
-                        and getattr(last, 'type', None) == 'newline'):
-                    # parso stores trailing comments on the newline leaf's
-                    # ``prefix`` (e.g. ``"  # comment"``) while the newline
-                    # character itself is the leaf's ``value``. Concatenate
-                    # both so the printer reproduces the trailing comment.
-                    after = Space([], last.prefix + last.value)
-            statements.append(JRightPadded(stmt, after, Markers.EMPTY))
-        # Any leftover newline gets attached as trailing-after on the last
-        # statement, so the file's terminal `\n` round-trips.
-        if pending_prefix and statements:
+            statements.append(self._pad_statement(stmt))
+
+        if not pending_prefix:
+            return statements, Space.EMPTY
+        if statements:
             last = statements[-1]
-            combined = (last.after.whitespace if last.after else '') + pending_prefix
-            statements[-1] = JRightPadded(last.element, Space([], combined), last.markers)
-        return statements
+            if last.markers.find_first(Semicolon) is None:
+                # Last statement has no trailing ``;``: append the
+                # leftover whitespace to its ``.after`` (the existing
+                # convention — this is how the file's terminal ``\n``
+                # normally round-trips).
+                statements[-1] = last.replace(
+                    after=Space([], last.after.whitespace + pending_prefix),
+                )
+                return statements, Space.EMPTY
+        return statements, Space([], pending_prefix)
 
     @staticmethod
     def _prepend_prefix(stmt, leading: str):
-        """Prepend a whitespace string to a node's prefix, when possible."""
+        """Prepend a whitespace string to a node's prefix, preserving
+        any comments already attached.
+        """
         if not hasattr(stmt, 'prefix'):
             return stmt
-        existing = stmt.prefix.whitespace if stmt.prefix is not None else ''
-        new_prefix = Space([], leading + existing)
+        existing = stmt.prefix if stmt.prefix is not None else Space.EMPTY
+        new_prefix = Space(existing.comments, leading + existing.whitespace)
         try:
-            return stmt.replace(_prefix=new_prefix)
+            return stmt.replace(prefix=new_prefix)
         except (TypeError, AttributeError):
             return stmt
 
@@ -190,7 +207,10 @@ class Py2ParserVisitor:
 
         converters = {
             'file_input': lambda n: None,  # Handled by _convert_module
-            'simple_stmt': self._convert_simple_stmt,
+            # 'simple_stmt' is intentionally absent: it must be routed
+            # through ``_convert_simple_stmt_padded`` by the block walker
+            # so semicolon-separated small_stmts each surface as their
+            # own LST statement.
             'expr_stmt': self._convert_expr_stmt,
             'print_stmt': self._convert_print_stmt,
             'exec_stmt': self._convert_exec_stmt,
@@ -466,15 +486,55 @@ class Py2ParserVisitor:
     # --- Stub implementations for other node types ---
     # These will be implemented incrementally
 
-    def _convert_simple_stmt(self, node) -> Optional[j.J]:
-        """Convert a simple_stmt node."""
-        # simple_stmt: small_stmt (';' small_stmt)* [';'] NEWLINE
+    def _convert_simple_stmt_padded(self, node) -> Tuple[List[JRightPadded], str]:
+        """Convert a ``simple_stmt`` to one padded LST statement per
+        semicolon-separated ``small_stmt``.
+
+        Grammar (parso): ``simple_stmt: small_stmt (';' small_stmt)* [';'] NEWLINE``.
+
+        Each ``;`` attaches a :class:`Semicolon` marker to the preceding
+        statement; the whitespace before the ``;`` lives in that
+        statement's :attr:`JRightPadded.after`. The trailing newline goes
+        on the last small_stmt's ``.after`` — *unless* the line ends with
+        a trailing ``;``, in which case the printer's ``element →
+        after → markers`` order would put the newline before the ``;``.
+        For that case the newline is returned as the second tuple element
+        so the caller can route it to ``cu.eof`` / ``block.end``.
+        """
+        result: List[JRightPadded] = []
+        trailing_after_marker = ''
         for child in node.children:
-            if hasattr(child, 'type') and child.type != 'NEWLINE' and child.type != 'SEMI':
-                result = self._convert_node(child)
+            ctype = getattr(child, 'type', None)
+            cval = getattr(child, 'value', None)
+            if ctype == 'newline':
+                # parso stores any trailing comment in this leaf's
+                # ``prefix`` (e.g. ``"  # comment"``), with the bare
+                # ``\n`` as its ``value``. When there's a small_stmt to
+                # absorb it the trailing whitespace/comment becomes its
+                # ``.after``; otherwise (trailing ``;``) we return it.
+                if result and result[-1].markers.find_first(Semicolon) is None:
+                    last = result[-1]
+                    trailing_space = self._parse_space(child.prefix + cval)
+                    if last.after.whitespace:
+                        trailing_space = Space(
+                            trailing_space.comments,
+                            last.after.whitespace + trailing_space.whitespace,
+                        )
+                    result[-1] = last.replace(after=trailing_space)
+                else:
+                    trailing_after_marker = child.prefix + cval
+                continue
+            if cval == ';':
                 if result:
-                    return result
-        return None
+                    result[-1] = result[-1].replace(
+                        after=self._parse_space(child.prefix),
+                        markers=Markers.build(random_id(), [Semicolon(random_id())]),
+                    )
+                continue
+            stmt = self._convert_node(child)
+            if stmt is not None:
+                result.append(self._pad_statement(stmt))
+        return result, trailing_after_marker
 
     def _convert_expr_stmt(self, node) -> Optional[j.J]:
         """Convert an expression statement.
@@ -1311,16 +1371,19 @@ class Py2ParserVisitor:
     def _convert_suite_to_block(self, suite_node, block_prefix) -> j.Block:
         """Convert a parso ``suite`` to a :class:`j.Block`, threading
         newlines onto statement prefixes / trailing-padding so the printer
-        can faithfully reproduce the original line layout.
+        can faithfully reproduce the original line layout. Any leftover
+        whitespace that must follow a trailing-``;`` marker is routed to
+        :attr:`j.Block.end` (the printer renders ``.after`` before
+        markers, so it can't live in the last statement's ``.after``).
         """
-        statements = self._convert_stmt_block_children(suite_node.children)
+        statements, end_ws = self._convert_stmt_block_children(suite_node.children)
         return j.Block(
             random_id(),
             block_prefix,
             Markers.EMPTY,
             JRightPadded(False, Space.EMPTY, Markers.EMPTY),  # not static
             statements,
-            Space.EMPTY,
+            end_ws,
         )
 
     def _convert_try_stmt(self, node) -> Optional[j.J]:
@@ -2906,16 +2969,41 @@ class Py2ParserVisitor:
     # --- Helper methods ---
 
     def _parse_space(self, text: str) -> Space:
-        """Convert whitespace/comment string to Space object.
+        """Convert a parso prefix string into a :class:`Space`.
 
-        Parso includes whitespace and comments in the 'prefix' attribute of nodes.
+        parso embeds whitespace and ``# ...`` comments together in a
+        single ``prefix`` string. We tokenize them so recipes can query
+        :attr:`Space.comments` instead of grovelling through the raw
+        whitespace; the printer's render order (whitespace, then each
+        comment with its trailing ``suffix``) keeps round-trip output
+        byte-identical.
         """
         if not text:
             return Space.EMPTY
+        if '#' not in text:
+            return Space([], text)
 
-        # TODO: Parse comments from the whitespace
-        # For now, just return the whitespace
-        return Space([], text)
+        comments: List[TextComment] = []
+        prefix = ''
+        i = 0
+        n = len(text)
+        while i < n:
+            hash_idx = text.find('#', i)
+            if hash_idx < 0:
+                tail = text[i:]
+                if comments and tail:
+                    comments[-1] = comments[-1].replace(suffix=tail)
+                break
+            inter = text[i:hash_idx]
+            if not comments:
+                prefix = inter
+            elif inter:
+                comments[-1] = comments[-1].replace(suffix=inter)
+            nl = text.find('\n', hash_idx + 1)
+            end = n if nl < 0 else nl
+            comments.append(TextComment(False, text[hash_idx + 1:end], '', Markers.EMPTY))
+            i = end
+        return Space(comments, prefix)
 
     def _pad_statement(self, stmt: j.J) -> JRightPadded:
         """Wrap a statement in JRightPadded."""
@@ -2986,7 +3074,13 @@ class Py2ParserVisitor:
             '>=':  (j.Binary, j.Binary.Type.GreaterThanOrEqual),
             '==':  (j.Binary, j.Binary.Type.Equal),
             '!=':  (j.Binary, j.Binary.Type.NotEqual),
-            '<>':  (j.Binary, j.Binary.Type.NotEqual),  # Py2 spelling; tagged via marker
+            # Py2 spelling of '!='. parso < 0.8 never emits '<>' as a
+            # token (it pre-rewrites it to '!='), so this entry is
+            # unreachable through the normal fold path; it is kept so
+            # that a future parso upgrade — or source pre-processing
+            # that injects a '<>' operator leaf directly — finds the
+            # marker/printer wiring already in place.
+            '<>':  (j.Binary, j.Binary.Type.NotEqual),
             'and': (j.Binary, j.Binary.Type.And),
             'or':  (j.Binary, j.Binary.Type.Or),
             '//':  (py.Binary, py.Binary.Type.FloorDivision),
@@ -2994,8 +3088,6 @@ class Py2ParserVisitor:
             '@':   (py.Binary, py.Binary.Type.MatrixMultiplication),
             'in':  (py.Binary, py.Binary.Type.In),
             'is':  (py.Binary, py.Binary.Type.Is),
-            # TODO: '<>' (Py2 not-equal) requires a LegacyNotEqual marker + printer support.
-            # TODO: 'not in' / 'is not' are two-token operators; need lookahead in the fold.
         }
 
     # parso unary-operator text -> j.Unary.Type
@@ -3116,144 +3208,3 @@ class Py2ParserVisitor:
             None,
         )
 
-    # --- Placeholder methods for complex constructs ---
-
-    def _placeholder_method(self, prefix: Space, name: str) -> j.MethodDeclaration:
-        """Create a placeholder method declaration."""
-        return j.MethodDeclaration(
-            random_id(),
-            prefix,
-            Markers.EMPTY,
-            [],  # leading_annotations
-            [],  # modifiers
-            None,  # type_parameters
-            None,  # return_type_expression
-            [],  # name_annotations
-            j.Identifier(random_id(), Space.EMPTY, Markers.EMPTY, [], name, None, None),
-            JContainer(Space.EMPTY, [], Markers.EMPTY),  # parameters
-            None,  # throws
-            j.Block(random_id(), Space.EMPTY, Markers.EMPTY,
-                    JRightPadded(False, Space.EMPTY, Markers.EMPTY), [], Space.EMPTY),
-            None,  # default_value
-            None   # method_type
-        )
-
-    def _placeholder_class(self, prefix: Space, name: str) -> j.ClassDeclaration:
-        """Create a placeholder class declaration."""
-        return j.ClassDeclaration(
-            random_id(),
-            prefix,
-            Markers.EMPTY,
-            [],  # leading_annotations
-            [],  # modifiers
-            j.ClassDeclaration.Kind([], random_id(), Space.EMPTY, Markers.EMPTY,
-                                     j.ClassDeclaration.Kind.Type.Class),
-            j.Identifier(random_id(), Space.EMPTY, Markers.EMPTY, [], name, None, None),
-            None,  # type_parameters
-            None,  # primary_constructor
-            None,  # extends
-            None,  # implements
-            None,  # permits
-            j.Block(random_id(), Space.EMPTY, Markers.EMPTY,
-                    JRightPadded(False, Space.EMPTY, Markers.EMPTY), [], Space.EMPTY),
-            None   # class_type
-        )
-
-    def _placeholder_if(self, prefix: Space) -> j.If:
-        """Create a placeholder if statement."""
-        return j.If(
-            random_id(),
-            prefix,
-            Markers.EMPTY,
-            j.ControlParentheses(
-                random_id(), Space.EMPTY, Markers.EMPTY,
-                JRightPadded(
-                    j.Literal(random_id(), Space.EMPTY, Markers.EMPTY, True, "True", None, None),
-                    Space.EMPTY, Markers.EMPTY
-                )
-            ),
-            JRightPadded(
-                j.Block(random_id(), Space.EMPTY, Markers.EMPTY,
-                        JRightPadded(False, Space.EMPTY, Markers.EMPTY), [], Space.EMPTY),
-                Space.EMPTY, Markers.EMPTY
-            ),
-            None  # else
-        )
-
-    def _placeholder_while(self, prefix: Space) -> j.WhileLoop:
-        """Create a placeholder while loop."""
-        return j.WhileLoop(
-            random_id(),
-            prefix,
-            Markers.EMPTY,
-            j.ControlParentheses(
-                random_id(), Space.EMPTY, Markers.EMPTY,
-                JRightPadded(
-                    j.Literal(random_id(), Space.EMPTY, Markers.EMPTY, True, "True", None, None),
-                    Space.EMPTY, Markers.EMPTY
-                )
-            ),
-            JRightPadded(
-                j.Block(random_id(), Space.EMPTY, Markers.EMPTY,
-                        JRightPadded(False, Space.EMPTY, Markers.EMPTY), [], Space.EMPTY),
-                Space.EMPTY, Markers.EMPTY
-            )
-        )
-
-    def _placeholder_for(self, prefix: Space) -> j.ForEachLoop:
-        """Create a placeholder for loop."""
-        return j.ForEachLoop(
-            random_id(),
-            prefix,
-            Markers.EMPTY,
-            j.ForEachLoop.Control(
-                random_id(), Space.EMPTY, Markers.EMPTY,
-                JRightPadded(
-                    j.VariableDeclarations(
-                        random_id(), Space.EMPTY, Markers.EMPTY, [], [], None, None, [],
-                        [JRightPadded(
-                            j.VariableDeclarations.NamedVariable(
-                                random_id(), Space.EMPTY, Markers.EMPTY,
-                                j.Identifier(random_id(), Space.EMPTY, Markers.EMPTY, [], "_", None, None),
-                                [], None, None
-                            ),
-                            Space.EMPTY, Markers.EMPTY
-                        )]
-                    ),
-                    Space.EMPTY, Markers.EMPTY
-                ),
-                JRightPadded(
-                    j.Literal(random_id(), Space.EMPTY, Markers.EMPTY, [], "[]", None, None),
-                    Space.EMPTY, Markers.EMPTY
-                )
-            ),
-            JRightPadded(
-                j.Block(random_id(), Space.EMPTY, Markers.EMPTY,
-                        JRightPadded(False, Space.EMPTY, Markers.EMPTY), [], Space.EMPTY),
-                Space.EMPTY, Markers.EMPTY
-            )
-        )
-
-    def _placeholder_try(self, prefix: Space) -> j.Try:
-        """Create a placeholder try statement."""
-        return j.Try(
-            random_id(),
-            prefix,
-            Markers.EMPTY,
-            None,  # resources
-            j.Block(random_id(), Space.EMPTY, Markers.EMPTY,
-                    JRightPadded(False, Space.EMPTY, Markers.EMPTY), [], Space.EMPTY),
-            [],    # catches
-            None   # finally
-        )
-
-    def _placeholder_import(self, prefix: Space) -> j.Import:
-        """Create a placeholder import."""
-        return j.Import(
-            random_id(),
-            prefix,
-            Markers.EMPTY,
-            JLeftPadded(Space.EMPTY, False, Markers.EMPTY),  # static
-            j.Identifier(random_id(), Space.EMPTY, Markers.EMPTY, [], "placeholder", None, None),
-            None  # alias
-        )

--- a/rewrite-python/rewrite/src/rewrite/python/_version_detect.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_version_detect.py
@@ -1,0 +1,182 @@
+# Copyright 2026 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Heuristics for auto-detecting the Python language version of a source file
+or project.
+
+The parser's effective version resolves in this order:
+
+1. Explicit ``language_level`` argument (from the RPC ``options`` payload).
+2. In-source signals via :func:`detect_from_source` (magic comment, then shebang).
+3. Project-level signals via :func:`detect_from_project` (pyproject.toml,
+   setup.cfg).
+4. Process-wide default (``REWRITE_PYTHON_VERSION``).
+
+Both detectors return ``None`` when no signal is present, allowing the caller
+to fall through to the next layer.
+"""
+
+import re
+from pathlib import Path
+from typing import Optional, Union
+
+# `# -*- python: 2 -*-` / `# -*- python: 2.7 -*-` — mirrors PEP-263's encoding
+# declaration style. Must appear on line 1 or 2 of the source.
+_MAGIC_COMMENT_RE = re.compile(r"#.*?\bpython\s*:\s*(?P<ver>\d+(?:\.\d+)?)")
+
+# Shebangs: #!/usr/bin/env python2.7, #!/usr/bin/python2, #!python3, etc.
+# Anchored to the start of line 1 (a shebang anywhere else is not honored by
+# the OS and is not a reliable signal).
+_SHEBANG_RE = re.compile(r"^#!.*\bpython(?P<ver>\d+(?:\.\d+)?)\b")
+
+# pyproject.toml [project] classifier: "Programming Language :: Python :: 2.7"
+_CLASSIFIER_RE = re.compile(
+    r"Programming Language\s*::\s*Python\s*::\s*(?P<ver>\d+(?:\.\d+)?)"
+)
+
+
+def detect_from_source(source: str) -> Optional[str]:
+    """Return the Python version declared in the source file, or ``None``.
+
+    Recognized signals (highest priority first):
+
+    * ``# -*- python: 2 -*-`` on line 1 or 2 (PEP-263-style magic comment)
+    * ``#!/usr/bin/env python2.7`` shebang on line 1
+
+    The magic comment is checked first because it is an explicit author
+    intent, whereas a shebang may carry stale tooling info on legacy files.
+    """
+    if not source:
+        return None
+
+    if source.startswith("﻿"):
+        source = source[1:]
+
+    # Inspect only the first two lines — these are the only places PEP-263
+    # and shebang declarations are recognized by Python itself.
+    lines = source.split("\n", 2)[:2]
+
+    for line in lines:
+        m = _MAGIC_COMMENT_RE.search(line)
+        if m:
+            return m.group("ver")
+
+    if lines:
+        m = _SHEBANG_RE.match(lines[0])
+        if m:
+            return m.group("ver")
+
+    return None
+
+
+def detect_from_project(project_path: Union[str, Path, None]) -> Optional[str]:
+    """Return the Python version declared at the project level, or ``None``.
+
+    Reads, in order:
+
+    * ``pyproject.toml`` ``[project].classifiers`` for
+      ``Programming Language :: Python :: <ver>``.
+    * ``pyproject.toml`` ``[project].requires-python`` when it pins a major
+      version (e.g. ``"<3"`` or ``">=2.7,<3"`` resolves to ``"2.7"``).
+    * ``setup.cfg`` ``[metadata].classifiers`` (same shape as pyproject).
+
+    The most specific version found wins; if multiple major versions are
+    declared (e.g. both ``2.7`` and ``3.10``), returns ``None`` because the
+    project supports both and per-file detection should decide.
+    """
+    if project_path is None:
+        return None
+
+    root = Path(project_path)
+    if not root.exists():
+        return None
+
+    versions = set()
+
+    pyproject = root / "pyproject.toml"
+    if pyproject.is_file():
+        try:
+            text = pyproject.read_text(encoding="utf-8")
+        except OSError:
+            text = ""
+        versions.update(_classifier_versions(text))
+        requires = _requires_python(text)
+        if requires:
+            versions.add(requires)
+
+    setup_cfg = root / "setup.cfg"
+    if setup_cfg.is_file():
+        try:
+            text = setup_cfg.read_text(encoding="utf-8")
+        except OSError:
+            text = ""
+        versions.update(_classifier_versions(text))
+
+    return _resolve(versions)
+
+
+def _classifier_versions(text: str):
+    for m in _CLASSIFIER_RE.finditer(text):
+        ver = m.group("ver")
+        # Skip the bare "Programming Language :: Python :: 3" form when
+        # accompanied by more specific entries — handled by _resolve.
+        yield ver
+
+
+def _requires_python(pyproject_text: str) -> Optional[str]:
+    """Best-effort parse of ``requires-python`` from a pyproject.toml.
+
+    Avoids a TOML dependency; only looks for the ``requires-python = "..."``
+    line under any section. Returns the most restrictive major version
+    implied by the constraint, or None if it spans both 2 and 3.
+    """
+    m = re.search(
+        r'(?m)^\s*requires-python\s*=\s*"([^"]+)"', pyproject_text
+    )
+    if not m:
+        return None
+    spec = m.group(1)
+    allows_two = bool(re.search(r"(^|,)\s*[<>=!~]*\s*2(\.|\b)", spec))
+    allows_three = bool(re.search(r"(^|,)\s*[<>=!~]*\s*3(\.|\b)", spec))
+    upper_excludes_three = bool(re.search(r"<\s*3(\.|\b)", spec))
+    if allows_two and upper_excludes_three:
+        return "2.7"
+    if allows_three and not allows_two:
+        return "3"
+    return None
+
+
+def _resolve(versions) -> Optional[str]:
+    """Reduce a set of version strings to a single effective version.
+
+    * Multiple major versions → ``None`` (project supports both; defer).
+    * Any Py2 entry → most specific Py2 version found.
+    * Otherwise → most specific Py3 version found.
+    """
+    if not versions:
+        return None
+
+    majors = {v.split(".", 1)[0] for v in versions}
+    if "2" in majors and "3" in majors:
+        return None
+
+    py2 = sorted(v for v in versions if v.startswith("2"))
+    if py2:
+        return py2[-1]
+
+    py3 = sorted(v for v in versions if v.startswith("3"))
+    if py3:
+        return py3[-1]
+
+    return None

--- a/rewrite-python/rewrite/src/rewrite/python/markers.py
+++ b/rewrite-python/rewrite/src/rewrite/python/markers.py
@@ -89,6 +89,58 @@ class SuppressNewline(Marker):
 
 
 @dataclass(frozen=True, eq=False)
+class LegacyNotEqual(Marker):
+    """Marker for the Python 2 ``<>`` not-equal operator on a :class:`j.Binary`.
+
+    The default printer renders ``Binary.Type.NotEqual`` as ``!=``; when
+    this marker is present it emits the legacy ``<>`` spelling instead.
+    """
+    _id: UUID
+
+    @property
+    def id(self) -> UUID:
+        return self._id
+
+    def with_id(self, id_: UUID) -> 'LegacyNotEqual':
+        return self if id_ is self._id else replace(self, _id=id_)
+
+
+@dataclass(frozen=True, eq=False)
+class RaiseTuple(Marker):
+    """Marker for the Python 2 three-argument ``raise E, v, tb`` form on a :class:`j.Throw`.
+
+    The exception slot of the Throw is a tuple literal of the three operands;
+    when this marker is present the printer drops the parentheses and renders
+    the legacy comma-separated form instead.
+    """
+    _id: UUID
+
+    @property
+    def id(self) -> UUID:
+        return self._id
+
+    def with_id(self, id_: UUID) -> 'RaiseTuple':
+        return self if id_ is self._id else replace(self, _id=id_)
+
+
+@dataclass(frozen=True, eq=False)
+class TupleExceptClause(Marker):
+    """Marker for the Python 2 ``except E, e:`` (comma) form on a J.Try.Catch.
+
+    The default printer renders the catch as ``except E as e:``; when this
+    marker is present it should emit the Py2 comma-based syntax instead.
+    """
+    _id: UUID
+
+    @property
+    def id(self) -> UUID:
+        return self._id
+
+    def with_id(self, id_: UUID) -> 'TupleExceptClause':
+        return self if id_ is self._id else replace(self, _id=id_)
+
+
+@dataclass(frozen=True, eq=False)
 class PrintSyntax(Marker):
     """Marker indicating a J.MethodInvocation represents a Python 2 print statement.
 

--- a/rewrite-python/rewrite/src/rewrite/python/markers.pyi
+++ b/rewrite-python/rewrite/src/rewrite/python/markers.pyi
@@ -94,3 +94,36 @@ class ExecSyntax(Marker):
     def id(self) -> UUID: ...
 
     def with_id(self, id_: UUID) -> 'ExecSyntax': ...
+
+@dataclass(frozen=True)
+class LegacyNotEqual(Marker):
+    _id: UUID
+
+    def replace(self, **kwargs: Any) -> Self: ...
+
+    @property
+    def id(self) -> UUID: ...
+
+    def with_id(self, id_: UUID) -> 'LegacyNotEqual': ...
+
+@dataclass(frozen=True)
+class RaiseTuple(Marker):
+    _id: UUID
+
+    def replace(self, **kwargs: Any) -> Self: ...
+
+    @property
+    def id(self) -> UUID: ...
+
+    def with_id(self, id_: UUID) -> 'RaiseTuple': ...
+
+@dataclass(frozen=True)
+class TupleExceptClause(Marker):
+    _id: UUID
+
+    def replace(self, **kwargs: Any) -> Self: ...
+
+    @property
+    def id(self) -> UUID: ...
+
+    def with_id(self, id_: UUID) -> 'TupleExceptClause': ...

--- a/rewrite-python/rewrite/src/rewrite/python/printer.py
+++ b/rewrite-python/rewrite/src/rewrite/python/printer.py
@@ -33,7 +33,11 @@ from rewrite.java import (
 )
 from rewrite.java.markers import Semicolon, TrailingComma, OmitParentheses
 from rewrite.python.support_types import Py
-from rewrite.python.markers import KeywordArguments, KeywordOnlyArguments, Quoted, SuppressNewline, PrintSyntax, ExecSyntax
+from rewrite.python.markers import (
+    KeywordArguments, KeywordOnlyArguments, Quoted, SuppressNewline,
+    PrintSyntax, ExecSyntax,
+    LegacyNotEqual, RaiseTuple, TupleExceptClause,
+)
 
 if TYPE_CHECKING:
     from rewrite.python import tree as py
@@ -1271,6 +1275,11 @@ class PythonJavaPrinter:
         }
 
         keyword = op_map.get(binary.operator, "")
+        # Python 2 spelling `<>` for NotEqual is recorded via the
+        # LegacyNotEqual marker; emit the legacy operator literally.
+        if (binary.operator == Binary.Type.NotEqual
+                and binary.markers.find_first(LegacyNotEqual) is not None):
+            keyword = "<>"
 
         self._before_syntax(binary, p)
         self.visit(binary.left, p)
@@ -1314,9 +1323,15 @@ class PythonJavaPrinter:
         return case
 
     def visit_catch(self, catch: 'j.Try.Catch', p: PrintOutputCapture) -> J:
-        """Visit a catch clause (except in Python)."""
+        """Visit a catch clause (``except`` in Python).
+
+        Honors the :class:`TupleExceptClause` marker by emitting the Python 2
+        ``except E, e:`` (comma) form instead of the default ``except E as e:``.
+        """
         self._before_syntax(catch, p)
         p.append("except")
+
+        legacy_comma = catch.markers.find_first(TupleExceptClause) is not None
 
         multi_variable = catch.parameter.tree
         self._before_syntax(multi_variable, p)
@@ -1327,7 +1342,10 @@ class PythonJavaPrinter:
             if variable.name.simple_name:
                 self._visit_space(padded_variable.after, p)
                 self._before_syntax(variable, p)
-                p.append("as")
+                if legacy_comma:
+                    p.append(",")
+                else:
+                    p.append("as")
                 self.visit(variable.name, p)
                 self._after_syntax(variable, p)
 
@@ -1690,10 +1708,27 @@ class PythonJavaPrinter:
         return ternary
 
     def visit_throw(self, throw: 'j.Throw', p: PrintOutputCapture) -> J:
-        """Visit a throw statement (raise in Python)."""
+        """Visit a throw statement (``raise`` in Python).
+
+        The Python 2 multi-argument form ``raise E, v[, tb]`` is encoded as
+        a TUPLE CollectionLiteral tagged with :class:`RaiseTuple`; we emit
+        the operands inline (comma-separated, no parens) when that marker
+        is present.
+        """
+        from rewrite.python import tree as py
         self._before_syntax(throw, p)
         p.append("raise")
-        self.visit(throw.exception, p)
+        if (throw.markers.find_first(RaiseTuple) is not None
+                and isinstance(throw.exception, py.CollectionLiteral)
+                and throw.exception.kind == py.CollectionLiteral.Kind.TUPLE):
+            # Print operands inline without the surrounding (...).
+            self._visit_space(throw.exception.prefix, p)
+            elements = throw.exception.padding.elements.padding.elements
+            for i, padded in enumerate(elements):
+                self._visit_right_padded(padded, p,
+                                         "," if i < len(elements) - 1 else "")
+        else:
+            self.visit(throw.exception, p)
         self._after_syntax(throw, p)
         return throw
 

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -255,20 +255,45 @@ def generate_id() -> str:
     return str(uuid4())
 
 
-def parse_python_file(path: str, relative_to: Optional[str] = None, ty_client=None) -> dict:
+def parse_python_file(path: str, relative_to: Optional[str] = None, ty_client=None,
+                      language_level: Optional[str] = None,
+                      project_language_level: Optional[str] = None) -> dict:
     """Parse a Python file and return its LST."""
     with open(path, 'r', encoding='utf-8') as f:
         source = f.read()
-    return parse_python_source(source, path, relative_to, ty_client)
+    return parse_python_source(source, path, relative_to, ty_client,
+                               language_level=language_level,
+                               project_language_level=project_language_level)
 
 
-def parse_python_source(source: str, path: str = "<unknown>", relative_to: Optional[str] = None, ty_client=None) -> dict:
+def parse_python_source(source: str, path: str = "<unknown>", relative_to: Optional[str] = None, ty_client=None,
+                        language_level: Optional[str] = None,
+                        project_language_level: Optional[str] = None) -> dict:
     """Parse Python source code and return its LST.
 
-    The parser used depends on the REWRITE_PYTHON_VERSION environment variable:
-    - "2" or "2.7": Use parso-based Py2ParserVisitor for Python 2 code
-    - "3" (default): Use ast-based ParserVisitor for Python 3 code
+    The parser used depends on the effective language version, resolved in
+    this order (first non-empty wins):
+
+    1. ``language_level`` — explicit per-parse override (from the RPC request).
+    2. In-source signals: PEP-263-style ``# -*- python: 2 -*-`` magic comment,
+       then ``#!/usr/bin/env python2`` shebang.
+    3. ``project_language_level`` — project metadata (pyproject.toml /
+       setup.cfg classifier or ``requires-python``); resolved once per RPC
+       call by the handler.
+    4. ``REWRITE_PYTHON_VERSION`` environment variable (process-wide default).
+
+    Values starting with "2" select the parso-based Py2ParserVisitor; anything
+    else uses the ast-based Python 3 parser.
     """
+    from rewrite.python._version_detect import detect_from_source
+
+    effective_version = (
+        language_level
+        or detect_from_source(source)
+        or project_language_level
+        or _python_version
+    )
+
     # Compute the source_path that will be stored on the LST
     source_path = Path(path)
     if relative_to is not None:
@@ -280,7 +305,7 @@ def parse_python_source(source: str, path: str = "<unknown>", relative_to: Optio
     try:
         from rewrite import Markers
 
-        if _python_version.startswith("2"):
+        if effective_version.startswith("2"):
             # Python 2: Try Python 3 ast-based parser first (handles most Python 2 code),
             # fall back to parso-based parser for Python 2-specific syntax
             from rewrite.python._parser_visitor import ParserVisitor
@@ -290,7 +315,7 @@ def parse_python_source(source: str, path: str = "<unknown>", relative_to: Optio
                 cu = ParserVisitor(source, path, ty_client).visit(tree)
             except SyntaxError:
                 from rewrite.python._py2_parser_visitor import Py2ParserVisitor
-                cu = Py2ParserVisitor(source, path, _python_version).parse()
+                cu = Py2ParserVisitor(source, path, effective_version).parse()
         else:
             # Python 3: Use standard ast-based parser
             from rewrite.python._parser_visitor import ParserVisitor
@@ -396,11 +421,21 @@ def handle_parse(params: dict) -> List[str]:
 
     inputs = params.get('inputs', [])
     relative_to = params.get('relativeTo')
+    # Per-parse options forwarded from the client (e.g. {"languageLevel": "2.7"}).
+    # Absent for older clients; absent or unknown keys are silently ignored.
+    options = params.get('options') or {}
+    language_level = options.get('languageLevel')
     results = []
 
     # If no relativeTo provided, try to infer from absolute input paths
     if not relative_to:
         relative_to = _infer_project_root(inputs)
+
+    # Resolve project-level language version once per request; per-file
+    # detection (shebang / magic comment) can still override this inside
+    # parse_python_source.
+    from rewrite.python._version_detect import detect_from_project
+    project_language_level = detect_from_project(relative_to) if relative_to else None
 
     # Create a ty-types client for this parse batch
     ty_client = None
@@ -421,9 +456,13 @@ def handle_parse(params: dict) -> List[str]:
     try:
         for i, input_item in enumerate(inputs):
             if isinstance(input_item, str):
-                result = parse_python_file(input_item, relative_to, ty_client)
+                result = parse_python_file(input_item, relative_to, ty_client,
+                                           language_level=language_level,
+                                           project_language_level=project_language_level)
             elif 'path' in input_item:
-                result = parse_python_file(input_item['path'], relative_to, ty_client)
+                result = parse_python_file(input_item['path'], relative_to, ty_client,
+                                           language_level=language_level,
+                                           project_language_level=project_language_level)
             elif 'text' in input_item or 'source' in input_item:
                 source = input_item.get('text') if 'text' in input_item else input_item.get('source')
                 path = input_item.get('sourcePath') or input_item.get('relativePath', '<unknown>')
@@ -436,9 +475,13 @@ def handle_parse(params: dict) -> List[str]:
                     os.makedirs(os.path.dirname(disk_path), exist_ok=True)
                     with open(disk_path, 'w', encoding='utf-8') as f:
                         f.write(source)
-                    result = parse_python_source(source, disk_path, base_dir, ty_client)
+                    result = parse_python_source(source, disk_path, base_dir, ty_client,
+                                                 language_level=language_level,
+                                                 project_language_level=project_language_level)
                 else:
-                    result = parse_python_source(source, path, relative_to, ty_client)
+                    result = parse_python_source(source, path, relative_to, ty_client,
+                                                 language_level=language_level,
+                                                 project_language_level=project_language_level)
             else:
                 logger.warning(f"  [{i}] unknown input type: {type(input_item)}")
                 continue
@@ -459,6 +502,14 @@ def handle_parse_project(params: dict) -> List[dict]:
     project_path = params.get('projectPath', '.')
     exclusions = params.get('exclusions', ['__pycache__', '.venv', 'venv', '.git', '.tox', '*.egg-info', '.moderne'])
     relative_to = params.get('relativeTo') or project_path
+    # Per-request explicit override (mirror of the Parse RPC options carrier).
+    options = params.get('options') or {}
+    language_level = options.get('languageLevel')
+
+    # Resolve project-level language version once for the whole walk; each
+    # file may still override it via in-source signals inside parse_python_source.
+    from rewrite.python._version_detect import detect_from_project
+    project_language_level = detect_from_project(project_path)
 
     results = []
 
@@ -478,7 +529,9 @@ def handle_parse_project(params: dict) -> List[dict]:
                 if file.endswith('.py'):
                     path = os.path.join(root, file)
                     try:
-                        result = parse_python_file(path, relative_to, ty_client)
+                        result = parse_python_file(path, relative_to, ty_client,
+                                                   language_level=language_level,
+                                                   project_language_level=project_language_level)
                         results.append(result)
                     except Exception as e:
                         logger.error(f"Error parsing {path}: {e}")

--- a/rewrite-python/rewrite/tests/python/py27/bom_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/bom_test.py
@@ -1,0 +1,49 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""UTF-8 BOM handling for the Py2 parser visitor.
+
+The visitor strips the BOM before handing the source to parso and records
+the fact on ``CompilationUnit.charset_bom_marked`` so the parsed file
+remains distinguishable from one without a BOM.
+"""
+
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+
+
+_BOM = "﻿"
+
+
+def test_bom_is_recorded_on_cu():
+    cu = Py2ParserVisitor(_BOM + "x = 1\n", "<test>", "2.7").parse()
+    assert cu.charset_bom_marked is True
+
+
+def test_no_bom_is_recorded_on_cu():
+    cu = Py2ParserVisitor("x = 1\n", "<test>", "2.7").parse()
+    assert cu.charset_bom_marked is False
+
+
+def test_parse_succeeds_with_bom():
+    # Body still parses to a real Assignment, not a placeholder.
+    cu = Py2ParserVisitor(_BOM + "x = 1\n", "<test>", "2.7").parse()
+    stmt = cu.statements[0]
+    from rewrite.java import tree as j
+    assert isinstance(stmt, j.Assignment)
+
+
+def test_bom_with_py2_specific_syntax():
+    cu = Py2ParserVisitor(_BOM + "print \"hi\"\n", "<test>", "2.7").parse()
+    from rewrite.java import tree as j
+    assert isinstance(cu.statements[0], j.MethodInvocation)

--- a/rewrite-python/rewrite/tests/python/py27/comment_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/comment_test.py
@@ -14,20 +14,29 @@
 
 """Comment preservation through parse-and-print.
 
-Comments live in :class:`Space.whitespace` (parso stores them in leaf
-``prefix`` strings, which we keep verbatim). The printer just emits
-:class:`Space.whitespace`, so as long as the right LST slot holds the
-comment, byte-for-byte round-trip works.
+parso embeds comments inside leaf ``prefix`` strings (e.g.
+``"  # comment\\n"``). :meth:`Py2ParserVisitor._parse_space` tokenizes
+those strings into :class:`Space.whitespace` plus one
+:class:`TextComment` per ``#`` line, so comments are visible to recipes
+that query :attr:`Space.comments` — and round-trip output stays
+byte-for-byte identical (the printer renders whitespace then iterates
+comments).
 """
 
 import pytest
 
+from rewrite.java.support_types import TextComment
 from rewrite.python._py2_parser_visitor import Py2ParserVisitor
 from rewrite.python.printer import PythonPrinter
+from rewrite.python.visitor import PythonVisitor
+
+
+def _parse(src: str):
+    return Py2ParserVisitor(src, "<test>", "2.7").parse()
 
 
 def _round_trip(src: str) -> str:
-    return PythonPrinter().print(Py2ParserVisitor(src, "<test>", "2.7").parse())
+    return PythonPrinter().print(_parse(src))
 
 
 @pytest.mark.parametrize("src", [
@@ -55,3 +64,54 @@ def test_comment_only_file_at_top():
 def test_trailing_comment_no_final_newline():
     src = "x = 1  # final comment"
     assert _round_trip(src) == src
+
+
+# ---------------------------------------------------------------------------
+# Structural tests — recipes need to *see* comments, not just round-trip them.
+# ---------------------------------------------------------------------------
+
+def _all_comments(cu):
+    """Collect every :class:`TextComment` reachable from ``cu`` via the
+    visitor's ``visit_space`` hook, which the framework invokes on every
+    :class:`Space` slot in the tree (prefixes, padding ``.before`` /
+    ``.after``, block ends, ``cu.eof``, etc.). Using the visitor guarantees
+    we see the same Space objects the printer would render — no
+    handwritten field-list to drift out of date.
+    """
+    collected = []
+
+    class _Collector(PythonVisitor):
+        def visit_space(self, space, p):
+            if space is not None:
+                collected.extend(space.comments)
+            return space
+
+    _Collector().visit(cu, None)
+    return collected
+
+
+class TestCommentStructure:
+    def test_top_line_comment_is_a_text_comment(self):
+        cu = _parse("# header\nx = 1\n")
+        comments = list(_all_comments(cu))
+        texts = [c.text for c in comments if isinstance(c, TextComment)]
+        assert " header" in texts
+
+    def test_trailing_comment_is_a_text_comment(self):
+        cu = _parse("x = 1  # trailing\n")
+        comments = list(_all_comments(cu))
+        texts = [c.text for c in comments if isinstance(c, TextComment)]
+        assert " trailing" in texts
+
+    def test_two_consecutive_comments_both_captured(self):
+        cu = _parse("# one\n# two\nx = 1\n")
+        comments = list(_all_comments(cu))
+        texts = [c.text for c in comments if isinstance(c, TextComment)]
+        assert " one" in texts
+        assert " two" in texts
+
+    def test_comment_inside_block_body(self):
+        cu = _parse("def f():\n    # body comment\n    pass\n")
+        comments = list(_all_comments(cu))
+        texts = [c.text for c in comments if isinstance(c, TextComment)]
+        assert " body comment" in texts

--- a/rewrite-python/rewrite/tests/python/py27/comment_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/comment_test.py
@@ -1,0 +1,57 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Comment preservation through parse-and-print.
+
+Comments live in :class:`Space.whitespace` (parso stores them in leaf
+``prefix`` strings, which we keep verbatim). The printer just emits
+:class:`Space.whitespace`, so as long as the right LST slot holds the
+comment, byte-for-byte round-trip works.
+"""
+
+import pytest
+
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+from rewrite.python.printer import PythonPrinter
+
+
+def _round_trip(src: str) -> str:
+    return PythonPrinter().print(Py2ParserVisitor(src, "<test>", "2.7").parse())
+
+
+@pytest.mark.parametrize("src", [
+    "# top-line comment\nx = 1\n",
+    "# first\n# second\nx = 1\n",
+    "x = 1  # trailing\n",
+    "x = 1  # trailing\ny = 2\n",
+    "# leading\nx = 1  # trailing\n",
+    "def f():\n    # body comment\n    pass\n",
+    "if x:\n    # inside if\n    pass\n",
+    "class Foo:\n    # docstring slot\n    pass\n",
+    "x = 1\n# between\ny = 2\n",
+    "x = (1 +  # mid-expression\n     2)\n",
+])
+def test_comment_round_trip(src):
+    assert _round_trip(src) == src
+
+
+def test_comment_only_file_at_top():
+    # A file with leading comments before any statement.
+    src = "# license header line 1\n# license header line 2\n\nx = 1\n"
+    assert _round_trip(src) == src
+
+
+def test_trailing_comment_no_final_newline():
+    src = "x = 1  # final comment"
+    assert _round_trip(src) == src

--- a/rewrite-python/rewrite/tests/python/py27/control_flow_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/control_flow_test.py
@@ -1,0 +1,165 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structural tests for Py2 control-flow constructs: if/elif/else, while, for.
+
+Each test asserts the rich LST shape (no ``<grammar_node>`` placeholders),
+including correct nesting for elif chains and the
+:class:`py.TrailingElseWrapper` for loop ``else:`` clauses.
+"""
+
+import pytest
+
+from rewrite.java import tree as j
+from rewrite.python import tree as py
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+
+
+def _stmt(source: str):
+    cu = Py2ParserVisitor(source, "<test>", "2.7").parse()
+    return cu.statements[0]
+
+
+class TestIf:
+    def test_simple_if(self):
+        stmt = _stmt("if x:\n    pass\n")
+        assert isinstance(stmt, j.If)
+        assert isinstance(stmt.if_condition, j.ControlParentheses)
+        # The condition wraps an Identifier 'x'.
+        inner = stmt.if_condition.tree
+        assert isinstance(inner, j.Identifier)
+        assert inner.simple_name == "x"
+        assert isinstance(stmt.then_part, j.Block)
+        assert stmt.else_part is None
+
+    def test_if_with_complex_condition(self):
+        stmt = _stmt("if a and b:\n    pass\n")
+        assert isinstance(stmt, j.If)
+        inner = stmt.if_condition.tree
+        assert isinstance(inner, j.Binary)
+        assert inner.operator == j.Binary.Type.And
+
+    def test_if_else(self):
+        stmt = _stmt("if x:\n    a\nelse:\n    b\n")
+        assert isinstance(stmt, j.If)
+        assert stmt.else_part is not None
+        assert isinstance(stmt.else_part, j.If.Else)
+        assert isinstance(stmt.else_part.body, j.Block)
+
+    def test_if_elif_else(self):
+        stmt = _stmt("if x:\n    a\nelif y:\n    b\nelse:\n    c\n")
+        assert isinstance(stmt, j.If)
+        # outer if -> else -> body is a nested If
+        outer_else = stmt.else_part
+        assert outer_else is not None
+        nested = outer_else.body
+        assert isinstance(nested, j.If)
+        # nested if's condition is 'y'
+        assert nested.if_condition.tree.simple_name == "y"
+        # nested if's else holds the final block
+        assert nested.else_part is not None
+        assert isinstance(nested.else_part.body, j.Block)
+
+    def test_if_elif_elif_else(self):
+        # Three-way elif chain. Each elif should nest one level deeper.
+        stmt = _stmt(
+            "if a:\n    pass\n"
+            "elif b:\n    pass\n"
+            "elif c:\n    pass\n"
+            "else:\n    pass\n"
+        )
+        assert isinstance(stmt, j.If)
+        level1 = stmt.else_part.body
+        assert isinstance(level1, j.If)
+        assert level1.if_condition.tree.simple_name == "b"
+        level2 = level1.else_part.body
+        assert isinstance(level2, j.If)
+        assert level2.if_condition.tree.simple_name == "c"
+        assert isinstance(level2.else_part.body, j.Block)
+
+    def test_block_contains_converted_statements(self):
+        # The body holds rich statements, not placeholders.
+        stmt = _stmt("if x:\n    y = a + b\n")
+        body = stmt.then_part
+        inner = body.statements[0]
+        assert isinstance(inner, j.Assignment)
+        assert isinstance(inner.assignment, j.Binary)
+        assert inner.assignment.operator == j.Binary.Type.Addition
+
+
+class TestWhile:
+    def test_simple_while(self):
+        stmt = _stmt("while x:\n    pass\n")
+        assert isinstance(stmt, j.WhileLoop)
+        assert isinstance(stmt.condition, j.ControlParentheses)
+        assert isinstance(stmt.body, j.Block)
+
+    def test_while_with_else(self):
+        stmt = _stmt("while x:\n    pass\nelse:\n    cleanup\n")
+        assert isinstance(stmt, py.TrailingElseWrapper)
+        assert isinstance(stmt.statement, j.WhileLoop)
+        assert isinstance(stmt.else_block, j.Block)
+
+
+class TestFor:
+    def test_simple_for(self):
+        stmt = _stmt("for i in xs:\n    pass\n")
+        assert isinstance(stmt, j.ForEachLoop)
+        # Control holds the loop variable + iterable.
+        assert isinstance(stmt.control, j.ForEachLoop.Control)
+        assert isinstance(stmt.body, j.Block)
+
+    def test_for_with_iterable_expression(self):
+        # Iterable is a method call, not just a name.
+        stmt = _stmt("for item in items.values():\n    pass\n")
+        assert isinstance(stmt, j.ForEachLoop)
+        assert isinstance(stmt.control.iterable, j.MethodInvocation)
+        assert stmt.control.iterable.name.simple_name == "values"
+
+    def test_for_with_else(self):
+        stmt = _stmt("for i in xs:\n    pass\nelse:\n    z\n")
+        assert isinstance(stmt, py.TrailingElseWrapper)
+        assert isinstance(stmt.statement, j.ForEachLoop)
+
+    def test_tuple_target(self):
+        # Tuple destructuring produces a TUPLE-kind CollectionLiteral as
+        # the target.
+        stmt = _stmt("for i, j in items:\n    pass\n")
+        assert isinstance(stmt, j.ForEachLoop)
+        target_holder = stmt.control.variable
+        from rewrite.python import tree as py
+        target = target_holder.expression if hasattr(target_holder, 'expression') else target_holder
+        assert isinstance(target, py.CollectionLiteral)
+        assert target.kind == py.CollectionLiteral.Kind.TUPLE
+
+
+class TestNoPlaceholders:
+    """Whole-tree regression: no ``<grammar_node>`` placeholders survive."""
+
+    @pytest.mark.parametrize("src", [
+        "if x:\n    pass\n",
+        "if a == b:\n    y = 1\n",
+        "if x:\n    a\nelse:\n    b\n",
+        "if x:\n    a\nelif y:\n    b\nelse:\n    c\n",
+        "while x < 10:\n    x += 1\n",
+        "while True:\n    pass\nelse:\n    cleanup()\n",
+        "for i in range(10):\n    print(i)\n",
+        "for item in items.values():\n    process(item)\n",
+    ])
+    def test_no_placeholders(self, src):
+        from tests.python.py27.expressions_test import _collect_placeholders
+        cu = Py2ParserVisitor(src, "<test>", "2.7").parse()
+        stmt = cu.statements[0]
+        placeholders = list(_collect_placeholders(stmt))
+        assert placeholders == [], f"unexpected placeholders in {src!r}: {placeholders}"

--- a/rewrite-python/rewrite/tests/python/py27/expressions_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/expressions_test.py
@@ -1,0 +1,311 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structural tests for the Py2ParserVisitor expression layer.
+
+These bypass the RPC pipeline and exercise the visitor directly, asserting
+that the LST contains rich ``j.Binary`` / ``j.Unary`` nodes rather than the
+fallback ``<arith_expr>`` / ``<term>`` placeholder identifiers that signal
+an unimplemented production.
+"""
+
+import pytest
+
+from rewrite.java import tree as j
+from rewrite.python import tree as py
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+
+
+def _first_stmt(source: str):
+    """Parse a single-statement source and return the first statement (unwrapped)."""
+    cu = Py2ParserVisitor(source, "<test>", "2.7").parse()
+    return cu.statements[0]
+
+
+def _first_expr(source: str):
+    """Parse a single-statement source and return the first expression/assignment."""
+    stmt = _first_stmt(source)
+    if isinstance(stmt, py.ExpressionStatement):
+        return stmt.expression
+    if isinstance(stmt, j.Assignment):
+        return stmt.assignment
+    return stmt
+
+
+def _collect_placeholders(node):
+    """Walk the LST and yield identifier names that look like ``<grammar_node>`` —
+    the fallback shape emitted by ``_convert_generic`` when a production has
+    no real mapping yet."""
+    if isinstance(node, j.Identifier) and node.simple_name.startswith("<") and node.simple_name.endswith(">"):
+        yield node.simple_name
+    for attr in ("left", "right", "operand", "expression"):
+        child = getattr(node, attr, None)
+        if child is not None:
+            yield from _collect_placeholders(child)
+    op = getattr(node, "operator", None)
+    if op is not None and hasattr(op, "element"):
+        pass  # operator type, not a tree node
+    # JLeftPadded carrying expressions
+    for attr in ("assignment",):
+        wrapped = getattr(node, attr, None)
+        if wrapped is not None and hasattr(wrapped, "element"):
+            yield from _collect_placeholders(wrapped.element)
+
+
+class TestArithmetic:
+    def test_simple_addition(self):
+        expr = _first_expr("x = 1 + 2\n")
+        assert isinstance(expr, j.Binary)
+        assert expr.operator == j.Binary.Type.Addition
+        assert isinstance(expr.left, j.Literal)
+        assert expr.left.value_source == "1"
+        assert isinstance(expr.right, j.Literal)
+        assert expr.right.value_source == "2"
+
+    def test_left_associative_fold(self):
+        # 1 + 2 + 3 should fold as ((1 + 2) + 3)
+        expr = _first_expr("x = 1 + 2 + 3\n")
+        assert isinstance(expr, j.Binary)
+        assert expr.operator == j.Binary.Type.Addition
+        assert isinstance(expr.right, j.Literal)
+        assert expr.right.value_source == "3"
+        assert isinstance(expr.left, j.Binary)
+        assert expr.left.operator == j.Binary.Type.Addition
+
+    def test_mul_div_mod(self):
+        for src, op_type in [
+            ("x = a * b\n", j.Binary.Type.Multiplication),
+            ("x = a / b\n", j.Binary.Type.Division),
+            ("x = a % b\n", j.Binary.Type.Modulo),
+        ]:
+            expr = _first_expr(src)
+            assert isinstance(expr, j.Binary), src
+            assert expr.operator == op_type, src
+
+    def test_floor_division_uses_py_binary(self):
+        expr = _first_expr("x = a // b\n")
+        assert isinstance(expr, py.Binary)
+        assert expr.operator == py.Binary.Type.FloorDivision
+
+    def test_power_uses_py_binary(self):
+        expr = _first_expr("x = 2 ** 3\n")
+        assert isinstance(expr, py.Binary)
+        assert expr.operator == py.Binary.Type.Power
+
+
+class TestComparison:
+    @pytest.mark.parametrize("src,op_type", [
+        ("x = a == b\n", j.Binary.Type.Equal),
+        ("x = a != b\n", j.Binary.Type.NotEqual),
+        ("x = a < b\n", j.Binary.Type.LessThan),
+        ("x = a <= b\n", j.Binary.Type.LessThanOrEqual),
+        ("x = a > b\n", j.Binary.Type.GreaterThan),
+        ("x = a >= b\n", j.Binary.Type.GreaterThanOrEqual),
+    ])
+    def test_simple_comparison(self, src, op_type):
+        expr = _first_expr(src)
+        assert isinstance(expr, j.Binary)
+        assert expr.operator == op_type
+
+
+class TestBoolean:
+    def test_and(self):
+        expr = _first_expr("x = a and b\n")
+        assert isinstance(expr, j.Binary)
+        assert expr.operator == j.Binary.Type.And
+
+    def test_or(self):
+        expr = _first_expr("x = a or b\n")
+        assert isinstance(expr, j.Binary)
+        assert expr.operator == j.Binary.Type.Or
+
+    def test_and_or_chain(self):
+        # `a and b or c` parses as `(a and b) or c` (Python precedence:
+        # `and` binds tighter than `or`).
+        expr = _first_expr("x = a and b or c\n")
+        assert isinstance(expr, j.Binary)
+        assert expr.operator == j.Binary.Type.Or
+        assert isinstance(expr.left, j.Binary)
+        assert expr.left.operator == j.Binary.Type.And
+
+
+class TestUnary:
+    @pytest.mark.parametrize("src,op_type", [
+        ("x = -a\n", j.Unary.Type.Negative),
+        ("x = +a\n", j.Unary.Type.Positive),
+        ("x = ~a\n", j.Unary.Type.Complement),
+        ("x = not a\n", j.Unary.Type.Not),
+    ])
+    def test_unary(self, src, op_type):
+        expr = _first_expr(src)
+        assert isinstance(expr, j.Unary), src
+        assert expr.operator == op_type
+
+    def test_double_negation(self):
+        expr = _first_expr("x = --a\n")
+        assert isinstance(expr, j.Unary)
+        assert expr.operator == j.Unary.Type.Negative
+        assert isinstance(expr.expression, j.Unary)
+        assert expr.expression.operator == j.Unary.Type.Negative
+
+
+class TestNoPlaceholdersLeak:
+    """Regression tests: any LST produced by these expressions must not contain
+    a `<grammar_node>` placeholder identifier."""
+
+    @pytest.mark.parametrize("src", [
+        "x = 1 + 2 * 3\n",
+        "x = (a - b) * c\n",  # Note: parens still placeholder, will fail until atom is wired
+        "x = a == b and c != d\n",
+        "x = not (a or b)\n",
+        "x = -a + b\n",
+    ])
+    def test_no_placeholders(self, src):
+        cu = Py2ParserVisitor(src, "<test>", "2.7").parse()
+        stmt = cu.statements[0]
+        placeholders = list(_collect_placeholders(stmt))
+        # Filter to non-atom placeholders for now — parenthesized atoms
+        # are not yet wired.
+        non_atom = [p for p in placeholders if p != "<atom>"]
+        assert non_atom == [], f"unexpected placeholders in {src!r}: {placeholders}"
+
+
+class TestCalls:
+    def test_simple_call_no_args(self):
+        expr = _first_expr("x = f()\n")
+        assert isinstance(expr, j.MethodInvocation)
+        assert isinstance(expr.name, j.Identifier)
+        assert expr.name.simple_name == "f"
+        assert expr.select is None
+
+    def test_simple_call_one_arg(self):
+        expr = _first_expr("x = f(a)\n")
+        assert isinstance(expr, j.MethodInvocation)
+        assert expr.name.simple_name == "f"
+        assert len(expr.arguments) == 1
+        assert isinstance(expr.arguments[0], j.Identifier)
+        assert expr.arguments[0].simple_name == "a"
+
+    def test_simple_call_multiple_args(self):
+        expr = _first_expr("x = f(a, b, c)\n")
+        assert isinstance(expr, j.MethodInvocation)
+        names = [a.simple_name for a in expr.arguments if isinstance(a, j.Identifier)]
+        assert names == ["a", "b", "c"]
+
+    def test_method_call(self):
+        expr = _first_expr("x = obj.method(arg)\n")
+        assert isinstance(expr, j.MethodInvocation)
+        assert expr.name.simple_name == "method"
+        assert expr.select is not None
+        assert isinstance(expr.select, j.Identifier)
+        assert expr.select.simple_name == "obj"
+        assert len(expr.arguments) == 1
+
+    def test_chained_method_call(self):
+        # obj.foo().bar() — call result is the receiver of another call.
+        expr = _first_expr("x = obj.foo().bar()\n")
+        assert isinstance(expr, j.MethodInvocation)
+        assert expr.name.simple_name == "bar"
+        inner = expr.select
+        assert isinstance(inner, j.MethodInvocation)
+        assert inner.name.simple_name == "foo"
+
+    def test_call_arg_is_expression(self):
+        expr = _first_expr("x = f(a + 1)\n")
+        assert isinstance(expr, j.MethodInvocation)
+        assert isinstance(expr.arguments[0], j.Binary)
+        assert expr.arguments[0].operator == j.Binary.Type.Addition
+
+
+class TestAttributeAndSubscript:
+    def test_attribute_chain(self):
+        expr = _first_expr("x = a.b.c\n")
+        assert isinstance(expr, j.FieldAccess)
+        assert expr.name.simple_name == "c"
+        assert isinstance(expr.target, j.FieldAccess)
+        assert expr.target.name.simple_name == "b"
+        assert isinstance(expr.target.target, j.Identifier)
+        assert expr.target.target.simple_name == "a"
+
+    def test_subscript(self):
+        expr = _first_expr("x = a[0]\n")
+        assert isinstance(expr, j.ArrayAccess)
+        assert isinstance(expr.indexed, j.Identifier)
+        assert expr.indexed.simple_name == "a"
+
+    def test_attribute_then_subscript(self):
+        expr = _first_expr("x = obj.data[i]\n")
+        assert isinstance(expr, j.ArrayAccess)
+        assert isinstance(expr.indexed, j.FieldAccess)
+        assert expr.indexed.name.simple_name == "data"
+
+
+class TestParens:
+    def test_paren_preserves_inner(self):
+        expr = _first_expr("x = (a + b)\n")
+        assert isinstance(expr, j.Parentheses)
+        inner = expr.tree
+        assert isinstance(inner, j.Binary)
+        assert inner.operator == j.Binary.Type.Addition
+
+    def test_paren_changes_precedence(self):
+        # `(a + b) * c` — the parens make the addition the LHS of multiplication.
+        expr = _first_expr("x = (a + b) * c\n")
+        assert isinstance(expr, j.Binary)
+        assert expr.operator == j.Binary.Type.Multiplication
+        assert isinstance(expr.left, j.Parentheses)
+        inner = expr.left.tree
+        assert isinstance(inner, j.Binary)
+        assert inner.operator == j.Binary.Type.Addition
+
+
+class TestAugmentedAssignment:
+    @pytest.mark.parametrize("src,op_type", [
+        ("x += 1\n",   j.AssignmentOperation.Type.Addition),
+        ("x -= 1\n",   j.AssignmentOperation.Type.Subtraction),
+        ("x *= 2\n",   j.AssignmentOperation.Type.Multiplication),
+        ("x /= 2\n",   j.AssignmentOperation.Type.Division),
+        ("x //= 2\n",  j.AssignmentOperation.Type.FloorDivision),
+        ("x **= 2\n",  j.AssignmentOperation.Type.Exponentiation),
+        ("x %= 2\n",   j.AssignmentOperation.Type.Modulo),
+        ("x &= 1\n",   j.AssignmentOperation.Type.BitAnd),
+        ("x |= 1\n",   j.AssignmentOperation.Type.BitOr),
+        ("x ^= 1\n",   j.AssignmentOperation.Type.BitXor),
+        ("x <<= 1\n",  j.AssignmentOperation.Type.LeftShift),
+        ("x >>= 1\n",  j.AssignmentOperation.Type.RightShift),
+    ])
+    def test_augmented(self, src, op_type):
+        stmt = _first_stmt(src)
+        assert isinstance(stmt, j.AssignmentOperation), src
+        assert stmt.operator == op_type
+
+
+class TestExpressionRegressions:
+    """No placeholder identifiers should leak through these constructs."""
+
+    @pytest.mark.parametrize("src", [
+        "x = f(a, b)\n",
+        "x = obj.method()\n",
+        "x = a.b.c\n",
+        "x = arr[i]\n",
+        "x = 2 ** 3 + 1\n",
+        "x = (a + b) * c\n",
+        "x += 1\n",
+        "x = f(a + b, c * d)\n",
+    ])
+    def test_no_placeholders(self, src):
+        cu = Py2ParserVisitor(src, "<test>", "2.7").parse()
+        stmt = cu.statements[0]
+        placeholders = list(_collect_placeholders(stmt))
+        assert placeholders == [], f"unexpected placeholders in {src!r}: {placeholders}"

--- a/rewrite-python/rewrite/tests/python/py27/funcdef_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/funcdef_test.py
@@ -1,0 +1,144 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structural tests for Py2 function definitions, including decorators."""
+
+import pytest
+
+from rewrite.java import tree as j
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+from rewrite.python.markers import KeywordArguments
+
+
+def _stmt(source: str):
+    cu = Py2ParserVisitor(source, "<test>", "2.7").parse()
+    return cu.statements[0]
+
+
+def _param_names(method: j.MethodDeclaration):
+    names = []
+    for param in method.parameters:
+        if isinstance(param, j.VariableDeclarations):
+            for v in param.variables:
+                names.append(v.name.simple_name)
+    return names
+
+
+class TestFuncdefBasics:
+    def test_no_arg(self):
+        m = _stmt("def f():\n    pass\n")
+        assert isinstance(m, j.MethodDeclaration)
+        assert m.name.simple_name == "f"
+        # Empty parameter list still produces a JContainer with an Empty
+        # sentinel — matches the Py3 visitor convention.
+        assert _param_names(m) == []
+
+    def test_def_modifier_present(self):
+        m = _stmt("def f():\n    pass\n")
+        kinds = [mod.type for mod in m.modifiers]
+        assert j.Modifier.Type.Default in kinds
+        keywords = [mod.keyword for mod in m.modifiers]
+        assert 'def' in keywords
+
+    def test_single_positional(self):
+        m = _stmt("def f(a):\n    pass\n")
+        assert _param_names(m) == ["a"]
+
+    def test_multi_positional(self):
+        m = _stmt("def f(a, b, c):\n    pass\n")
+        assert _param_names(m) == ["a", "b", "c"]
+
+    def test_positional_with_default(self):
+        m = _stmt("def f(a, b=1):\n    pass\n")
+        # The second parameter holds a NamedVariable with an initializer.
+        params = m.parameters
+        b_param = params[1]
+        assert isinstance(b_param, j.VariableDeclarations)
+        b_var = b_param.variables[0]
+        assert b_var.initializer is not None
+        assert isinstance(b_var.initializer, j.Literal)
+        assert b_var.initializer.value_source == "1"
+
+    def test_vararg(self):
+        m = _stmt("def f(*args):\n    pass\n")
+        assert _param_names(m) == ["args"]
+        vararg_param = m.parameters[0]
+        assert vararg_param.varargs is not None  # populated for *args
+
+    def test_kwarg(self):
+        m = _stmt("def f(**kw):\n    pass\n")
+        assert _param_names(m) == ["kw"]
+        kwarg_param = m.parameters[0]
+        # KeywordArguments marker should be present so the printer emits `**`.
+        kwarg_markers = [type(mk).__name__ for mk in kwarg_param.markers.markers]
+        assert 'KeywordArguments' in kwarg_markers
+
+    def test_full_signature(self):
+        m = _stmt("def f(a, b=1, *args, **kw):\n    pass\n")
+        assert _param_names(m) == ["a", "b", "args", "kw"]
+
+    def test_body_contains_real_statements(self):
+        m = _stmt("def f(x):\n    y = x + 1\n    return y\n")
+        body_stmts = m.body.statements
+        assert isinstance(body_stmts[0], j.Assignment)
+        assert isinstance(body_stmts[1], j.Return)
+
+
+class TestDecorators:
+    def test_simple_decorator(self):
+        m = _stmt("@d\ndef f():\n    pass\n")
+        assert isinstance(m, j.MethodDeclaration)
+        assert len(m.leading_annotations) == 1
+
+    def test_call_decorator(self):
+        m = _stmt("@d(x)\ndef f():\n    pass\n")
+        assert len(m.leading_annotations) == 1
+        ann = m.leading_annotations[0]
+        # Call decorators have arguments populated.
+        assert ann.arguments is not None
+        assert len(ann.arguments) == 1
+
+    def test_attribute_decorator(self):
+        m = _stmt("@a.b.c\ndef f():\n    pass\n")
+        assert len(m.leading_annotations) == 1
+        ann_type = m.leading_annotations[0].annotation_type
+        # a.b.c → FieldAccess(FieldAccess(FieldAccess(Empty, a), b), c)
+        assert isinstance(ann_type, j.FieldAccess)
+        assert ann_type.name.simple_name == "c"
+
+    def test_multiple_decorators(self):
+        m = _stmt("@d1\n@d2\ndef f():\n    pass\n")
+        assert len(m.leading_annotations) == 2
+
+
+class TestFuncdefRegressions:
+    """Whole-tree placeholder sweep."""
+
+    @pytest.mark.parametrize("src", [
+        "def f():\n    pass\n",
+        "def f(a):\n    pass\n",
+        "def f(a, b=1):\n    pass\n",
+        "def f(*args, **kw):\n    pass\n",
+        "def f(x):\n    return x + 1\n",
+        "@d\ndef f():\n    pass\n",
+        "@d(x)\ndef f():\n    pass\n",
+        "@a.b\ndef f(x):\n    return x\n",
+        "def outer(a):\n    def inner(b):\n        return a + b\n    return inner\n",
+    ])
+    def test_no_placeholders(self, src):
+        from tests.python.py27.expressions_test import _collect_placeholders
+        cu = Py2ParserVisitor(src, "<test>", "2.7").parse()
+        stmt = cu.statements[0]
+        placeholders = list(_collect_placeholders(stmt))
+        assert placeholders == [], f"unexpected placeholders in {src!r}: {placeholders}"

--- a/rewrite-python/rewrite/tests/python/py27/imports_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/imports_test.py
@@ -1,0 +1,165 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structural tests for Py2 ``import`` and ``from ... import`` statements."""
+
+import pytest
+
+from rewrite.java import tree as j
+from rewrite.python import tree as py
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+
+
+def _stmt(source: str):
+    cu = Py2ParserVisitor(source, "<test>", "2.7").parse()
+    return cu.statements[0]
+
+
+def _qualid_to_str(qualid) -> str:
+    """Render a qualid (Identifier or FieldAccess chain) back to dotted form."""
+    if isinstance(qualid, j.Identifier):
+        return qualid.simple_name
+    # j.FieldAccess: target is either Empty (single-name special form) or
+    # a nested Identifier / FieldAccess.
+    if isinstance(qualid.target, j.Empty):
+        return qualid.name.simple_name
+    return f"{_qualid_to_str(qualid.target)}.{qualid.name.simple_name}"
+
+
+class TestImportName:
+    def test_simple_import(self):
+        stmt = _stmt("import os\n")
+        assert isinstance(stmt, j.Import)
+        assert _qualid_to_str(stmt.qualid) == "os"
+        assert stmt.alias is None
+
+    def test_dotted_import(self):
+        stmt = _stmt("import os.path\n")
+        assert isinstance(stmt, j.Import)
+        assert _qualid_to_str(stmt.qualid) == "os.path"
+
+    def test_deeply_dotted_import(self):
+        stmt = _stmt("import a.b.c.d\n")
+        assert isinstance(stmt, j.Import)
+        assert _qualid_to_str(stmt.qualid) == "a.b.c.d"
+
+    def test_import_with_alias(self):
+        stmt = _stmt("import os as o\n")
+        assert isinstance(stmt, j.Import)
+        assert _qualid_to_str(stmt.qualid) == "os"
+        assert isinstance(stmt.alias, j.Identifier)
+        assert stmt.alias.simple_name == "o"
+
+    def test_import_multiple_names_uses_multi_import(self):
+        stmt = _stmt("import os, sys\n")
+        assert isinstance(stmt, py.MultiImport)
+        assert stmt.from_ is None
+        assert len(stmt.names) == 2
+        assert [_qualid_to_str(n.qualid) for n in stmt.names] == ["os", "sys"]
+
+    def test_import_multiple_with_aliases(self):
+        stmt = _stmt("import os as o, sys as s\n")
+        assert isinstance(stmt, py.MultiImport)
+        names = stmt.names
+        assert [_qualid_to_str(n.qualid) for n in names] == ["os", "sys"]
+        assert [n.alias.simple_name for n in names] == ["o", "s"]
+
+
+class TestImportFrom:
+    def test_from_single(self):
+        stmt = _stmt("from os import path\n")
+        assert isinstance(stmt, py.MultiImport)
+        assert _qualid_to_str(stmt.from_) == "os"
+        assert len(stmt.names) == 1
+        assert _qualid_to_str(stmt.names[0].qualid) == "path"
+        assert stmt.parenthesized is False
+
+    def test_from_multiple(self):
+        stmt = _stmt("from os import path, environ\n")
+        assert isinstance(stmt, py.MultiImport)
+        assert _qualid_to_str(stmt.from_) == "os"
+        assert [_qualid_to_str(n.qualid) for n in stmt.names] == ["path", "environ"]
+
+    def test_from_dotted_module(self):
+        stmt = _stmt("from os.path import join\n")
+        assert isinstance(stmt, py.MultiImport)
+        assert _qualid_to_str(stmt.from_) == "os.path"
+        assert _qualid_to_str(stmt.names[0].qualid) == "join"
+
+    def test_from_with_alias(self):
+        stmt = _stmt("from os import path as p, environ as e\n")
+        assert isinstance(stmt, py.MultiImport)
+        names = stmt.names
+        assert [_qualid_to_str(n.qualid) for n in names] == ["path", "environ"]
+        assert [n.alias.simple_name for n in names] == ["p", "e"]
+
+    def test_from_parenthesized(self):
+        stmt = _stmt("from os import (path, environ)\n")
+        assert isinstance(stmt, py.MultiImport)
+        assert stmt.parenthesized is True
+        assert [_qualid_to_str(n.qualid) for n in stmt.names] == ["path", "environ"]
+
+    def test_from_star(self):
+        stmt = _stmt("from os import *\n")
+        assert isinstance(stmt, py.MultiImport)
+        assert _qualid_to_str(stmt.from_) == "os"
+        assert len(stmt.names) == 1
+        # The star is encoded as an Identifier with value '*' inside the qualid.
+        assert stmt.names[0].qualid.name.simple_name == "*"
+
+
+class TestRelativeImports:
+    def test_from_dot_import(self):
+        stmt = _stmt("from . import foo\n")
+        assert isinstance(stmt, py.MultiImport)
+        assert isinstance(stmt.from_, j.Identifier)
+        assert stmt.from_.simple_name == "."
+        assert _qualid_to_str(stmt.names[0].qualid) == "foo"
+
+    def test_from_double_dot_import(self):
+        stmt = _stmt("from .. import bar\n")
+        assert isinstance(stmt, py.MultiImport)
+        assert isinstance(stmt.from_, j.Identifier)
+        assert stmt.from_.simple_name == ".."
+
+    def test_from_dot_pkg_import(self):
+        stmt = _stmt("from .pkg import x\n")
+        assert isinstance(stmt, py.MultiImport)
+        assert isinstance(stmt.from_, j.Identifier)
+        assert stmt.from_.simple_name == ".pkg"
+
+
+class TestImportRegressions:
+    """No placeholder identifiers leak through these import shapes."""
+
+    @pytest.mark.parametrize("src", [
+        "import os\n",
+        "import os.path\n",
+        "import os as o\n",
+        "import os, sys\n",
+        "from os import path\n",
+        "from os import path, environ\n",
+        "from os import path as p\n",
+        "from os.path import join\n",
+        "from os import (path, environ)\n",
+        "from os import *\n",
+        "from . import foo\n",
+        "from .. import bar\n",
+    ])
+    def test_no_placeholders(self, src):
+        from tests.python.py27.expressions_test import _collect_placeholders
+        cu = Py2ParserVisitor(src, "<test>", "2.7").parse()
+        stmt = cu.statements[0]
+        placeholders = list(_collect_placeholders(stmt))
+        assert placeholders == [], f"unexpected placeholders in {src!r}: {placeholders}"

--- a/rewrite-python/rewrite/tests/python/py27/legacy_not_equal_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/legacy_not_equal_test.py
@@ -1,0 +1,69 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pin the :class:`LegacyNotEqual` marker → printer wiring.
+
+The Py2 spelling ``<>`` for "not equal" is not actually reachable through
+the current parso 0.7 pipeline (parso pre-rewrites ``<>`` to ``!=`` before
+the visitor sees it), so the :class:`LegacyNotEqual` marker is dormant in
+practice. The fold logic in :mod:`_py2_parser_visitor` and the printer
+branch in :mod:`printer` are nonetheless wired up so a future parso
+upgrade — or source pre-processing that injects a ``<>`` operator leaf —
+will Just Work.
+
+This test pins that wiring by constructing the LST node directly. If a
+future change breaks the marker → ``<>`` rendering path, this test fails
+loudly instead of silently letting the bug ship the day the parser
+upstream gains ``<>`` support.
+"""
+
+from rewrite import random_id, Markers
+from rewrite.java import Space, JLeftPadded
+from rewrite.java import tree as j
+from rewrite.python.markers import LegacyNotEqual
+from rewrite.python.printer import PythonPrinter
+
+
+def _identifier(name: str, prefix: str = "") -> j.Identifier:
+    return j.Identifier(
+        random_id(), Space([], prefix), Markers.EMPTY, [], name, None, None,
+    )
+
+
+def _binary_ne(left_name: str, right_name: str, *, legacy: bool) -> j.Binary:
+    """Build ``a != b`` (or ``a <> b`` when ``legacy=True``) directly."""
+    markers = Markers.EMPTY
+    if legacy:
+        markers = Markers.build(random_id(), [LegacyNotEqual(random_id())])
+    return j.Binary(
+        random_id(),
+        Space.EMPTY,
+        markers,
+        _identifier(left_name),
+        JLeftPadded(Space([], " "), j.Binary.Type.NotEqual, Markers.EMPTY),
+        _identifier(right_name, prefix=" "),
+        None,  # type
+    )
+
+
+def test_legacy_marker_emits_angle_brackets():
+    """LegacyNotEqual marker on a ``NotEqual`` binary prints as ``<>``."""
+    binary = _binary_ne("a", "b", legacy=True)
+    assert PythonPrinter().print(binary) == "a <> b"
+
+
+def test_no_marker_emits_bang_equals():
+    """Without the marker, ``NotEqual`` prints as the Py3-style ``!=``."""
+    binary = _binary_ne("a", "b", legacy=False)
+    assert PythonPrinter().print(binary) == "a != b"

--- a/rewrite-python/rewrite/tests/python/py27/line_continuation_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/line_continuation_test.py
@@ -1,0 +1,47 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backslash line continuation (``\\`` at end-of-line).
+
+parso treats the backslash + newline + leading whitespace of the next
+line as part of the following token's prefix. The LST stores it as
+whitespace in the relevant :class:`Space`, and the printer emits it
+verbatim — so as long as the parser threads the prefix through correctly,
+round-trip works.
+"""
+
+import pytest
+
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+from rewrite.python.printer import PythonPrinter
+
+
+def _round_trip(src: str) -> str:
+    return PythonPrinter().print(Py2ParserVisitor(src, "<test>", "2.7").parse())
+
+
+@pytest.mark.parametrize("src", [
+    "x = 1 + \\\n    2\n",
+    "x = a + b + \\\n    c + d\n",
+    "if a == 1 and \\\n   b == 2:\n    pass\n",
+    "result = foo(\\\n    a,\\\n    b,\\\n)\n",
+])
+def test_line_continuation_round_trips(src):
+    assert _round_trip(src) == src
+
+
+def test_continuation_with_comment_after_paren_open():
+    # Inside parens, a true newline (no backslash) is allowed and stays.
+    src = "x = (\n    1 +\n    2\n)\n"
+    assert _round_trip(src) == src

--- a/rewrite-python/rewrite/tests/python/py27/literal_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/literal_test.py
@@ -1,0 +1,135 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Python 2-specific literal forms.
+
+Covers the literal shapes that differ from Python 3:
+
+* Long-integer suffix ``100L``
+* Octal ``0777`` (Py2 form; Py3 requires ``0o777``)
+* Unicode string prefix ``u"..."`` / ``ur"..."``
+* Raw string ``r"..."`` and byte string ``b"..."`` (both also valid in Py3)
+* Trailing-dot float ``1.`` / leading-dot float ``.5``
+* Scientific notation ``1e10``
+* Implicit string concatenation ``"a" "b"`` (also valid in Py3)
+"""
+
+import pytest
+
+from rewrite.java import tree as j
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+from rewrite.python.printer import PythonPrinter
+
+
+def _expr(src: str):
+    cu = Py2ParserVisitor(src, "<test>", "2.7").parse()
+    stmt = cu.statements[0]
+    return stmt.assignment if isinstance(stmt, j.Assignment) else stmt
+
+
+def _round_trip(src: str) -> str:
+    return PythonPrinter().print(Py2ParserVisitor(src, "<test>", "2.7").parse())
+
+
+class TestNumericLiterals:
+    @pytest.mark.parametrize("src,value_source", [
+        ("x = 100L\n",   "100L"),
+        ("x = 0777\n",   "0777"),
+        ("x = 0xff\n",   "0xff"),
+        ("x = 0b101\n",  "0b101"),
+        ("x = 1.\n",     "1."),
+        ("x = .5\n",     ".5"),
+        ("x = 1e10\n",   "1e10"),
+        ("x = 1.5e-3\n", "1.5e-3"),
+        ("x = 42\n",     "42"),
+    ])
+    def test_value_source_preserved(self, src, value_source):
+        e = _expr(src)
+        assert isinstance(e, j.Literal), src
+        assert e.value_source == value_source
+
+    @pytest.mark.parametrize("src", [
+        "x = 100L\n",
+        "x = 0777\n",
+        "x = 0xff\n",
+        "x = 1.\n",
+        "x = .5\n",
+        "x = 1e10\n",
+    ])
+    def test_round_trip(self, src):
+        assert _round_trip(src) == src
+
+
+class TestStringLiterals:
+    @pytest.mark.parametrize("src,value_source", [
+        ('x = "hello"\n', '"hello"'),
+        ("x = 'hello'\n", "'hello'"),
+        ('x = u"unicode"\n', 'u"unicode"'),
+        ('x = U"unicode"\n', 'U"unicode"'),
+        ('x = r"raw"\n', 'r"raw"'),
+        ('x = R"raw"\n', 'R"raw"'),
+        ('x = ur"both"\n', 'ur"both"'),
+        ('x = b"bytes"\n', 'b"bytes"'),
+        ('x = """triple"""\n', '"""triple"""'),
+        ("x = '''triple'''\n", "'''triple'''"),
+    ])
+    def test_string_literal_round_trips(self, src, value_source):
+        e = _expr(src)
+        assert isinstance(e, j.Literal), src
+        assert e.value_source == value_source
+        assert _round_trip(src) == src
+
+
+class TestImplicitConcatenation:
+    def test_two_pieces(self):
+        e = _expr('x = "a" "b"\n')
+        assert isinstance(e, j.Literal)
+        assert e.value_source == '"a" "b"'
+
+    def test_three_pieces(self):
+        e = _expr('x = "a" "b" "c"\n')
+        assert isinstance(e, j.Literal)
+        assert e.value_source == '"a" "b" "c"'
+
+    def test_mixed_styles(self):
+        e = _expr('x = "a" \'b\'\n')
+        assert isinstance(e, j.Literal)
+        assert e.value_source == '"a" \'b\''
+
+    @pytest.mark.parametrize("src", [
+        'x = "a" "b"\n',
+        'x = "a" "b" "c"\n',
+        'x = u"a" u"b"\n',
+        'x = r"a" "b"\n',
+    ])
+    def test_round_trip(self, src):
+        assert _round_trip(src) == src
+
+
+class TestTrailingCommas:
+    """Trailing commas on call args, collection literals, and parenthesized
+    tuples must round-trip — both the comma itself and the whitespace
+    between it and the closing delimiter."""
+
+    @pytest.mark.parametrize("src", [
+        "x = (1, 2,)\n",
+        "x = [1, 2,]\n",
+        "x = {1: 2, 3: 4,}\n",
+        "x = {1, 2,}\n",
+        "x = f(a, b,)\n",
+        "x = f(\n    a,\n    b,\n)\n",
+        "result = foo(\\\n    a,\\\n    b,\\\n)\n",
+    ])
+    def test_trailing_comma_round_trips(self, src):
+        assert _round_trip(src) == src

--- a/rewrite-python/rewrite/tests/python/py27/remaining_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/remaining_test.py
@@ -1,0 +1,313 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structural tests for Py2 constructs added in Rounds 2-9:
+classdef, try/with, atom literals, lambda, subscript slices, kwarg/star calls,
+comprehensions, chained assignment, two-token comparison operators."""
+
+import pytest
+
+from rewrite.java import tree as j
+from rewrite.python import tree as py
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+from rewrite.python.markers import TupleExceptClause
+
+
+def _stmt(src: str):
+    return Py2ParserVisitor(src, "<test>", "2.7").parse().statements[0]
+
+
+def _expr(src: str):
+    stmt = _stmt(src)
+    if isinstance(stmt, py.ExpressionStatement):
+        return stmt.expression
+    if isinstance(stmt, j.Assignment):
+        return stmt.assignment
+    return stmt
+
+
+# ---------------------------------------------------------------------------
+# Classdef
+# ---------------------------------------------------------------------------
+
+class TestClassdef:
+    def test_old_style_no_parens(self):
+        s = _stmt("class Foo:\n    pass\n")
+        assert isinstance(s, j.ClassDeclaration)
+        assert s.name.simple_name == "Foo"
+        assert s.implements is None
+
+    def test_single_base(self):
+        s = _stmt("class Foo(Base):\n    pass\n")
+        assert isinstance(s, j.ClassDeclaration)
+        assert s.implements is not None
+        assert len(s.implements) == 1
+
+    def test_multi_base(self):
+        s = _stmt("class Foo(A, B):\n    pass\n")
+        assert s.implements is not None
+        assert len(s.implements) == 2
+
+    def test_empty_parens(self):
+        s = _stmt("class Foo():\n    pass\n")
+        # Empty paren list still produces a JContainer (with Empty inside).
+        assert s.implements is not None
+
+    def test_decorated(self):
+        s = _stmt("@d\nclass Foo:\n    pass\n")
+        assert isinstance(s, j.ClassDeclaration)
+        assert len(s.leading_annotations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Try / With
+# ---------------------------------------------------------------------------
+
+class TestTry:
+    def test_simple(self):
+        s = _stmt("try:\n    a\nexcept:\n    b\n")
+        assert isinstance(s, j.Try)
+        assert len(s.catches) == 1
+
+    def test_typed(self):
+        s = _stmt("try:\n    a\nexcept E:\n    b\n")
+        assert isinstance(s, j.Try)
+        assert len(s.catches) == 1
+
+    def test_as_form(self):
+        s = _stmt("try:\n    a\nexcept E as e:\n    b\n")
+        assert isinstance(s, j.Try)
+        names = [type(m).__name__ for m in s.catches[0].markers.markers]
+        # `as` form should NOT carry the TupleExceptClause marker.
+        assert "TupleExceptClause" not in names
+
+    def test_py2_comma_form(self):
+        s = _stmt("try:\n    a\nexcept E, e:\n    b\n")
+        assert isinstance(s, j.Try)
+        names = [type(m).__name__ for m in s.catches[0].markers.markers]
+        assert "TupleExceptClause" in names
+
+    def test_multiple_catches(self):
+        s = _stmt("try:\n    a\nexcept E:\n    b\nexcept F:\n    c\n")
+        assert isinstance(s, j.Try)
+        assert len(s.catches) == 2
+
+    def test_finally_only(self):
+        s = _stmt("try:\n    a\nfinally:\n    b\n")
+        assert isinstance(s, j.Try)
+        assert s.finally_ is not None or s.padding.finally_ is not None
+
+    def test_full(self):
+        s = _stmt(
+            "try:\n    a\n"
+            "except E:\n    b\n"
+            "else:\n    c\n"
+            "finally:\n    d\n"
+        )
+        # The else clause makes it a TrailingElseWrapper.
+        assert isinstance(s, py.TrailingElseWrapper)
+
+
+class TestWith:
+    def test_single_context(self):
+        s = _stmt("with foo:\n    pass\n")
+        assert isinstance(s, j.Try)
+        assert s.resources is not None
+
+    def test_with_as(self):
+        s = _stmt("with foo as f:\n    pass\n")
+        assert isinstance(s, j.Try)
+        assert len(s.resources) == 1
+
+    def test_multi_with(self):
+        s = _stmt("with foo as f, bar as b:\n    pass\n")
+        assert isinstance(s, j.Try)
+        assert len(s.resources) == 2
+
+
+# ---------------------------------------------------------------------------
+# Atom literals
+# ---------------------------------------------------------------------------
+
+class TestLiterals:
+    def test_list(self):
+        e = _expr("x = [1, 2, 3]\n")
+        assert isinstance(e, py.CollectionLiteral)
+        assert e.kind == py.CollectionLiteral.Kind.LIST
+        assert len(e.elements) == 3
+
+    def test_empty_list(self):
+        e = _expr("x = []\n")
+        assert isinstance(e, py.CollectionLiteral)
+        assert e.kind == py.CollectionLiteral.Kind.LIST
+
+    def test_dict(self):
+        e = _expr("x = {1: 'a', 2: 'b'}\n")
+        assert isinstance(e, py.DictLiteral)
+        assert len(e.elements) == 2
+
+    def test_empty_dict(self):
+        e = _expr("x = {}\n")
+        # Empty {} is a dict per Python convention.
+        assert isinstance(e, py.DictLiteral)
+
+    def test_set(self):
+        e = _expr("x = {1, 2, 3}\n")
+        assert isinstance(e, py.CollectionLiteral)
+        assert e.kind == py.CollectionLiteral.Kind.SET
+
+    def test_tuple(self):
+        e = _expr("x = (1, 2, 3)\n")
+        assert isinstance(e, py.CollectionLiteral)
+        assert e.kind == py.CollectionLiteral.Kind.TUPLE
+
+    def test_single_tuple(self):
+        # `(1,)` is a 1-element tuple.
+        e = _expr("x = (1,)\n")
+        assert isinstance(e, py.CollectionLiteral)
+        assert e.kind == py.CollectionLiteral.Kind.TUPLE
+
+
+# ---------------------------------------------------------------------------
+# Lambda
+# ---------------------------------------------------------------------------
+
+class TestLambda:
+    def test_no_args(self):
+        e = _expr("f = lambda: 1\n")
+        assert isinstance(e, j.Lambda)
+
+    def test_one_arg(self):
+        e = _expr("f = lambda x: x + 1\n")
+        assert isinstance(e, j.Lambda)
+        assert isinstance(e.body, j.Binary)
+
+    def test_multi_arg_with_default(self):
+        e = _expr("f = lambda x, y=1: x * y\n")
+        assert isinstance(e, j.Lambda)
+
+
+# ---------------------------------------------------------------------------
+# Subscript variants
+# ---------------------------------------------------------------------------
+
+class TestSlices:
+    def test_basic_slice(self):
+        e = _expr("x = a[1:5]\n")
+        assert isinstance(e, j.ArrayAccess)
+        # The index should be a py.Slice with start and stop set.
+        dim = e.dimension
+        idx = dim.index if hasattr(dim, 'index') else dim.padding.index.element
+        assert isinstance(idx, py.Slice)
+        assert idx.start is not None and idx.stop is not None
+
+    def test_slice_with_step(self):
+        e = _expr("x = a[::2]\n")
+        assert isinstance(e, j.ArrayAccess)
+
+    def test_multi_subscript(self):
+        # ``a[i, j]`` is a TUPLE index.
+        e = _expr("x = a[i, j]\n")
+        assert isinstance(e, j.ArrayAccess)
+
+
+# ---------------------------------------------------------------------------
+# Call arg variants
+# ---------------------------------------------------------------------------
+
+class TestCallArgs:
+    def test_keyword_arg(self):
+        e = _expr("x = f(a=1)\n")
+        assert isinstance(e, j.MethodInvocation)
+        assert isinstance(e.arguments[0], py.NamedArgument)
+
+    def test_mixed_args(self):
+        e = _expr("x = f(a, b=2)\n")
+        assert isinstance(e, j.MethodInvocation)
+        assert isinstance(e.arguments[0], j.Identifier)
+        assert isinstance(e.arguments[1], py.NamedArgument)
+
+    def test_star_arg(self):
+        e = _expr("x = f(*xs)\n")
+        assert isinstance(e, j.MethodInvocation)
+        assert isinstance(e.arguments[0], py.Star)
+        assert e.arguments[0].kind == py.Star.Kind.LIST
+
+    def test_double_star_arg(self):
+        e = _expr("x = f(**kw)\n")
+        assert isinstance(e, j.MethodInvocation)
+        assert isinstance(e.arguments[0], py.Star)
+        assert e.arguments[0].kind == py.Star.Kind.DICT
+
+
+# ---------------------------------------------------------------------------
+# Comprehensions
+# ---------------------------------------------------------------------------
+
+class TestComprehensions:
+    def test_list_comp(self):
+        e = _expr("x = [v for v in xs]\n")
+        assert isinstance(e, py.ComprehensionExpression)
+        assert e.kind == py.ComprehensionExpression.Kind.LIST
+        assert len(e.clauses) == 1
+
+    def test_list_comp_with_if(self):
+        e = _expr("x = [v for v in xs if v > 0]\n")
+        assert isinstance(e, py.ComprehensionExpression)
+        assert e.clauses[0].conditions is not None
+        assert len(e.clauses[0].conditions) == 1
+
+    def test_set_comp(self):
+        e = _expr("x = {v for v in xs}\n")
+        assert isinstance(e, py.ComprehensionExpression)
+        assert e.kind == py.ComprehensionExpression.Kind.SET
+
+    def test_dict_comp(self):
+        e = _expr("x = {k: v for k, v in items}\n")
+        assert isinstance(e, py.ComprehensionExpression)
+        assert e.kind == py.ComprehensionExpression.Kind.DICT
+
+    def test_generator_in_parens(self):
+        e = _expr("x = (v for v in xs)\n")
+        assert isinstance(e, py.ComprehensionExpression)
+        assert e.kind == py.ComprehensionExpression.Kind.GENERATOR
+
+    def test_generator_as_call_arg(self):
+        e = _expr("x = sum(v for v in xs)\n")
+        assert isinstance(e, j.MethodInvocation)
+        assert isinstance(e.arguments[0], py.ComprehensionExpression)
+
+
+# ---------------------------------------------------------------------------
+# Round 9 cleanup
+# ---------------------------------------------------------------------------
+
+class TestRound9:
+    def test_chained_assign(self):
+        s = _stmt("a = b = c = 0\n")
+        assert isinstance(s, py.ChainedAssignment)
+
+    def test_for_tuple_destructure(self):
+        s = _stmt("for k, v in d:\n    pass\n")
+        assert isinstance(s, j.ForEachLoop)
+
+    def test_not_in(self):
+        e = _expr("x = a not in b\n")
+        assert isinstance(e, py.Binary)
+        assert e.operator == py.Binary.Type.NotIn
+
+    def test_is_not(self):
+        e = _expr("x = a is not b\n")
+        assert isinstance(e, py.Binary)
+        assert e.operator == py.Binary.Type.IsNot

--- a/rewrite-python/rewrite/tests/python/py27/round_trip_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/round_trip_test.py
@@ -1,0 +1,125 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Direct parse-print round-trip tests for the Py2 parser visitor.
+
+Each test parses a Python 2 source string with :class:`Py2ParserVisitor`,
+runs the result through :class:`PythonPrinter`, and asserts byte-for-byte
+equality with the original input — the same invariant that
+``print_equals_input`` enforces inside the RPC pipeline. Tests here run
+without RPC, so a printer regression fails fast and locally.
+"""
+
+import pytest
+
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+from rewrite.python.printer import PythonPrinter
+
+
+def _round_trip(src: str) -> str:
+    cu = Py2ParserVisitor(src, "<test>", "2.7").parse()
+    return PythonPrinter().print(cu)
+
+
+# ---------------------------------------------------------------------------
+# Each test asserts byte-for-byte round-trip on a representative idiom.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("src", [
+    # bare statements and expressions
+    "x = 1\n",
+    "x = 1 + 2 * 3\n",
+    "x = a == b and c != d\n",
+    "x += 1\n",
+    "a = b = 1\n",
+
+    # Py2-specific forms
+    "print \"hello\", x\n",
+    "print >> sys.stderr, \"err\"\n",
+    "raise E, v, tb\n",
+
+    # comments
+    "# top-line comment\nx = 1\n",
+
+    # control flow
+    "if x:\n    pass\nelse:\n    pass\n",
+    "if x:\n    a\nelif y:\n    b\nelse:\n    c\n",
+    "for i in xs:\n    pass\n",
+    "while x:\n    pass\n",
+
+    # try / with
+    "try:\n    a\nexcept:\n    b\n",
+    "try:\n    a\nexcept E, e:\n    b\n",
+    "try:\n    a\nexcept E as e:\n    b\n",
+    "try:\n    a\nfinally:\n    c\n",
+    "with foo as f:\n    pass\n",
+    "with foo as f, bar as b:\n    pass\n",
+
+    # imports
+    "import os\n",
+    "import os.path\n",
+    "from os import path\n",
+    "from os.path import join\n",
+    "from os import path, environ\n",
+    "from . import foo\n",
+
+    # functions and classes
+    "def f():\n    pass\n",
+    "def f(a, b=1):\n    return a + b\n",
+    "def f(*args, **kw):\n    return args\n",
+    "@d\ndef f():\n    pass\n",
+    "class Foo:\n    pass\n",
+    "class Foo(Base):\n    def m(self):\n        return self.x\n",
+
+    # collections and comprehensions
+    "x = [1, 2, 3]\n",
+    "x = {1: 2, 3: 4}\n",
+    "x = (1, 2, 3)\n",
+    "x = [i for i in xs if i > 0]\n",
+
+    # calls
+    "x = obj.method(a, b)\n",
+    "x = f(a=1, b=2)\n",
+    "x = f(*args, **kw)\n",
+])
+def test_round_trip(src):
+    assert _round_trip(src) == src
+
+
+def test_comprehensive_round_trip():
+    """Full Py2 program round-trips byte-for-byte."""
+    src = (
+        "import os\n"
+        "from os.path import join, dirname\n"
+        "\n"
+        "\n"
+        "def greet(name, greeting=\"hello\"):\n"
+        "    if name:\n"
+        "        print greeting, name\n"
+        "    else:\n"
+        "        print >> sys.stderr, \"missing name\"\n"
+        "    return greeting + name\n"
+        "\n"
+        "\n"
+        "class Worker(Base):\n"
+        "    def run(self, items):\n"
+        "        results = []\n"
+        "        for item in items:\n"
+        "            try:\n"
+        "                results.append(self.process(item))\n"
+        "            except ValueError, e:\n"
+        "                self.log(e)\n"
+        "        return results\n"
+    )
+    assert _round_trip(src) == src

--- a/rewrite-python/rewrite/tests/python/py27/semicolon_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/semicolon_test.py
@@ -1,0 +1,110 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Semicolon-separated simple_stmt round-trip and structural tests.
+
+In Python 2 (and 3) the grammar allows several ``small_stmt`` nodes on the
+same physical line, separated by ``;``::
+
+    x = 1; y = 2
+    x = 1;       # trailing ';'
+    a = 1; b = 2; c = 3
+
+Each ``small_stmt`` must surface as its own LST statement, with the
+:class:`Semicolon` marker attached to every statement that is followed by
+``;``. Without that, the printer cannot reproduce the source and any
+trailing small_stmts are silently dropped.
+"""
+
+import pytest
+
+from rewrite.java.markers import Semicolon
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+from rewrite.python.printer import PythonPrinter
+from tests.python.py27.expressions_test import _collect_placeholders
+
+
+def _parse(src: str):
+    return Py2ParserVisitor(src, "<test>", "2.7").parse()
+
+
+def _round_trip(src: str) -> str:
+    return PythonPrinter().print(_parse(src))
+
+
+@pytest.mark.parametrize("src", [
+    # two small_stmts on one line
+    "x = 1; y = 2\n",
+    # three small_stmts on one line
+    "a = 1; b = 2; c = 3\n",
+    # trailing ';' with no following small_stmt
+    "x = 1;\n",
+    # mixed kinds: assignment + augmented
+    "x = 1; y += 2\n",
+    # mixed kinds: import + expression
+    "import os; print os\n",
+    # mixed kinds: print + assignment (Py2-only print statement)
+    "print x; y = 1\n",
+    # bare keywords mixed in
+    "x = 1; pass\n",
+    # del / global on the same line
+    "del x; del y\n",
+    # whitespace variations around ';'
+    "x = 1 ; y = 2\n",
+    "x = 1 ;y = 2\n",
+    # nested inside a block — the suite body uses the same plumbing
+    "def f():\n    a = 1; b = 2\n",
+    "if True:\n    x = 1; y = 2\n",
+    "for i in xs:\n    a = i; b = i + 1\n",
+])
+def test_semicolon_round_trip(src):
+    assert _round_trip(src) == src
+
+
+class TestSemicolonStructure:
+    """Each small_stmt becomes its own LST statement with the correct marker."""
+
+    def test_two_statements_emitted(self):
+        cu = _parse("x = 1; y = 2\n")
+        assert len(cu.statements) == 2
+
+    def test_three_statements_emitted(self):
+        cu = _parse("a = 1; b = 2; c = 3\n")
+        assert len(cu.statements) == 3
+
+    def test_trailing_semicolon_keeps_one_statement(self):
+        cu = _parse("x = 1;\n")
+        assert len(cu.statements) == 1
+
+    def test_semicolon_marker_on_preceding_statements(self):
+        cu = _parse("a = 1; b = 2; c = 3\n")
+        padded = cu.padding.statements
+        for p in padded[:-1]:
+            assert p.markers.find_first(Semicolon) is not None, (
+                "expected Semicolon marker on statement preceding ';'"
+            )
+        assert padded[-1].markers.find_first(Semicolon) is None, (
+            "last statement on a line should not carry Semicolon"
+        )
+
+    def test_trailing_semicolon_marker(self):
+        cu = _parse("x = 1;\n")
+        padded = cu.padding.statements
+        assert len(padded) == 1
+        assert padded[0].markers.find_first(Semicolon) is not None
+
+    def test_no_placeholders_in_semicolon_line(self):
+        cu = _parse("a = 1; b = 2; c = 3\n")
+        for stmt in cu.statements:
+            assert list(_collect_placeholders(stmt)) == [], stmt

--- a/rewrite-python/rewrite/tests/python/py27/simple_stmts_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/simple_stmts_test.py
@@ -1,0 +1,137 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structural tests for Py2 simple statements: raise / assert / del / yield / global,
+and the bare-keyword shortcuts that parso emits for ``pass`` / ``break`` etc."""
+
+import pytest
+
+from rewrite.java import tree as j
+from rewrite.python import tree as py
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+
+
+def _stmt(source: str):
+    cu = Py2ParserVisitor(source, "<test>", "2.7").parse()
+    return cu.statements[0]
+
+
+class TestBareKeywords:
+    @pytest.mark.parametrize("src,cls", [
+        ("pass\n",     py.Pass),
+        ("break\n",    j.Break),
+        ("continue\n", j.Continue),
+        ("return\n",   j.Return),
+    ])
+    def test_bare(self, src, cls):
+        assert isinstance(_stmt(src), cls)
+
+    def test_bare_raise(self):
+        stmt = _stmt("raise\n")
+        assert isinstance(stmt, j.Throw)
+        assert isinstance(stmt.exception, j.Empty)
+
+    def test_bare_yield(self):
+        stmt = _stmt("yield\n")
+        assert isinstance(stmt, py.StatementExpression)
+        assert isinstance(stmt.statement, j.Yield)
+
+
+class TestRaise:
+    def test_raise_with_name(self):
+        stmt = _stmt("raise E\n")
+        assert isinstance(stmt, j.Throw)
+        assert isinstance(stmt.exception, j.Identifier)
+        assert stmt.exception.simple_name == "E"
+
+    def test_raise_with_call(self):
+        stmt = _stmt("raise E()\n")
+        assert isinstance(stmt, j.Throw)
+        assert isinstance(stmt.exception, j.MethodInvocation)
+
+    def test_py2_multi_arg_raise(self):
+        # Py2 `raise E, v, tb`. Wrapped in a tuple tagged with the
+        # RaiseTuple marker so the printer renders the legacy syntax.
+        stmt = _stmt("raise E, v, tb\n")
+        assert isinstance(stmt, j.Throw)
+        marker_names = [type(m).__name__ for m in stmt.markers.markers]
+        assert "RaiseTuple" in marker_names
+        assert isinstance(stmt.exception, py.CollectionLiteral)
+
+
+class TestAssert:
+    def test_simple(self):
+        stmt = _stmt("assert x\n")
+        assert isinstance(stmt, j.Assert)
+        assert isinstance(stmt.condition, j.Identifier)
+        assert stmt.detail is None
+
+    def test_with_message(self):
+        stmt = _stmt('assert x, "boom"\n')
+        assert isinstance(stmt, j.Assert)
+        assert stmt.detail is not None
+
+
+class TestDel:
+    def test_single(self):
+        stmt = _stmt("del x\n")
+        assert isinstance(stmt, py.Del)
+        assert len(stmt.targets) == 1
+
+    def test_multi(self):
+        stmt = _stmt("del x, y, z\n")
+        assert isinstance(stmt, py.Del)
+        assert len(stmt.targets) == 3
+        names = [t.simple_name for t in stmt.targets if isinstance(t, j.Identifier)]
+        assert names == ["x", "y", "z"]
+
+
+class TestGlobal:
+    def test_single(self):
+        stmt = _stmt("global x\n")
+        assert isinstance(stmt, py.VariableScope)
+        assert stmt.kind == py.VariableScope.Kind.GLOBAL
+        assert [n.simple_name for n in stmt.names] == ["x"]
+
+    def test_multi(self):
+        stmt = _stmt("global x, y, z\n")
+        assert isinstance(stmt, py.VariableScope)
+        assert [n.simple_name for n in stmt.names] == ["x", "y", "z"]
+
+
+class TestYield:
+    def test_yield_value(self):
+        stmt = _stmt("yield x\n")
+        assert isinstance(stmt, py.StatementExpression)
+        inner = stmt.statement
+        assert isinstance(inner, j.Yield)
+        assert isinstance(inner.value, j.Identifier)
+        assert inner.value.simple_name == "x"
+
+
+class TestSimpleStmtRegressions:
+    @pytest.mark.parametrize("src", [
+        "raise E\n",
+        "raise SomeError()\n",
+        "assert x > 0\n",
+        "assert items, 'no items'\n",
+        "del a, b\n",
+        "global counter\n",
+        "yield value\n",
+    ])
+    def test_no_placeholders(self, src):
+        from tests.python.py27.expressions_test import _collect_placeholders
+        cu = Py2ParserVisitor(src, "<test>", "2.7").parse()
+        stmt = cu.statements[0]
+        assert list(_collect_placeholders(stmt)) == [], src

--- a/rewrite-python/rewrite/tests/python/py27/sweep_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/sweep_test.py
@@ -1,0 +1,238 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cross-construct regression sweep for the Py2 parser visitor.
+
+Parses representative Py2 idioms covering the constructs each round in the
+Phase 3 effort added, and asserts no ``<grammar_node>`` placeholder
+identifiers survive anywhere in the resulting LST.
+"""
+
+import dataclasses
+from typing import Iterator
+
+import pytest
+
+from rewrite.java import tree as j
+from rewrite.python import tree as py
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+
+
+def _walk(node) -> Iterator:
+    """Yield every dataclass-field descendant of ``node`` exactly once,
+    skipping non-tree containers gracefully."""
+    if node is None:
+        return
+    yield node
+    if dataclasses.is_dataclass(node):
+        for f in dataclasses.fields(node):
+            val = getattr(node, f.name, None)
+            yield from _walk_value(val)
+
+
+def _walk_value(val) -> Iterator:
+    if val is None:
+        return
+    if isinstance(val, (list, tuple)):
+        for item in val:
+            yield from _walk_value(item)
+        return
+    # JRightPadded / JLeftPadded / JContainer all expose `.element` or
+    # `.elements`.
+    if hasattr(val, 'element') and not dataclasses.is_dataclass(val):
+        yield from _walk_value(val.element)
+        return
+    if hasattr(val, 'elements') and not dataclasses.is_dataclass(val):
+        yield from _walk_value(val.elements)
+        return
+    if dataclasses.is_dataclass(val):
+        yield from _walk(val)
+
+
+def _placeholder_names(tree) -> list:
+    """Return any identifier name shaped like ``<grammar_node>``."""
+    out = []
+    for node in _walk(tree):
+        if isinstance(node, j.Identifier):
+            name = node.simple_name
+            if name.startswith("<") and name.endswith(">"):
+                out.append(name)
+    return out
+
+
+COMPREHENSIVE = '''\
+# Copyright header — should be tolerated.
+"""Module docstring."""
+
+import os
+import sys as system
+from collections import OrderedDict
+from os.path import join, dirname
+from . import siblings
+from .. import grandparent
+
+CONST = 42
+PI = 3.14
+NAME = "hello"
+
+GLOBAL_DICT = {"a": 1, "b": 2}
+TUPLE_C = (1, 2, 3)
+SET_C = {1, 2, 3}
+EMPTY_LIST = []
+EMPTY_DICT = {}
+EMPTY_TUPLE = ()
+
+
+def _private(x, y=1, *args, **kw):
+    """Function with all parameter shapes."""
+    total = x + y
+    for arg in args:
+        total += arg
+    for key in kw:
+        total += kw[key]
+    return total
+
+
+def consumer(items):
+    yield items[0]
+    yield items[1:]
+    yield items[::2]
+    yield items[1:10:2]
+
+
+@cached
+@logger.timing
+def decorated(a, b):
+    return _private(a, b=b)
+
+
+class Old:
+    pass
+
+
+class Modern(Base):
+    CLASS_ATTR = 1
+
+    def __init__(self, value):
+        self.value = value
+        self.entries = [v * 2 for v in range(value) if v > 0]
+
+    def method(self):
+        try:
+            result = self._compute()
+        except ValueError, e:
+            return None
+        except (TypeError, KeyError) as err:
+            raise RuntimeError("composite")
+        else:
+            return result
+        finally:
+            self._cleanup()
+
+
+class Multi(A, B):
+    @classmethod
+    def factory(cls, **kwargs):
+        return cls(**kwargs)
+
+    @staticmethod
+    def helper(*items):
+        return sum(items)
+
+
+def compound(xs):
+    if not xs:
+        return None
+    elif len(xs) == 1:
+        return xs[0]
+    else:
+        return sum(xs) / len(xs)
+
+
+def memberships(items, valid):
+    matches = [x for x in items if x in valid and x not in EXCLUDED]
+    missing = {k: v for k, v in items if v is not None}
+    return matches, missing
+
+
+def streams():
+    for i, j in enumerate(items):
+        if i % 2 == 0:
+            print "even", i, j
+        else:
+            print >> sys.stderr, "odd", i
+
+
+def cleanup():
+    global counter
+    counter += 1
+    del temp_a, temp_b
+    assert counter > 0, "negative count"
+
+
+with open("f") as fh:
+    contents = fh.read()
+
+
+with open("a") as a, open("b") as b:
+    combined = a.read() + b.read()
+
+
+f = lambda x, y=1: x * y
+double = lambda *args: [a * 2 for a in args]
+
+
+# Augmented assignments
+x = 0
+x += 1
+x -= 1
+x *= 2
+x //= 2
+x **= 2
+
+# Chained assignment
+a = b = c = 0
+
+
+# Generator expression as a call argument
+total = sum(v for v in values)
+'''
+
+
+def test_comprehensive_no_placeholders():
+    cu = Py2ParserVisitor(COMPREHENSIVE, "<test>", "2.7").parse()
+    placeholders = []
+    for stmt in cu.statements:
+        placeholders.extend(_placeholder_names(stmt))
+    assert placeholders == [], (
+        f"placeholders survived in the comprehensive Py2 sweep: "
+        f"{sorted(set(placeholders))}"
+    )
+
+
+def test_compilation_unit_is_well_formed():
+    cu = Py2ParserVisitor(COMPREHENSIVE, "<test>", "2.7").parse()
+    assert isinstance(cu, py.CompilationUnit)
+    # The full file should parse to many top-level statements.
+    assert len(cu.statements) >= 20
+
+    # Type spot-checks across the file.
+    types = [type(s).__name__ for s in cu.statements]
+    assert "MethodDeclaration" in types
+    assert "ClassDeclaration" in types
+    assert "Import" in types or "MultiImport" in types
+    # An augmented assignment should appear.
+    assert "AssignmentOperation" in types
+    # A chained assignment should appear.
+    assert "ChainedAssignment" in types

--- a/rewrite-python/rewrite/tests/python/py27/ternary_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/ternary_test.py
@@ -1,0 +1,71 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Conditional expressions (``a if b else c``).
+
+parso emits the ternary as a flat ``test`` node with five children. The
+visitor converts it to :class:`j.Ternary`, whose source order is
+``true_part if condition else false_part``.
+"""
+
+import pytest
+
+from rewrite.java import tree as j
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+from rewrite.python.printer import PythonPrinter
+
+
+def _expr(src: str):
+    cu = Py2ParserVisitor(src, "<test>", "2.7").parse()
+    stmt = cu.statements[0]
+    return stmt.assignment if isinstance(stmt, j.Assignment) else stmt
+
+
+def _round_trip(src: str) -> str:
+    return PythonPrinter().print(Py2ParserVisitor(src, "<test>", "2.7").parse())
+
+
+def test_simple_ternary_shape():
+    e = _expr("x = a if b else c\n")
+    assert isinstance(e, j.Ternary)
+    assert isinstance(e.true_part, j.Identifier)
+    assert e.true_part.simple_name == "a"
+    assert isinstance(e.condition, j.Identifier)
+    assert e.condition.simple_name == "b"
+    assert isinstance(e.false_part, j.Identifier)
+    assert e.false_part.simple_name == "c"
+
+
+@pytest.mark.parametrize("src", [
+    "x = a if b else c\n",
+    "x = 1 if cond else 0\n",
+    "x = (a + 1) if b > 0 else (a - 1)\n",
+    "x = f(a) if a is not None else f(b)\n",
+])
+def test_round_trip(src):
+    assert _round_trip(src) == src
+
+
+def test_nested_ternary():
+    src = "x = a if c1 else b if c2 else d\n"
+    e = _expr(src)
+    assert isinstance(e, j.Ternary)
+    # Right-associative: a if c1 else (b if c2 else d)
+    assert isinstance(e.false_part, j.Ternary)
+    assert _round_trip(src) == src
+
+
+def test_ternary_as_call_arg():
+    src = "x = f(a if cond else b)\n"
+    assert _round_trip(src) == src

--- a/rewrite-python/rewrite/tests/python/py27/trailing_newline_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/trailing_newline_test.py
@@ -1,0 +1,52 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Round-trip the presence (or absence) of a trailing newline.
+
+Real-world Py2 files end with or without ``\\n``. The parser must preserve
+the original layout byte-for-byte; a missing trailing newline cannot be
+silently inserted.
+"""
+
+import pytest
+
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+from rewrite.python.printer import PythonPrinter
+
+
+def _round_trip(src: str) -> str:
+    return PythonPrinter().print(Py2ParserVisitor(src, "<test>", "2.7").parse())
+
+
+@pytest.mark.parametrize("src", [
+    "x = 1\n",
+    "x = 1",
+    "x = 1\n\n",
+    "x = 1\ny = 2\n",
+    "x = 1\ny = 2",
+    "\nx = 1\n",
+    "\n\nx = 1\n",
+])
+def test_trailing_newline_variants_round_trip(src):
+    assert _round_trip(src) == src
+
+
+def test_compound_statement_no_trailing_newline():
+    src = "def f():\n    pass"
+    assert _round_trip(src) == src
+
+
+def test_blank_lines_between_statements_preserved():
+    src = "x = 1\n\n\ny = 2\n"
+    assert _round_trip(src) == src

--- a/rewrite-python/rewrite/tests/python/py27/tuple_assign_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/tuple_assign_test.py
@@ -1,0 +1,71 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tuple destructuring assignment.
+
+In Python 2 ``a, b = 1, 2`` is a common idiom. The left-hand and
+right-hand sides are both bare ``testlist`` nodes (no parentheses); the
+LST represents each as a :class:`py.CollectionLiteral` of kind ``TUPLE``
+with the ``OmitParentheses`` marker on its elements container, so the
+printer doesn't reintroduce the ``()`` wrappers.
+"""
+
+import pytest
+
+from rewrite.java import tree as j
+from rewrite.python import tree as py
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+from rewrite.python.printer import PythonPrinter
+
+
+def _stmt(src: str):
+    return Py2ParserVisitor(src, "<test>", "2.7").parse().statements[0]
+
+
+def _round_trip(src: str) -> str:
+    return PythonPrinter().print(Py2ParserVisitor(src, "<test>", "2.7").parse())
+
+
+class TestShape:
+    def test_lhs_is_tuple(self):
+        stmt = _stmt("a, b = 1, 2\n")
+        assert isinstance(stmt, j.Assignment)
+        assert isinstance(stmt.variable, py.CollectionLiteral)
+        assert stmt.variable.kind == py.CollectionLiteral.Kind.TUPLE
+
+    def test_rhs_is_tuple(self):
+        stmt = _stmt("a, b = 1, 2\n")
+        assert isinstance(stmt.assignment, py.CollectionLiteral)
+        assert stmt.assignment.kind == py.CollectionLiteral.Kind.TUPLE
+
+    def test_three_way_destructure(self):
+        stmt = _stmt("a, b, c = 1, 2, 3\n")
+        assert isinstance(stmt.variable, py.CollectionLiteral)
+        assert len(stmt.variable.elements) == 3
+        assert len(stmt.assignment.elements) == 3
+
+
+class TestRoundTrip:
+    @pytest.mark.parametrize("src", [
+        "a, b = 1, 2\n",
+        "a, b, c = 1, 2, 3\n",
+        "a, b = c, d\n",
+        "(a, b) = (1, 2)\n",
+        "(a, b, c) = (1, 2, 3)\n",
+        "first, second = pair\n",
+        "k, v = items[0]\n",
+        "head, tail = xs[0], xs[1:]\n",
+    ])
+    def test_round_trip(self, src):
+        assert _round_trip(src) == src

--- a/rewrite-python/rewrite/tests/python/version_detect_test.py
+++ b/rewrite-python/rewrite/tests/python/version_detect_test.py
@@ -1,0 +1,141 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the auto-detection heuristics used by the Python RPC server
+to pick between the Py2 (parso) and Py3 (ast) parser per file/project."""
+
+from pathlib import Path
+
+import pytest
+
+from rewrite.python._version_detect import detect_from_source, detect_from_project
+
+
+class TestSourceDetection:
+    def test_returns_none_for_empty(self):
+        assert detect_from_source("") is None
+
+    def test_returns_none_when_no_signal(self):
+        assert detect_from_source("x = 1\nprint(x)\n") is None
+
+    @pytest.mark.parametrize(
+        "shebang,expected",
+        [
+            ("#!/usr/bin/env python2", "2"),
+            ("#!/usr/bin/env python2.7", "2.7"),
+            ("#!/usr/bin/python2", "2"),
+            ("#!/usr/bin/python2.7", "2.7"),
+            ("#!python2", "2"),
+            ("#!python3", "3"),
+            ("#!/usr/bin/env python3.11", "3.11"),
+        ],
+    )
+    def test_shebang(self, shebang, expected):
+        assert detect_from_source(f"{shebang}\nx = 1\n") == expected
+
+    def test_unversioned_shebang_yields_none(self):
+        # `python` with no version digit is ambiguous — must not be a Py2 signal.
+        assert detect_from_source("#!/usr/bin/env python\nx = 1\n") is None
+
+    def test_shebang_only_on_line_one(self):
+        # A `#!` on line 3 is not a real shebang and must not be honored.
+        assert detect_from_source("# foo\n# bar\n#!/usr/bin/env python2\n") is None
+
+    @pytest.mark.parametrize(
+        "comment,expected",
+        [
+            ("# -*- python: 2 -*-", "2"),
+            ("# -*- python: 2.7 -*-", "2.7"),
+            ("# -*- python: 3 -*-", "3"),
+            ("#  python:2.7", "2.7"),
+        ],
+    )
+    def test_magic_comment(self, comment, expected):
+        assert detect_from_source(f"{comment}\nx = 1\n") == expected
+
+    def test_magic_comment_line_two(self):
+        # PEP-263 allows the magic comment on line 2 (after a shebang).
+        src = "#!/usr/bin/env python\n# -*- python: 2.7 -*-\nx = 1\n"
+        assert detect_from_source(src) == "2.7"
+
+    def test_magic_comment_not_after_line_two(self):
+        src = "# foo\n# bar\n# -*- python: 2 -*-\n"
+        assert detect_from_source(src) is None
+
+    def test_magic_comment_beats_shebang(self):
+        # If both are present, magic comment is the authoritative signal.
+        src = "#!/usr/bin/env python3\n# -*- python: 2.7 -*-\nx = 1\n"
+        assert detect_from_source(src) == "2.7"
+
+    def test_bom_is_stripped(self):
+        src = "﻿#!/usr/bin/env python2\nx = 1\n"
+        assert detect_from_source(src) == "2"
+
+
+class TestProjectDetection:
+    def test_returns_none_for_none_path(self):
+        assert detect_from_project(None) is None
+
+    def test_returns_none_for_missing_dir(self, tmp_path):
+        assert detect_from_project(tmp_path / "does-not-exist") is None
+
+    def test_returns_none_when_no_metadata(self, tmp_path):
+        assert detect_from_project(tmp_path) is None
+
+    def test_pyproject_classifier_py2(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nclassifiers = ["Programming Language :: Python :: 2.7"]\n'
+        )
+        assert detect_from_project(tmp_path) == "2.7"
+
+    def test_pyproject_classifier_py3(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nclassifiers = ["Programming Language :: Python :: 3.10"]\n'
+        )
+        assert detect_from_project(tmp_path) == "3.10"
+
+    def test_pyproject_mixed_major_versions_yields_none(self, tmp_path):
+        # A project that declares support for both 2.7 and 3.x cannot be
+        # routed at the project level; per-file detection must decide.
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nclassifiers = ['
+            '"Programming Language :: Python :: 2.7", '
+            '"Programming Language :: Python :: 3.10"]\n'
+        )
+        assert detect_from_project(tmp_path) is None
+
+    def test_requires_python_pinned_to_py2(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nrequires-python = ">=2.7,<3"\n'
+        )
+        assert detect_from_project(tmp_path) == "2.7"
+
+    def test_requires_python_pinned_to_py3(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nrequires-python = ">=3.10"\n'
+        )
+        assert detect_from_project(tmp_path) == "3"
+
+    def test_setup_cfg_classifier(self, tmp_path):
+        (tmp_path / "setup.cfg").write_text(
+            "[metadata]\nclassifiers =\n"
+            "    Programming Language :: Python :: 2.7\n"
+        )
+        assert detect_from_project(tmp_path) == "2.7"
+
+    def test_accepts_string_path(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nclassifiers = ["Programming Language :: Python :: 2.7"]\n'
+        )
+        assert detect_from_project(str(tmp_path)) == "2.7"

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -25,7 +25,7 @@ def test_handle_parse_preserves_empty_text(tmp_path, monkeypatch):
     observed = {}
 
     # given
-    def fake_parse_python_source(source, path="<unknown>", relative_to=None, ty_client=None):
+    def fake_parse_python_source(source, path="<unknown>", relative_to=None, ty_client=None, **_):
         observed["source"] = source
         observed["path"] = path
         return {"id": "empty-file"}

--- a/rewrite-python/src/main/java/org/openrewrite/python/PythonParser.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/PythonParser.java
@@ -28,7 +28,9 @@ import org.openrewrite.tree.ParseError;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -43,6 +45,14 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class PythonParser implements Parser {
     private final long maxSizeBytes;
+
+    /**
+     * Per-parse Python language version override. When {@code null}, the RPC
+     * server uses its process-wide default (controlled by
+     * {@code REWRITE_PYTHON_VERSION} via
+     * {@link PythonRewriteRpc.Builder#pythonVersion(String)}).
+     */
+    private final @Nullable PythonLanguageLevel languageLevel;
 
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sources, @Nullable Path relativeTo, ExecutionContext ctx) {
@@ -69,8 +79,11 @@ public class PythonParser implements Parser {
         Stream<SourceFile> smallFileStream = Stream.empty();
         if (!smallFiles.isEmpty()) {
             PythonValidator<Integer> validator = new PythonValidator<>();
+            Map<String, String> options = languageLevel != null
+                    ? Collections.singletonMap("languageLevel", languageLevel.version())
+                    : null;
             smallFileStream = PythonRewriteRpc.getOrStart().parse(smallFiles, relativeTo, this,
-                    Py.CompilationUnit.class.getName(), ctx).map(source -> {
+                    Py.CompilationUnit.class.getName(), ctx, options).map(source -> {
                 try {
                     validator.visit(source, 0);
                     return source;
@@ -103,6 +116,7 @@ public class PythonParser implements Parser {
 
     public static class Builder extends Parser.Builder {
         private long maxSizeBytes = 2 * 1024 * 1024; // 2MB default
+        private @Nullable PythonLanguageLevel languageLevel;
 
         public Builder() {
             super(Py.CompilationUnit.class);
@@ -120,14 +134,58 @@ public class PythonParser implements Parser {
             return this;
         }
 
+        /**
+         * Per-parse Python language version. Overrides the RPC server's
+         * process-wide default for the inputs parsed through this parser
+         * instance only.
+         * <p>
+         * When unset, the server falls back to the version configured on
+         * {@link PythonRewriteRpc.Builder#pythonVersion(String)} (default
+         * {@link PythonLanguageLevel#PYTHON_3}).
+         *
+         * @param languageLevel The Python version to parse with.
+         * @return This builder.
+         */
+        public Builder languageLevel(@Nullable PythonLanguageLevel languageLevel) {
+            this.languageLevel = languageLevel;
+            return this;
+        }
+
         @Override
         public PythonParser build() {
-            return new PythonParser(maxSizeBytes);
+            return new PythonParser(maxSizeBytes, languageLevel);
         }
 
         @Override
         public String getDslName() {
             return "python";
+        }
+    }
+
+    /**
+     * Python language version selectable on the parser.
+     * <p>
+     * Only the levels the parser actually branches on are exposed: the Py2.7
+     * grammar (via the parso-based path) is distinct from the Py3 grammar
+     * (via the {@code ast} module). New minor versions are added as the
+     * parser starts to distinguish them.
+     */
+    public enum PythonLanguageLevel {
+        PYTHON_2_7("2.7"),
+        PYTHON_3("3");
+
+        private final String version;
+
+        PythonLanguageLevel(String version) {
+            this.version = version;
+        }
+
+        /**
+         * @return The version string sent over the RPC parse request to
+         * select the corresponding parser path on the server.
+         */
+        public String version() {
+            return version;
         }
     }
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/marker/LegacyNotEqual.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marker/LegacyNotEqual.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.rpc.RpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.util.UUID;
+
+/**
+ * Marker indicating that a {@code J.Binary} of type {@code NotEqual} was written using
+ * the Python 2 {@code <>} spelling rather than {@code !=}.
+ * <p>
+ * The default printer renders {@code Binary.Type.NotEqual} as {@code !=}; when this
+ * marker is present it emits the legacy {@code <>} spelling instead, so Python 2
+ * sources round-trip byte-for-byte.
+ */
+@Value
+@With
+public class LegacyNotEqual implements Marker, RpcCodec<LegacyNotEqual> {
+    UUID id;
+
+    @Override
+    public void rpcSend(LegacyNotEqual after, RpcSendQueue q) {
+        q.getAndSend(after, Marker::getId);
+    }
+
+    @Override
+    public LegacyNotEqual rpcReceive(LegacyNotEqual before, RpcReceiveQueue q) {
+        return before.withId(q.receiveAndGet(before.getId(), UUID::fromString));
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/marker/RaiseTuple.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marker/RaiseTuple.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.rpc.RpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.util.UUID;
+
+/**
+ * Marker indicating that a {@code J.Throw} represents a Python 2 three-argument
+ * {@code raise E, v, tb} form.
+ * <p>
+ * The exception slot of the {@code J.Throw} holds a {@code Py.CollectionLiteral} of
+ * kind {@code TUPLE} containing the three operands; when this marker is present the
+ * printer drops the tuple's enclosing parentheses and renders the legacy comma-
+ * separated syntax so Python 2 sources round-trip byte-for-byte.
+ */
+@Value
+@With
+public class RaiseTuple implements Marker, RpcCodec<RaiseTuple> {
+    UUID id;
+
+    @Override
+    public void rpcSend(RaiseTuple after, RpcSendQueue q) {
+        q.getAndSend(after, Marker::getId);
+    }
+
+    @Override
+    public RaiseTuple rpcReceive(RaiseTuple before, RpcReceiveQueue q) {
+        return before.withId(q.receiveAndGet(before.getId(), UUID::fromString));
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/marker/TupleExceptClause.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marker/TupleExceptClause.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.rpc.RpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.util.UUID;
+
+/**
+ * Marker indicating that a {@code J.Try.Catch} was written using the Python 2
+ * {@code except E, e:} comma form rather than the Python 3 {@code except E as e:}
+ * form.
+ * <p>
+ * The default printer renders the catch as {@code except E as e:}; when this
+ * marker is present it emits the Py2 comma-based syntax instead so Python 2
+ * sources round-trip byte-for-byte.
+ */
+@Value
+@With
+public class TupleExceptClause implements Marker, RpcCodec<TupleExceptClause> {
+    UUID id;
+
+    @Override
+    public void rpcSend(TupleExceptClause after, RpcSendQueue q) {
+        q.getAndSend(after, Marker::getId);
+    }
+
+    @Override
+    public TupleExceptClause rpcReceive(TupleExceptClause before, RpcReceiveQueue q) {
+        return before.withId(q.receiveAndGet(before.getId(), UUID::fromString));
+    }
+}

--- a/rewrite-python/src/test/java/org/openrewrite/python/PythonParserTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/PythonParserTest.java
@@ -107,4 +107,53 @@ class PythonParserTest implements RewriteTest {
             softly.assertThat(sf.getMarkers().getMarkers()).isEmpty();
         });
     }
+
+    @Test
+    void parsePython2WithLanguageLevel() {
+        SourceFile sf = PythonParser.builder().languageLevel(PythonParser.PythonLanguageLevel.PYTHON_2_7).build()
+          .parse("print \"hello\"\n")
+          .findFirst()
+          .get();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(sf).isInstanceOf(Py.CompilationUnit.class);
+            softly.assertThat(sf.getMarkers().getMarkers()).isEmpty();
+        });
+    }
+
+    @Test
+    void parsePython2ComprehensiveRoundTrip() {
+        String source =
+          "import os\n" +
+          "from os.path import join, dirname\n" +
+          "\n" +
+          "\n" +
+          "def greet(name, greeting=\"hello\"):\n" +
+          "    if name:\n" +
+          "        print greeting, name\n" +
+          "    else:\n" +
+          "        print >> sys.stderr, \"missing name\"\n" +
+          "    return greeting + name\n" +
+          "\n" +
+          "\n" +
+          "class Worker(Base):\n" +
+          "    def run(self, items):\n" +
+          "        results = []\n" +
+          "        for item in items:\n" +
+          "            try:\n" +
+          "                results.append(self.process(item))\n" +
+          "            except ValueError, e:\n" +
+          "                self.log(e)\n" +
+          "        return results\n";
+
+        SourceFile sf = PythonParser.builder().languageLevel(PythonParser.PythonLanguageLevel.PYTHON_2_7).build()
+          .parse(source)
+          .findFirst()
+          .get();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(sf).isInstanceOf(Py.CompilationUnit.class);
+            softly.assertThat(sf.getMarkers().getMarkers()).isEmpty();
+            softly.assertThat(sf.printAll()).isEqualTo(source);
+        });
+    }
 }


### PR DESCRIPTION
Adds full Python 2.7 parsing support, plumbed end-to-end from Java through the RPC pipeline to the in-process printer's round-trip check.

## Public API

- `PythonParser.builder().languageLevel(PythonLanguageLevel.PYTHON_2_7)` —  per-parse version selection. Enum follows the `KotlinParser` /  `KotlinLanguageLevel` house style.
- `Parse` RPC request gains a nullable `Map<String, String> options` field (backwards-compatible; null on older clients).

## Auto-detection

When `languageLevel` isn't set, the Python RPC server picks Py2 vs Py3 per parse using (in order): explicit option, in-source signals (PEP-263 magic comment / shebang), project metadata (`pyproject.toml` classifiers and `requires-python`, `setup.cfg` classifiers), `REWRITE_PYTHON_VERSION` env default. The Moderne CLI's existing `parseProject(...)` path picks up Py2 repos with no CLI change required.

## Parser

The pre-existing `_py2_parser_visitor.py` was a stub: it handled only leaves, `print`/`exec`, simple assignment, and backticks; everything else returned placeholder identifiers like `<funcdef>`. This PR fills in the grammar:

- Expressions: binary fold (incl. `not in` / `is not`), unary, ternary, parens, lambda, calls (positional + keyword + `*`/`**`), attribute chains, subscripts, slices.
- Statements: `if`/`elif`/`else`, `while`, `for` (with tuple destructure and `else:` clause), `try`/`except`/`else`/`finally`, `with` (multi-context), all import shapes (incl. relative + star + parenthesized), `raise`/`assert`/`del`/`global`/`yield`, chained and augmented assignment, decorators (single, call-form, dotted, multi), classes (incl. old-style no-parens), functions (all param shapes).
- Atoms: list/dict/tuple/set/empty literals, all comprehension kinds, generator-as-call-arg.
- Literals: long suffix `100L`, Py2 octal `0777`, all string prefixes (`u`, `r`, `ur`, `b`), implicit string concatenation.
- Whitespace: newline-between-statement threading, trailing-comma preservation via `TrailingComma` marker, trailing-comment preservation, `OmitParentheses` on bare testlists.

## Py2-only markers + matching printer branches

- `TupleExceptClause` → emits `except E, e:` (Py2 comma form)
- `LegacyNotEqual` → emits `<>` (note: parso < 0.8 doesn't actually parse `<>`, so the marker is reachable only via future grammar work)
- `RaiseTuple` → emits `raise E, v, tb`

## Known gaps (documented in code)

- `<>` operator support requires source pre-processing because parso doesn't parse it. Marker, fold logic, and printer hook are in place; the parse rewrite is left for a follow-up.