### PR TITLE
Scala: various parser fixes for whitespace in try-catch

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -278,16 +278,11 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 }
                 visitSpace(paramPadded.getAfter(), Space.Location.CONTROL_PARENTHESES_PREFIX, p);
                 p.append("=>");
-                J.Block catchBody = aCatch.getBody();
-                visitSpace(catchBody.getPrefix(), Space.Location.BLOCK_PREFIX, p);
-                for (JRightPadded<Statement> stmtPadded : catchBody.getPadding().getStatements()) {
-                    visit(stmtPadded.getElement(), p);
-                    visitSpace(stmtPadded.getAfter(), Space.Location.LANGUAGE_EXTENSION, p);
-                }
+                // Catch case body is a J.Block with OmitBraces — delegate to visitBlock
+                // so the block prefix, inter-statement padding (incl. Semicolon markers),
+                // and end space are all printed correctly.
+                visit(aCatch.getBody(), p);
             }
-            // Close catch block — use end space from last catch body if available
-            J.Try.Catch lastCatch = tryable.getCatches().get(tryable.getCatches().size() - 1);
-            visitSpace(lastCatch.getBody().getEnd(), Space.Location.BLOCK_END, p);
             if (!indentedCatch) {
                 p.append("}");
             }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -278,8 +278,11 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 }
                 visitSpace(paramPadded.getAfter(), Space.Location.CONTROL_PARENTHESES_PREFIX, p);
                 p.append("=>");
-                for (Statement stmt : aCatch.getBody().getStatements()) {
-                    visit(stmt, p);
+                J.Block catchBody = aCatch.getBody();
+                visitSpace(catchBody.getPrefix(), Space.Location.BLOCK_PREFIX, p);
+                for (JRightPadded<Statement> stmtPadded : catchBody.getPadding().getStatements()) {
+                    visit(stmtPadded.getElement(), p);
+                    visitSpace(stmtPadded.getAfter(), Space.Location.LANGUAGE_EXTENSION, p);
                 }
             }
             // Close catch block — use end space from last catch body if available

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
@@ -461,4 +461,44 @@ class MatchTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void matchCaseWithMultiStatementBody() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              def handle(x: Any): String = x match {
+                case s: String =>
+                  println("got string")
+                  s
+                case _ =>
+                  println("other")
+                  "other"
+              }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void partialFunctionLiteralWithMultiStatementCaseBody() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              val handler: PartialFunction[Any, String] = {
+                case s: String =>
+                  println("got string")
+                  s
+                case _ =>
+                  println("other")
+                  "other"
+              }
+            }
+            """
+          )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
@@ -290,6 +290,25 @@ class TryTest implements RewriteTest {
     }
 
     @Test
+    void catchCaseWithMultipleStatementBody() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                try {
+                  println("risky")
+                } catch {
+                  case _: Exception =>
+                    Thread.sleep(500)
+                    println("recover")
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void spaceBeforeColonOnCatchParameter() {
         rewriteRun(scala(
             """

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
@@ -309,6 +309,41 @@ class TryTest implements RewriteTest {
     }
 
     @Test
+    void catchMultipleCasesWithMultiStatementBodies() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                try {
+                  println("risky")
+                } catch {
+                  case _: NumberFormatException =>
+                    println("nfe a")
+                    println("nfe b")
+                  case _: Exception =>
+                    println("ex a")
+                    println("ex b")
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void catchCaseWithSemicolonSeparatedBody() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                try { 1 } catch { case _: Exception => println("a"); println("b") }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void spaceBeforeColonOnCatchParameter() {
         rewriteRun(scala(
             """


### PR DESCRIPTION
## What's changed?

Scala parser fixes for handling of whitespace around and within try-catch statements.

## What's your motivation?

They suffer from idempotency issues.
