### PR TITLE
Scala: fix parsing of closing braces in try-catch

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5922,7 +5922,15 @@ class ScalaTreeVisitor(
         val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), controlPrefix, Markers.EMPTY, JRightPadded.build(varDecl).withAfter(spaceBeforeArrow))
 
         val caseBody = visitTree(caseDef.body) match {
-          case block: J.Block => block
+          case block: J.Block if block.getMarkers.findFirst(classOf[OmitBraces]).isPresent => block
+          case block: J.Block =>
+            // Block has its own braces (e.g. `case _ => { stmts }`). Wrap it in an
+            // OmitBraces shell so the inner block keeps its own end space and the
+            // shell can carry the catch's trailing space (before the outer `}`).
+            val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(block))
+            new J.Block(Tree.randomId(), Space.EMPTY,
+              Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId()))),
+              JRightPadded.build(false), s, Space.EMPTY)
           case stmt: Statement =>
             val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(stmt))
             new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), s, Space.EMPTY)
@@ -6067,7 +6075,12 @@ class ScalaTreeVisitor(
         val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), controlPrefix, Markers.EMPTY, JRightPadded.build(varDecl).withAfter(spaceBeforeArrow))
 
         val caseBody = visitTree(caseDef.body) match {
-          case block: J.Block => block
+          case block: J.Block if block.getMarkers.findFirst(classOf[OmitBraces]).isPresent => block
+          case block: J.Block =>
+            val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(block))
+            new J.Block(Tree.randomId(), Space.EMPTY,
+              Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId()))),
+              JRightPadded.build(false), s, Space.EMPTY)
           case stmt: Statement =>
             val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(stmt))
             new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), s, Space.EMPTY)

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
@@ -344,6 +344,28 @@ class TryTest implements RewriteTest {
     }
 
     @Test
+    void catchCaseWithBlockBody() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                def foo: Boolean = {
+                  try {
+                    true
+                  } catch {
+                    case e: Exception => {
+                      e.printStackTrace()
+                      false
+                    }
+                  }
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void spaceBeforeColonOnCatchParameter() {
         rewriteRun(scala(
             """


### PR DESCRIPTION
## What's changed?

Fix one specific case of Scala parsing of closing braces in try-catch.

## What's your motivation?

It suffers from idempotency issues.