### PR TITLE
Scala: another set of fixes for parsing of indentation-significant syntax

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -1076,6 +1076,12 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             for (Expression arg : fc.getArguments()) {
                 visit(arg, p);
             }
+        } else if (fc.getMarkers().findFirst(IndentedSyntax.class).isPresent()) {
+            // Colon-indented arg list: `foo(x):\n  ...`. The arg's prefix carries the indent.
+            p.append(':');
+            for (Expression arg : fc.getArguments()) {
+                visit(arg, p);
+            }
         } else {
             visitContainer("(", fc.getPadding().getArguments(), JContainer.Location.METHOD_INVOCATION_ARGUMENTS, ",", ")", p);
         }
@@ -1443,16 +1449,22 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return lambda;
         }
 
-        // Partial-function literal `{ case pat => ... }` — the body is a J.Block of J.Case.
+        // Partial-function literal: brace form `{ case pat => ... }` or indented form
+        // (after a colon-arg call) where braces are absent.
         if (lambda.getMarkers().findFirst(PartialFunctionLiteral.class).isPresent() &&
                 lambda.getBody() instanceof J.Block) {
+            boolean indented = lambda.getMarkers().findFirst(IndentedSyntax.class).isPresent();
             J.Block cases = (J.Block) lambda.getBody();
-            p.append('{');
+            if (!indented) {
+                p.append('{');
+            }
             for (Statement caseStmt : cases.getStatements()) {
                 visit(caseStmt, p);
             }
             visitSpace(cases.getEnd(), Space.Location.BLOCK_END, p);
-            p.append('}');
+            if (!indented) {
+                p.append('}');
+            }
             afterSyntax(lambda, p);
             return lambda;
         }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -1314,6 +1314,38 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
     
     @Override
     public J visitMethodInvocation(J.MethodInvocation method, PrintOutputCapture<P> p) {
+        // Colon-indented argument: `f: arg`, `obj.method: arg`, or `obj.method[T]: arg`.
+        // The arg's prefix carries the indent; we emit `:` in place of `(...)`.
+        if (method.getMarkers().findFirst(IndentedSyntax.class).isPresent()) {
+            beforeSyntax(method, Space.Location.METHOD_INVOCATION_PREFIX, p);
+
+            if (method.getMarkers().findFirst(org.openrewrite.scala.marker.FunctionApplication.class).isPresent()) {
+                // Function application: `f: arg` — skip the `.apply` name
+                visitRightPadded(method.getPadding().getSelect(), JRightPadded.Location.METHOD_SELECT, "", p);
+            } else {
+                if (method.getPadding().getSelect() != null) {
+                    visitRightPadded(method.getPadding().getSelect(), JRightPadded.Location.METHOD_SELECT, ".", p);
+                }
+                visit(method.getName(), p);
+            }
+
+            if (method.getTypeParameters() != null && !method.getTypeParameters().isEmpty()) {
+                visitContainer("[", method.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, ",", "]", p);
+            }
+
+            JContainer<Expression> colonArgs = method.getPadding().getArguments();
+            if (colonArgs != null) {
+                visitSpace(colonArgs.getBefore(), Space.Location.METHOD_INVOCATION_ARGUMENTS, p);
+                p.append(':');
+                for (Expression arg : method.getArguments()) {
+                    visit(arg, p);
+                }
+            }
+
+            afterSyntax(method, p);
+            return method;
+        }
+
         // Check block argument BEFORE function application — when both are present
         // (e.g. `Seq { 1 }`), the block-arg path should win.
         if (method.getMarkers().findFirst(BlockArgument.class).isPresent()) {

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -938,7 +938,8 @@ class ScalaTreeVisitor(
         val innerEnd = Math.max(0, innerApp.span.end - offsetAdjustment)
         if (innerEnd > cursor && innerEnd <= source.length) cursor = innerEnd
 
-        // Outer arg list is `{ ... }` when next non-ws is `{`, otherwise `(...)`.
+        // Outer arg list is `{ ... }` when next non-ws is `{`, `: ...` when it's `:`,
+        // otherwise parenthesized `(...)`.
         val firstNonWs = indexOfNextNonWhitespace(cursor)
         val outerArgs = new util.ArrayList[JRightPadded[Expression]]()
 
@@ -949,6 +950,20 @@ class ScalaTreeVisitor(
           val markers = Markers.build(Collections.singletonList(new BlockArgument(Tree.randomId())))
           return S.FunctionCall.build(Tree.randomId(), prefix, markers,
             JRightPadded.build(fn), JContainer.build(Space.EMPTY, outerArgs, Markers.EMPTY), methodType)
+        }
+
+        if (firstNonWs < source.length && source.charAt(firstNonWs) == ':') {
+          // Colon-indented arg list: `foldLeft(0):\n  case ... => ...` — the fn-after space
+          // captures any whitespace between `)` and `:`, then the cursor moves past `:`
+          // so the arg's own prefix carries the newline+indent before its first token.
+          val functionAfterSpace = if (firstNonWs > cursor) Space.format(source, cursor, firstNonWs) else Space.EMPTY
+          cursor = firstNonWs + 1
+          for (arg <- app.args) outerArgs.add(JRightPadded.build(asExpression(visitTree(arg))))
+          finishAtAppEnd()
+          val markers = Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId())))
+          return S.FunctionCall.build(Tree.randomId(), prefix, markers,
+            new JRightPadded(fn, functionAfterSpace, Markers.EMPTY),
+            JContainer.build(Space.EMPTY, outerArgs, Markers.EMPTY), methodType)
         }
 
         val functionAfterSpace = if (firstNonWs > cursor) Space.format(source, cursor, firstNonWs) else Space.EMPTY
@@ -6128,19 +6143,25 @@ class ScalaTreeVisitor(
   private def visitMatchImpl(matchTree: Trees.Match[?]): J = {
     val prefix = extractPrefix(matchTree.span)
 
-    // Partial-function literal `{ case pat => ... }` has a synthetic selector with NoSpan.
-    // Emit a J.Lambda (no params) whose body is the cases block; printer uses the marker
-    // to emit the `{ case ... => ... }` form.
+    // Partial-function literal: either `{ case pat => ... }` (brace form) or an
+    // indented form following a colon-arg call like `foldLeft(0):\n  case ...`.
+    // Both have a synthetic match selector with NoSpan.
     if (!matchTree.selector.span.exists) {
       val bs = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 20, source.length)) else ""
-      val bi = bs.indexOf('{'); if (bi >= 0) cursor = cursor + bi + 1
-      val casesBlock = buildCasesBlock(matchTree)
+      val bi = bs.indexOf('{')
+      val ci = bs.indexOf("case")
+      val isBraceForm = bi >= 0 && (ci < 0 || bi < ci)
+      if (isBraceForm) cursor = cursor + bi + 1
+      val casesBlock = buildCasesBlock(matchTree, isBraceForm)
       updateCursor(matchTree.span.end)
       val parameters = new J.Lambda.Parameters(
         Tree.randomId(), Space.EMPTY, Markers.EMPTY, false, Collections.emptyList())
+      val lambdaMarkers = new util.ArrayList[org.openrewrite.marker.Marker]()
+      lambdaMarkers.add(new PartialFunctionLiteral(Tree.randomId()))
+      if (!isBraceForm) lambdaMarkers.add(new IndentedSyntax(Tree.randomId()))
       return new J.Lambda(
         Tree.randomId(), prefix,
-        Markers.build(Collections.singletonList(new PartialFunctionLiteral(Tree.randomId()))),
+        Markers.build(lambdaMarkers),
         parameters, Space.EMPTY, casesBlock, null)
     }
 

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -734,11 +734,15 @@ class ScalaTreeVisitor(
     // The select is the identifier (e.g., "arr")
     val select = visitIdent(id).asInstanceOf[Expression]
 
-    // Detect block argument syntax: `Seq { 1 }` vs parenthesized `Seq(1)`.
-    val isBlockArg = if (app.args.nonEmpty) {
-      val pos = indexOfNextNonWhitespace(cursor)
-      pos < source.length && source.charAt(pos) == '{'
-    } else false
+    // Detect argument delimiter form:
+    //   `{ ... }` — block argument (`Seq { 1 }`)
+    //   `: ...`   — Scala 3 colon-indented argument (`f: x => ...`)
+    //   `( ... )` — normal parenthesized argument list
+    val firstArgNonWs = if (app.args.nonEmpty) indexOfNextNonWhitespace(cursor) else -1
+    val isBlockArg = firstArgNonWs >= 0 && firstArgNonWs < source.length &&
+      source.charAt(firstArgNonWs) == '{'
+    val isColonArg = !isBlockArg && firstArgNonWs >= 0 && firstArgNonWs < source.length &&
+      source.charAt(firstArgNonWs) == ':'
 
     val args = new util.ArrayList[JRightPadded[Expression]]()
     var argContainerPrefix = Space.EMPTY
@@ -757,6 +761,26 @@ class ScalaTreeVisitor(
           case block: J.Block =>
             val blockExpr = new S.StatementExpression(Tree.randomId(), block.withPrefix(argSpace))
             args.add(JRightPadded.build(blockExpr.asInstanceOf[Expression]))
+          case _ =>
+        }
+      }
+    } else if (isColonArg) {
+      // Colon-indented argument: `f: arg` or `f:\n  arg`.
+      markers.add(new IndentedSyntax(Tree.randomId()))
+      if (firstArgNonWs > cursor) {
+        argContainerPrefix = Space.format(source, cursor, firstArgNonWs)
+      }
+      cursor = firstArgNonWs + 1
+      for (arg <- app.args) {
+        visitTree(arg) match {
+          case expr: Expression =>
+            args.add(JRightPadded.build(expr))
+          case block: J.Block =>
+            val blockExpr = new S.StatementExpression(Tree.randomId(), block)
+            args.add(JRightPadded.build(blockExpr.asInstanceOf[Expression]))
+          case stmt: Statement =>
+            val stmtExpr = new S.StatementExpression(Tree.randomId(), stmt)
+            args.add(JRightPadded.build(stmtExpr.asInstanceOf[Expression]))
           case _ =>
         }
       }
@@ -1034,14 +1058,15 @@ class ScalaTreeVisitor(
           JContainer.build(Space.EMPTY, outerArgs, Markers.EMPTY), mt)
     }
 
-    // Determine if this is a block argument call (no parentheses):
-    //   list.foreach { x => println(x) }
-    // vs a normal parenthesized call:
-    //   list.foreach(x => println(x))
-    val isBlockArg = if (app.args.nonEmpty) {
-      val pos = indexOfNextNonWhitespace(cursor)
-      pos < source.length && source.charAt(pos) == '{'
-    } else false
+    // Determine the argument delimiter form:
+    //   `{ ... }` — block argument (`list.foreach { x => ... }`)
+    //   `: ...`   — Scala 3 colon-indented argument (`list.foreach: x => ...`)
+    //   `( ... )` — normal parenthesized argument list
+    val firstArgNonWs = if (app.args.nonEmpty) indexOfNextNonWhitespace(cursor) else -1
+    val isBlockArg = firstArgNonWs >= 0 && firstArgNonWs < source.length &&
+      source.charAt(firstArgNonWs) == '{'
+    val isColonArg = !isBlockArg && firstArgNonWs >= 0 && firstArgNonWs < source.length &&
+      source.charAt(firstArgNonWs) == ':'
 
     var argContainerPrefix = Space.EMPTY
     val args = new util.ArrayList[JRightPadded[Expression]]()
@@ -1056,6 +1081,27 @@ class ScalaTreeVisitor(
             // Keep the block as-is — the printer uses BlockArgument marker to print { }
             val blockExpr = new S.StatementExpression(Tree.randomId(), block)
             args.add(JRightPadded.build(blockExpr.asInstanceOf[Expression]))
+          case _ => cursor = savedCursor; return visitUnknown(app)
+        }
+      }
+    } else if (isColonArg) {
+      // Colon-indented argument: `f: arg` or `obj.method:\n  arg`. The captured
+      // space-before-`:` goes on the JContainer's prefix so it round-trips; the
+      // argument's own prefix carries the newline+indent before its first token.
+      if (firstArgNonWs > cursor) {
+        argContainerPrefix = Space.format(source, cursor, firstArgNonWs)
+      }
+      cursor = firstArgNonWs + 1
+      for (arg <- app.args) {
+        visitTree(arg) match {
+          case expr: Expression =>
+            args.add(JRightPadded.build(expr))
+          case block: J.Block =>
+            val blockExpr = new S.StatementExpression(Tree.randomId(), block)
+            args.add(JRightPadded.build(blockExpr.asInstanceOf[Expression]))
+          case stmt: Statement =>
+            val stmtExpr = new S.StatementExpression(Tree.randomId(), stmt)
+            args.add(JRightPadded.build(stmtExpr.asInstanceOf[Expression]))
           case _ => cursor = savedCursor; return visitUnknown(app)
         }
       }
@@ -1159,6 +1205,8 @@ class ScalaTreeVisitor(
 
     val markers = if (isBlockArg) {
       Markers.build(Collections.singletonList(new BlockArgument(Tree.randomId())))
+    } else if (isColonArg) {
+      Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId())))
     } else {
       Markers.EMPTY
     }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
@@ -309,4 +309,95 @@ class CompilationUnitTest implements RewriteTest {
         );
     }
 
+    @Test
+    void curriedMethodWithColonLambda() {
+        rewriteRun(
+          scala(
+            """
+            val x = List(1, 2, 3).foldLeft(0): (acc, n) =>
+              acc + n
+            """
+          )
+        );
+    }
+
+    @Test
+    void chainedMethodWithColonLambda() {
+        rewriteRun(
+          scala(
+            """
+            val x = List(1, 2).map: i =>
+              i + 1
+            """
+          )
+        );
+    }
+
+    @Test
+    void topLevelMethodWithColonLambda() {
+        rewriteRun(
+          scala(
+            """
+            def f(g: Int => Int): Int = g(1)
+            val x = f: i =>
+              i + 1
+            """
+          )
+        );
+    }
+
+    @Test
+    void chainedMethodWithColonPartialFunction() {
+        rewriteRun(
+          scala(
+            """
+            val x = List(1, 2).map:
+              case 1 => "one"
+              case _ => "other"
+            """
+          )
+        );
+    }
+
+    @Test
+    void colonArgWithMultilineBlock() {
+        rewriteRun(
+          scala(
+            """
+            def f(body: => Int): Int = body
+            val x = f:
+              val y = 1
+              y + 2
+            """
+          )
+        );
+    }
+
+    @Test
+    void typeApplyMethodWithColonArg() {
+        rewriteRun(
+          scala(
+            """
+            def f[A](g: A => A): Int = 0
+            val x = f[Int]:
+              n => n + 1
+            """
+          )
+        );
+    }
+
+    @Test
+    void nestedColonArgLambdas() {
+        rewriteRun(
+          scala(
+            """
+            def f(g: Int => Int => Int): Int = 0
+            val x = f: a =>
+              b =>
+                a + b
+            """
+          )
+        );
+    }
+
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
@@ -289,10 +289,24 @@ class CompilationUnitTest implements RewriteTest {
           scala(
             """
             val x = 42
-            
-            
+
+
             """
           )
         );
     }
+
+    @Test
+    void foldLeftWithColonPartialFunction() {
+        rewriteRun(
+          scala(
+            """
+            val x = List(1, 2, 3).foldLeft(0):
+              case (acc, n) if n > 0 => acc + n
+              case (acc, _) => acc
+            """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?

Another set of fixes for Scala parser wrt indentation-significant syntax.

## What's your motivation?

It suffers from idempotency issues.