### PR TITLE
Scala: introducing `S.RepeatedType`

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -602,6 +602,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return visitFunctionCall((S.FunctionCall) tree, p);
         } else if (tree instanceof S.SingletonType) {
             return visitSingletonType((S.SingletonType) tree, p);
+        } else if (tree instanceof S.RepeatedType) {
+            return visitRepeatedType((S.RepeatedType) tree, p);
         } else if (tree instanceof S.Alternative) {
             return visitAlternative((S.Alternative) tree, p);
         } else if (tree instanceof S.QualifiedSuper) {
@@ -1185,14 +1187,14 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             }
             p.append(":");
             visit(parent.getTypeExpression(), p);
-            
+
             // If there's an initializer, use visitLeftPadded to handle it properly
             visitLeftPadded("=", variable.getPadding().getInitializer(), JLeftPadded.Location.VARIABLE_INITIALIZER, p);
         } else {
             // No type annotation, handle initializer normally
             visitLeftPadded("=", variable.getPadding().getInitializer(), JLeftPadded.Location.VARIABLE_INITIALIZER, p);
         }
-        
+
         afterSyntax(variable, p);
         return variable;
     }
@@ -1578,6 +1580,15 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         p.append(".type");
         afterSyntax(singletonType, p);
         return singletonType;
+    }
+
+    public J visitRepeatedType(S.RepeatedType repeatedType, PrintOutputCapture<P> p) {
+        beforeSyntax(repeatedType, Space.Location.LANGUAGE_EXTENSION, p);
+        visit(repeatedType.getElementType(), p);
+        visitSpace(repeatedType.getBeforeStar(), Space.Location.LANGUAGE_EXTENSION, p);
+        p.append('*');
+        afterSyntax(repeatedType, p);
+        return repeatedType;
     }
 
     public J visitAlternative(S.Alternative alternative, PrintOutputCapture<P> p) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -193,6 +193,15 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         return s;
     }
 
+    public J visitRepeatedType(S.RepeatedType repeatedType, P p) {
+        S.RepeatedType r = repeatedType;
+        r = r.withPrefix(visitSpace(r.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        r = r.withMarkers(visitMarkers(r.getMarkers(), p));
+        r = r.withElementType(visitAndCast(r.getElementType(), p));
+        r = r.withBeforeStar(visitSpace(r.getBeforeStar(), Space.Location.LANGUAGE_EXTENSION, p));
+        return r;
+    }
+
     public J visitAlternative(S.Alternative alternative, P p) {
         S.Alternative a = alternative;
         a = a.withPrefix(visitSpace(a.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -989,6 +989,57 @@ public interface S extends J {
     }
 
     /**
+     * Represents a Scala repeated/vararg type: {@code T*}. Appears in method parameter
+     * positions ({@code def foo(args: String*)}) and in argument ascriptions
+     * ({@code f(xs: _*)}). Modeled as a {@link TypeTree} so it composes with anywhere
+     * a type can appear. {@code beforeStar} preserves whitespace between the element
+     * type and the trailing {@code *} (e.g. {@code String *}).
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    final class RepeatedType implements S, TypeTree, Expression {
+
+        @With @Getter @EqualsAndHashCode.Include
+        UUID id;
+
+        @With @Getter
+        Space prefix;
+
+        @With @Getter
+        Markers markers;
+
+        @With @Getter
+        TypeTree elementType;
+
+        @With @Getter
+        Space beforeStar;
+
+        @With @Getter
+        @Nullable
+        JavaType type;
+
+        public RepeatedType(UUID id, Space prefix, Markers markers, TypeTree elementType,
+                            Space beforeStar, @Nullable JavaType type) {
+            this.id = id;
+            this.prefix = prefix;
+            this.markers = markers;
+            this.elementType = elementType;
+            this.beforeStar = beforeStar;
+            this.type = type;
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitRepeatedType(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+    }
+
+    /**
      * Represents a Scala pattern alternative: {@code p1 | p2 | p3}.
      * Used in {@code case 1 | 2 | 3 => "small"} or {@code case _: A | _: B => ...}.
      */

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -6911,12 +6911,37 @@ class ScalaTreeVisitor(
    */
   private def visitTypeTree(tpt: Trees.Tree[?]): TypeTree = tpt match {
     case f: untpd.Function => visitFunctionType(f)
+    case po: untpd.PostfixOp if po.op != null && po.op.name.toString == "*" =>
+      visitRepeatedType(po)
     case _ =>
       visitTree(tpt) match {
         case tt: TypeTree => tt
         case id: J.Identifier => id
         case _ => null
       }
+  }
+
+  /**
+   * Build an `S.RepeatedType` for a repeated/vararg type position (e.g. `String*`).
+   * Scala 3's parser represents `T*` as `PostfixOp(T, Ident("*"))`.
+   */
+  private def visitRepeatedType(po: untpd.PostfixOp): S.RepeatedType = {
+    val prefix = extractPrefix(po.span)
+    val elementType = visitTypeTree(po.od)
+    val innerEnd = if (po.od.span.exists) Math.max(0, po.od.span.end - offsetAdjustment) else cursor
+    val starStart = if (po.op.span.exists) Math.max(0, po.op.span.start - offsetAdjustment) else innerEnd
+    val beforeStar = if (cursor < starStart && starStart <= source.length) {
+      Space.format(source, cursor, starStart)
+    } else Space.EMPTY
+    if (po.span.exists) updateCursor(po.span.end)
+    new S.RepeatedType(
+      Tree.randomId(),
+      prefix,
+      Markers.EMPTY,
+      elementType,
+      beforeStar,
+      typeOfTree(po)
+    )
   }
 
   /**

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -168,6 +168,45 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void methodWithVarargsParameter() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def foo(x: Int, more: String*): Int = x
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void methodWithOnlyVarargsParameter() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def foo(args: String*): Int = args.size
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void methodWithVarargsParameterizedType() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def foo(args: Array[String]*): Int = 0
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void methodWithDefaultParameter() {
         rewriteRun(
             scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -172,33 +172,13 @@ class MethodDeclarationTest implements RewriteTest {
         rewriteRun(
             scala(
                 """
-                object Test {
+                object A {
                   def foo(x: Int, more: String*): Int = x
                 }
-                """
-            )
-        );
-    }
-
-    @Test
-    void methodWithOnlyVarargsParameter() {
-        rewriteRun(
-            scala(
-                """
-                object Test {
+                object B {
                   def foo(args: String*): Int = args.size
                 }
-                """
-            )
-        );
-    }
-
-    @Test
-    void methodWithVarargsParameterizedType() {
-        rewriteRun(
-            scala(
-                """
-                object Test {
+                object C {
                   def foo(args: Array[String]*): Int = 0
                 }
                 """


### PR DESCRIPTION
## What's changed?

Introducing new LST element for repeated (varargs) types, e.g. `String*`

## What's your motivation?

Otherwise they are mishandled and suffer from idempotency issues.