### PR TITLE
Scala: fix unapply matching in catch clauses

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5964,7 +5964,11 @@ class ScalaTreeVisitor(
             // Multi-pattern: `_: A | _: B` — preserve full source as the "name", no separate type
             val patSource = extractSource(caseDef.pat.span)
             (patSource, null)
-          case _ => ("_", null)
+          case _ =>
+            // Any other pattern (e.g. UnApply extractor `NonFatal(e)`, tuple, literal) —
+            // preserve the full source text so the binding/extractor isn't lost on print.
+            val patSource = if (caseDef.pat.span.exists) extractSource(caseDef.pat.span) else ""
+            (if (patSource.nonEmpty) patSource else "_", null)
         }
         // Capture the whitespace between the param name and `:` (e.g. `e : Exception`).
         val beforeColon: Space = if (paramType != null && caseDef.pat.span.exists) {
@@ -6117,7 +6121,11 @@ class ScalaTreeVisitor(
             // Multi-pattern: `_: A | _: B` — preserve full source as the "name", no separate type
             val patSource = extractSource(caseDef.pat.span)
             (patSource, null)
-          case _ => ("_", null)
+          case _ =>
+            // Any other pattern (e.g. UnApply extractor `NonFatal(e)`, tuple, literal) —
+            // preserve the full source text so the binding/extractor isn't lost on print.
+            val patSource = if (caseDef.pat.span.exists) extractSource(caseDef.pat.span) else ""
+            (if (patSource.nonEmpty) patSource else "_", null)
         }
         // Capture the whitespace between the param name and `:` (e.g. `e : Exception`).
         val beforeColon: Space = if (paramType != null && caseDef.pat.span.exists) {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
@@ -377,6 +377,21 @@ class TryTest implements RewriteTest {
     }
 
     @Test
+    void catchExtractorPatternWithBinding() {
+        rewriteRun(scala(
+            """
+            object Test {
+              try {
+                println("risky")
+              } catch {
+                case NonFatal(e) => println(e)
+              }
+            }
+            """
+        ));
+    }
+
+    @Test
     void significantCharactersInComments() {
         // visitParsedTry / visitTryImpl — `=>` arrow in catch case line comment
         rewriteRun(scala(


### PR DESCRIPTION
## What's changed?

Fix Scala parser behavior for unapply matches in case, e.g. `case NonFatal(e) => println(e)`

## What's your motivation?

They suffer from idempotency issues.