### PR TITLE
Scala: fix parsing of binary expressions with no space on the left

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -699,7 +699,7 @@ class ScalaTreeVisitor(
         val opName = postfixOp.op.name.toString
         val odEnd = Math.max(0, postfixOp.od.span.end - offsetAdjustment)
         val opStart = Math.max(0, postfixOp.op.span.start - offsetAdjustment)
-        val namePrefix = if (odEnd < opStart && odEnd >= 0 && opStart <= source.length) {
+        val namePrefix = if (odEnd <= opStart && odEnd >= 0 && opStart <= source.length) {
           Space.format(source, odEnd, opStart)
         } else {
           Space.format(" ")
@@ -1576,11 +1576,11 @@ class ScalaTreeVisitor(
       var operatorSpace = Space.EMPTY
       var valueSpace = Space.EMPTY
       
-      if (leftEnd < opStart && leftEnd >= cursor && opStart <= source.length) {
+      if (leftEnd <= opStart && leftEnd >= cursor && opStart <= source.length) {
         operatorSpace = Space.format(source, leftEnd, opStart)
       }
-      
-      if (opEnd < rightStart && opEnd >= cursor && rightStart <= source.length) {
+
+      if (opEnd <= rightStart && opEnd >= cursor && rightStart <= source.length) {
         valueSpace = Space.format(source, opEnd, rightStart)
       }
       
@@ -1634,12 +1634,12 @@ class ScalaTreeVisitor(
     
     var operatorSpace = Space.format(" ")
     var rightSpace = Space.format(" ")
-    
-    if (leftEnd < opStart && leftEnd >= cursor && opStart <= source.length) {
+
+    if (leftEnd <= opStart && leftEnd >= cursor && opStart <= source.length) {
       operatorSpace = Space.format(source, leftEnd, opStart)
     }
-    
-    if (opEnd < rightStart && opEnd >= cursor && rightStart <= source.length) {
+
+    if (opEnd <= rightStart && opEnd >= cursor && rightStart <= source.length) {
       rightSpace = Space.format(source, opEnd, rightStart)
     }
     
@@ -1682,7 +1682,7 @@ class ScalaTreeVisitor(
     // Extract space before the method name
     val leftEnd = Math.max(0, infixOp.left.span.end - offsetAdjustment)
     val opStart = Math.max(0, infixOp.op.span.start - offsetAdjustment)
-    val methodNameSpace = if (leftEnd < opStart && leftEnd >= cursor && opStart <= source.length) {
+    val methodNameSpace = if (leftEnd <= opStart && leftEnd >= cursor && opStart <= source.length) {
       cursor = opStart
       Space.format(source, leftEnd, opStart)
     } else {
@@ -1695,7 +1695,7 @@ class ScalaTreeVisitor(
     // Extract space between the operator and the right-hand-side expression
     val opEnd = Math.max(0, infixOp.op.span.end - offsetAdjustment)
     val rightStart = Math.max(0, infixOp.right.span.start - offsetAdjustment)
-    val rhsSpace = if (opEnd < rightStart && opEnd >= cursor && rightStart <= source.length) {
+    val rhsSpace = if (opEnd <= rightStart && opEnd >= cursor && rightStart <= source.length) {
       cursor = rightStart
       Space.format(source, opEnd, rightStart)
     } else {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixTest.java
@@ -140,6 +140,22 @@ class InfixTest implements RewriteTest {
         );
     }
 
+    @Test
+    void noSpaceOnTheLeft() {
+        rewriteRun(
+          scala(
+            """
+            val arrowLeft = Map(key-> "true")
+            val plusNone = 1+2
+            val plusLeft = 1+ 2
+            val plusRight = 1 +2
+            val eqNone = 1==2
+            val arrowBoth = Map(1->2)
+            """
+          )
+        );
+    }
+
     @Nested
     class Postfix implements RewriteTest {
 

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InfixTest.java
@@ -141,6 +141,41 @@ class InfixTest implements RewriteTest {
     }
 
     @Test
+    void noSpaceOnTheRight() {
+        rewriteRun(
+          scala(
+            """
+            val plus = 1 +2
+            val minus = 5 -3
+            val mul = 2 *3
+            val div = 10 /2
+            val mod = 10 %3
+            val eq = 1 ==2
+            val neq = 1 !=2
+            val lt = 1 <2
+            val gt = 2 >1
+            val lte = 1 <=2
+            val gte = 2 >=1
+            val and = true &&false
+            val or = true ||false
+            val bitAnd = 1 &2
+            val bitOr = 1 |2
+            val xor = 1 ^2
+            val shl = 1 <<2
+            val shr = 8 >>2
+            val arrow = Map(1 ->2)
+            val cons = 1 ::Nil
+            object T {
+              var x = 10
+              x +=5
+              x -=5
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void noSpaceOnTheLeft() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

Fix Scala parser for code which involves a binary expression with no space on the left of the operator.

## What's your motivation?

These cases suffer from idempotency issues.