### PR TITLE
RPC: Fix RPC startup when the underlying binary is missing

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -75,6 +75,9 @@ public class RewriteRpcProcess extends Thread {
     @Nullable
     private Thread stderrDrainThread;
 
+    @Nullable
+    private IOException startupFailure;
+
     public RewriteRpcProcess(String... command) {
         this.command = command;
         this.setName("RewriteRpcProcess");
@@ -104,7 +107,9 @@ public class RewriteRpcProcess extends Thread {
             process = pb.start();
             stderrDrainThread = drainStderr(process, stderrRedirect);
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            // Record the failure so start() can surface it instead of busy-waiting forever
+            // on `process == null`. Throwing here would just kill this thread silently.
+            this.startupFailure = e;
         }
     }
 
@@ -164,9 +169,18 @@ public class RewriteRpcProcess extends Thread {
     }
 
     @Override
-    public synchronized void start() {
+    public void start() {
         super.start();
         while (this.process == null) {
+            if (!this.isAlive()) {
+                if (startupFailure != null) {
+                    throw new UncheckedIOException(
+                            "Failed to start RPC process: " + String.join(" ", command),
+                            startupFailure);
+                }
+                throw new IllegalStateException(
+                        "RPC startup thread exited without starting process: " + String.join(" ", command));
+            }
             try {
                 //noinspection BusyWait
                 Thread.sleep(100);

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
@@ -19,9 +19,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -29,6 +31,8 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 class RewriteRpcProcessTest {
 
@@ -140,6 +144,26 @@ class RewriteRpcProcessTest {
                 Files.deleteIfExists(log);
             }
         }
+    }
+
+    /**
+     * If the subprocess binary cannot be exec'd (e.g. missing from PATH), the spawn thread
+     * dies with an {@link java.io.IOException} but {@code start()} previously busy-waited
+     * on {@code process != null} forever — see the Moderne CLI hang when {@code rewrite-go-rpc}
+     * is not installed. {@code start()} must observe the dead spawn thread and surface the
+     * failure instead of hanging.
+     */
+    @Test
+    void startFailsFastWhenBinaryMissing() {
+        // given: a command pointing at a binary that does not exist anywhere
+        String missing = "definitely-no-such-binary-7a3f9e2c";
+        RewriteRpcProcess process = new RewriteRpcProcess(missing);
+
+        // when / then: start() must surface the failure within a bounded time, not hang
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () ->
+                assertThatThrownBy(process::start)
+                        .isInstanceOf(UncheckedIOException.class)
+                        .hasMessageContaining(missing));
     }
 
     /**


### PR DESCRIPTION
## What's changed?

Store the potential RPC startup failure exception in a separate field.

## What's your motivation?

Fix the RPC common machinery for the case when there's a total startup failure.
Currently when executed via Moderne CLI, the exception is logged to the console and the whole process hangs infinitely.
