### PR TITLE
Scala: S.TupleType

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -614,6 +614,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return visitRefinedType((S.RefinedType) tree, p);
         } else if (tree instanceof S.FunctionType) {
             return visitFunctionType((S.FunctionType) tree, p);
+        } else if (tree instanceof S.TupleType) {
+            return visitTupleType((S.TupleType) tree, p);
         } else if (tree instanceof S.Macro) {
             return visitMacro((S.Macro) tree, p);
         } else if (tree instanceof S.ExtensionMethods) {
@@ -1649,6 +1651,25 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         visit(rt.getElement(), p);
         afterSyntax(functionType, p);
         return functionType;
+    }
+
+    public J visitTupleType(S.TupleType tupleType, PrintOutputCapture<P> p) {
+        beforeSyntax(tupleType, Space.Location.LANGUAGE_EXTENSION, p);
+        JContainer<TypeTree> elements = tupleType.getPadding().getElements();
+        visitSpace(elements.getBefore(), Space.Location.LANGUAGE_EXTENSION, p);
+        p.append('(');
+        List<JRightPadded<TypeTree>> padded = elements.getPadding().getElements();
+        for (int i = 0; i < padded.size(); i++) {
+            JRightPadded<TypeTree> element = padded.get(i);
+            visit(element.getElement(), p);
+            visitSpace(element.getAfter(), Space.Location.LANGUAGE_EXTENSION, p);
+            if (i < padded.size() - 1) {
+                p.append(',');
+            }
+        }
+        p.append(')');
+        afterSyntax(tupleType, p);
+        return tupleType;
     }
 
     public J visitRefinedType(S.RefinedType refinedType, PrintOutputCapture<P> p) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -242,6 +242,14 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         return f;
     }
 
+    public J visitTupleType(S.TupleType tupleType, P p) {
+        S.TupleType t = tupleType;
+        t = t.withPrefix(visitSpace(t.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        t = t.withMarkers(visitMarkers(t.getMarkers(), p));
+        t = t.getPadding().withElements(visitContainer(t.getPadding().getElements(), JContainer.Location.LANGUAGE_EXTENSION, p));
+        return t;
+    }
+
     public J visitRefinedType(S.RefinedType refinedType, P p) {
         S.RefinedType r = refinedType;
         r = r.withPrefix(visitSpace(r.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -393,6 +393,89 @@ public interface S extends J {
     }
 
     /**
+     * Represents a Scala tuple type: {@code (T1, T2, ...)}.
+     * For example, the return type in {@code def f(): (Int, String)} or a value type like
+     * {@code val pair: (Int, Int) = ...}. The element container's {@code before} space is
+     * the whitespace immediately before {@code (}.
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class TupleType implements S, TypeTree, Expression {
+
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @With @Getter @EqualsAndHashCode.Include
+        UUID id;
+
+        @With @Getter
+        Space prefix;
+
+        @With @Getter
+        Markers markers;
+
+        JContainer<TypeTree> elements;
+
+        @With @Getter
+        @Nullable
+        JavaType type;
+
+        public static TupleType build(UUID id, Space prefix, Markers markers,
+                                      JContainer<TypeTree> elements, @Nullable JavaType type) {
+            return new TupleType(null, id, prefix, markers, elements, type);
+        }
+
+        public List<TypeTree> getElements() {
+            return elements.getElements();
+        }
+
+        public TupleType withElements(List<TypeTree> elements) {
+            return getPadding().withElements(JContainer.withElements(this.elements, elements));
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitTupleType(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final TupleType t;
+
+            public JContainer<TypeTree> getElements() {
+                return t.elements;
+            }
+
+            public TupleType withElements(JContainer<TypeTree> elements) {
+                return t.elements == elements ? t :
+                        new TupleType(null, t.id, t.prefix, t.markers, elements, t.type);
+            }
+        }
+    }
+
+    /**
      * Represents a wildcard/underscore placeholder in expressions.
      * Used for partially applied functions (e.g., add(5, _)) and pattern matching.
      * This is NOT for type wildcards (use J.Wildcard) or import wildcards (use * in J.Import).

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -6992,12 +6992,50 @@ class ScalaTreeVisitor(
     case f: untpd.Function => visitFunctionType(f)
     case po: untpd.PostfixOp if po.op != null && po.op.name.toString == "*" =>
       visitRepeatedType(po)
+    case tuple: untpd.Tuple => visitTupleType(tuple)
     case _ =>
       visitTree(tpt) match {
         case tt: TypeTree => tt
         case id: J.Identifier => id
         case _ => null
       }
+  }
+
+  /**
+   * Build an `S.TupleType` for a tuple in a type position (e.g. `(Int, Int)` as a return type
+   * or value type ascription). Scala 3's parser uses `untpd.Tuple` for both value and type
+   * tuples; we dispatch to this builder only when the parent context is a type.
+   */
+  private def visitTupleType(tuple: untpd.Tuple): S.TupleType = {
+    // An empty `Tuple(Nil)` shouldn't appear in a type position: `()` parses as the
+    // unit value, `() => T` parses as `Function`, and `Unit` is the canonical empty
+    // type. Fail loudly if we encounter it so the gap is discovered, not silently
+    // round-tripped to wrong source.
+    if (tuple.trees.isEmpty) {
+      throw new IllegalStateException("Empty tuple in type position is not supported")
+    }
+
+    val prefix = extractPrefix(tuple.span)
+
+    // Space between the prefix and `(`. extractPrefix usually lands the cursor
+    // exactly at `(`, but if the compiler span starts inside the parens we still
+    // want to capture any whitespace here instead of dropping it.
+    val beforeOpenParen = sourceBefore("(")
+
+    val elements = new util.ArrayList[JRightPadded[TypeTree]]()
+    for (i <- tuple.trees.indices) {
+      val elem = visitTypeTree(tuple.trees(i))
+      val after = if (i < tuple.trees.size - 1) sourceBefore(",") else sourceBefore(")")
+      elements.add(JRightPadded.build(elem).withAfter(after))
+    }
+
+    S.TupleType.build(
+      Tree.randomId(),
+      prefix,
+      Markers.EMPTY,
+      JContainer.build(beforeOpenParen, elements, Markers.EMPTY),
+      typeOfTree(tuple)
+    )
   }
 
   /**

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TupleTypeTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TupleTypeTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.scala.Assertions.scala;
+
+class TupleTypeTest implements RewriteTest {
+
+    @Test
+    void returnType() {
+        rewriteRun(
+          scala(
+            """
+            object O {
+              def f(): (Int, Int) = (1, 2)
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void valAscription() {
+        rewriteRun(
+          scala(
+            """
+            object O {
+              val pair: (Int, String) = (1, "a")
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void tripleReturnType() {
+        rewriteRun(
+          scala(
+            """
+            object O {
+              def g(): (Int, String, Boolean) = (1, "a", true)
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void extraSpacesInsideParens() {
+        rewriteRun(
+          scala(
+            """
+            object O {
+              def f() :  ( Int ,  String ) = (1, "a")
+            }
+            """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?

Introducing `S.TupleType` LST Element for Scala.

## What's your motivation?

To handle code like:
```scala
val x: (Int, Int) = (436, 504)
```