### PR TITLE
Scala: fix empty parens constructors

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -761,9 +761,10 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             needsScalaHandling = true;
         }
         
-        // Or if we have a primary constructor with actual parameters
-        if (classDecl.getPadding().getPrimaryConstructor() != null && 
-            !classDecl.getPadding().getPrimaryConstructor().getElements().isEmpty()) {
+        // Or if we have a primary constructor at all — Scala distinguishes
+        // `class Foo`, `class Foo()`, and `class Foo(x)` via container presence,
+        // emptiness, and an OmitParentheses marker on the container.
+        if (classDecl.getPadding().getPrimaryConstructor() != null) {
             needsScalaHandling = true;
         }
         
@@ -823,7 +824,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             // J.VariableDeclarations modeled like a Scala parameter (no implicit val/var,
             // type comes after the name with `:`). We can't fall through to visitVariableDeclarations
             // because that one is for field/local declarations and always emits a val/var keyword.
-            if (classDecl.getPadding().getPrimaryConstructor() != null) {
+            if (classDecl.getPadding().getPrimaryConstructor() != null &&
+                !classDecl.getPadding().getPrimaryConstructor().getMarkers().findFirst(OmitParentheses.class).isPresent()) {
                 JContainer<Statement> primaryConstructor = classDecl.getPadding().getPrimaryConstructor();
                 visitSpace(primaryConstructor.getBefore(), Space.Location.RECORD_STATE_VECTOR, p);
                 p.append('(');
@@ -916,49 +918,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             afterSyntax(classDecl, p);
             return classDecl;
         } else {
-            // For classes without Scala features, use Java printing but skip empty primary constructors
-            // The Java printer would print empty parentheses for primary constructors
-            if (classDecl.getPadding().getPrimaryConstructor() != null && 
-                classDecl.getPadding().getPrimaryConstructor().getElements().isEmpty()) {
-                // We have an empty primary constructor that shouldn't be printed
-                // Use the default Java printer logic but without the primary constructor
-                beforeSyntax(classDecl, Space.Location.CLASS_DECLARATION_PREFIX, p);
-                visit(classDecl.getLeadingAnnotations(), p);
-                for (J.Modifier m : classDecl.getModifiers()) {
-                    visit(m, p);
-                }
-                visit(classDecl.getPadding().getKind().getAnnotations(), p);
-                visitSpace(classDecl.getPadding().getKind().getPrefix(), Space.Location.CLASS_KIND, p);
-                // For Scala, print "trait" for Interface kind
-                String classKind = classDecl.getKind() == J.ClassDeclaration.Kind.Type.Interface ? 
-                    "trait" : classDecl.getKind().name().toLowerCase();
-                p.append(classKind);
-                visit(classDecl.getName(), p);
-                // Use our custom type parameter printing for Scala
-                visitTypeParameters(classDecl.getPadding().getTypeParameters(), p);
-                // Skip the empty primary constructor
-                
-                if (classDecl.getPadding().getExtends() != null) {
-                    visitSpace(classDecl.getPadding().getExtends().getBefore(), Space.Location.EXTENDS, p);
-                    p.append("extends");
-                    visit(classDecl.getPadding().getExtends().getElement(), p);
-                }
-
-                if (classDecl.getPadding().getImplements() != null) {
-                    visitContainer(" implements", classDecl.getPadding().getImplements(), JContainer.Location.IMPLEMENTS, ",", "", p);
-                }
-
-                if (classDecl.getPadding().getPermits() != null) {
-                    visitContainer(" permits", classDecl.getPadding().getPermits(), JContainer.Location.PERMITS, ",", "", p);
-                }
-
-                visit(classDecl.getBody(), p);
-                afterSyntax(classDecl, p);
-                return classDecl;
-            } else {
-                // Use the default Java printing
-                return super.visitClassDeclaration(classDecl, p);
-            }
+            // No Scala-specific structure (no primary constructor, no object/trait/with/type-params).
+            // Fall through to default Java printing.
+            return super.visitClassDeclaration(classDecl, p);
         }
     }
     

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -4399,8 +4399,8 @@ class ScalaTreeVisitor(
       if (i < source.length && source.charAt(i) == '(') i else -1
     }
 
-    val primaryConstructor: JContainer[Statement] = if (ctorParenPos >= 0 && firstValueParamList.isDefined) {
-      val params = firstValueParamList.get
+    val primaryConstructor: JContainer[Statement] = if (ctorParenPos >= 0) {
+      val params = firstValueParamList.getOrElse(Nil)
       val parenSpace = Space.format(source, cursor, ctorParenPos)
       cursor = ctorParenPos + 1
 
@@ -4440,7 +4440,12 @@ class ScalaTreeVisitor(
       }
 
       JContainer.build(parenSpace, jParams, Markers.EMPTY)
-    } else null
+    } else {
+      // No `(` in source — non-constructor class definition. Emit an empty container
+      // marked with OmitParentheses so the printer skips emitting `(...)`.
+      JContainer.build(Space.EMPTY, new util.ArrayList[JRightPadded[Statement]](),
+        Markers.build(Collections.singletonList(new OmitParentheses(Tree.randomId()))))
+    }
     
     // Extract extends/implements from Template
     var extendings: JLeftPadded[TypeTree] = null

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
@@ -214,6 +214,19 @@ class ClassDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void abstractClassWithEmptyParensAndAbstractDef() {
+        rewriteRun(
+            scala(
+                """
+                abstract class Foo() {
+                  def x: Boolean
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void classExtendingAnother() {
         rewriteRun(
             scala(


### PR DESCRIPTION
## What's changed?

Fix Scala parser behavior for class declarations with empty parens (no args).

## What's your motivation?

It suffers from idempotency issues.