### PR TITLE
UpgradeDependencyVersion for Gradle preserves shared version variable references when upgrading dependencies

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -131,6 +131,14 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
         Map<GroupArtifact, @Nullable Object> gaToNewVersion = new HashMap<>();
 
         Map<String, Map<GroupArtifact, Set<String>>> configurationPerGAPerModule = new HashMap<>();
+
+        /**
+         * Cache of {@code safeUpdatedVersion} verdicts keyed by variable name. Populated when a
+         * {@code GradleProject} is available (build.gradle visit phase) and consumed by paths that
+         * do not have repository context (e.g. {@code gradle.properties}). A {@code null} value
+         * means the variable cannot be safely bumped; absence means the verdict is not yet known.
+         */
+        Map<String, @Nullable String> safeVariableVerdict = new HashMap<>();
     }
 
     @Override
@@ -408,11 +416,19 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
 
     /**
      * Returns the agreed-upon resolved version when it is safe to update the shared variable,
-     * or null otherwise. A variable can only be updated when every dependency using it is
-     * targeted by the recipe's matcher AND every targeted dependency resolves to the same
-     * concrete version. Otherwise the matched dependency is detached to a literal version
-     * via {@code updateDependency} and the variable is left untouched so other neighbours
-     * sharing it stay on a working version.
+     * or null otherwise. The check has two phases:
+     * <ol>
+     *   <li>Agreement among targeted users: every dependency matched by the recipe must resolve
+     *       to the same concrete version.</li>
+     *   <li>Resolution for untargeted neighbours: the agreed version must be published for every
+     *       dependency that shares the variable but is not matched by the recipe. This protects
+     *       the original concern of PR #7491 (don't bump a shared variable to a version that does
+     *       not exist for one of its sharers) while restoring pre-#7491 GString preservation
+     *       whenever the bump is safe.</li>
+     * </ol>
+     * When the verdict cannot be computed because no {@code GradleProject} is available (e.g.
+     * the {@code gradle.properties} visitor path), the previously-cached verdict from the
+     * build.gradle visit is consulted instead.
      */
     private @Nullable String safeUpdatedVersion(
             String varName,
@@ -426,10 +442,12 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
         }
         DependencyVersionSelector selector = null;
         String agreedVersion = null;
+        List<Map.Entry<GroupArtifact, Set<String>>> untargetedNeighbours = new ArrayList<>();
         for (Map.Entry<GroupArtifact, Set<String>> entry : usages.entrySet()) {
             GroupArtifact ga = entry.getKey();
             if (!dependencyMatcher.matches(ga.getGroupId(), ga.getArtifactId())) {
-                return null;
+                untargetedNeighbours.add(entry);
+                continue;
             }
             Object cached = acc.gaToNewVersion.get(ga);
             if (cached instanceof Exception) {
@@ -461,7 +479,53 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 return null;
             }
         }
-        return agreedVersion;
+        if (agreedVersion == null) {
+            return null;
+        }
+        if (untargetedNeighbours.isEmpty()) {
+            return agreedVersion;
+        }
+        if (gradleProject == null) {
+            // No repos available; defer to the cached verdict produced by the build.gradle visit.
+            if (acc.safeVariableVerdict.containsKey(varName)) {
+                String verdict = acc.safeVariableVerdict.get(varName);
+                return agreedVersion.equals(verdict) ? agreedVersion : null;
+            }
+            return null;
+        }
+        boolean publishedForAllNeighbours = isVersionPublishedForAll(agreedVersion, untargetedNeighbours, gradleProject, ctx);
+        acc.safeVariableVerdict.put(varName, publishedForAllNeighbours ? agreedVersion : null);
+        return publishedForAllNeighbours ? agreedVersion : null;
+    }
+
+    /**
+     * Returns {@code true} only when {@code agreedVersion} is listed in the Maven metadata of every
+     * untargeted neighbour. Any unresolvable metadata or missing version disqualifies the bump and
+     * causes the caller to fall back to the detach-to-literal path.
+     */
+    private boolean isVersionPublishedForAll(
+            String agreedVersion,
+            List<Map.Entry<GroupArtifact, Set<String>>> untargetedNeighbours,
+            GradleProject gradleProject,
+            ExecutionContext ctx) {
+        MavenPomDownloader downloader = new MavenPomDownloader(ctx);
+        for (Map.Entry<GroupArtifact, Set<String>> entry : untargetedNeighbours) {
+            GroupArtifact ga = entry.getKey();
+            Set<String> configs = entry.getValue();
+            String configName = configs == null ? null : configs.stream().findFirst().orElse(null);
+            List<MavenRepository> repos = "classpath".equals(configName) ?
+                    gradleProject.getBuildscript().getMavenRepositories() :
+                    gradleProject.getMavenRepositories();
+            try {
+                MavenMetadata metadata = metadataFailures.insertRows(ctx, () -> downloader.downloadMetadata(ga, null, repos));
+                if (!metadata.getVersioning().getVersions().contains(agreedVersion)) {
+                    return false;
+                }
+            } catch (MavenDownloadingException e) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @RequiredArgsConstructor

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -369,6 +369,54 @@ class UpgradeDependencyVersionTest implements RewriteTest {
         );
     }
 
+    /**
+     * The shared {@code guavaVersion} variable is used by the targeted artifact ({@code guava}) and
+     * by a neighbor ({@code guava-testlib}) that the recipe matcher does not match.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "def guavaVersion = 'VERSION'",
+      "ext { guavaVersion = 'VERSION' }"
+    })
+    void sharedVersionVariableWithUntargetedNeighbour(String variableDeclarationTemplate) {
+        String beforeDeclaration = variableDeclarationTemplate.replace("VERSION", "29.0-jre");
+        String afterDeclaration = variableDeclarationTemplate.replace("VERSION", "30.1.1-jre");
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+
+              %s
+              repositories {
+                mavenCentral()
+              }
+
+              dependencies {
+                implementation "com.google.guava:guava:$guavaVersion"
+                implementation "com.google.guava:guava-testlib:$guavaVersion"
+              }
+              """.formatted(beforeDeclaration),
+            """
+              plugins {
+                id 'java-library'
+              }
+
+              %s
+              repositories {
+                mavenCentral()
+              }
+
+              dependencies {
+                implementation "com.google.guava:guava:$guavaVersion"
+                implementation "com.google.guava:guava-testlib:$guavaVersion"
+              }
+              """.formatted(afterDeclaration)
+          )
+        );
+    }
+
     @Test
     void updateVersionInVariableToRelease() {
         rewriteRun(


### PR DESCRIPTION
## Summary

`UpgradeDependencyVersion` (Gradle) used a matcher-only gate inside `safeUpdatedVersion` to decide whether a shared version variable could be bumped: if any artifact referencing the variable was not matched by the recipe, the recipe refused to bump it and detached the targeted call site to a literal version via `dependency.withDeclaredVersion((String) scanResult)`.

That gate was stricter than the original intent — "do not bump a shared variable to a version that does not exist for one of its sharers" — and produced a user-surprising outcome: the targeted line silently lost its GString interpolation while neighbours kept theirs, leaving inconsistent versions across artifacts that the user clearly meant to keep aligned (e.g. `tomcat-embed-core` getting a literal version while `tomcat-embed-jasper` stays on `${tomcatVersion}`).

This change replaces the matcher gate with a Maven metadata probe. After computing the agreed version from the matched users, `isVersionPublishedForAll` verifies that the agreed version is published for every untargeted neighbour. When all neighbours publish it, the shared variable is bumped and every GString reference is preserved. When at least one neighbour does not publish it, the code falls through to the existing detach-to-literal path so the build isn't broken by bumping a neighbour to a non-existent version. A per-variable verdict cache on the accumulator lets the `gradle.properties` visitor reach the same conclusion without re-running the probe.

- Relaxes the constraints introduces with https://github.com/openrewrite/rewrite/pull/7491.