### PR TITLE
Delegate kotlin.* classes to parent in RecipeClassLoader

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
@@ -180,8 +180,15 @@ public class RecipeClassLoader extends URLClassLoader {
             }
         }
 
-        // SLF4J and Jackson should always be from parent
-        if (className.startsWith("org.slf4j") || className.startsWith("com.fasterxml.jackson")) {
+        // SLF4J, Jackson, and the Kotlin runtime should always come from the parent.
+        // Why kotlin: if both the parent and a recipe jar ship kotlin-stdlib, types like
+        // kotlin.jvm.functions.Function1 get defined by both loaders. When Jackson (loaded
+        // from parent) interacts with jackson-module-kotlin (typically bundled in the recipe
+        // jar), the JVM raises a LinkageError on loader-constraint violations.
+        // See moderneinc/customer-requests#2372.
+        if (className.startsWith("org.slf4j") ||
+            className.startsWith("com.fasterxml.jackson") ||
+            className.startsWith("kotlin.")) {
             return true;
         }
 

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeClassLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeClassLoaderTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.marketplace;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.objectweb.asm.ClassWriter;
 import org.openrewrite.Recipe;
 import org.openrewrite.config.ClasspathScanningLoader;
 import org.openrewrite.config.Environment;
@@ -34,6 +35,9 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
+
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.V1_8;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -142,6 +146,56 @@ class RecipeClassLoaderTest {
                 assertThat(resources.hasMoreElements()).isFalse();
             }
         }
+    }
+
+    @Test
+    void kotlinClassesShouldDelegateToParent(@TempDir Path tempDir) throws Exception {
+        // Reproduces moderneinc/customer-requests#2372: when both the parent and the
+        // recipe classloader can define a kotlin.* class (e.g., kotlin.jvm.functions.Function1),
+        // the JVM raises LinkageError on loader-constraint violations once Jackson, loaded
+        // from the parent, interacts with jackson-module-kotlin from the recipe jar.
+        // The fix is to delegate kotlin.* classes to the parent, mirroring slf4j/jackson.
+        Path parentLib = tempDir.resolve("parent");
+        Files.createDirectories(parentLib.resolve("kotlin/jvm/functions"));
+        Files.write(parentLib.resolve("kotlin/jvm/functions/Function1.class"),
+          stubClass("kotlin/jvm/functions/Function1"));
+
+        Path childLib = tempDir.resolve("child");
+        Files.createDirectories(childLib.resolve("kotlin/jvm/functions"));
+        Files.write(childLib.resolve("kotlin/jvm/functions/Function1.class"),
+          stubClass("kotlin/jvm/functions/Function1"));
+
+        try (URLClassLoader parent = new URLClassLoader(new URL[]{parentLib.toUri().toURL()}, null);
+             RecipeClassLoader classLoader = new RecipeClassLoader(new URL[]{childLib.toUri().toURL()}, parent)) {
+            Class<?> loaded = classLoader.loadClass("kotlin.jvm.functions.Function1");
+            assertThat(loaded.getClassLoader())
+              .as("kotlin.* classes must come from the parent to avoid LinkageError")
+              .isSameAs(parent);
+        }
+    }
+
+    @Test
+    void kotlinClassesFallBackToChildWhenParentLacksThem(@TempDir Path tempDir) throws Exception {
+        // The parent-first delegation must still fall back to the child if the parent
+        // does not provide the kotlin class, so recipes can ship their own kotlin runtime
+        // when the host application has none.
+        Path childLib = tempDir.resolve("child");
+        Files.createDirectories(childLib.resolve("kotlin"));
+        Files.write(childLib.resolve("kotlin/Standalone.class"),
+          stubClass("kotlin/Standalone"));
+
+        try (URLClassLoader parent = new URLClassLoader(new URL[0], null);
+             RecipeClassLoader classLoader = new RecipeClassLoader(new URL[]{childLib.toUri().toURL()}, parent)) {
+            Class<?> loaded = classLoader.loadClass("kotlin.Standalone");
+            assertThat(loaded.getClassLoader()).isSameAs(classLoader);
+        }
+    }
+
+    private static byte[] stubClass(String internalName) {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(V1_8, ACC_PUBLIC, internalName, null, "java/lang/Object", null);
+        cw.visitEnd();
+        return cw.toByteArray();
     }
 
     @Test


### PR DESCRIPTION
## Summary

When both the parent and a recipe jar ship kotlin-stdlib, types like `kotlin.jvm.functions.Function1` get defined by both loaders, and Jackson (parent-loaded) interacting with `jackson-module-kotlin` from the recipe jar trips a `LinkageError` on loader-constraint violations. Mirror the existing slf4j/jackson rule and delegate `kotlin.*` to the parent, with the existing fallback to the child when the parent lacks the class.

- See [moderneinc/customer-requests#2372](https://github.com/moderneinc/customer-requests/issues/2372).

## Test plan

- [x] New `kotlinClassesShouldDelegateToParent` test: parent and child both define `kotlin.jvm.functions.Function1`; asserts the parent's copy wins.
- [x] New `kotlinClassesFallBackToChildWhenParentLacksThem` test: parent has no kotlin classes; the recipe loader still resolves the class from the child.
- [x] `./gradlew :rewrite-core:test --tests RecipeClassLoaderTest` is green.