### PR TITLE
UpdateGradleWrapper: support Maven-layout Artifactory repos

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
@@ -186,7 +186,14 @@ public class GradleWrapper {
 
     private static List<GradleVersion> listAllPrivateArtifactoryVersions(String artifactoryUrl, ExecutionContext ctx) {
         URI artifactoryUri = URI.create(artifactoryUrl);
-        String artifactoryApiUrl = String.format("%s://%s%s", artifactoryUri.getScheme(), artifactoryUri.getHost(), artifactoryUri.getPath().replace("/artifactory", "/artifactory/api/storage"));
+        String path = artifactoryUri.getPath();
+        String lastSegment = path.substring(path.lastIndexOf('/') + 1);
+        // Maven-layout repos store each version in its own subdirectory (e.g. .../gradle/8.10.1/gradle-8.10.1-all.zip).
+        // When distributionUrl points inside such a version directory, crawl up one level to discover sibling versions.
+        boolean mavenLayout = MAVEN_VERSION_FOLDER_PATTERN.matcher(lastSegment).matches();
+        String listingPath = mavenLayout ? path.substring(0, path.lastIndexOf('/')) : path;
+        String downloadBaseUrl = mavenLayout ? artifactoryUrl.substring(0, artifactoryUrl.lastIndexOf('/')) : artifactoryUrl;
+        String artifactoryApiUrl = String.format("%s://%s%s", artifactoryUri.getScheme(), artifactoryUri.getHost(), listingPath.replace("/artifactory", "/artifactory/api/storage"));
         HttpSender httpSender = HttpSenderExecutionContextView.view(ctx).getHttpSender();
         try (HttpSender.Response resp = httpSender.send(httpSender.get(artifactoryApiUrl).build())) {
             if (resp.isSuccessful()) {
@@ -194,12 +201,19 @@ public class GradleWrapper {
                 List<GradleVersion> gradleVersions = new ArrayList<>();
                 for (JsonNode child : node.get("children")) {
                     boolean folder = child.get("folder").asBoolean();
-                    if (!folder) {
-                        String uri = child.get("uri").asText();
+                    String uri = child.get("uri").asText();
+                    if (mavenLayout && folder) {
+                        String version = uri.startsWith("/") ? uri.substring(1) : uri;
+                        if (MAVEN_VERSION_FOLDER_PATTERN.matcher(version).matches()) {
+                            String folderUrl = downloadBaseUrl + uri;
+                            gradleVersions.add(new GradleVersion(version, folderUrl + "/gradle-" + version + "-bin.zip", DistributionType.Bin, null, null));
+                            gradleVersions.add(new GradleVersion(version, folderUrl + "/gradle-" + version + "-all.zip", DistributionType.All, null, null));
+                        }
+                    } else if (!folder) {
                         Matcher matcher = GRADLE_VERSION_PATTERN.matcher(uri);
                         if (matcher.find()) {
                             String version = matcher.group(1);
-                            gradleVersions.add(new GradleVersion(version, artifactoryUrl + uri, uri.endsWith("-all.zip") ? DistributionType.All : DistributionType.Bin, null, null));
+                            gradleVersions.add(new GradleVersion(version, downloadBaseUrl + uri, uri.endsWith("-all.zip") ? DistributionType.All : DistributionType.Bin, null, null));
                         }
                     }
                 }
@@ -216,6 +230,7 @@ public class GradleWrapper {
     }
 
     private static final Pattern GRADLE_VERSION_PATTERN = Pattern.compile("gradle-([0-9.]+)");
+    private static final Pattern MAVEN_VERSION_FOLDER_PATTERN = Pattern.compile("\\d+\\.\\d+(?:\\.\\d+)?(?:-[\\w.-]+)?");
 
     /**
      * Construct a Gradle wrapper from a URI.

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -1099,6 +1099,70 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
+    void supportsSemverAgainstMavenLayoutArtifactory() {
+        HttpSender customDistributionHost = request -> {
+            String url = request.getUrl().toString();
+            if ("https://company.com/artifactory/api/storage/gradle-distributions/org/gradle/services/gradle".equals(url)) {
+                return new HttpSender.Response(200, new ByteArrayInputStream("""
+                  {
+                    "repo" : "gradle-distributions",
+                    "path" : "/org/gradle/services/gradle",
+                    "created" : "2025-08-25T07:12:28.801Z",
+                    "createdBy" : "admin",
+                    "lastModified" : "2025-08-25T07:12:28.801Z",
+                    "modifiedBy" : "admin",
+                    "lastUpdated" : "2025-08-25T07:12:28.801Z",
+                    "children" : [ {
+                      "uri" : "/8.2",
+                      "folder" : true
+                    }, {
+                      "uri" : "/8.8",
+                      "folder" : true
+                    }, {
+                      "uri" : "/8.10.1",
+                      "folder" : true
+                    } ],
+                    "uri" : "https://company.com/artifactory/api/storage/gradle-distributions/org/gradle/services/gradle"
+                  }
+                  """.getBytes(StandardCharsets.UTF_8)), () -> {
+                });
+            } else if ("https://company.com/artifactory/gradle-distributions/org/gradle/services/gradle/8.10.1/gradle-8.10.1-bin.zip".equals(url)) {
+                return new HttpSender.Response(200, UpdateGradleWrapperTest.class.getClassLoader().getResourceAsStream("gradle-8.10-bin.zip"), () -> {
+                });
+            }
+            return new HttpUrlConnectionSender().send(request);
+        };
+        HttpSenderExecutionContextView ctx = HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
+          .setHttpSender(customDistributionHost)
+          .setLargeFileHttpSender(customDistributionHost);
+        rewriteRun(
+          spec -> spec.recipe(new UpdateGradleWrapper("8.x", null, null, null, null))
+            .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "8.2")))
+            .executionContext(ctx),
+          properties(
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://company.com/artifactory/gradle-distributions/org/gradle/services/gradle/8.2/gradle-8.2-bin.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              """,
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://company.com/artifactory/gradle-distributions/org/gradle/services/gradle/8.10.1/gradle-8.10.1-bin.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              """,
+            spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
+          ),
+          gradlew,
+          gradlewBat,
+          gradleWrapperJarQuark
+        );
+    }
+
+    @Test
     void usesExecutableJarFrom8_14() {
         rewriteRun(
           spec -> spec.recipe(new UpdateGradleWrapper("8.14", null, null, null, null))


### PR DESCRIPTION
## Summary

- Fixes [customer request #2373](https://github.com/moderneinc/customer-requests/issues/2373): `UpdateGradleWrapper` failed on Artifactory repos using a Maven directory layout (e.g. `.../gradle/8.10.1/gradle-8.10.1-all.zip`) because the storage-API listing of the zip's parent directory only contained that single version.
- When the directory directly containing the zip is named like a version, `listAllPrivateArtifactoryVersions` now crawls up one level and treats each version-named subfolder as a discovered version, fabricating both \`-bin.zip\` and \`-all.zip\` candidate URLs. Flat-layout behavior is unchanged.

## Test plan

- [x] New \`supportsSemverAgainstMavenLayoutArtifactory\` test in \`UpdateGradleWrapperTest\` covers the Maven-layout case.
- [x] Existing flat-layout Artifactory tests (\`supportsSemverAgainstJFrogArtifactory\`, \`...WithPath\`) still pass.