### PR TITLE
C#: fix InstallRecipes echoing wildcard versions in response.Version

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/InstallVersionResolverTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/InstallVersionResolverTests.cs
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.CSharp;
+
+namespace OpenRewrite.Tests.Rpc;
+
+/// <summary>
+/// Regression coverage for the InstallRecipes RPC, which used to echo wildcard versions
+/// (e.g. "*", "*-*") back to the caller because it read the version off the csproj's
+/// PackageReference Version attribute instead of the resolved value in project.assets.json.
+/// </summary>
+public class InstallVersionResolverTests
+{
+    private const string Pkg = "OpenRewrite.CSharp";
+
+    [Theory]
+    [InlineData("*",   "8.81.17")]
+    [InlineData("*-*", "8.82.0-snapshot.20260514132053")]
+    public void WildcardRequestResolvesToConcreteVersion(string requested, string resolved)
+    {
+        WithAssetsJson(requested, resolved, projectDir =>
+            Assert.Equal(resolved,
+                MSBuildProjectHelper.GetResolvedPackageVersion(projectDir, Pkg)));
+    }
+
+    [Fact]
+    public void PackageNameMatchIsCaseInsensitive()
+    {
+        // Caller-supplied package name may differ in casing from the ID recorded in
+        // project.assets.json; resolution must still succeed.
+        WithAssetsJson("*", "8.81.17", projectDir =>
+            Assert.Equal("8.81.17",
+                MSBuildProjectHelper.GetResolvedPackageVersion(projectDir, Pkg.ToLowerInvariant())));
+    }
+
+    [Fact]
+    public void UnknownPackageThrows()
+    {
+        WithAssetsJson("*", "8.81.17", projectDir =>
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                MSBuildProjectHelper.GetResolvedPackageVersion(projectDir, "Does.Not.Exist"));
+            Assert.Contains("not a direct dependency", ex.Message);
+        });
+    }
+
+    [Fact]
+    public void MissingAssetsJsonThrows()
+    {
+        WithTempDir(projectDir =>
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                MSBuildProjectHelper.GetResolvedPackageVersion(projectDir, Pkg));
+            Assert.Contains("project.assets.json not found", ex.Message);
+        });
+    }
+
+    private static void WithAssetsJson(
+        string requestedVersion,
+        string resolvedVersion,
+        Action<string> assert)
+    {
+        WithTempDir(projectDir =>
+        {
+            var objDir = Path.Combine(projectDir, "obj");
+            Directory.CreateDirectory(objDir);
+            File.WriteAllText(Path.Combine(objDir, "project.assets.json"), $$"""
+                {
+                  "version": 3,
+                  "targets": {
+                    "net10.0": {
+                      "{{Pkg}}/{{resolvedVersion}}": { "type": "package" }
+                    }
+                  },
+                  "libraries": {
+                    "{{Pkg}}/{{resolvedVersion}}": { "type": "package" }
+                  },
+                  "project": {
+                    "frameworks": {
+                      "net10.0": {
+                        "dependencies": {
+                          "{{Pkg}}": {
+                            "target": "Package",
+                            "version": "[{{requestedVersion}}, )"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                """);
+            assert(projectDir);
+        });
+    }
+
+    private static void WithTempDir(Action<string> assert)
+    {
+        var projectDir = Path.Combine(Path.GetTempPath(),
+            "openrewrite-installrecipes-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(projectDir);
+        try
+        {
+            assert(projectDir);
+        }
+        finally
+        {
+            try { Directory.Delete(projectDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
@@ -537,4 +537,86 @@ public static class MSBuildProjectHelper
     }
 
     #endregion
+
+    #region Direct version resolution
+
+    /// <summary>
+    ///     Returns the resolved concrete version of a direct package dependency from
+    ///     <c>obj/project.assets.json</c>. Used by callers (such as the InstallRecipes
+    ///     RPC handler) that need the concrete SemVer that NuGet selected after a
+    ///     restore, rather than the version constraint authored in the csproj —
+    ///     <c>dotnet add package &lt;pkg&gt; --version *</c> preserves the wildcard
+    ///     verbatim in the csproj, so the resolved version must be read from the
+    ///     NuGet restore output.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when <c>obj/project.assets.json</c> is missing (restore did not
+    ///     complete), when the package is not a direct dependency under any TFM, or
+    ///     when no matching resolved entry exists in the assets file's libraries.
+    /// </exception>
+    public static string GetResolvedPackageVersion(string projectDir, string packageName)
+    {
+        var assetsPath = Path.Combine(projectDir, "obj", "project.assets.json");
+        if (!File.Exists(assetsPath))
+        {
+            throw new InvalidOperationException(
+                $"project.assets.json not found at {assetsPath}; restore did not complete");
+        }
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(assetsPath));
+        var root = doc.RootElement;
+
+        if (!IsDirectDependency(root, packageName))
+        {
+            throw new InvalidOperationException(
+                $"{packageName} is not a direct dependency in {assetsPath}");
+        }
+
+        // Read from targets — NuGet's per-TFM resolution map — rather than libraries,
+        // which is a flat package graph including PackageDownload assets that don't
+        // resolve to a single version. Matches what ReadResolvedPackages does above.
+        if (root.TryGetProperty("targets", out var targets))
+        {
+            foreach (var tfm in targets.EnumerateObject())
+            foreach (var entry in tfm.Value.EnumerateObject())
+            {
+                if (!entry.Value.TryGetProperty("type", out var typeProp) ||
+                    typeProp.GetString() != "package")
+                    continue;
+
+                var slash = entry.Name.IndexOf('/');
+                if (slash > 0 &&
+                    string.Equals(entry.Name[..slash], packageName, StringComparison.OrdinalIgnoreCase))
+                {
+                    var version = entry.Name[(slash + 1)..];
+                    if (!string.IsNullOrEmpty(version))
+                        return version;
+                }
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Could not find resolved version for {packageName} in {assetsPath}");
+    }
+
+    private static bool IsDirectDependency(JsonElement root, string packageName)
+    {
+        if (!root.TryGetProperty("project", out var project) ||
+            !project.TryGetProperty("frameworks", out var frameworks))
+            return false;
+
+        foreach (var fw in frameworks.EnumerateObject())
+        {
+            if (!fw.Value.TryGetProperty("dependencies", out var deps))
+                continue;
+
+            foreach (var dep in deps.EnumerateObject())
+                if (string.Equals(dep.Name, packageName, StringComparison.OrdinalIgnoreCase))
+                    return true;
+        }
+
+        return false;
+    }
+
+    #endregion
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -17,7 +17,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Xml.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
@@ -574,7 +573,11 @@ public class RewriteRpcServer
                     args += $" --version {version}";
                 RunDotnet(args);
 
-                version = ResolveVersionFromCsproj(csprojPath, packageName);
+                // dotnet add package preserves the user-supplied version constraint
+                // verbatim in the csproj's PackageReference, so wildcards like "*" survive
+                // there. The resolved concrete version lives in obj/project.assets.json.
+                version = MSBuildProjectHelper.GetResolvedPackageVersion(
+                    Path.GetDirectoryName(csprojPath)!, packageName);
 
                 var assemblies = PublishAndLoadPlugin(csprojPath, packageName);
                 foreach (var assembly in assemblies)
@@ -690,20 +693,6 @@ public class RewriteRpcServer
             throw new InvalidOperationException(
                 $"dotnet {arguments} failed (exit code {process.ExitCode}):\n{stderr}\n{stdout}");
         }
-    }
-
-    private static string ResolveVersionFromCsproj(string csprojPath, string packageName)
-    {
-        var doc = XDocument.Load(csprojPath);
-        var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
-
-        var packageRef = doc.Descendants(ns + "PackageReference")
-            .FirstOrDefault(e => string.Equals(
-                e.Attribute("Include")?.Value, packageName, StringComparison.OrdinalIgnoreCase));
-
-        return packageRef?.Attribute("Version")?.Value
-               ?? throw new InvalidOperationException(
-                   $"Could not find resolved version for {packageName} in {csprojPath}");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- **Fixed:** the `InstallRecipes` RPC was returning the literal version-constraint string (`*`, `*-*`, etc.) as `InstallRecipesResponse.Version` instead of the resolved concrete SemVer. Downstream consumers (moderne-cli `recipes-v5.csv`, moderne-saas GraphQL) surfaced these as the "installed version" and had to work around it.
- **Root cause:** `dotnet add package <pkg> --version *` preserves the wildcard verbatim in the csproj's `<PackageReference>`. The old `ResolveVersionFromCsproj` read from that attribute, so wildcards flowed through unchanged. Verified against real `dotnet` output (`Version="*"` is written literally).
- **Fix:** new public helper `MSBuildProjectHelper.GetResolvedPackageVersion(projectDir, packageName)` reads `obj/project.assets.json` (NuGet's per-TFM resolution map written by restore) and returns the resolved version of a direct dependency. Reads from `targets` to match the convention already used by `ReadResolvedPackages` in the same file. Throws `InvalidOperationException` with specific diagnostics for: missing `project.assets.json`, package not a direct dep, or no matching resolved entry.
- **`InstallRecipes` call site** (`RewriteRpcServer.cs`) now delegates to the helper; the old private `ResolveVersionFromCsproj` is removed along with the unused `System.Xml.Linq` import.
- **Regression coverage** in `OpenRewrite.Tests/Rpc/InstallVersionResolverTests.cs`: theory rows for `*` and `*-*` against concrete-resolved fixtures, plus facts for case-insensitive package match, unknown-package throw, and missing-assets-json throw.

## Test plan

- [x] `dotnet test --filter InstallVersionResolverTests` — 5/5 pass in ~10 ms.
- [x] `./gradlew :rewrite-csharp:csharpTest` — 1936/1936 pass.
- [x] Mutation test: replacing the `targets` lookup with `project.frameworks.<tfm>.dependencies.<pkg>.version` (the original bug shape) causes the two wildcard rows + case-insensitive case to fail (3/5 failures). Confirms the tests actually cover the regression.
- [x] Verified against real `dotnet add package Newtonsoft.Json --version "*"` output: csproj receives `Version="*"`; `obj/project.assets.json` contains `targets.<tfm>."Newtonsoft.Json/13.0.4"` and `libraries."Newtonsoft.Json/13.0.4"`; helper returns `13.0.4`.

## Out of scope

- Pre-existing `_recipesProjectDir` caching across `InstallRecipes` calls (no per-call cleanup, no concurrency control). Not introduced by this PR.
- moderne-cli and moderne-saas workarounds that scan `~/.nuget/packages/` or post-process the version string; those become dead code once this fix ships.