### PR TITLE
rpc: discover DynamicDispatchRpcCodec providers across classloaders

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
@@ -18,9 +18,12 @@ package org.openrewrite.rpc;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.Collections.emptyList;
@@ -28,12 +31,41 @@ import static java.util.Collections.emptyList;
 public abstract class DynamicDispatchRpcCodec<T> implements RpcCodec<T> {
     private static final Map<String, List<DynamicDispatchRpcCodec<?>>> CODEC_BY_TYPE = new ConcurrentHashMap<>();
 
+    /**
+     * Classloaders we've already scanned for {@code ServiceLoader} providers. We re-scan
+     * any new thread context classloader we see, so codecs from plugin/recipe classloaders
+     * are picked up even when {@link DynamicDispatchRpcCodec} itself was loaded by a parent
+     * classloader that didn't have them visible at class-init time.
+     */
+    private static final Set<ClassLoader> SCANNED_CLASSLOADERS =
+            Collections.newSetFromMap(new WeakHashMap<>());
+
     static {
-        @SuppressWarnings({"unchecked", "rawtypes"}) ServiceLoader<DynamicDispatchRpcCodec<?>> loader = (ServiceLoader<DynamicDispatchRpcCodec<?>>)
-                (ServiceLoader) ServiceLoader.load(DynamicDispatchRpcCodec.class);
+        // Scan with this class's defining classloader so codecs co-located with rewrite-core
+        // are always found, even before any caller triggers the per-context-CL discovery below.
+        discoverFrom(DynamicDispatchRpcCodec.class.getClassLoader());
+    }
+
+    private static synchronized void discoverFrom(@Nullable ClassLoader cl) {
+        if (cl == null || !SCANNED_CLASSLOADERS.add(cl)) {
+            return;
+        }
+        @SuppressWarnings({"unchecked", "rawtypes"}) ServiceLoader<DynamicDispatchRpcCodec<?>> loader =
+                (ServiceLoader<DynamicDispatchRpcCodec<?>>) (ServiceLoader) ServiceLoader.load(DynamicDispatchRpcCodec.class, cl);
         for (DynamicDispatchRpcCodec<?> provider : loader) {
-            CODEC_BY_TYPE.computeIfAbsent(provider.getSourceFileType(), p -> new ArrayList<>())
-                    .add(provider);
+            List<DynamicDispatchRpcCodec<?>> bucket = CODEC_BY_TYPE.computeIfAbsent(
+                    provider.getSourceFileType(), k -> new ArrayList<>());
+            // Dedup by concrete codec class so re-scans don't accumulate duplicates.
+            boolean alreadyPresent = false;
+            for (DynamicDispatchRpcCodec<?> existing : bucket) {
+                if (existing.getClass() == provider.getClass()) {
+                    alreadyPresent = true;
+                    break;
+                }
+            }
+            if (!alreadyPresent) {
+                bucket.add(provider);
+            }
         }
     }
 
@@ -61,6 +93,10 @@ public abstract class DynamicDispatchRpcCodec<T> implements RpcCodec<T> {
         if (sourceFileType == null) {
             return null;
         }
+        // Discover codecs from any classloader we haven't seen yet. Covers plugin/recipe
+        // classloaders that weren't visible when this class's static initializer ran.
+        discoverFrom(Thread.currentThread().getContextClassLoader());
+        discoverFrom(t.getClass().getClassLoader());
         for (DynamicDispatchRpcCodec<?> codec : CODEC_BY_TYPE.getOrDefault(sourceFileType, emptyList())) {
             if (codec.getType().isAssignableFrom(t.getClass())) {
                 return (RpcCodec<T>) codec;


### PR DESCRIPTION
## Summary

`DynamicDispatchRpcCodec`'s static initializer ran `ServiceLoader.load(DynamicDispatchRpcCodec.class)` once, against whichever classloader happened to load the class. When `rewrite-core` is loaded by a bootstrap/parent classloader and language jars (`rewrite-csharp`, `rewrite-python`, …) are loaded by recipe/plugin classloaders that aren't visible to the bootstrap CL, `CODEC_BY_TYPE` ends up empty for the JVM lifetime. With no codec found, `RpcSendQueue` falls back to inline Jackson JSON for the whole tree; the receiving side then fails to deserialize complex tree types and surfaces it as a `JObject → Tree` cast error.

This PR replaces the one-shot load with a lazy `discoverFrom(ClassLoader)` that:

- Eagerly scans `DynamicDispatchRpcCodec.class.getClassLoader()` at static init, so co-located codecs still work in single-classloader topologies.
- On every `getCodec(...)` call, also scans `Thread.currentThread().getContextClassLoader()` and the candidate object's classloader if either hasn't been scanned yet.
- Tracks scanned classloaders in a `WeakHashMap`-backed set so each is scanned at most once.
- Dedups providers by concrete codec class so repeat scans (across multiple recipe/plugin CLs that share parents) don't accumulate duplicates.

## Test plan

- [x] Reproduced the failure end-to-end against a multi-classloader host where `rewrite-core` and a language jar load via different classloaders — observed `CODEC_BY_TYPE.keySet() == []` with the pre-fix code and the expected `Cs.CompilationUnit` print failure (codec missed → inline JSON → Newtonsoft can't construct the sealed primary-ctor record).
- [x] With the fix applied, the same host populates `CODEC_BY_TYPE` lazily on first `getCodec` invocation and the round-trip succeeds.
- [x] Existing `rewrite-csharp` `:test` suite still passes — single-classloader test harness behaviour is unchanged because the static-init scan still runs against the defining classloader.