### PR TITLE
Scala: handle varargs splat expressions

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7716,7 +7716,43 @@ class ScalaTreeVisitor(
   }
   
   private def visitTyped(typed: Trees.Typed[?]): J = {
-    
+
+    // Scala 3 vararg splat `f(xs*)` and Scala 2 form `f(xs: _*)` both parse to
+    // `Typed(expr, Ident("_*"))`. Distinguish by checking whether the source
+    // between the expression and the trailing `*` contains a `:`.
+    typed.tpt match {
+      case id: Trees.Ident[?] if id.name.toString == "_*" =>
+        val exprEnd = if (typed.expr.span.exists) Math.max(0, typed.expr.span.end - offsetAdjustment) else cursor
+        val typedEnd = if (typed.span.exists) Math.max(0, typed.span.end - offsetAdjustment) else exprEnd
+        val between = if (exprEnd >= 0 && typedEnd <= source.length && exprEnd <= typedEnd) {
+          source.substring(exprEnd, typedEnd)
+        } else ""
+        if (!between.contains(":")) {
+          // Scala 3 form: `xs*`. Build S.RepeatedType directly with the expression as element.
+          val prefix = extractPrefix(typed.span)
+          val element = visitTree(typed.expr) match {
+            case tt: TypeTree => tt
+            case other => throw new IllegalStateException(
+              s"Scala 3 vararg splat element must be a TypeTree-compatible expression, got: ${if (other == null) "null" else other.getClass.getName}")
+          }
+          val starPos = source.indexOf('*', cursor)
+          val beforeStar = if (starPos >= cursor && starPos < typedEnd) {
+            Space.format(source, cursor, starPos)
+          } else Space.EMPTY
+          updateCursor(typed.span.end)
+          return new S.RepeatedType(
+            Tree.randomId(),
+            prefix,
+            Markers.EMPTY,
+            element,
+            beforeStar,
+            typeOfTree(typed)
+          )
+        }
+        // Fall through to general type-ascription handling for the Scala 2 form.
+      case _ =>
+    }
+
     // Check if this is a member reference pattern (expr _)
     typed.tpt match {
       case id: Trees.Ident[?] if id.name.toString == "_" =>

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.scala.tree;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
 
@@ -371,5 +372,54 @@ class MethodInvocationTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Nested
+    class VarargSplat implements RewriteTest {
+
+        @Test
+        void scala3Splat() {
+            rewriteRun(
+              scala(
+                """
+                object Test {
+                  val xs = Seq(1, 2)
+                  def f(x: Int*): Unit = ()
+                  f(xs*)
+                }
+                """
+              )
+            );
+        }
+
+        @Test
+        void scala2Splat() {
+            rewriteRun(
+              scala(
+                """
+                object Test {
+                  val xs = Seq(1, 2)
+                  def f(x: Int*): Unit = ()
+                  f(xs: _*)
+                }
+                """
+              )
+            );
+        }
+
+        @Test
+        void scala3SplatWithSpaceBeforeStar() {
+            rewriteRun(
+              scala(
+                """
+                object Test {
+                  val xs = Seq(1, 2)
+                  def f(x: Int*): Unit = ()
+                  f(xs *)
+                }
+                """
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
## What's changed?

Teach Scala parser to handle (varargs) splat expressions.

## What's your motivation?

They are not supported at all.