### PR TITLE
Preconditions: expose `And`/`Or`/`Not` as public classes with getters

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Preconditions.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Preconditions.java
@@ -39,65 +39,17 @@ public class Preconditions {
     }
 
     public static TreeVisitor<?, ExecutionContext> not(TreeVisitor<?, ExecutionContext> v) {
-        return new TreeVisitor<Tree, ExecutionContext>() {
-            @Override
-            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
-                SourceFile sourceFile = tree instanceof SourceFile ? (SourceFile) tree : null;
-                // calling `isAcceptable()` in case `v` overrides `visit(Tree, P)`
-                if (sourceFile != null && !v.isAcceptable(sourceFile, ctx)) {
-                    return SearchResult.found(tree);
-                }
-                Tree t2 = v.visit(tree, DataTableSuppressingExecutionContextView.view(ctx));
-                return tree == t2 && tree != null ?
-                        SearchResult.found(tree) :
-                        tree;
-            }
-        };
+        return new Not(v);
     }
 
     @SafeVarargs
     public static TreeVisitor<?, ExecutionContext> or(TreeVisitor<?, ExecutionContext>... vs) {
-        return new TreeVisitor<Tree, ExecutionContext>() {
-            @Override
-            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
-                SourceFile sourceFile = tree instanceof SourceFile ? (SourceFile) tree : null;
-                DataTableSuppressingExecutionContextView suppressingCtx = DataTableSuppressingExecutionContextView.view(ctx);
-                for (TreeVisitor<?, ExecutionContext> v : vs) {
-                    // calling `isAcceptable()` in case `v` overrides `visit(Tree, P)`
-                    if (sourceFile != null && !v.isAcceptable(sourceFile, ctx)) {
-                        continue;
-                    }
-                    Tree t2 = v.visit(tree, suppressingCtx);
-                    if (tree != t2) {
-                        return t2;
-                    }
-                }
-                return tree;
-            }
-        };
+        return new Or(vs);
     }
 
     @SafeVarargs
     public static TreeVisitor<?, ExecutionContext> and(TreeVisitor<?, ExecutionContext>... vs) {
-        return new TreeVisitor<Tree, ExecutionContext>() {
-            @Override
-            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
-                SourceFile sourceFile = tree instanceof SourceFile ? (SourceFile) tree : null;
-                DataTableSuppressingExecutionContextView suppressingCtx = DataTableSuppressingExecutionContextView.view(ctx);
-                Tree t2 = tree;
-                for (TreeVisitor<?, ExecutionContext> v : vs) {
-                    // calling `isAcceptable()` in case `v` overrides `visit(Tree, P)`
-                    if (sourceFile != null && !v.isAcceptable(sourceFile, ctx)) {
-                        continue;
-                    }
-                    t2 = v.visit(tree, suppressingCtx);
-                    if (tree == t2) {
-                        return tree;
-                    }
-                }
-                return t2;
-            }
-        };
+        return new And(vs);
     }
 
     @SafeVarargs
@@ -123,6 +75,81 @@ public class Preconditions {
 
         public Recipe getRecipe() {
             return check;
+        }
+    }
+
+    public static class Not extends TreeVisitor<Tree, ExecutionContext> {
+        @Getter
+        private final TreeVisitor<?, ExecutionContext> visitor;
+
+        public Not(TreeVisitor<?, ExecutionContext> visitor) {
+            this.visitor = visitor;
+        }
+
+        @Override
+        public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+            SourceFile sourceFile = tree instanceof SourceFile ? (SourceFile) tree : null;
+            // calling `isAcceptable()` in case `visitor` overrides `visit(Tree, P)`
+            if (sourceFile != null && !visitor.isAcceptable(sourceFile, ctx)) {
+                return SearchResult.found(tree);
+            }
+            Tree t2 = visitor.visit(tree, DataTableSuppressingExecutionContextView.view(ctx));
+            return tree == t2 && tree != null ?
+                    SearchResult.found(tree) :
+                    tree;
+        }
+    }
+
+    public static class Or extends TreeVisitor<Tree, ExecutionContext> {
+        @Getter
+        private final TreeVisitor<?, ExecutionContext>[] visitors;
+
+        public Or(TreeVisitor<?, ExecutionContext>[] visitors) {
+            this.visitors = visitors;
+        }
+
+        @Override
+        public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+            SourceFile sourceFile = tree instanceof SourceFile ? (SourceFile) tree : null;
+            DataTableSuppressingExecutionContextView suppressingCtx = DataTableSuppressingExecutionContextView.view(ctx);
+            for (TreeVisitor<?, ExecutionContext> v : visitors) {
+                // calling `isAcceptable()` in case `v` overrides `visit(Tree, P)`
+                if (sourceFile != null && !v.isAcceptable(sourceFile, ctx)) {
+                    continue;
+                }
+                Tree t2 = v.visit(tree, suppressingCtx);
+                if (tree != t2) {
+                    return t2;
+                }
+            }
+            return tree;
+        }
+    }
+
+    public static class And extends TreeVisitor<Tree, ExecutionContext> {
+        @Getter
+        private final TreeVisitor<?, ExecutionContext>[] visitors;
+
+        public And(TreeVisitor<?, ExecutionContext>[] visitors) {
+            this.visitors = visitors;
+        }
+
+        @Override
+        public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+            SourceFile sourceFile = tree instanceof SourceFile ? (SourceFile) tree : null;
+            DataTableSuppressingExecutionContextView suppressingCtx = DataTableSuppressingExecutionContextView.view(ctx);
+            Tree t2 = tree;
+            for (TreeVisitor<?, ExecutionContext> v : visitors) {
+                // calling `isAcceptable()` in case `v` overrides `visit(Tree, P)`
+                if (sourceFile != null && !v.isAcceptable(sourceFile, ctx)) {
+                    continue;
+                }
+                t2 = v.visit(tree, suppressingCtx);
+                if (tree == t2) {
+                    return tree;
+                }
+            }
+            return t2;
         }
     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/PreconditionsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/PreconditionsTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 import static org.openrewrite.test.SourceSpecs.other;
 import static org.openrewrite.test.SourceSpecs.text;
@@ -159,6 +160,24 @@ class PreconditionsTest implements RewriteTest {
           )),
           other("hello", "~~(recipe)~~>⚛⚛⚛ The contents of this file are not visible. ⚛⚛⚛")
         );
+    }
+
+    @Test
+    void andOrNotExposeStructure() {
+        TreeVisitor<?, ExecutionContext> a = contains("a");
+        TreeVisitor<?, ExecutionContext> b = contains("b");
+
+        TreeVisitor<?, ExecutionContext> and = Preconditions.and(a, b);
+        assertThat(and).isInstanceOf(Preconditions.And.class);
+        assertThat(((Preconditions.And) and).getVisitors()).containsExactly(a, b);
+
+        TreeVisitor<?, ExecutionContext> or = Preconditions.or(a, b);
+        assertThat(or).isInstanceOf(Preconditions.Or.class);
+        assertThat(((Preconditions.Or) or).getVisitors()).containsExactly(a, b);
+
+        TreeVisitor<?, ExecutionContext> not = Preconditions.not(a);
+        assertThat(not).isInstanceOf(Preconditions.Not.class);
+        assertThat(((Preconditions.Not) not).getVisitor()).isSameAs(a);
     }
 
     Recipe recipe(TreeVisitor<?, ExecutionContext> applicability) {


### PR DESCRIPTION
## Summary

`Preconditions.and(...)`, `or(...)`, and `not(...)` currently return anonymous `TreeVisitor` instances whose wrapped children live inside synthetic `val$vs` / `val$v` fields. That makes compound preconditions opaque to anything that wants to inspect a recipe's precondition structure (e.g., static analysis, tooling that filters a corpus before deserializing).

This PR turns them into public concrete classes:

```java
Preconditions.And { TreeVisitor<?, ExecutionContext>[] getVisitors(); }
Preconditions.Or  { TreeVisitor<?, ExecutionContext>[] getVisitors(); }
Preconditions.Not { TreeVisitor<?, ExecutionContext>  getVisitor();  }
```

The factory method signatures (`TreeVisitor<?, ExecutionContext>` return type) are unchanged, so existing callers compile and run identically. `visit()` bodies are copied verbatim from the prior anonymous implementations — behavior is preserved by construction.

## Motivation

We want to use the per-file `typesInUse[]` / `usedMethods[]` indices in Moderne's V3 LST format to skip body deserialization for SourceFiles that can't match a recipe's precondition. Doing that needs to walk a recipe's precondition tree statically and translate it into an index query. Today, only `Preconditions.Check` is inspectable; everything compound collapses into an anonymous class and we lose the optimization wherever recipe authors use AND/OR/NOT.

## Test plan

- [x] `:rewrite-core:test --tests PreconditionsTest` — all 14 tests pass (13 existing + 1 new `andOrNotExposeStructure` lock-in test).
- [x] `:rewrite-core:compileJava` and `:rewrite-core:compileTestJava` clean.
- [x] Behavior preservation by construction: `visit()` bodies are byte-identical to the prior anonymous implementations.