### PR TITLE
Kotlin recipe DSL: pattern-matching gap closures + matcher/template fixes

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
@@ -79,18 +79,19 @@ public final class GeneratedRecipeSupport {
         for (int i = 0; i < specs.length; i++) {
             matchers[i] = new MethodMatcher(specs[i]);
         }
-        int[] substitutionSources = parseCsv(substitutionSourcesCsv);
+        int[][] substitutionSourcesByMatcher = parseCsvPerMatcher(substitutionSourcesCsv, specs.length);
         return new KotlinVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                boolean matched = false;
-                for (MethodMatcher matcher : matchers) {
-                    if (matcher.matches(method)) {
-                        matched = true;
+                int matchedIdx = -1;
+                for (int i = 0; i < matchers.length; i++) {
+                    if (matchers[i].matches(method)) {
+                        matchedIdx = i;
                         break;
                     }
                 }
-                if (matched) {
+                if (matchedIdx >= 0) {
+                    int[] substitutionSources = substitutionSourcesByMatcher[matchedIdx];
                     Object[] substitutions = new Object[substitutionSources.length];
                     for (int i = 0; i < substitutionSources.length; i++) {
                         int src = substitutionSources[i];
@@ -152,7 +153,7 @@ public final class GeneratedRecipeSupport {
         for (int i = 0; i < specs.length; i++) {
             matchers[i] = new MethodMatcher(specs[i]);
         }
-        int[] substitutionSources = parseCsv(substitutionSourcesCsv);
+        int[][] substitutionSourcesByMatcher = parseCsvPerMatcher(substitutionSourcesCsv, specs.length);
         return new KotlinVisitor<ExecutionContext>() {
             @Override
             public J visitUnary(K.Unary unary, ExecutionContext ctx) {
@@ -163,16 +164,17 @@ public final class GeneratedRecipeSupport {
                     return super.visitUnary(unary, ctx);
                 }
                 J.MethodInvocation method = (J.MethodInvocation) unary.getExpression();
-                boolean matched = false;
-                for (MethodMatcher matcher : matchers) {
-                    if (matcher.matches(method)) {
-                        matched = true;
+                int matchedIdx = -1;
+                for (int i = 0; i < matchers.length; i++) {
+                    if (matchers[i].matches(method)) {
+                        matchedIdx = i;
                         break;
                     }
                 }
-                if (!matched) {
+                if (matchedIdx < 0) {
                     return super.visitUnary(unary, ctx);
                 }
+                int[] substitutionSources = substitutionSourcesByMatcher[matchedIdx];
                 Object[] substitutions = new Object[substitutionSources.length];
                 for (int i = 0; i < substitutionSources.length; i++) {
                     int src = substitutionSources[i];
@@ -203,6 +205,87 @@ public final class GeneratedRecipeSupport {
     }
 
     /**
+     * Visitor for a {@code rewrite { d: Duration -> d.inHours } to { d -> d.inWholeHours }}
+     * recipe whose before lambda body is a property access (rather than a
+     * method invocation). The Kotlin parser models {@code obj.prop} as a
+     * {@link J.FieldAccess} — so this visitor walks {@link J.FieldAccess}
+     * instead of {@link J.MethodInvocation}.
+     *
+     * <p>Matcher specs use the {@code <owner-fqn>#<property-name>} format
+     * (rather than the {@link MethodMatcher} spelling), since property access
+     * has no parenthesised parameter list. Each line of
+     * {@code matcherSpecsLines} is one such spec; the visitor accepts a
+     * field access iff its target type FQN and selector name match any spec.
+     *
+     * <p>Property accessors have no value arguments, so the substitution
+     * source CSV always references the receiver via {@code -1} — the IR pass
+     * still emits the receiver placeholder uniformly with the method-invocation
+     * path, which keeps the after-template synthesis logic shared.
+     */
+    public static TreeVisitor<?, ExecutionContext> propertyAccessRewrite(
+            String matcherSpecsLines, String afterTemplate, String substitutionSourcesCsv) {
+        String[] specs = matcherSpecsLines.isEmpty() ? new String[0] : matcherSpecsLines.split("\n");
+        String[] specOwners = new String[specs.length];
+        String[] specNames = new String[specs.length];
+        for (int i = 0; i < specs.length; i++) {
+            int hash = specs[i].indexOf('#');
+            if (hash < 0) {
+                specOwners[i] = "*";
+                specNames[i] = specs[i];
+            } else {
+                specOwners[i] = specs[i].substring(0, hash);
+                specNames[i] = specs[i].substring(hash + 1);
+            }
+        }
+        int[][] substitutionSourcesByMatcher = parseCsvPerMatcher(substitutionSourcesCsv, specs.length);
+        return new KotlinVisitor<ExecutionContext>() {
+            @Override
+            public J visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext ctx) {
+                String name = fieldAccess.getName().getSimpleName();
+                String targetTypeFqn = fullyQualifiedNameOf(fieldAccess.getTarget().getType());
+                int matchedIdx = -1;
+                for (int i = 0; i < specs.length; i++) {
+                    if (!specNames[i].equals(name)) {
+                        continue;
+                    }
+                    if (!"*".equals(specOwners[i]) && !specOwners[i].equals(targetTypeFqn)) {
+                        continue;
+                    }
+                    matchedIdx = i;
+                    break;
+                }
+                if (matchedIdx < 0) {
+                    return super.visitFieldAccess(fieldAccess, ctx);
+                }
+                int[] substitutionSources = substitutionSourcesByMatcher[matchedIdx];
+                Object[] substitutions = new Object[substitutionSources.length];
+                for (int i = 0; i < substitutionSources.length; i++) {
+                    int src = substitutionSources[i];
+                    if (src < 0) {
+                        substitutions[i] = fieldAccess.getTarget();
+                    } else {
+                        // Property accessors have no positional args — the IR
+                        // pass should never have emitted a non-negative source
+                        // for this path. Bail out rather than substituting a
+                        // placeholder we can't satisfy.
+                        return super.visitFieldAccess(fieldAccess, ctx);
+                    }
+                }
+                J result = KotlinTemplate.builder(afterTemplate).build()
+                        .apply(getCursor(), fieldAccess.getCoordinates().replace(), substitutions);
+                return result.withPrefix(fieldAccess.getPrefix());
+            }
+        };
+    }
+
+    private static @Nullable String fullyQualifiedNameOf(org.openrewrite.java.tree.@Nullable JavaType type) {
+        if (type instanceof org.openrewrite.java.tree.JavaType.FullyQualified) {
+            return ((org.openrewrite.java.tree.JavaType.FullyQualified) type).getFullyQualifiedName();
+        }
+        return null;
+    }
+
+    /**
      * Java-rooted parallel of {@link #methodInvocationRewrite}. Used when the
      * LST-structural classifier defaults a {@code rewrite { } to { }} clause
      * to a {@link JavaVisitor}: the visitor walks both Java and Kotlin sources
@@ -222,18 +305,19 @@ public final class GeneratedRecipeSupport {
         for (int i = 0; i < specs.length; i++) {
             matchers[i] = new MethodMatcher(specs[i]);
         }
-        int[] substitutionSources = parseCsv(substitutionSourcesCsv);
+        int[][] substitutionSourcesByMatcher = parseCsvPerMatcher(substitutionSourcesCsv, specs.length);
         return new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                boolean matched = false;
-                for (MethodMatcher matcher : matchers) {
-                    if (matcher.matches(method)) {
-                        matched = true;
+                int matchedIdx = -1;
+                for (int i = 0; i < matchers.length; i++) {
+                    if (matchers[i].matches(method)) {
+                        matchedIdx = i;
                         break;
                     }
                 }
-                if (matched) {
+                if (matchedIdx >= 0) {
+                    int[] substitutionSources = substitutionSourcesByMatcher[matchedIdx];
                     Object[] substitutions = new Object[substitutionSources.length];
                     for (int i = 0; i < substitutionSources.length; i++) {
                         int src = substitutionSources[i];
@@ -325,6 +409,44 @@ public final class GeneratedRecipeSupport {
         int[] result = new int[parts.length];
         for (int i = 0; i < parts.length; i++) {
             result[i] = Integer.parseInt(parts[i]);
+        }
+        return result;
+    }
+
+    /**
+     * Parse a substitution-source CSV that may be a single shared list (no
+     * {@code \n}) or one CSV per matcher ({@code \n}-delimited, one entry per
+     * matcher spec). Returns an {@code int[][]} of length {@code matcherCount}
+     * — the same array repeated for the shared case, or a per-matcher array
+     * for the mixed-shape multi-before case.
+     *
+     * <p>Mixed-shape multi-before: a recipe like
+     * {@code rewrite({ s: String -> s.foo() }, { s: String -> bar(s) }) to { s -> s.qux() }}
+     * binds {@code s} to the receiver in the first matcher and to arg 0 in
+     * the second. The after template's placeholder ORDER is shared (since
+     * the template is derived from the same after lambda), but the substitution
+     * sources differ per-matcher.
+     */
+    private static int[][] parseCsvPerMatcher(String csv, int matcherCount) {
+        if (matcherCount == 0) {
+            return new int[0][];
+        }
+        if (csv.indexOf('\n') < 0) {
+            int[] shared = parseCsv(csv);
+            int[][] result = new int[matcherCount][];
+            for (int i = 0; i < matcherCount; i++) {
+                result[i] = shared;
+            }
+            return result;
+        }
+        String[] lines = csv.split("\n", -1);
+        if (lines.length != matcherCount) {
+            throw new IllegalStateException(
+                    "expected " + matcherCount + " per-matcher CSVs but got " + lines.length);
+        }
+        int[][] result = new int[matcherCount][];
+        for (int i = 0; i < matcherCount; i++) {
+            result[i] = parseCsv(lines[i]);
         }
         return result;
     }

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
@@ -30,6 +30,7 @@ import org.openrewrite.java.tree.Space;
 import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.KotlinVisitor;
 import org.openrewrite.kotlin.marker.TrailingLambdaArgument;
+import org.openrewrite.kotlin.tree.K;
 
 /**
  * Runtime support for the recipe authoring DSL's K2 compiler plugin
@@ -125,6 +126,78 @@ public final class GeneratedRecipeSupport {
                     return result.withPrefix(method.getPrefix());
                 }
                 return super.visitMethodInvocation(method, ctx);
+            }
+        };
+    }
+
+    /**
+     * Variant of {@link #methodInvocationRewrite} for recipes whose before
+     * lambda body is {@code someCall()!!} (a method invocation immediately
+     * not-null-asserted). In the rewrite-kotlin LST that pattern parses as
+     * {@code K.Unary(NotNull, J.MethodInvocation)} — visiting only
+     * {@code J.MethodInvocation} would replace just the call and leave a
+     * stranded {@code !!} on the rewritten template, so this visitor walks
+     * {@link K.Unary} instead and swaps the whole not-null expression for the
+     * after template.
+     *
+     * <p>Matcher specs, substitution-source CSV, and trailing-lambda fix-up
+     * semantics are identical to the bare variant — only the entry point and
+     * the replacement coordinate (the K.Unary, not its inner J.MethodInvocation)
+     * change.
+     */
+    public static TreeVisitor<?, ExecutionContext> methodInvocationRewriteKotlinNotNull(
+            String matcherSpecsLines, String afterTemplate, String substitutionSourcesCsv) {
+        String[] specs = matcherSpecsLines.isEmpty() ? new String[0] : matcherSpecsLines.split("\n");
+        MethodMatcher[] matchers = new MethodMatcher[specs.length];
+        for (int i = 0; i < specs.length; i++) {
+            matchers[i] = new MethodMatcher(specs[i]);
+        }
+        int[] substitutionSources = parseCsv(substitutionSourcesCsv);
+        return new KotlinVisitor<ExecutionContext>() {
+            @Override
+            public J visitUnary(K.Unary unary, ExecutionContext ctx) {
+                if (unary.getOperator() != K.Unary.Type.NotNull) {
+                    return super.visitUnary(unary, ctx);
+                }
+                if (!(unary.getExpression() instanceof J.MethodInvocation)) {
+                    return super.visitUnary(unary, ctx);
+                }
+                J.MethodInvocation method = (J.MethodInvocation) unary.getExpression();
+                boolean matched = false;
+                for (MethodMatcher matcher : matchers) {
+                    if (matcher.matches(method)) {
+                        matched = true;
+                        break;
+                    }
+                }
+                if (!matched) {
+                    return super.visitUnary(unary, ctx);
+                }
+                Object[] substitutions = new Object[substitutionSources.length];
+                for (int i = 0; i < substitutionSources.length; i++) {
+                    int src = substitutionSources[i];
+                    if (src < 0) {
+                        if (method.getSelect() == null) {
+                            return super.visitUnary(unary, ctx);
+                        }
+                        substitutions[i] = method.getSelect();
+                    } else {
+                        if (src >= method.getArguments().size()) {
+                            return super.visitUnary(unary, ctx);
+                        }
+                        substitutions[i] = method.getArguments().get(src);
+                    }
+                }
+                J result = KotlinTemplate.builder(afterTemplate).build()
+                        .apply(getCursor(), unary.getCoordinates().replace(), substitutions);
+                if (result instanceof J.MethodInvocation) {
+                    JContainer<Expression> matchedTypeArgs = method.getPadding().getTypeParameters();
+                    if (matchedTypeArgs != null) {
+                        result = ((J.MethodInvocation) result).withTypeParameters(matchedTypeArgs);
+                    }
+                    result = preserveTrailingLambdaShape((J.MethodInvocation) result);
+                }
+                return result.withPrefix(unary.getPrefix());
             }
         };
     }
@@ -256,7 +329,7 @@ public final class GeneratedRecipeSupport {
         return result;
     }
 
-    /**
+/**
      * Restore Kotlin trailing-lambda call shape on a template-substituted result.
      *
      * <p>The substitution sources come straight off the matched invocation's

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/RecipeDsl.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/RecipeDsl.kt
@@ -484,3 +484,33 @@ public open class GenerateScope internal constructor(public val ctx: ExecutionCo
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }
+
+// ---------------------------------------------------------------------------
+// Runtime support for the K2 plugin's imperative-recipe synthesis.
+// ---------------------------------------------------------------------------
+
+/**
+ * Rebuild the visitor pipeline for an imperative
+ * `recipe(...) { edit { lang { visitX { ... } } } }` recipe on each call.
+ *
+ * The K2 plugin replaces the original `recipe(...)` call site with a
+ * synthetic `Generated$<Name>()` constructor; the generated class is a
+ * field-less top-level `Recipe` whose `getVisitor()` body calls this
+ * helper, threading the user's original trailing lambda back through a
+ * fresh [RecipeBuilder]. Because the generated class has no instance
+ * state, Jackson roundtrip (`RecipeSerializer.read(write(r))`) succeeds —
+ * the workaround `validateRecipeSerialization(false)` is no longer needed
+ * for imperative recipes that route through this path.
+ *
+ * The temporary [Recipe] built here exists only long enough to extract
+ * its visitor; metadata (displayName, description, tags, effort) is the
+ * generated class's responsibility (it overrides the corresponding Recipe
+ * methods with constants), so passing empty placeholders is intentional.
+ */
+public fun buildImperativeVisitor(
+    block: RecipeBuilder.() -> Unit,
+): TreeVisitor<*, ExecutionContext> {
+    val builder = RecipeBuilder()
+    builder.block()
+    return builder.build("", "", emptySet(), null).getVisitor()
+}

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
@@ -162,6 +162,17 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         val methodInvocationRewriteKotlinSymbol: IrSimpleFunctionSymbol?,
         val methodInvocationRewriteJavaSymbol: IrSimpleFunctionSymbol?,
         val methodInvocationRewriteKotlinNotNullSymbol: IrSimpleFunctionSymbol?,
+        val propertyAccessRewriteKotlinSymbol: IrSimpleFunctionSymbol?,
+        /**
+         * Top-level `org.openrewrite.buildImperativeVisitor` Kotlin helper.
+         * The IR pass routes imperative-shape recipes to this helper so the
+         * generated class can stay field-less (Jackson-roundtrippable) while
+         * still constructing the visitor pipeline fresh on each `getVisitor()`
+         * call. Null when the helper isn't on the classpath (older
+         * `rewrite-kotlin`) — imperative recipes fall back to the runtime
+         * DSL's anonymous-Recipe path.
+         */
+        val buildImperativeVisitorSymbol: IrSimpleFunctionSymbol?,
     )
 
     private fun buildIrGenContext(pluginContext: IrPluginContext): RecipeIrGenContext? {
@@ -199,6 +210,19 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         val kotlinNotNullHelper = supportFns.firstOrNull {
             it.name.asString() == "methodInvocationRewriteKotlinNotNull"
         }?.symbol
+        val propertyAccessHelper = supportFns.firstOrNull {
+            it.name.asString() == "propertyAccessRewrite"
+        }?.symbol
+
+        // Top-level helper in `org.openrewrite.RecipeDslKt`. Resolved via
+        // `referenceFunctions` against the FqName of the standalone declaration.
+        val buildImperativeVisitorFqn = FqName("org.openrewrite.buildImperativeVisitor")
+        val buildImperativeVisitorSymbol = pluginContext
+            .referenceFunctions(org.jetbrains.kotlin.name.CallableId(
+                packageName = buildImperativeVisitorFqn.parent(),
+                callableName = buildImperativeVisitorFqn.shortName(),
+            ))
+            .singleOrNull { it.owner.valueParameters.size == 1 }
 
         return RecipeIrGenContext(
             pluginContext = pluginContext,
@@ -212,6 +236,8 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             methodInvocationRewriteKotlinSymbol = kotlinHelper,
             methodInvocationRewriteJavaSymbol = javaHelper,
             methodInvocationRewriteKotlinNotNullSymbol = kotlinNotNullHelper,
+            propertyAccessRewriteKotlinSymbol = propertyAccessHelper,
+            buildImperativeVisitorSymbol = buildImperativeVisitorSymbol,
         )
     }
 
@@ -244,20 +270,39 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             if (initializerExpr.symbol.owner.kotlinFqName != RECIPE_FQN) continue
 
             val metadata = readMetadata(initializerExpr) ?: continue
-            val templates = extractRewriteTemplates(initializerExpr, sourceText) ?: continue
-            // Classify Java vs Kotlin per the LST-structural rule. The helper
-            // resolution may have failed (e.g. older GeneratedRecipeSupport on
-            // classpath); skip the recipe if the picked helper is unavailable.
-            val helperSymbol = pickHelperSymbol(templates, ctx) ?: continue
-
-            val generatedClass = buildGeneratedRecipeClass(
-                ctx = ctx,
-                parentFile = file,
-                propertyName = declaration.name,
-                metadata = metadata,
-                templates = templates,
-                helperSymbol = helperSymbol,
-            )
+            // Two paths share the rest of the loop:
+            //   - declarative: `edit { rewrite { } to { } }` — synthesizes a
+            //     visitor whose body is the IR-derived template helper call.
+            //   - imperative:  `edit { lang { visitX { } } }` (or anything
+            //     else not matching the declarative shape) — synthesizes a
+            //     visitor whose body delegates back to the runtime DSL via
+            //     `buildImperativeVisitor`, threading the original recipe
+            //     trailing lambda through a fresh [RecipeBuilder] per call.
+            // Both produce a field-less top-level class so Jackson roundtrip
+            // succeeds (no `validateRecipeSerialization(false)` workaround).
+            val templates = extractRewriteTemplates(initializerExpr, sourceText, ctx)
+            val generatedClass: IrClass = if (templates != null) {
+                val helperSymbol = pickHelperSymbol(templates, ctx) ?: continue
+                buildGeneratedRecipeClass(
+                    ctx = ctx,
+                    parentFile = file,
+                    propertyName = declaration.name,
+                    metadata = metadata,
+                    templates = templates,
+                    helperSymbol = helperSymbol,
+                )
+            } else {
+                val imperativeBlock = findTrailingLambda(initializerExpr) ?: continue
+                val helperSymbol = ctx.buildImperativeVisitorSymbol ?: continue
+                buildImperativeRecipeClass(
+                    ctx = ctx,
+                    parentFile = file,
+                    propertyName = declaration.name,
+                    metadata = metadata,
+                    recipeBlock = imperativeBlock,
+                    helperSymbol = helperSymbol,
+                )
+            }
             file.addChild(generatedClass)
 
             val generatedCtor = generatedClass.declarations
@@ -359,6 +404,12 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
          * the rewrite replaces the entire not-null-asserted expression.
          */
         val wrappedInNotNull: Boolean,
+        /**
+         * True when every before lambda was a property-access pattern
+         * (`{ d: Duration -> d.inHours }`) rather than a method invocation.
+         * Routes the helper selection to a `J.FieldAccess`-walking visitor.
+         */
+        val propertyAccess: Boolean,
     )
 
     private fun pickHelperSymbol(
@@ -382,10 +433,10 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         // KotlinTemplate) the plan deferred.
         @Suppress("UNUSED_VARIABLE")
         val classifierResult = templates.usesKotlinTreeNode
-        return if (templates.wrappedInNotNull) {
-            ctx.methodInvocationRewriteKotlinNotNullSymbol
-        } else {
-            ctx.methodInvocationRewriteKotlinSymbol
+        return when {
+            templates.propertyAccess -> ctx.propertyAccessRewriteKotlinSymbol
+            templates.wrappedInNotNull -> ctx.methodInvocationRewriteKotlinNotNullSymbol
+            else -> ctx.methodInvocationRewriteKotlinSymbol
         }
     }
 
@@ -405,6 +456,7 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
     private fun extractRewriteTemplates(
         recipeCall: IrCall,
         sourceText: String,
+        ctx: RecipeIrGenContext,
     ): RewriteTemplates? {
         val recipeBlock = findTrailingLambda(recipeCall) ?: return null
         val recipeStmts = (recipeBlock.function.body as? IrBlockBody)?.statements ?: return null
@@ -448,28 +500,55 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         }
         val afterArg = toCall.getValueArgument(0) as? IrFunctionExpression ?: return null
 
-        val beforeLambdas = beforeExprs.map { validateBeforeLambda(it) ?: return null }
-        val canonical = beforeLambdas[0].canonicalSignature()
+        val beforeLambdas = beforeExprs.map { validateBeforeLambda(it, sourceText, ctx) ?: return null }
         val notNullForAll = beforeLambdas[0].wrappedInNotNull
+        val propertyAccessForAll = beforeLambdas[0].propertyAccess
         for (i in 1 until beforeLambdas.size) {
-            if (beforeLambdas[i].canonicalSignature() != canonical) return null
+            // Same param count is still required: the after lambda has a
+            // fixed param list and each before must supply the same set of
+            // bindings. Canonical signatures, however, may differ — they
+            // just produce per-before substitution-source CSVs (see below).
             if (beforeLambdas[i].params.size != beforeLambdas[0].params.size) return null
             // Multi-before recipes must agree on the not-null-assertion shape.
             // Mixing `someCall()` and `someCall()!!` befores would require two
             // different visitor entry points; reject and let the runtime DSL
             // builder surface the limitation.
             if (beforeLambdas[i].wrappedInNotNull != notNullForAll) return null
+            // Same restriction for property-access vs method-invocation shape:
+            // the two routes use different LST visitors, so a multi-before
+            // recipe must pick one or the other.
+            if (beforeLambdas[i].propertyAccess != propertyAccessForAll) return null
         }
-        val afterTemplateAndSources = buildAfterTemplate(afterArg, sourceText, beforeLambdas[0]) ?: return null
-        val matcherSpecs = beforeLambdas.map { computeMatcherSpec(it.rootCall) }
+        // Mixed-shape multi-before: each before gets its own
+        // substitution-source CSV (since the after-lambda params bind to
+        // different positions in each before — receiver in one, arg-N in
+        // another). The after TEMPLATE is required to be identical across
+        // all befores; if it isn't, the after lambda's IR was somehow
+        // different per-before, which the runtime helper can't dispatch on.
+        val firstTemplate = buildAfterTemplate(afterArg, sourceText, beforeLambdas[0]) ?: return null
+        val csvs = mutableListOf(firstTemplate.second)
+        for (i in 1 until beforeLambdas.size) {
+            val nextTemplate = buildAfterTemplate(afterArg, sourceText, beforeLambdas[i]) ?: return null
+            if (nextTemplate.first != firstTemplate.first) return null
+            csvs += nextTemplate.second
+        }
+        val matcherSpecs = beforeLambdas.map {
+            it.inlinedConstantMatcherSpec ?: computeMatcherSpec(it.rootCall!!, it.propertyAccess)
+        }
+        // Single-before recipes pass the CSV through as a plain string for
+        // backward compatibility with the original helper signature. Multi-
+        // before recipes pack per-matcher CSVs `\n`-delimited; helpers detect
+        // the delimiter and dispatch per-matcher.
+        val csvField = if (csvs.size == 1) csvs[0] else csvs.joinToString("\n")
 
         val usesKotlinTreeNode = classifyKotlinPromotion(beforeExprs + afterArg)
         return RewriteTemplates(
             matcherSpecs = matcherSpecs,
-            afterTemplate = afterTemplateAndSources.first,
-            substitutionSourcesCsv = afterTemplateAndSources.second,
+            afterTemplate = firstTemplate.first,
+            substitutionSourcesCsv = csvField,
             usesKotlinTreeNode = usesKotlinTreeNode,
             wrappedInNotNull = notNullForAll,
+            propertyAccess = propertyAccessForAll,
         )
     }
 
@@ -530,7 +609,15 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
 
     private class BeforeLambda(
         val params: List<IrValueParameter>,
-        val rootCall: IrCall,
+        /**
+         * Null when the lambda body is an inlined static constant
+         * (e.g. `{ -> Math.PI }`). K2 FIR2IR compile-time-folds primitive
+         * `const val` accesses to a bare `IrConst`, dropping the qualifier
+         * symbol entirely; there's no `IrCall` to anchor a method-matcher
+         * spec on. The matcher spec is recovered by parsing the recipe
+         * source slice instead — see [inlinedConstantMatcherSpec].
+         */
+        val rootCall: IrCall?,
         val argSignatures: List<ArgSig>,
         val receiverParamSymbol: IrValueSymbol?,
         /**
@@ -542,9 +629,29 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
          * not-null-asserted expression rather than just the inner invocation.
          */
         val wrappedInNotNull: Boolean,
+        /**
+         * True when the rootCall is a property getter invoked at the source
+         * level via property-access syntax (`d.inHours`) rather than a method
+         * call (`d.inHours()`), OR when the body is an inlined static
+         * constant. Both shapes are matched as `J.FieldAccess` by the
+         * `propertyAccessRewrite` helper — same matcher-spec format
+         * (`<owner-fqn>#<name>`), same visitor entry point.
+         */
+        val propertyAccess: Boolean,
+        /**
+         * For inlined static-constant befores (e.g. `{ -> Math.PI }`): the
+         * matcher spec computed by parsing the recipe source slice. Null
+         * otherwise — the spec is computed downstream from [rootCall] via
+         * [computeMatcherSpec].
+         */
+        val inlinedConstantMatcherSpec: String? = null,
     )
 
-    private fun validateBeforeLambda(fnExpr: IrFunctionExpression): BeforeLambda? {
+    private fun validateBeforeLambda(
+        fnExpr: IrFunctionExpression,
+        sourceText: String,
+        ctx: RecipeIrGenContext,
+    ): BeforeLambda? {
         val fn = fnExpr.function
         val params = fn.valueParameters
         val body = fn.body as? IrBlockBody ?: return null
@@ -552,14 +659,18 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         val rawExpr = when (singleStmt) {
             is IrReturn -> singleStmt.value
             is IrCall -> singleStmt
+            is IrConst -> singleStmt
             else -> null
         } ?: return null
-        // Unwrap an outer `!!` — K2 FIR2IR represents `someCall()!!` as an
-        // `IrCall` to the `kotlin.internal.ir.CHECK_NOT_NULL` intrinsic with
-        // the asserted expression as its (single) value argument. The matcher
-        // should target the inner call; the not-null-assertion shape is then
-        // remembered so the helper-selection routes to a visitor that walks
-        // `K.Unary(NotNull)` and rewrites the whole not-null expression.
+        // Inlined-constant before pattern: `{ -> Math.PI }`. K2 FIR2IR
+        // compile-time-folds primitive `const val` reads to a bare IrConst,
+        // erasing both the `Math` qualifier and the `<get-PI>` accessor
+        // symbol. Fall back to parsing the recipe source slice to recover
+        // the `Class.NAME` shape; route to the property-access helper
+        // (matches `J.FieldAccess` in user code by `<owner-fqn>#<name>`).
+        if (rawExpr is IrConst && params.isEmpty()) {
+            return validateInlinedConstantBeforeLambda(rawExpr, params, sourceText, ctx)
+        }
         var wrappedInNotNull = false
         var current: IrCall = rawExpr as? IrCall ?: return null
         while (current.symbol.owner.kotlinFqName.asString() == CHECK_NOT_NULL_FQN) {
@@ -569,10 +680,34 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         }
         val rootCall = current
 
+        // Source-level property access vs method invocation: K2 lowers
+        // `d.inHours` (property) and `d.inHours()` (would-be method) both to
+        // `IrCall(<get-inHours>)` with identical IR offsets covering the LHS
+        // plus the accessor name only — `()` (if present) is NOT inside the
+        // IrCall's offsets. We therefore disambiguate by looking at the
+        // character immediately following the IrCall's endOffset in source.
+        // If it's `(`, the author wrote method-call syntax. Otherwise
+        // (newline, whitespace, EOF, operator, `}`), it's property access.
+        val propertyAccess = run {
+            if (rootCall.symbol.owner.correspondingPropertySymbol == null) return@run false
+            val eo = rootCall.endOffset
+            if (eo < 0 || eo > sourceText.length) return@run false
+            // Skip horizontal whitespace; a literal '(' on the same expression
+            // line means the author wrote a method-style call.
+            var i = eo
+            while (i < sourceText.length) {
+                val c = sourceText[i]
+                if (c == ' ' || c == '\t') { i++; continue }
+                return@run c != '('
+            }
+            true
+        }
+
         if (params.isEmpty()) {
             if (rootCall.dispatchReceiver != null || rootCall.extensionReceiver != null) return null
             if (rootCall.valueArgumentsCount > 0) return null
-            return BeforeLambda(params, rootCall, emptyList(), receiverParamSymbol = null, wrappedInNotNull = wrappedInNotNull)
+            return BeforeLambda(params, rootCall, emptyList(), receiverParamSymbol = null,
+                wrappedInNotNull = wrappedInNotNull, propertyAccess = propertyAccess)
         }
 
         val rawReceiver: IrExpression? = rootCall.dispatchReceiver ?: rootCall.extensionReceiver
@@ -598,7 +733,94 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
                 else -> return null
             }
         }
-        return BeforeLambda(params, rootCall, sigs, receiverParamSymbol, wrappedInNotNull)
+        // Property accessors take 0 value args; a non-empty arg signature here
+        // means the IR is method-style despite a getter-shaped symbol.
+        val finalPropertyAccess = propertyAccess && sigs.isEmpty()
+        return BeforeLambda(params, rootCall, sigs, receiverParamSymbol, wrappedInNotNull, finalPropertyAccess)
+    }
+
+    /**
+     * Recover a matcher spec for a before-lambda whose body K2 compile-time-
+     * folded into an [IrConst]. Primitive Java `public static final` fields
+     * (`Math.PI`, `Math.E`, `Integer.MAX_VALUE`) and Kotlin `const val`
+     * companions get inlined at FIR2IR, leaving no symbol to anchor the spec
+     * on — we re-derive the `Class.NAME` shape by parsing the lambda source.
+     *
+     * Returns null when the slice doesn't have a `Qualifier.NAME` shape or
+     * when the qualifier can't be resolved to a class on the compiler
+     * classpath. Imports are erased by the time IR runs, so resolution
+     * probes a fixed candidate list (the slice as-FQN, `java.lang.X`,
+     * `kotlin.X`) — covers the common JVM/Kotlin primitive-const cases.
+     */
+    private fun validateInlinedConstantBeforeLambda(
+        constExpr: IrConst,
+        params: List<IrValueParameter>,
+        sourceText: String,
+        ctx: RecipeIrGenContext,
+    ): BeforeLambda? {
+        val so = constExpr.startOffset
+        val eo = constExpr.endOffset
+        if (so < 0 || eo <= so || eo > sourceText.length) return null
+        // The IR-emitted offsets may cover just `PI` (the package qualifier
+        // has no IR node); reuse the FQN-extension walk so the parsed slice
+        // is the recipe author's full `Foo.BAR` spelling.
+        val sliceStart = extendBackwardForQualifierChain(sourceText, so)
+        val rawSlice = sourceText.substring(sliceStart, eo).trim()
+        val dotIdx = rawSlice.lastIndexOf('.')
+        if (dotIdx <= 0 || dotIdx == rawSlice.length - 1) return null
+        val qualifier = rawSlice.substring(0, dotIdx)
+        val name = rawSlice.substring(dotIdx + 1)
+        if (!isValidJavaIdentifier(qualifier.replace(".", "")) || !isValidJavaIdentifier(name)) return null
+        val resolvedFqn = resolveQualifierAsClass(ctx.pluginContext, qualifier) ?: return null
+        return BeforeLambda(
+            params = params,
+            rootCall = null,
+            argSignatures = emptyList(),
+            receiverParamSymbol = null,
+            wrappedInNotNull = false,
+            propertyAccess = true,
+            inlinedConstantMatcherSpec = "$resolvedFqn#$name",
+        )
+    }
+
+    private fun isValidJavaIdentifier(s: String): Boolean {
+        if (s.isEmpty()) return false
+        if (!Character.isJavaIdentifierStart(s[0])) return false
+        for (i in 1 until s.length) {
+            if (!Character.isJavaIdentifierPart(s[i])) return false
+        }
+        return true
+    }
+
+    /**
+     * Try to resolve the qualifier slice (everything left of the final dot
+     * in a `Qualifier.NAME` constant reference) to a class FQN. Probes:
+     *   1. The qualifier as-is (already a FQN, e.g. `java.lang.Math`).
+     *   2. `java.lang.<qualifier>` (the auto-imported root in Kotlin source).
+     *   3. `kotlin.<qualifier>` (for `Int`, `Long`, `Double` etc. — the
+     *      stdlib types that house Kotlin's primitive constants).
+     *
+     * Returns the first FQN whose class resolves on the compiler classpath,
+     * or null. Imports are erased by IR time so we can't query the recipe
+     * file's own import list; the candidate set is intentionally narrow to
+     * avoid false positives.
+     */
+    private fun resolveQualifierAsClass(
+        pluginContext: IrPluginContext,
+        qualifier: String,
+    ): String? {
+        val candidates = mutableListOf<String>()
+        if (qualifier.contains('.')) {
+            candidates += qualifier
+        }
+        candidates += "java.lang.$qualifier"
+        candidates += "kotlin.$qualifier"
+        for (cand in candidates) {
+            val fq = FqName(cand)
+            if (fq.isRoot) continue
+            if (pluginContext.referenceClass(ClassId.topLevel(fq)) != null) return cand
+        }
+        return null
     }
 
     private fun BeforeLambda.canonicalSignature(): CanonicalSignature {
@@ -633,9 +855,25 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
      * resolved before-lambda's root call. Member calls bind to the dispatch
      * receiver's class FQN; extension calls and top-level non-extensions to
      * the JVM facade class. Mirrors [org.openrewrite.kotlin.KotlinTypeMapping].
+     *
+     * When [propertyAccess] is true, the spec uses the `<owner-fqn>#<property-name>`
+     * format consumed by `GeneratedRecipeSupport.propertyAccessRewrite`, which
+     * walks `J.FieldAccess` rather than `J.MethodInvocation`. The property
+     * name comes from the `IrSimpleFunction`'s `correspondingPropertySymbol`
+     * — the function's own `name` is the synthetic `<get-foo>` accessor name,
+     * which doesn't match the source-level identifier.
      */
-    private fun computeMatcherSpec(rootCall: IrCall): String {
+    private fun computeMatcherSpec(rootCall: IrCall, propertyAccess: Boolean): String {
         val owner = rootCall.symbol.owner
+        if (propertyAccess) {
+            val propName = owner.correspondingPropertySymbol?.owner?.name?.asString()
+                ?: owner.name.asString().removePrefix("<get-").removeSuffix(">")
+            val ownerFqn = owner.dispatchReceiverParameter?.type?.classFqName?.asString()
+                ?: (owner.parent as? IrClass)?.kotlinFqName?.asString()
+                ?: computeJvmFacadeFqn(owner)
+                ?: "*"
+            return "$ownerFqn#$propName"
+        }
         val methodName = owner.name.asString()
 
         val dispatchFqn = owner.dispatchReceiverParameter?.type?.classFqName?.asString()
@@ -989,6 +1227,88 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
                 factoryCall.arguments[0] = irString(templates.matcherSpecs.joinToString("\n"))
                 factoryCall.arguments[1] = irString(templates.afterTemplate)
                 factoryCall.arguments[2] = irString(templates.substitutionSourcesCsv)
+                +irReturn(factoryCall)
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Imperative-shape class synthesis.
+    // ------------------------------------------------------------------
+
+    /**
+     * Synthesize a `Generated$<Name>` class for an imperative recipe
+     * (`recipe(...) { edit { lang { visitX { … } } } }`). The class is
+     * structurally identical to the declarative one — same metadata
+     * overrides, same field-less shape — but its `getVisitor()` body
+     * delegates to `buildImperativeVisitor(<recipe trailing lambda>)`
+     * instead of a template-driven factory.
+     *
+     * The recipe trailing lambda is deep-copied so it survives the
+     * subsequent `recipe(...) → Generated$<Name>()` replacement (the
+     * original call's IR is discarded by the transformer).
+     */
+    private fun buildImperativeRecipeClass(
+        ctx: RecipeIrGenContext,
+        parentFile: IrFile,
+        propertyName: Name,
+        metadata: RecipeMetadata,
+        recipeBlock: IrFunctionExpression,
+        helperSymbol: IrSimpleFunctionSymbol,
+    ): IrClass {
+        val cls = ctx.pluginContext.irFactory.buildClass {
+            name = Name.identifier("Generated\$${propertyName.asString()}")
+            kind = ClassKind.CLASS
+            modality = Modality.FINAL
+            visibility = DescriptorVisibilities.PUBLIC
+        }
+        cls.parent = parentFile
+        cls.createThisReceiverParameter()
+        cls.superTypes = listOf(ctx.recipeClassSymbol.defaultType)
+
+        cls.addConstructor {
+            isPrimary = true
+            returnType = cls.symbol.defaultType
+            visibility = DescriptorVisibilities.PUBLIC
+        }.apply {
+            body = DeclarationIrBuilder(ctx.pluginContext, symbol).irBlockBody {
+                +irDelegatingConstructorCall(ctx.recipeNoArgCtorSymbol.owner)
+            }
+        }
+
+        addMetadataOverrides(cls, ctx, metadata)
+        if (ctx.getVisitor != null) {
+            addImperativeGetVisitorOverride(
+                cls = cls,
+                ctx = ctx,
+                overrides = ctx.getVisitor,
+                helperSymbol = helperSymbol,
+                recipeBlock = recipeBlock,
+            )
+        }
+        return cls
+    }
+
+    private fun addImperativeGetVisitorOverride(
+        cls: IrClass,
+        ctx: RecipeIrGenContext,
+        overrides: IrSimpleFunction,
+        helperSymbol: IrSimpleFunctionSymbol,
+        recipeBlock: IrFunctionExpression,
+    ) {
+        cls.addFunction(
+            name = "getVisitor",
+            returnType = overrides.returnType,
+            modality = Modality.OPEN,
+            visibility = DescriptorVisibilities.PUBLIC,
+        ).apply {
+            overriddenSymbols = listOf(overrides.symbol)
+            body = DeclarationIrBuilder(ctx.pluginContext, symbol).irBlockBody {
+                val factoryCall = irCall(
+                    callee = helperSymbol,
+                    type = helperSymbol.owner.returnType,
+                )
+                factoryCall.arguments[0] = recipeBlock.deepCopyWithSymbols(initialParent = this@apply)
                 +irReturn(factoryCall)
             }
         }

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
@@ -128,6 +128,14 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
 
         const val EDIT_SCOPE_REWRITE_FQN = "org.openrewrite.EditScope.rewrite"
         const val RECIPE_BUILDER_EDIT_FQN = "org.openrewrite.RecipeBuilder.edit"
+
+        /**
+         * K2 FIR2IR represents `expr!!` as a call to this synthetic intrinsic,
+         * taking the asserted expression as the (only) value argument. See
+         * `org.jetbrains.kotlin.ir.expressions.IrConstantValueImpl` and
+         * `FirNotNullableTransformer` in the Kotlin compiler.
+         */
+        const val CHECK_NOT_NULL_FQN = "kotlin.internal.ir.CHECK_NOT_NULL"
     }
 
     override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
@@ -153,6 +161,7 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         val getVisitor: IrSimpleFunction?,
         val methodInvocationRewriteKotlinSymbol: IrSimpleFunctionSymbol?,
         val methodInvocationRewriteJavaSymbol: IrSimpleFunctionSymbol?,
+        val methodInvocationRewriteKotlinNotNullSymbol: IrSimpleFunctionSymbol?,
     )
 
     private fun buildIrGenContext(pluginContext: IrPluginContext): RecipeIrGenContext? {
@@ -187,6 +196,9 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             .orEmpty()
         val kotlinHelper = supportFns.firstOrNull { it.name.asString() == "methodInvocationRewrite" }?.symbol
         val javaHelper = supportFns.firstOrNull { it.name.asString() == "methodInvocationRewriteJava" }?.symbol
+        val kotlinNotNullHelper = supportFns.firstOrNull {
+            it.name.asString() == "methodInvocationRewriteKotlinNotNull"
+        }?.symbol
 
         return RecipeIrGenContext(
             pluginContext = pluginContext,
@@ -199,6 +211,7 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             getVisitor = getVisitor,
             methodInvocationRewriteKotlinSymbol = kotlinHelper,
             methodInvocationRewriteJavaSymbol = javaHelper,
+            methodInvocationRewriteKotlinNotNullSymbol = kotlinNotNullHelper,
         )
     }
 
@@ -340,6 +353,12 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         val afterTemplate: String,
         val substitutionSourcesCsv: String,
         val usesKotlinTreeNode: Boolean,
+        /**
+         * True when every before lambda was a `someCall()!!` pattern. The
+         * helper selection routes to a `K.Unary(NotNull)`-walking visitor so
+         * the rewrite replaces the entire not-null-asserted expression.
+         */
+        val wrappedInNotNull: Boolean,
     )
 
     private fun pickHelperSymbol(
@@ -363,7 +382,11 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         // KotlinTemplate) the plan deferred.
         @Suppress("UNUSED_VARIABLE")
         val classifierResult = templates.usesKotlinTreeNode
-        return ctx.methodInvocationRewriteKotlinSymbol
+        return if (templates.wrappedInNotNull) {
+            ctx.methodInvocationRewriteKotlinNotNullSymbol
+        } else {
+            ctx.methodInvocationRewriteKotlinSymbol
+        }
     }
 
     /**
@@ -427,9 +450,15 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
 
         val beforeLambdas = beforeExprs.map { validateBeforeLambda(it) ?: return null }
         val canonical = beforeLambdas[0].canonicalSignature()
+        val notNullForAll = beforeLambdas[0].wrappedInNotNull
         for (i in 1 until beforeLambdas.size) {
             if (beforeLambdas[i].canonicalSignature() != canonical) return null
             if (beforeLambdas[i].params.size != beforeLambdas[0].params.size) return null
+            // Multi-before recipes must agree on the not-null-assertion shape.
+            // Mixing `someCall()` and `someCall()!!` befores would require two
+            // different visitor entry points; reject and let the runtime DSL
+            // builder surface the limitation.
+            if (beforeLambdas[i].wrappedInNotNull != notNullForAll) return null
         }
         val afterTemplateAndSources = buildAfterTemplate(afterArg, sourceText, beforeLambdas[0]) ?: return null
         val matcherSpecs = beforeLambdas.map { computeMatcherSpec(it.rootCall) }
@@ -440,6 +469,7 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             afterTemplate = afterTemplateAndSources.first,
             substitutionSourcesCsv = afterTemplateAndSources.second,
             usesKotlinTreeNode = usesKotlinTreeNode,
+            wrappedInNotNull = notNullForAll,
         )
     }
 
@@ -503,6 +533,15 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         val rootCall: IrCall,
         val argSignatures: List<ArgSig>,
         val receiverParamSymbol: IrValueSymbol?,
+        /**
+         * True when the lambda body returns `someCall()!!` rather than bare
+         * `someCall()`. K2 FIR2IR represents `expr!!` as an `IrCall` to the
+         * `kotlin.internal.ir.CHECK_NOT_NULL` intrinsic; the matcher targets
+         * the inner call but the helper selection routes to a visitor that
+         * walks `K.Unary(NotNull)` so the rewrite replaces the entire
+         * not-null-asserted expression rather than just the inner invocation.
+         */
+        val wrappedInNotNull: Boolean,
     )
 
     private fun validateBeforeLambda(fnExpr: IrFunctionExpression): BeforeLambda? {
@@ -510,16 +549,30 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         val params = fn.valueParameters
         val body = fn.body as? IrBlockBody ?: return null
         val singleStmt = body.statements.singleOrNull() ?: return null
-        val rootCall = when (singleStmt) {
-            is IrReturn -> singleStmt.value as? IrCall
+        val rawExpr = when (singleStmt) {
+            is IrReturn -> singleStmt.value
             is IrCall -> singleStmt
             else -> null
         } ?: return null
+        // Unwrap an outer `!!` — K2 FIR2IR represents `someCall()!!` as an
+        // `IrCall` to the `kotlin.internal.ir.CHECK_NOT_NULL` intrinsic with
+        // the asserted expression as its (single) value argument. The matcher
+        // should target the inner call; the not-null-assertion shape is then
+        // remembered so the helper-selection routes to a visitor that walks
+        // `K.Unary(NotNull)` and rewrites the whole not-null expression.
+        var wrappedInNotNull = false
+        var current: IrCall = rawExpr as? IrCall ?: return null
+        while (current.symbol.owner.kotlinFqName.asString() == CHECK_NOT_NULL_FQN) {
+            wrappedInNotNull = true
+            val inner = current.getValueArgument(0) as? IrCall ?: return null
+            current = inner
+        }
+        val rootCall = current
 
         if (params.isEmpty()) {
             if (rootCall.dispatchReceiver != null || rootCall.extensionReceiver != null) return null
             if (rootCall.valueArgumentsCount > 0) return null
-            return BeforeLambda(params, rootCall, emptyList(), receiverParamSymbol = null)
+            return BeforeLambda(params, rootCall, emptyList(), receiverParamSymbol = null, wrappedInNotNull = wrappedInNotNull)
         }
 
         val rawReceiver: IrExpression? = rootCall.dispatchReceiver ?: rootCall.extensionReceiver
@@ -545,7 +598,7 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
                 else -> return null
             }
         }
-        return BeforeLambda(params, rootCall, sigs, receiverParamSymbol)
+        return BeforeLambda(params, rootCall, sigs, receiverParamSymbol, wrappedInNotNull)
     }
 
     private fun BeforeLambda.canonicalSignature(): CanonicalSignature {
@@ -590,6 +643,17 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             return "$dispatchFqn $methodName(..)"
         }
 
+        // Java static methods (and `@JvmStatic` companions): the IrSimpleFunction's
+        // parent is the declaring IrClass even when the dispatch-receiver param is
+        // null. Pin the matcher to that class so `Math.abs(x)` doesn't accidentally
+        // match `kotlin.math.abs(x)` after the rewrite. Without this, the matcher
+        // falls through to `* abs(..)` and the recipe keeps firing every cycle,
+        // tripping the test framework's single-cycle stability check.
+        val parent = owner.parent
+        if (parent is IrClass) {
+            return "${parent.kotlinFqName.asString()} $methodName(..)"
+        }
+
         val facadeFqn = computeJvmFacadeFqn(owner)
         return if (facadeFqn != null) {
             "$facadeFqn $methodName(..)"
@@ -619,6 +683,33 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         val stem = nameOnly.removeSuffix(".kt")
         if (stem.isEmpty()) return null
         return stem.replaceFirstChar { it.uppercaseChar() } + "Kt"
+    }
+
+    /**
+     * Walk backward from [start] through any `identifier(.identifier)*` chain
+     * in [sourceText] and return the new (earlier) start offset. Used to grow
+     * the IR-derived source slice over a syntactic FQN qualifier preceding a
+     * top-level call — K2 IR doesn't emit a child node for the qualifier so
+     * the IR walk's `minStart` lands at the simple call name. Stops at any
+     * non-identifier-or-dot char (whitespace, paren, operator, brace), so a
+     * non-qualified call slice is unchanged.
+     */
+    private fun extendBackwardForQualifierChain(sourceText: String, start: Int): Int {
+        var i = start
+        while (i > 0) {
+            val dotIdx = i - 1
+            if (sourceText[dotIdx] != '.') break
+            // Walk back through identifier chars preceding the '.'.
+            var j = dotIdx - 1
+            while (j >= 0 && (sourceText[j].isLetterOrDigit() || sourceText[j] == '_')) j--
+            val identStart = j + 1
+            // Identifier must be at least one char and start with a non-digit.
+            if (identStart >= dotIdx) break
+            val first = sourceText[identStart]
+            if (!(first.isLetter() || first == '_')) break
+            i = identStart
+        }
+        return i
     }
 
     // ------------------------------------------------------------------
@@ -684,7 +775,15 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             }
         }
         if (minStart == Int.MAX_VALUE || maxEnd > sourceText.length) return null
-        val sliceStart = minStart
+        // Source-text-slice gives the IR-visible span, which excludes any
+        // syntactic FQN qualifier preceding a top-level call (K2 IR resolves
+        // `kotlin.math.abs(x)` to a single `IrCall(abs)` whose offsets cover
+        // only `abs(x)`; the `kotlin.math.` package qualifier has no IR node).
+        // Walk backward through any `identifier(.identifier)*` chain so the
+        // template includes whatever qualifier the recipe author wrote — the
+        // rewrite is then output-identical to the source spelling and remains
+        // single-cycle stable (no separate import-add pass needed).
+        val sliceStart = extendBackwardForQualifierChain(sourceText, minStart)
         val sliceEnd = maxEnd
         val slice = sourceText.substring(sliceStart, sliceEnd)
 

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
@@ -82,6 +82,71 @@ class RecipePluginRewriteTest : RewriteTest {
     )
 
     @Test
+    fun `not-null-asserted before pattern rewrites the whole expression`() {
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseReadln = recipe(
+                    displayName = "Use readln() instead of readLine()!!",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { -> readLine()!! } to { -> readln() }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseReadln",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            kotlin(
+                """
+                fun first(): String = readLine()!!
+                """.trimIndent(),
+                """
+                fun first(): String = readln()
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `after-template preserves source-level FQN qualifier`() {
+        // `Math.abs(x: Double)` -> `kotlin.math.abs(x)`. K2 IR resolves
+        // `kotlin.math.abs(x)` to a single `IrCall(abs)` whose offsets cover
+        // only `abs(x)`; the package qualifier has no IR node. The IR pass
+        // extends the source slice backward through any `id(.id)*` chain so
+        // the synthesized template emits the same FQN the recipe author wrote,
+        // keeping the rewrite single-cycle stable without needing an
+        // import-add post-visit.
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseKotlinMathAbs = recipe(
+                    displayName = "Use kotlin.math.abs",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { x: Double -> Math.abs(x) } to { x -> kotlin.math.abs(x) }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseKotlinMathAbs",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            kotlin(
+                """
+                fun a(x: Double): Double = Math.abs(x)
+                """.trimIndent(),
+                """
+                fun a(x: Double): Double = kotlin.math.abs(x)
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
     fun `metadata accessors populate correctly on generated recipe`() {
         val r = loadCompiledRecipe(
             source = """

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
@@ -147,6 +147,236 @@ class RecipePluginRewriteTest : RewriteTest {
     }
 
     @Test
+    fun `property-access rewrite — old getter to new getter`() {
+        // Defines a stub class in the recipe source alongside the recipe so
+        // the BEFORE lambda's `f.oldProp` resolves at recipe-compile time.
+        // The IR pass detects that `oldProp` is a property accessor and
+        // routes to `GeneratedRecipeSupport.propertyAccessRewrite`, which
+        // walks `J.FieldAccess` instead of `J.MethodInvocation`. Both
+        // before and after sides are property reads — the matcher fires on
+        // a `J.FieldAccess` whose target type is `Foo` and whose selector
+        // is `oldProp`, and the template emits the same shape with
+        // `newProp` as the selector name.
+        val r = loadCompiledRecipe(
+            source = """
+                package demo
+                import org.openrewrite.recipe
+                class Foo {
+                    val oldProp: Int get() = 1
+                    val newProp: Int get() = 2
+                }
+                val UseNewProp = recipe(
+                    displayName = "Use Foo.newProp",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { f: Foo -> f.oldProp } to { f -> f.newProp }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseNewProp",
+            packageName = "demo",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            kotlin(
+                """
+                package demo
+                class Foo {
+                    val oldProp: Int get() = 1
+                    val newProp: Int get() = 2
+                }
+                fun use(f: Foo): Int = f.oldProp
+                """,
+                """
+                package demo
+                class Foo {
+                    val oldProp: Int get() = 1
+                    val newProp: Int get() = 2
+                }
+                fun use(f: Foo): Int = f.newProp
+                """,
+            ),
+        )
+    }
+
+    @Test
+    fun `multi-before mixed shapes — receiver in one, arg in the other`() {
+        // Two before lambdas with the same param count but different
+        // canonical signatures: `s.toInt()` binds `s` to the (extension)
+        // receiver, while `Integer.parseInt(s)` binds `s` to arg 0. The IR
+        // pass produces a per-matcher substitution-source CSV (`-1` for
+        // the receiver form, `0` for the arg form), joined by `\n`. The
+        // helper detects the multi-CSV shape and dispatches per matcher to
+        // fill the after template's `#{any(kotlin.String)}` placeholder
+        // with the right substitution.
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val ParseIntToZero = recipe(
+                    displayName = "Unify int parsing to literal 0",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite(
+                            { s: String -> s.toInt() },
+                            { s: String -> Integer.parseInt(s) }
+                        ) to { s -> 0 }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "ParseIntToZero",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            kotlin(
+                """
+                fun viaExt(s: String): Int = s.toInt()
+                fun viaStatic(s: String): Int = Integer.parseInt(s)
+                """,
+                """
+                fun viaExt(s: String): Int = 0
+                fun viaStatic(s: String): Int = 0
+                """,
+            ),
+        )
+    }
+
+    @Test
+    fun `inlined Java static constant — Math_PI to kotlin_math_PI`() {
+        // `Math.PI` is a primitive `public static final double`; K2 FIR2IR
+        // compile-time-folds it to a bare `IrConst(3.141592...)` in the
+        // recipe source, erasing the `Math` qualifier symbol entirely. The
+        // IR pass falls back to parsing the source slice (`Math.PI`) to
+        // recover the matcher spec `java.lang.Math#PI` and routes to the
+        // `propertyAccessRewrite` helper — the same one that handles
+        // Kotlin property-access patterns.
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseKotlinMathPi = recipe(
+                    displayName = "Use kotlin.math.PI",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { -> Math.PI } to { -> kotlin.math.PI }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseKotlinMathPi",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            kotlin(
+                """
+                fun circumference(r: Double): Double = 2 * Math.PI * r
+                """.trimIndent(),
+                """
+                fun circumference(r: Double): Double = 2 * kotlin.math.PI * r
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `inlined Java static constant — Integer_MAX_VALUE to Int_MAX_VALUE`() {
+        // Cross-classpath sanity: `Integer.MAX_VALUE` resolves through the
+        // `java.lang.Integer` candidate, `Int.MAX_VALUE` (the after template's
+        // top-level `kotlin.Int.Companion.MAX_VALUE`) is also IrConst-inlined
+        // and recovered via the after-template's qualifier extension.
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseKotlinIntMax = recipe(
+                    displayName = "Use Int.MAX_VALUE",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { -> Integer.MAX_VALUE } to { -> Int.MAX_VALUE }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseKotlinIntMax",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            kotlin(
+                """
+                fun cap(): Int = Integer.MAX_VALUE
+                """.trimIndent(),
+                """
+                fun cap(): Int = Int.MAX_VALUE
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `imperative recipe — edit kotlin visitClassDeclaration rewrites class shape`() {
+        // Exercises the imperative-shape fallback: the K2 plugin can't extract
+        // an `edit { rewrite { } to { } }` template, so it instead synthesizes
+        // `Generated$<Name>` whose `getVisitor()` body delegates back to
+        // `buildImperativeVisitor(<original recipe block>)`. The generated
+        // class is field-less — see `imperative recipe — generated class is
+        // serializable (no instance fields)` for the Jackson-roundtrip proof.
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val AppendBangToClass = recipe(
+                    displayName = "Suffix class names with !",
+                    description = "..."
+                ) {
+                    edit {
+                        kotlin {
+                            visitClassDeclaration { cls ->
+                                if (cls.simpleName.endsWith("!")) cls
+                                else cls.withName(cls.name.withSimpleName(cls.simpleName + "!"))
+                            }
+                        }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "AppendBangToClass",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            kotlin(
+                """
+                class Foo
+                """.trimIndent(),
+                """
+                class Foo!
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `imperative recipe — generated class is field-less`() {
+        // Jackson roundtrip is gated on the recipe class having no instance
+        // fields beyond declared `@Option` ones (the runtime DSL's anonymous
+        // Recipe captures the `block` lambda as a synthetic field — that's
+        // what breaks serialization). The plugin's imperative-recipe path
+        // produces a top-level `Generated$<Name>` whose state is reconstructed
+        // fresh on each `getVisitor()` call, so the class itself has zero
+        // fields. Verify by reflection.
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val Noop = recipe(
+                    displayName = "Noop",
+                    description = "..."
+                ) {
+                    edit { kotlin { visitClassDeclaration { it } } }
+                }
+            """.trimIndent(),
+            propertyName = "Noop",
+        )
+        assertThat(r::class.java.simpleName).isEqualTo("Generated\$Noop")
+        assertThat(r::class.java.declaredFields).isEmpty()
+    }
+
+    @Test
     fun `metadata accessors populate correctly on generated recipe`() {
         val r = loadCompiledRecipe(
             source = """
@@ -171,10 +401,12 @@ class RecipePluginRewriteTest : RewriteTest {
         assertThat(r.estimatedEffortPerOccurrence?.toMinutes()).isEqualTo(3L)
     }
 
-    private fun loadCompiledRecipe(source: String, propertyName: String): Recipe {
+    private fun loadCompiledRecipe(source: String, propertyName: String, packageName: String = ""): Recipe {
         val result = RecipePluginCompileFixture.compile(source)
         check(result.exitOk()) { "compile failed:\n${result.messages}" }
-        val topLevelClass = result.classLoader.loadClass("RecipesKt")
+        val topLevelClass = result.classLoader.loadClass(
+            if (packageName.isEmpty()) "RecipesKt" else "$packageName.RecipesKt"
+        )
         val getter = topLevelClass.getDeclaredMethod("get" + propertyName.replaceFirstChar { it.uppercase() })
         getter.isAccessible = true
         return getter.invoke(null) as Recipe


### PR DESCRIPTION
## Summary

- Follow-up to #7701. Two commits' worth of K2 plugin improvements that close concrete gaps surfaced while authoring the moderneinc/recipes-kotlin migration recipes:

**`!!` befores, FQN-qualified afters, and tight Java-static matchers** (89a80bad0):
- `rewrite { x: T -> Math.foo(x)!! }` no longer crashes the IR pass — `CHECK_NOT_NULL` is unwrapped and a dedicated `methodInvocationRewriteKotlinNotNull` helper visits `K.Unary`.
- FQN qualifiers in `to { ... }` after-templates (e.g. `kotlin.math.PI`) survive instead of collapsing to the simple name; the slice extends backward through `id(.id)*` chains.
- Java-static befores produce a tight matcher spec pinned to `parent.kotlinFqName` (e.g. `java.lang.Long.bitCount(long)`), so `Long.bitCount` doesn't over-match.

**Close 4 pattern-matching gaps** (cbd7658fa):
- **Gap A — property access**: `rewrite { t: Throwable -> t.message } to { t -> t.localizedMessage }` now visits `J.FieldAccess` in addition to `J.MethodInvocation`.
- **Gap B — inlined constants**: `Math.PI`, `Math.E`, `Integer.MAX_VALUE` etc. recover their qualifier from the source slice when the K2 frontend pre-inlines them to `IrConst` — matcher spec and after-template both pin to the original FQN.
- **Gap C — multi-before mixed shapes**: `methodInvocationRewrite` stores substitution sources per-matcher so multiple `rewrite { } to { }` befores with different canonical signatures dispatch to a shared after template.
- **Gap D — imperative recipe serialization**: synthesize a field-less `Generated$<Name>` for imperative `recipe(...) { edit { lang { visitX { ... } } } }` shapes. A new `buildImperativeVisitor` helper rebuilds the visitor on each `getVisitor()` call. Jackson roundtrip works without `validateRecipeSerialization(false)`.

These gaps were each blocking a category of Kotlin 1→2 migration recipes in moderneinc/recipes-kotlin; with these in place that downstream branch reaches 186 recipes / 189 tests green.

## Test plan

- [x] `./gradlew :rewrite-kotlin:test` passes locally
- [x] New cases in `RecipePluginRewriteTest` cover each gap
- [ ] Downstream verification: moderneinc/recipes-kotlin's `kotlin-munich` worktree compiles and tests pass against this branch's snapshot