### PR TITLE
Kotlin recipe DSL: `recipes()` builder for fixed-list composites

### DIFF
--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/RecipeDsl.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/RecipeDsl.kt
@@ -15,6 +15,8 @@
  */
 package org.openrewrite
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
 import org.openrewrite.dsl.scopes.LanguageScope
 import org.openrewrite.java.search.UsesField
 import org.openrewrite.java.search.UsesJavaVersion
@@ -60,6 +62,46 @@ public fun recipe(
 ): Recipe {
     val builder = RecipeBuilder().apply(block)
     return builder.build(displayName, description, tags, estimatedEffortPerOccurrence)
+}
+
+/**
+ * Group a fixed list of recipes under a single named composite. The returned
+ * [Recipe] has no edit phase of its own — its only effect is to run each
+ * element of [recipes] in order via [Recipe.getRecipeList]. Useful for
+ * assembling several fine-grained recipes into a higher-level migration
+ * target.
+ *
+ * Unlike [recipe], this builder requires no K2 compiler-plugin support — the
+ * returned [Recipe] is a plain JVM class ([KotlinCompositeRecipe]) and
+ * round-trips cleanly through the standard recipe serializer.
+ */
+public fun recipes(
+    displayName: String,
+    description: String,
+    vararg recipes: Recipe,
+): Recipe = KotlinCompositeRecipe(displayName, description, recipes.toList())
+
+/**
+ * Backing class for [recipes]. Holds a fixed display name, description, and
+ * recipe list, exposing them through the [Recipe] API. Public so Jackson can
+ * round-trip it via the standard recipe serializer (`@c` polymorphic type tag
+ * + property-based constructor detection).
+ *
+ * The constructor uses `@JsonCreator` + `@JsonProperty` directly so the class
+ * deserializes without the optional `jackson-module-kotlin` runtime — only the
+ * always-present `ParameterNamesModule` is required. Parameters are nullable
+ * because [org.openrewrite.internal.RecipeLoader] validates instantiability by
+ * calling the constructor with empty arguments; the public [recipes] entry
+ * point always passes real, non-null values.
+ */
+public class KotlinCompositeRecipe @JsonCreator constructor(
+    @JsonProperty("displayName") private val displayName: String?,
+    @JsonProperty("description") private val description: String?,
+    @JsonProperty("recipeList") private val recipeList: List<Recipe>?,
+) : Recipe() {
+    override fun getDisplayName(): String = displayName ?: name
+    override fun getDescription(): String = description ?: "A composite recipe."
+    override fun getRecipeList(): List<Recipe> = recipeList ?: emptyList()
 }
 
 /**

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/RecipeDslSurfaceTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/RecipeDslSurfaceTest.kt
@@ -133,4 +133,28 @@ class RecipeDslSurfaceTest {
         val initial = sr.getInitialValue(InMemoryExecutionContext())
         assertThat(initial).isInstanceOf(MutableList::class.java)
     }
+
+    @Test
+    fun `recipes composite exposes its children via getRecipeList`() {
+        val a = recipe("A", "a") { edit { java { /* no-op */ } } }
+        val b = recipe("B", "b") { edit { java { /* no-op */ } } }
+        val r = recipes("Combo", "a + b", a, b)
+        assertThat(r.displayName).isEqualTo("Combo")
+        assertThat(r.description).isEqualTo("a + b")
+        assertThat(r.recipeList).containsExactly(a, b)
+    }
+
+    @Test
+    fun `recipes composite round-trips through RecipeSerializer`() {
+        // The K2 compiler plugin is not applied to this module's own test
+        // sources, so children built through `recipe { }` here would be
+        // anonymous and break serialization. Use `Recipe.noop()` — a named
+        // singleton class — to exercise the round-trip independent of K2.
+        val r = recipes("Combo", "noop only", Recipe.noop())
+        val ser = RecipeSerializer()
+        val restored = ser.read(ser.write(r))
+        assertThat(restored.displayName).isEqualTo("Combo")
+        assertThat(restored.description).isEqualTo("noop only")
+        assertThat(restored.recipeList).hasSize(1)
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a `recipes(displayName, description, vararg recipes: Recipe)` builder alongside the existing `recipe { … }` builder shipped in #7701. Useful for grouping several fine-grained recipes into a higher-level migration target.

```kotlin
val Kotlin1To2: Recipe = recipes(
    displayName = "Migrate to Kotlin 2.x",
    description = "…",
    UseModernKotlinStdlibApis,
    UseKotlinMath,
    UseKotlinNumberApis,
    // …
)
```

The returned `KotlinCompositeRecipe` is a Jackson-serializable class so it round-trips through the standard recipe serializer. The constructor uses `@JsonCreator` + `@JsonProperty` directly so deserialization works without the optional `jackson-module-kotlin` runtime — only the always-present `ParameterNamesModule` is required. Parameters are nullable so `RecipeLoader`'s empty-args instantiability check passes; the public builder always passes real values.

Driving consumer: [moderneinc/recipes-kotlin](https://github.com/moderneinc/recipes-kotlin) collapses 9 hand-written `class Foo : Recipe()` composites down to single-line `val Foo = recipes(…)` calls.

## Test plan

- [x] `RecipeDslSurfaceTest.recipes composite exposes its children via getRecipeList`
- [x] `RecipeDslSurfaceTest.recipes composite round-trips through RecipeSerializer`
- [x] Downstream `moderneinc/recipes-kotlin` test suite (190 tests) green with the published SNAPSHOT