### PR TITLE
Kotlin: release `KotlinCoreEnvironment` on every parse path

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -176,51 +176,53 @@ public class KotlinParser implements Parser {
 
         // TODO: FIR and disposable may not be necessary using the IR.
         Disposable disposable = Disposer.newDisposable();
-        CompiledSource compilerCus;
         List<Input> acceptedInputs = ListUtils.concatAll(resolvedDependsOn, acceptedInputs(sources).collect(toList()));
+        // Eagerly materialize all source files inside try/finally so the disposable
+        // is released even when downstream consumers short-circuit the returned
+        // stream (e.g. JavaTemplateParser uses `.findFirst()` when parsing
+        // template stubs). A previous implementation deferred disposal to a
+        // tail Stream.generate(...).limit(1) element, which never ran on a
+        // short-circuited consumer and leaked one KotlinCoreEnvironment plus
+        // ~25MB of classpath ProtoBuf metadata per template apply.
+        List<SourceFile> parsed;
         try {
-            compilerCus = parse(acceptedInputs, disposable, pctx);
+            CompiledSource compilerCus = parse(acceptedInputs, disposable, pctx);
+            FirSession firSession = compilerCus.getFirSession();
+            parsed = new ArrayList<>(compilerCus.getSources().size());
+            for (KotlinSource kotlinSource : compilerCus.getSources()) {
+                try {
+                    assert kotlinSource.getFirFile() != null;
+                    assert kotlinSource.getFirFile().getSource() != null;
+                    PsiElement psi = ((KtRealPsiSourceElement) kotlinSource.getFirFile().getSource()).getPsi();
+                    AnalyzerWithCompilerReport.SyntaxErrorReport report =
+                            AnalyzerWithCompilerReport.Companion.reportSyntaxErrors(psi, new PrintingMessageCollector(System.err, PLAIN_FULL_PATHS, true));
+                    if (report.isHasErrors()) {
+                        parsed.add(ParseError.build(KotlinParser.this, kotlinSource.getInput(), relativeTo, ctx, new RuntimeException()));
+                        continue;
+                    }
+
+                    KotlinTypeMapping typeMapping = new KotlinTypeMapping(firSession, kotlinSource.getFirFile(), typeFactory);
+                    PsiElementAssociations associations = new PsiElementAssociations(typeMapping, kotlinSource.getFirFile());
+                    associations.initialize();
+                    KotlinTreeParserVisitor psiParser = new KotlinTreeParserVisitor(kotlinSource, associations, styles, relativeTo, ctx);
+                    SourceFile cu = psiParser.parse();
+
+                    parsingListener.parsed(kotlinSource.getInput(), cu);
+                    parsed.add(requirePrintEqualsInput(cu, kotlinSource.getInput(), relativeTo, ctx));
+                } catch (Throwable t) {
+                    ctx.getOnError().accept(t);
+                    parsed.add(ParseError.build(this, kotlinSource.getInput(), relativeTo, ctx, t));
+                }
+            }
         } catch (Throwable t) {
-            disposable.dispose();
             return acceptedInputs.stream()
                     .filter(input -> !dependsOnPaths.contains(input.getRelativePath(relativeTo)))
                     .map(input -> ParseError.build(this, input, relativeTo, ctx, t));
+        } finally {
+            Disposer.dispose(disposable);
         }
 
-        FirSession firSession = compilerCus.getFirSession();
-        return Stream.concat(
-                        compilerCus.getSources().stream()
-                                .map(kotlinSource -> {
-                                    try {
-                                        assert kotlinSource.getFirFile() != null;
-                                        assert kotlinSource.getFirFile().getSource() != null;
-                                        PsiElement psi = ((KtRealPsiSourceElement) kotlinSource.getFirFile().getSource()).getPsi();
-                                        AnalyzerWithCompilerReport.SyntaxErrorReport report =
-                                                AnalyzerWithCompilerReport.Companion.reportSyntaxErrors(psi, new PrintingMessageCollector(System.err, PLAIN_FULL_PATHS, true));
-                                        if (report.isHasErrors()) {
-                                            return ParseError.build(KotlinParser.this, kotlinSource.getInput(), relativeTo, ctx, new RuntimeException());
-                                        }
-
-                                        KotlinTypeMapping typeMapping = new KotlinTypeMapping(firSession, kotlinSource.getFirFile(), typeFactory);
-                                        PsiElementAssociations associations = new PsiElementAssociations(typeMapping, kotlinSource.getFirFile());
-                                        associations.initialize();
-                                        KotlinTreeParserVisitor psiParser = new KotlinTreeParserVisitor(kotlinSource, associations, styles, relativeTo, ctx);
-                                        SourceFile cu = psiParser.parse();
-
-                                        parsingListener.parsed(kotlinSource.getInput(), cu);
-                                        return requirePrintEqualsInput(cu, kotlinSource.getInput(), relativeTo, ctx);
-                                    } catch (Throwable t) {
-                                        ctx.getOnError().accept(t);
-                                        return ParseError.build(this, kotlinSource.getInput(), relativeTo, ctx, t);
-                                    }
-                                }),
-                        Stream.generate(() -> {
-                                    // The disposable should be disposed of exactly once after all sources have been parsed
-                                    Disposer.dispose(disposable);
-                                    return (SourceFile) null;
-                                })
-                                .limit(1))
-                .filter(Objects::nonNull)
+        return parsed.stream()
                 .filter(source -> !dependsOnPaths.contains(source.getSourcePath()));
     }
 


### PR DESCRIPTION
## Summary

`KotlinParser.parseInputs` deferred `Disposer.dispose(disposable)` to a tail `Stream.generate(...).limit(1)` element, so the disposable only ran when the caller iterated past every parsed source. `JavaTemplateParser`'s template-stub path consumes the parser stream via `.findFirst()`, which short-circuits before the dispose element is reached, leaking one `KotlinCoreEnvironment` per `KotlinTemplate.apply()` call. Each leaked environment retains the full Kotlin/JDK classpath `ProtoBuf` metadata (~25MB on a typical recipe-module classpath), so heavy template-driven suites OOM well below their nominal heap ceiling.

## Fix

Materialize all source files inside `try { … } finally { Disposer.dispose(…); }` and return a stream over the materialized list. The existing `parse(…)` already built every `CompiledSource` eagerly before the stream produced any element, so the change loses no streaming property — it just makes the cleanup unconditional.

## Diagnostic evidence

Captured via `jcmd GC.class_histogram` snapshots while a downstream Kotlin-recipe suite (189 tests, ~200 template applies) ran at `-Xmx2g`:

| t       | `KotlinCoreEnvironment` live | `ProtoBuf$Type` live | total heap |
|---------|------------------------------|----------------------|------------|
| +0s     | 61                           | 1.70M                | 1.83GB     |
| +15s    | 71                           | 2.00M                | 2.14GB (Full-GC churn — OOM) |

71 × ~25MB ≈ 1.8GB, matching the heap at OOM. With the fix, the same suite passes at the Gradle default `-Xmx512m` in ~30s.

## Test plan

- [x] `./gradlew :rewrite-kotlin:test` — 1205 / 1205 green
- [x] Downstream recipes-kotlin (`Kotlin1To2Test`, 189 tests) passes at default heap (was OOMing at 6g)