### PR TITLE
Kotlin recipe DSL: trailing-lambda parens + Java-static chain inner + bare-param after body

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
@@ -571,22 +571,36 @@ public final class GeneratedRecipeSupport {
         JRightPadded<Expression> lastPadded = padded.get(padded.size() - 1);
         Expression last = lastPadded.getElement();
         if (!(last instanceof J.Lambda) ||
-            !last.getMarkers().findFirst(TrailingLambdaArgument.class).isPresent() ||
-            args.getMarkers().findFirst(OmitParentheses.class).isPresent()) {
+            !last.getMarkers().findFirst(TrailingLambdaArgument.class).isPresent()) {
+            return method;
+        }
+        // Two cases:
+        //   (1) single lambda arg → `obj.foo { ... }` (no parens anywhere). Add
+        //       OmitParentheses to the args container so the printer drops the
+        //       call's parens entirely.
+        //   (2) multi-arg with trailing lambda → `obj.foo(a, b) { ... }`. The
+        //       printer already handles this when OmitParentheses is absent and
+        //       the trailing lambda carries TrailingLambdaArgument: it emits
+        //       `(` ... `)` around the non-lambda args, then the lambda. We
+        //       must NOT add OmitParentheses here — doing so would drop the
+        //       call's parens and produce `obj.fooab { ... }`.
+        boolean singleArg = padded.size() == 1;
+        if (singleArg && args.getMarkers().findFirst(OmitParentheses.class).isPresent()) {
             return method;
         }
         // The template parsed without trailing-lambda syntax, so the lambda's
         // own prefix is "" (it sat flush against the placeholder). Once the
-        // parens are gone, Kotlin convention is one space between the method
-        // name and `{`.
+        // lambda moves outside the call's args, Kotlin convention is one space
+        // between the closing position and `{`.
         Expression spaced = last.getPrefix().getWhitespace().isEmpty()
                 ? last.withPrefix(Space.SINGLE_SPACE)
                 : last;
         List<JRightPadded<Expression>> rebuilt = new ArrayList<>(padded);
         rebuilt.set(rebuilt.size() - 1, lastPadded.withElement(spaced));
-        JContainer<Expression> reshaped = args.getPadding()
-                .withElements(rebuilt)
-                .withMarkers(args.getMarkers().addIfAbsent(new OmitParentheses(Tree.randomId())));
+        JContainer<Expression> withElements = args.getPadding().withElements(rebuilt);
+        JContainer<Expression> reshaped = singleArg
+                ? withElements.withMarkers(args.getMarkers().addIfAbsent(new OmitParentheses(Tree.randomId())))
+                : withElements;
         return method.getPadding().withArguments(reshaped);
     }
 }

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
@@ -53,6 +53,8 @@ import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
+import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
 import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
 import org.jetbrains.kotlin.ir.expressions.IrReturn
@@ -788,7 +790,12 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
                 wrappedInNotNull = wrappedInNotNull, propertyAccess = propertyAccess)
         }
 
-        val rawReceiver: IrExpression? = rootCall.dispatchReceiver ?: rootCall.extensionReceiver
+        // K2 wraps Java-platform-typed call results (e.g. `Optional.of(x)`
+        // returning `Optional<T>!`) in an `IrTypeOperatorCall(IMPLICIT_CAST)`.
+        // Peel those off when looking at the receiver — for the chain
+        // validator, the wrapped IrCall IS the inner segment we care about,
+        // and the cast is downstream-visible only through the same IR offsets.
+        val rawReceiver: IrExpression? = unwrapImplicitCasts(rootCall.dispatchReceiver ?: rootCall.extensionReceiver)
         val paramSyms: Set<IrValueSymbol> = params.map { it.symbol }.toSet()
 
         // Chain detection (v1: depth-2 only). When the root call's receiver is
@@ -800,14 +807,14 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         if (rawReceiver is IrCall && !wrappedInNotNull && !propertyAccess) {
             val outerSigs = mutableListOf<ArgSig>()
             for (i in 0 until rootCall.valueArgumentsCount) {
-                val arg = rootCall.getValueArgument(i) ?: continue
+                val arg = unwrapImplicitCasts(rootCall.getValueArgument(i)) ?: continue
                 when (arg) {
                     is IrConst -> outerSigs += ArgSig.LiteralConst(arg.kind, arg.value)
                     else -> return null  // outer args binding lambda params not yet supported
                 }
             }
             val innerCall = rawReceiver
-            val innerRawRecv: IrExpression? = innerCall.dispatchReceiver ?: innerCall.extensionReceiver
+            val innerRawRecv: IrExpression? = unwrapImplicitCasts(innerCall.dispatchReceiver ?: innerCall.extensionReceiver)
             // Reject depth-3+ chains: inner.receiver must not be another IrCall.
             val innerReceiverSym: IrValueSymbol? = when (innerRawRecv) {
                 null -> null
@@ -819,7 +826,7 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             }
             val innerSigs = mutableListOf<ArgSig>()
             for (i in 0 until innerCall.valueArgumentsCount) {
-                val arg = innerCall.getValueArgument(i) ?: continue
+                val arg = unwrapImplicitCasts(innerCall.getValueArgument(i)) ?: continue
                 when (arg) {
                     is IrGetValue -> {
                         if (arg.symbol !in paramSyms) return null
@@ -859,7 +866,7 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
 
         val sigs = mutableListOf<ArgSig>()
         for (i in 0 until rootCall.valueArgumentsCount) {
-            val arg = rootCall.getValueArgument(i) ?: continue
+            val arg = unwrapImplicitCasts(rootCall.getValueArgument(i)) ?: continue
             when (arg) {
                 is IrGetValue -> {
                     if (arg.symbol !in paramSyms) return null
@@ -999,6 +1006,26 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
      * — the function's own `name` is the synthetic `<get-foo>` accessor name,
      * which doesn't match the source-level identifier.
      */
+    /**
+     * Peel off `IrTypeOperatorCall` wrappers that K2 inserts to mark implicit
+     * coercions — most commonly the platform-type-to-Kotlin cast on the return
+     * of a Java call (`Optional<T>!` → `Optional<T>`). For the validator's
+     * purposes, the cast is invisible: the wrapped IrCall has the same source
+     * offsets and is the call we want to introspect.
+     *
+     * Unwraps both `IMPLICIT_CAST` and `IMPLICIT_NOTNULL` recursively. Other
+     * type ops (`SAFE_CAST`, `INSTANCEOF`, `CAST`) are intentionally left
+     * alone — they're load-bearing for matcher dispatch.
+     */
+    private fun unwrapImplicitCasts(expr: IrExpression?): IrExpression? {
+        var e: IrExpression? = expr
+        while (e is IrTypeOperatorCall &&
+            (e.operator == IrTypeOperator.IMPLICIT_CAST || e.operator == IrTypeOperator.IMPLICIT_NOTNULL)) {
+            e = e.argument
+        }
+        return e
+    }
+
     private fun computeMatcherSpec(rootCall: IrCall, propertyAccess: Boolean): String {
         val owner = rootCall.symbol.owner
         if (propertyAccess) {
@@ -1200,7 +1227,13 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         )
         val spots = mutableListOf<Spot>()
 
-        expr.acceptChildrenVoid(object : IrVisitorVoid() {
+        // `accept(visitor, null)` includes `expr` itself; `acceptChildrenVoid`
+        // would only visit its children. The distinction matters for after
+        // bodies that are a single bare param reference (`{ x -> x }`) — the
+        // IrGetValue IS the expression, not a child, so a children-only walk
+        // would miss it and the template would render the literal `x` instead
+        // of a substitution placeholder.
+        expr.accept(object : IrVisitorVoid() {
             override fun visitElement(element: IrElement) { element.acceptChildrenVoid(this) }
 
             override fun visitGetValue(expression: IrGetValue) {
@@ -1224,7 +1257,7 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
                     typeFqn = renderPlaceholderType(expression.type),
                 )
             }
-        })
+        }, null)
 
         val inSliceSpots = mutableListOf<Spot>()
         val prependSpots = mutableListOf<Spot>()

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
@@ -201,6 +201,42 @@ class RecipePluginRewriteTest : RewriteTest {
     }
 
     @Test
+    fun `chain with Java-static inner segment — Optional_of_x_get to x`() {
+        // The chain validator must accept an inner segment that is a Java
+        // static call (`Optional.of(x)`). The inner has no dispatch receiver
+        // (statics carry the class via the symbol's parent IrClass) but does
+        // bind the lambda param to its value arg.
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                import java.util.Optional
+                val UseValueForOptionalOfGet = recipe(
+                    displayName = "Optional.of(x).get() -> x",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { x: String -> Optional.of(x).get() } to { x -> x }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseValueForOptionalOfGet",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            kotlin(
+                """
+                import java.util.Optional
+                fun example(): String = Optional.of("hi").get()
+                """.trimIndent(),
+                """
+                import java.util.Optional
+                fun example(): String = "hi"
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
     fun `multi-before mixed shapes — receiver in one, arg in the other`() {
         // Two before lambdas with the same param count but different
         // canonical signatures: `s.toInt()` binds `s` to the (extension)


### PR DESCRIPTION
## Summary

- Three fixes in the recipe DSL's K2 compiler plugin and runtime helper, all surfaced by trying to author recipes whose shape PR #7708 (chained-call patterns) already accepts in theory:

1. **`preserveTrailingLambdaShape` was dropping parens around non-lambda args.** Multi-arg calls with a trailing lambda (`obj.method(arg) { lambda }`) were rendering as `obj.methodarg { lambda }`. Caused by unconditionally adding `OmitParentheses` to the args container whenever the last arg carried `TrailingLambdaArgument`. Fix: gate `OmitParentheses` on `padded.size() == 1`. For multi-arg trailing-lambda calls, the marker on the lambda is sufficient — `KotlinPrinter.visitArgumentsContainer` already handles the rendering.

2. **Chain validator rejected Java-static inner segments.** Patterns like `Optional.of(x).get()` were silently falling through to the imperative path (the `pluginRequired` runtime stub). Root cause: K2 wraps Java-platform-typed call results (`Optional<T>!` → `Optional<T>`) in `IrTypeOperatorCall(IMPLICIT_CAST)`, so the chain detector's `rawReceiver is IrCall` check was false. Fix: added `unwrapImplicitCasts(expr)` and called it at every `IrCall`-shape-check site in `validateBeforeLambda`.

3. **`buildAfterTemplate` missed bare-param after bodies.** With (2) in place, `Optional.of("hi").get()` matched but rewrote to the literal `x` instead of `"hi"`. The substitution-spot visitor used `expr.acceptChildrenVoid(visitor)`, which only walks `expr`'s CHILDREN. For an after body like `{ x -> x }`, `expr` IS the `IrGetValue` — it has no children, so the visitor never registered it and the template rendered the source slice unchanged. Fix: `expr.accept(visitor, null)` instead.

New end-to-end test `RecipePluginRewriteTest."chain with Java-static inner segment — Optional_of_x_get to x"` exercises all three fixes.

## Test plan

- [x] `:rewrite-kotlin:test` — all 1205+ tests green locally.
- [x] Tested downstream in `moderneinc/recipes-kotlin` Performance and Interop recipe families against the rebuilt `8.82.0-SNAPSHOT`. Unblocks `xs.map(f).toMutableList() → xs.mapTo(mutableListOf(), f)` (and the `filterTo`/`filterNotTo`/`flatMapTo` siblings) and `Optional.of(x).get() → x`.