### PR TITLE
RecipeClassLoader: parent-delegate `@AbstractRecipe`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
@@ -38,6 +38,7 @@ public class RecipeClassLoader extends URLClassLoader {
 
     // Core OpenRewrite types that must be loaded from parent (from Moderne's RecipeClassLoader)
     private static final List<String> PARENT_DELEGATED_PREFIXES = Arrays.asList(
+            "org.openrewrite.AbstractRecipe",
             "org.openrewrite.Column",
             "org.openrewrite.Cursor",
             "org.openrewrite.DelegatingExecutionContext",

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/RecipeDsl.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/RecipeDsl.kt
@@ -112,6 +112,11 @@ public class KotlinCompositeRecipe @JsonCreator constructor(
         // the scanner's own classloader) can't see it. Throwing here trips the
         // scanner's catch-Throwable in `configureRecipe`, so the class is silently
         // skipped rather than enumerated as a phantom empty composite.
+        //
+        // FIXME: remove this `require` once 8.83.0+ (which parent-delegates
+        //  `org.openrewrite.AbstractRecipe` in `RecipeClassLoader`) is the
+        //  minimum supported version of build-plugin/CLI scanners in the wild.
+        //  At that point the annotation alone is sufficient.
         require(displayName != null) { "KotlinCompositeRecipe requires a non-null displayName" }
     }
 


### PR DESCRIPTION
## Summary

The `@AbstractRecipe` annotation introduced in 8.82.0 lets a Recipe subclass opt out of classpath-scanning enumeration. The filter (`ClasspathScanningLoader.configureRecipesAndStyles`) uses `Class.isAnnotationPresent(AbstractRecipe.class)` — a `Class<?>` identity comparison.

In a marketplace scan, the recipe JAR is loaded by a `RecipeClassLoader` whose parent is the scanner's classloader. Two lookups need to agree:

- The annotation type on the candidate recipe class resolves via the **recipe-JAR classloader**.
- The `AbstractRecipe.class` literal inside the scanner resolves via the **scanner's classloader**.

- With child-first delegation, these end up as two distinct `Class<?>` objects whenever both classloaders provide `org.openrewrite.AbstractRecipe`, and `isAnnotationPresent` returns false — the annotation is silently ignored, despite being present in the bytecode. We hit this exact failure mode in #7710's CI investigation against `rewrite-build-gradle-plugin 2.17.0` + `rewrite-core 8.82.0`.

- Adding `org.openrewrite.AbstractRecipe` to `PARENT_DELEGATED_PREFIXES` forces both lookups through the parent classloader, restoring identity. After this lands, the `init { require(displayName != null) }` backstop on `KotlinCompositeRecipe` (added in #7710) becomes redundant for scanners using this version of `RecipeClassLoader` — but it stays in place as defense in depth for older plugin versions in the wild.

## Test plan

- [x] `./gradlew :rewrite-core:assemble :rewrite-core:test --tests "org.openrewrite.marketplace.*"` passes locally
- [ ] CI green on `build`