### PR TITLE
Scala: add support for `with` syntax in intersection types

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
@@ -61,7 +61,7 @@ class ScalaCompilerBridge {
     val storeReporter = new StoreReporter(null)
 
     // Configure source version, output directory, and classpath.
-    given ctx: Context = {
+    val configuredCtx: Context = {
       val fresh = baseCtx.fresh
       // Accept both Scala 2 and Scala 3 syntax (including indentation-based).
       fresh.setSetting(fresh.settings.source, "3.6-migration")
@@ -76,6 +76,27 @@ class ScalaCompilerBridge {
       }
       fresh
     }
+
+    // Create the Run up front. Run construction initializes Definitions and
+    // ContextBase state (e.g., `ctx.base.TypeBoundsEmpty`) that the parser
+    // requires when it sees `A with B` types — those go through
+    // `untpd.makeAndType` → `Definitions.andType`, which would NPE on an
+    // uninitialized base. Parsing under `run.runContext` keeps that path safe.
+    //
+    // Run construction requires the Scala stdlib on the classpath (to resolve
+    // `scala.Any`, etc.). Some callers (e.g. ScalaTemplate-style usage that
+    // intentionally narrows the classpath) supply none, so fall back to the
+    // configured base context if Run init fails. Code paths that don't hit
+    // `with` types continue to parse fine; `with` types will fail loudly.
+    val compiler = new Compiler()
+    val (runOpt, parseContext): (Option[Run], Context) =
+      try {
+        val r = compiler.newRun(using configuredCtx)
+        (Some(r), r.runContext)
+      } catch {
+        case _: Throwable => (None, configuredCtx)
+      }
+    given ctx: Context = parseContext
 
     // Phase 1: Parse all sources into CompilationUnits
     val units = new ArrayList[CompilationUnit]()
@@ -117,43 +138,42 @@ class ScalaCompilerBridge {
       sourceEntries.add(entry)
     }
 
-    // Phase 2: Attempt batch type-checking
-    try {
-      val compiler = new Compiler()
-      val run = compiler.newRun(using ctx)
-
-      // Convert to Scala list for the compiler
-      val unitList = {
-        val buf = new ListBuffer[CompilationUnit]()
-        val uIter = units.iterator()
-        while (uIter.hasNext) buf += uIter.next()
-        buf.toList
-      }
-
-      run.compileUnits(unitList)
-
-      // Use the run's context — symbols from tpd.Tree are only valid in this context
-      given runCtx: Context = run.runContext
-
-      // Extract typed trees per unit
-      for (i <- 0 until units.size()) {
-        val unit = units.get(i)
-        val entry = sourceEntries.get(i)
-        val path = entry.path
-        val existing = results.get(path)
-
-        try {
-          val typedTree = unit.tpdTree
-          if (typedTree != null && !typedTree.isEmpty) {
-            results.put(path, existing.copy(typedTree = Some(typedTree), context = runCtx))
-          }
-        } catch {
-          case _: Throwable =>
+    // Phase 2: Attempt batch type-checking (only if we managed to create a Run).
+    runOpt.foreach { run =>
+      try {
+        // Convert to Scala list for the compiler
+        val unitList = {
+          val buf = new ListBuffer[CompilationUnit]()
+          val uIter = units.iterator()
+          while (uIter.hasNext) buf += uIter.next()
+          buf.toList
         }
+
+        run.compileUnits(unitList)
+
+        // Use the run's context — symbols from tpd.Tree are only valid in this context
+        given runCtx: Context = run.runContext
+
+        // Extract typed trees per unit
+        for (i <- 0 until units.size()) {
+          val unit = units.get(i)
+          val entry = sourceEntries.get(i)
+          val path = entry.path
+          val existing = results.get(path)
+
+          try {
+            val typedTree = unit.tpdTree
+            if (typedTree != null && !typedTree.isEmpty) {
+              results.put(path, existing.copy(typedTree = Some(typedTree), context = runCtx))
+            }
+          } catch {
+            case _: Throwable =>
+          }
+        }
+      } catch {
+        case _: Throwable =>
+          // Batch compilation failed entirely; all units keep typedTree=None
       }
-    } catch {
-      case _: Throwable =>
-        // Batch compilation failed entirely; all units keep typedTree=None
     }
 
     // Drain buffered diagnostics into per-source `warnings` lists so callers
@@ -196,13 +216,21 @@ class ScalaCompilerBridge {
     // Buffer diagnostics in-memory so they don't leak to stderr via Dotty's default ConsoleReporter.
     val storeReporter = new StoreReporter(null)
 
-    // Create our custom driver and get a proper context with Scala 2 compat
+    // Create our custom driver and get a proper context with Scala 2 compat.
+    // Best-effort Run init so `ctx.base` is wired up for `A with B` parsing
+    // (which goes through `Definitions.andType` and NPEs on a bare context);
+    // fall back to the raw context if no Scala stdlib is on the classpath.
     val driver = new ParsingDriver()
-    given Context = {
+    val configuredCtx: Context = {
       val fresh = driver.getInitialContext.fresh
       fresh.setSetting(fresh.settings.source, "3.6-migration")
       fresh.setReporter(storeReporter)
       fresh
+    }
+    given Context = try {
+      (new Compiler()).newRun(using configuredCtx).runContext
+    } catch {
+      case _: Throwable => configuredCtx
     }
 
     // For simple expressions, wrap in a valid compilation unit

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5008,13 +5008,21 @@ class ScalaTreeVisitor(
   }
   
   private def visitAppliedTypeTree(at: Trees.AppliedTypeTree[?]): J = {
+    // Dotty's parser desugars `A with B` (and `&` intersections introduced via
+    // `makeAndType`) into an AppliedTypeTree whose `tpt` is a synthetic, zero-
+    // span reference to `scala.&`. Detect that shape and emit J.IntersectionType
+    // instead of falling through to the parameterized-type path.
+    if (isWithIntersectionType(at)) {
+      return visitWithIntersectionType(at)
+    }
+
     // AppliedTypeTree represents a parameterized type like List[String]
     val savedCursor = cursor
     val prefix = extractPrefix(at.span)
 
     // Save original cursor position
     val originalCursor = cursor
-    
+
     // Visit the base type (e.g., List, Map, Option)
     val clazz = visitTree(at.tpt) match {
       case nt: NameTree => nt
@@ -5131,6 +5139,69 @@ class ScalaTreeVisitor(
       clazz,
       typeParameters,
       paramType
+    )
+  }
+
+  /**
+   * True when `at` is the desugared form of an `A with B` intersection type:
+   * a synthetic (zero-span) `tpt` reference to `scala.&` and exactly two args,
+   * with the literal keyword `with` appearing in source between the two args.
+   *
+   * `A & B` syntax is parsed as an `untpd.InfixOp` (not via `makeAndType`), so
+   * it doesn't match here.
+   */
+  private def isWithIntersectionType(at: Trees.AppliedTypeTree[?]): Boolean = {
+    if (at.args.size != 2) return false
+    val tpt = at.tpt
+    // Synthetic tpt: either no span at all, or a zero-length span.
+    if (tpt.span.exists && tpt.span.start != tpt.span.end) return false
+    val left = at.args.head
+    val right = at.args(1)
+    if (!left.span.exists || !right.span.exists) return false
+    val leftEnd = Math.max(0, left.span.end - offsetAdjustment)
+    val rightStart = Math.max(0, right.span.start - offsetAdjustment)
+    if (leftEnd >= rightStart || rightStart > source.length) return false
+    // Match `with` as a whole keyword (avoid e.g. an identifier containing "with").
+    val between = source.substring(leftEnd, rightStart)
+    "(?s).*\\bwith\\b.*".r.matches(between)
+  }
+
+  /**
+   * Flatten a right-associative `A with B with C` (parsed as
+   * `AppliedTypeTree(&, [A, AppliedTypeTree(&, [B, C])])`) into the list of
+   * leaf type trees `[A, B, C]`.
+   */
+  private def flattenWithIntersection(at: Trees.AppliedTypeTree[?]): List[Trees.Tree[?]] = {
+    val tail = at.args(1) match {
+      case inner: Trees.AppliedTypeTree[?] if isWithIntersectionType(inner) =>
+        flattenWithIntersection(inner)
+      case other =>
+        List(other)
+    }
+    at.args.head :: tail
+  }
+
+  private def visitWithIntersectionType(at: Trees.AppliedTypeTree[?]): J = {
+    val prefix = extractPrefix(at.span)
+    val parts = flattenWithIntersection(at)
+
+    val elements = new util.ArrayList[JRightPadded[TypeTree]](parts.size)
+    for (i <- parts.indices) {
+      // Don't clobber the cursor here: visitTypeTree → extractPrefix relies on
+      // the gap between `cursor` and the part's span.start to capture the
+      // whitespace after the previous `with` keyword.
+      val tt = visitTypeTree(parts(i))
+      if (tt == null) return visitUnknown(parts(i))
+      val isLast = i == parts.size - 1
+      val afterSpace = if (isLast) Space.EMPTY else sourceBefore("with")
+      elements.add(new JRightPadded[TypeTree](tt, afterSpace, Markers.EMPTY))
+    }
+    updateCursor(at.span.end)
+    new J.IntersectionType(
+      Tree.randomId(),
+      prefix,
+      Markers.EMPTY,
+      JContainer.build(Space.EMPTY, elements, Markers.EMPTY)
     )
   }
 

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/IntersectionTypeTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/IntersectionTypeTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.scala.Assertions.scala;
+
+class IntersectionTypeTest implements RewriteTest {
+
+    @Test
+    void valWithIntersectionType() {
+        rewriteRun(
+          scala(
+            """
+              trait A
+              trait B
+              object Test {
+                val x: A with B = null
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void valWithTripleIntersection() {
+        rewriteRun(
+          scala(
+            """
+              trait A
+              trait B
+              trait C
+              object Test {
+                val x: A with B with C = null
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void defReturnIntersection() {
+        rewriteRun(
+          scala(
+            """
+              trait A
+              trait B
+              object Test {
+                def foo(): A with B = null
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void defParamIntersection() {
+        rewriteRun(
+          scala(
+            """
+              trait A
+              trait B
+              object Test {
+                def foo(x: A with B): Unit = ()
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void typeAliasIntersection() {
+        rewriteRun(
+          scala(
+            """
+              trait A
+              trait B
+              object Test {
+                type AB = A with B
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void extraSpacing() {
+        rewriteRun(
+          scala(
+            """
+              trait A
+              trait B
+              object Test {
+                val x:  A   with   B = null
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?

Mapping `with` intersection types in Scala parsing.

## What's your motivation?

They are currently not handled at all.