### PR TITLE
Scala: introduce S.SplatExpression

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -604,6 +604,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return visitSingletonType((S.SingletonType) tree, p);
         } else if (tree instanceof S.RepeatedType) {
             return visitRepeatedType((S.RepeatedType) tree, p);
+        } else if (tree instanceof S.SplatExpression) {
+            return visitSplatExpression((S.SplatExpression) tree, p);
         } else if (tree instanceof S.Alternative) {
             return visitAlternative((S.Alternative) tree, p);
         } else if (tree instanceof S.QualifiedSuper) {
@@ -1553,6 +1555,21 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         p.append('*');
         afterSyntax(repeatedType, p);
         return repeatedType;
+    }
+
+    public J visitSplatExpression(S.SplatExpression splatExpression, PrintOutputCapture<P> p) {
+        beforeSyntax(splatExpression, Space.Location.LANGUAGE_EXTENSION, p);
+        visit(splatExpression.getExpression(), p);
+        if (splatExpression.getBeforeColon() != null) {
+            visitSpace(splatExpression.getBeforeColon(), Space.Location.LANGUAGE_EXTENSION, p);
+            p.append(':');
+            visitSpace(splatExpression.getAfterColon(), Space.Location.LANGUAGE_EXTENSION, p);
+            p.append('_');
+        }
+        visitSpace(splatExpression.getBeforeStar(), Space.Location.LANGUAGE_EXTENSION, p);
+        p.append('*');
+        afterSyntax(splatExpression, p);
+        return splatExpression;
     }
 
     public J visitAlternative(S.Alternative alternative, PrintOutputCapture<P> p) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -202,6 +202,21 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         return r;
     }
 
+    public J visitSplatExpression(S.SplatExpression splatExpression, P p) {
+        S.SplatExpression s = splatExpression;
+        s = s.withPrefix(visitSpace(s.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        s = s.withMarkers(visitMarkers(s.getMarkers(), p));
+        s = s.withExpression(visitAndCast(s.getExpression(), p));
+        if (s.getBeforeColon() != null) {
+            s = s.withBeforeColon(visitSpace(s.getBeforeColon(), Space.Location.LANGUAGE_EXTENSION, p));
+        }
+        if (s.getAfterColon() != null) {
+            s = s.withAfterColon(visitSpace(s.getAfterColon(), Space.Location.LANGUAGE_EXTENSION, p));
+        }
+        s = s.withBeforeStar(visitSpace(s.getBeforeStar(), Space.Location.LANGUAGE_EXTENSION, p));
+        return s;
+    }
+
     public J visitAlternative(S.Alternative alternative, P p) {
         S.Alternative a = alternative;
         a = a.withPrefix(visitSpace(a.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -1072,11 +1072,12 @@ public interface S extends J {
     }
 
     /**
-     * Represents a Scala repeated/vararg type: {@code T*}. Appears in method parameter
-     * positions ({@code def foo(args: String*)}) and in argument ascriptions
-     * ({@code f(xs: _*)}). Modeled as a {@link TypeTree} so it composes with anywhere
-     * a type can appear. {@code beforeStar} preserves whitespace between the element
-     * type and the trailing {@code *} (e.g. {@code String *}).
+     * Represents a Scala repeated/vararg type at a type position: {@code T*}, as in
+     * {@code def foo(args: String*)}. {@code beforeStar} preserves whitespace between
+     * the element type and the trailing {@code *} (e.g. {@code String *}).
+     *
+     * <p>Call-site varargs splats ({@code f(xs*)} or {@code f(xs: _*)}) are modeled by
+     * {@link SplatExpression}, not this class.
      */
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
@@ -1114,6 +1115,66 @@ public interface S extends J {
         @Override
         public <P> J acceptScala(ScalaVisitor<P> v, P p) {
             return v.visitRepeatedType(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+    }
+
+    /**
+     * Represents a call-site varargs splat. Scala 3 form: {@code f(xs*)}.
+     * Scala 2 form: {@code f(xs: _*)} — for the Scala 2 form, {@link #beforeColon}
+     * and {@link #afterColon} are non-null; for the Scala 3 form they are null.
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    final class SplatExpression implements S, Expression, TypedTree {
+
+        @With @Getter @EqualsAndHashCode.Include
+        UUID id;
+
+        @With @Getter
+        Space prefix;
+
+        @With @Getter
+        Markers markers;
+
+        @With @Getter
+        Expression expression;
+
+        @With @Getter
+        @Nullable
+        Space beforeColon;
+
+        @With @Getter
+        @Nullable
+        Space afterColon;
+
+        @With @Getter
+        Space beforeStar;
+
+        @With @Getter
+        @Nullable
+        JavaType type;
+
+        public SplatExpression(UUID id, Space prefix, Markers markers, Expression expression,
+                               @Nullable Space beforeColon, @Nullable Space afterColon,
+                               Space beforeStar, @Nullable JavaType type) {
+            this.id = id;
+            this.prefix = prefix;
+            this.markers = markers;
+            this.expression = expression;
+            this.beforeColon = beforeColon;
+            this.afterColon = afterColon;
+            this.beforeStar = beforeStar;
+            this.type = type;
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitSplatExpression(this, p);
         }
 
         @Override

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7787,39 +7787,48 @@ class ScalaTreeVisitor(
   
   private def visitTyped(typed: Trees.Typed[?]): J = {
 
-    // Scala 3 vararg splat `f(xs*)` and Scala 2 form `f(xs: _*)` both parse to
-    // `Typed(expr, Ident("_*"))`. Distinguish by checking whether the source
-    // between the expression and the trailing `*` contains a `:`.
+    // Call-site varargs splat. Scala 3 form: `f(xs*)`. Scala 2 form: `f(xs: _*)`.
+    // Both parse to `Typed(expr, Ident("_*"))`. Distinguish by inspecting the source
+    // between the expression and the trailing `*`: a `:` indicates Scala 2 form.
     typed.tpt match {
       case id: Trees.Ident[?] if id.name.toString == "_*" =>
-        val exprEnd = if (typed.expr.span.exists) Math.max(0, typed.expr.span.end - offsetAdjustment) else cursor
-        val typedEnd = if (typed.span.exists) Math.max(0, typed.span.end - offsetAdjustment) else exprEnd
-        val between = if (exprEnd >= 0 && typedEnd <= source.length && exprEnd <= typedEnd) {
-          source.substring(exprEnd, typedEnd)
-        } else ""
-        if (!between.contains(":")) {
-          // Scala 3 form: `xs*`. Build S.RepeatedType directly with the expression as element.
-          val prefix = extractPrefix(typed.span)
-          val element = visitTree(typed.expr) match {
-            case tt: TypeTree => tt
-            case other => throw new IllegalStateException(
-              s"Scala 3 vararg splat element must be a TypeTree-compatible expression, got: ${if (other == null) "null" else other.getClass.getName}")
-          }
-          val starPos = source.indexOf('*', cursor)
-          val beforeStar = if (starPos >= cursor && starPos < typedEnd) {
-            Space.format(source, cursor, starPos)
-          } else Space.EMPTY
-          updateCursor(typed.span.end)
-          return new S.RepeatedType(
-            Tree.randomId(),
-            prefix,
-            Markers.EMPTY,
-            element,
-            beforeStar,
-            typeOfTree(typed)
-          )
+        val prefix = extractPrefix(typed.span)
+        val element = visitTree(typed.expr) match {
+          case e: Expression => e
+          case other => throw new IllegalStateException(
+            s"Varargs splat element must be an Expression, got: ${if (other == null) "null" else other.getClass.getName}")
         }
-        // Fall through to general type-ascription handling for the Scala 2 form.
+        val typedEnd = if (typed.span.exists) Math.max(0, typed.span.end - offsetAdjustment) else cursor
+        val starPos = source.indexOf('*', cursor)
+        val starIdx = if (starPos >= cursor && starPos < typedEnd) starPos else typedEnd - 1
+        val between = if (cursor >= 0 && starIdx >= cursor && starIdx <= source.length) {
+          source.substring(cursor, starIdx)
+        } else ""
+        val colonIdx = between.indexOf(':')
+        val (beforeColon, afterColon, beforeStar) = if (colonIdx >= 0) {
+          // Scala 2 form: `<expr> [ws]:[ws]_[ws]*`
+          val bColon = Space.format(between.substring(0, colonIdx))
+          val afterColonStart = cursor + colonIdx + 1
+          val underscoreIdx = source.indexOf('_', afterColonStart)
+          val uIdx = if (underscoreIdx >= afterColonStart && underscoreIdx < starIdx) underscoreIdx else starIdx
+          val aColon = Space.format(source, afterColonStart, uIdx)
+          val bStar = Space.format(source, uIdx + 1, starIdx)
+          (bColon, aColon, bStar)
+        } else {
+          // Scala 3 form: `<expr>[ws]*`
+          (null.asInstanceOf[Space], null.asInstanceOf[Space], Space.format(between))
+        }
+        updateCursor(typed.span.end)
+        return new S.SplatExpression(
+          Tree.randomId(),
+          prefix,
+          Markers.EMPTY,
+          element,
+          beforeColon,
+          afterColon,
+          beforeStar,
+          typeOfTree(typed)
+        )
       case _ =>
     }
 

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
@@ -421,5 +421,20 @@ class MethodInvocationTest implements RewriteTest {
               )
             );
         }
+
+        @Test
+        void scala3SplatOfMethodCall() {
+            rewriteRun(
+              scala(
+                """
+                object Test {
+                  def f(x: Int*): Unit = ()
+                  def g(): Seq[Int] = Seq(1, 2)
+                  f(g()*)
+                }
+                """
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
## What's changed?

Add the LST element of `S.SplatExpression` to counterpart the `S.RepeatedType` added in #7700.

## What's your motivation?

We need to handle the splat expressions (not types) somehow too.