### PR TITLE
Java parser: handle JDK 26 implicit lambda parameter type

### DIFF
--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
@@ -1750,6 +1750,16 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
                 visitVariables(singletonList(node), fmt); // method arguments cannot be multi-declarations
     }
 
+    private boolean isImplicitLambdaParameterType(JCVariableDecl node, JCExpression vartype) {
+        if ((node.sym.flags() & Flags.PARAMETER) == 0) {
+            return false;
+        }
+        int end = endPos(vartype);
+        // JDK ≤ 25: synthesized vartype has NOPOS, so end == -1.
+        // JDK 26+: synthesized vartype is a zero-width JCErroneous at the parameter name's position.
+        return end <= vartype.getStartPosition();
+    }
+
     private J.VariableDeclarations visitVariables(List<VariableTree> nodes, Space fmt) {
         JCVariableDecl node = (JCVariableDecl) nodes.get(0);
 
@@ -1762,24 +1772,21 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
         List<J.Annotation> typeExprAnnotations = collectAnnotations(annotationPosTable);
 
         TypeTree typeExpr;
-        if (vartype == null) {
+        if (vartype == null || isImplicitLambdaParameterType(node, vartype)) {
+            // Lambda parameter with an inferred type. The synthesized vartype has either
+            // NOPOS (JDK ≤ 25) or is a zero-width JCErroneous at the parameter name (JDK 26+).
             typeExpr = null;
         } else if (endPos(vartype) < 0) {
-            if ((node.sym.flags() & Flags.PARAMETER) > 0) {
-                // this is a lambda parameter with an inferred type expression
-                typeExpr = null;
-            } else {
-                Space space = whitespace();
-                boolean lombokVal = source.startsWith("val", cursor);
-                cursor += 3; // skip `val` or `var`
-                typeExpr = new J.Identifier(randomId(),
-                        space,
-                        Markers.build(singletonList(JavaVarKeyword.build())),
-                        emptyList(),
-                        lombokVal ? "val" : "var",
-                        typeMapping.type(vartype),
-                        null);
-            }
+            Space space = whitespace();
+            boolean lombokVal = source.startsWith("val", cursor);
+            cursor += 3; // skip `val` or `var`
+            typeExpr = new J.Identifier(randomId(),
+                    space,
+                    Markers.build(singletonList(JavaVarKeyword.build())),
+                    emptyList(),
+                    lombokVal ? "val" : "var",
+                    typeMapping.type(vartype),
+                    null);
         } else if (vartype instanceof JCArrayTypeTree) {
             JCExpression elementType = vartype;
             while (elementType instanceof JCArrayTypeTree || elementType instanceof JCAnnotatedType) {

--- a/rewrite-java-25/src/test/java/org/openrewrite/java/Java26ImplicitLambdaParameterTest.java
+++ b/rewrite-java-25/src/test/java/org/openrewrite/java/Java26ImplicitLambdaParameterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class Java26ImplicitLambdaParameterTest implements RewriteTest {
+
+    /**
+     * On JDK 26+ the synthesized {@code vartype} for an implicit lambda parameter
+     * is reported as a zero-width {@code JCErroneous} sitting at the parameter
+     * name (instead of having {@code NOPOS} as on JDK ≤ 25). The parser used to
+     * detect the synthesized vartype only via {@code endPos(vartype) < 0}; on
+     * JDK 26 that check no longer fires and {@code convert(vartype)} produced a
+     * {@code J.Erroneous} that failed the cast to {@code TypeTree}.
+     */
+    @Issue("https://github.com/openrewrite/rewrite/issues/7554")
+    @Test
+    void implicitLambdaParameterInMethodChain() {
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+              import java.util.stream.Collectors;
+              import java.util.stream.Stream;
+
+              class Test {
+                  List<String> matches(String request) {
+                      return Stream.of("a", "b")
+                                   .filter(field -> field.toLowerCase().contains(request.toLowerCase()))
+                                   .collect(Collectors.toList());
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- On JDK 26 the synthesized `vartype` for an implicit lambda parameter (e.g. `field` in `.filter(field -> ...)`) is a zero-width `JCErroneous` sitting at the parameter name, not a `NOPOS` node as on JDK ≤ 25 — so the existing `endPos(vartype) < 0` check in `ReloadableJava25ParserVisitor#visitVariables` no longer fires, and `convert(vartype)` produces a `J.Erroneous` that fails the implicit cast to `TypeTree` (surfacing downstream as the `StringIndexOutOfBoundsException` reported in #7554).

Fix detects both shapes via `endPos(vartype) <= vartype.getStartPosition()` gated on `Flags.PARAMETER`. Only `rewrite-java-25` is touched: `JavaParser` picks `Java25Parser` for any `version >= 25` so the older modules are never selected on JDK 26.

- Refs https://github.com/openrewrite/rewrite/issues/7554

## Test plan

- [x] New `Java26ImplicitLambdaParameterTest` parses a stream-chain `.filter(field -> ...)` — fails before the fix on JDK 26, passes after on both JDK 25 and JDK 26.
- [x] `:rewrite-java-25:compatibilityTest` still green on JDK 25.