### PR TITLE
Java parser: handle JDK 26 synthesized annotation `value=` and enum-constant identifiers

### DIFF
--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
@@ -136,12 +136,10 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
             List<JRightPadded<Expression>> expressions;
             if (node.getArguments().size() == 1) {
                 ExpressionTree arg = node.getArguments().get(0);
-                if (arg instanceof JCAssign) {
-                    if (endPos(arg) < 0) {
-                        expressions = singletonList(convert(((JCAssign) arg).rhs, t -> sourceBefore(")")));
-                    } else {
-                        expressions = singletonList(convert(arg, t -> sourceBefore(")")));
-                    }
+                if (arg instanceof JCAssign && isSyntheticValueAssignment((JCAssign) arg)) {
+                    // Single-element annotation shorthand like `@Ann("foo")`. javac
+                    // synthesizes a `value=` JCAssign that doesn't appear in source.
+                    expressions = singletonList(convert(((JCAssign) arg).rhs, t -> sourceBefore(")")));
                 } else {
                     expressions = singletonList(convert(arg, t -> sourceBefore(")")));
                 }
@@ -1276,8 +1274,11 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
             whitespaceBeforeNew = sourceBefore("new");
         }
 
-        // for enum definitions with anonymous class initializers, endPos of node identifier will be -1
-        TypeTree clazz = endPos(node.getIdentifier()) >= 0 ? convert(node.getIdentifier()) : null;
+        // For enum constants, the identifier is synthesized: on JDK ≤ 25 with endPos < 0,
+        // on JDK 26+ as a zero-width node at the enum-constant's own name position.
+        // In both cases we want `clazz = null` so the cursor isn't advanced past the args.
+        JCTree ident = (JCTree) node.getIdentifier();
+        TypeTree clazz = endPos(ident) > ident.getStartPosition() ? convert(node.getIdentifier()) : null;
 
         JContainer<Expression> args;
         if (positionOfNext("(", '{') > -1) {
@@ -1748,6 +1749,14 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
         return hasFlag(node.getModifiers(), Flags.ENUM) ?
                 visitEnumVariable(node, fmt) :
                 visitVariables(singletonList(node), fmt); // method arguments cannot be multi-declarations
+    }
+
+    private boolean isSyntheticValueAssignment(JCAssign arg) {
+        // Single-element annotation shorthand `@Ann("foo")` is reported by javac as a
+        // JCAssign whose lhs is a synthesized `value=` identifier. On JDK ≤ 25 the
+        // synthesized assignment had NOPOS as its end position; on JDK 26+ it carries
+        // a zero-width range at the rhs's start position. Either way, `endPos <= startPos`.
+        return endPos(arg) <= arg.getStartPosition();
     }
 
     private boolean isImplicitLambdaParameterType(JCVariableDecl node, JCExpression vartype) {

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
@@ -1750,6 +1750,16 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
                 visitVariables(singletonList(node), fmt); // method arguments cannot be multi-declarations
     }
 
+    private boolean isImplicitLambdaParameterType(JCVariableDecl node, JCExpression vartype) {
+        if ((node.sym.flags() & Flags.PARAMETER) == 0) {
+            return false;
+        }
+        int end = endPos(vartype);
+        // JDK ≤ 25: synthesized vartype has NOPOS, so end == -1.
+        // JDK 26+: synthesized vartype is a zero-width JCErroneous at the parameter name's position.
+        return end <= vartype.getStartPosition();
+    }
+
     private J.VariableDeclarations visitVariables(List<VariableTree> nodes, Space fmt) {
         JCVariableDecl node = (JCVariableDecl) nodes.get(0);
 
@@ -1762,24 +1772,21 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
         List<J.Annotation> typeExprAnnotations = collectAnnotations(annotationPosTable);
 
         TypeTree typeExpr;
-        if (vartype == null) {
+        if (vartype == null || isImplicitLambdaParameterType(node, vartype)) {
+            // Lambda parameter with an inferred type. The synthesized vartype has either
+            // NOPOS (JDK ≤ 25) or is a zero-width JCErroneous at the parameter name (JDK 26+).
             typeExpr = null;
         } else if (endPos(vartype) < 0) {
-            if ((node.sym.flags() & Flags.PARAMETER) > 0) {
-                // this is a lambda parameter with an inferred type expression
-                typeExpr = null;
-            } else {
-                Space space = whitespace();
-                boolean lombokVal = source.startsWith("val", cursor);
-                cursor += 3; // skip `val` or `var`
-                typeExpr = new J.Identifier(randomId(),
-                        space,
-                        Markers.build(singletonList(JavaVarKeyword.build())),
-                        emptyList(),
-                        lombokVal ? "val" : "var",
-                        typeMapping.type(vartype),
-                        null);
-            }
+            Space space = whitespace();
+            boolean lombokVal = source.startsWith("val", cursor);
+            cursor += 3; // skip `val` or `var`
+            typeExpr = new J.Identifier(randomId(),
+                    space,
+                    Markers.build(singletonList(JavaVarKeyword.build())),
+                    emptyList(),
+                    lombokVal ? "val" : "var",
+                    typeMapping.type(vartype),
+                    null);
         } else if (vartype instanceof JCArrayTypeTree) {
             JCExpression elementType = vartype;
             while (elementType instanceof JCArrayTypeTree || elementType instanceof JCAnnotatedType) {

--- a/rewrite-java-25/src/test/java/org/openrewrite/java/Java26AnnotationValueTest.java
+++ b/rewrite-java-25/src/test/java/org/openrewrite/java/Java26AnnotationValueTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class Java26AnnotationValueTest implements RewriteTest {
+
+    /**
+     * On JDK 26+ a single-element annotation shorthand like {@code @SuppressWarnings("foo")}
+     * is reported by javac as a {@code JCAssign} whose lhs is a synthesized
+     * {@code value=} identifier, even though that identifier does not appear in
+     * source. On JDK ≤ 25 that synthesized assignment had {@code endPos < 0}, so
+     * the parser could detect it and print only the rhs. On JDK 26 the assignment
+     * carries the same source positions as its rhs, so the old check no longer
+     * fires and the printer renders {@code value} into the literal, breaking
+     * print-idempotence (e.g. {@code @SuppressWarnings(valueecked")}).
+     */
+    @Issue("https://github.com/openrewrite/rewrite/issues/7554")
+    @Test
+    void singleElementAnnotationShorthand() {
+        rewriteRun(
+          java(
+            """
+              @SuppressWarnings("unchecked")
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7554")
+    @Test
+    void singleElementAnnotationOnMethod() {
+        rewriteRun(
+          java(
+            """
+              import java.util.ArrayList;
+              import java.util.List;
+
+              class Test {
+                  @SuppressWarnings("unchecked")
+                  List<String> raw() {
+                      return (List<String>) (List) new ArrayList<>();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7554")
+    @Test
+    void singleElementAnnotationWithExplicitValueKeyword() {
+        rewriteRun(
+          java(
+            """
+              @SuppressWarnings(value = "unchecked")
+              class Test {
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java-25/src/test/java/org/openrewrite/java/Java26EnumConstructorTest.java
+++ b/rewrite-java-25/src/test/java/org/openrewrite/java/Java26EnumConstructorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class Java26EnumConstructorTest implements RewriteTest {
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7554")
+    @Test
+    void simpleEnumConstantWithStringArg() {
+        rewriteRun(
+          java(
+            """
+              enum Action {
+                  COPY_TO("Copy to"),
+                  COPY_MORE("Copy");
+
+                  private final String text;
+
+                  Action(String text) {
+                      this.text = text;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7554")
+    @Test
+    void enumConstantWithMethodCallArg() {
+        rewriteRun(
+          java(
+            """
+              enum Action {
+                  COPY_TO(label("Copy to")),
+                  COPY_MORE(label("Copy"));
+
+                  private final String text;
+
+                  Action(String text) {
+                      this.text = text;
+                  }
+
+                  static String label(String s) {
+                      return s;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7554")
+    @Test
+    void enumConstantWithStringConcat() {
+        rewriteRun(
+          java(
+            """
+              enum Action {
+                  COPY_TO("Copy to"),
+                  COPY_MORE("Copy" + "...");
+
+                  private final String text;
+
+                  Action(String text) {
+                      this.text = text;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7554")
+    @Test
+    void enumConstantWithMethodCallAndConcat() {
+        rewriteRun(
+          java(
+            """
+              enum Action {
+                  COPY_TO(label("Copy to")),
+                  COPY_MORE(label("Copy") + "...");
+
+                  private final String text;
+
+                  Action(String text) {
+                      this.text = text;
+                  }
+
+                  static String label(String s) {
+                      return s;
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java-25/src/test/java/org/openrewrite/java/Java26ImplicitLambdaParameterTest.java
+++ b/rewrite-java-25/src/test/java/org/openrewrite/java/Java26ImplicitLambdaParameterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class Java26ImplicitLambdaParameterTest implements RewriteTest {
+
+    /**
+     * On JDK 26+ the synthesized {@code vartype} for an implicit lambda parameter
+     * is reported as a zero-width {@code JCErroneous} sitting at the parameter
+     * name (instead of having {@code NOPOS} as on JDK ≤ 25). The parser used to
+     * detect the synthesized vartype only via {@code endPos(vartype) < 0}; on
+     * JDK 26 that check no longer fires and {@code convert(vartype)} produced a
+     * {@code J.Erroneous} that failed the cast to {@code TypeTree}.
+     */
+    @Issue("https://github.com/openrewrite/rewrite/issues/7554")
+    @Test
+    void implicitLambdaParameterInMethodChain() {
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+              import java.util.stream.Collectors;
+              import java.util.stream.Stream;
+
+              class Test {
+                  List<String> matches(String request) {
+                      return Stream.of("a", "b")
+                                   .filter(field -> field.toLowerCase().contains(request.toLowerCase()))
+                                   .collect(Collectors.toList());
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Follow-up to #7716 for the JDK 26 parse regressions in [#7554](https://github.com/openrewrite/rewrite/issues/7554). On JDK 26 javac no longer marks synthesized AST nodes with `NOPOS`; instead they carry a zero-width range at their rhs's start, so the existing `endPos < 0` guards no longer fire and the parser proceeds as if the synthesized nodes were real source.

- **Annotation shorthand** `@Ann("foo")`: javac synthesizes a `value=` `JCAssign`; new `isSyntheticValueAssignment` detects both the JDK ≤ 25 (NOPOS) and JDK 26 (zero-width) shapes and renders only the rhs.
- **Enum constants** like `COPY_TO("Copy to")`: the synthesized class identifier is now zero-width, so the old guard let it through and `visitIdentifier` advanced the cursor by `name.length()`, corrupting subsequent printing. Now also skipped when zero-width.

- This branch is currently stacked on top of #7716's lambda fix; once that merges the diff here will be just the annotation + enum changes.

## Test plan

- [x] Three new tests in `Java26AnnotationValueTest` (shorthand, on method, explicit `value =`) — fail on JDK 26 without the fix, pass with it.
- [x] Four new tests in `Java26EnumConstructorTest` (plain string, method call, concat, method call + concat) — fail on JDK 26 without the fix, pass with it.
- [x] `./gradlew :rewrite-java-25:test :rewrite-java-25:compatibilityTest` passes on the default JDK 25 toolchain (no TCK regressions).