### PR TITLE
Skip incompatible registered mixins in TreeVisitorAdapter

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/TreeVisitorAdapter.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/TreeVisitorAdapter.java
@@ -368,6 +368,15 @@ public class TreeVisitorAdapter {
                                 throw new IllegalStateException(
                                         "Registered mixin " + line + " is not a TreeVisitor (registered at " + url + ").");
                             }
+                            // A single base visitor (e.g. RemoveAnnotationVisitor) may have
+                            // mixins registered from multiple language modules — Kotlin's
+                            // mixin extends KotlinIsoVisitor, a (hypothetical) Groovy mixin
+                            // would extend GroovyVisitor, etc. Only one can compose with
+                            // the current adaptTo target; skip mixins that aren't a subtype
+                            // so dispatch for other languages falls through to the base.
+                            if (!adaptTo.isAssignableFrom(mixinClass)) {
+                                continue;
+                            }
                             return (TreeVisitor<?, ?>) mixinClass.getDeclaredConstructor().newInstance();
                         } catch (ReflectiveOperationException e) {
                             throw new IllegalStateException(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/TreeVisitorAdapterTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/TreeVisitorAdapterTest.java
@@ -24,11 +24,13 @@ import org.openrewrite.internal.FindRecipeRunException;
 import org.openrewrite.internal.RecipeRunException;
 import org.openrewrite.internal.TreeVisitorAdapter;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.text.PlainTextVisitor;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class TreeVisitorAdapterTest {
 
@@ -88,6 +90,36 @@ class TreeVisitorAdapterTest {
             n.incrementAndGet();
             return tree;
         }
+    }
+
+    /**
+     * A single base visitor can have language-specific mixins registered from
+     * multiple language modules (one extends KotlinIsoVisitor, another extends
+     * GroovyVisitor, etc.). When adapting the base to {@code adaptTo} for one
+     * language, registered mixins for other languages must be skipped — not
+     * cause {@code adapt(...)} to throw — so dispatch for the current language
+     * falls through to the base visitor.
+     *
+     * <p>Regression for: adapting {@code RemoveAnnotationVisitor} to
+     * {@code GroovyVisitor} threw because {@code RemoveAnnotationKotlinMixin}
+     * (registered for that base) extends {@code KotlinIsoVisitor}.
+     */
+    @Test
+    void crossLanguageRegisteredMixinSkipped() {
+        // META-INF/rewrite/mixins/org.openrewrite.java.TreeVisitorAdapterTest$RegistryAdaptable
+        // registers JavaOnlyMixin (extends JavaIsoVisitor). Adapting to
+        // PlainTextVisitor — which the Java mixin is not assignable to —
+        // must silently skip the mixin rather than throw.
+        assertThatCode(() ->
+          //noinspection unchecked
+          TreeVisitorAdapter.adapt(new RegistryAdaptable(), PlainTextVisitor.class)
+        ).doesNotThrowAnyException();
+    }
+
+    public static class RegistryAdaptable extends TreeVisitor<Tree, Integer> {
+    }
+
+    public static class JavaOnlyMixin extends JavaIsoVisitor<Integer> {
     }
 
     @Test

--- a/rewrite-java-test/src/test/resources/META-INF/rewrite/mixins/org.openrewrite.java.TreeVisitorAdapterTest$RegistryAdaptable
+++ b/rewrite-java-test/src/test/resources/META-INF/rewrite/mixins/org.openrewrite.java.TreeVisitorAdapterTest$RegistryAdaptable
@@ -1,0 +1,1 @@
+org.openrewrite.java.TreeVisitorAdapterTest$JavaOnlyMixin


### PR DESCRIPTION
## Summary

Filter registered mixins by language compatibility in `TreeVisitorAdapter.discoverRegisteredMixin` so that adapting a base visitor to one language's `adaptTo` doesn't pick up another language's mixin and crash.

## Background

`RemoveAnnotationKotlinMixin` is registered for `RemoveAnnotationVisitor` via `META-INF/rewrite/mixins/org.openrewrite.java.RemoveAnnotationVisitor`. When `RemoveAnnotationVisitor` runs against a Groovy file, `G.accept` adapts it to `GroovyVisitor` — but `discoverRegisteredMixin` returned the Kotlin mixin unconditionally, and the assignability check at the top of `adapt` then threw:

```
java.lang.IllegalArgumentException: Mixin org.openrewrite.kotlin.RemoveAnnotationKotlinMixin
  is not assignable to org.openrewrite.groovy.GroovyVisitor; the mixin must extend
  (or be a subtype of) the adaptTo class so that proxy generation can extend it.
```

This affects any recipe that uses `RemoveAnnotation` (or any other base visitor with a language-specific mixin registered) when it touches a Groovy / non-Kotlin source file. Surfaced via `SpringBootVersionUpgradeTest.upgradeSpringCloudAwsVersion` in `rewrite-spring`, which exercises this on a Gradle Groovy build script.

## Fix

In `discoverRegisteredMixin`, skip entries whose class isn't a subtype of `adaptTo` rather than returning them. A registry file may list multiple language-specific mixins for the same base — the discovery loop now passes over incompatible ones and finds the matching one (or returns `null` so dispatch falls through to the base).

## Test plan

- [x] New `crossLanguageRegisteredMixinSkipped` in `TreeVisitorAdapterTest` — fails without the fix with the exact `IllegalArgumentException` above, passes with it.
- [x] Existing `TreeVisitorAdapterTest` cases still pass.
- [x] End-to-end: published locally and re-ran the originally failing `SpringBootVersionUpgradeTest.upgradeSpringCloudAwsVersion` in `rewrite-spring` — now green.