### PR TITLE
Fix RemoveAnnotation crash on Groovy trees when rewrite-kotlin is on the classpath

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/TreeVisitorAdapter.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/TreeVisitorAdapter.java
@@ -368,6 +368,15 @@ public class TreeVisitorAdapter {
                                 throw new IllegalStateException(
                                         "Registered mixin " + line + " is not a TreeVisitor (registered at " + url + ").");
                             }
+                            if (!adaptTo.isAssignableFrom(mixinClass)) {
+                                // The registry is keyed by base-visitor FQN and shared across
+                                // language modules. When multiple language modules are on the
+                                // classpath (e.g. rewrite-groovy + rewrite-kotlin in
+                                // rewrite-gradle), a registry entry that targets another
+                                // language's visitor will surface here. Skip it — the proxy
+                                // must be able to extend the mixin's class.
+                                continue;
+                            }
                             return (TreeVisitor<?, ?>) mixinClass.getDeclaredConstructor().newInstance();
                         } catch (ReflectiveOperationException e) {
                             throw new IllegalStateException(

--- a/rewrite-core/src/main/java/org/openrewrite/internal/TreeVisitorAdapter.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/TreeVisitorAdapter.java
@@ -369,12 +369,6 @@ public class TreeVisitorAdapter {
                                         "Registered mixin " + line + " is not a TreeVisitor (registered at " + url + ").");
                             }
                             if (!adaptTo.isAssignableFrom(mixinClass)) {
-                                // The registry is keyed by base-visitor FQN and shared across
-                                // language modules. When multiple language modules are on the
-                                // classpath (e.g. rewrite-groovy + rewrite-kotlin in
-                                // rewrite-gradle), a registry entry that targets another
-                                // language's visitor will surface here. Skip it — the proxy
-                                // must be able to extend the mixin's class.
                                 continue;
                             }
                             return (TreeVisitor<?, ?>) mixinClass.getDeclaredConstructor().newInstance();

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveAnnotationGradleTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveAnnotationGradleTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.java.RemoveAnnotation;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.gradle.Assertions.buildGradle;
+
+class RemoveAnnotationGradleTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveAnnotation("@java.lang.SuppressWarnings(\"deprecation\")"));
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/pull/7701")
+    @Test
+    void doesNotApplyKotlinMixinToGroovyTree() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- PR #7701 introduced the cross-language mixin SPI: language modules can contribute mixins via `META-INF/rewrite/mixins/<base-visitor-fqn>`. `rewrite-kotlin` ships `RemoveAnnotationKotlinMixin` for `org.openrewrite.java.RemoveAnnotationVisitor`.

The registry is a *shared* namespace — multiple language modules can register a mixin for the same base visitor. But `TreeVisitorAdapter.discoverRegisteredMixin` returned the first entry it found without checking it was assignable to the requested `adaptTo` class. With both `rewrite-groovy` and `rewrite-kotlin` on the classpath (e.g. via `rewrite-gradle`, `rewrite-spring`, etc.), visiting a Groovy `build.gradle` did this:

1. `G.accept` → `v.adapt(GroovyVisitor.class)`
2. `discoverRegisteredMixin` returned `RemoveAnnotationKotlinMixin` (registered by `rewrite-kotlin`)
3. `adapt()`'s assignability guard threw:

```
java.lang.IllegalArgumentException: Mixin org.openrewrite.kotlin.RemoveAnnotationKotlinMixin
is not assignable to org.openrewrite.groovy.GroovyVisitor; the mixin must extend (or be a
subtype of) the adaptTo class so that proxy generation can extend it.
```

This broke every downstream user that runs `RemoveAnnotation` (or any Java recipe that ends up adapting through `G`) against a Groovy build script — reported via `SpringBootVersionUpgradeTest.upgradeVersionGradle` in rewrite-spring.

## Fix

Filter the registry entries inside `discoverRegisteredMixin` by `adaptTo.isAssignableFrom(mixinClass)` and `continue` past mismatched entries. A Kotlin mixin is silently ignored when adapting to `GroovyVisitor` (and vice versa) while still being picked up when the visit target really is a Kotlin tree.

- `rewrite-core/src/main/java/org/openrewrite/internal/TreeVisitorAdapter.java` — skip cross-language mixin entries.
- `rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveAnnotationGradleTest.java` — regression test: runs `RemoveAnnotation` against a Groovy `build.gradle` (in a module where both `rewrite-groovy` and `rewrite-kotlin` are on the classpath). Fails on `main` with the exact stack trace above, passes with the fix.

## Test plan

- [x] New `RemoveAnnotationGradleTest.doesNotApplyKotlinMixinToGroovyTree` fails on `main` with the reported `IllegalArgumentException`.
- [x] Same test passes after the fix.
- [ ] `./gradlew :rewrite-core:test :rewrite-kotlin:test :rewrite-groovy:test :rewrite-gradle:test` (running locally; no Kotlin `@file:OptIn` removal coverage exists in `rewrite-kotlin` itself, so the Kotlin mixin path is only covered indirectly by the existing adapter-level tests).
- [ ] Downstream repro `SpringBootVersionUpgradeTest.upgradeVersionGradle` in rewrite-spring should pass once this lands.