### PR TITLE
Groovy: preserve folded constant references in nested annotation arguments

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -3504,7 +3504,7 @@ public class GroovyParserVisitor {
                                 if (arg.getValue() instanceof AnnotationConstantExpression) {
                                     expression = visitAnnotation((AnnotationNode) ((AnnotationConstantExpression) arg.getValue()).getValue(), classVisitor);
                                 } else {
-                                    expression = bodyVisitor.doVisit(arg.getValue());
+                                    expression = recoverFoldedAnnotationMemberValue(arg.getValue(), bodyVisitor);
                                 }
                                 Expression element = isImplicitValue ? expression.withPrefix(argPrefix) :
                                         (new J.Assignment(randomId(), argPrefix, Markers.EMPTY,
@@ -3528,6 +3528,37 @@ public class GroovyParserVisitor {
         }
 
         return new J.Annotation(randomId(), prefix, Markers.EMPTY, annotationType, arguments);
+    }
+
+    /**
+     * Under {@code @CompileStatic}, Groovy's compiler folds constant references like
+     * {@code TestConstants.CATEGORY} inside nested annotation arguments into a
+     * {@link ConstantExpression} carrying the resolved value. When that happens, the original
+     * source position is preserved via {@code setSourcePosition}, but the AST node no longer
+     * matches what is in the source. Recover the original identifier chain from source so the
+     * round-trip is preserved.
+     */
+    private Expression recoverFoldedAnnotationMemberValue(org.codehaus.groovy.ast.expr.Expression value, RewriteGroovyVisitor bodyVisitor) {
+        if (value instanceof ConstantExpression && !(value instanceof AnnotationConstantExpression)) {
+            int savedCursor = cursor;
+            Space prefix = whitespace();
+            if (cursor < source.length()) {
+                char c = source.charAt(cursor);
+                boolean isKeywordLiteral = source.startsWith("null", cursor) ||
+                        source.startsWith("true", cursor) ||
+                        source.startsWith("false", cursor);
+                if (Character.isJavaIdentifierStart(c) && !isKeywordLiteral) {
+                    String name = name();
+                    if (!name.isEmpty()) {
+                        return TypeTree.build(name)
+                                .withType(typeMapping.type(value.getType()))
+                                .withPrefix(prefix);
+                    }
+                }
+            }
+            cursor = savedCursor;
+        }
+        return bodyVisitor.doVisit(value);
     }
 
     private static LineColumn pos(ASTNode node) {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
@@ -173,6 +173,41 @@ class AnnotationTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/291")
+    @Test
+    void nestedAnnotationsInListLiteralWithConstantReferenceUnderCompileStatic() {
+        rewriteRun(
+          groovy(
+            """
+              import java.lang.annotation.*
+              import groovy.transform.CompileStatic
+
+              interface TestConstants {
+                  public static final String PROVIDER = "Provider1"
+                  public static final String CATEGORY = "Category1"
+              }
+
+              @Retention(RetentionPolicy.RUNTIME)
+              @Target(ElementType.TYPE)
+              @interface Tag {
+                  String id()
+                  String category()
+                  String provider()
+              }
+
+              @Retention(RetentionPolicy.RUNTIME)
+              @Target(ElementType.TYPE)
+              @interface Tags { Tag[] value() }
+
+              @CompileStatic
+              @Tags(value = [@Tag(id="tag1", category= TestConstants.CATEGORY, provider = "prov1"),
+                             @Tag(id="tag2", category="cat2", provider = "prov2")])
+              class Main {}
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4254")
     @Test
     void groovyTransformAnnotation() {


### PR DESCRIPTION
## Summary

Under `@CompileStatic`, Groovy folds references like `TestConstants.CATEGORY` inside nested annotation arguments into a `ConstantExpression` carrying the resolved value. The existing `NoInlineAnnotationTransformationResolveVisitor` prevents folding for top-level annotation members, but it does not recurse into annotations nested in list literals — so the inner annotation's members get folded.

Because the folded `ConstantExpression` keeps the original source position via `setSourcePosition`, the printer would emit the inlined value glued in front of the original reference text. For example, this source:

```groovy
@Tags(value = [@Tag(id="tag1", category= TestConstants.CATEGORY, provider = "prov1"),
               @Tag(id="tag2", category="cat2", provider = "prov2")])
class Main {}
```

…round-tripped to

```groovy
@Tag(id="tag1", category= Category1TestConstants.CATEGORY, ...)
```

i.e. the literal value `"Category1"` (unquoted, with leading whitespace eaten) was glued in front of `TestConstants.CATEGORY`.

This change detects the case in `GroovyParserVisitor.visitAnnotation`: when an annotation member's value is a `ConstantExpression` but the source at the cursor begins with an identifier (and not a literal keyword like `null`/`true`/`false`), we recover the original identifier chain from source and emit a `J.FieldAccess`, restoring the round-trip.

- closes openrewrite/rewrite-logging-frameworks#291.

## Test plan

- [x] New round-trip test `AnnotationTest#nestedAnnotationsInListLiteralWithConstantReferenceUnderCompileStatic` reproduces the bug (fails without the parser fix).
- [x] Test passes with the fix.
- [x] `./gradlew :rewrite-groovy:test` passes — no regressions.