### PR TITLE
Revert inline Maven mirror (now in gh-automation#95)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,45 +20,20 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    if: github.event_name != 'schedule' || github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc'
-    steps:
-      - uses: openrewrite/gh-automation/.github/actions/setup@main
-        with:
-          java_version: |
-            25
-            21
-          develocity_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-
-      # Route Maven resolution through Moderne's Artifactory cache to avoid
-      # Maven Central rate-limiting (HTTP 404 + Retry-After) under parallel
-      # test load. Picked up by MavenSettingsAutoLoadingExtension at test time.
-      - uses: s4u/maven-settings-action@v4.0.0
-        with:
-          mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
-          servers: ${{ secrets.ARTIFACTORY_USERNAME != '' && format('[{{"id":"moderne-cache","username":"{0}","password":"{1}"}}]', secrets.ARTIFACTORY_USERNAME, secrets.ARTIFACTORY_PASSWORD) || '[]' }}
-
-      - uses: openrewrite/gh-automation/.github/actions/build@main
-        env:
-          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
-          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-
-      - if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
-        uses: openrewrite/gh-automation/.github/actions/slack-failure@main
-        with:
-          webhook: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
-
-      - if: >
-          github.event_name != 'pull_request' &&
-          github.ref == 'refs/heads/main' &&
-          (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
-        uses: openrewrite/gh-automation/.github/actions/publish-snapshots@main
-        with:
-          sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
-          sonatype_token: ${{ secrets.SONATYPE_TOKEN }}
-          ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
-          ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
-          node_auth_token: ${{ secrets.NPM_TOKEN }}
-          pypi_token: ${{ secrets.PYPI_OPENREWRITE_PUBLISH }}
-          nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+    uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main
+    with:
+      java_version: |
+        25
+        21
+    secrets:
+      gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
+      sonatype_token: ${{ secrets.SONATYPE_TOKEN }}
+      ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
+      ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+      artifactory_username: ${{ secrets.ARTIFACTORY_USERNAME }}
+      artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+      OPS_GITHUB_ACTIONS_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
+      node_auth_token: ${{ secrets.NPM_TOKEN }}
+      pypi_token: ${{ secrets.PYPI_OPENREWRITE_PUBLISH }}
+      nuget_api_key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,8 @@ jobs:
       sonatype_token: ${{ secrets.SONATYPE_TOKEN}}
       ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
       ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+      artifactory_username: ${{ secrets.ARTIFACTORY_USERNAME }}
+      artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       node_auth_token: ${{ secrets.NPM_TOKEN }}
       pypi_token: ${{ secrets.PYPI_OPENREWRITE_PUBLISH }}
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
## Summary
- Revert the inline Maven mirror configuration in `ci.yml`. The same configuration now lives centrally in [openrewrite/gh-automation#95](https://github.com/openrewrite/gh-automation/pull/95) (and is consumed by 8 other recipe repos via the reusable workflows), so this repo can use the thin-caller form too.

Also passes the new `artifactory_username` / `artifactory_password` secrets through to both `ci.yml` and `publish.yml` so the centralized mirror config can authenticate against `artifactory.moderne.ninja`.

## What stays
- The rewrite-core test-side changes from #7566 (`MavenSettingsAutoLoadingExtension` plumbing, `expectedWithUrls` helper, etc.) are independent of this PR and stay as-is. Only the workflow YAML is touched here.

## No behavioral change
- Maven resolution still routes through `moderne-cache-3` (now via the reusable workflow's `s4u/maven-settings-action` step).
- `REWRITE_GRADLE_MIRROR_*` is still set on the `build` action call (inside the reusable workflow).
- `publish.yml` gains the mirror coverage it was missing (`publish-gradle.yml` in gh-automation#95 now applies the same s4u step and env vars).

## Test plan
- [ ] CI passes
- [ ] No `HTTP 429` lines in build logs
- [ ] Mirror auth works (build log shows `s4u/maven-settings-action` ran and uses authenticated credentials, no `HTTP 401` from the mirror)