### PR TITLE
Kotlin recipe DSL: wrap generated visitors with UsesMethod/UsesField preconditions

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
@@ -22,6 +23,8 @@ import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.marker.OmitParentheses;
+import org.openrewrite.java.search.UsesField;
+import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JContainer;
@@ -87,7 +90,7 @@ public final class GeneratedRecipeSupport {
             matchers[i] = new MethodMatcher(specs[i]);
         }
         int[][] substitutionSourcesByMatcher = parseCsvPerMatcher(substitutionSourcesCsv, specs.length);
-        return new KotlinVisitor<ExecutionContext>() {
+        TreeVisitor<?, ExecutionContext> walker = new KotlinVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 int matchedIdx = -1;
@@ -136,6 +139,7 @@ public final class GeneratedRecipeSupport {
                 return super.visitMethodInvocation(method, ctx);
             }
         };
+        return wrapWithPrecondition(matcherSpecsLines, walker);
     }
 
     /**
@@ -157,7 +161,7 @@ public final class GeneratedRecipeSupport {
         MethodMatcher outerMatcher = new MethodMatcher(matcherSpecsLine.substring(0, tabIdx));
         MethodMatcher innerMatcher = new MethodMatcher(matcherSpecsLine.substring(tabIdx + 1));
         ChainSourceRef[] sources = parseChainCsv(substitutionSourcesCsv);
-        return new KotlinVisitor<ExecutionContext>() {
+        TreeVisitor<?, ExecutionContext> walker = new KotlinVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 if (!outerMatcher.matches(method)) {
@@ -198,6 +202,7 @@ public final class GeneratedRecipeSupport {
                 return result.withPrefix(method.getPrefix());
             }
         };
+        return wrapWithPrecondition(matcherSpecsLine, walker);
     }
 
     private static class ChainSourceRef {
@@ -248,7 +253,7 @@ public final class GeneratedRecipeSupport {
             matchers[i] = new MethodMatcher(specs[i]);
         }
         int[][] substitutionSourcesByMatcher = parseCsvPerMatcher(substitutionSourcesCsv, specs.length);
-        return new KotlinVisitor<ExecutionContext>() {
+        TreeVisitor<?, ExecutionContext> walker = new KotlinVisitor<ExecutionContext>() {
             @Override
             public J visitUnary(K.Unary unary, ExecutionContext ctx) {
                 if (unary.getOperator() != K.Unary.Type.NotNull) {
@@ -296,6 +301,7 @@ public final class GeneratedRecipeSupport {
                 return result.withPrefix(unary.getPrefix());
             }
         };
+        return wrapWithPrecondition(matcherSpecsLines, walker);
     }
 
     /**
@@ -332,7 +338,7 @@ public final class GeneratedRecipeSupport {
             }
         }
         int[][] substitutionSourcesByMatcher = parseCsvPerMatcher(substitutionSourcesCsv, specs.length);
-        return new KotlinVisitor<ExecutionContext>() {
+        TreeVisitor<?, ExecutionContext> walker = new KotlinVisitor<ExecutionContext>() {
             @Override
             public J visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext ctx) {
                 String name = fieldAccess.getName().getSimpleName();
@@ -370,6 +376,7 @@ public final class GeneratedRecipeSupport {
                 return result.withPrefix(fieldAccess.getPrefix());
             }
         };
+        return wrapWithPrecondition(matcherSpecsLines, walker);
     }
 
     private static @Nullable String fullyQualifiedNameOf(org.openrewrite.java.tree.@Nullable JavaType type) {
@@ -400,7 +407,7 @@ public final class GeneratedRecipeSupport {
             matchers[i] = new MethodMatcher(specs[i]);
         }
         int[][] substitutionSourcesByMatcher = parseCsvPerMatcher(substitutionSourcesCsv, specs.length);
-        return new JavaVisitor<ExecutionContext>() {
+        TreeVisitor<?, ExecutionContext> walker = new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 int matchedIdx = -1;
@@ -440,6 +447,7 @@ public final class GeneratedRecipeSupport {
                 return super.visitMethodInvocation(method, ctx);
             }
         };
+        return wrapWithPrecondition(matcherSpecsLines, walker);
     }
 
     /**
@@ -493,6 +501,77 @@ public final class GeneratedRecipeSupport {
                 return current;
             }
         };
+    }
+
+    /**
+     * Wrap a generated walker in {@link Preconditions#check(TreeVisitor, TreeVisitor)}
+     * using {@link UsesMethod} / {@link UsesField} derived from the recipe's
+     * matcher spec(s). Same idea as the {@code Preconditions.check(Preconditions.and(
+     * new UsesType<>(...), new UsesMethod<>(...)), visitor)} pattern that Refaster
+     * emits for its generated Java recipes — the walker only runs against a source
+     * file that actually uses the relevant member, letting the framework
+     * short-circuit unrelated files before they're walked.
+     *
+     * <p>We deliberately skip the {@link UsesType} prefilter that Refaster pairs
+     * with {@link UsesMethod}: for Kotlin extension functions and properties
+     * the matcher's owner is the synthetic JVM facade class (e.g.
+     * {@code kotlin.text.StringsKt} for {@code String.lowercase()}), which the
+     * source never references directly and which {@link UsesType} therefore
+     * always reports as absent. {@link UsesMethod} and {@link UsesField} each
+     * already constrain on the owner via the methods-/fields-in-use cache, so
+     * dropping {@link UsesType} loses no real filtering power.
+     *
+     * <p>Spec shapes (set by
+     * {@link org.openrewrite.kotlin.recipe.internal.RecipeIrGenerationExtension}):
+     * <ul>
+     *   <li>{@code "<owner-fqn> <name>(<args>)"} — method invocation. Yields
+     *       {@code UsesMethod(spec)}.</li>
+     *   <li>{@code "<owner-fqn>#<name>"} — property/field access (also the
+     *       inlined-constant fallback for {@code Math.PI} etc.). Yields
+     *       {@code UsesField(owner, name)}.</li>
+     *   <li>{@code "<outer>\t<inner>"} — two-segment chain. Yields the
+     *       AND of both segments' per-spec preconditions.</li>
+     * </ul>
+     * Multiple specs ({@code \n}-delimited, from {@code rewrite(b1, b2) to a})
+     * compose as {@link Preconditions#or}: the walker runs when ANY before
+     * pattern's member appears in the source.
+     *
+     * <p>Empty {@code specsLines} falls through to the bare walker without
+     * a precondition.
+     */
+    @SuppressWarnings("unchecked")
+    private static TreeVisitor<?, ExecutionContext> wrapWithPrecondition(
+            String specsLines, TreeVisitor<?, ExecutionContext> walker) {
+        if (specsLines == null || specsLines.isEmpty()) {
+            return walker;
+        }
+        String[] specs = specsLines.split("\n");
+        TreeVisitor<?, ExecutionContext>[] perSpec = new TreeVisitor[specs.length];
+        for (int i = 0; i < specs.length; i++) {
+            perSpec[i] = preconditionForSpec(specs[i]);
+        }
+        TreeVisitor<?, ExecutionContext> combined = perSpec.length == 1
+                ? perSpec[0]
+                : Preconditions.or(perSpec);
+        return Preconditions.check(combined, walker);
+    }
+
+    private static TreeVisitor<?, ExecutionContext> preconditionForSpec(String spec) {
+        int tabIdx = spec.indexOf('\t');
+        if (tabIdx >= 0) {
+            // Chain: BOTH segments must be present in the source file for the
+            // chained pattern to ever match.
+            return Preconditions.and(
+                    preconditionForSpec(spec.substring(0, tabIdx)),
+                    preconditionForSpec(spec.substring(tabIdx + 1)));
+        }
+        int hashIdx = spec.indexOf('#');
+        if (hashIdx >= 0) {
+            String owner = spec.substring(0, hashIdx);
+            String field = spec.substring(hashIdx + 1);
+            return new UsesField<>(owner, field);
+        }
+        return new UsesMethod<>(spec);
     }
 
     private static int[] parseCsv(String csv) {

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/JavaKotlinClassifierTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/JavaKotlinClassifierTest.kt
@@ -18,7 +18,9 @@ package org.openrewrite.kotlin.recipe
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.openrewrite.Preconditions
 import org.openrewrite.Recipe
+import org.openrewrite.TreeVisitor
 import org.openrewrite.kotlin.KotlinVisitor
 
 /**
@@ -49,7 +51,7 @@ class JavaKotlinClassifierTest {
             """.trimIndent(),
             propertyName = "UseUpper",
         )
-        assertThat(r.getVisitor()).isInstanceOf(KotlinVisitor::class.java)
+        assertThat(unwrap(r.getVisitor())).isInstanceOf(KotlinVisitor::class.java)
     }
 
     @Test
@@ -65,7 +67,7 @@ class JavaKotlinClassifierTest {
             """.trimIndent(),
             propertyName = "UseAppendLine",
         )
-        assertThat(r.getVisitor()).isInstanceOf(KotlinVisitor::class.java)
+        assertThat(unwrap(r.getVisitor())).isInstanceOf(KotlinVisitor::class.java)
     }
 
     @Test
@@ -82,7 +84,7 @@ class JavaKotlinClassifierTest {
             """.trimIndent(),
             propertyName = "EnumEntriesRename",
         )
-        assertThat(r.getVisitor()).isInstanceOf(KotlinVisitor::class.java)
+        assertThat(unwrap(r.getVisitor())).isInstanceOf(KotlinVisitor::class.java)
     }
 
     /**
@@ -92,6 +94,21 @@ class JavaKotlinClassifierTest {
      * The synthesized class lives at `<file-package>.<propertyName>$KtRecipe`;
      * the property's getter returns an instance of it.
      */
+    /**
+     * Peel off the [Preconditions.Check] wrapper added by
+     * [org.openrewrite.kotlin.recipe.GeneratedRecipeSupport] so the
+     * classifier dispatch assertion sees the inner walker. The wrapper is
+     * present for every rewrite/to recipe (UsesMethod / UsesField gating)
+     * but isn't what the classifier picks — `KotlinVisitor` vs `JavaVisitor`
+     * lives inside.
+     */
+    private fun unwrap(v: TreeVisitor<*, *>): TreeVisitor<*, *> =
+        if (v is Preconditions.Check) {
+            val field = Preconditions.Check::class.java.getDeclaredField("v")
+            field.isAccessible = true
+            field.get(v) as TreeVisitor<*, *>
+        } else v
+
     private fun compileRecipe(source: String, propertyName: String): Recipe {
         val result = RecipePluginCompileFixture.compile(source)
         check(result.exitOk()) { "compile failed:\n${result.messages}" }

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
@@ -18,7 +18,10 @@ package org.openrewrite.kotlin.recipe
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.openrewrite.Preconditions
 import org.openrewrite.Recipe
+import org.openrewrite.java.search.UsesField
+import org.openrewrite.java.search.UsesMethod
 import org.openrewrite.test.RecipeSpec
 import org.openrewrite.test.RewriteTest
 import org.openrewrite.kotlin.Assertions.kotlin
@@ -435,6 +438,68 @@ class RecipePluginRewriteTest : RewriteTest {
         assertThat(r.recipeList).hasSize(2)
         assertThat(r.recipeList.map { it::class.java.simpleName })
             .containsExactly("A\$KtRecipe", "B\$KtRecipe")
+    }
+
+    @Test
+    fun `generated visitor is wrapped with UsesMethod precondition`() {
+        // Mirrors what Refaster does in its generated Java recipes: the
+        // synthesized `getVisitor()` returns a Preconditions.Check whose
+        // inner `check` visitor is a UsesMethod for the recipe's matcher
+        // spec. The framework uses this to skip files that don't reference
+        // the targeted member at all.
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseUppercase = recipe("d", "desc") {
+                    edit {
+                        rewrite { s: String -> s.lowercase() } to { s -> s.uppercase() }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseUppercase",
+        )
+        val visitor = r.getVisitor()
+        assertThat(visitor).isInstanceOf(Preconditions.Check::class.java)
+        val check = (visitor as Preconditions.Check).check
+        assertThat(check).isInstanceOf(UsesMethod::class.java)
+        assertThat((check as UsesMethod<*>).methodMatcher.toString())
+            .contains("lowercase")
+    }
+
+    @Test
+    fun `property-access recipe is wrapped with UsesField precondition`() {
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseKotlinMathPi = recipe("d", "desc") {
+                    edit {
+                        rewrite { -> Math.PI } to { -> kotlin.math.PI }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseKotlinMathPi",
+        )
+        val visitor = r.getVisitor()
+        assertThat(visitor).isInstanceOf(Preconditions.Check::class.java)
+        assertThat((visitor as Preconditions.Check).check).isInstanceOf(UsesField::class.java)
+    }
+
+    @Test
+    fun `precondition skips files that don't use the targeted method`() {
+        // A source that doesn't call `lowercase()` anywhere must be left
+        // untouched even though the walker, if invoked, would visit every
+        // method invocation in the file. RewriteTest's single-arg `kotlin(...)`
+        // form asserts no change.
+        rewriteRun(
+            kotlin(
+                """
+                fun unrelated() {
+                    val n = 1 + 2
+                    println(n)
+                }
+                """,
+            ),
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds Refaster-style precondition wrapping for the synthesized visitors that come out of the K2 recipe DSL's `rewrite { } to { }` shape. The generated `getVisitor()` now returns a `Preconditions.check(...)` so files that don't reference the targeted member are skipped without being walked.
- Wrapping is added at runtime inside `GeneratedRecipeSupport` (where the matcher specs are already in hand), not in the K2 IR codegen — from the framework's perspective the effect is identical to the `Preconditions.check(Preconditions.and(new UsesType<>(...), new UsesMethod<>(...)), visitor)` pattern that `rewrite-templating` emits for generated Java recipes.
- `UsesType` is **deliberately omitted** (Refaster pairs it with `UsesMethod`). For Kotlin extension functions and properties the matcher's owner is a synthetic JVM facade class — `kotlin.text.StringsKt` for `String.lowercase()`, `kotlin.io.ConsoleKt` for `readLine()`, etc. — that source never references directly, so adding `UsesType` would always report it as absent and gate every file away. `UsesMethod` and `UsesField` each already constrain on the owner via the methods-/fields-in-use cache, so dropping `UsesType` loses no real filtering power.

### Spec → precondition mapping

| Spec shape | Precondition |
| --- | --- |
| `"<owner> <name>(<args>)"` (method call) | `UsesMethod(spec)` |
| `"<owner>#<name>"` (property / inlined-constant) | `UsesField(owner, name)` |
| `"<outer>\t<inner>"` (chain) | `AND` of each segment's precondition |
| `\n`-delimited (multi-before) | `Preconditions.or(...)` across per-spec preconditions |

## Test plan

- [x] `./gradlew :rewrite-kotlin:test` green
- [x] New `RecipePluginRewriteTest` cases pin:
  - method recipe → `getVisitor()` is `Preconditions.Check` whose inner check is `UsesMethod` for the matcher spec
  - property/inlined-constant recipe → inner check is `UsesField`
  - a file that doesn't use the targeted method is left untouched
- [x] Pre-existing classifier test updated to peek through the new `Preconditions.Check` wrapper before asserting `KotlinVisitor` / `JavaVisitor` dispatch