### PR TITLE
C#: restore legacy packages.config projects via NuGet CLI

### DIFF
--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -377,6 +377,17 @@ val csharpPublishLocal by tasks.registering {
                     packageCacheDir.deleteRecursively()
                 }
 
+                // Clear the persistent tool-path install for the C# Tool so that
+                // CSharpRewriteRpc reinstalls from the freshly published nupkg on the
+                // next run instead of reusing a stale binary.
+                if (packageId.equals("OpenRewrite.CSharp.Tool", ignoreCase = true)) {
+                    val toolPathDir = file("${System.getProperty("user.home")}/.dotnet/rewrite-tools/$nugetVersion")
+                    if (toolPathDir.exists()) {
+                        logger.lifecycle("Clearing installed tool: ${toolPathDir.absolutePath}")
+                        toolPathDir.deleteRecursively()
+                    }
+                }
+
                 nupkg.copyTo(localFeed.resolve(nupkg.name), overwrite = true)
                 logger.lifecycle("Published $packageId@$nugetVersion to ${localFeed.absolutePath}")
             }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
@@ -261,6 +261,11 @@ public static class MSBuildProjectHelper
         if (tfm.StartsWith(".NETCoreApp,Version=v"))
         {
             var version = tfm[".NETCoreApp,Version=v".Length..];
+            // .NET Core 1.x/2.x/3.x ship as "netcoreappN.M" in project.frameworks;
+            // .NET 5+ unified to "netN.M". Match the short-form on each side so
+            // declared deps cross-reference the resolved target correctly.
+            if (version.Length > 0 && (version[0] is '1' or '2' or '3'))
+                return "netcoreapp" + version;
             return "net" + version;
         }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/AddFrameworkReference.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/AddFrameworkReference.cs
@@ -47,6 +47,14 @@ public class AddFrameworkReference : ScanningRecipe<DotNetBuildContext>
         Required = false)]
     public string? TriggerPackageGlob { get; set; }
 
+    [Option(DisplayName = "Regenerate MSBuild marker",
+        Description = "Whether to re-run `dotnet restore` after the edit to refresh the project's " +
+                      "MSBuildProject marker. Defaults to `true`. Composite recipes that chain " +
+                      "multiple csproj-mutating steps may set this to `false` on intermediate steps " +
+                      "and finalize once with `EnsureCsprojAttestation`.",
+        Required = false)]
+    public bool RegenerateMarker { get; set; } = true;
+
     public override DotNetBuildContext GetInitialValue(ExecutionContext ctx) => DotNetBuildContext.GetOrCreate(ctx);
 
     public override ITreeVisitor<ExecutionContext> GetScanner(DotNetBuildContext acc) => new BuildContextScanner();
@@ -55,6 +63,6 @@ public class AddFrameworkReference : ScanningRecipe<DotNetBuildContext>
     {
         return Preconditions.Check(
             new IsProjectFile(),
-            new AddFrameworkReferenceVisitor(FrameworkName, TriggerPackageGlob));
+            new AddFrameworkReferenceVisitor(FrameworkName, TriggerPackageGlob, RegenerateMarker));
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/AddFrameworkReferenceVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/AddFrameworkReferenceVisitor.cs
@@ -26,7 +26,7 @@ namespace OpenRewrite.CSharp.Recipes;
 /// (<c>Microsoft.NET.Sdk.Web</c> implicitly references
 /// <c>Microsoft.AspNetCore.App</c>).
 /// </summary>
-public class AddFrameworkReferenceVisitor(string frameworkName, string? triggerPackageGlob = null) : XmlVisitor<ExecutionContext>
+public class AddFrameworkReferenceVisitor(string frameworkName, string? triggerPackageGlob = null, bool regenerateMarker = true) : XmlVisitor<ExecutionContext>
 {
     private bool _alreadyPresent;
     private bool _triggerMatched;
@@ -50,7 +50,8 @@ public class AddFrameworkReferenceVisitor(string frameworkName, string? triggerP
         var itemGroup = TagExtensions.BuildTag(
             $"<ItemGroup>\n    {tag}\n  </ItemGroup>");
         DoAfterVisit(new AddToTagVisitor<ExecutionContext>(d.Root, itemGroup));
-        DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+        if (regenerateMarker)
+            DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
         return d;
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/AddNuGetPackageReference.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/AddNuGetPackageReference.cs
@@ -42,6 +42,14 @@ public class AddNuGetPackageReference : ScanningRecipe<DotNetBuildContext>
         Required = false)]
     public string? Version { get; set; }
 
+    [Option(DisplayName = "Regenerate MSBuild marker",
+        Description = "Whether to re-run `dotnet restore` after the edit to refresh the project's " +
+                      "MSBuildProject marker. Defaults to `true`. Composite recipes that chain " +
+                      "multiple csproj-mutating steps may set this to `false` on intermediate steps " +
+                      "and finalize once with `EnsureCsprojAttestation`.",
+        Required = false)]
+    public bool RegenerateMarker { get; set; } = true;
+
     public override DotNetBuildContext GetInitialValue(ExecutionContext ctx) => DotNetBuildContext.GetOrCreate(ctx);
 
     public override ITreeVisitor<ExecutionContext> GetScanner(DotNetBuildContext acc) => new BuildContextScanner();
@@ -50,6 +58,6 @@ public class AddNuGetPackageReference : ScanningRecipe<DotNetBuildContext>
     {
         return Preconditions.Check(
             new IsProjectFile(),
-            new AddNuGetPackageReferenceVisitor(PackageName, Version));
+            new AddNuGetPackageReferenceVisitor(PackageName, Version, RegenerateMarker));
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/AddNuGetPackageReferenceVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/AddNuGetPackageReferenceVisitor.cs
@@ -23,7 +23,7 @@ namespace OpenRewrite.CSharp.Recipes;
 /// Visitor that adds a NuGet PackageReference to .csproj files if not already present.
 /// Can be used standalone in custom recipe edit phases.
 /// </summary>
-public class AddNuGetPackageReferenceVisitor(string packageName, string? version) : XmlVisitor<ExecutionContext>
+public class AddNuGetPackageReferenceVisitor(string packageName, string? version, bool regenerateMarker = true) : XmlVisitor<ExecutionContext>
 {
     private bool _alreadyPresent;
     private Tag? _lastItemGroup;
@@ -76,7 +76,8 @@ public class AddNuGetPackageReferenceVisitor(string packageName, string? version
             DoAfterVisit(new AddToTagVisitor<ExecutionContext>(d.Root, itemGroup));
         }
 
-        DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+        if (regenerateMarker)
+            DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
         return d;
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetFrameworkVersion.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetFrameworkVersion.cs
@@ -44,6 +44,14 @@ public class ChangeDotNetFrameworkVersion : Recipe
         Example = "v4.8")]
     public string NewVersion { get; set; } = "";
 
+    [Option(DisplayName = "Regenerate MSBuild marker",
+        Description = "Whether to re-run `dotnet restore` after the edit to refresh the project's " +
+                      "MSBuildProject marker. Defaults to `true`. Composite recipes that chain " +
+                      "multiple csproj-mutating steps may set this to `false` on intermediate steps " +
+                      "and finalize once with `EnsureCsprojAttestation`.",
+        Required = false)]
+    public bool RegenerateMarker { get; set; } = true;
+
     public override ITreeVisitor<ExecutionContext> GetVisitor() =>
-        new ChangeDotNetFrameworkVersionVisitor(OldVersion, NewVersion);
+        new ChangeDotNetFrameworkVersionVisitor(OldVersion, NewVersion, RegenerateMarker);
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetFrameworkVersionVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetFrameworkVersionVisitor.cs
@@ -23,7 +23,7 @@ namespace OpenRewrite.CSharp.Recipes;
 /// Visitor that changes the .NET Framework version in legacy .csproj &lt;TargetFrameworkVersion&gt;
 /// elements and in app.config &lt;supportedRuntime sku=...&gt; attributes.
 /// </summary>
-public class ChangeDotNetFrameworkVersionVisitor(string oldVersion, string newVersion) : XmlVisitor<ExecutionContext>
+public class ChangeDotNetFrameworkVersionVisitor(string oldVersion, string newVersion, bool regenerateMarker = true) : XmlVisitor<ExecutionContext>
 {
     // ".NETFramework,Version=v4.7.2" — the prefix that precedes the version inside the sku attribute.
     private const string SkuVersionPrefix = ".NETFramework,Version=";
@@ -37,7 +37,7 @@ public class ChangeDotNetFrameworkVersionVisitor(string oldVersion, string newVe
     {
         _modified = false;
         var d = (Document)base.VisitDocument(document, ctx);
-        if (_modified && d.Markers.FindFirst<MSBuildProject>() != null)
+        if (_modified && regenerateMarker && d.Markers.FindFirst<MSBuildProject>() != null)
             DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
         return d;
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetTargetFramework.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetTargetFramework.cs
@@ -43,6 +43,14 @@ public class ChangeDotNetTargetFramework : ScanningRecipe<DotNetBuildContext>
         Example = "net9.0")]
     public string NewTargetFramework { get; set; } = "";
 
+    [Option(DisplayName = "Regenerate MSBuild marker",
+        Description = "Whether to re-run `dotnet restore` after the edit to refresh the project's " +
+                      "MSBuildProject marker. Defaults to `true`. Composite recipes that chain " +
+                      "multiple csproj-mutating steps may set this to `false` on intermediate steps " +
+                      "and finalize once with `EnsureCsprojAttestation`.",
+        Required = false)]
+    public bool RegenerateMarker { get; set; } = true;
+
     public override DotNetBuildContext GetInitialValue(ExecutionContext ctx) => DotNetBuildContext.GetOrCreate(ctx);
 
     public override ITreeVisitor<ExecutionContext> GetScanner(DotNetBuildContext acc) => new BuildContextScanner();
@@ -51,6 +59,6 @@ public class ChangeDotNetTargetFramework : ScanningRecipe<DotNetBuildContext>
     {
         return Preconditions.Check(
             new IsProjectFile(),
-            new ChangeDotNetTargetFrameworkVisitor(OldTargetFramework, NewTargetFramework));
+            new ChangeDotNetTargetFrameworkVisitor(OldTargetFramework, NewTargetFramework, RegenerateMarker));
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetTargetFrameworkVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetTargetFrameworkVisitor.cs
@@ -25,7 +25,7 @@ namespace OpenRewrite.CSharp.Recipes;
 /// Handles both single-TFM (&lt;TargetFramework&gt;) and multi-TFM (&lt;TargetFrameworks&gt;) elements.
 /// Can be used standalone in custom recipe edit phases.
 /// </summary>
-public class ChangeDotNetTargetFrameworkVisitor(string oldTfm, string newTfm) : XmlVisitor<ExecutionContext>
+public class ChangeDotNetTargetFrameworkVisitor(string oldTfm, string newTfm, bool regenerateMarker = true) : XmlVisitor<ExecutionContext>
 {
     private static readonly Regex ShortFormTfm = new(@"^net\d+$", RegexOptions.Compiled);
 
@@ -35,7 +35,7 @@ public class ChangeDotNetTargetFrameworkVisitor(string oldTfm, string newTfm) : 
     {
         _modified = false;
         var d = (Document)base.VisitDocument(document, ctx);
-        if (_modified)
+        if (_modified && regenerateMarker)
             DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
         return d;
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/EnsureCsprojAttestation.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/EnsureCsprojAttestation.cs
@@ -21,31 +21,21 @@ using ExecutionContext = OpenRewrite.Core.ExecutionContext;
 namespace OpenRewrite.CSharp.Recipes;
 
 /// <summary>
-/// Removes an MSBuild property element (e.g. <c>RuntimeFrameworkVersion</c>) from a
-/// <c>PropertyGroup</c> in .csproj files. Useful for stripping legacy properties that
-/// are no longer applicable after upgrading the target framework.
+/// Regenerates the <see cref="MSBuildProject"/> marker on every .csproj that carries one,
+/// by running <c>dotnet restore</c> against the current (possibly modified) project state.
+/// Intended as the terminator step in a composite recipe that suppresses intermediate
+/// marker reattestation via <c>RegenerateMarker = false</c> on csproj-mutating sub-recipes.
 /// </summary>
 [Category, Csproj]
-public class RemoveMSBuildProperty : ScanningRecipe<DotNetBuildContext>
+public class EnsureCsprojAttestation : ScanningRecipe<DotNetBuildContext>
 {
-    public override string DisplayName => "Remove MSBuild property";
+    public override string DisplayName => "Ensure csproj attestation";
 
     public override string Description =>
-        "Removes an MSBuild property element (e.g. `<RuntimeFrameworkVersion>`) from " +
-        "`<PropertyGroup>` in .csproj files.";
-
-    [Option(DisplayName = "Property name",
-        Description = "The MSBuild property element name to remove (case-sensitive).",
-        Example = "RuntimeFrameworkVersion")]
-    public string PropertyName { get; set; } = "";
-
-    [Option(DisplayName = "Regenerate MSBuild marker",
-        Description = "Whether to re-run `dotnet restore` after the edit to refresh the project's " +
-                      "MSBuildProject marker. Defaults to `true`. Composite recipes that chain " +
-                      "multiple csproj-mutating steps may set this to `false` on intermediate steps " +
-                      "and finalize once with `EnsureCsprojAttestation`.",
-        Required = false)]
-    public bool RegenerateMarker { get; set; } = true;
+        "Re-runs `dotnet restore` against each .csproj that has an `MSBuildProject` marker and " +
+        "refreshes the marker from the resulting `project.assets.json`. Use this at the end of a " +
+        "composite recipe whose csproj-mutating sub-recipes have `RegenerateMarker = false`, " +
+        "so reattestation happens once on the final consistent state instead of after every edit.";
 
     public override DotNetBuildContext GetInitialValue(ExecutionContext ctx) => DotNetBuildContext.GetOrCreate(ctx);
 
@@ -55,6 +45,6 @@ public class RemoveMSBuildProperty : ScanningRecipe<DotNetBuildContext>
     {
         return Preconditions.Check(
             new IsProjectFile(),
-            new RemoveMSBuildPropertyVisitor(PropertyName, RegenerateMarker));
+            MSBuildProjectHelper.RegenerateMarkerVisitor());
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveDotNetCliToolReference.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveDotNetCliToolReference.cs
@@ -42,6 +42,14 @@ public class RemoveDotNetCliToolReference : ScanningRecipe<DotNetBuildContext>
         Example = "Microsoft.DotNet.Watcher.Tools")]
     public string ToolName { get; set; } = "";
 
+    [Option(DisplayName = "Regenerate MSBuild marker",
+        Description = "Whether to re-run `dotnet restore` after the edit to refresh the project's " +
+                      "MSBuildProject marker. Defaults to `true`. Composite recipes that chain " +
+                      "multiple csproj-mutating steps may set this to `false` on intermediate steps " +
+                      "and finalize once with `EnsureCsprojAttestation`.",
+        Required = false)]
+    public bool RegenerateMarker { get; set; } = true;
+
     public override DotNetBuildContext GetInitialValue(ExecutionContext ctx) => DotNetBuildContext.GetOrCreate(ctx);
 
     public override ITreeVisitor<ExecutionContext> GetScanner(DotNetBuildContext acc) => new BuildContextScanner();
@@ -50,6 +58,6 @@ public class RemoveDotNetCliToolReference : ScanningRecipe<DotNetBuildContext>
     {
         return Preconditions.Check(
             new IsProjectFile(),
-            new RemoveDotNetCliToolReferenceVisitor(ToolName));
+            new RemoveDotNetCliToolReferenceVisitor(ToolName, RegenerateMarker));
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveDotNetCliToolReferenceVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveDotNetCliToolReferenceVisitor.cs
@@ -23,7 +23,7 @@ namespace OpenRewrite.CSharp.Recipes;
 /// Visitor that removes a <c>&lt;DotNetCliToolReference&gt;</c> element from
 /// .csproj files. Supports glob patterns for the tool name.
 /// </summary>
-public class RemoveDotNetCliToolReferenceVisitor(string toolName) : XmlVisitor<ExecutionContext>
+public class RemoveDotNetCliToolReferenceVisitor(string toolName, bool regenerateMarker = true) : XmlVisitor<ExecutionContext>
 {
     private bool _modified;
 
@@ -31,7 +31,7 @@ public class RemoveDotNetCliToolReferenceVisitor(string toolName) : XmlVisitor<E
     {
         _modified = false;
         var d = (Document)base.VisitDocument(document, ctx);
-        if (_modified)
+        if (_modified && regenerateMarker)
             DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
         return d;
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveMSBuildPropertyVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveMSBuildPropertyVisitor.cs
@@ -24,7 +24,7 @@ namespace OpenRewrite.CSharp.Recipes;
 /// <c>PropertyGroup</c> in .csproj files. Can be used standalone in custom recipe
 /// edit phases.
 /// </summary>
-public class RemoveMSBuildPropertyVisitor(string propertyName) : XmlVisitor<ExecutionContext>
+public class RemoveMSBuildPropertyVisitor(string propertyName, bool regenerateMarker = true) : XmlVisitor<ExecutionContext>
 {
     private bool _modified;
 
@@ -32,7 +32,7 @@ public class RemoveMSBuildPropertyVisitor(string propertyName) : XmlVisitor<Exec
     {
         _modified = false;
         var d = (Document)base.VisitDocument(document, ctx);
-        if (_modified)
+        if (_modified && regenerateMarker)
             DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
         return d;
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveNuGetPackageReference.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveNuGetPackageReference.cs
@@ -37,6 +37,14 @@ public class RemoveNuGetPackageReference : ScanningRecipe<DotNetBuildContext>
         Example = "Newtonsoft.Json")]
     public string PackageName { get; set; } = "";
 
+    [Option(DisplayName = "Regenerate MSBuild marker",
+        Description = "Whether to re-run `dotnet restore` after the edit to refresh the project's " +
+                      "MSBuildProject marker. Defaults to `true`. Composite recipes that chain " +
+                      "multiple csproj-mutating steps may set this to `false` on intermediate steps " +
+                      "and finalize once with `EnsureCsprojAttestation`.",
+        Required = false)]
+    public bool RegenerateMarker { get; set; } = true;
+
     public override DotNetBuildContext GetInitialValue(ExecutionContext ctx) => DotNetBuildContext.GetOrCreate(ctx);
 
     public override ITreeVisitor<ExecutionContext> GetScanner(DotNetBuildContext acc) => new BuildContextScanner();
@@ -45,6 +53,6 @@ public class RemoveNuGetPackageReference : ScanningRecipe<DotNetBuildContext>
     {
         return Preconditions.Check(
             new IsProjectFile(),
-            new RemoveNuGetPackageReferenceVisitor(PackageName));
+            new RemoveNuGetPackageReferenceVisitor(PackageName, RegenerateMarker));
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveNuGetPackageReferenceVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveNuGetPackageReferenceVisitor.cs
@@ -24,7 +24,7 @@ namespace OpenRewrite.CSharp.Recipes;
 /// Supports glob patterns for the package name.
 /// Can be used standalone in custom recipe edit phases.
 /// </summary>
-public class RemoveNuGetPackageReferenceVisitor(string packageName) : XmlVisitor<ExecutionContext>
+public class RemoveNuGetPackageReferenceVisitor(string packageName, bool regenerateMarker = true) : XmlVisitor<ExecutionContext>
 {
     private bool _modified;
 
@@ -32,7 +32,7 @@ public class RemoveNuGetPackageReferenceVisitor(string packageName) : XmlVisitor
     {
         _modified = false;
         var d = (Document)base.VisitDocument(document, ctx);
-        if (_modified)
+        if (_modified && regenerateMarker)
             DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
         return d;
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/UpgradeNuGetPackageVersion.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/UpgradeNuGetPackageVersion.cs
@@ -56,6 +56,14 @@ public class UpgradeNuGetPackageVersion : ScanningRecipe<UpgradeNuGetPackageVers
         Required = false)]
     public bool IncludePrerelease { get; set; }
 
+    [Option(DisplayName = "Regenerate MSBuild marker",
+        Description = "Whether to re-run `dotnet restore` after the edit to refresh the project's " +
+                      "MSBuildProject marker. Defaults to `true`. Composite recipes that chain " +
+                      "multiple csproj-mutating steps may set this to `false` on intermediate steps " +
+                      "and finalize once with `EnsureCsprojAttestation`.",
+        Required = false)]
+    public bool RegenerateMarker { get; set; } = true;
+
     public class Accumulator
     {
         /// <summary>
@@ -94,7 +102,7 @@ public class UpgradeNuGetPackageVersion : ScanningRecipe<UpgradeNuGetPackageVers
     {
         return Preconditions.Check(
             new IsProjectFile(),
-            new UpgradeNuGetPackageVersionVisitor(PackageName, acc.ResolvedVersions, acc.PropertyUpdates));
+            new UpgradeNuGetPackageVersionVisitor(PackageName, acc.ResolvedVersions, acc.PropertyUpdates, RegenerateMarker));
     }
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/UpgradeNuGetPackageVersionVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/UpgradeNuGetPackageVersionVisitor.cs
@@ -27,7 +27,8 @@ namespace OpenRewrite.CSharp.Recipes;
 public class UpgradeNuGetPackageVersionVisitor(
     string packageName,
     Dictionary<string, string> resolvedVersions,
-    Dictionary<string, Dictionary<string, string>> propertyUpdates)
+    Dictionary<string, Dictionary<string, string>> propertyUpdates,
+    bool regenerateMarker = true)
     : XmlVisitor<ExecutionContext>
 {
     private bool _modified;
@@ -40,7 +41,7 @@ public class UpgradeNuGetPackageVersionVisitor(
         {
             _modified = true;
         }
-        if (_modified)
+        if (_modified && regenerateMarker)
         {
             DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
         }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -151,6 +151,245 @@ internal static class DotNetRestore
 }
 
 /// <summary>
+/// Serializes <c>nuget restore</c> invocations (and the one-time restore of the .NET
+/// Framework build assets) so only one runs at a time, and caches which paths have
+/// already been restored. Unlike <see cref="DotNetRestore"/>, the standalone NuGet CLI
+/// can restore legacy <c>packages.config</c> (non-SDK-style) projects, which
+/// <c>dotnet restore</c> treats as a no-op. On non-Windows machines the NuGet CLI runs
+/// through <c>mono</c>.
+/// </summary>
+internal static class NuGetRestore
+{
+    private static readonly SemaphoreSlim Gate = new(1, 1);
+    private static readonly HashSet<string> Restored = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly TimeSpan Timeout = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// .NET Framework build assets that are not present on non-Windows machines. They are
+    /// restored as NuGet packages and handed to MSBuildWorkspace as MSBuild properties so
+    /// legacy projects can be evaluated: <c>VSToolsPath</c> resolves the web-application
+    /// targets import and <c>TargetFrameworkRootPath</c> resolves the reference assemblies.
+    /// </summary>
+    private const string WebTargetsPackage = "MSBuild.Microsoft.VisualStudio.Web_WebApplication.Targets";
+    private const string WebTargetsVersion = "12.0.2";
+    private const string ReferenceAssembliesPackage = "Microsoft.NETFramework.ReferenceAssemblies.net48";
+    private const string ReferenceAssembliesVersion = "1.0.3";
+
+    private static NetFrameworkBuildAssets? _buildAssets;
+
+    internal record RestoreResult(int ExitCode, string Stdout, string Stderr, TimeSpan Elapsed, bool TimedOut);
+
+    /// <summary>
+    /// MSBuild property values pointing at restored .NET Framework build assets. A value is
+    /// null when the corresponding package could not be restored.
+    /// </summary>
+    internal record NetFrameworkBuildAssets(string? VSToolsPath, string? TargetFrameworkRootPath);
+
+    public static async Task<RestoreResult> RunAsync(string path, CancellationToken ct)
+    {
+        var key = "restore:" + Path.GetFullPath(path);
+
+        lock (Restored)
+        {
+            if (Restored.Contains(key))
+            {
+                Log.Debug("nuget restore: skipped (already restored) {Path}", path);
+                return new RestoreResult(0, "", "", TimeSpan.Zero, false);
+            }
+        }
+
+        await Gate.WaitAsync(ct);
+        try
+        {
+            lock (Restored)
+            {
+                if (Restored.Contains(key))
+                    return new RestoreResult(0, "", "", TimeSpan.Zero, false);
+            }
+
+            var cli = FindNuGetCli();
+            if (cli == null)
+            {
+                return new RestoreResult(-1, "",
+                    "NuGet CLI not found on PATH (need `nuget` on macOS/Linux or `nuget.exe` on Windows)",
+                    TimeSpan.Zero, false);
+            }
+
+            var args = new List<string>(cli.Value.PrefixArgs) { "restore", path, "-NonInteractive" };
+            var workingDir = Path.GetDirectoryName(Path.GetFullPath(path)) ?? ".";
+            Log.Debug("nuget restore: starting for {Path}", path);
+            var result = await RunProcessAsync(cli.Value.Exe, args, workingDir, ct);
+
+            if (result.ExitCode == 0 && !result.TimedOut)
+            {
+                lock (Restored)
+                {
+                    Restored.Add(key);
+                }
+            }
+
+            return result;
+        }
+        finally
+        {
+            Gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Restores the .NET Framework reference assemblies and web-application targets as NuGet
+    /// packages into a stable per-machine cache directory, so MSBuildWorkspace can evaluate
+    /// legacy projects on non-Windows machines. The result is cached for the process lifetime.
+    /// </summary>
+    public static async Task<NetFrameworkBuildAssets> RestoreNetFrameworkBuildAssetsAsync(CancellationToken ct)
+    {
+        if (_buildAssets != null)
+            return _buildAssets;
+
+        await Gate.WaitAsync(ct);
+        try
+        {
+            if (_buildAssets != null)
+                return _buildAssets;
+
+            // -ExcludeVersion keeps the installed folder names stable across versions.
+            var cacheDir = Path.Combine(Path.GetTempPath(), "openrewrite-netfx-build-assets");
+            var vsToolsPath = Path.Combine(cacheDir, WebTargetsPackage, "tools", "VSToolsPath");
+            var targetFrameworkRootPath = Path.Combine(cacheDir, ReferenceAssembliesPackage, "build");
+
+            var cli = FindNuGetCli();
+            if (cli == null)
+            {
+                Log.Debug("nuget install: NuGet CLI not found on PATH; skipping .NET Framework build assets");
+                _buildAssets = new NetFrameworkBuildAssets(null, null);
+                return _buildAssets;
+            }
+
+            if (!Directory.Exists(vsToolsPath))
+                await NuGetInstallAsync(cli.Value, WebTargetsPackage, WebTargetsVersion, cacheDir, ct);
+            if (!Directory.Exists(targetFrameworkRootPath))
+                await NuGetInstallAsync(cli.Value, ReferenceAssembliesPackage, ReferenceAssembliesVersion, cacheDir, ct);
+
+            _buildAssets = new NetFrameworkBuildAssets(
+                Directory.Exists(vsToolsPath) ? vsToolsPath : null,
+                Directory.Exists(targetFrameworkRootPath) ? targetFrameworkRootPath : null);
+            Log.Debug("nuget install: .NET Framework build assets — VSToolsPath={VSToolsPath}, TargetFrameworkRootPath={TargetFrameworkRootPath}",
+                _buildAssets.VSToolsPath ?? "(missing)", _buildAssets.TargetFrameworkRootPath ?? "(missing)");
+            return _buildAssets;
+        }
+        finally
+        {
+            Gate.Release();
+        }
+    }
+
+    private static async Task NuGetInstallAsync((string Exe, string[] PrefixArgs) cli, string package,
+        string version, string outputDirectory, CancellationToken ct)
+    {
+        Directory.CreateDirectory(outputDirectory);
+        var args = new List<string>(cli.PrefixArgs)
+        {
+            "install", package,
+            "-Version", version,
+            "-OutputDirectory", outputDirectory,
+            "-ExcludeVersion",
+            "-NonInteractive"
+        };
+        Log.Debug("nuget install: {Package} {Version} -> {OutputDirectory}", package, version, outputDirectory);
+        var result = await RunProcessAsync(cli.Exe, args, outputDirectory, ct);
+        if (result.ExitCode != 0)
+        {
+            Log.Debug("nuget install: {Package} failed (exit code {ExitCode})\n{Stdout}\n{Stderr}",
+                package, result.ExitCode, result.Stdout, result.Stderr);
+        }
+    }
+
+    private static async Task<RestoreResult> RunProcessAsync(string exe, IReadOnlyList<string> args,
+        string workingDirectory, CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+        var psi = new ProcessStartInfo(exe)
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var a in args)
+            psi.ArgumentList.Add(a);
+
+        using var process = Process.Start(psi);
+        if (process == null)
+        {
+            sw.Stop();
+            return new RestoreResult(-1, "", $"Failed to start process: {exe}", sw.Elapsed, false);
+        }
+
+        using var procCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        procCts.CancelAfter(Timeout);
+        try
+        {
+            // Read stdout/stderr before WaitForExitAsync to avoid a pipe-buffer deadlock.
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(procCts.Token);
+            var stderrTask = process.StandardError.ReadToEndAsync(procCts.Token);
+            await Task.WhenAll(stdoutTask, stderrTask);
+            await process.WaitForExitAsync(procCts.Token);
+            sw.Stop();
+            return new RestoreResult(process.ExitCode, stdoutTask.Result, stderrTask.Result, sw.Elapsed, false);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            sw.Stop();
+            return new RestoreResult(-1, "", "", sw.Elapsed, true);
+        }
+    }
+
+    /// <summary>
+    /// Resolves how to invoke the NuGet CLI: <c>nuget.exe</c> on Windows, <c>nuget</c> on
+    /// other platforms, falling back to <c>mono nuget.exe</c>. Returns null when no NuGet CLI
+    /// is found on the PATH.
+    /// </summary>
+    private static (string Exe, string[] PrefixArgs)? FindNuGetCli()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var win = FindOnPath("nuget.exe") ?? FindOnPath("nuget");
+            return win == null ? null : (win, Array.Empty<string>());
+        }
+        var nuget = FindOnPath("nuget");
+        if (nuget != null)
+            return (nuget, Array.Empty<string>());
+        var nugetExe = FindOnPath("nuget.exe");
+        if (nugetExe != null)
+            return ("mono", new[] { nugetExe });
+        return null;
+    }
+
+    private static string? FindOnPath(string fileName)
+    {
+        var pathVar = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathVar))
+            return null;
+        foreach (var dir in pathVar.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            try
+            {
+                var candidate = Path.Combine(dir.Trim(), fileName);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+            catch
+            {
+                // Skip invalid PATH entries.
+            }
+        }
+        return null;
+    }
+}
+
+/// <summary>
 /// Loads .sln or .csproj files via MSBuildWorkspace and parses all user source files
 /// in each project with correct references and configuration-derived preprocessor symbols.
 /// Generated files (source generator output in obj/) are excluded from the LST —
@@ -171,6 +410,11 @@ public class SolutionParser
         Log.Debug("LoadAsync: starting for {Path}", path);
         EnsureMSBuildRegistered();
 
+        // Legacy non-SDK projects use packages.config and must be restored with the
+        // standalone NuGet CLI; dotnet restore is a no-op for them. A solution can mix
+        // SDK-style and non-SDK projects, so when packages.config is present we run both.
+        var hasPackagesConfig = HasPackagesConfig(path);
+
         // Run dotnet restore to ensure NuGet packages are available for MSBuildWorkspace
         Log.Debug(">> dotnet restore ({FileName})", Path.GetFileName(path));
         var restoreResult = await DotNetRestore.RunAsync(path, ct);
@@ -187,15 +431,64 @@ public class SolutionParser
             var details = string.Join("\n",
                 new[] { restoreResult.Stdout, restoreResult.Stderr }
                     .Where(s => !string.IsNullOrWhiteSpace(s)));
-            throw new InvalidOperationException(
-                $"dotnet restore failed (exit code {restoreResult.ExitCode}) for {path}\n{details}");
+            if (hasPackagesConfig)
+            {
+                // For packages.config projects the authoritative restore is the nuget
+                // restore below; a dotnet restore failure here is not fatal.
+                Log.Debug("dotnet restore failed (exit code {ExitCode}) for {Path}; continuing with nuget restore\n{Details}",
+                    restoreResult.ExitCode, path, details);
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    $"dotnet restore failed (exit code {restoreResult.ExitCode}) for {path}\n{details}");
+            }
+        }
+        else
+        {
+            Log.Debug("dotnet restore succeeded in {Elapsed}", restoreResult.Elapsed);
         }
 
-        Log.Debug("dotnet restore succeeded in {Elapsed}", restoreResult.Elapsed);
+        // MSBuild properties handed to MSBuildWorkspace. For packages.config projects these
+        // point MSBuild at the .NET Framework reference assemblies and web-application
+        // targets that are not present on non-Windows machines.
+        var msbuildProperties = new Dictionary<string, string>();
+
+        if (hasPackagesConfig)
+        {
+            Log.Debug(">> nuget restore ({FileName})", Path.GetFileName(path));
+            var nugetResult = await NuGetRestore.RunAsync(path, ct);
+            Log.Debug("<< nuget restore ({FileName}) ({Elapsed})", Path.GetFileName(path), nugetResult.Elapsed);
+
+            if (nugetResult.TimedOut)
+            {
+                throw new InvalidOperationException(
+                    $"nuget restore timed out after {nugetResult.Elapsed} for {path}");
+            }
+
+            if (nugetResult.ExitCode != 0)
+            {
+                var details = string.Join("\n",
+                    new[] { nugetResult.Stdout, nugetResult.Stderr }
+                        .Where(s => !string.IsNullOrWhiteSpace(s)));
+                throw new InvalidOperationException(
+                    $"nuget restore failed (exit code {nugetResult.ExitCode}) for {path}\n{details}");
+            }
+
+            // Restore the .NET Framework reference assemblies and web-application targets
+            // so MSBuildWorkspace can evaluate legacy projects on non-Windows machines.
+            var buildAssets = await NuGetRestore.RestoreNetFrameworkBuildAssetsAsync(ct);
+            if (buildAssets.VSToolsPath != null)
+                msbuildProperties["VSToolsPath"] = buildAssets.VSToolsPath;
+            if (buildAssets.TargetFrameworkRootPath != null)
+                msbuildProperties["TargetFrameworkRootPath"] = buildAssets.TargetFrameworkRootPath;
+        }
 
         var sw = Stopwatch.StartNew();
         Log.Debug("MSBuildWorkspace: creating workspace");
-        var workspace = MSBuildWorkspace.Create();
+        var workspace = msbuildProperties.Count > 0
+            ? MSBuildWorkspace.Create(msbuildProperties)
+            : MSBuildWorkspace.Create();
         var progress = new Progress<ProjectLoadProgress>(p =>
         {
             Log.Debug("MSBuild progress: {Operation} {FilePath}", p.Operation, Path.GetFileName(p.FilePath));
@@ -556,6 +849,28 @@ public class SolutionParser
         {
             MSBuildLocator.RegisterDefaults();
             _msbuildRegistered = true;
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the solution/project directory tree contains a <c>packages.config</c>,
+    /// which marks a legacy non-SDK-style project whose NuGet dependencies must be restored
+    /// with the standalone NuGet CLI rather than <c>dotnet restore</c>.
+    /// </summary>
+    private static bool HasPackagesConfig(string path)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(Path.GetFullPath(path));
+            if (dir == null)
+                return false;
+            return Directory.EnumerateFiles(dir, "packages.config", SearchOption.AllDirectories).Any();
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("HasPackagesConfig: failed for {Path} ({ExType}: {ExMessage}), assuming none",
+                path, ex.GetType().Name, ex.Message);
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary

MSBuildWorkspace cannot load non-SDK-style (legacy) projects unless their NuGet packages are present on disk, and `dotnet restore` is a no-op for `packages.config`. This change detects `packages.config` anywhere in the solution tree and additionally runs `nuget restore` (serialized via a semaphore and cached per path) so legacy projects can be loaded. It also restores the .NET Framework reference assemblies and web-application MSBuild targets as NuGet packages and passes them to `MSBuildWorkspace` as `VSToolsPath` / `TargetFrameworkRootPath`, allowing legacy projects to be evaluated on non-Windows machines (using `mono` to invoke `nuget.exe` when needed).

## Test plan

- [ ] Load an SDK-style solution and confirm behavior is unchanged
- [ ] Load a solution containing a legacy `packages.config` project on macOS/Linux and confirm it parses