### PR TITLE
Scala: support for scala-xml parsing

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -606,6 +606,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return visitRepeatedType((S.RepeatedType) tree, p);
         } else if (tree instanceof S.SplatExpression) {
             return visitSplatExpression((S.SplatExpression) tree, p);
+        } else if (tree instanceof S.XmlLiteral) {
+            return visitXmlLiteral((S.XmlLiteral) tree, p);
         } else if (tree instanceof S.Alternative) {
             return visitAlternative((S.Alternative) tree, p);
         } else if (tree instanceof S.QualifiedSuper) {
@@ -1570,6 +1572,13 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         p.append('*');
         afterSyntax(splatExpression, p);
         return splatExpression;
+    }
+
+    public J visitXmlLiteral(S.XmlLiteral xmlLiteral, PrintOutputCapture<P> p) {
+        beforeSyntax(xmlLiteral, Space.Location.LANGUAGE_EXTENSION, p);
+        p.append(xmlLiteral.getSource());
+        afterSyntax(xmlLiteral, p);
+        return xmlLiteral;
     }
 
     public J visitAlternative(S.Alternative alternative, PrintOutputCapture<P> p) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -217,6 +217,13 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         return s;
     }
 
+    public J visitXmlLiteral(S.XmlLiteral xmlLiteral, P p) {
+        S.XmlLiteral x = xmlLiteral;
+        x = x.withPrefix(visitSpace(x.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        x = x.withMarkers(visitMarkers(x.getMarkers(), p));
+        return x;
+    }
+
     public J visitAlternative(S.Alternative alternative, P p) {
         S.Alternative a = alternative;
         a = a.withPrefix(visitSpace(a.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -1882,4 +1882,49 @@ public interface S extends J {
             }
         }
     }
+
+    /**
+     * A Scala XML literal expression such as {@code <message>Hello</message>}.
+     * Stored opaquely as raw source text — the Scala compiler desugars XML into
+     * {@code scala.xml.Elem}/{@code Group}/{@code NodeBuffer} constructor calls,
+     * but the original syntax is preserved here for round-trip fidelity.
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    final class XmlLiteral implements S, Expression, Statement, TypedTree {
+
+        @With @Getter @EqualsAndHashCode.Include
+        UUID id;
+
+        @With @Getter
+        Space prefix;
+
+        @With @Getter
+        Markers markers;
+
+        @With @Getter
+        String source;
+
+        @With @Getter
+        @Nullable
+        JavaType type;
+
+        public XmlLiteral(UUID id, Space prefix, Markers markers, String source, @Nullable JavaType type) {
+            this.id = id;
+            this.prefix = prefix;
+            this.markers = markers;
+            this.source = source;
+            this.type = type;
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitXmlLiteral(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Statement getCoordinates() {
+            return new CoordinateBuilder.Statement(this);
+        }
+    }
 }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -211,6 +211,7 @@ class ScalaTreeVisitor(
       case ifTree: Trees.If[?] => visitIf(ifTree)
       case whileTree: Trees.WhileDo[?] => visitWhileDo(whileTree)
       case forTree: untpd.ForDo => visitForDo(forTree)
+      case xmlb: untpd.XMLBlock => visitXmlLiteral(xmlb)
       case block: Trees.Block[?] => visitBlock(block)
       case td: Trees.TypeDef[?] if td.isClassDef => visitClassDef(td)
       case td: Trees.TypeDef[?] => visitTypeAlias(td)
@@ -2965,8 +2966,8 @@ class ScalaTreeVisitor(
         }
       }
     } else if (vd.rhs != null && !vd.rhs.isEmpty && vd.rhs.span.exists) {
-      val rhsStart = Math.max(0, vd.rhs.span.start - offsetAdjustment)
-      
+      val rhsStart = effectiveStart(vd.rhs)
+
       // Look for equals sign
       if (cursor < rhsStart && rhsStart <= source.length) {
         val beforeRhs = source.substring(cursor, rhsStart)
@@ -3408,7 +3409,7 @@ class ScalaTreeVisitor(
 
     // Find the position of the equals sign
     val lhsEnd = Math.max(cursor, Math.max(0, asg.lhs.span.end - offsetAdjustment))
-    val rhsStart = Math.max(0, asg.rhs.span.start - offsetAdjustment)
+    val rhsStart = effectiveStart(asg.rhs)
     var equalsSpace = Space.EMPTY
     var valueSpace = Space.EMPTY
     var isCompoundAssignment = false
@@ -5694,7 +5695,7 @@ class ScalaTreeVisitor(
         // The actual body exists in source. Re-parse to get AST nodes.
         reparseProcedureBody(dd)
       case rhs if rhs != untpd.EmptyTree && rhs.span.exists =>
-        val rhsStart = Math.max(0, rhs.span.start - offsetAdjustment)
+        val rhsStart = effectiveStart(rhs)
         var beforeEquals = Space.EMPTY
         if (!isProcedureSyntax && cursor < rhsStart && rhsStart <= source.length) {
           val beforeBody = source.substring(cursor, rhsStart)
@@ -5866,7 +5867,7 @@ class ScalaTreeVisitor(
     // Default value `= expr`
     var initBefore: Space = Space.EMPTY
     val initializer: Expression = if (vd.rhs != untpd.EmptyTree && vd.rhs.span.exists) {
-      val rhsStart = Math.max(0, vd.rhs.span.start - offsetAdjustment)
+      val rhsStart = effectiveStart(vd.rhs)
       if (cursor < rhsStart) {
         val before = source.substring(cursor, rhsStart)
         val eqIdx = positionOfNextIn(before, "=", 0)
@@ -5989,7 +5990,7 @@ class ScalaTreeVisitor(
     // Handle default value
     var initBefore: Space = Space.EMPTY
     val initializer: Expression = if (vd.rhs != untpd.EmptyTree && vd.rhs.span.exists) {
-      val rhsStart = Math.max(0, vd.rhs.span.start - offsetAdjustment)
+      val rhsStart = effectiveStart(vd.rhs)
       if (cursor < rhsStart) {
         val before = source.substring(cursor, rhsStart)
         val eqIdx = positionOfNextIn(before, "=", 0)
@@ -6539,6 +6540,56 @@ class ScalaTreeVisitor(
     updateCursor(superTree.span.end)
     new S.QualifiedSuper(Tree.randomId(), prefix, Markers.EMPTY,
       qualifierIdent, mixIdent, typeFor(superTree.span))
+  }
+
+  /**
+   * Dotty's `untpd.XMLBlock` span starts one character past the leading `<`. Parent visitors
+   * (ValDef, Assign, DefDef, ...) compute `rhs.span.start - offsetAdjustment` to advance the
+   * cursor to the rhs, which for XML would leave the `<` behind as a stray non-whitespace
+   * character in the parent's "before-rhs" Space. Use this helper instead of the raw
+   * `tree.span.start - offsetAdjustment` computation so the cursor lands on the `<`.
+   */
+  private def effectiveStart(tree: Trees.Tree[?]): Int = {
+    val adjStart = Math.max(0, tree.span.start - offsetAdjustment)
+    tree match {
+      case _: untpd.XMLBlock
+          if adjStart > 0 && adjStart <= source.length && source.charAt(adjStart - 1) == '<' =>
+        adjStart - 1
+      case _ => adjStart
+    }
+  }
+
+  private def visitXmlLiteral(xmlb: untpd.XMLBlock): S.XmlLiteral = {
+    // Scala XML literals are parsed into untpd.XMLBlock, whose span covers the original
+    // XML source — *except* it starts one char past the leading `<`. Back up to include
+    // it. The desugared scala.xml.Elem/NodeBuffer subtree is ignored on purpose: walking
+    // it would collide with the actual XML syntax in source.
+    val adjustedStart = Math.max(0, xmlb.span.start - offsetAdjustment)
+    val adjustedEnd = Math.max(0, xmlb.span.end - offsetAdjustment)
+    val realStart =
+      if (adjustedStart > 0 && adjustedStart <= source.length && source.charAt(adjustedStart - 1) == '<') adjustedStart - 1
+      else adjustedStart
+
+    val prefixStart = cursor
+    val prefix = if (realStart > cursor && realStart <= source.length) {
+      cursor = realStart
+      Space.format(source, prefixStart, realStart)
+    } else Space.EMPTY
+
+    val sourceText =
+      if (realStart >= 0 && adjustedEnd <= source.length && adjustedEnd > realStart) {
+        val s = source.substring(realStart, adjustedEnd)
+        cursor = adjustedEnd
+        s
+      } else ""
+
+    new S.XmlLiteral(
+      Tree.randomId(),
+      prefix,
+      Markers.EMPTY,
+      sourceText,
+      typeOfTree(xmlb)
+    )
   }
 
   private def visitInterpolatedString(interp: untpd.InterpolatedString): J.Identifier = {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaXmlLiteralTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaXmlLiteralTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.scala.Assertions.scala;
+
+class ScalaXmlLiteralTest implements RewriteTest {
+
+    @Test
+    void simpleElement() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  val x = <message>Hello World!</message>
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void selfClosingElement() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  val x = <br/>
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void nestedElements() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  val x = <a><b>text</b></a>
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void elementWithAttributes() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  val x = <a href="x">y</a>
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void adjacentElements() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  val x = <a/><b/>
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void xmlAsMethodBody() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def greet: scala.xml.Elem = <hello/>
+                }
+                """
+            )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?

Adding support for parsing scala-xml syntax, e.g.
```
                object Test {
                  val x = <a href="x">y</a>
                }
```

## What's your motivation?

This hasn't been supported yet.