### PR TITLE
Pass --skip-existing to twine upload for Python snapshots

### DIFF
--- a/rewrite-python/build.gradle.kts
+++ b/rewrite-python/build.gradle.kts
@@ -363,6 +363,7 @@ val pythonPublish by tasks.registering(Exec::class) {
     commandLine(
         pythonExe.absolutePath, "-m", "twine", "upload",
         "--config-file", ".pypirc",
+        "--skip-existing",
         "dist/*"
     )
 


### PR DESCRIPTION
## Summary
- The Python snapshot version is built from the git commit timestamp, so re-running `pythonPublish` on the same commit produces a byte-identical wheel filename.
- PyPI rejects repeat uploads with `400 Bad Request` (seen in [this run](https://github.com/openrewrite/rewrite/actions/runs/26047703539/job/76576108365)), even when the contents match — unlike Sonatype it doesn't timestamp snapshot uploads.
- Adding `--skip-existing` turns those re-runs into a no-op instead of failing the build, matching the semantics we want here ("same commit → same artifact → re-publish is idempotent").

## Test plan
- [ ] CI green on this branch
- [ ] Next merge to `main` publishes Python snapshot successfully; re-running the publish job on the same commit succeeds rather than 400-ing