### PR TITLE
Kotlin recipe DSL: preserve dot-on-its-own-line layout across chain collapse

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
@@ -132,6 +132,7 @@ public final class GeneratedRecipeSupport {
                         if (matchedTypeArgs != null) {
                             result = ((J.MethodInvocation) result).withTypeParameters(matchedTypeArgs);
                         }
+                        result = preserveSelectAfter((J.MethodInvocation) result, method);
                         result = preserveTrailingLambdaShape((J.MethodInvocation) result);
                     }
                     return result.withPrefix(method.getPrefix());
@@ -197,12 +198,42 @@ public final class GeneratedRecipeSupport {
                     if (matchedTypeArgs != null) {
                         result = ((J.MethodInvocation) result).withTypeParameters(matchedTypeArgs);
                     }
+                    result = preserveSelectAfter((J.MethodInvocation) result, method);
                     result = preserveTrailingLambdaShape((J.MethodInvocation) result);
                 }
                 return result.withPrefix(method.getPrefix());
             }
         };
         return wrapWithPrecondition(matcherSpecsLine, walker);
+    }
+
+    /**
+     * When a chain-collapse rewrite replaces a multi-line chain like
+     * <pre>{@code xs
+     *     .filter(p)
+     *     .firstOrNull()}</pre>
+     * with a single fused call ({@code xs.firstOrNull(p)}), the synthesized result's
+     * outer call has an empty {@link J.MethodInvocation.Padding#getSelect() select.after}
+     * — the whitespace that used to sit between the inner's text end and the outer's
+     * {@code .}. The author's intent (and Kotlin convention for long chains) was to
+     * keep the trailing call on its own indented line. We carry the original outer's
+     * select.after onto the result so the dot-on-its-own-line layout survives the
+     * rewrite.
+     *
+     * <p>No-op when the original outer had no select.after (already single-line)
+     * or when the result has no select (e.g. the template produced a non-method
+     * shape).
+     */
+    private static J.MethodInvocation preserveSelectAfter(J.MethodInvocation result, J.MethodInvocation matched) {
+        JRightPadded<Expression> resultSelect = result.getPadding().getSelect();
+        JRightPadded<Expression> matchedSelect = matched.getPadding().getSelect();
+        if (resultSelect == null || matchedSelect == null) {
+            return result;
+        }
+        if (matchedSelect.getAfter().getWhitespace().isEmpty()) {
+            return result;
+        }
+        return result.getPadding().withSelect(resultSelect.withAfter(matchedSelect.getAfter()));
     }
 
     private static class ChainSourceRef {
@@ -296,6 +327,7 @@ public final class GeneratedRecipeSupport {
                     if (matchedTypeArgs != null) {
                         result = ((J.MethodInvocation) result).withTypeParameters(matchedTypeArgs);
                     }
+                    result = preserveSelectAfter((J.MethodInvocation) result, method);
                     result = preserveTrailingLambdaShape((J.MethodInvocation) result);
                 }
                 return result.withPrefix(unary.getPrefix());
@@ -441,6 +473,7 @@ public final class GeneratedRecipeSupport {
                         if (matchedTypeArgs != null) {
                             result = ((J.MethodInvocation) result).withTypeParameters(matchedTypeArgs);
                         }
+                        result = preserveSelectAfter((J.MethodInvocation) result, method);
                     }
                     return result.withPrefix(method.getPrefix());
                 }

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
@@ -240,6 +240,173 @@ class RecipePluginRewriteTest : RewriteTest {
     }
 
     @Test
+    fun `chain collapse preserves dot-on-its-own-line layout`() {
+        // Real-world Kotlin chains are formatted with each `.member(...)` on its
+        // own indented line. The chain-collapse rewrite synthesizes a single
+        // fused call (`xs.firstOrNull(p)`), whose select.after defaults to ""
+        // — jamming the trailing `.firstOrNull` onto the previous line and
+        // clobbering the author's formatting. `preserveSelectAfter` copies the
+        // matched outer call's select.after onto the result so the new outer
+        // sits on its own dot-prefixed line, matching where the matched outer
+        // originally was.
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseFirstOrNullWithPredicate = recipe(
+                    displayName = "Use firstOrNull(p) instead of filter(p).firstOrNull()",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { xs: List<Any>, p: (Any) -> Boolean -> xs.filter(p).firstOrNull() } to { xs, p -> xs.firstOrNull(p) }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseFirstOrNullWithPredicate",
+        )
+        rewriteRun(
+            { spec ->
+                spec.recipe(r)
+                // The synthesized `firstOrNull(p)` outer call doesn't get a
+                // resolved JavaType.Method on the template-substituted MethodInvocation;
+                // the formatting check is what this test is about, not type
+                // attribution.
+                spec.typeValidationOptions(org.openrewrite.test.TypeValidation.none())
+            },
+            kotlin(
+                """
+                fun first(xs: List<Int>): Int? = xs
+                    .filter { it > 0 }
+                    .firstOrNull()
+                """,
+                """
+                fun first(xs: List<Int>): Int? = xs
+                    .firstOrNull { it > 0 }
+                """,
+            ),
+        )
+    }
+
+    @Test
+    fun `chain collapse — single-line input stays single-line (no false-positive newline)`() {
+        // Negative case for `preserveSelectAfter`: if the matched outer call's
+        // select.after has no whitespace (the chain was on one line), we must
+        // NOT add any newline to the result. The helper's empty-whitespace
+        // guard short-circuits, leaving the result's select.after at the
+        // template-substituted default (also empty).
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseFirstOrNullWithPredicate = recipe(
+                    displayName = "...",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { xs: List<Any>, p: (Any) -> Boolean -> xs.filter(p).firstOrNull() } to { xs, p -> xs.firstOrNull(p) }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseFirstOrNullWithPredicate",
+        )
+        rewriteRun(
+            { spec ->
+                spec.recipe(r)
+                spec.typeValidationOptions(org.openrewrite.test.TypeValidation.none())
+            },
+            kotlin(
+                """
+                fun first(xs: List<Int>): Int? = xs.filter { it > 0 }.firstOrNull()
+                """,
+                """
+                fun first(xs: List<Int>): Int? = xs.firstOrNull { it > 0 }
+                """,
+            ),
+        )
+    }
+
+    @Test
+    fun `chain collapse — alternate shape (map then filterNotNull) also preserves layout`() {
+        // Second chain-shape variant to prove the fix isn't specific to
+        // filter/firstOrNull. The `map { f }.filterNotNull()` collapse is the
+        // pattern that surfaced the formatting bug in moderneinc/recipes-kotlin
+        // corpus runs.
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseMapNotNull = recipe(
+                    displayName = "...",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { xs: List<Any>, f: (Any) -> Int? -> xs.map(f).filterNotNull() } to { xs, f -> xs.mapNotNull(f) }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseMapNotNull",
+        )
+        rewriteRun(
+            { spec ->
+                spec.recipe(r)
+                spec.typeValidationOptions(org.openrewrite.test.TypeValidation.none())
+            },
+            kotlin(
+                """
+                fun nonNull(xs: List<Int>): List<Int> = xs
+                    .map { it.takeIf { v -> v > 0 } }
+                    .filterNotNull()
+                """,
+                """
+                fun nonNull(xs: List<Int>): List<Int> = xs
+                    .mapNotNull { it.takeIf { v -> v > 0 } }
+                """,
+            ),
+        )
+    }
+
+    @Test
+    fun `bare single-call rewrite preserves dot-on-its-own-line layout`() {
+        // Same fix, different rewrite path: `methodInvocationRewrite` (the
+        // non-chain bare path) also runs the template through
+        // `KotlinTemplate.builder(...).apply(...)`, which loses the matched
+        // outer's `select.after`. The fix is the same shared helper, but the
+        // wiring is per-path — exercise the bare path explicitly so we don't
+        // regress one branch while fixing another. The recipe pair here
+        // (`lowercase` → `uppercase`) is semantically nonsensical; the test
+        // is about formatting only. `toUpperCase`-style stdlib deprecations
+        // are `@Deprecated(level=ERROR)` in modern Kotlin and won't compile
+        // inside `RecipePluginCompileFixture`.
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseUppercase = recipe(
+                    displayName = "Use uppercase()",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { s: String -> s.lowercase() } to { s -> s.uppercase() }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseUppercase",
+        )
+        rewriteRun(
+            { spec ->
+                spec.recipe(r)
+                spec.typeValidationOptions(org.openrewrite.test.TypeValidation.none())
+            },
+            kotlin(
+                """
+                fun upper(s: String): String = s
+                    .lowercase()
+                """,
+                """
+                fun upper(s: String): String = s
+                    .uppercase()
+                """,
+            ),
+        )
+    }
+
+    @Test
     fun `multi-before mixed shapes — receiver in one, arg in the other`() {
         // Two before lambdas with the same param count but different
         // canonical signatures: `s.toInt()` binds `s` to the (extension)


### PR DESCRIPTION
## Summary

Real-world Kotlin chains are formatted with each `.member(...)` on its own indented line:

```kotlin
xs
    .filter { p }
    .firstOrNull()
```

The K2 plugin's chain-collapse rewrite synthesizes a single fused call (`xs.firstOrNull(p)`) by applying a `KotlinTemplate` at the matched outer's coordinates. The result's outer-call `select.after` defaults to `""` — the whitespace that used to sit between the inner's text end and the outer's `.` is lost — and the synthesized `.firstOrNull(p)` ends up jammed onto the previous line. Surfaced by Performance / BestPractices chain-collapse recipes in `moderneinc/recipes-kotlin` running against real corpora.

`preserveSelectAfter` copies the matched outer call's `select.after` onto the template-substituted result so the new outer sits on its own dot-prefixed line, matching where the matched outer originally was.

Wired into every method-invocation rewrite path so chain-shape and bare-shape rewrites both preserve the author's line layout:
- `methodInvocationRewrite` (bare Kotlin)
- `methodInvocationRewriteJava` (Java template)
- `methodInvocationRewriteKotlinNotNull` (K.Unary unwrap)
- `chainMethodInvocationRewrite` (two-segment chain)

No-op when the matched outer has no `select.after` whitespace (already single-line) or when the result has no select (template produced a non-method shape).

## Test plan

Four new tests in `RecipePluginRewriteTest`:

- [x] `chain collapse preserves dot-on-its-own-line layout` — positive case for the chain path (`filter(p).firstOrNull()` collapse with multi-line layout in the source)
- [x] `chain collapse — single-line input stays single-line (no false-positive newline)` — negative case proving the empty-whitespace guard doesn't insert newlines into single-line chains
- [x] `chain collapse — alternate shape (map then filterNotNull) also preserves layout` — second chain-shape variant proving the fix isn't specific to filter/firstOrNull (this is the shape that surfaced the bug)
- [x] `bare single-call rewrite preserves dot-on-its-own-line layout` — exercises the non-chain `methodInvocationRewrite` path so we don't regress one branch while fixing another

`./gradlew :rewrite-kotlin:test` green.