### PR TITLE
Semver: accept globs in metadataPattern; fix backpatch-style upgrades

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
@@ -402,6 +402,40 @@ public class StringUtils {
     }
 
     /**
+     * Translate a simple glob pattern (using {@code *} for any run of characters and {@code ?}
+     * for any single character) into an equivalent Java regular expression that can be fed
+     * into {@link Pattern#compile(String)}. All other characters are escaped via
+     * {@link Pattern#quote(String)} so they are treated literally.
+     *
+     * @param glob the glob pattern; {@code null} returns {@code null}
+     * @return a regex that matches the same set of strings as the glob, or {@code null} if {@code glob} is null
+     * @see #matchesGlob(String, String)
+     */
+    public static @Nullable String globToRegex(@Nullable String glob) {
+        if (glob == null) {
+            return null;
+        }
+        StringBuilder regex = new StringBuilder(glob.length() + 8);
+        StringBuilder literal = new StringBuilder();
+        for (int i = 0; i < glob.length(); i++) {
+            char c = glob.charAt(i);
+            if (c == '*' || c == '?') {
+                if (literal.length() > 0) {
+                    regex.append(Pattern.quote(literal.toString()));
+                    literal.setLength(0);
+                }
+                regex.append(c == '*' ? ".*" : ".");
+            } else {
+                literal.append(c);
+            }
+        }
+        if (literal.length() > 0) {
+            regex.append(Pattern.quote(literal.toString()));
+        }
+        return regex.toString();
+    }
+
+    /**
      * Checks if a given string matches a specified glob pattern. A glob pattern may include
      * special characters such as '*' to represent any sequence of characters and '?' to
      * represent any single character.

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -153,7 +153,33 @@ public class LatestRelease implements VersionComparator {
         }
 
         // Both are either pre-release or release versions, do string comparison
-        return normalized1.compareTo(normalized2);
+        int normalizedCompare = normalized1.compareTo(normalized2);
+        if (normalizedCompare != 0) {
+            return normalizedCompare;
+        }
+        // When the metadata-stripped versions are equal, fall back to comparing the
+        // un-normalized versions lexicographically — but only when BOTH originals match
+        // the metadata pattern, so that build-metadata-only differences within a matching
+        // family (e.g. 1.2.3+backpatch.001 vs 1.2.3+backpatch.002) are ordered
+        // deterministically while heterogeneous metadata (e.g. 29.0-jre vs 29, under
+        // pattern `-jre`) continues to compare equal as a HyphenRange would expect.
+        if (metadataPattern != null && bothMatchMetadata(nv1, nv2, metadataPattern)) {
+            return nv1.compareTo(nv2);
+        }
+        return 0;
+    }
+
+    private static boolean bothMatchMetadata(String nv1, String nv2, String metadataPattern) {
+        return matchesMetadata(nv1, metadataPattern) && matchesMetadata(nv2, metadataPattern);
+    }
+
+    private static boolean matchesMetadata(String version, String metadataPattern) {
+        java.util.regex.Matcher m = VersionComparator.RELEASE_PATTERN.matcher(version);
+        if (!m.matches()) {
+            return false;
+        }
+        String qualifier = m.group("qualifier");
+        return qualifier != null && qualifier.matches(metadataPattern);
     }
 
     /**

--- a/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
@@ -35,40 +35,59 @@ public class Semver {
     }
 
     /**
-     * Validates the given version against an optional pattern
+     * Validates the given version against an optional pattern.
+     * <p>
+     * The {@code metadataPattern} is interpreted first as a regular expression. If that fails to
+     * compile, it is treated as a glob (where {@code *} matches any run of characters and {@code ?}
+     * matches any single character) and converted to an equivalent regex via
+     * {@link StringUtils#globToRegex(String)}. This lets simple patterns like {@code "+backpatch*"}
+     * work without needing to be regex-escaped.
      *
      * @param toVersion       the version to validate. Node-style [version selectors](https://docs.openrewrite.org/reference/dependency-version-selectors) may be used.
      * @param metadataPattern optional metadata appended to the version. Allows version selection to be extended beyond the original Node Semver semantics. So for example,
-     *                        Setting 'version' to "25-29" can be paired with a metadata pattern of "-jre" to select Guava 29.0-jre
+     *                        setting 'version' to "25-29" can be paired with a metadata pattern of "-jre" to select Guava 29.0-jre. Accepts either a regex or a glob.
      * @return the validation result
      */
     public static Validated<VersionComparator> validate(String toVersion, @Nullable String metadataPattern) {
+        String canonicalPattern = canonicalizeMetadataPattern(metadataPattern);
         return Validated.<VersionComparator, String>testNone(
                 "metadataPattern",
-                "must be a valid regular expression",
-                metadataPattern, metadata -> {
-                    try {
-                        if (metadata != null) {
-                            Pattern.compile(metadata);
-                        }
-                        return true;
-                    } catch (Throwable e) {
-                        return false;
-                    }
-                }
+                "must be a valid regular expression or glob",
+                metadataPattern, metadata -> metadata == null || canonicalPattern != null
         ).and(Validated.<VersionComparator>none()
-                .or(LatestRelease.buildLatestRelease(toVersion, metadataPattern))
-                .or(LatestIntegration.build(toVersion, metadataPattern))
-                .or(LatestMinor.build(toVersion, metadataPattern))
-                .or(LatestPatch.build(toVersion, metadataPattern))
-                .or(HyphenRange.build(toVersion, metadataPattern))
-                .or(XRange.build(toVersion, metadataPattern))
-                .or(TildeRange.build(toVersion, metadataPattern))
-                .or(CaretRange.build(toVersion, metadataPattern))
-                .or(SetRange.build(toVersion, metadataPattern))
-                .or(ExactVersionWithPattern.build(toVersion, metadataPattern))
+                .or(LatestRelease.buildLatestRelease(toVersion, canonicalPattern))
+                .or(LatestIntegration.build(toVersion, canonicalPattern))
+                .or(LatestMinor.build(toVersion, canonicalPattern))
+                .or(LatestPatch.build(toVersion, canonicalPattern))
+                .or(HyphenRange.build(toVersion, canonicalPattern))
+                .or(XRange.build(toVersion, canonicalPattern))
+                .or(TildeRange.build(toVersion, canonicalPattern))
+                .or(CaretRange.build(toVersion, canonicalPattern))
+                .or(SetRange.build(toVersion, canonicalPattern))
+                .or(ExactVersionWithPattern.build(toVersion, canonicalPattern))
                 .or(ExactVersion.build(toVersion))
         );
+    }
+
+    private static @Nullable String canonicalizeMetadataPattern(@Nullable String metadataPattern) {
+        if (metadataPattern == null) {
+            return null;
+        }
+        try {
+            Pattern.compile(metadataPattern);
+            return metadataPattern;
+        } catch (Throwable regexFailure) {
+            String asRegex = StringUtils.globToRegex(metadataPattern);
+            try {
+                if (asRegex != null) {
+                    Pattern.compile(asRegex);
+                    return asRegex;
+                }
+            } catch (Throwable ignored) {
+                // fall through
+            }
+            return null;
+        }
     }
 
     public static String majorVersion(String version) {

--- a/rewrite-core/src/test/java/org/openrewrite/semver/SemverGlobMetadataTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/SemverGlobMetadataTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.semver;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Validated;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SemverGlobMetadataTest {
+
+    @Test
+    void globMetadataPatternAcceptedAndMatches() {
+        Validated<VersionComparator> validated = Semver.validate("latest.patch", "+backpatch*");
+        assertThat(validated.isValid()).isTrue();
+        VersionComparator vc = validated.getValue();
+        assertThat(vc).isNotNull();
+        assertThat(vc.isValid("1.2.3", "1.2.3+backpatch.001")).isTrue();
+        assertThat(vc.isValid("1.2.3", "1.2.3+backpatch.999")).isTrue();
+        assertThat(vc.isValid("1.2.3", "1.2.3")).isFalse();
+        assertThat(vc.isValid("1.2.3", "1.2.3+something-else")).isFalse();
+    }
+
+    @Test
+    void globQuestionMarkMatchesSingleCharacter() {
+        Validated<VersionComparator> validated = Semver.validate("latest.patch", "+backpatch.00?");
+        assertThat(validated.isValid()).isTrue();
+        VersionComparator vc = validated.getValue();
+        assertThat(vc).isNotNull();
+        assertThat(vc.isValid("1.2.3", "1.2.3+backpatch.001")).isTrue();
+        assertThat(vc.isValid("1.2.3", "1.2.3+backpatch.0010")).isFalse();
+    }
+
+    @Test
+    void literalMetadataPatternStillWorks() {
+        Validated<VersionComparator> validated = Semver.validate("25-29", "-jre");
+        assertThat(validated.isValid()).isTrue();
+        VersionComparator vc = validated.getValue();
+        assertThat(vc).isNotNull();
+        assertThat(vc.isValid("25", "29.0-jre")).isTrue();
+        assertThat(vc.isValid("25", "29.0-android")).isFalse();
+    }
+
+    @Test
+    void regexMetadataPatternStillWorks() {
+        Validated<VersionComparator> validated = Semver.validate("latest.patch", "\\+backpatch\\..*");
+        assertThat(validated.isValid()).isTrue();
+        VersionComparator vc = validated.getValue();
+        assertThat(vc).isNotNull();
+        assertThat(vc.isValid("1.2.3", "1.2.3+backpatch.001")).isTrue();
+        assertThat(vc.isValid("1.2.3", "1.2.3")).isFalse();
+    }
+
+    @Test
+    void unbalancedRegexFallsBackToGlobThatHappensToBeValid() {
+        // "(" is invalid regex on its own, and the glob form Pattern.quotes it -> valid regex.
+        Validated<VersionComparator> validated = Semver.validate("latest.patch", "+(suffix");
+        assertThat(validated.isValid()).isTrue();
+        VersionComparator vc = validated.getValue();
+        assertThat(vc).isNotNull();
+        assertThat(vc.isValid("1.2.3", "1.2.3+(suffix")).isTrue();
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/trait/MavenDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/trait/MavenDependency.java
@@ -63,8 +63,11 @@ public class MavenDependency implements Trait<Xml.Tag> {
         String finalVersion = !Semver.isVersion(currentVersion) ? "0.0.0" : currentVersion;
 
         // in the case of "latest.patch", a new version can only be derived if the
-        // current version is a semantic version
-        if (versionComparator instanceof LatestPatch && !versionComparator.isValid(finalVersion, finalVersion)) {
+        // current version is a semantic version. The metadata pattern is intentionally
+        // omitted here — it filters candidate target versions, not the source version
+        // (e.g. upgrading 1.2.3 to 1.2.3+backpatch.001 is valid even though the source
+        // doesn't carry the metadata suffix).
+        if (versionComparator instanceof LatestPatch && !new LatestPatch(null).isValid(finalVersion, finalVersion)) {
             return null;
         }
 


### PR DESCRIPTION
## Summary

- **`Semver.validate` accepts glob syntax** for `metadataPattern`. Previously the pattern was compiled as a regex only, so simple inputs like `+backpatch*` failed validation. Now the validator tries regex first and, on failure, converts the pattern from glob (`*` → `.*`, `?` → `.`, everything else `Pattern.quote`d) via the new `StringUtils.globToRegex`. Pure literals and existing regex patterns are unaffected.
- **`MavenDependency.findNewerVersion`** no longer short-circuits when the source version doesn't match the metadata pattern. The pattern is meant to filter target candidates, not the source. The semver-only base-version sanity check is preserved via `new LatestPatch(null).isValid(...)`.
- **`LatestRelease.compare`** breaks ties lexicographically when both candidates' originals match the metadata pattern, so `1.2.3+backpatch.001` < `1.2.3+backpatch.002` instead of comparing equal. The HyphenRange behaviour where `28-jre` and `28` are equivalent under pattern `-jre` is preserved by the both-match guard.

Together these three fixes unblock recipes that upgrade dependencies from a base version with no build metadata to a `M.N.P+suffix` artifact (e.g. emergency backpatch releases that retain the upstream patch level but add a build-metadata identifier for ordering).

## Test plan
- [x] New `SemverGlobMetadataTest` covers `+backpatch*` glob, `+backpatch.00?` glob, literal `-jre`, regex `\\+backpatch\\..*`, and a mixed regex/glob fallback case.
- [x] Existing `LatestRelease`, `LatestPatch`, `HyphenRange`, `TildeRange`, `CaretRange`, `XRange`, `SetRange`, `LatestMinor`, `LatestIntegration`, and `Semver` tests pass unchanged.
- [x] `rewrite-maven` `UpgradeDependencyVersion` / `UpgradeTransitiveDependencyVersion` test suites pass.