### PR TITLE
Scala: fix parsing of whitespace after annotations

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
@@ -290,9 +290,14 @@ class ScalaCompilerBridge {
     val declarationPattern = """^\s*(package|import|class|object|trait|def|val|var|type|private|protected|public|final|lazy|implicit|case\s+class|case\s+object)\s""".r
     val startsWithDeclaration = declarationPattern.findFirstIn(trimmed).isDefined
 
+    // A leading `@Ann` (optionally `@Ann(...)`) is a declaration annotation, not an
+    // expression — wrapping it as `val result = @Ann object Foo` produces garbage.
+    val startsWithAnnotation = trimmed.startsWith("@")
+
     !hasMultipleLines &&
     !hasPostfixOperator &&
     !startsWithDeclaration &&
+    !startsWithAnnotation &&
     !trimmed.startsWith("//") &&
     !trimmed.startsWith("/*") &&
     trimmed.nonEmpty

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -3047,16 +3047,32 @@ class ScalaTreeVisitor(
   }
   
   private def visitModuleDef(md: untpd.ModuleDef): J.ClassDeclaration = {
-    val prefix = extractPrefix(md.span)
-    
-    // Extract the source text to find modifiers  
+    val hasAnnotations = md.mods != null && md.mods.annotations.nonEmpty
+    // When annotations are present they own the leading whitespace; otherwise
+    // the prefix lives on the ModuleDef itself.
+    val prefix = if (hasAnnotations) Space.EMPTY else extractPrefix(md.span)
+
+    val leadingAnnotations = new util.ArrayList[J.Annotation]()
+    if (hasAnnotations) {
+      for (annot <- md.mods.annotations) {
+        visitTree(annot) match {
+          case ann: J.Annotation => leadingAnnotations.add(ann)
+          case _ =>
+        }
+      }
+    }
+
+    // Extract the source text to find modifiers
     val adjustedStart = Math.max(0, md.span.start - offsetAdjustment)
     val adjustedEnd = Math.max(0, md.span.end - offsetAdjustment)
     var modifierText = ""
     var objectIndex = -1
-    
+
     var isEnumCase = false
-    if (adjustedStart >= cursor && adjustedEnd <= source.length) {
+    // When annotations were consumed, cursor sits after them; modifierText must
+    // be derived from the post-annotation position, not the ModuleDef span start.
+    val modifierScanStart = if (hasAnnotations) cursor else adjustedStart
+    if (modifierScanStart >= cursor && adjustedEnd <= source.length) {
       val sourceSnippet = source.substring(cursor, adjustedEnd)
       objectIndex = findKeyword(sourceSnippet, "object")
       val caseIndex = findKeyword(sourceSnippet, "case")
@@ -3388,7 +3404,7 @@ class ScalaTreeVisitor(
       Tree.randomId(),
       prefix,
       objectMarkers,
-      Collections.emptyList(), // annotations
+      leadingAnnotations,
       modifiers,
       kind,
       name,

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -2717,7 +2717,13 @@ class ScalaTreeVisitor(
       var scanning = true
       while (scanning && modifierEndPos < sourceSnippet.length) {
         val remaining = sourceSnippet.substring(modifierEndPos)
-        val modSpace = if (modifierEndPos > leadingWs) Space.SINGLE_SPACE else Space.EMPTY
+        // When the first modifier in this loop sits directly after annotations (no preceding access
+        // modifier consumed leadingWs), preserve that whitespace as the modifier's prefix. Otherwise
+        // a newline between `@Ann` and e.g. `lazy val` is silently collapsed to nothing on print.
+        val modSpace =
+          if (modifierEndPos > leadingWs) Space.SINGLE_SPACE
+          else if (leadingWs > 0) Space.format(sourceSnippet.substring(0, leadingWs))
+          else Space.EMPTY
 
         if (remaining.startsWith("final ")) {
           hasExplicitFinal = true

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/AnnotationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/AnnotationTest.java
@@ -136,4 +136,18 @@ public class AnnotationTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void annotationOnOwnLineBeforeLazyVal() {
+        rewriteRun(
+            scala(
+                """
+                class Test {
+                  @JsonIgnore
+                  lazy val schema: String = "x"
+                }
+                """
+            )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/AnnotationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/AnnotationTest.java
@@ -216,6 +216,17 @@ public class AnnotationTest implements RewriteTest {
     }
 
     @Test
+    void annotationOnSameLineBeforeObject() {
+        rewriteRun(
+            scala(
+                """
+                @deprecated object Marker
+                """
+            )
+        );
+    }
+
+    @Test
     void annotationOnOwnLineBeforeCaseObject() {
         rewriteRun(
             scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/AnnotationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/AnnotationTest.java
@@ -150,4 +150,109 @@ public class AnnotationTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void annotationOnOwnLineBeforeFinalClass() {
+        rewriteRun(
+            scala(
+                """
+                @SerialVersionUID(1L)
+                final class Box(val x: Int)
+                """
+            )
+        );
+    }
+
+    @Test
+    void annotationOnOwnLineBeforeOverrideDef() {
+        rewriteRun(
+            scala(
+                """
+                class Test {
+                  @Override
+                  override def toString: String = "x"
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void annotationOnOwnLineBeforePrivateVal() {
+        rewriteRun(
+            scala(
+                """
+                class Test {
+                  @JsonIgnore
+                  private val secret: String = "x"
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void annotationOnOwnLineBeforeSealedTrait() {
+        rewriteRun(
+            scala(
+                """
+                @SerialVersionUID(1L)
+                sealed trait Status
+                """
+            )
+        );
+    }
+
+    @Test
+    void annotationOnOwnLineBeforeObject() {
+        rewriteRun(
+            scala(
+                """
+                @deprecated
+                object Marker
+                """
+            )
+        );
+    }
+
+    @Test
+    void annotationOnOwnLineBeforeCaseObject() {
+        rewriteRun(
+            scala(
+                """
+                @SerialVersionUID(1L)
+                case object Marker
+                """
+            )
+        );
+    }
+
+    @Test
+    void multipleAnnotationsBeforeLazyVal() {
+        rewriteRun(
+            scala(
+                """
+                class Test {
+                  @JsonIgnore
+                  @transient
+                  lazy val schema: String = "x"
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void annotationOnOwnLineBeforeImplicitVal() {
+        rewriteRun(
+            scala(
+                """
+                class Test {
+                  @JsonIgnore
+                  implicit val schema: String = "x"
+                }
+                """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fix Scala parsing behavior around annotations and whitespace.

## What's your motivation?

They suffer from idempotency issues.