### PR TITLE
Scala: support `_=>`

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -40,6 +40,7 @@ import org.openrewrite.scala.marker.TypeProjection;
 import org.openrewrite.scala.marker.ScalaForLoop;
 import org.openrewrite.scala.marker.TypeAscription;
 import org.openrewrite.scala.marker.PartialFunctionLiteral;
+import org.openrewrite.scala.marker.ContextFunctionArrow;
 import org.openrewrite.scala.marker.UnderscorePlaceholderLambda;
 import org.openrewrite.scala.marker.ValVarKeyword;
 import org.openrewrite.scala.marker.PackageSemicolon;
@@ -1487,11 +1488,15 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         
         // Print arrow with spacing
         visitSpace(lambda.getArrow(), Space.Location.LAMBDA_ARROW_PREFIX, p);
-        p.append("=>");
-        
+        if (lambda.getMarkers().findFirst(ContextFunctionArrow.class).isPresent()) {
+            p.append("?=>");
+        } else {
+            p.append("=>");
+        }
+
         // Print lambda body
         visit(lambda.getBody(), p);
-        
+
         afterSyntax(lambda, p);
         return lambda;
     }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/ContextFunctionArrow.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/ContextFunctionArrow.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.marker;
+
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Marker for a context-function arrow: {@code ?=>} instead of {@code =>}.
+ * Applied to {@link org.openrewrite.java.tree.J.Lambda} when the source uses
+ * Scala 3 context-function syntax (e.g. {@code _ ?=> body}).
+ */
+public class ContextFunctionArrow implements Marker {
+    private final UUID id;
+
+    public ContextFunctionArrow(UUID id) {
+        this.id = id;
+    }
+
+    @Override
+    public UUID getId() {
+        return id;
+    }
+
+    @Override
+    public ContextFunctionArrow withId(UUID id) {
+        return new ContextFunctionArrow(id);
+    }
+}

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -39,6 +39,7 @@ import org.openrewrite.scala.marker.FunctionApplication
 import org.openrewrite.scala.marker.TypeAscription
 import org.openrewrite.scala.marker.UnderscorePlaceholderLambda
 import org.openrewrite.scala.marker.PartialFunctionLiteral
+import org.openrewrite.scala.marker.ContextFunctionArrow
 import org.openrewrite.scala.marker.Curried
 import org.openrewrite.scala.marker.InfixNotation
 import org.openrewrite.scala.marker.RightAssociative
@@ -8161,29 +8162,41 @@ class ScalaTreeVisitor(
       params
     )
     
-    // Extract arrow and spacing (arrowIndex already computed above)
+    // Extract arrow and spacing (arrowIndex already computed above).
+    // Scala 3 context-function arrow `?=>` puts a `?` immediately before `=>`;
+    // treat the `?` as part of the arrow so that whitespace before it is captured
+    // as the arrow prefix.
     var arrowPrefix = Space.EMPTY
+    var isContextArrow = false
     if (arrowIndex >= 0) {
-      // Find the space before =>
-      var spaceStart = arrowIndex - 1
+      val arrowTokenStart = if (arrowIndex > 0 && funcSource.charAt(arrowIndex - 1) == '?') {
+        isContextArrow = true
+        arrowIndex - 1
+      } else arrowIndex
+      // Find the space before the arrow token
+      var spaceStart = arrowTokenStart - 1
       while (spaceStart >= 0 && Character.isWhitespace(funcSource.charAt(spaceStart))) {
         spaceStart -= 1
       }
-      if (spaceStart < arrowIndex - 1) {
-        arrowPrefix = Space.format(funcSource.substring(spaceStart + 1, arrowIndex))
+      if (spaceStart < arrowTokenStart - 1) {
+        arrowPrefix = Space.format(funcSource.substring(spaceStart + 1, arrowTokenStart))
       }
       // Move cursor to right after the arrow (past =>)
       val arrowEndPos = func.span.start + arrowIndex + 2 - offsetAdjustment
       cursor = arrowEndPos
     }
-    
+
     // Visit the lambda body - it will extract its own prefix including space after =>
     val body = visitTree(func.body)
-    
+
+    val lambdaMarkers = if (isContextArrow) {
+      Markers.build(Collections.singletonList(new ContextFunctionArrow(java.util.UUID.randomUUID())))
+    } else Markers.EMPTY
+
     new J.Lambda(
       Tree.randomId(),
       prefix,
-      Markers.EMPTY,
+      lambdaMarkers,
       updatedParams,
       arrowPrefix,
       body,

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
@@ -387,6 +387,28 @@ class CompilationUnitTest implements RewriteTest {
     }
 
     @Test
+    void contextFunctionWithWildcardParam() {
+        rewriteRun(
+          scala(
+            """
+            val f: Int ?=> Int = _ ?=> 1
+            """
+          )
+        );
+    }
+
+    @Test
+    void contextFunctionWithNamedParam() {
+        rewriteRun(
+          scala(
+            """
+            val f: Int ?=> Int = x ?=> x + 1
+            """
+          )
+        );
+    }
+
+    @Test
     void nestedColonArgLambdas() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

Fix Scala parser handling of the new `_=>` operator.

## What's your motivation?

It's currently not recognized at all.