### PR TITLE
JavaScript: make `prettier` a devDependency to fix flaky npmBuild

### DIFF
--- a/rewrite-javascript/rewrite/package-lock.json
+++ b/rewrite-javascript/rewrite/package-lock.json
@@ -33,6 +33,7 @@
         "@types/tmp": "^0.2.6",
         "benchmark": "^2.1.4",
         "bun": "^1.3.5",
+        "prettier": "^3.7.4",
         "vitest": "^4.0.18"
       },
       "optionalDependencies": {
@@ -1654,8 +1655,8 @@
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/rewrite-javascript/rewrite/package.json
+++ b/rewrite-javascript/rewrite/package.json
@@ -83,6 +83,7 @@
     "@types/tmp": "^0.2.6",
     "benchmark": "^2.1.4",
     "bun": "^1.3.5",
+    "prettier": "^3.7.4",
     "vitest": "^4.0.18"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Summary

- `:rewrite-javascript:npmBuild` failed on main with 9 `TS2307: Cannot find module 'prettier'` errors ([run 26104109474](https://github.com/openrewrite/rewrite/actions/runs/26104109474/job/76763012176)).
- Root cause: `prettier` was in `optionalDependencies` only. npm normally installs optional deps, but silently skips them on transient install failures. The successful run earlier the same day installed 81 packages in 29s; the failing run installed 80 in 45s — prettier was the one quietly dropped. Reproducible locally with `rm -rf node_modules/prettier && npm run build`.
- Fix: also list `prettier` in `devDependencies` so it's always installed for the build. Kept it in `optionalDependencies` so end-user installs of `@openrewrite/rewrite` still pull it in (with the existing bundled-prettier fallback if they `--omit=optional`).

## Test plan

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] Confirmed previous failure mode: removing `node_modules/prettier` before this change reproduces the exact 9 TS2307 errors from CI; after this change, prettier is reinstalled by `npm install` as a devDep so the failure can't recur