### PR TITLE
Kotlin recipe DSL: emit precise arg-count matcher patterns instead of (..)

### DIFF
--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
@@ -1038,10 +1038,11 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             return "$ownerFqn#$propName"
         }
         val methodName = owner.name.asString()
+        val argsPattern = computeArgsPattern(owner)
 
         val dispatchFqn = owner.dispatchReceiverParameter?.type?.classFqName?.asString()
         if (dispatchFqn != null) {
-            return "$dispatchFqn $methodName(..)"
+            return "$dispatchFqn $methodName($argsPattern)"
         }
 
         // Java static methods (and `@JvmStatic` companions): the IrSimpleFunction's
@@ -1052,15 +1053,42 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         // tripping the test framework's single-cycle stability check.
         val parent = owner.parent
         if (parent is IrClass) {
-            return "${parent.kotlinFqName.asString()} $methodName(..)"
+            return "${parent.kotlinFqName.asString()} $methodName($argsPattern)"
         }
 
         val facadeFqn = computeJvmFacadeFqn(owner)
         return if (facadeFqn != null) {
-            "$facadeFqn $methodName(..)"
+            "$facadeFqn $methodName($argsPattern)"
         } else {
-            "* $methodName(..)"
+            "* $methodName($argsPattern)"
         }
+    }
+
+    /**
+     * Emit a precise MethodMatcher arg pattern (e.g. `*,*` for two args, empty for
+     * zero) instead of the `..` wildcard. Tightening the arg count is what
+     * distinguishes overloaded methods on the same name: `Iterable<T>.any()` (no
+     * predicate) versus `Iterable<T>.any(predicate: (T) -> Boolean)`. A recipe
+     * authored as `xs.filter(p).any()` would otherwise also match
+     * `xs.filter(p1).any { p2 }` via `(..)` and silently drop the `p2` predicate.
+     *
+     * Arg count is computed against the JVM-resolved signature, which differs by
+     * call shape:
+     * <ul>
+     *   <li>Member call (dispatch receiver, e.g. {@code String.lowercase()}): the
+     *       receiver is dispatched, so the JVM arg list is just the source-level
+     *       value args.</li>
+     *   <li>Extension or top-level facade call (e.g. {@code Iterable<T>.any(p)}):
+     *       the receiver is lifted to the first arg of the static facade method,
+     *       so the JVM arg list is the (extension) receiver plus value args.</li>
+     * </ul>
+     */
+    private fun computeArgsPattern(owner: IrSimpleFunction): String {
+        val isDispatched = owner.dispatchReceiverParameter != null
+        val extReceiverArg = if (!isDispatched && owner.extensionReceiverParameter != null) 1 else 0
+        val jvmArgCount = owner.valueParameters.size + extReceiverArg
+        if (jvmArgCount == 0) return ""
+        return List(jvmArgCount) { "*" }.joinToString(",")
     }
 
     private fun computeJvmFacadeFqn(fn: IrSimpleFunction): String? {

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
@@ -407,6 +407,47 @@ class RecipePluginRewriteTest : RewriteTest {
     }
 
     @Test
+    fun `recipe targeting no-arg overload does not match the with-predicate overload`() {
+        // Regression: with a `(..)` wildcard arg pattern, the recipe
+        // `xs.filter(p).any() -> xs.any(p)` also matched the *predicate*
+        // overload `xs.filter(p1).any { p2 }` and silently dropped `p2` (along
+        // with the entire `.any { ... }` body the author wrote). `(..)` was
+        // tightened to `(*,*)` / `(*)` / `()` — the precise JVM arg count —
+        // so overloaded names no longer cross-match.
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseAnyWithPredicateInsteadOfFilterAny = recipe(
+                    displayName = "...",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { xs: List<Any>, p: (Any) -> Boolean -> xs.filter(p).any() } to { xs, p -> xs.any(p) }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseAnyWithPredicateInsteadOfFilterAny",
+        )
+        rewriteRun(
+            { spec ->
+                spec.recipe(r)
+                spec.typeValidationOptions(org.openrewrite.test.TypeValidation.none())
+            },
+            kotlin(
+                // `filter { ... }.any { ... }` — the WITH-predicate any. The
+                // recipe targets the NO-arg any. Without the arg-count guard,
+                // the rewrite drops the inner `.any { p2 }` body. With the
+                // guard it leaves the source untouched (no expected diff).
+                """
+                fun hasMatch(xs: List<Int>): Boolean = xs
+                    .filter { it > 0 }
+                    .any { it > 10 }
+                """,
+            ),
+        )
+    }
+
+    @Test
     fun `multi-before mixed shapes — receiver in one, arg in the other`() {
         // Two before lambdas with the same param count but different
         // canonical signatures: `s.toInt()` binds `s` to the (extension)


### PR DESCRIPTION
## Summary

Recipe `xs.filter(p).any()` → `xs.any(p)` was silently dropping code when the source had `xs.filter(p1).any { p2 }` — the *with-predicate* `any` overload. The K2 plugin's computed matcher spec was `kotlin.collections.CollectionsKt any(..)`, where `(..)` matches any arity, so both `any()` and `any(predicate)` matched. The substitution-source CSV references only the inner's arg slot, so the runtime helper happily produced `xs.any(p1)`, throwing away the outer `.any { p2 }` body the author wrote.

Real-world surface: a ~15-line `.any { bounds -> Rectangle(...).intersects(...) }` in `YiiGuxing/TranslationPlugin` collapsed to a one-line `.any { windowLocation == ... }`. The `.any { }` body was the actual intersect check; it just vanished.

Tighten `computeMatcherSpec` to emit the precise JVM arg count instead of `(..)`:

- 0 args → `()`
- 1 arg  → `(*)`
- 2 args → `(*,*)`
- etc.

Arg count is computed against the JVM-resolved signature, differing by call shape:

- Member call (dispatch receiver, e.g. `String.lowercase()`): just the source-level value args.
- Extension or top-level facade call (e.g. `Iterable<T>.any(p)`): the receiver is lifted to the first arg of the static facade method, so the JVM arg list is (extension) receiver + value args.

Overloaded names like `any` / `none` / `count` no longer cross-match across overloads.

## Test plan

- [x] New `recipe targeting no-arg overload does not match the with-predicate overload` test in `RecipePluginRewriteTest` pins the user-reported case: the `xs.filter(p).any() → xs.any(p)` recipe leaves `xs.filter { ... }.any { ... }` untouched instead of clobbering it.
- [x] `./gradlew :rewrite-kotlin:test` green (no regression in the existing single-overload recipes).