### PR TITLE
Scala: fix parsing of a block following a partial function

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -806,26 +806,30 @@ class ScalaTreeVisitor(
       }
 
       for ((arg, i) <- app.args.zipWithIndex) {
-        visitTree(arg) match {
-          case expr: Expression =>
-            val isLast = i == app.args.length - 1
-            if (!isLast) {
-              val argEnd = Math.max(0, arg.span.end - offsetAdjustment)
-              val commaPos = positionOfNext(",", Math.max(cursor, argEnd))
-              val beforeComma = if (commaPos > argEnd) Space.format(source, argEnd, commaPos) else Space.EMPTY
-              if (commaPos >= 0 && commaPos + 1 < source.length) {
-                cursor = commaPos + 1
-              }
-              args.add(JRightPadded.build(expr).withAfter(beforeComma))
-            } else {
-              val argEnd = Math.max(0, arg.span.end - offsetAdjustment)
-              val closePos = positionOfNext(")", Math.max(cursor, argEnd))
-              val beforeClose = if (closePos > argEnd) {
-                Space.format(source, argEnd, closePos)
-              } else Space.EMPTY
-              args.add(new JRightPadded(expr, beforeClose, Markers.EMPTY))
+        val visited = visitTree(arg)
+        val expr: Expression = visited match {
+          case e: Expression => e
+          case j: J => new S.StatementExpression(Tree.randomId(), j)
+          case _ => null
+        }
+        if (expr != null) {
+          val isLast = i == app.args.length - 1
+          if (!isLast) {
+            val argEnd = Math.max(0, arg.span.end - offsetAdjustment)
+            val commaPos = positionOfNext(",", Math.max(cursor, argEnd))
+            val beforeComma = if (commaPos > argEnd) Space.format(source, argEnd, commaPos) else Space.EMPTY
+            if (commaPos >= 0 && commaPos + 1 < source.length) {
+              cursor = commaPos + 1
             }
-          case _ =>
+            args.add(JRightPadded.build(expr).withAfter(beforeComma))
+          } else {
+            val argEnd = Math.max(0, arg.span.end - offsetAdjustment)
+            val closePos = positionOfNext(")", Math.max(cursor, argEnd))
+            val beforeClose = if (closePos > argEnd) {
+              Space.format(source, argEnd, closePos)
+            } else Space.EMPTY
+            args.add(new JRightPadded(expr, beforeClose, Markers.EMPTY))
+          }
         }
       }
 

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MethodInvocationTest.java
@@ -148,6 +148,69 @@ class MethodInvocationTest implements RewriteTest {
     }
 
     @Test
+    void partialFunctionBlockAndTupleLambdaBlockArgs() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                def quick[A](read: PartialFunction[Any, A], write: (Int, Int) => Any): A = ???
+                val h = quick(
+                  { case s: String => s },
+                  { (a, b) => a + b }
+                )
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void partialFunctionFollowedByPlainLambda() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                def quick[A](read: PartialFunction[Any, A], write: Int => Any): A = ???
+                val h = quick({ case s: String => s }, x => x)
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void partialFunctionFollowedByBlockLambda() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                def quick[A](read: PartialFunction[Any, A], write: Int => Any): A = ???
+                val h = quick({ case s: String => s }, { x => x })
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void quickHandlerLilaPattern() {
+        rewriteRun(
+          scala(
+            """
+              object Handlers {
+                trait BSONHandler[T]
+                def quickHandler[T](read: PartialFunction[Any, T], write: (Int, Int) => Any): BSONHandler[T] = ???
+                val h: BSONHandler[Int] = quickHandler(
+                  { case Seq(a, b) => a },
+                  { (a, b) => Seq(a, b) }
+                )
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void methodCallInExpression() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

Scala: fix a specific case of a block following a partial function.

## What's your motivation?

It suffers from idempotency issues.
