### PR TITLE
Scala: enabling postfixOps compiler setting

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
@@ -65,6 +65,12 @@ class ScalaCompilerBridge {
       val fresh = baseCtx.fresh
       // Accept both Scala 2 and Scala 3 syntax (including indentation-based).
       fresh.setSetting(fresh.settings.source, "3.6-migration")
+      // Enable `postfixOps` so the parser emits `PostfixOp` AST nodes for trailing
+      // postfix calls (e.g., `xs filter p list`). Without this, Dotty's parser
+      // silently drops the trailing token rather than emitting an AST node.
+      fresh.setSetting(fresh.settings.language, List(
+        new dotty.tools.dotc.config.Settings.Setting.ChoiceWithHelp[String]("postfixOps", "")
+      ))
       fresh.setReporter(storeReporter)
       // Send compiler output to a designated dir so .class files don't pollute cwd.
       if (outputDir != null) {
@@ -224,6 +230,12 @@ class ScalaCompilerBridge {
     val configuredCtx: Context = {
       val fresh = driver.getInitialContext.fresh
       fresh.setSetting(fresh.settings.source, "3.6-migration")
+      // Enable `postfixOps` so the parser emits `PostfixOp` AST nodes for trailing
+      // postfix calls (e.g., `xs filter p list`). Without this, Dotty's parser
+      // silently drops the trailing token rather than emitting an AST node.
+      fresh.setSetting(fresh.settings.language, List(
+        new dotty.tools.dotc.config.Settings.Setting.ChoiceWithHelp[String]("postfixOps", "")
+      ))
       fresh.setReporter(storeReporter)
       fresh
     }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/Scala2CompatTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/Scala2CompatTest.java
@@ -1313,6 +1313,20 @@ class Scala2CompatTest implements RewriteTest {
     }
 
     @Test
+    void trailingPostfixAfterInfixChain() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def foo(xs: List[Int]) =
+                    xs filter (_ > 0) sortBy (_.toString) list
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void forComprehensionWithBlockBody() {
         rewriteRun(
             scala(


### PR DESCRIPTION
## What's changed?

Enabling the postfixOps Scala compiler setting.

## What's your motivation?

Some pieces of code which we want to parse rely on this.