### PR TITLE
Scala: fix parameterless method declaration with type parameters

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5467,9 +5467,9 @@ class ScalaTreeVisitor(
       val nameEnd = Math.max(0, dd.nameSpan.end - offsetAdjustment)
       var i = nameEnd
       while (i < source.length && source.charAt(i).isWhitespace) i += 1
-      // Skip a `[...]` type parameter list (only relevant for given aliases — for
-      // ordinary defs, `def foo[T]` always has either `()` or `:` after `]`).
-      if (isGivenDefDef && i < source.length && source.charAt(i) == '[') {
+      // Skip a `[...]` type parameter list. After the type params, an ordinary
+      // def may have `()` (regular method) or `:`/`=` (parameterless method).
+      if (i < source.length && source.charAt(i) == '[') {
         var depth = 1
         i += 1
         while (i < source.length && depth > 0) {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -577,6 +577,21 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void parameterlessDefWithTypeParameter() {
+        rewriteRun(
+            scala(
+                """
+                trait T {
+                  def underlying[A]: A
+                  def empty[A]: List[A] = Nil
+                  def nil[A] = List.empty[A]
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void spaceBeforeEqualsWithNoSpaceAfter() {
         rewriteRun(scala("def f(): Unit ={ }"));
     }


### PR DESCRIPTION
## What's changed?

Fix Scala parser for parameterless method declaration with (generics) type parameters.

## What's your motivation?

They suffer from idempotency issues.