### PR TITLE
Scala: fix printing of curried method declaration with default values

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -575,6 +575,14 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                     }
                     visit(te, p);
                 }
+                if (!vd.getVariables().isEmpty()) {
+                    JLeftPadded<Expression> init = vd.getVariables().get(0).getPadding().getInitializer();
+                    if (init != null) {
+                        visitSpace(init.getBefore(), Space.Location.VARIABLE_INITIALIZER, p);
+                        p.append('=');
+                        visit(init.getElement(), p);
+                    }
+                }
             } else {
                 visit(elem, p);
             }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -300,6 +300,21 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void curriedParamsWithDefaults() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  def foo(name: String)(insert: String = null, targetSchema: String = null): Unit = {
+                    println(insert)
+                  }
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void tripleCurriedParamList() {
         rewriteRun(
             scala(


### PR DESCRIPTION
## What's changed?

Fix Scala parser for curried method declarations with default values of arguments.

## What's your motivation?

They suffer from idempotency issues.