### PR TITLE
Scala: fix bodyless classes

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -4797,12 +4797,13 @@ class ScalaTreeVisitor(
           // If there are body statements, we definitely have a body
           true
         } else if (td.span.exists) {
-          // For empty bodies, check if there's a "{" in the entire class span
-          val classStart = Math.max(0, td.span.start - offsetAdjustment)
+          // For empty bodies, check if there's a "{" in the source after the cursor.
+          // The cursor has been advanced past the name, type params, constructor params,
+          // and extends clause, so any `{` here is the body delimiter — not one that
+          // could appear earlier inside a string interpolation like `s"${x}"`.
           val classEnd = Math.max(0, td.span.end - offsetAdjustment)
-          if (classStart < classEnd && classEnd <= source.length) {
-            val classSource = source.substring(classStart, classEnd)
-            classSource.contains("{")
+          if (cursor < classEnd && classEnd <= source.length) {
+            source.substring(cursor, classEnd).contains("{")
           } else {
             false
           }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
@@ -450,4 +450,31 @@ class ClassDeclarationTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void extendsWithBraceLikeContentInParentArgs() {
+        // Each class has no body, but the parent's constructor args contain a `{` that
+        // must not be mistaken for the body opener:
+        //   - block-form string interpolation `s"${x}"`
+        //   - literal `{` inside a plain string
+        //   - `{` inside a block comment
+        //   - `{` introducing a block expression argument
+        //   - interpolation followed by a `with` trait
+        //   - multi-line extends used by `case class`
+        rewriteRun(
+            scala(
+                """
+                trait T
+                class A(msg: String) extends Exception(msg)
+                class B1(x: Int) extends Exception(s"${x}")
+                class B2(x: Int) extends Exception("{ not a body")
+                class B3(x: Int) extends Exception(/* { */ "x")
+                class B4(x: Int) extends Exception({ val m = "msg"; m })
+                class B5(x: Int) extends Exception(s"${x}") with T
+                case class B6(json: String, err: String)
+                    extends A(s"[x] $json --- ${err.length}")
+                """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fix parsing of Scala classes which have no body, e.g.
```
class A(msg: String) extends Exception(msg)
```

## What's your motivation?

They might suffer from idempotency issues.