### PR TITLE
Provide JDK 26 toolchain for scheduled Gradle workflows

### DIFF
--- a/.github/workflows/eol-images-update.yml
+++ b/.github/workflows/eol-images-update.yml
@@ -19,7 +19,9 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 25
+          java-version: |
+            26
+            25
 
       - name: Update EOL images
         run: ./gradlew :rewrite-docker:syncEolImages

--- a/.github/workflows/gradle-wrapper-update.yml
+++ b/.github/workflows/gradle-wrapper-update.yml
@@ -19,7 +19,9 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 25
+          java-version: |
+            26
+            25
 
       - name: Update versions
         run: ./gradlew :rewrite-gradle:syncWrapperScripts


### PR DESCRIPTION
Two scheduled workflows have been failing (or about to fail) during Gradle configuration:

> A problem occurred configuring project ':rewrite-java-next'.
> Cannot find a Java installation on your machine matching: {languageVersion=26, ...}. Toolchain download repositories have not been configured.

`rewrite-java-next` was introduced in #7719 (2026-05-20) and pins its toolchain to JDK 26. Gradle resolves toolchains at configuration time for every invocation, so any workflow that runs a Gradle task needs a JDK 26 install available.

Affected workflows (both set up only JDK 25):
- `.github/workflows/eol-images-update.yml` — fails now: https://github.com/openrewrite/rewrite/actions/runs/26158388582/job/76943600026 (runs Wednesdays)
- `.github/workflows/gradle-wrapper-update.yml` — last run on 2026-05-19 passed (predates rewrite-java-next); next Tuesday run would fail

`ci.yml` already installs 26 + 25 + 21, so it is unaffected. `repository-backup.yml` and `stale.yml` reuse shared workflows that don't run Gradle, so they are unaffected.

Fix: add JDK 26 to the `actions/setup-java` step in both workflows so `setup-java` writes a `toolchains.xml` Gradle can use.