### PR TITLE
Scala: S.Import and support for rich import/export syntax

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaParserVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaParserVisitor.java
@@ -73,7 +73,6 @@ public class ScalaParserVisitor {
         CompilationUnitResult result = converter.convertToCompilationUnit(parseResult, source, typeFactory);
 
         J.Package packageDecl = result.getPackageDecl();
-        List<J.Import> imports = result.getImports();
         List<Statement> statements = result.getStatements();
 
 
@@ -102,8 +101,8 @@ public class ScalaParserVisitor {
         }
 
         // If we didn't get any statements and have source content, create an Unknown node
-        // But skip if we already have a package declaration or imports (to avoid duplication)
-        if (statements.isEmpty() && !source.trim().isEmpty() && packageDecl == null && imports.isEmpty()) {
+        // But skip if we already have a package declaration (to avoid duplication)
+        if (statements.isEmpty() && !source.trim().isEmpty() && packageDecl == null) {
             J.Unknown.Source unknownSource = new J.Unknown.Source(
                 randomId(),
                 EMPTY,
@@ -136,7 +135,6 @@ public class ScalaParserVisitor {
             charsetBomMarked,              // boolean charsetBomMarked
             null,                          // Checksum checksum
             packageDecl == null ? null : JRightPadded.build(packageDecl),
-            JRightPadded.withElements(Collections.emptyList(), imports),
             JRightPadded.withElements(Collections.emptyList(), statements),
             eof                            // Space eof
         );

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -616,6 +616,10 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return visitTypeAlias((S.TypeAlias) tree, p);
         } else if (tree instanceof S.Export) {
             return visitExport((S.Export) tree, p);
+        } else if (tree instanceof S.Import) {
+            return visitSImport((S.Import) tree, p);
+        } else if (tree instanceof S.ImportSelector) {
+            return visitImportSelector((S.ImportSelector) tree, p);
         } else if (tree instanceof S.PatternDefinition) {
             return visitPatternDefinition((S.PatternDefinition) tree, p);
         } else if (tree instanceof S.AnonymousGiven) {
@@ -660,28 +664,12 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         if (scu.getPackageDeclaration() != null) {
             visit(scu.getPackageDeclaration(), p);
             boolean packageEndsWithSemicolon = scu.getPackageDeclaration().getMarkers().findFirst(PackageSemicolon.class).isPresent();
-            // In Scala, package declarations are followed by a newline
-            // Check if the next element has a newline in its prefix, if not add one
-            if (!packageEndsWithSemicolon && !scu.getImports().isEmpty()) {
-                J.Import firstImport = scu.getImports().get(0);
-                String firstImportPrefix = firstImport.getPrefix().getWhitespace();
-                if (!firstImportPrefix.startsWith("\n") && !firstImportPrefix.startsWith(";")) {
-                    p.append("\n");
-                }
-            } else if (!packageEndsWithSemicolon && !scu.getStatements().isEmpty()) {
+            if (!packageEndsWithSemicolon && !scu.getStatements().isEmpty()) {
                 Statement firstStatement = scu.getStatements().get(0);
                 String firstStatementPrefix = firstStatement.getPrefix().getWhitespace();
                 if (!firstStatementPrefix.startsWith("\n") && !firstStatementPrefix.startsWith(";")) {
                     p.append("\n");
                 }
-            }
-        }
-
-        for (J.Import anImport : scu.getImports()) {
-            visit(anImport, p);
-            // Scala imports don't end with semicolons but need newlines between them
-            if (!anImport.getPrefix().getWhitespace().isEmpty() || scu.getImports().indexOf(anImport) < scu.getImports().size() - 1) {
-                // Already has whitespace or not the last import
             }
         }
 
@@ -727,8 +715,16 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
     @Override
     public J visitImport(J.Import import_, PrintOutputCapture<P> p) {
         beforeSyntax(import_, Space.Location.IMPORT_PREFIX, p);
-        p.append("import ");
-        
+        // For the continuation in a comma-separated import (e.g. the second
+        // `b._` in `import a._, b._`), the parser emits a `J.Import` with a
+        // CommaContinuation marker. The prefix carries any whitespace before
+        // the `,`; the qualifier's prefix carries whitespace after.
+        if (import_.getMarkers().findFirst(org.openrewrite.scala.marker.CommaContinuation.class).isPresent()) {
+            p.append(',');
+        } else {
+            p.append("import ");
+        }
+
         // Visit the import expression
         // Wildcard imports: Scala 2 uses `._`, Scala 3 uses `.*`
         // The name field preserves which was used in source.
@@ -1568,9 +1564,20 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
 
     public J visitExport(S.Export export, PrintOutputCapture<P> p) {
         beforeSyntax(export, Space.Location.LANGUAGE_EXTENSION, p);
-        p.append("export ");
+        if (export.getMarkers().findFirst(org.openrewrite.scala.marker.CommaContinuation.class).isPresent()) {
+            p.append(',');
+        } else {
+            p.append("export ");
+        }
         Expression clause = export.getExportClause();
-        if (clause instanceof J.FieldAccess && isWildcardImport((J.FieldAccess) clause)) {
+        if (export.getPadding().getSelectors() != null) {
+            visit(clause, p);
+            p.append('.');
+            if (export.getBeforeBrace() != null) {
+                visitSpace(export.getBeforeBrace(), Space.Location.LANGUAGE_EXTENSION, p);
+            }
+            visitContainer("{", export.getPadding().getSelectors(), JContainer.Location.LANGUAGE_EXTENSION, ",", "}", p);
+        } else if (clause instanceof J.FieldAccess && isWildcardImport((J.FieldAccess) clause)) {
             J.FieldAccess fa = (J.FieldAccess) clause;
             visitFieldAccessUpToWildcard(fa, p);
             p.append("." + fa.getName().getSimpleName());
@@ -1579,6 +1586,43 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         }
         afterSyntax(export, p);
         return export;
+    }
+
+    public J visitSImport(S.Import sImport, PrintOutputCapture<P> p) {
+        beforeSyntax(sImport, Space.Location.LANGUAGE_EXTENSION, p);
+        if (sImport.getMarkers().findFirst(org.openrewrite.scala.marker.CommaContinuation.class).isPresent()) {
+            p.append(',');
+        } else {
+            p.append("import ");
+        }
+        visitRightPadded(sImport.getPadding().getQualifier(), JRightPadded.Location.LANGUAGE_EXTENSION, p);
+        p.append('.');
+        visitSpace(sImport.getBeforeBrace(), Space.Location.LANGUAGE_EXTENSION, p);
+        visitContainer("{", sImport.getPadding().getSelectors(), JContainer.Location.LANGUAGE_EXTENSION, ",", "}", p);
+        afterSyntax(sImport, p);
+        return sImport;
+    }
+
+    public J visitImportSelector(S.ImportSelector selector, PrintOutputCapture<P> p) {
+        beforeSyntax(selector, Space.Location.LANGUAGE_EXTENSION, p);
+        if (selector.isGiven()) {
+            p.append("given");
+            if (selector.getGivenType() != null) {
+                visit(selector.getGivenType(), p);
+            }
+        } else if (selector.isWildcard()) {
+            p.append(selector.isLegacyUnderscore() ? "_" : "*");
+        } else if (selector.getName() != null) {
+            visit(selector.getName(), p);
+            JLeftPadded<J.Identifier> alias = selector.getPadding().getAlias();
+            if (alias != null) {
+                visitSpace(alias.getBefore(), Space.Location.LANGUAGE_EXTENSION, p);
+                p.append(selector.isUseAsKeyword() ? "as" : "=>");
+                visit(alias.getElement(), p);
+            }
+        }
+        afterSyntax(selector, p);
+        return selector;
     }
 
     public J visitPatternDefinition(S.PatternDefinition patDef, PrintOutputCapture<P> p) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -58,7 +58,6 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
             c = c.withPackageDeclaration(visitAndCast(c.getPackageDeclaration(), p));
         }
 
-        c = c.withImports(ListUtils.map(c.getImports(), i -> visitAndCast(i, p)));
         c = c.withStatements(ListUtils.map(c.getStatements(), s -> {
             try {
                 return visitAndCast(s, p);
@@ -95,9 +94,7 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         // Sync changes from the J.CompilationUnit back to S.CompilationUnit
         if (result != tempJcu) {
             List<JRightPadded<J.Import>> newImports = result.getPadding().getImports();
-            if (newImports != c.getPadding().getImports()) {
-                c = (S.CompilationUnit) c.getPadding().withImports(newImports);
-            }
+            c = (S.CompilationUnit) c.getPadding().withImports(newImports);
             if (result.getPrefix() != c.getPrefix()) {
                 c = c.withPrefix(result.getPrefix());
             }
@@ -166,7 +163,44 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         }
         e = (S.Export) temp;
         e = e.withExportClause(visitAndCast(e.getExportClause(), p));
+        if (e.getBeforeBrace() != null) {
+            e = e.withBeforeBrace(visitSpace(e.getBeforeBrace(), Space.Location.LANGUAGE_EXTENSION, p));
+        }
+        if (e.getPadding().getSelectors() != null) {
+            e = e.getPadding().withSelectors(visitContainer(e.getPadding().getSelectors(), JContainer.Location.LANGUAGE_EXTENSION, p));
+        }
         return e;
+    }
+
+    public J visitSImport(S.Import sImport, P p) {
+        S.Import i = sImport;
+        i = i.withPrefix(visitSpace(i.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        i = i.withMarkers(visitMarkers(i.getMarkers(), p));
+        Statement temp = (Statement) visitStatement(i, p);
+        if (!(temp instanceof S.Import)) {
+            return temp;
+        }
+        i = (S.Import) temp;
+        i = i.getPadding().withQualifier(visitRightPadded(i.getPadding().getQualifier(), JRightPadded.Location.LANGUAGE_EXTENSION, p));
+        i = i.withBeforeBrace(visitSpace(i.getBeforeBrace(), Space.Location.LANGUAGE_EXTENSION, p));
+        i = i.getPadding().withSelectors(visitContainer(i.getPadding().getSelectors(), JContainer.Location.LANGUAGE_EXTENSION, p));
+        return i;
+    }
+
+    public J visitImportSelector(S.ImportSelector selector, P p) {
+        S.ImportSelector s = selector;
+        s = s.withPrefix(visitSpace(s.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        s = s.withMarkers(visitMarkers(s.getMarkers(), p));
+        if (s.getGivenType() != null) {
+            s = s.withGivenType(visitAndCast(s.getGivenType(), p));
+        }
+        if (s.getName() != null) {
+            s = s.withName(visitAndCast(s.getName(), p));
+        }
+        if (s.getPadding().getAlias() != null) {
+            s = s.getPadding().withAlias(visitLeftPadded(s.getPadding().getAlias(), JLeftPadded.Location.LANGUAGE_EXTENSION, p));
+        }
+        return s;
     }
 
     public J visitPatternDefinition(S.PatternDefinition patDef, P p) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/CommaContinuation.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/CommaContinuation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.marker;
+
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Marker applied to an import (or export) statement that is the continuation
+ * of a comma-separated group: the second {@code b._} in
+ * {@code import a._, b._}. The printer emits a {@code ,} instead of the
+ * {@code import} (or {@code export}) keyword for marked statements.
+ * <p>
+ * The marker carries no payload — whitespace before the comma is the
+ * statement's own prefix; whitespace after the comma is the qualifier's
+ * leading prefix.
+ */
+public class CommaContinuation implements Marker {
+    private final UUID id;
+
+    public CommaContinuation(UUID id) {
+        this.id = id;
+    }
+
+    @Override
+    public UUID getId() {
+        return id;
+    }
+
+    @Override
+    public CommaContinuation withId(UUID id) {
+        return new CommaContinuation(id);
+    }
+}

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -133,16 +133,65 @@ public interface S extends J {
             return getPadding().withPackageDeclaration(JRightPadded.withElement(this.packageDeclaration, packageDeclaration));
         }
 
-        List<JRightPadded<J.Import>> imports;
-
         @Override
         public List<J.Import> getImports() {
-            return JRightPadded.getElements(imports);
+            List<J.Import> result = new ArrayList<>();
+            for (JRightPadded<Statement> rp : statements) {
+                if (rp.getElement() instanceof J.Import) {
+                    result.add((J.Import) rp.getElement());
+                }
+            }
+            return result;
         }
 
+        /**
+         * Scala imports can appear anywhere — they're stored inline in
+         * {@link #statements} alongside other statements. {@code withImports}
+         * replaces the existing {@link J.Import} elements in source order,
+         * keeping non-import statements in place. Extra new imports are
+         * inserted at the position of the first existing import (or at the
+         * top of the statements list if there are none).
+         */
         @Override
-        public S.CompilationUnit withImports(List<J.Import> imports) {
-            return (S.CompilationUnit) getPadding().withImports(JRightPadded.withElements(this.imports, imports));
+        public S.CompilationUnit withImports(List<J.Import> newImports) {
+            List<J.Import> current = getImports();
+            if (current.size() == newImports.size()) {
+                boolean changed = false;
+                for (int i = 0; i < current.size(); i++) {
+                    if (current.get(i) != newImports.get(i)) {
+                        changed = true;
+                        break;
+                    }
+                }
+                if (!changed) {
+                    return this;
+                }
+            }
+            List<JRightPadded<Statement>> rebuilt = new ArrayList<>(statements.size() + newImports.size());
+            int idx = 0;
+            int firstImportSlot = -1;
+            int lastImportSlotInRebuilt = -1;
+            for (JRightPadded<Statement> rp : statements) {
+                if (rp.getElement() instanceof J.Import) {
+                    if (firstImportSlot < 0) {
+                        firstImportSlot = rebuilt.size();
+                    }
+                    if (idx < newImports.size()) {
+                        rebuilt.add(rp.withElement(newImports.get(idx++)));
+                        lastImportSlotInRebuilt = rebuilt.size() - 1;
+                    }
+                    // Existing slots beyond newImports.size() are dropped.
+                } else {
+                    rebuilt.add(rp);
+                }
+            }
+            int insertAt = lastImportSlotInRebuilt >= 0
+                    ? lastImportSlotInRebuilt + 1
+                    : (firstImportSlot >= 0 ? firstImportSlot : 0);
+            while (idx < newImports.size()) {
+                rebuilt.add(insertAt++, new JRightPadded<>(newImports.get(idx++), Space.EMPTY, Markers.EMPTY));
+            }
+            return getPadding().withStatements(rebuilt);
         }
 
         List<JRightPadded<Statement>> statements;
@@ -172,8 +221,8 @@ public interface S extends J {
 
         public S.CompilationUnit withCharsetName(String charsetName) {
             return this.charsetName == charsetName ? this : new S.CompilationUnit(
-                this.typesInUse, this.padding, id, prefix, markers, sourcePath, fileAttributes, 
-                charsetName, charsetBomMarked, checksum, packageDeclaration, imports, statements, eof
+                this.typesInUse, this.padding, id, prefix, markers, sourcePath, fileAttributes,
+                charsetName, charsetBomMarked, checksum, packageDeclaration, statements, eof
             );
         }
 
@@ -263,21 +312,73 @@ public interface S extends J {
             public S.CompilationUnit withPackageDeclaration(@Nullable JRightPadded<J.Package> packageDeclaration) {
                 return t.packageDeclaration == packageDeclaration ? t : new S.CompilationUnit(
                     t.typesInUse, t.padding, t.id, t.prefix, t.markers, t.sourcePath, t.fileAttributes,
-                    t.charsetName, t.charsetBomMarked, t.checksum, packageDeclaration, t.imports, t.statements, t.eof
+                    t.charsetName, t.charsetBomMarked, t.checksum, packageDeclaration, t.statements, t.eof
                 );
             }
 
+            /**
+             * Derived view of {@link J.Import}s found inside {@link S.CompilationUnit#statements}.
+             * The right-padding seen here is the statement's right-padding —
+             * mutating it through {@link #withImports} replaces the statement
+             * slot in place.
+             */
             @Override
             public List<JRightPadded<J.Import>> getImports() {
-                return t.imports;
+                List<JRightPadded<J.Import>> result = new ArrayList<>();
+                for (JRightPadded<Statement> rp : t.statements) {
+                    if (rp.getElement() instanceof J.Import) {
+                        //noinspection unchecked,rawtypes
+                        result.add((JRightPadded<J.Import>) (JRightPadded) rp);
+                    }
+                }
+                return result;
             }
 
             @Override
-            public S.CompilationUnit withImports(List<JRightPadded<J.Import>> imports) {
-                return t.imports == imports ? t : new S.CompilationUnit(
-                    t.typesInUse, t.padding, t.id, t.prefix, t.markers, t.sourcePath, t.fileAttributes,
-                    t.charsetName, t.charsetBomMarked, t.checksum, t.packageDeclaration, imports, t.statements, t.eof
-                );
+            public S.CompilationUnit withImports(List<JRightPadded<J.Import>> newImports) {
+                // Detect "nothing changed" by reference. JRightPadded.equals is
+                // identity-based (no @EqualsAndHashCode.Include fields), so a
+                // .equals() check would always say "equal". A reference check
+                // on each JRightPadded gives us the correct semantics.
+                List<JRightPadded<J.Import>> current = getImports();
+                if (current.size() == newImports.size()) {
+                    boolean changed = false;
+                    for (int i = 0; i < current.size(); i++) {
+                        if (current.get(i) != newImports.get(i)) {
+                            changed = true;
+                            break;
+                        }
+                    }
+                    if (!changed) {
+                        return t;
+                    }
+                }
+                List<JRightPadded<Statement>> rebuilt = new ArrayList<>(t.statements.size() + newImports.size());
+                int idx = 0;
+                int firstImportSlot = -1;
+                int lastImportSlotInRebuilt = -1;
+                for (JRightPadded<Statement> rp : t.statements) {
+                    if (rp.getElement() instanceof J.Import) {
+                        if (firstImportSlot < 0) {
+                            firstImportSlot = rebuilt.size();
+                        }
+                        if (idx < newImports.size()) {
+                            //noinspection unchecked,rawtypes
+                            rebuilt.add((JRightPadded<Statement>) (JRightPadded) newImports.get(idx++));
+                            lastImportSlotInRebuilt = rebuilt.size() - 1;
+                        }
+                    } else {
+                        rebuilt.add(rp);
+                    }
+                }
+                int insertAt = lastImportSlotInRebuilt >= 0
+                        ? lastImportSlotInRebuilt + 1
+                        : (firstImportSlot >= 0 ? firstImportSlot : 0);
+                while (idx < newImports.size()) {
+                    //noinspection unchecked,rawtypes
+                    rebuilt.add(insertAt++, (JRightPadded<Statement>) (JRightPadded) newImports.get(idx++));
+                }
+                return withStatements(rebuilt);
             }
 
             public List<JRightPadded<Statement>> getStatements() {
@@ -287,7 +388,7 @@ public interface S extends J {
             public S.CompilationUnit withStatements(List<JRightPadded<Statement>> statements) {
                 return t.statements == statements ? t : new S.CompilationUnit(
                     t.typesInUse, t.padding, t.id, t.prefix, t.markers, t.sourcePath, t.fileAttributes,
-                    t.charsetName, t.charsetBomMarked, t.checksum, t.packageDeclaration, t.imports, statements, t.eof
+                    t.charsetName, t.charsetBomMarked, t.checksum, t.packageDeclaration, statements, t.eof
                 );
             }
         }
@@ -792,28 +893,30 @@ public interface S extends J {
     }
 
     /**
-     * Represents a Scala 3 {@code export} clause, which re-exports a member of a
-     * value into the enclosing scope. Export clauses were introduced in Scala 3
-     * and have no Scala 2 equivalent.
+     * Represents a Scala import statement that cannot be expressed by {@link J.Import}.
+     * Used for all brace-selector and alias forms; plain single-path imports
+     * (including trailing {@code *}, {@code _}, and {@code given} wildcards) still
+     * map to {@link J.Import}.
      * <p>
-     * The {@code exportClause} is the dotted path identifying what is exported,
-     * structured the same way as {@link J.Import#getQualid()} (i.e., a
-     * {@link J.FieldAccess} whose final segment is the exported name, or
-     * {@code "*"} / {@code "_"} for wildcards).
-     * <p>
-     * Examples:
+     * Examples mapped here:
      * <ul>
-     *   <li>{@code export A.B.c}</li>
-     *   <li>{@code export A.B.*} (canonical Scala 3 wildcard)</li>
-     *   <li>{@code export A.B._} (legacy wildcard form still accepted by the compiler)</li>
+     *   <li>{@code import a.b.{c, d}}</li>
+     *   <li>{@code import a.b.{c => C, d as D}}</li>
+     *   <li>{@code import a.b.{given, given Foo}}</li>
+     *   <li>{@code import a.b.{c, _}}</li>
      * </ul>
-     * Brace-selector forms ({@code export A.{x, y}}) and aliased forms
-     * ({@code export A.{x as y}}) are not yet modelled and cause the parser to
-     * raise an exception.
+     * Comma-separated forms (e.g. {@code import a._, b._}) are parsed into a
+     * sequence of separate statements, one per top-level path.
      */
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    final class Export implements S, Statement {
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class Import implements S, Statement {
+
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
 
         @With @Getter @EqualsAndHashCode.Include
         UUID id;
@@ -825,20 +928,305 @@ public interface S extends J {
         Markers markers;
 
         /**
-         * The exported path. For simple exports this is a {@link J.FieldAccess}
-         * built the same way as {@link J.Import#getQualid()}, where the final
-         * segment names the exported member (or {@code *} / {@code _} for
-         * wildcards). Typed as {@link Expression} to leave room for richer
-         * forms (named-export containers, etc.) once brace selectors are modelled.
+         * The qualifier expression (everything between {@code import} and the
+         * opening brace, e.g. {@code a.b} in {@code import a.b.{c, d}}). The
+         * trailing space before the {@code .} that introduces the brace block
+         * is captured by the qualifier's right-padding.
+         */
+        JRightPadded<Expression> qualifier;
+
+        public Expression getQualifier() {
+            return qualifier.getElement();
+        }
+
+        public S.Import withQualifier(Expression qualifier) {
+            return getPadding().withQualifier(JRightPadded.withElement(this.qualifier, qualifier));
+        }
+
+        /**
+         * Whitespace between the {@code .} dot and the opening {@code {} brace.
+         * Almost always {@link Space#EMPTY} but kept for source fidelity.
+         */
+        @With @Getter
+        Space beforeBrace;
+
+        /**
+         * The brace-enclosed selector list. The container's {@code before} holds
+         * any space inside the opening brace before the first selector; the
+         * final selector's right-padding holds space before the closing brace.
+         */
+        JContainer<ImportSelector> selectors;
+
+        public List<ImportSelector> getSelectors() {
+            return selectors.getElements();
+        }
+
+        public S.Import withSelectors(List<ImportSelector> selectors) {
+            return getPadding().withSelectors(JContainer.withElements(this.selectors, selectors));
+        }
+
+        public static S.Import build(UUID id, Space prefix, Markers markers,
+                                     JRightPadded<Expression> qualifier,
+                                     Space beforeBrace,
+                                     JContainer<ImportSelector> selectors) {
+            return new S.Import(null, id, prefix, markers, qualifier, beforeBrace, selectors);
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitSImport(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Statement getCoordinates() {
+            return new CoordinateBuilder.Statement(this);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final S.Import t;
+
+            public JRightPadded<Expression> getQualifier() {
+                return t.qualifier;
+            }
+
+            public S.Import withQualifier(JRightPadded<Expression> qualifier) {
+                return t.qualifier == qualifier ? t : new S.Import(null, t.id, t.prefix, t.markers, qualifier, t.beforeBrace, t.selectors);
+            }
+
+            public JContainer<ImportSelector> getSelectors() {
+                return t.selectors;
+            }
+
+            public S.Import withSelectors(JContainer<ImportSelector> selectors) {
+                return t.selectors == selectors ? t : new S.Import(null, t.id, t.prefix, t.markers, t.qualifier, t.beforeBrace, selectors);
+            }
+        }
+    }
+
+    /**
+     * One entry inside a brace-enclosed import or export selector list.
+     * Encodes every Scala 3 variant:
+     * <ul>
+     *   <li>{@code name}                      — plain selector</li>
+     *   <li>{@code name => alias}             — legacy rename arrow</li>
+     *   <li>{@code name as alias}             — Scala 3 rename keyword</li>
+     *   <li>{@code *} / {@code _}             — wildcard (Scala 3 / legacy)</li>
+     *   <li>{@code given}                     — wildcard given selector</li>
+     *   <li>{@code given Foo}                 — typed given selector</li>
+     * </ul>
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class ImportSelector implements S {
+
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @With @Getter @EqualsAndHashCode.Include
+        UUID id;
+
+        @With @Getter
+        Space prefix;
+
+        @With @Getter
+        Markers markers;
+
+        /**
+         * True for {@code given} and {@code given Foo} selectors. When true,
+         * {@link #name} and {@link #wildcard} are ignored and {@link #givenType}
+         * is the optional bound.
+         */
+        @With @Getter
+        boolean given;
+
+        /**
+         * Type bound on a {@code given Foo} selector. {@code null} for a bare
+         * {@code given} (wildcard given selector). Ignored when {@link #given}
+         * is {@code false}.
+         */
+        @With @Getter @Nullable
+        TypeTree givenType;
+
+        /**
+         * True for {@code *} and {@code _} wildcard selectors. When true,
+         * {@link #name} and {@link #alias} are {@code null}.
+         */
+        @With @Getter
+        boolean wildcard;
+
+        /**
+         * When {@link #wildcard} is true, {@code true} means the wildcard was
+         * written as {@code _} (legacy) rather than {@code *} (Scala 3 canonical).
+         */
+        @With @Getter
+        boolean legacyUnderscore;
+
+        /**
+         * The selector name. {@code null} for wildcard or {@code given}-only forms.
+         */
+        @With @Getter
+        J.@Nullable Identifier name;
+
+        /**
+         * Optional rename target. The left-padding carries whitespace before
+         * the arrow / {@code as} keyword; the identifier's own prefix carries
+         * whitespace after.
+         */
+        @Nullable
+        JLeftPadded<J.Identifier> alias;
+
+        public J.@Nullable Identifier getAlias() {
+            return alias == null ? null : alias.getElement();
+        }
+
+        public ImportSelector withAlias(J.@Nullable Identifier alias) {
+            return getPadding().withAlias(JLeftPadded.withElement(this.alias, alias));
+        }
+
+        /**
+         * When {@link #alias} is non-null, {@code true} means the rename used
+         * the Scala 3 {@code as} keyword; {@code false} means the legacy
+         * {@code =>} arrow.
+         */
+        @With @Getter
+        boolean useAsKeyword;
+
+        public static ImportSelector build(UUID id, Space prefix, Markers markers,
+                                           boolean given, @Nullable TypeTree givenType,
+                                           boolean wildcard, boolean legacyUnderscore,
+                                           J.@Nullable Identifier name,
+                                           @Nullable JLeftPadded<J.Identifier> alias,
+                                           boolean useAsKeyword) {
+            return new ImportSelector(null, id, prefix, markers, given, givenType,
+                    wildcard, legacyUnderscore, name, alias, useAsKeyword);
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitImportSelector(this, p);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final ImportSelector t;
+
+            public @Nullable JLeftPadded<J.Identifier> getAlias() {
+                return t.alias;
+            }
+
+            public ImportSelector withAlias(@Nullable JLeftPadded<J.Identifier> alias) {
+                return t.alias == alias ? t : new ImportSelector(null, t.id, t.prefix, t.markers, t.given, t.givenType, t.wildcard, t.legacyUnderscore, t.name, alias, t.useAsKeyword);
+            }
+        }
+    }
+
+    /**
+     * Represents a Scala 3 {@code export} clause, which re-exports a member of a
+     * value into the enclosing scope. Export clauses were introduced in Scala 3
+     * and have no Scala 2 equivalent.
+     * <p>
+     * Two shapes:
+     * <ul>
+     *   <li><b>Simple form</b> ({@link #selectors} is {@code null}):
+     *       {@link #exportClause} is the full dotted path, structured the same way
+     *       as {@link J.Import#getQualid()} — a {@link J.FieldAccess} whose final
+     *       segment is the exported name (or {@code *} / {@code _} for wildcards).
+     *       <br>Examples: {@code export A.B.c}, {@code export A.B.*}, {@code export A.B._}.</li>
+     *   <li><b>Brace form</b> ({@link #selectors} is non-null):
+     *       {@link #exportClause} is the qualifier only ({@code a.b}) and the
+     *       brace-enclosed selectors carry the exported names.
+     *       <br>Examples: {@code export a.b.{x, y}}, {@code export a.b.{x as Y}}.</li>
+     * </ul>
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class Export implements S, Statement {
+
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @With @Getter @EqualsAndHashCode.Include
+        UUID id;
+
+        @With @Getter
+        Space prefix;
+
+        @With @Getter
+        Markers markers;
+
+        /**
+         * The exported path. For the simple form this is the full path
+         * (including the trailing exported name). For the brace form this is
+         * the qualifier only.
          */
         @With @Getter
         Expression exportClause;
 
+        /**
+         * Whitespace between the {@code .} dot and the opening {@code {} brace,
+         * for the brace form. {@code null} for the simple form.
+         */
+        @With @Getter @Nullable
+        Space beforeBrace;
+
+        /**
+         * The brace-enclosed selector list, or {@code null} for the simple form.
+         */
+        @Nullable
+        JContainer<ImportSelector> selectors;
+
+        public @Nullable List<ImportSelector> getSelectors() {
+            return selectors == null ? null : selectors.getElements();
+        }
+
+        public Export withSelectors(@Nullable List<ImportSelector> selectors) {
+            return getPadding().withSelectors(selectors == null ? null : JContainer.withElements(this.selectors, selectors));
+        }
+
         public Export(UUID id, Space prefix, Markers markers, Expression exportClause) {
-            this.id = id;
-            this.prefix = prefix;
-            this.markers = markers;
-            this.exportClause = exportClause;
+            this(null, id, prefix, markers, exportClause, null, null);
+        }
+
+        public static Export build(UUID id, Space prefix, Markers markers, Expression exportClause,
+                                   @Nullable Space beforeBrace,
+                                   @Nullable JContainer<ImportSelector> selectors) {
+            return new Export(null, id, prefix, markers, exportClause, beforeBrace, selectors);
         }
 
         @Override
@@ -849,6 +1237,34 @@ public interface S extends J {
         @Override
         public CoordinateBuilder.Statement getCoordinates() {
             return new CoordinateBuilder.Statement(this);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final Export t;
+
+            public @Nullable JContainer<ImportSelector> getSelectors() {
+                return t.selectors;
+            }
+
+            public Export withSelectors(@Nullable JContainer<ImportSelector> selectors) {
+                return t.selectors == selectors ? t : new Export(null, t.id, t.prefix, t.markers, t.exportClause, t.beforeBrace, selectors);
+            }
         }
     }
 

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaASTConverter.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaASTConverter.scala
@@ -22,22 +22,23 @@ import org.openrewrite.java.internal.JavaTypeFactory
 import org.openrewrite.java.tree.*
 import org.openrewrite.marker.Markers
 import org.openrewrite.scala.marker.{IndentedSyntax, PackageBraces, PackageSemicolon}
+import org.openrewrite.scala.tree.S
 
 import java.util
 import java.util.{Collections, List as JList}
 
 /**
  * Result of converting a Scala AST to compilation unit components.
+ * Imports (plain `J.Import` and brace-form `S.Import`) are part of
+ * [[statements]] in source order — Scala allows them anywhere a statement
+ * can appear, so there is no separate imports list.
  */
 class CompilationUnitResult(
                              val packageDecl: J.Package,
-                             val imports: JList[J.Import],
                              val statements: JList[Statement],
                              val lastCursorPosition: Int
                            ) {
   def getPackageDecl: J.Package = packageDecl
-
-  def getImports: JList[J.Import] = imports
 
   def getStatements: JList[Statement] = statements
 
@@ -53,7 +54,6 @@ class ScalaASTConverter {
    * Converts a Scala parse result to compilation unit components.
    */
   def convertToCompilationUnit(parseResult: ScalaParseResult, source: String, typeFactory: JavaTypeFactory = null): CompilationUnitResult = {
-    val imports = new util.ArrayList[J.Import]()
     val statements = new util.ArrayList[Statement]()
     var packageDecl: J.Package = null
 
@@ -80,7 +80,7 @@ class ScalaASTConverter {
     // Check if tree is empty (parse error case)
     if (tree.isEmpty) {
       // Return empty result for parse errors
-      return new CompilationUnitResult(packageDecl, imports, statements, 0)
+      return new CompilationUnitResult(packageDecl, statements, 0)
     }
 
     // Handle different types of top-level trees
@@ -103,15 +103,9 @@ class ScalaASTConverter {
           case imp: Trees.Import[?] =>
             val converted = visitor.visitTree(imp)
             converted match {
-              case jImport: J.Import =>
-                imports.add(jImport)
-              case unknown: J.Unknown =>
-                // Complex imports (braces, aliases) that can't map to J.Import.
-                // Add as statements - they'll be interleaved correctly since
-                // both lists are in source order.
-                statements.add(unknown)
+              case stmt: Statement =>
+                statements.add(stmt)
               case null =>
-              case _: J.Empty =>
               case _ =>
             }
           case stat =>
@@ -146,16 +140,11 @@ class ScalaASTConverter {
           }
         }
       case imp: Trees.Import[?] =>
-        // Top-level import - simple ones as J.Import, complex ones as statements
+        // Top-level import (no enclosing package).
         val converted = visitor.visitTree(imp)
         converted match {
-          case jImport: J.Import =>
-            imports.add(jImport)
-          case unknown: J.Unknown =>
-            // Complex imports that we can't map to J.Import yet
-            statements.add(unknown)
+          case stmt: Statement => statements.add(stmt)
           case null => // Skip null returns
-          case _: J.Empty => // Skip empty nodes
           case _ => // Skip non-statements
         }
       case _ =>
@@ -170,7 +159,7 @@ class ScalaASTConverter {
         }
     }
 
-    new CompilationUnitResult(packageDecl, imports, statements, visitor.getCursor)
+    new CompilationUnitResult(packageDecl, statements, visitor.getCursor)
   }
 
   /**

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -35,6 +35,7 @@ import org.openrewrite.scala.marker.Semicolon
 import org.openrewrite.scala.marker.TypeProjection
 import org.openrewrite.scala.marker.ScalaForLoop
 import org.openrewrite.scala.marker.BlockArgument
+import org.openrewrite.scala.marker.CommaContinuation
 import org.openrewrite.scala.marker.FunctionApplication
 import org.openrewrite.scala.marker.TypeAscription
 import org.openrewrite.scala.marker.UnderscorePlaceholderLambda
@@ -2291,83 +2292,390 @@ class ScalaTreeVisitor(
   }
 
   private def visitImport(imp: Trees.Import[?]): J = {
-    if (isSimpleImportOrExport(imp, "import")) {
-      val (prefix, qualid) = buildImportOrExportQualid(imp)
-      // J.Import requires a static-import flag and supports an alias slot;
-      // Scala has neither for simple imports.
-      new J.Import(
-        Tree.randomId(),
-        prefix,
-        Markers.EMPTY,
-        JLeftPadded.build(false),
-        qualid,
-        null
-      )
-    } else {
-      // Complex imports: braces, aliases (as/=>), wildcards with braces, etc.
-      // Preserve the full source text since these can't map cleanly to J.Import's
-      // FieldAccess-based qualid model.
-      val prefix = extractPrefix(imp.span)
-      val sourceText = extractSource(imp.span)
-      val isContinuation = !sourceText.trim.startsWith("import")
-      if (isContinuation) {
-        // Continuation of a comma-separated import: `import A._, B._`
-        // The prefix may contain a comma — include it in the source text.
-        // Find the comma before this import's span and include everything from there.
-        val adjustedStart = Math.max(0, imp.span.start - offsetAdjustment)
-        val commaSearch = if (adjustedStart > 0) source.lastIndexOf(',', adjustedStart) else -1
-        val fullText = if (commaSearch >= 0 && commaSearch < adjustedStart) {
-          source.substring(commaSearch, Math.max(0, imp.span.end - offsetAdjustment))
-        } else sourceText
-        updateCursor(imp.span.end)
-        return new J.Unknown(
-          Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-          new J.Unknown.Source(Tree.randomId(), Space.EMPTY, Markers.EMPTY, fullText)
+    val classification = classifyImportOrExport(imp, "import")
+    classification match {
+      case ImportShape.Simple =>
+        val (prefix, qualid) = buildImportOrExportQualid(imp)
+        new J.Import(
+          Tree.randomId(),
+          prefix,
+          Markers.EMPTY,
+          JLeftPadded.build(false),
+          qualid,
+          null
         )
-      }
-
-      val afterImportStart = "import".length
-      val afterImport = sourceText.substring(afterImportStart)
-      val qualidStart = afterImport.indexWhere(ch => !Character.isWhitespace(ch))
-      val qualidPrefix = if (qualidStart > 1) Space.format(afterImport.substring(1, qualidStart)) else Space.EMPTY
-      val qualidText = if (qualidStart >= 0) afterImport.substring(qualidStart) else ""
-
-      // Wrap in FieldAccess with Empty target (required by J.Import).
-      val qualid = new J.FieldAccess(
-        Tree.randomId(), qualidPrefix, Markers.EMPTY,
-        new J.Empty(Tree.randomId(), Space.EMPTY, Markers.EMPTY),
-        JLeftPadded.build(ident(qualidText)),
-        null
-      )
-
-      updateCursor(imp.span.end)
-
-      new J.Import(
-        Tree.randomId(),
-        prefix,
-        Markers.EMPTY,
-        JLeftPadded.build(false),
-        qualid,
-        null
-      )
+      case ImportShape.Brace =>
+        visitBraceImportOrExport(imp, "import")
+      case ImportShape.SimpleContinuation =>
+        visitContinuationSimple(imp, "import")
+      case ImportShape.BraceContinuation =>
+        throw new IllegalStateException(
+          s"Comma-continuation brace imports not yet modelled: '${spanSource(imp)}'"
+        )
     }
   }
 
   private def visitExport(exp: Trees.Export[?]): J = {
     // Scala 3 export clauses share their AST shape with imports
     // (Dotty: both extend `Trees.ImportOrExport` with `expr` + `selectors`),
-    // so we reuse the same qualid-building logic. Brace and alias forms are
-    // not yet modelled; visitUnknown throws so the gap surfaces in tests.
-    if (!isSimpleImportOrExport(exp, "export")) {
-      return visitUnknown(exp)
+    // so we reuse the same qualid-building logic.
+    val classification = classifyImportOrExport(exp, "export")
+    classification match {
+      case ImportShape.Simple =>
+        val (prefix, qualid) = buildImportOrExportQualid(exp)
+        new S.Export(Tree.randomId(), prefix, Markers.EMPTY, qualid)
+      case ImportShape.Brace =>
+        visitBraceImportOrExport(exp, "export")
+      case ImportShape.SimpleContinuation =>
+        visitContinuationSimple(exp, "export")
+      case ImportShape.BraceContinuation =>
+        throw new IllegalStateException(
+          s"Comma-continuation brace exports not yet modelled: '${spanSource(exp)}'"
+        )
     }
-    val (prefix, qualid) = buildImportOrExportQualid(exp)
-    new S.Export(
-      Tree.randomId(),
-      prefix,
-      Markers.EMPTY,
-      qualid
-    )
+  }
+
+  private object ImportShape extends Enumeration {
+    val Simple, Brace, SimpleContinuation, BraceContinuation = Value
+  }
+
+  private def spanSource(tree: Trees.ImportOrExport[?]): String = {
+    if (!tree.span.exists) return ""
+    val s = Math.max(0, tree.span.start - offsetAdjustment)
+    val e = Math.max(0, tree.span.end - offsetAdjustment)
+    if (s < e && e <= source.length) source.substring(s, e) else ""
+  }
+
+  private def classifyImportOrExport(
+    tree: Trees.ImportOrExport[?],
+    keyword: String
+  ): ImportShape.Value = {
+    val text = spanSource(tree)
+    val hasBraces = text.contains("{") || text.contains(" as ") || text.contains("=>")
+    val startsWithKeyword = text.trim.startsWith(keyword)
+    if (startsWithKeyword) {
+      if (hasBraces) ImportShape.Brace else ImportShape.Simple
+    } else {
+      if (hasBraces) ImportShape.BraceContinuation else ImportShape.SimpleContinuation
+    }
+  }
+
+  /**
+   * Emit a `J.Import` (or simple `S.Export`) for the *continuation* of a
+   * comma-separated group, e.g. the second {@code b._} in
+   * {@code import a._, b._}. The Dotty tree's span starts at the qualifier
+   * (after the comma); whitespace before the comma becomes the statement's
+   * prefix, whitespace after the comma is folded into the qualifier's
+   * prefix. The resulting statement carries a `CommaContinuation` marker so
+   * the printer emits {@code ,} instead of the keyword.
+   */
+  private def visitContinuationSimple(
+    tree: Trees.ImportOrExport[?],
+    keyword: String
+  ): J = {
+    val adjustedStart = Math.max(0, tree.span.start - offsetAdjustment)
+    val commaIdx = source.lastIndexOf(',', adjustedStart - 1)
+    if (commaIdx < cursor) {
+      throw new IllegalStateException(
+        s"Continuation $keyword without preceding ',': '${spanSource(tree)}'"
+      )
+    }
+    val prefix = if (cursor < commaIdx)
+      Space.format(source.substring(cursor, commaIdx))
+    else Space.EMPTY
+    cursor = commaIdx + 1
+
+    val qualid = buildQualidFromTree(tree)
+    val markers = Markers.EMPTY.addIfAbsent(new CommaContinuation(Tree.randomId()))
+
+    if (keyword == "import") {
+      new J.Import(Tree.randomId(), prefix, markers, JLeftPadded.build(false), qualid, null)
+    } else {
+      new S.Export(Tree.randomId(), prefix, markers, qualid)
+    }
+  }
+
+  /**
+   * Shared qualid construction used by both the keyword-led path and the
+   * continuation path. Assumes the cursor is positioned at (or before) the
+   * qualifier — whitespace between cursor and the qualifier's source span
+   * is captured as the qualifier element's prefix via {@code visitTree}.
+   */
+  private def buildQualidFromTree(tree: Trees.ImportOrExport[?]): J.FieldAccess = {
+    val oldInImportContext = isInImportContext
+    isInImportContext = true
+    val expr = visitTree(tree.expr)
+    isInImportContext = oldInImportContext
+
+    var qualid: J.FieldAccess = expr match {
+      case fa: J.FieldAccess => fa
+      case id: J.Identifier if tree.selectors.nonEmpty =>
+        val selector = tree.selectors.head
+        selector match {
+          case is @ untpd.ImportSelector(sIdent: Trees.Ident[?], untpd.EmptyTree, untpd.EmptyTree) =>
+            if (cursor < source.length && source.charAt(cursor) == '.') cursor += 1
+            val selName = wildcardOrName(is, sIdent, tree.span)
+            val displaySelName = if (cursor < source.length && source.charAt(cursor) == '`') "`" + selName + "`" else selName
+            val selectorType: JavaType = lookupSelectorType(tree.expr, selName)
+            new J.FieldAccess(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+              id, JLeftPadded.build(ident(displaySelName, Space.EMPTY, selectorType)), selectorType)
+          case _ =>
+            throw new IllegalStateException("Unexpected non-simple selector in continuation")
+        }
+      case _ =>
+        throw new IllegalStateException(
+          s"Expected FieldAccess or Identifier qualifier, got ${expr.getClass.getSimpleName}"
+        )
+    }
+
+    val alreadyHandledSelector = expr.isInstanceOf[J.Identifier] && tree.selectors.nonEmpty
+    if (!alreadyHandledSelector && tree.selectors.nonEmpty && tree.selectors.size == 1) {
+      val selector = tree.selectors.head
+      selector match {
+        case is @ untpd.ImportSelector(idTree: Trees.Ident[?], untpd.EmptyTree, untpd.EmptyTree) =>
+          if (cursor < source.length && source.charAt(cursor) == '.') cursor += 1
+          val selectorName = wildcardOrName(is, idTree, tree.span)
+          val displaySelectorName = if (cursor < source.length && source.charAt(cursor) == '`') "`" + selectorName + "`" else selectorName
+          val selectorType: JavaType = lookupSelectorType(tree.expr, selectorName)
+          qualid = new J.FieldAccess(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+            qualid, JLeftPadded.build(ident(displaySelectorName, Space.EMPTY, selectorType)), selectorType)
+        case _ =>
+      }
+    }
+
+    if (tree.span.exists) {
+      val adjustedEnd = Math.max(0, tree.span.end - offsetAdjustment)
+      updateCursor(adjustedEnd)
+    }
+
+    qualid
+  }
+
+  /**
+   * Parse a brace-form import or export: `keyword qualifier.{ selector, ... }`.
+   * Returns an `S.Import` (for `keyword == "import"`) or an `S.Export`
+   * (for `"export"`). Comma-continuation forms (e.g. `import a._, b._`) are
+   * not yet modelled and raise an exception.
+   */
+  private def visitBraceImportOrExport(
+    tree: Trees.ImportOrExport[?],
+    keyword: String
+  ): J = {
+    val adjustedStart = Math.max(0, tree.span.start - offsetAdjustment)
+    val adjustedEnd = Math.max(0, tree.span.end - offsetAdjustment)
+    val spanText = if (adjustedStart < adjustedEnd && adjustedEnd <= source.length)
+      source.substring(adjustedStart, adjustedEnd)
+    else ""
+    if (!spanText.trim.startsWith(keyword)) {
+      throw new IllegalStateException(
+        s"Comma-continuation $keyword forms are not yet modelled: '$spanText'"
+      )
+    }
+
+    val prefix: Space = if (cursor < adjustedStart) {
+      val text = source.substring(cursor, adjustedStart)
+      cursor = adjustedStart
+      Space.format(text)
+    } else Space.EMPTY
+
+    // Consume the keyword and at most one trailing whitespace (additional
+    // whitespace becomes the qualifier element's prefix).
+    cursor = adjustedStart + keyword.length
+    if (cursor < source.length && Character.isWhitespace(source.charAt(cursor))) {
+      cursor += 1
+    }
+
+    val oldInImportContext = isInImportContext
+    isInImportContext = true
+    val qualifierJ = visitTree(tree.expr)
+    isInImportContext = oldInImportContext
+    val qualifier: Expression = qualifierJ match {
+      case e: Expression => e
+      case other => throw new IllegalStateException(
+        s"Expected Expression for $keyword qualifier, got ${other.getClass.getSimpleName}"
+      )
+    }
+
+    // Whitespace between the qualifier and the `.`.
+    val afterQualifier = cursor
+    var i = afterQualifier
+    while (i < source.length && Character.isWhitespace(source.charAt(i))) i += 1
+    val qualifierRightPad = Space.format(source.substring(afterQualifier, i))
+    if (i >= source.length || source.charAt(i) != '.') {
+      throw new IllegalStateException(
+        s"Expected '.' before brace in $keyword at position $i: '${spanText}'"
+      )
+    }
+    cursor = i + 1
+
+    // Whitespace between `.` and `{`.
+    val afterDot = cursor
+    var j = afterDot
+    while (j < source.length && Character.isWhitespace(source.charAt(j))) j += 1
+    val beforeBrace = Space.format(source.substring(afterDot, j))
+    if (j >= source.length || source.charAt(j) != '{') {
+      throw new IllegalStateException(
+        s"Expected '{' after '.' in $keyword at position $j: '${spanText}'"
+      )
+    }
+    cursor = j + 1
+
+    val selectorElems = new util.ArrayList[JRightPadded[S.ImportSelector]]()
+    val selectors = tree.selectors
+    var idx = 0
+    while (idx < selectors.size) {
+      val sel = selectors(idx)
+
+      // Whitespace before this selector (after `{` for the first, after `,` for the rest).
+      val selStart = cursor
+      var p = selStart
+      while (p < source.length && Character.isWhitespace(source.charAt(p))) p += 1
+      val selPrefix = Space.format(source.substring(selStart, p))
+      cursor = p
+
+      val selectorNode = parseImportSelector(sel)
+
+      // After the selector, expect `,` (more selectors) or `}` (end).
+      val afterSel = cursor
+      var q = afterSel
+      while (q < source.length && Character.isWhitespace(source.charAt(q))) q += 1
+      val afterChar = if (q < source.length) source.charAt(q) else 0.toChar
+      if (afterChar == ',') {
+        val sepSpace = Space.format(source.substring(afterSel, q))
+        cursor = q + 1
+        selectorElems.add(new JRightPadded(selectorNode.withPrefix(selPrefix), sepSpace, Markers.EMPTY))
+      } else if (afterChar == '}') {
+        val tailSpace = Space.format(source.substring(afterSel, q))
+        cursor = q
+        selectorElems.add(new JRightPadded(selectorNode.withPrefix(selPrefix), tailSpace, Markers.EMPTY))
+      } else {
+        throw new IllegalStateException(
+          s"Expected ',' or '}' after selector in $keyword at position $q (got '$afterChar')"
+        )
+      }
+      idx += 1
+    }
+
+    if (cursor >= source.length || source.charAt(cursor) != '}') {
+      throw new IllegalStateException(
+        s"Expected '}' to close $keyword selectors at position $cursor: '${spanText}'"
+      )
+    }
+    cursor += 1
+    if (cursor < adjustedEnd) cursor = adjustedEnd
+
+    val selectorContainer: JContainer[S.ImportSelector] =
+      JContainer.build(Space.EMPTY, selectorElems, Markers.EMPTY)
+
+    if (keyword == "import") {
+      S.Import.build(
+        Tree.randomId(),
+        prefix,
+        Markers.EMPTY,
+        new JRightPadded(qualifier, qualifierRightPad, Markers.EMPTY),
+        beforeBrace,
+        selectorContainer
+      )
+    } else {
+      S.Export.build(
+        Tree.randomId(),
+        prefix,
+        Markers.EMPTY,
+        qualifier,
+        beforeBrace,
+        selectorContainer
+      )
+    }
+  }
+
+  /**
+   * Parse a single brace-import / brace-export selector, advancing the cursor.
+   * The prefix space is set by the caller; this method produces a selector
+   * with `Space.EMPTY` prefix.
+   */
+  private def parseImportSelector(sel: untpd.ImportSelector): S.ImportSelector = {
+    if (sel.isGiven) {
+      val kw = "given"
+      if (cursor + kw.length > source.length || !source.startsWith(kw, cursor)) {
+        throw new IllegalStateException(s"Expected 'given' selector at position $cursor")
+      }
+      cursor += kw.length
+      val givenType: TypeTree = sel.bound match {
+        case untpd.EmptyTree => null
+        case bound =>
+          visitTree(bound) match {
+            case tt: TypeTree => tt
+            case other => throw new IllegalStateException(
+              s"Expected TypeTree for given bound, got ${other.getClass.getSimpleName}"
+            )
+          }
+      }
+      S.ImportSelector.build(
+        Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+        true /* given */, givenType,
+        false /* wildcard */, false /* legacyUnderscore */,
+        null /* name */, null /* alias */, false /* useAsKeyword */
+      )
+    } else if (sel.isWildcard) {
+      if (cursor >= source.length) {
+        throw new IllegalStateException("Unexpected EOF for wildcard selector")
+      }
+      val wildcardChar = source.charAt(cursor)
+      if (wildcardChar != '_' && wildcardChar != '*') {
+        throw new IllegalStateException(
+          s"Expected '_' or '*' for wildcard selector at position $cursor, got '$wildcardChar'"
+        )
+      }
+      cursor += 1
+      S.ImportSelector.build(
+        Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+        false, null, true, wildcardChar == '_', null, null, false
+      )
+    } else {
+      // Named selector, optionally with `=> alias` or `as alias`.
+      val nameStartAbs = Math.max(0, sel.imported.span.start - offsetAdjustment)
+      val nameEndAbs = Math.max(0, sel.imported.span.end - offsetAdjustment)
+      val displayName = source.substring(nameStartAbs, nameEndAbs)
+      val nameIdent = ident(displayName, Space.EMPTY, null)
+      cursor = nameEndAbs
+
+      sel.renamed match {
+        case untpd.EmptyTree =>
+          S.ImportSelector.build(
+            Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+            false, null, false, false, nameIdent, null, false
+          )
+        case renamed: Trees.Ident[?] =>
+          var p = cursor
+          while (p < source.length && Character.isWhitespace(source.charAt(p))) p += 1
+          val beforeArrow = Space.format(source.substring(cursor, p))
+          val useAsKeyword = source.startsWith("as", p)
+          val useArrow = source.startsWith("=>", p)
+          if (!useAsKeyword && !useArrow) {
+            throw new IllegalStateException(
+              s"Expected '=>' or 'as' between selector name and alias at position $p"
+            )
+          }
+          cursor = p + 2
+
+          val renamedStartAbs = Math.max(0, renamed.span.start - offsetAdjustment)
+          val renamedEndAbs = Math.max(0, renamed.span.end - offsetAdjustment)
+          val aliasPrefix = Space.format(source.substring(cursor, renamedStartAbs))
+          val aliasDisplay = source.substring(renamedStartAbs, renamedEndAbs)
+          cursor = renamedEndAbs
+          val aliasIdent = ident(aliasDisplay, aliasPrefix, null)
+          S.ImportSelector.build(
+            Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+            false, null, false, false, nameIdent,
+            new JLeftPadded(beforeArrow, aliasIdent, Markers.EMPTY),
+            useAsKeyword
+          )
+        case other =>
+          throw new IllegalStateException(
+            s"Unexpected rename tree in import selector: ${other.getClass.getSimpleName}"
+          )
+      }
+    }
   }
 
   /**
@@ -2401,63 +2709,7 @@ class ScalaTreeVisitor(
       cursor += 1
     }
 
-    // Identifier resolution inside an import/export path differs from regular
-    // expression context (e.g. `_` becomes `*` for wildcards), so flag the
-    // visit and restore the previous value when done.
-    val oldInImportContext = isInImportContext
-    isInImportContext = true
-
-    val expr = visitTree(tree.expr)
-    isInImportContext = oldInImportContext
-
-    // Build the qualid: for `(import|export) java.util.List`, expr is
-    // Select(Ident(java), util) and the trailing selector is `List`.
-    // For `(import|export) java.util`, expr is Ident(java) and the only
-    // selector is `util`.
-    var qualid: J.FieldAccess = expr match {
-      case fa: J.FieldAccess => fa
-      case id: J.Identifier if tree.selectors.nonEmpty =>
-        val selector = tree.selectors.head
-        selector match {
-          case is @ untpd.ImportSelector(sIdent: Trees.Ident[?], untpd.EmptyTree, untpd.EmptyTree) =>
-            if (cursor < source.length && source.charAt(cursor) == '.') cursor += 1
-            val selName = wildcardOrName(is, sIdent, tree.span)
-            val displaySelName = if (cursor < source.length && source.charAt(cursor) == '`') "`" + selName + "`" else selName
-            val selectorType: JavaType = lookupSelectorType(tree.expr, selName)
-            new J.FieldAccess(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-              id, JLeftPadded.build(ident(displaySelName, Space.EMPTY, selectorType)), selectorType)
-          case _ =>
-            return visitUnknown(tree)
-        }
-      case _ =>
-        return visitUnknown(tree)
-    }
-
-    // Multi-segment paths (e.g., `import java.util.List`): apply the trailing
-    // selector to the FieldAccess produced from the expression. Skipped if the
-    // single-Ident-root branch above already consumed it.
-    val alreadyHandledSelector = expr.isInstanceOf[J.Identifier] && tree.selectors.nonEmpty
-    if (!alreadyHandledSelector && tree.selectors.nonEmpty && tree.selectors.size == 1) {
-      val selector = tree.selectors.head
-      selector match {
-        case is @ untpd.ImportSelector(idTree: Trees.Ident[?], untpd.EmptyTree, untpd.EmptyTree) =>
-          if (cursor < source.length && source.charAt(cursor) == '.') cursor += 1
-          val selectorName = wildcardOrName(is, idTree, tree.span)
-          val displaySelectorName = if (cursor < source.length && source.charAt(cursor) == '`') "`" + selectorName + "`" else selectorName
-          val selectorType: JavaType = lookupSelectorType(tree.expr, selectorName)
-          qualid = new J.FieldAccess(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-            qualid,
-            JLeftPadded.build(ident(displaySelectorName, Space.EMPTY, selectorType)),
-            selectorType)
-        case _ =>
-      }
-    }
-
-    if (tree.span.exists) {
-      val adjustedEnd = Math.max(0, tree.span.end - offsetAdjustment)
-      updateCursor(adjustedEnd)
-    }
-
+    val qualid = buildQualidFromTree(tree)
     (prefix, qualid)
   }
 

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -2309,9 +2309,7 @@ class ScalaTreeVisitor(
       case ImportShape.SimpleContinuation =>
         visitContinuationSimple(imp, "import")
       case ImportShape.BraceContinuation =>
-        throw new IllegalStateException(
-          s"Comma-continuation brace imports not yet modelled: '${spanSource(imp)}'"
-        )
+        visitContinuationBrace(imp, "import")
     }
   }
 
@@ -2329,9 +2327,7 @@ class ScalaTreeVisitor(
       case ImportShape.SimpleContinuation =>
         visitContinuationSimple(exp, "export")
       case ImportShape.BraceContinuation =>
-        throw new IllegalStateException(
-          s"Comma-continuation brace exports not yet modelled: '${spanSource(exp)}'"
-        )
+        visitContinuationBrace(exp, "export")
     }
   }
 
@@ -2454,24 +2450,13 @@ class ScalaTreeVisitor(
   /**
    * Parse a brace-form import or export: `keyword qualifier.{ selector, ... }`.
    * Returns an `S.Import` (for `keyword == "import"`) or an `S.Export`
-   * (for `"export"`). Comma-continuation forms (e.g. `import a._, b._`) are
-   * not yet modelled and raise an exception.
+   * (for `"export"`).
    */
   private def visitBraceImportOrExport(
     tree: Trees.ImportOrExport[?],
     keyword: String
   ): J = {
     val adjustedStart = Math.max(0, tree.span.start - offsetAdjustment)
-    val adjustedEnd = Math.max(0, tree.span.end - offsetAdjustment)
-    val spanText = if (adjustedStart < adjustedEnd && adjustedEnd <= source.length)
-      source.substring(adjustedStart, adjustedEnd)
-    else ""
-    if (!spanText.trim.startsWith(keyword)) {
-      throw new IllegalStateException(
-        s"Comma-continuation $keyword forms are not yet modelled: '$spanText'"
-      )
-    }
-
     val prefix: Space = if (cursor < adjustedStart) {
       val text = source.substring(cursor, adjustedStart)
       cursor = adjustedStart
@@ -2484,6 +2469,50 @@ class ScalaTreeVisitor(
     if (cursor < source.length && Character.isWhitespace(source.charAt(cursor))) {
       cursor += 1
     }
+
+    parseBraceImportOrExportBody(tree, keyword, prefix, Markers.EMPTY)
+  }
+
+  /**
+   * Emit a brace-form `S.Import` (or `S.Export`) for the continuation of a
+   * comma-separated group, e.g. the second `b.{y}` in
+   * `import a.{x}, b.{y}`. Mirrors [[visitContinuationSimple]] but feeds
+   * the brace parser.
+   */
+  private def visitContinuationBrace(
+    tree: Trees.ImportOrExport[?],
+    keyword: String
+  ): J = {
+    val adjustedStart = Math.max(0, tree.span.start - offsetAdjustment)
+    val commaIdx = source.lastIndexOf(',', adjustedStart - 1)
+    if (commaIdx < cursor) {
+      throw new IllegalStateException(
+        s"Continuation brace $keyword without preceding ',': '${spanSource(tree)}'"
+      )
+    }
+    val prefix = if (cursor < commaIdx)
+      Space.format(source.substring(cursor, commaIdx))
+    else Space.EMPTY
+    cursor = commaIdx + 1
+
+    val markers = Markers.EMPTY.addIfAbsent(new CommaContinuation(Tree.randomId()))
+    parseBraceImportOrExportBody(tree, keyword, prefix, markers)
+  }
+
+  /**
+   * Shared body of the brace-form parser. Assumes the cursor is positioned
+   * at the qualifier start (after the keyword for the leading form, after
+   * the comma for a continuation). The qualifier element's prefix absorbs
+   * any leading whitespace.
+   */
+  private def parseBraceImportOrExportBody(
+    tree: Trees.ImportOrExport[?],
+    keyword: String,
+    prefix: Space,
+    markers: Markers
+  ): J = {
+    val adjustedEnd = Math.max(0, tree.span.end - offsetAdjustment)
+    val spanText = spanSource(tree)
 
     val oldInImportContext = isInImportContext
     isInImportContext = true
@@ -2526,7 +2555,6 @@ class ScalaTreeVisitor(
     while (idx < selectors.size) {
       val sel = selectors(idx)
 
-      // Whitespace before this selector (after `{` for the first, after `,` for the rest).
       val selStart = cursor
       var p = selStart
       while (p < source.length && Character.isWhitespace(source.charAt(p))) p += 1
@@ -2535,7 +2563,6 @@ class ScalaTreeVisitor(
 
       val selectorNode = parseImportSelector(sel)
 
-      // After the selector, expect `,` (more selectors) or `}` (end).
       val afterSel = cursor
       var q = afterSel
       while (q < source.length && Character.isWhitespace(source.charAt(q))) q += 1
@@ -2571,7 +2598,7 @@ class ScalaTreeVisitor(
       S.Import.build(
         Tree.randomId(),
         prefix,
-        Markers.EMPTY,
+        markers,
         new JRightPadded(qualifier, qualifierRightPad, Markers.EMPTY),
         beforeBrace,
         selectorContainer
@@ -2580,7 +2607,7 @@ class ScalaTreeVisitor(
       S.Export.build(
         Tree.randomId(),
         prefix,
-        Markers.EMPTY,
+        markers,
         qualifier,
         beforeBrace,
         selectorContainer

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -2525,10 +2525,9 @@ class ScalaTreeVisitor(
       )
     }
 
-    // Whitespace between the qualifier and the `.`.
+    // Whitespace (and comments) between the qualifier and the `.`.
     val afterQualifier = cursor
-    var i = afterQualifier
-    while (i < source.length && Character.isWhitespace(source.charAt(i))) i += 1
+    val i = indexOfNextNonWhitespace(afterQualifier)
     val qualifierRightPad = Space.format(source.substring(afterQualifier, i))
     if (i >= source.length || source.charAt(i) != '.') {
       throw new IllegalStateException(
@@ -2537,10 +2536,9 @@ class ScalaTreeVisitor(
     }
     cursor = i + 1
 
-    // Whitespace between `.` and `{`.
+    // Whitespace (and comments) between `.` and `{`.
     val afterDot = cursor
-    var j = afterDot
-    while (j < source.length && Character.isWhitespace(source.charAt(j))) j += 1
+    val j = indexOfNextNonWhitespace(afterDot)
     val beforeBrace = Space.format(source.substring(afterDot, j))
     if (j >= source.length || source.charAt(j) != '{') {
       throw new IllegalStateException(
@@ -2556,16 +2554,14 @@ class ScalaTreeVisitor(
       val sel = selectors(idx)
 
       val selStart = cursor
-      var p = selStart
-      while (p < source.length && Character.isWhitespace(source.charAt(p))) p += 1
+      val p = indexOfNextNonWhitespace(selStart)
       val selPrefix = Space.format(source.substring(selStart, p))
       cursor = p
 
       val selectorNode = parseImportSelector(sel)
 
       val afterSel = cursor
-      var q = afterSel
-      while (q < source.length && Character.isWhitespace(source.charAt(q))) q += 1
+      val q = indexOfNextNonWhitespace(afterSel)
       val afterChar = if (q < source.length) source.charAt(q) else 0.toChar
       if (afterChar == ',') {
         val sepSpace = Space.format(source.substring(afterSel, q))

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ExportTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ExportTest.java
@@ -141,4 +141,36 @@ class ExportTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void commaContinuationBraceExport() {
+        rewriteRun(
+          scala(
+            """
+            class C(a: A, b: B) {
+              export a.{x}, b.{y}
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void scala3DocExample() {
+        rewriteRun(
+          scala(
+            """
+            object math:
+              def add(a: Int, b: Int) = a + b
+              def sub(a: Int, b: Int) = a - b
+
+            object api:
+              export math.{add, sub}
+
+            @main def run() =
+              println(api.add(1, 2))
+            """
+          )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ExportTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ExportTest.java
@@ -102,4 +102,43 @@ class ExportTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void braceExport() {
+        rewriteRun(
+          scala(
+            """
+            class C(a: A) {
+              export a.{x, y}
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void braceExportWithAlias() {
+        rewriteRun(
+          scala(
+            """
+            class C(a: A) {
+              export a.{x as X, y}
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void braceExportWithArrowAlias() {
+        rewriteRun(
+          scala(
+            """
+            class C(a: A) {
+              export a.{x => X}
+            }
+            """
+          )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ImportTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ImportTest.java
@@ -126,11 +126,115 @@ class ImportTest implements RewriteTest {
           scala(
             """
             package com.example
-            
+
             import scala.collection.mutable
             import java.util.List
-            
+
             val x = 42
+            """
+          )
+        );
+    }
+
+    @Test
+    void scala3AliasKeyword() {
+        rewriteRun(
+          scala(
+            """
+            import java.io.{File as JFile}
+            """
+          )
+        );
+    }
+
+    @Test
+    void givenSelector() {
+        rewriteRun(
+          scala(
+            """
+            import a.b.{given}
+            """
+          )
+        );
+    }
+
+    @Test
+    void givenWithTypeSelector() {
+        rewriteRun(
+          scala(
+            """
+            import a.b.{given Ordering[Int]}
+            """
+          )
+        );
+    }
+
+    @Test
+    void mixedSelectorsIncludingGiven() {
+        rewriteRun(
+          scala(
+            """
+            import a.b.{c, d => D, given Foo, *}
+            """
+          )
+        );
+    }
+
+    @Test
+    void importInsideClass() {
+        rewriteRun(
+          scala(
+            """
+            class C {
+              import scala.util._
+              val x = 1
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void braceImportFollowedByClass() {
+        rewriteRun(
+          scala(
+            """
+            package com.example
+
+            import a.b.{c, d}
+
+            class X {
+              val y = 1
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void braceImportInterleavedWithPlainImports() {
+        rewriteRun(
+          scala(
+            """
+            package com.example
+
+            import a.b
+            import c.d.{e, f}
+            import g.h
+            """
+          )
+        );
+    }
+
+    @Test
+    void importAfterStatement() {
+        // Scala allows imports to appear after other top-level statements.
+        rewriteRun(
+          scala(
+            """
+            class A { val x = 1 }
+            import scala.collection.mutable
+            class B { val y = 2 }
             """
           )
         );

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ImportTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ImportTest.java
@@ -227,6 +227,50 @@ class ImportTest implements RewriteTest {
     }
 
     @Test
+    void multipleNamedSelectorsRealWorld() {
+        rewriteRun(
+          scala(
+            """
+            import com.a.b.{Inspection, InspectionContext, Inspector, Levels}
+            """
+          )
+        );
+    }
+
+    @Test
+    void commaContinuationBrace() {
+        rewriteRun(
+          scala(
+            """
+            import a.{x}, b.{y}
+            """
+          )
+        );
+    }
+
+    @Test
+    void commaContinuationSimpleAndBrace() {
+        rewriteRun(
+          scala(
+            """
+            import a._, b.{x, y}
+            """
+          )
+        );
+    }
+
+    @Test
+    void commaContinuationBraceWithAlias() {
+        rewriteRun(
+          scala(
+            """
+            import a.{x => X}, b.{y as Y}
+            """
+          )
+        );
+    }
+
+    @Test
     void importAfterStatement() {
         // Scala allows imports to appear after other top-level statements.
         rewriteRun(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ImportTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ImportTest.java
@@ -238,6 +238,99 @@ class ImportTest implements RewriteTest {
     }
 
     @Test
+    void hidingAliasUnderscore() {
+        // Classic Scala idiom: import everything from Predef except `println`.
+        rewriteRun(
+          scala(
+            """
+            import scala.Predef.{println => _, _}
+            """
+          )
+        );
+    }
+
+    @Test
+    void hidingAliasAsUnderscore() {
+        // Scala 3 spelling of the same idiom.
+        rewriteRun(
+          scala(
+            """
+            import scala.Predef.{println as _, *}
+            """
+          )
+        );
+    }
+
+    @Test
+    void givenWithParameterizedType() {
+        rewriteRun(
+          scala(
+            """
+            import a.b.{given Conversion[Int, String]}
+            """
+          )
+        );
+    }
+
+    @Test
+    void backtickedSelector() {
+        rewriteRun(
+          scala(
+            """
+            import a.b.{`weird name`, c}
+            """
+          )
+        );
+    }
+
+    @Test
+    void backtickedQualifier() {
+        rewriteRun(
+          scala(
+            """
+            import a.`weird name`.c
+            """
+          )
+        );
+    }
+
+    @Test
+    void wildcardGivenWithoutBraces() {
+        // Imports all givens from a.b — Scala 3 shorthand.
+        rewriteRun(
+          scala(
+            """
+            import a.b.given
+            """
+          )
+        );
+    }
+
+    @Test
+    void commentInsideBraceSelectors() {
+        rewriteRun(
+          scala(
+            """
+            import a.b.{c /* the c */, d}
+            """
+          )
+        );
+    }
+
+    @Test
+    void importInsideMethodBody() {
+        rewriteRun(
+          scala(
+            """
+            def foo(): Int =
+              import scala.math._
+              max(1, 2)
+            """
+          )
+        );
+    }
+
+    @Test
     void commaContinuationBrace() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

Adding proper support for non-trivial `import` and `export` statements in Scala.
Some of them fit into `J.Import`, but the rest need an LST element on its own.
Also in Scala the import statements might appear in random order with other statements, so deleting the `imports` fields from `S.CompilationUnit`.

## What's your motivation?

More complete handling of Scala language.
That's the biggest gap in our parsing coverage left.