### PR TITLE
Suppress gradleApi() transitive CVEs in rewrite-gradle-tooling-model:plugin

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -16,7 +16,7 @@
         <packageUrl regex="true">^pkg:maven/org\.scala-sbt/sbinary_2\.13@.*$</packageUrl>
         <cve>CVE-2023-46122</cve>
     </suppress>
-    <suppress until="2026-11-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
            file name: jline-2.14.7-sbt-9c3b6aca11c57e339441442bbf58e550cdfecb79.jar
            reason: This jline fork is bundled inside the Gradle distribution and is only pulled in
@@ -27,7 +27,7 @@
         <packageUrl regex="true">^pkg:maven/org\.scala-sbt\.jline/jline@.*$</packageUrl>
         <cve>CVE-2023-50572</cve>
     </suppress>
-    <suppress until="2026-11-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
            file name: log4j-api-2.17.1.jar / log4j-core-2.17.1.jar
            reason: log4j 2.17.1 is bundled inside the Gradle distribution and is only pulled in

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -16,4 +16,29 @@
         <packageUrl regex="true">^pkg:maven/org\.scala-sbt/sbinary_2\.13@.*$</packageUrl>
         <cve>CVE-2023-46122</cve>
     </suppress>
+    <suppress until="2026-11-01Z">
+        <notes><![CDATA[
+           file name: jline-2.14.7-sbt-9c3b6aca11c57e339441442bbf58e550cdfecb79.jar
+           reason: This jline fork is bundled inside the Gradle distribution and is only pulled in
+           transitively via gradleApi() in rewrite-gradle-tooling-model:plugin. It is provided by
+           the user's Gradle runtime, not shipped with our artifact, and is not used at runtime by
+           our plugin code.
+           ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.scala-sbt\.jline/jline@.*$</packageUrl>
+        <cve>CVE-2023-50572</cve>
+    </suppress>
+    <suppress until="2026-11-01Z">
+        <notes><![CDATA[
+           file name: log4j-api-2.17.1.jar / log4j-core-2.17.1.jar
+           reason: log4j 2.17.1 is bundled inside the Gradle distribution and is only pulled in
+           transitively via gradleApi() in rewrite-gradle-tooling-model:plugin. It is provided by
+           the user's Gradle runtime, not shipped with our artifact, and is not used at runtime by
+           our plugin code. The Gradle version users run determines which log4j is on the classpath.
+           ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j-(api|core)@.*$</packageUrl>
+        <cve>CVE-2025-68161</cve>
+        <cve>CVE-2026-34477</cve>
+        <cve>CVE-2026-34479</cve>
+        <cve>CVE-2026-34480</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Summary
- Adds OWASP dependency-check suppressions for 5 CVEs (CVE-2023-50572 in jline; CVE-2025-68161, CVE-2026-34477, CVE-2026-34479, CVE-2026-34480 in log4j 2.17.1) reported against `rewrite-gradle-tooling-model:plugin`.
- These jars are pulled in transitively via `gradleApi()` and are provided by the user's Gradle runtime at execution time — they are not bundled in our published artifact, so the user's Gradle version (not our build) determines the classpath versions.
- Suppressions are dated `until="2026-11-01Z"` consistent with the project's `UpdateOwaspSuppressionDate` convention.
- https://github.com/moderneinc/dependency-vulnerability-reports/issues/1073

## Test plan
- [ ] CI `dependencyCheckAggregate` no longer reports the 7 vulnerabilities on `rewrite-gradle-tooling-model:plugin`