### PR TITLE
npm-publish: infer release version from git tag instead of SNAPSHOT

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -66,10 +66,14 @@ jobs:
           CI: 'true'
         run: |
           # The upstream `publish` workflow is tag-only and already restricts
-          # releases to version tags.
+          # releases to version tags. Mirror its nebula-release flags so the
+          # version is inferred from the tag (e.g. 8.83.0) rather than falling
+          # back to a SNAPSHOT — npm 11 refuses to publish a prerelease without
+          # an explicit --tag.
           if [[ '${{ github.event.workflow_run.name }}' == 'publish' ]]; then
             ./gradlew --no-daemon --console=plain --info --stacktrace \
-              :rewrite-javascript:npmPublish -Preleasing
+              -Preleasing -Prelease.disableGitChecks=true -Prelease.useLastTag=true \
+              final :rewrite-javascript:npmPublish
           else
             ./gradlew --no-daemon --console=plain --info --stacktrace \
               :rewrite-javascript:npmPublish


### PR DESCRIPTION
## Summary

- When `npm-publish.yml` was triggered by the tag-based `publish` workflow for **v8.83.0** ([failed run](https://github.com/openrewrite/rewrite/actions/runs/26217563099/job/77143773999)), it invoked `:rewrite-javascript:npmPublish -Preleasing`. `-Preleasing` suppresses the `--tag next` fallback in `rewrite-javascript/build.gradle.kts:242-244`, expecting a final version.
- But without a release-stage flag, the nebula-release plugin fell back to its snapshot strategy (`Using snapshot default strategy because repo is clean and no stage defined`) and inferred `8.84.0-SNAPSHOT` even though `v8.83.0` pointed at HEAD. After `datedSnapshotVersion` substitution that becomes a SemVer prerelease, and npm 11 refuses to publish a prerelease to the implicit `latest` dist-tag:

  ```
  npm error You must specify a tag using --tag when publishing a prerelease version.
  ```

- Mirror the nebula-release flags that [`openrewrite/gh-automation/.github/workflows/publish-gradle.yml`](https://github.com/openrewrite/gh-automation/blob/main/.github/workflows/publish-gradle.yml) uses for its tag-triggered release path: `-Prelease.disableGitChecks=true -Prelease.useLastTag=true final`. The version is then taken from the tag (e.g. `8.83.0`) and npm publishes to `latest` as intended.
- The previous successful npm-publish (the `ci`-triggered snapshot path) is unchanged — it still publishes to dist-tag `next`.

## Test plan

- [ ] After merge, re-run the failed npm-publish job for v8.83.0: `gh run rerun 26217563099 --repo openrewrite/rewrite --failed`. `workflow_run` loads the workflow YAML from the default branch, so the patched workflow runs against the v8.83.0 head_sha.
- [ ] Confirm `@openrewrite/rewrite@8.83.0` is published to npm at dist-tag `latest`.
- [ ] Watch the next tagged release to confirm the release path stays healthy.