### PR TITLE
Scala: handle whitespace before asInstanceOf cast

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -31,6 +31,7 @@ import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeTree;
 import org.openrewrite.marker.Marker;
+import org.openrewrite.scala.marker.AsInstanceOfPrefix;
 import org.openrewrite.scala.marker.BlockArgument;
 import org.openrewrite.scala.marker.IndentedSyntax;
 import org.openrewrite.scala.marker.PackageBraces;
@@ -1091,6 +1092,10 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         // asInstanceOf handling
         beforeSyntax(typeCast, Space.Location.TYPE_CAST_PREFIX, p);
         visit(typeCast.getExpression(), p);
+        Optional<AsInstanceOfPrefix> asInstanceOfPrefix = typeCast.getMarkers().findFirst(AsInstanceOfPrefix.class);
+        if (asInstanceOfPrefix.isPresent()) {
+            visitSpace(asInstanceOfPrefix.get().getPrefix(), Space.Location.LANGUAGE_EXTENSION, p);
+        }
         p.append(".asInstanceOf");
         if (typeCast.getClazz() instanceof J.ControlParentheses) {
             J.ControlParentheses<?> controlParens = (J.ControlParentheses<?>) typeCast.getClazz();

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -37,6 +37,7 @@ import org.openrewrite.scala.marker.ScalaForLoop
 import org.openrewrite.scala.marker.BlockArgument
 import org.openrewrite.scala.marker.CommaContinuation
 import org.openrewrite.scala.marker.FunctionApplication
+import org.openrewrite.scala.marker.AsInstanceOfPrefix
 import org.openrewrite.scala.marker.TypeAscription
 import org.openrewrite.scala.marker.UnderscorePlaceholderLambda
 import org.openrewrite.scala.marker.PartialFunctionLiteral
@@ -5317,8 +5318,19 @@ class ScalaTreeVisitor(
             case _ => return visitUnknown(ta)
           }
           
+          // Capture whitespace between the qualifier and ".asInstanceOf"
+          // (e.g. when ".asInstanceOf" sits on its own line as part of a chain).
+          val asInstanceOfEnd = Math.max(0, sel.span.end - offsetAdjustment)
+          val asInstanceOfNameLen = "asInstanceOf".length
+          val dotPos = asInstanceOfEnd - asInstanceOfNameLen - 1
+          val asInstanceOfPrefix: Space =
+            if (cursor >= 0 && cursor <= dotPos && dotPos <= source.length) {
+              Space.format(source.substring(cursor, dotPos))
+            } else {
+              Space.EMPTY
+            }
+
           // Update cursor past ".asInstanceOf"
-          val asInstanceOfEnd = sel.span.end
           if (asInstanceOfEnd > cursor) {
             cursor = asInstanceOfEnd
           }
@@ -5351,10 +5363,17 @@ class ScalaTreeVisitor(
             cursor = ta.span.end
           }
           
+          val typeCastMarkers =
+            if (asInstanceOfPrefix.getWhitespace.nonEmpty || !asInstanceOfPrefix.getComments.isEmpty) {
+              Markers.EMPTY.addIfAbsent(AsInstanceOfPrefix.create(asInstanceOfPrefix))
+            } else {
+              Markers.EMPTY
+            }
+
           return new J.TypeCast(
             Tree.randomId(),
             Space.EMPTY,  // TypeCast itself has no prefix - the space is handled by the variable initializer
-            Markers.EMPTY,
+            typeCastMarkers,
             new J.ControlParentheses[TypeTree](
               Tree.randomId(),
               spaceBeforeBracket,
@@ -5386,24 +5405,36 @@ class ScalaTreeVisitor(
             case j: J => new S.StatementExpression(Tree.randomId(), j)
             case _ => return visitUnknown(ta)
           }
-          
+
+          // Capture whitespace between the qualifier and ".isInstanceOf"
+          // (e.g. when ".isInstanceOf" sits on its own line as part of a chain).
+          val isInstanceOfEnd = Math.max(0, sel.span.end - offsetAdjustment)
+          val isInstanceOfNameLen = "isInstanceOf".length
+          val isInstanceOfDotPos = isInstanceOfEnd - isInstanceOfNameLen - 1
+          val exprAfterSpace: Space =
+            if (cursor >= 0 && cursor <= isInstanceOfDotPos && isInstanceOfDotPos <= source.length) {
+              Space.format(source.substring(cursor, isInstanceOfDotPos))
+            } else {
+              Space.EMPTY
+            }
+
           // Update cursor to start of type argument
           cursor = Math.max(0, ta.args.head.span.start - offsetAdjustment)
-          
+
           // Visit the target type
           val clazz = visitTree(ta.args.head) match {
             case tt: TypeTree => tt
             case _ => return visitUnknown(ta)
           }
-          
+
           // Update cursor to the end of the TypeApply
           updateCursor(ta.span.end)
-          
+
           return new J.InstanceOf(
             Tree.randomId(),
             prefix,
             Markers.EMPTY,
-            JRightPadded.build(expr),
+            new JRightPadded(expr, exprAfterSpace, Markers.EMPTY),
             clazz,
             null, // pattern (not used in Scala)
             null  // type

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InstanceOfTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InstanceOfTest.java
@@ -135,4 +135,16 @@ class InstanceOfTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void chainedIsInstanceOfOnNewLine() {
+        rewriteRun(
+          scala(
+            """
+            val b = something.dataType
+              .isInstanceOf[StructType]
+            """
+          )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TypeCastTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TypeCastTest.java
@@ -135,4 +135,16 @@ class TypeCastTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void chainedAsInstanceOfOnNewLine() {
+        rewriteRun(
+          scala(
+            """
+            val hudiSchemaAsStruct = something.dataType
+              .asInstanceOf[StructType]
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fix Scala parser handling of newline before `.asInstanceOf` cast, e.g.
```
            val hudiSchemaAsStruct = something.dataType
              .asInstanceOf[StructType]
```

## What's your motivation?

It suffers from idempotency issues.