### PR TITLE
Scala: amendments to import handling

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -743,12 +743,19 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
     }
     
     private boolean isSyntheticPredefChain(J.FieldAccess fa) {
-        // Detect _root_.scala.Predef.??? chains added by compiler for procedure syntax
-        if ("???".equals(fa.getSimpleName()) || "$qmark$qmark$qmark".equals(fa.getSimpleName())) {
-            return true;
+        // Detect compiler-synthetic _root_.scala.Predef.??? chains from procedure-syntax
+        // desugaring. Require both the `???` leaf and the `_root_` root so that real
+        // user-written `_root_.foo.bar` imports/qualifiers aren't suppressed.
+        String leaf = fa.getSimpleName();
+        if (!"???".equals(leaf) && !"$qmark$qmark$qmark".equals(leaf)) {
+            return false;
         }
+        return chainStartsAtRoot(fa);
+    }
+
+    private boolean chainStartsAtRoot(J.FieldAccess fa) {
         if (fa.getTarget() instanceof J.FieldAccess) {
-            return isSyntheticPredefChain((J.FieldAccess) fa.getTarget());
+            return chainStartsAtRoot((J.FieldAccess) fa.getTarget());
         }
         if (fa.getTarget() instanceof J.Identifier) {
             return "_root_".equals(((J.Identifier) fa.getTarget()).getSimpleName());
@@ -1576,7 +1583,11 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             if (export.getBeforeBrace() != null) {
                 visitSpace(export.getBeforeBrace(), Space.Location.LANGUAGE_EXTENSION, p);
             }
-            visitContainer("{", export.getPadding().getSelectors(), JContainer.Location.LANGUAGE_EXTENSION, ",", "}", p);
+            if (export.getMarkers().findFirst(org.openrewrite.scala.marker.OmitImportBraces.class).isPresent()) {
+                visitContainer("", export.getPadding().getSelectors(), JContainer.Location.LANGUAGE_EXTENSION, ",", "", p);
+            } else {
+                visitContainer("{", export.getPadding().getSelectors(), JContainer.Location.LANGUAGE_EXTENSION, ",", "}", p);
+            }
         } else if (clause instanceof J.FieldAccess && isWildcardImport((J.FieldAccess) clause)) {
             J.FieldAccess fa = (J.FieldAccess) clause;
             visitFieldAccessUpToWildcard(fa, p);
@@ -1598,7 +1609,11 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         visitRightPadded(sImport.getPadding().getQualifier(), JRightPadded.Location.LANGUAGE_EXTENSION, p);
         p.append('.');
         visitSpace(sImport.getBeforeBrace(), Space.Location.LANGUAGE_EXTENSION, p);
-        visitContainer("{", sImport.getPadding().getSelectors(), JContainer.Location.LANGUAGE_EXTENSION, ",", "}", p);
+        if (sImport.getMarkers().findFirst(org.openrewrite.scala.marker.OmitImportBraces.class).isPresent()) {
+            visitContainer("", sImport.getPadding().getSelectors(), JContainer.Location.LANGUAGE_EXTENSION, ",", "", p);
+        } else {
+            visitContainer("{", sImport.getPadding().getSelectors(), JContainer.Location.LANGUAGE_EXTENSION, ",", "}", p);
+        }
         afterSyntax(sImport, p);
         return sImport;
     }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/OmitImportBraces.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/OmitImportBraces.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.marker;
+
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Marker applied to a Scala 3 single-selector import that uses the unbraced
+ * {@code as} rename form, e.g. {@code import a.b.X as Y}. The selector still
+ * lives in the {@link org.openrewrite.scala.tree.S.Import}'s selector
+ * container, but the printer omits the surrounding braces.
+ */
+public class OmitImportBraces implements Marker {
+    private final UUID id;
+
+    public OmitImportBraces(UUID id) {
+        this.id = id;
+    }
+
+    @Override
+    public UUID getId() {
+        return id;
+    }
+
+    @Override
+    public OmitImportBraces withId(UUID id) {
+        return new OmitImportBraces(id);
+    }
+}

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -29,6 +29,7 @@ import org.openrewrite.scala.marker.Implicit
 import org.openrewrite.scala.marker.LambdaParameter
 import org.openrewrite.scala.marker.IndentedSyntax
 import org.openrewrite.scala.marker.OmitBraces
+import org.openrewrite.scala.marker.OmitImportBraces
 import org.openrewrite.scala.marker.PackageObject
 import org.openrewrite.scala.marker.SObject
 import org.openrewrite.scala.marker.Semicolon
@@ -2536,19 +2537,59 @@ class ScalaTreeVisitor(
     }
     cursor = i + 1
 
-    // Whitespace (and comments) between `.` and `{`.
+    // Whitespace (and comments) between `.` and `{` (or, for the Scala 3
+    // unbraced single-selector rename form `import a.b.X as Y`, between `.`
+    // and the selector name).
     val afterDot = cursor
     val j = indexOfNextNonWhitespace(afterDot)
-    val beforeBrace = Space.format(source.substring(afterDot, j))
-    if (j >= source.length || source.charAt(j) != '{') {
-      throw new IllegalStateException(
-        s"Expected '{' after '.' in $keyword at position $j: '${spanText}'"
-      )
+    val isBraceless = j < source.length && source.charAt(j) != '{'
+    val beforeBrace = if (isBraceless) Space.EMPTY
+      else Space.format(source.substring(afterDot, j))
+    if (!isBraceless) {
+      cursor = j + 1
     }
-    cursor = j + 1
+    val bracelessMarkers = if (isBraceless)
+      markers.addIfAbsent(new OmitImportBraces(Tree.randomId()))
+      else markers
 
     val selectorElems = new util.ArrayList[JRightPadded[S.ImportSelector]]()
     val selectors = tree.selectors
+    if (isBraceless) {
+      if (selectors.size != 1) {
+        throw new IllegalStateException(
+          s"Expected exactly one selector for braceless $keyword at position $j: '${spanText}'"
+        )
+      }
+      val sel = selectors.head
+      val selStart = cursor
+      val p = indexOfNextNonWhitespace(selStart)
+      val selPrefix = Space.format(source.substring(selStart, p))
+      cursor = p
+      val selectorNode = parseImportSelector(sel)
+      selectorElems.add(new JRightPadded(selectorNode.withPrefix(selPrefix), Space.EMPTY, Markers.EMPTY))
+      if (cursor < adjustedEnd) cursor = adjustedEnd
+      val selectorContainerB: JContainer[S.ImportSelector] =
+        JContainer.build(Space.EMPTY, selectorElems, Markers.EMPTY)
+      return (if (keyword == "import") {
+        S.Import.build(
+          Tree.randomId(),
+          prefix,
+          bracelessMarkers,
+          new JRightPadded(qualifier, qualifierRightPad, Markers.EMPTY),
+          beforeBrace,
+          selectorContainerB
+        )
+      } else {
+        S.Export.build(
+          Tree.randomId(),
+          prefix,
+          bracelessMarkers,
+          qualifier,
+          beforeBrace,
+          selectorContainerB
+        )
+      })
+    }
     var idx = 0
     while (idx < selectors.size) {
       val sel = selectors(idx)
@@ -2669,8 +2710,7 @@ class ScalaTreeVisitor(
             false, null, false, false, nameIdent, null, false
           )
         case renamed: Trees.Ident[?] =>
-          var p = cursor
-          while (p < source.length && Character.isWhitespace(source.charAt(p))) p += 1
+          val p = indexOfNextNonWhitespace(cursor)
           val beforeArrow = Space.format(source.substring(cursor, p))
           val useAsKeyword = source.startsWith("as", p)
           val useArrow = source.startsWith("=>", p)
@@ -5145,7 +5185,9 @@ class ScalaTreeVisitor(
           val visitedSpans = new java.util.HashSet[Int]()
           // Sort by source position to preserve source order
           val sortedBody = template.body.sortBy(s => if (s.span.exists) s.span.start else Int.MaxValue)
-          for (stat <- sortedBody) {
+          val classEndForBody = if (td.span.exists) Math.max(0, td.span.end - offsetAdjustment) else source.length
+          for (idx <- sortedBody.indices) {
+            val stat = sortedBody(idx)
             val isSyntheticStat = stat.span.isSynthetic || {
               def hasTripleQ(t: Trees.Tree[?]): Boolean = t match {
                 case sel: Trees.Select[?] => sel.name.toString == "???" || sel.name.toString == "$qmark$qmark$qmark" || hasTripleQ(sel.qualifier)
@@ -5158,13 +5200,30 @@ class ScalaTreeVisitor(
             }
             if (stat.span.exists && !isSyntheticStat) {
               if (visitedSpans.add(stat.span.start)) {
-                visitTree(stat) match {
-                  case null =>
-                  case stmt: Statement =>
-                    statements.add(JRightPadded.build(stmt))
-                  case expr: Expression =>
-                    statements.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
-                  case _ =>
+                val visitedStmt: Statement = visitTree(stat) match {
+                  case null => null
+                  case stmt: Statement => stmt
+                  case expr: Expression => new S.ExpressionStatement(Tree.randomId(), expr)
+                  case _ => null
+                }
+                if (visitedStmt != null) {
+                  val statEnd = Math.max(0, stat.span.end - offsetAdjustment)
+                  val nextStart = {
+                    var k = idx + 1
+                    var ns = classEndForBody
+                    while (k < sortedBody.size) {
+                      val s = sortedBody(k)
+                      if (s.span.exists && !s.span.isSynthetic) {
+                        ns = Math.max(0, s.span.start - offsetAdjustment)
+                        k = sortedBody.size
+                      } else {
+                        k += 1
+                      }
+                    }
+                    ns
+                  }
+                  val (trailingSpace, rpMarkers) = consumeTrailingSemicolon(statEnd, nextStart)
+                  statements.add(new JRightPadded[Statement](visitedStmt, trailingSpace, rpMarkers))
                 }
               }
             }
@@ -8123,6 +8182,35 @@ class ScalaTreeVisitor(
    * position of the next significant character. Returns `source.length` if no
    * such character exists.
    */
+  /**
+   * After visiting a statement that ended at `statEnd`, detect an explicit `;`
+   * separator on the same line and consume it. Returns the JRightPadded
+   * trailing space and markers; advances `cursor`.
+   */
+  private def consumeTrailingSemicolon(statEnd: Int, nextStart: Int): (Space, Markers) = {
+    val trailStart = Math.max(statEnd, cursor)
+    if (trailStart >= nextStart || nextStart > source.length) {
+      return (Space.EMPTY, Markers.EMPTY)
+    }
+    val between = source.substring(trailStart, nextStart)
+    var semiIdx = -1
+    var j = 0
+    while (semiIdx < 0 && j < between.length) {
+      val c = between.charAt(j)
+      if (c == ';') semiIdx = j
+      else if (c == '\n' || c == '\r') j = between.length
+      else if (c != ' ' && c != '\t') j = between.length
+      else j += 1
+    }
+    if (semiIdx >= 0) {
+      val trailing = if (semiIdx > 0) Space.format(between.substring(0, semiIdx)) else Space.EMPTY
+      cursor = trailStart + semiIdx + 1
+      (trailing, Markers.EMPTY.add(new Semicolon(Tree.randomId())))
+    } else {
+      (Space.EMPTY, Markers.EMPTY)
+    }
+  }
+
   private def indexOfNextNonWhitespace(startFrom: Int = cursor): Int = {
     var i = startFrom
     while (i < source.length) {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ImportTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ImportTest.java
@@ -295,6 +295,50 @@ class ImportTest implements RewriteTest {
     }
 
     @Test
+    void scala3AliasKeywordWithoutBraces() {
+        rewriteRun(
+          scala(
+            """
+            import a.b.c.X as Y
+            """
+          )
+        );
+    }
+
+    @Test
+    void rootPrefix() {
+        rewriteRun(
+          scala(
+            """
+            import _root_.scala.collection.mutable
+            """
+          )
+        );
+    }
+
+    @Test
+    void semicolonAfterImportInsideClass() {
+        rewriteRun(
+          scala(
+            """
+            class C { import scala.math._; val x = 1 }
+            """
+          )
+        );
+    }
+
+    @Test
+    void commentBetweenSelectorNameAndAs() {
+        rewriteRun(
+          scala(
+            """
+            import a.b.{X /* hi */ as Y}
+            """
+          )
+        );
+    }
+
+    @Test
     void wildcardGivenWithoutBraces() {
         // Imports all givens from a.b — Scala 3 shorthand.
         rewriteRun(


### PR DESCRIPTION
## What's changed?

Continuation of #7751. Handling more variants of imports in Scala including:
- `import _root_.something`
- braceless import with alias, e.g. `import a.b.X as Y`
- etc.

## What's your motivation?

They are currently not supported.