### PR TITLE
RecipeClassLoader: child-load Kotlin recipe-DSL builder classes

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
@@ -36,6 +36,19 @@ import static java.util.Collections.emptyList;
 public class RecipeClassLoader extends URLClassLoader {
     private final ClassLoader parent;
 
+    // Classes whose FQN collides with a {@link #PARENT_DELEGATED_PREFIXES} entry by
+    // accident — `org.openrewrite.RecipeBuilder` etc. all `startsWith("org.openrewrite.Recipe")`
+    // — but which are Kotlin recipe-DSL internals that must resolve through the recipe-jar's
+    // classloader. Without this exclusion the lambda receivers (child-loaded `EditScope`,
+    // `ScanScope`, etc.) and the anonymous `Recipe` synthesized inside `RecipeBuilder.build()`
+    // (parent-loaded) end up on different loaders, producing a `ClassCastException` on the
+    // first `getVisitor()` call. See moderneinc/moderne-cli#3949.
+    private static final Set<String> NON_DELEGATED_CLASSES = new HashSet<>(Arrays.asList(
+            "org.openrewrite.RecipeBuilder",
+            "org.openrewrite.RecipeDsl",
+            "org.openrewrite.RecipeDslKt"
+    ));
+
     // Core OpenRewrite types that must be loaded from parent (from Moderne's RecipeClassLoader)
     private static final List<String> PARENT_DELEGATED_PREFIXES = Arrays.asList(
             "org.openrewrite.AbstractRecipe",
@@ -178,6 +191,21 @@ public class RecipeClassLoader extends URLClassLoader {
         for (String prefix : getAdditionalParentDelegatedPackages()) {
             if (className.startsWith(prefix)) {
                 return true;
+            }
+        }
+
+        // Force child-load for Kotlin recipe-DSL types that would otherwise be caught by
+        // a coarse `org.openrewrite.Recipe*` prefix match below. Recipe authors compile
+        // their `recipe { … }` lambdas against the bundled rewrite-kotlin version; the
+        // receiver-type linkage and the in-builder `EditScope()` construction must agree
+        // on which `Class<?>` they resolve to. Covers nested anonymous classes
+        // (`RecipeBuilder$buildSimpleRecipe$1`, etc.).
+        if (NON_DELEGATED_CLASSES.contains(className)) {
+            return false;
+        }
+        for (String cls : NON_DELEGATED_CLASSES) {
+            if (className.startsWith(cls + "$")) {
+                return false;
             }
         }
 

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeClassLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeClassLoaderTest.java
@@ -199,6 +199,71 @@ class RecipeClassLoaderTest {
     }
 
     @Test
+    void kotlinRecipeDslClassesShouldBeChildLoaded(@TempDir Path tempDir) throws Exception {
+        // Reproduces moderneinc/moderne-cli#3949: `org.openrewrite.RecipeBuilder` collides with
+        // the `org.openrewrite.Recipe` allowlist entry under startsWith() matching, which would
+        // route it to the parent classloader. That conflicts with the lambda receivers
+        // (EditScope, ScanScope) — those don't match any prefix and are child-loaded —
+        // producing a ClassCastException on the first getVisitor() call. The Kotlin
+        // recipe-DSL builder must come from the recipe jar so all DSL types resolve through
+        // one loader.
+        Path parentLib = tempDir.resolve("parent");
+        Files.createDirectories(parentLib.resolve("org/openrewrite"));
+        Files.write(parentLib.resolve("org/openrewrite/RecipeBuilder.class"),
+          stubClass("org/openrewrite/RecipeBuilder"));
+        Files.write(parentLib.resolve("org/openrewrite/RecipeBuilder$buildSimpleRecipe$1.class"),
+          stubClass("org/openrewrite/RecipeBuilder$buildSimpleRecipe$1"));
+        Files.write(parentLib.resolve("org/openrewrite/RecipeDslKt.class"),
+          stubClass("org/openrewrite/RecipeDslKt"));
+
+        Path childLib = tempDir.resolve("child");
+        Files.createDirectories(childLib.resolve("org/openrewrite"));
+        Files.write(childLib.resolve("org/openrewrite/RecipeBuilder.class"),
+          stubClass("org/openrewrite/RecipeBuilder"));
+        Files.write(childLib.resolve("org/openrewrite/RecipeBuilder$buildSimpleRecipe$1.class"),
+          stubClass("org/openrewrite/RecipeBuilder$buildSimpleRecipe$1"));
+        Files.write(childLib.resolve("org/openrewrite/RecipeDslKt.class"),
+          stubClass("org/openrewrite/RecipeDslKt"));
+
+        try (URLClassLoader parent = new URLClassLoader(new URL[]{parentLib.toUri().toURL()}, null);
+             RecipeClassLoader classLoader = new RecipeClassLoader(new URL[]{childLib.toUri().toURL()}, parent)) {
+            assertThat(classLoader.loadClass("org.openrewrite.RecipeBuilder").getClassLoader())
+              .as("RecipeBuilder must be child-loaded for DSL receiver/constructor agreement")
+              .isSameAs(classLoader);
+            assertThat(classLoader.loadClass("org.openrewrite.RecipeBuilder$buildSimpleRecipe$1").getClassLoader())
+              .as("RecipeBuilder's synthetic inner classes must share the loader of their host")
+              .isSameAs(classLoader);
+            assertThat(classLoader.loadClass("org.openrewrite.RecipeDslKt").getClassLoader())
+              .as("RecipeDslKt (top-level fn holder) must be child-loaded")
+              .isSameAs(classLoader);
+        }
+    }
+
+    @Test
+    void recipeFrameworkClassesStillDelegateToParent(@TempDir Path tempDir) throws Exception {
+        // The NON_DELEGATED_CLASSES override is narrow: framework types under the
+        // `org.openrewrite.Recipe*` umbrella that aren't DSL internals — RecipeException,
+        // RecipeRun, RecipeSerializer, etc. — must remain parent-delegated so exceptions
+        // thrown across the loader boundary are catchable and result objects round-trip.
+        Path parentLib = tempDir.resolve("parent");
+        Files.createDirectories(parentLib.resolve("org/openrewrite"));
+        Files.write(parentLib.resolve("org/openrewrite/RecipeException.class"),
+          stubClass("org/openrewrite/RecipeException"));
+
+        Path childLib = tempDir.resolve("child");
+        Files.createDirectories(childLib.resolve("org/openrewrite"));
+        Files.write(childLib.resolve("org/openrewrite/RecipeException.class"),
+          stubClass("org/openrewrite/RecipeException"));
+
+        try (URLClassLoader parent = new URLClassLoader(new URL[]{parentLib.toUri().toURL()}, null);
+             RecipeClassLoader classLoader = new RecipeClassLoader(new URL[]{childLib.toUri().toURL()}, parent)) {
+            assertThat(classLoader.loadClass("org.openrewrite.RecipeException").getClassLoader())
+              .as("RecipeException stays parent-delegated under the Recipe-prefix entry")
+              .isSameAs(parent);
+        }
+    }
+
+    @Test
     void allResourcesShouldFindFromParentLast(@TempDir Path tempDir) throws IOException {
         Path lib1 = tempDir.resolve("lib1");
         Files.createDirectories(lib1);


### PR DESCRIPTION
## Summary
- `shouldDelegateToParent`'s coarse `startsWith` match against `org.openrewrite.Recipe` accidentally routes `RecipeBuilder` / `RecipeDsl` / `RecipeDslKt` (Kotlin recipe-DSL internals) to the parent classloader. The lambda receivers in the same DSL (`EditScope`, `ScanScope`, …) don't match any prefix and are child-loaded, so the two halves end up on different `Class<?>` objects.
- Result: any imperative `recipe { edit { kotlin { visitX { … } } } }` recipe whose jar bundles a different `rewrite-kotlin` than the host throws `ClassCastException: class org.openrewrite.EditScope cannot be cast to class org.openrewrite.EditScope` on its first `getVisitor()` call.
- Add a narrow `NON_DELEGATED_CLASSES` override checked before the prefix loop (including `prefix + "$"` for synthetic inner classes like `RecipeBuilder$buildSimpleRecipe$1`) so the three accidentally-matched DSL types come from the recipe jar alongside their lambda peers. Framework types under the same `Recipe*` umbrella (`RecipeException`, `RecipeRun`, `RecipeSerializer`, …) continue to parent-delegate so exceptions cross the loader boundary and result objects round-trip.

- Fixes [moderneinc/moderne-cli#3949](https://github.com/moderneinc/moderne-cli/issues/3949).

## Test plan
- [x] New `kotlinRecipeDslClassesShouldBeChildLoaded` — asserts `RecipeBuilder`, `RecipeBuilder$buildSimpleRecipe$1`, and `RecipeDslKt` all resolve from the child loader when both child and parent define them.
- [x] New `recipeFrameworkClassesStillDelegateToParent` — asserts `RecipeException` still resolves from the parent, confirming the override is narrow.
- [x] Existing `RecipeClassLoaderTest` suite still passes.