### PR TITLE
Go: employ modfile for parsing go.mod files

### DIFF
--- a/rewrite-go/go.mod
+++ b/rewrite-go/go.mod
@@ -2,11 +2,13 @@ module github.com/openrewrite/rewrite/rewrite-go
 
 go 1.25.0
 
-require github.com/google/uuid v1.6.0
+require (
+	github.com/google/uuid v1.6.0
+	github.com/grafana/pyroscope-go v1.2.8
+	golang.org/x/mod v0.35.0
+)
 
 require (
-	github.com/grafana/pyroscope-go v1.2.8 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/klauspost/compress v1.17.8 // indirect
-	golang.org/x/mod v0.35.0 // indirect
 )

--- a/rewrite-go/go.sum
+++ b/rewrite-go/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grafana/pyroscope-go v1.2.8 h1:UvCwIhlx9DeV7F6TW/z8q1Mi4PIm3vuUJ2ZlCEvmA4M=
@@ -6,5 +8,13 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=
 github.com/klauspost/compress v1.17.8/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rewrite-go/pkg/recipe/installer/installer.go
+++ b/rewrite-go/pkg/recipe/installer/installer.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"text/template"
 
+	"golang.org/x/mod/modfile"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 )
 
@@ -458,14 +460,17 @@ func (inst *Installer) propagateReplaces(moduleDir string) error {
 
 // readResolvedVersion reads the resolved version of a module from the workspace go.mod.
 func (inst *Installer) readResolvedVersion(modulePath string) string {
-	data, _ := os.ReadFile(filepath.Join(inst.WorkspaceDir, "go.mod"))
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.Contains(line, modulePath) && !strings.HasPrefix(line, "module") {
-			parts := strings.Fields(line)
-			if len(parts) >= 2 {
-				return parts[len(parts)-1]
-			}
+	data, err := os.ReadFile(filepath.Join(inst.WorkspaceDir, "go.mod"))
+	if err != nil {
+		return ""
+	}
+	f, err := modfile.Parse("go.mod", data, nil)
+	if err != nil {
+		return ""
+	}
+	for _, r := range f.Require {
+		if r.Mod.Path == modulePath {
+			return r.Mod.Version
 		}
 	}
 	return ""

--- a/rewrite-go/pkg/recipe/installer/installer_test.go
+++ b/rewrite-go/pkg/recipe/installer/installer_test.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeGoMod(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(contents), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	return dir
+}
+
+func TestReadResolvedVersion_DirectRequireInBlock(t *testing.T) {
+	// given
+	goMod := `module example.com/workspace
+
+go 1.25
+
+require (
+	github.com/foo/bar v1.2.3
+)
+`
+	inst := &Installer{WorkspaceDir: writeGoMod(t, goMod)}
+
+	// when
+	got := inst.readResolvedVersion("github.com/foo/bar")
+
+	// then
+	if got != "v1.2.3" {
+		t.Errorf("expected v1.2.3, got %q", got)
+	}
+}
+
+func TestReadResolvedVersion_IndirectRequireInBlock(t *testing.T) {
+	// given
+	goMod := `module example.com/workspace
+
+go 1.25
+
+require (
+	github.com/foo/bar v1.2.3 // indirect
+)
+`
+	inst := &Installer{WorkspaceDir: writeGoMod(t, goMod)}
+
+	// when
+	got := inst.readResolvedVersion("github.com/foo/bar")
+
+	// then
+	if got != "v1.2.3" {
+		t.Errorf("expected v1.2.3, got %q", got)
+	}
+}
+
+func TestReadResolvedVersion_SingleLineRequire(t *testing.T) {
+	// given
+	goMod := `module example.com/workspace
+
+go 1.25
+
+require github.com/foo/bar v1.2.3
+`
+	inst := &Installer{WorkspaceDir: writeGoMod(t, goMod)}
+
+	// when
+	got := inst.readResolvedVersion("github.com/foo/bar")
+
+	// then
+	if got != "v1.2.3" {
+		t.Errorf("expected v1.2.3, got %q", got)
+	}
+}
+
+func TestReadResolvedVersion_PrefixCollision(t *testing.T) {
+	// given - looking up github.com/foo/bar must not match github.com/foo/barbaz
+	goMod := `module example.com/workspace
+
+go 1.25
+
+require (
+	github.com/foo/barbaz v0.9.9
+	github.com/foo/bar v1.2.3
+)
+`
+	inst := &Installer{WorkspaceDir: writeGoMod(t, goMod)}
+
+	// when
+	got := inst.readResolvedVersion("github.com/foo/bar")
+
+	// then
+	if got != "v1.2.3" {
+		t.Errorf("expected v1.2.3 (the exact match, not the prefix-collision sibling), got %q", got)
+	}
+}


### PR DESCRIPTION
## What's changed?

Delegate to the `modfile` module for parsing `go.mod` files instead of textual/substring attempts.

## What's your motivation?

The parsing logic is fragile and suffers from bugs.