### PR TITLE
Go: tests to observe the markers added by a recipe in 'after'

### DIFF
--- a/rewrite-go/pkg/test/spec.go
+++ b/rewrite-go/pkg/test/spec.go
@@ -403,8 +403,9 @@ type JavaRecipeConfig struct {
 type RecipeSpec struct {
 	CheckParsePrintIdempotence bool
 	Recipe                     recipe.Recipe
-	JavaRecipe                 *JavaRecipeConfig // when set, delegates to Java RPC
-	JavaRpcClient              *JavaRpcClient    // injected Java RPC client
+	JavaRecipe                 *JavaRecipeConfig     // when set, delegates to Java RPC
+	JavaRpcClient              *JavaRpcClient        // injected Java RPC client
+	MarkerPrinter              printer.MarkerPrinter // printer for cross-cutting markers in recipe output; defaults to printer.DefaultMarkerPrinter
 }
 
 // NewRecipeSpec creates a new RecipeSpec with default settings.
@@ -433,6 +434,16 @@ func (spec *RecipeSpec) WithJavaRecipe(recipeName string, options map[string]any
 // WithJavaRpcClient sets the Java RPC client for recipe delegation.
 func (spec *RecipeSpec) WithJavaRpcClient(client *JavaRpcClient) *RecipeSpec {
 	spec.JavaRpcClient = client
+	return spec
+}
+
+// WithMarkerPrinter overrides the MarkerPrinter used when printing recipe output.
+// Mirrors RewriteTest's spec.markerPrinter(...) on the Java side. When unset,
+// RewriteRun uses printer.DefaultMarkerPrinter so SearchResult/Markup markers
+// surface as /*~~>*/ comments in the expected "after" source — matching Java
+// and TypeScript test conventions.
+func (spec *RecipeSpec) WithMarkerPrinter(mp printer.MarkerPrinter) *RecipeSpec {
+	spec.MarkerPrinter = mp
 	return spec
 }
 
@@ -522,7 +533,11 @@ func (spec *RecipeSpec) RewriteRun(t *testing.T, sources ...Sources) {
 				}
 				continue
 			}
-			actual := printer.Print(result)
+			mp := spec.MarkerPrinter
+			if mp == nil {
+				mp = printer.DefaultMarkerPrinter
+			}
+			actual := printer.PrintWithMarkers(result, mp)
 			if src.After != nil {
 				if actual != *src.After {
 					t.Errorf("recipe result mismatch\n\nexpected:\n%s\n\nactual:\n%s", *src.After, actual)

--- a/rewrite-go/test/recipe_test.go
+++ b/rewrite-go/test/recipe_test.go
@@ -111,6 +111,34 @@ func TestRecipeNoChange(t *testing.T) {
 	)
 }
 
+// TestSearchRecipeViaRewriteRun verifies that RewriteRun prints SearchResult
+// markers as /*~~(...)~~>*/ comments by default, so search-style recipes can
+// be tested with the same convention used in Java and TypeScript.
+func TestSearchRecipeViaRewriteRun(t *testing.T) {
+	spec := test.NewRecipeSpec().WithRecipe(&findFoo{})
+	spec.RewriteRun(t,
+		test.GolangRaw(
+			"package main\n\nfunc foo() {\n}\n",
+			"package main\n\nfunc /*~~(found foo)~~>*/foo() {\n}\n",
+		),
+	)
+}
+
+// TestSearchRecipeWithSanitizedMarkerPrinter verifies that
+// WithMarkerPrinter(SanitizedMarkerPrinter) lets tests opt out of marker
+// rendering — matching Java's spec.markerPrinter(SANITIZED).
+func TestSearchRecipeWithSanitizedMarkerPrinter(t *testing.T) {
+	spec := test.NewRecipeSpec().
+		WithRecipe(&findFoo{}).
+		WithMarkerPrinter(printer.SanitizedMarkerPrinter)
+	spec.RewriteRun(t,
+		test.GolangRaw(
+			"package main\n\nfunc foo() {\n}\n",
+			"package main\n\nfunc foo() {\n}\n",
+		),
+	)
+}
+
 func TestSearchRecipeWithMarkerPrinting(t *testing.T) {
 	r := &findFoo{}
 	editor := r.Editor()


### PR DESCRIPTION
## What's changed?

A fix to the Go recipe testing harness.
The tests should print out and expect the textual representation of the markers in the `after` part of the recipe. Just like we do for other languages, e.g.
```
			"package main\n\nfunc /*~~(found foo)~~>*/foo() {\n}\n",
```

## What's your motivation?

So that I can have more meaningful tests for Go recipes. Especially these which add markers.