### PR TITLE
JavaTemplate: recurse into lambda bodies so coords-targeting-body actually apply

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -1656,4 +1656,85 @@ class JavaTemplateTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void replaceExpressionLambdaBody() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitLambda(J.Lambda lambda, ExecutionContext ctx) {
+                  if (!(lambda.getBody() instanceof J.Literal) ||
+                      !Boolean.TRUE.equals(((J.Literal) lambda.getBody()).getValue())) {
+                      return super.visitLambda(lambda, ctx);
+                  }
+                  J.Literal body = (J.Literal) lambda.getBody();
+                  return JavaTemplate.builder("Boolean.FALSE")
+                    .contextSensitive()
+                    .build()
+                    .apply(getCursor(), body.getCoordinates().replace());
+              }
+          })),
+          java(
+            """
+              import java.util.function.BooleanSupplier;
+
+              class Test {
+                  BooleanSupplier always = () -> true;
+              }
+              """,
+            """
+              import java.util.function.BooleanSupplier;
+
+              class Test {
+                  BooleanSupplier always = () -> Boolean.FALSE;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceStatementInsideLambdaBlockBody() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitLambda(J.Lambda lambda, ExecutionContext ctx) {
+                  if (!(lambda.getBody() instanceof J.Block)) {
+                      return super.visitLambda(lambda, ctx);
+                  }
+                  J.Block block = (J.Block) lambda.getBody();
+                  if (block.getStatements().size() != 1 ||
+                      !(block.getStatements().get(0) instanceof J.Return) ||
+                      !(((J.Return) block.getStatements().get(0)).getExpression() instanceof J.Literal) ||
+                      !Boolean.TRUE.equals(((J.Literal) ((J.Return) block.getStatements().get(0)).getExpression()).getValue())) {
+                      return super.visitLambda(lambda, ctx);
+                  }
+                  return JavaTemplate.builder("return Boolean.FALSE;")
+                    .contextSensitive()
+                    .build()
+                    .apply(getCursor(), block.getStatements().get(0).getCoordinates().replace());
+              }
+          })),
+          java(
+            """
+              import java.util.function.BooleanSupplier;
+
+              class Test {
+                  BooleanSupplier always = () -> {
+                      return true;
+                  };
+              }
+              """,
+            """
+              import java.util.function.BooleanSupplier;
+
+              class Test {
+                  BooleanSupplier always = () -> {
+                      return Boolean.FALSE;
+                  };
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -269,7 +269,14 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                 if (loc == LAMBDA_PARAMETERS_PREFIX && isScope(lambda.getParameters())) {
                     return lambda.withParameters(unsubstitute(templateParser.parseLambdaParameters(getCursor(), substitutedTemplate)));
                 }
-                return maybeReplaceStatement(lambda, J.class, 0);
+                if (loc == STATEMENT_PREFIX && isScope(lambda)) {
+                    return maybeReplaceStatement(lambda, J.class, 0);
+                }
+                // Recurse into the lambda's body so that templates targeting an expression or
+                // statement inside the body (e.g. `lambda.getBody().getCoordinates().replace()`)
+                // can find their scope. Without this, the visitor stops at the lambda and the
+                // apply call silently returns the input unchanged.
+                return super.visitLambda(lambda, p);
             }
 
             @Override


### PR DESCRIPTION
## Summary

`JavaTemplate.apply(cursor, coordinates)` silently returned the input unchanged when the coordinates pointed inside a `J.Lambda`'s body — both for expression-form bodies (`body.getCoordinates().replace()` on a `J.Literal`/`J.MethodInvocation`/etc.) and for block-form bodies (e.g. `((J.Block) lambda.getBody()).getStatements().get(0).getCoordinates().replace()`).

Root cause: `JavaTemplateJavaExtension.visitLambda` fell through to `maybeReplaceStatement(lambda, J.class, 0)` which delegated to `super.visitStatement(statement, p)`. `JavaVisitor.visitStatement` is a no-op that just returns the statement, so the visitor never descended into the lambda's body and never reached the coord scope.

By contrast `visitMethodDeclaration` ends with `super.visitMethodDeclaration(method, p)`, which delegates to `JavaVisitor.visitMethodDeclaration` and recurses through the method's body normally — that's why coords inside method bodies work fine.

## Change

Brings `visitLambda` in line with the other container visit methods: explicit branches for the cases where the lambda itself is the scope (parameter replacement, whole-lambda statement replacement), then fall through to `super.visitLambda(lambda, p)` so the standard recursion into `parameters`, `arrow`, and `body` runs and inner scopes can be matched.

## Tests

Two new tests in `JavaTemplateTest`. Both fail on `main` before this change (the recipe is expected to make a change but doesn't), and pass after:

- `replaceExpressionLambdaBody` — `() -> true` becomes `() -> Boolean.FALSE` via `body.getCoordinates().replace()`.
- `replaceStatementInsideLambdaBlockBody` — `() -> { return true; }` becomes `() -> { return Boolean.FALSE; }` via `block.getStatements().get(0).getCoordinates().replace()`.

Full `:rewrite-java:test` and `:rewrite-java-test:test` suites still pass.

## Downstream impact

Audited recipes in `rewrite-spring`, `rewrite-hibernate`, `rewrite-testing-frameworks`, `rewrite-dropwizard`, `rewrite-java-security`, `rewrite-static-analysis`, `rewrite-migrate-java`, `rewrite-java-dependencies`. No `visitLambda` override currently targets coords inside a lambda body (because that silently fails today), so no recipe relies on the broken behavior.