### PR TITLE
Go: handle markers with no RPC codecs

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcReceiveQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcReceiveQueue.java
@@ -132,13 +132,17 @@ public class RpcReceiveQueue {
                 // TODO handle enums here
 
                 RpcCodec<T> codec;
+                T inlineValue;
                 if (onChange != null) {
                     after = onChange.apply(before);
                 } else if (before != null && (codec = RpcCodec.forInstance(before, sourceFileType)) != null) {
                     after = codec.rpcReceive(before, this);
-                } else if (message.getValueType() == null) {
-                    after = message.getValue();
-                } else if (message.getState() == RpcObjectData.State.ADD && message.getValue() == null) {
+                } else if ((inlineValue = message.getValue()) != null) {
+                    // The remote inlined the value (no codec on this side, or none on either
+                    // side). getValue() Jackson-converts the map to the typed instance when
+                    // valueType is set; otherwise it returns the raw value.
+                    after = inlineValue;
+                } else if (message.getState() == RpcObjectData.State.ADD && message.getValueType() != null) {
                     throw new IllegalStateException(
                             "No RPC codec registered on the Java side for '" + message.getValueType() + "'. " +
                                     "The remote side has a codec and sent property messages that will not be consumed, " +

--- a/rewrite-go/pkg/rpc/receive_queue.go
+++ b/rewrite-go/pkg/rpc/receive_queue.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree"
 )
 
@@ -81,6 +82,21 @@ func (q *ReceiveQueue) Receive(before any, onChange func(any) any) any {
 			before = msg.Value
 		} else {
 			before = newObj(*msg.ValueType)
+			// Hydrate GenericMarker.Data from the inline value when the
+			// sender shipped a codec-less marker as `{ADD, valueType, value=map}`
+			// (matches what every other language's send queue does). Without
+			// this, the marker's fields would be silently dropped.
+			if gm, ok := before.(tree.GenericMarker); ok && !hasGenericMarkerCodec(gm.JavaType) {
+				if dataMap, ok := msg.Value.(map[string]any); ok {
+					gm.Data = dataMap
+					if idStr, ok := dataMap["id"].(string); ok {
+						if parsed, err := uuid.Parse(idStr); err == nil {
+							gm.Ident = parsed
+						}
+					}
+					before = gm
+				}
+			}
 		}
 		if ref != nil {
 			// Store before deserialization to handle cycles

--- a/rewrite-go/pkg/rpc/send_queue.go
+++ b/rewrite-go/pkg/rpc/send_queue.go
@@ -204,11 +204,26 @@ func (q *SendQueue) add(after any, onChange func(any)) {
 
 	vt := getValueType(afterVal)
 	var val any
-	if onChange == nil && vt == nil {
+	skipDoChange := false
+	if gm, ok := afterVal.(tree.GenericMarker); ok && !hasGenericMarkerCodec(gm.JavaType) {
+		// No RpcCodec on either side for this marker — inline the marker's
+		// data as the ADD message's Value so the receiver can reconstruct
+		// the typed instance. Skip sub-field dispatch, which would otherwise
+		// emit nothing (sendMarkerCodecFields default case) and leave the
+		// receiver waiting for fields that never arrive.
+		if gm.Data == nil {
+			val = map[string]any{}
+		} else {
+			val = gm.Data
+		}
+		skipDoChange = true
+	} else if onChange == nil && vt == nil {
 		val = afterVal
 	}
 	q.Put(RpcObjectData{State: Add, ValueType: vt, Value: val, Ref: ref})
-	q.doChange(afterVal, nil, onChange)
+	if !skipDoChange {
+		q.doChange(afterVal, nil, onChange)
+	}
 }
 
 func (q *SendQueue) doChange(after, before any, onChange func(any)) {

--- a/rewrite-go/pkg/rpc/space_rpc.go
+++ b/rewrite-go/pkg/rpc/space_rpc.go
@@ -135,6 +135,29 @@ func SendMarkersCodec(m tree.Markers, q *SendQueue) {
 		func(v any) { sendMarkerCodecFields(v, q) })
 }
 
+// hasGenericMarkerCodec reports whether sendMarkerCodecFields will dispatch
+// sub-field messages for a tree.GenericMarker with the given Java FQN.
+// Markers not listed here have no RpcCodec on either side and must travel
+// inline (as the ADD message's Value) so the receiver does not desync waiting
+// for sub-fields that never arrive.
+func hasGenericMarkerCodec(javaType string) bool {
+	switch javaType {
+	case "org.openrewrite.Checksum",
+		"org.openrewrite.FileAttributes",
+		"org.openrewrite.marker.Markup$Error",
+		"org.openrewrite.marker.Markup$Warn",
+		"org.openrewrite.marker.Markup$Info",
+		"org.openrewrite.marker.Markup$Debug",
+		"org.openrewrite.java.marker.OmitBraces",
+		"org.openrewrite.java.marker.OmitParentheses",
+		"org.openrewrite.java.marker.Semicolon",
+		"org.openrewrite.java.marker.NullSafe",
+		"org.openrewrite.java.marker.TrailingComma":
+		return true
+	}
+	return false
+}
+
 // sendMarkerCodecFields sends the sub-fields for markers that implement RpcCodec on the Java side.
 // This must match the field order in each marker's rpcSend method.
 func sendMarkerCodecFields(v any, q *SendQueue) {

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/MarkerRoundTripTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/MarkerRoundTripTest.java
@@ -25,6 +25,7 @@ import org.openrewrite.Tree;
 import org.openrewrite.golang.GolangParser;
 import org.openrewrite.golang.marker.GoProject;
 import org.openrewrite.golang.marker.GoResolutionResult;
+import org.openrewrite.marker.BuildTool;
 import org.openrewrite.marker.Markers;
 
 import java.nio.file.Path;
@@ -225,5 +226,43 @@ class MarkerRoundTripTest {
         assertThat(mrr.getModulePath()).isEqualTo("example.com/foo");
         assertThat(mrr.getRequires()).hasSize(1);
         assertThat(mrr.getRequires().get(0).getModulePath()).isEqualTo("github.com/google/uuid");
+    }
+
+    /**
+     * Reproduces an RPC codec desync where Go ships a {@link BuildTool} marker
+     * back to Java with {@code valueType="org.openrewrite.marker.BuildTool"} and
+     * {@code value=null}. Java has no {@code RpcCodec} for {@code BuildTool},
+     * so {@code RpcReceiveQueue.receive} throws
+     * {@code IllegalStateException("No RPC codec registered on the Java side
+     * for 'org.openrewrite.marker.BuildTool' ...")}.
+     * <p>
+     * The marker has no RpcCodec on either side; Go's send path sets a
+     * non-nil ValueType (from {@code GenericMarker.JavaType}) but emits no
+     * inline value and no sub-fields, which Java cannot decode.
+     */
+    @Test
+    void buildToolMarkerRoundTripsViaVisit() {
+        // given
+        GoRewriteRpc rpc = GoRewriteRpc.getOrStart();
+        String source = "package main\n\nfunc f() {\n\tvar x = true\n\t_ = x\n}\n";
+        SourceFile cu = GolangParser.builder().build()
+                .parse(source).findFirst().orElseThrow();
+
+        UUID buildToolId = UUID.randomUUID();
+        cu = cu.withMarkers(cu.getMarkers()
+                .addIfAbsent(new BuildTool(buildToolId, BuildTool.Type.Gradle, "8.5")));
+
+        // when
+        var recipe = rpc.prepareRecipe("org.openrewrite.golang.test.RenameXToFlag");
+        Tree result = recipe.getVisitor().visit(cu, new org.openrewrite.InMemoryExecutionContext());
+
+        // then
+        assertThat(result).isInstanceOf(SourceFile.class);
+        Markers resultMarkers = ((SourceFile) result).getMarkers();
+        BuildTool bt = resultMarkers.findFirst(BuildTool.class).orElseThrow(
+                () -> new AssertionError("BuildTool marker missing from round-trip result"));
+        assertThat(bt.getId()).isEqualTo(buildToolId);
+        assertThat(bt.getType()).isEqualTo(BuildTool.Type.Gradle);
+        assertThat(bt.getVersion()).isEqualTo("8.5");
     }
 }


### PR DESCRIPTION
## What's changed?

Changing the behavior for RPC for markers for which there are no codecs defined.
Aligning **Java** and Go with what's already implemented for JavaScript, C# and partly for Python. Instead of failing, take the inline value.

## What's your motivation?

Otherwise it fails with RPC mismatches when executing Go recipes using Moderne CLI.