### PR TITLE
RenameVariable: skip type-reference identifiers in method signatures and casts

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RenameVariableTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RenameVariableTest.java
@@ -981,6 +981,159 @@ class RenameVariableTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/902")
+    @Test
+    void doNotRenameMethodReturnType() {
+        rewriteRun(
+          spec -> spec.recipe(renameVariableTest("Foo", "foo", false)),
+          java(
+            """
+              class A {
+                  private Foo Foo;
+                  Foo create() { return new Foo(); }
+              }
+              class Foo {}
+              """,
+            """
+              class A {
+                  private Foo foo;
+                  Foo create() { return new Foo(); }
+              }
+              class Foo {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRenameTypeCast() {
+        rewriteRun(
+          spec -> spec.recipe(renameVariableTest("Foo", "foo", false)),
+          java(
+            """
+              class A {
+                  private Foo Foo;
+                  Object get(Object o) { return (Foo) o; }
+              }
+              class Foo {}
+              """,
+            """
+              class A {
+                  private Foo foo;
+                  Object get(Object o) { return (Foo) o; }
+              }
+              class Foo {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRenameInstanceOf() {
+        rewriteRun(
+          spec -> spec.recipe(renameVariableTest("Foo", "foo", false)),
+          java(
+            """
+              class A {
+                  private Foo Foo;
+                  boolean isFoo(Object o) { return o instanceof Foo; }
+              }
+              class Foo {}
+              """,
+            """
+              class A {
+                  private Foo foo;
+                  boolean isFoo(Object o) { return o instanceof Foo; }
+              }
+              class Foo {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRenameArrayReturnType() {
+        rewriteRun(
+          spec -> spec.recipe(renameVariableTest("Foo", "foo", false)),
+          java(
+            """
+              class A {
+                  private Foo Foo;
+                  Foo[] all() { return new Foo[0]; }
+              }
+              class Foo {}
+              """,
+            """
+              class A {
+                  private Foo foo;
+                  Foo[] all() { return new Foo[0]; }
+              }
+              class Foo {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRenameAnnotatedReturnType() {
+        rewriteRun(
+          spec -> spec.recipe(renameVariableTest("Foo", "foo", false)),
+          java(
+            """
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+              @Target(ElementType.TYPE_USE)
+              @interface Marker {}
+              class A {
+                  private Foo Foo;
+                  @Marker Foo create() { return new Foo(); }
+              }
+              class Foo {}
+              """,
+            """
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+              @Target(ElementType.TYPE_USE)
+              @interface Marker {}
+              class A {
+                  private Foo foo;
+                  @Marker Foo create() { return new Foo(); }
+              }
+              class Foo {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRenameAnnotationType() {
+        rewriteRun(
+          spec -> spec.recipe(renameVariableTest("Foo", "foo", false)),
+          java(
+            """
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+              @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
+              @interface Foo {}
+              class A {
+                  private Object Foo;
+                  @Foo Object get() { return Foo; }
+              }
+              """,
+            """
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+              @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
+              @interface Foo {}
+              class A {
+                  private Object foo;
+                  @Foo Object get() { return foo; }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4059")
     @Test
     void renameTypeCastedField() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/RenameVariable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RenameVariable.java
@@ -154,7 +154,7 @@ public class RenameVariable<P> extends JavaIsoVisitor<P> {
                 return m.getName() != ident;
             } else if (value instanceof J.MethodDeclaration) {
                 J.MethodDeclaration m = (J.MethodDeclaration) value;
-                return m.getName() != ident;
+                return m.getName() != ident && m.getReturnTypeExpression() != ident;
             } else if (value instanceof J.NewClass) {
                 J.NewClass m = (J.NewClass) value;
                 return m.getClazz() != ident;
@@ -164,6 +164,18 @@ public class RenameVariable<P> extends JavaIsoVisitor<P> {
             } else if (value instanceof J.VariableDeclarations) {
                 J.VariableDeclarations v = (J.VariableDeclarations) value;
                 return ident != v.getTypeExpression();
+            } else if (value instanceof J.InstanceOf) {
+                J.InstanceOf i = (J.InstanceOf) value;
+                return i.getClazz() != ident;
+            } else if (value instanceof J.ArrayType) {
+                J.ArrayType a = (J.ArrayType) value;
+                return a.getElementType() != ident;
+            } else if (value instanceof J.Annotation) {
+                J.Annotation a = (J.Annotation) value;
+                return a.getAnnotationType() != ident;
+            } else if (value instanceof J.ControlParentheses) {
+                // ControlParentheses wraps the type in a J.TypeCast (e.g. `(Foo) x`); elsewhere (if/while/switch) it wraps a value expression.
+                return !(getCursor().getParentTreeCursor().getParentTreeCursor().getValue() instanceof J.TypeCast);
             } else return !(value instanceof J.ParameterizedType);
         }
 


### PR DESCRIPTION
## Summary

- `RenameVariable$RenameVariableVisitor.isVariableName` only excluded the method-name identifier in its `J.MethodDeclaration` branch, so a return-type identifier matching the variable being renamed was treated as a variable reference and rewritten — turning `Foo create()` into `foo create()` when renaming a field named `Foo`. This caused downstream recipes like `RenamePrivateFieldsToCamelCase` (openrewrite/rewrite-static-analysis#902) to produce uncompilable code.

Audited the other branches for similar gaps and added exclusions for the type-reference positions that demonstrably regressed: `J.InstanceOf.getClazz()`, `J.ArrayType.getElementType()`, `J.Annotation.getAnnotationType()`, and the `J.ControlParentheses` inside `J.TypeCast`. Each new exclusion is covered by a test that fails without the corresponding fix; positions where I couldn't reproduce a failure (e.g. `J.AnnotatedType` for simple identifiers, since type-use annotations get folded into `J.Identifier.annotations`) were left alone.

## Test plan

- [x] `./gradlew :rewrite-java:test`
- [x] `./gradlew :rewrite-java-test:test`
- [x] New `RenameVariableTest` cases each fail before their fix and pass after