### PR TITLE
Go: RPC, filter for elements with nil

### DIFF
--- a/rewrite-go/pkg/rpc/go_sender.go
+++ b/rewrite-go/pkg/rpc/go_sender.go
@@ -94,7 +94,7 @@ func (s *GoSender) VisitCompilationUnit(cu *tree.CompilationUnit, p any) tree.J 
 			for i, s := range stmts {
 				result[i] = s
 			}
-			return result
+			return dropNilElements(result)
 		},
 		func(v any) any { return containerElementID(v) },
 		func(v any) { sendRightPadded(s, v, q) })
@@ -285,7 +285,7 @@ func (s *GoSender) VisitMultiAssignment(ma *tree.MultiAssignment, p any) tree.J 
 			for i, e := range vars {
 				result[i] = e
 			}
-			return result
+			return dropNilElements(result)
 		},
 		func(v any) any { return containerElementID(v) },
 		func(v any) { sendRightPadded(s, v, q) })
@@ -298,7 +298,7 @@ func (s *GoSender) VisitMultiAssignment(ma *tree.MultiAssignment, p any) tree.J 
 			for i, e := range vals {
 				result[i] = e
 			}
-			return result
+			return dropNilElements(result)
 		},
 		func(v any) any { return containerElementID(v) },
 		func(v any) { sendRightPadded(s, v, q) })
@@ -318,7 +318,7 @@ func (s *GoSender) VisitCommClause(cc *tree.CommClause, p any) tree.J {
 			for i, e := range body {
 				result[i] = e
 			}
-			return result
+			return dropNilElements(result)
 		},
 		func(v any) any { return containerElementID(v) },
 		func(v any) { sendRightPadded(s, v, q) })

--- a/rewrite-go/pkg/rpc/java_receiver.go
+++ b/rewrite-go/pkg/rpc/java_receiver.go
@@ -665,8 +665,11 @@ func (r *JavaReceiver) VisitCase(cs *tree.Case, p any) tree.J {
 	if result := q.Receive(cs.Expressions, func(v any) any { return receiveContainer(r, q, v) }); result != nil {
 		cs.Expressions = coerceContainerExpression(result)
 	}
-	// statements - Java sends Container<RightPadded<Statement>>, extract to Go's []RightPadded[Statement]
-	if result := q.Receive(nil, func(v any) any { return receiveContainerAs(r, q, v, ContainerStatement) }); result != nil {
+	// statements - Java sends Container<RightPadded<Statement>>, extract to Go's []RightPadded[Statement].
+	// Pass the existing body as BEFORE so NoChange responses preserve identity and position-based
+	// list tracking has a baseline (mirrors VisitBlock).
+	bodyBefore := tree.Container[tree.Statement]{Elements: cs.Body}
+	if result := q.Receive(bodyBefore, func(v any) any { return receiveContainerAs(r, q, v, ContainerStatement) }); result != nil {
 		cont := coerceContainerStatement(result)
 		cs.Body = cont.Elements
 	}

--- a/rewrite-go/pkg/rpc/java_sender.go
+++ b/rewrite-go/pkg/rpc/java_sender.go
@@ -151,7 +151,7 @@ func (s *JavaSender) VisitBlock(b *tree.Block, p any) tree.J {
 			for i, stmt := range stmts {
 				result[i] = stmt
 			}
-			return result
+			return dropNilElements(result)
 		},
 		func(v any) any { return containerElementID(v) },
 		func(v any) { sendRightPadded(s, v, q) })
@@ -406,17 +406,11 @@ func (s *JavaSender) VisitCase(c *tree.Case, p any) tree.J {
 	// caseLabels (container)
 	q.GetAndSend(c, func(v any) any { return v.(*tree.Case).Expressions },
 		func(v any) { sendContainer(s, v, q) })
-	// statements (container) — filter nil-Element entries so the Java side
-	// doesn't see a JRightPadded with a missing element (would NPE).
+	// statements (container) — sendContainer filters nil-Element entries.
 	q.GetAndSend(c, func(v any) any {
 		body := v.(*tree.Case).Body
-		result := make([]tree.RightPadded[tree.Statement], 0, len(body))
-		for _, rp := range body {
-			if rp.Element == nil {
-				continue
-			}
-			result = append(result, rp)
-		}
+		result := make([]tree.RightPadded[tree.Statement], len(body))
+		copy(result, body)
 		return tree.Container[tree.Statement]{Elements: result}
 	}, func(v any) { sendContainer(s, v, q) })
 	// body (right-padded, nil for Go-style case)

--- a/rewrite-go/pkg/rpc/java_sender.go
+++ b/rewrite-go/pkg/rpc/java_sender.go
@@ -406,11 +406,17 @@ func (s *JavaSender) VisitCase(c *tree.Case, p any) tree.J {
 	// caseLabels (container)
 	q.GetAndSend(c, func(v any) any { return v.(*tree.Case).Expressions },
 		func(v any) { sendContainer(s, v, q) })
-	// statements (container)
+	// statements (container) — filter nil-Element entries so the Java side
+	// doesn't see a JRightPadded with a missing element (would NPE).
 	q.GetAndSend(c, func(v any) any {
 		body := v.(*tree.Case).Body
-		result := make([]tree.RightPadded[tree.Statement], len(body))
-		copy(result, body)
+		result := make([]tree.RightPadded[tree.Statement], 0, len(body))
+		for _, rp := range body {
+			if rp.Element == nil {
+				continue
+			}
+			result = append(result, rp)
+		}
 		return tree.Container[tree.Statement]{Elements: result}
 	}, func(v any) { sendContainer(s, v, q) })
 	// body (right-padded, nil for Go-style case)

--- a/rewrite-go/pkg/rpc/padding_rpc.go
+++ b/rewrite-go/pkg/rpc/padding_rpc.go
@@ -83,14 +83,29 @@ func sendContainer(s Sender, c any, q *SendQueue) {
 	// Before space
 	q.GetAndSend(c, func(v any) any { return containerBefore(v) },
 		func(v any) { sendSpace(v.(tree.Space), q) })
-	// Elements (list of RightPadded)
+	// Elements (list of RightPadded) — filter nil-Element entries; see dropNilElements.
 	q.GetAndSendList(c,
-		func(v any) []any { return containerElements(v) },
+		func(v any) []any { return dropNilElements(containerElements(v)) },
 		func(v any) any { return containerElementID(v) },
 		func(v any) { sendRightPadded(s, v, q) })
 	// Markers
 	q.GetAndSend(c, func(v any) any { return containerMarkers(v) },
 		func(v any) { SendMarkersCodec(v.(tree.Markers), q) })
+}
+
+// dropNilElements drops RightPadded entries whose Element is nil. Java's
+// JRightPadded.element is non-nullable, so a nil leaks past sendRightPadded
+// as a NoChange wire message for the element slot, which NPEs on the Java
+// receiver. Apply before serializing any list of RightPadded values.
+func dropNilElements(elems []any) []any {
+	filtered := make([]any, 0, len(elems))
+	for _, e := range elems {
+		if rightPaddedElement(e) == nil {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	return filtered
 }
 
 // receiveRightPadded deserializes a RightPadded element.

--- a/rewrite-go/pkg/rpc/rpc_roundtrip_test.go
+++ b/rewrite-go/pkg/rpc/rpc_roundtrip_test.go
@@ -151,3 +151,33 @@ func TestAnnotationRpcRoundTrip_PrefixPreserved(t *testing.T) {
 		t.Errorf("Prefix.Whitespace: got %q, want %q", got.Prefix.Whitespace, " ")
 	}
 }
+
+// A Case whose Body contains a nil-Element entry alongside a real statement
+// should round-trip with the nil dropped. Shipping it as-is would NPE on the
+// Java side, where the field is non-nullable.
+func TestCaseRpcRoundTrip_DropsNilStatementsFromBody(t *testing.T) {
+	// given
+	realStmt := makeMethodInvocation() // a call to doThing()
+	before := &tree.Case{
+		ID: uuid.New(),
+		Body: []tree.RightPadded[tree.Statement]{
+			{Element: realStmt, Markers: tree.Markers{}},
+			{Element: nil, Markers: tree.Markers{}},
+		},
+	}
+
+	// when
+	after := roundTripNode(t, before, &tree.Case{ID: before.ID}).(*tree.Case)
+
+	// then
+	if len(after.Body) != 1 {
+		t.Fatalf("expected the nil-Element entry to be dropped, got %d body entries", len(after.Body))
+	}
+	mi, ok := after.Body[0].Element.(*tree.MethodInvocation)
+	if !ok {
+		t.Fatalf("expected the valid statement to survive as *MethodInvocation, got %T", after.Body[0].Element)
+	}
+	if mi.Name == nil || mi.Name.Name != "doThing" {
+		t.Errorf("expected surviving statement to be a call to doThing, got %+v", mi.Name)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Adding a Go-side filter in RPC logic for 

## What's your motivation?

Otherwise some recipe runs fail with:
```
org.openrewrite.internal.RecipeRunException: java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.J.getId()" because the return value of "org.openrewrite.java.tree.JRightPadded.getElement()" is null
        at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:278)
        at org.openrewrite.golang.internal.rpc.GolangSender$GolangSenderDelegate.visit(GolangSender.java:235)
        at org.openrewrite.golang.internal.rpc.GolangSender$GolangSenderDelegate.visit(GolangSender.java:223)
        at org.openrewrite.java.internal.rpc.JavaSender.lambda$visitRightPadded$296(JavaSender.java:606)
        at org.openrewrite.rpc.RpcSendQueue.lambda$getAndSend$0(RpcSendQueue.java:83)
        at org.openrewrite.rpc.RpcSendQueue.doChange(RpcSendQueue.java:200)
```