### PR TITLE
Go: introduce JavaTypeShallowClass

### DIFF
--- a/rewrite-go/pkg/matcher/matcher_test.go
+++ b/rewrite-go/pkg/matcher/matcher_test.go
@@ -61,7 +61,7 @@ func TestIsAssignableTo(t *testing.T) {
 	stringer := &tree.JavaTypeClass{FullyQualifiedName: "fmt.Stringer"}
 	myType := &tree.JavaTypeClass{
 		FullyQualifiedName: "main.MyType",
-		Interfaces:         []*tree.JavaTypeClass{stringer},
+		Interfaces:         []tree.FullyQualified{stringer},
 	}
 
 	if !IsAssignableTo(myType, "main.MyType") {

--- a/rewrite-go/pkg/matcher/method_matcher.go
+++ b/rewrite-go/pkg/matcher/method_matcher.go
@@ -187,7 +187,7 @@ func (m *MethodMatcher) MatchesMethod(mt *tree.JavaTypeMethod) bool {
 	if m.declaringTypePattern != nil {
 		declFQN := ""
 		if mt.DeclaringType != nil {
-			declFQN = mt.DeclaringType.FullyQualifiedName
+			declFQN = mt.DeclaringType.GetFullyQualifiedName()
 		}
 		if !m.declaringTypePattern.MatchString(declFQN) {
 			return false

--- a/rewrite-go/pkg/matcher/type_utils.go
+++ b/rewrite-go/pkg/matcher/type_utils.go
@@ -29,7 +29,7 @@ func GetFullyQualifiedName(t tree.JavaType) string {
 		return v.FullyQualifiedName
 	case *tree.JavaTypeParameterized:
 		if v.Type != nil {
-			return v.Type.FullyQualifiedName
+			return v.Type.GetFullyQualifiedName()
 		}
 	case *tree.JavaTypePrimitive:
 		return v.Keyword
@@ -146,13 +146,23 @@ func IsBool(t tree.JavaType) bool {
 	return IsOfClassType(t, "bool")
 }
 
-// AsClass safely casts a JavaType to *JavaTypeClass, returning nil if not a class.
+// AsClass safely casts a JavaType to *JavaTypeClass, returning nil if not a
+// class. A JavaTypeShallowClass is unwrapped to its embedded JavaTypeClass
+// — callers that need to distinguish ShallowClass from Class should type
+// switch on the original JavaType, not on this accessor's result.
 func AsClass(t tree.JavaType) *tree.JavaTypeClass {
-	if c, ok := t.(*tree.JavaTypeClass); ok {
-		return c
-	}
-	if p, ok := t.(*tree.JavaTypeParameterized); ok {
-		return p.Type
+	switch v := t.(type) {
+	case *tree.JavaTypeClass:
+		return v
+	case *tree.JavaTypeShallowClass:
+		return &v.JavaTypeClass
+	case *tree.JavaTypeParameterized:
+		if c, ok := v.Type.(*tree.JavaTypeClass); ok {
+			return c
+		}
+		if sc, ok := v.Type.(*tree.JavaTypeShallowClass); ok {
+			return &sc.JavaTypeClass
+		}
 	}
 	return nil
 }
@@ -212,7 +222,7 @@ func TypeOfExpression(expr tree.Expression) tree.JavaType {
 // For `t.Sub(...)`, this returns the type of the receiver.
 func DeclaringTypeFQN(mi *tree.MethodInvocation) string {
 	if mi.MethodType != nil && mi.MethodType.DeclaringType != nil {
-		return mi.MethodType.DeclaringType.FullyQualifiedName
+		return mi.MethodType.DeclaringType.GetFullyQualifiedName()
 	}
 	// Fallback: infer from Select expression
 	if mi.Select != nil {

--- a/rewrite-go/pkg/parser/type_mapper.go
+++ b/rewrite-go/pkg/parser/type_mapper.go
@@ -192,9 +192,11 @@ func (m *typeMapper) mapNamed(named *types.Named) *tree.JavaTypeClass {
 // mapSignature maps a function signature to JavaTypeMethod.
 func (m *typeMapper) mapSignature(sig *types.Signature, name string, declaringType *tree.JavaTypeClass) *tree.JavaTypeMethod {
 	mt := &tree.JavaTypeMethod{
-		Name:          name,
-		DeclaringType: declaringType,
-		FlagsBitMap:   flagsForExported(name),
+		Name:        name,
+		FlagsBitMap: flagsForExported(name),
+	}
+	if declaringType != nil {
+		mt.DeclaringType = declaringType
 	}
 
 	// Return type

--- a/rewrite-go/pkg/recipe/golang/internal/imports.go
+++ b/rewrite-go/pkg/recipe/golang/internal/imports.go
@@ -203,7 +203,7 @@ func (v *referencedPackagesVisitor) VisitIdentifier(ident *tree.Identifier, p an
 
 func (v *referencedPackagesVisitor) VisitMethodInvocation(mi *tree.MethodInvocation, p any) tree.J {
 	if mi.MethodType != nil && mi.MethodType.DeclaringType != nil {
-		if path := pkgPathOf(mi.MethodType.DeclaringType.FullyQualifiedName); path != "" {
+		if path := pkgPathOf(mi.MethodType.DeclaringType.GetFullyQualifiedName()); path != "" {
 			v.refs[path] = true
 		}
 	}

--- a/rewrite-go/pkg/rpc/java_type_receiver.go
+++ b/rewrite-go/pkg/rpc/java_type_receiver.go
@@ -40,7 +40,7 @@ func (r *JavaTypeReceiver) VisitAnnotation(a *tree.JavaTypeAnnotation, p any) tr
 	q := p.(*ReceiveQueue)
 	cc := *a
 	a = &cc
-	a.Type = receiveAsType[*tree.JavaTypeClass](r, q, a.Type)
+	a.Type = receiveAsFullyQualified(r, q, a.Type)
 	a.Values = r.receiveAnnotationElementValueList(q, a.Values)
 	return a
 }
@@ -122,18 +122,30 @@ func (r *JavaTypeReceiver) VisitIntersection(is *tree.JavaTypeIntersection, p an
 func (r *JavaTypeReceiver) VisitClass(c *tree.JavaTypeClass, p any) tree.JavaType {
 	q := p.(*ReceiveQueue)
 	cc := *c
-	c = &cc
+	r.receiveClassFields(&cc, q)
+	return &cc
+}
+
+// VisitShallowClass mirrors VisitClass — Java's ShallowClass extends Class
+// and uses the same field set; the discriminator is the wire valueType.
+func (r *JavaTypeReceiver) VisitShallowClass(sc *tree.JavaTypeShallowClass, p any) tree.JavaType {
+	q := p.(*ReceiveQueue)
+	cc := *sc
+	r.receiveClassFields(&cc.JavaTypeClass, q)
+	return &cc
+}
+
+func (r *JavaTypeReceiver) receiveClassFields(c *tree.JavaTypeClass, q *ReceiveQueue) {
 	c.FlagsBitMap = receiveScalar[int64](q, c.FlagsBitMap)
 	c.Kind = receiveScalar[string](q, c.Kind)
 	c.FullyQualifiedName = receiveScalar[string](q, c.FullyQualifiedName)
 	c.TypeParameters = receiveTypeList(r, q, c.TypeParameters)
-	c.Supertype = receiveAsType[*tree.JavaTypeClass](r, q, c.Supertype)
-	c.OwningClass = receiveAsType[*tree.JavaTypeClass](r, q, c.OwningClass)
+	c.Supertype = receiveAsFullyQualified(r, q, c.Supertype)
+	c.OwningClass = receiveAsFullyQualified(r, q, c.OwningClass)
 	c.Annotations = receiveClassList(r, q, c.Annotations)
 	c.Interfaces = receiveClassList(r, q, c.Interfaces)
 	c.Members = receiveVariableList(r, q, c.Members)
 	c.Methods = receiveMethodList(r, q, c.Methods)
-	return c
 }
 
 // VisitParameterized mirrors JavaTypeReceiver.visitParameterized
@@ -141,7 +153,7 @@ func (r *JavaTypeReceiver) VisitParameterized(pt *tree.JavaTypeParameterized, p 
 	q := p.(*ReceiveQueue)
 	cc := *pt
 	pt = &cc
-	pt.Type = receiveAsType[*tree.JavaTypeClass](r, q, pt.Type)
+	pt.Type = receiveAsFullyQualified(r, q, pt.Type)
 	pt.TypeParameters = receiveTypeList(r, q, pt.TypeParameters)
 	return pt
 }
@@ -183,7 +195,7 @@ func (r *JavaTypeReceiver) VisitMethod(m *tree.JavaTypeMethod, p any) tree.JavaT
 	q := p.(*ReceiveQueue)
 	cc := *m
 	m = &cc
-	m.DeclaringType = receiveAsType[*tree.JavaTypeClass](r, q, m.DeclaringType)
+	m.DeclaringType = receiveAsFullyQualified(r, q, m.DeclaringType)
 	m.Name = receiveScalar[string](q, m.Name)
 	m.FlagsBitMap = receiveScalar[int64](q, m.FlagsBitMap)
 	m.ReturnType = receiveAsType[tree.JavaType](r, q, m.ReturnType)
@@ -275,8 +287,11 @@ func receiveTypeList(r *JavaTypeReceiver, q *ReceiveQueue, before []tree.JavaTyp
 	return result
 }
 
-// receiveClassList receives a list of *JavaTypeClass from the queue.
-func receiveClassList(r *JavaTypeReceiver, q *ReceiveQueue, before []*tree.JavaTypeClass) []*tree.JavaTypeClass {
+// receiveClassList receives a list of FullyQualified class types from the
+// queue. The element type is widened (vs. concrete *JavaTypeClass) so
+// that JavaType$ShallowClass payloads keep their wire identity through
+// the round-trip.
+func receiveClassList(r *JavaTypeReceiver, q *ReceiveQueue, before []tree.FullyQualified) []tree.FullyQualified {
 	beforeAny := classSlice(before)
 	afterAny := q.ReceiveList(beforeAny, func(v any) any {
 		return r.Visit(v.(tree.JavaType), q)
@@ -284,14 +299,33 @@ func receiveClassList(r *JavaTypeReceiver, q *ReceiveQueue, before []*tree.JavaT
 	if afterAny == nil {
 		return nil
 	}
-	result := make([]*tree.JavaTypeClass, len(afterAny))
+	result := make([]tree.FullyQualified, len(afterAny))
 	for i, v := range afterAny {
-		if cls, ok := v.(*tree.JavaTypeClass); ok {
-			result[i] = cls
+		if fq, ok := v.(tree.FullyQualified); ok {
+			result[i] = fq
 		}
-		// Unknown types are skipped (nil in the list)
+		// Unknown / non-fully-qualified types are skipped (nil in the list)
 	}
 	return result
+}
+
+// receiveAsFullyQualified receives a class-typed JavaType (Class or
+// ShallowClass) and preserves its concrete identity.
+func receiveAsFullyQualified(r *JavaTypeReceiver, q *ReceiveQueue, before tree.FullyQualified) tree.FullyQualified {
+	var beforeAny any
+	if before != nil {
+		beforeAny = before
+	}
+	result := q.Receive(beforeAny, func(v any) any {
+		return r.Visit(v.(tree.JavaType), q)
+	})
+	if result == nil {
+		return nil
+	}
+	if fq, ok := result.(tree.FullyQualified); ok {
+		return fq
+	}
+	return nil
 }
 
 // receiveVariableList receives a list of *JavaTypeVariable from the queue.

--- a/rewrite-go/pkg/rpc/java_type_sender.go
+++ b/rewrite-go/pkg/rpc/java_type_sender.go
@@ -121,35 +121,64 @@ func (s *JavaTypeSender) VisitIntersection(is *tree.JavaTypeIntersection, p any)
 // flagsBitMap, kind, fullyQualifiedName, typeParameters, supertype, owningClass,
 // annotations, interfaces, members, methods
 func (s *JavaTypeSender) VisitClass(c *tree.JavaTypeClass, p any) tree.JavaType {
-	q := p.(*SendQueue)
-	q.GetAndSend(c, func(v any) any { return v.(*tree.JavaTypeClass).FlagsBitMap }, nil)
-	q.GetAndSend(c, func(v any) any { return v.(*tree.JavaTypeClass).Kind }, nil)
-	q.GetAndSend(c, func(v any) any { return v.(*tree.JavaTypeClass).FullyQualifiedName }, nil)
-	q.GetAndSendListAsRef(c,
-		func(v any) []any { return javaTypeSlice(v.(*tree.JavaTypeClass).TypeParameters) },
-		func(v any) any { return tree.TypeSignature(v.(tree.JavaType)) },
-		func(v any) { s.Visit(v.(tree.JavaType), q) })
-	q.GetAndSend(c, func(v any) any { return AsRef(v.(*tree.JavaTypeClass).Supertype) },
-		func(v any) { s.Visit(GetValueNonNull(v).(tree.JavaType), q) })
-	q.GetAndSend(c, func(v any) any { return AsRef(v.(*tree.JavaTypeClass).OwningClass) },
-		func(v any) { s.Visit(GetValueNonNull(v).(tree.JavaType), q) })
-	q.GetAndSendListAsRef(c,
-		func(v any) []any { return classSlice(v.(*tree.JavaTypeClass).Annotations) },
-		func(v any) any { return tree.TypeSignature(v.(tree.JavaType)) },
-		func(v any) { s.Visit(v.(tree.JavaType), q) })
-	q.GetAndSendListAsRef(c,
-		func(v any) []any { return classSlice(v.(*tree.JavaTypeClass).Interfaces) },
-		func(v any) any { return tree.TypeSignature(v.(tree.JavaType)) },
-		func(v any) { s.Visit(v.(tree.JavaType), q) })
-	q.GetAndSendListAsRef(c,
-		func(v any) []any { return variableSlice(v.(*tree.JavaTypeClass).Members) },
-		func(v any) any { return tree.TypeSignature(v.(tree.JavaType)) },
-		func(v any) { s.Visit(v.(tree.JavaType), q) })
-	q.GetAndSendListAsRef(c,
-		func(v any) []any { return methodSlice(v.(*tree.JavaTypeClass).Methods) },
-		func(v any) any { return tree.TypeSignature(v.(tree.JavaType)) },
-		func(v any) { s.Visit(v.(tree.JavaType), q) })
+	s.visitClassFields(c, p.(*SendQueue))
 	return c
+}
+
+// VisitShallowClass walks the same field set as VisitClass — Java's
+// ShallowClass extends Class and uses the same wire shape; only the
+// outgoing valueType discriminator differs (handled by valueTypeMap).
+func (s *JavaTypeSender) VisitShallowClass(sc *tree.JavaTypeShallowClass, p any) tree.JavaType {
+	s.visitClassFields(sc, p.(*SendQueue))
+	return sc
+}
+
+// toClassFields normalizes a Class-or-ShallowClass any to the embedded
+// *JavaTypeClass that holds the actual fields. Returns nil for any other
+// shape so callers can no-op on type-mismatched `before` states.
+func toClassFields(v any) *tree.JavaTypeClass {
+	switch c := v.(type) {
+	case *tree.JavaTypeClass:
+		return c
+	case *tree.JavaTypeShallowClass:
+		return &c.JavaTypeClass
+	}
+	return nil
+}
+
+// visitClassFields walks the wire-shape fields shared by JavaType$Class
+// and JavaType$ShallowClass. The `parent` argument is whichever outer
+// pointer the visitor was invoked with (either *JavaTypeClass or
+// *JavaTypeShallowClass); the closures call toClassFields so the
+// `before` value supplied by q.GetAndSend works for either type.
+func (s *JavaTypeSender) visitClassFields(parent any, q *SendQueue) {
+	q.GetAndSend(parent, func(v any) any { return toClassFields(v).FlagsBitMap }, nil)
+	q.GetAndSend(parent, func(v any) any { return toClassFields(v).Kind }, nil)
+	q.GetAndSend(parent, func(v any) any { return toClassFields(v).FullyQualifiedName }, nil)
+	q.GetAndSendListAsRef(parent,
+		func(v any) []any { return javaTypeSlice(toClassFields(v).TypeParameters) },
+		func(v any) any { return tree.TypeSignature(v.(tree.JavaType)) },
+		func(v any) { s.Visit(v.(tree.JavaType), q) })
+	q.GetAndSend(parent, func(v any) any { return AsRef(toClassFields(v).Supertype) },
+		func(v any) { s.Visit(GetValueNonNull(v).(tree.JavaType), q) })
+	q.GetAndSend(parent, func(v any) any { return AsRef(toClassFields(v).OwningClass) },
+		func(v any) { s.Visit(GetValueNonNull(v).(tree.JavaType), q) })
+	q.GetAndSendListAsRef(parent,
+		func(v any) []any { return classSlice(toClassFields(v).Annotations) },
+		func(v any) any { return tree.TypeSignature(v.(tree.JavaType)) },
+		func(v any) { s.Visit(v.(tree.JavaType), q) })
+	q.GetAndSendListAsRef(parent,
+		func(v any) []any { return classSlice(toClassFields(v).Interfaces) },
+		func(v any) any { return tree.TypeSignature(v.(tree.JavaType)) },
+		func(v any) { s.Visit(v.(tree.JavaType), q) })
+	q.GetAndSendListAsRef(parent,
+		func(v any) []any { return variableSlice(toClassFields(v).Members) },
+		func(v any) any { return tree.TypeSignature(v.(tree.JavaType)) },
+		func(v any) { s.Visit(v.(tree.JavaType), q) })
+	q.GetAndSendListAsRef(parent,
+		func(v any) []any { return methodSlice(toClassFields(v).Methods) },
+		func(v any) any { return tree.TypeSignature(v.(tree.JavaType)) },
+		func(v any) { s.Visit(v.(tree.JavaType), q) })
 }
 
 // VisitParameterized matches JavaTypeSender.visitParameterized
@@ -261,7 +290,7 @@ func javaTypeSlice(types []tree.JavaType) []any {
 	return result
 }
 
-func classSlice(classes []*tree.JavaTypeClass) []any {
+func classSlice(classes []tree.FullyQualified) []any {
 	if classes == nil {
 		return nil
 	}

--- a/rewrite-go/pkg/rpc/registry.go
+++ b/rewrite-go/pkg/rpc/registry.go
@@ -25,7 +25,7 @@ import (
 func init() {
 	// Register JavaType factories for RPC deserialization
 	RegisterFactory(tree.JavaTypeClassKind, func() any { return &tree.JavaTypeClass{} })
-	RegisterFactory(tree.JavaTypeShallowClassKind, func() any { return &tree.JavaTypeClass{} })
+	RegisterFactory(tree.JavaTypeShallowClassKind, func() any { return &tree.JavaTypeShallowClass{} })
 	RegisterFactory(tree.JavaTypeParameterizedKind, func() any { return &tree.JavaTypeParameterized{} })
 	RegisterFactory(tree.JavaTypeGenericTypeVariableKind, func() any { return &tree.JavaTypeGenericTypeVariable{} })
 	RegisterFactory(tree.JavaTypeArrayKind, func() any { return &tree.JavaTypeArray{} })
@@ -41,6 +41,7 @@ func init() {
 
 	// Register Go types -> Java class name mappings for send queue
 	RegisterValueType(reflect.TypeOf(&tree.JavaTypeClass{}), tree.JavaTypeClassKind)
+	RegisterValueType(reflect.TypeOf(&tree.JavaTypeShallowClass{}), tree.JavaTypeShallowClassKind)
 	RegisterValueType(reflect.TypeOf(&tree.JavaTypeParameterized{}), tree.JavaTypeParameterizedKind)
 	RegisterValueType(reflect.TypeOf(&tree.JavaTypeGenericTypeVariable{}), tree.JavaTypeGenericTypeVariableKind)
 	RegisterValueType(reflect.TypeOf(&tree.JavaTypeArray{}), tree.JavaTypeArrayKind)

--- a/rewrite-go/pkg/rpc/value_types.go
+++ b/rewrite-go/pkg/rpc/value_types.go
@@ -118,6 +118,7 @@ func init() {
 
 	// JavaType types
 	RegisterValueType(reflect.TypeOf((*tree.JavaTypeClass)(nil)), "org.openrewrite.java.tree.JavaType$Class")
+	RegisterValueType(reflect.TypeOf((*tree.JavaTypeShallowClass)(nil)), "org.openrewrite.java.tree.JavaType$ShallowClass")
 	RegisterValueType(reflect.TypeOf((*tree.JavaTypeParameterized)(nil)), "org.openrewrite.java.tree.JavaType$Parameterized")
 	RegisterValueType(reflect.TypeOf((*tree.JavaTypeGenericTypeVariable)(nil)), "org.openrewrite.java.tree.JavaType$GenericTypeVariable")
 	RegisterValueType(reflect.TypeOf((*tree.JavaTypeArray)(nil)), "org.openrewrite.java.tree.JavaType$Array")
@@ -248,6 +249,7 @@ func init() {
 
 
 	RegisterFactory("org.openrewrite.java.tree.JavaType$Class", func() any { return &tree.JavaTypeClass{} })
+	RegisterFactory("org.openrewrite.java.tree.JavaType$ShallowClass", func() any { return &tree.JavaTypeShallowClass{} })
 	RegisterFactory("org.openrewrite.java.tree.JavaType$Parameterized", func() any { return &tree.JavaTypeParameterized{} })
 	RegisterFactory("org.openrewrite.java.tree.JavaType$GenericTypeVariable", func() any { return &tree.JavaTypeGenericTypeVariable{} })
 	RegisterFactory("org.openrewrite.java.tree.JavaType$Array", func() any { return &tree.JavaTypeArray{} })

--- a/rewrite-go/pkg/test/expect_type.go
+++ b/rewrite-go/pkg/test/expect_type.go
@@ -93,7 +93,7 @@ func ExpectMethodType(t *testing.T, root tree.Tree, name string, expectedDeclari
 	if c.methodType.DeclaringType == nil {
 		t.Fatalf("ExpectMethodType(%q): method has nil DeclaringType", name)
 	}
-	if got := c.methodType.DeclaringType.FullyQualifiedName; got != expectedDeclaringFQN {
+	if got := c.methodType.DeclaringType.GetFullyQualifiedName(); got != expectedDeclaringFQN {
 		t.Errorf("ExpectMethodType(%q): declaring FQN = %q, want %q", name, got, expectedDeclaringFQN)
 	}
 }

--- a/rewrite-go/pkg/tree/java_type.go
+++ b/rewrite-go/pkg/tree/java_type.go
@@ -60,10 +60,10 @@ type JavaTypeClass struct {
 	Kind               string
 	FullyQualifiedName string
 	TypeParameters     []JavaType
-	Supertype          *JavaTypeClass
-	OwningClass        *JavaTypeClass
-	Annotations        []*JavaTypeClass
-	Interfaces         []*JavaTypeClass
+	Supertype          FullyQualified
+	OwningClass        FullyQualified
+	Annotations        []FullyQualified
+	Interfaces         []FullyQualified
 	Members            []*JavaTypeVariable
 	Methods            []*JavaTypeMethod
 }
@@ -71,12 +71,26 @@ type JavaTypeClass struct {
 func (*JavaTypeClass) isJavaType() {}
 
 func (c *JavaTypeClass) GetFullyQualifiedName() string {
+	if c == nil {
+		return ""
+	}
 	return c.FullyQualifiedName
 }
 
+// JavaTypeShallowClass mirrors Java's JavaType.ShallowClass — a Class
+// instance that carries minimal metadata (kind, FQN, owning class) and
+// otherwise behaves identically to JavaTypeClass. The wire format
+// preserves the distinction; on the Go side the embedded JavaTypeClass
+// supplies all fields and accessors.
+type JavaTypeShallowClass struct {
+	JavaTypeClass
+}
+
+func (*JavaTypeShallowClass) isJavaType() {}
+
 // JavaTypeParameterized represents a parameterized type like List<String>.
 type JavaTypeParameterized struct {
-	Type           *JavaTypeClass
+	Type           FullyQualified
 	TypeParameters []JavaType
 }
 
@@ -84,7 +98,7 @@ func (*JavaTypeParameterized) isJavaType() {}
 
 func (p *JavaTypeParameterized) GetFullyQualifiedName() string {
 	if p.Type != nil {
-		return p.Type.FullyQualifiedName
+		return p.Type.GetFullyQualifiedName()
 	}
 	return ""
 }
@@ -101,22 +115,22 @@ func (*JavaTypeGenericTypeVariable) isJavaType() {}
 // JavaTypeArray represents an array type.
 type JavaTypeArray struct {
 	ElemType    JavaType
-	Annotations []*JavaTypeClass
+	Annotations []FullyQualified
 }
 
 func (*JavaTypeArray) isJavaType() {}
 
 // JavaTypeMethod represents a method type signature.
 type JavaTypeMethod struct {
-	DeclaringType          *JavaTypeClass
-	Name                   string
-	FlagsBitMap            int64
-	ReturnType             JavaType
-	ParameterNames         []string
-	ParameterTypes         []JavaType
-	ThrownExceptions       []JavaType
-	Annotations            []*JavaTypeClass
-	DefaultValue           []string
+	DeclaringType           FullyQualified
+	Name                    string
+	FlagsBitMap             int64
+	ReturnType              JavaType
+	ParameterNames          []string
+	ParameterTypes          []JavaType
+	ThrownExceptions        []JavaType
+	Annotations             []FullyQualified
+	DefaultValue            []string
 	DeclaredFormalTypeNames []string
 }
 
@@ -127,14 +141,14 @@ type JavaTypeVariable struct {
 	Name        string
 	Owner       JavaType
 	Type        JavaType
-	Annotations []*JavaTypeClass
+	Annotations []FullyQualified
 }
 
 func (*JavaTypeVariable) isJavaType() {}
 
 // JavaTypeAnnotation represents an annotation type reference.
 type JavaTypeAnnotation struct {
-	Type   *JavaTypeClass
+	Type   FullyQualified
 	Values []JavaTypeAnnotationElementValue
 }
 
@@ -202,12 +216,14 @@ func TypeSignature(t JavaType) string {
 	switch v := t.(type) {
 	case *JavaTypePrimitive:
 		return v.Keyword
+	case *JavaTypeShallowClass:
+		return v.FullyQualifiedName
 	case *JavaTypeClass:
 		return v.FullyQualifiedName
 	case *JavaTypeParameterized:
 		sig := ""
 		if v.Type != nil {
-			sig = v.Type.FullyQualifiedName
+			sig = v.Type.GetFullyQualifiedName()
 		}
 		sig += "<"
 		for i, tp := range v.TypeParameters {
@@ -225,7 +241,7 @@ func TypeSignature(t JavaType) string {
 	case *JavaTypeMethod:
 		declSig := ""
 		if v.DeclaringType != nil {
-			declSig = v.DeclaringType.FullyQualifiedName
+			declSig = v.DeclaringType.GetFullyQualifiedName()
 		}
 		return fmt.Sprintf("%s{name=%s,return=%s,parameters=%s}",
 			declSig, v.Name, TypeSignature(v.ReturnType), typeListSignature(v.ParameterTypes))
@@ -234,7 +250,7 @@ func TypeSignature(t JavaType) string {
 		return fmt.Sprintf("%s{name=%s,type=%s}", ownerSig, v.Name, TypeSignature(v.Type))
 	case *JavaTypeAnnotation:
 		if v.Type != nil {
-			return "@" + v.Type.FullyQualifiedName
+			return "@" + v.Type.GetFullyQualifiedName()
 		}
 		return "@"
 	case *JavaTypeMultiCatch:

--- a/rewrite-go/pkg/visitor/java_type_visitor.go
+++ b/rewrite-go/pkg/visitor/java_type_visitor.go
@@ -32,6 +32,7 @@ type JavaTypeVisitorI interface {
 	VisitAnnotation(annotation *tree.JavaTypeAnnotation, p any) tree.JavaType
 	VisitArray(array *tree.JavaTypeArray, p any) tree.JavaType
 	VisitClass(class_ *tree.JavaTypeClass, p any) tree.JavaType
+	VisitShallowClass(shallow *tree.JavaTypeShallowClass, p any) tree.JavaType
 	VisitGenericTypeVariable(generic *tree.JavaTypeGenericTypeVariable, p any) tree.JavaType
 	VisitIntersection(intersection *tree.JavaTypeIntersection, p any) tree.JavaType
 	VisitMethod(method *tree.JavaTypeMethod, p any) tree.JavaType
@@ -60,6 +61,8 @@ func (v *JavaTypeVisitor) Visit(javaType tree.JavaType, p any) tree.JavaType {
 		return v.self().VisitAnnotation(t, p)
 	case *tree.JavaTypeArray:
 		return v.self().VisitArray(t, p)
+	case *tree.JavaTypeShallowClass:
+		return v.self().VisitShallowClass(t, p)
 	case *tree.JavaTypeClass:
 		return v.self().VisitClass(t, p)
 	case *tree.JavaTypeGenericTypeVariable:
@@ -107,6 +110,10 @@ func (v *JavaTypeVisitor) VisitArray(array *tree.JavaTypeArray, p any) tree.Java
 
 func (v *JavaTypeVisitor) VisitClass(class_ *tree.JavaTypeClass, p any) tree.JavaType {
 	return class_
+}
+
+func (v *JavaTypeVisitor) VisitShallowClass(shallow *tree.JavaTypeShallowClass, p any) tree.JavaType {
+	return shallow
 }
 
 func (v *JavaTypeVisitor) VisitGenericTypeVariable(generic *tree.JavaTypeGenericTypeVariable, p any) tree.JavaType {

--- a/rewrite-go/test/type_attribution_test.go
+++ b/rewrite-go/test/type_attribution_test.go
@@ -156,7 +156,7 @@ func divmod(a int, b int) (int, int) {
 	if !ok {
 		t.Fatalf("expected parameterized return type, got %T", mt.ReturnType)
 	}
-	if param.Type == nil || param.Type.FullyQualifiedName != "go.tuple" {
+	if param.Type == nil || param.Type.GetFullyQualifiedName() != "go.tuple" {
 		t.Errorf("expected tuple FQN 'go.tuple', got %+v", param.Type)
 	}
 	if len(param.TypeParameters) != 2 {
@@ -200,7 +200,7 @@ func split() (string, int, bool) {
 	if !ok {
 		t.Fatalf("expected parameterized return type, got %T", mt.ReturnType)
 	}
-	if param.Type == nil || param.Type.FullyQualifiedName != "go.tuple" {
+	if param.Type == nil || param.Type.GetFullyQualifiedName() != "go.tuple" {
 		t.Errorf("expected tuple FQN 'go.tuple', got %+v", param.Type)
 	}
 	if len(param.TypeParameters) != 3 {


### PR DESCRIPTION
## What's changed?

In Go, introducing the `JavaTypeShallowClass` next to the already existing `JavaTypeClass`.
As a consequence in a lot of places, we need to use `FullyQualified` super type instead of `JavaTypeClass`.

## What's your motivation?

Without this, the `JavaTypeShallowClass` objects get conflated/coerced into `JavaTypeClass` over RPC. And unexpected things happen. The symptoms observed include:
```
java.lang.IllegalArgumentException: No enum constant org.openrewrite.java.tree.JavaType.FullyQualified.Kind.
  java.base/java.lang.Enum.valueOf(Enum.java:293)
  org.openrewrite.java.tree.JavaType$FullyQualified$Kind.valueOf(JavaType.java:389)
  org.openrewrite.java.internal.rpc.JavaTypeReceiver.lambda$visitClass$7(JavaTypeReceiver.java:74)
  org.openrewrite.rpc.RpcReceiveQueue.receiveAndGet(RpcReceiveQueue.java:71)
  org.openrewrite.java.internal.rpc.JavaTypeReceiver.visitClass(JavaTypeReceiver.java:74)
```