### PR TITLE
Go: don't pick the container variant off the first element

### DIFF
--- a/rewrite-go/pkg/rpc/padding_rpc.go
+++ b/rewrite-go/pkg/rpc/padding_rpc.go
@@ -17,6 +17,8 @@
 package rpc
 
 import (
+	"fmt"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree"
 )
 
@@ -260,6 +262,12 @@ func rightPaddedFromElement(elem any, after tree.Space, markers tree.Markers) an
 		return tree.RightPadded[*tree.VariableDeclarator]{Element: e, After: after, Markers: markers}
 	case *tree.Import:
 		return tree.RightPadded[*tree.Import]{Element: e, After: after, Markers: markers}
+	case bool:
+		// Primitive wrappers like Block.static (JRightPadded<Boolean> on the Java side).
+		// The caller (VisitBlock) discards the result, so the wire shape is preserved
+		// even though Go can't represent the typed element.
+		_ = e
+		return tree.RightPadded[tree.J]{After: after, Markers: markers}
 	}
 	// For types that implement both Statement and Expression (like MethodInvocation),
 	// we create BOTH variants and let the caller decide. In practice, the parent container
@@ -287,8 +295,10 @@ func rightPaddedFromElement(elem any, after tree.Space, markers tree.Markers) an
 	return tree.RightPadded[tree.J]{After: after, Markers: markers}
 }
 
-// coerceToExpressionRP converts a RightPadded of any variant to RightPadded[Expression]
-// by extracting the element and verifying it implements Expression.
+// coerceToExpressionRP converts a RightPadded of any variant to RightPadded[Expression].
+// Panics if the underlying element does not implement Expression — silently dropping it
+// (the previous behavior) corrupts the LST. containerFromElements should ensure this
+// helper is only called when every element does satisfy Expression.
 func coerceToExpressionRP(rp any) tree.RightPadded[tree.Expression] {
 	if rp, ok := rp.(tree.RightPadded[tree.Expression]); ok {
 		return rp
@@ -299,10 +309,11 @@ func coerceToExpressionRP(rp any) tree.RightPadded[tree.Expression] {
 	if expr, ok := elem.(tree.Expression); ok {
 		return tree.RightPadded[tree.Expression]{Element: expr, After: after, Markers: m}
 	}
-	return tree.RightPadded[tree.Expression]{After: after, Markers: m}
+	panic(fmt.Sprintf("coerceToExpressionRP: element does not implement tree.Expression (rp=%T elem=%T nil=%v)", rp, elem, elem == nil))
 }
 
 // coerceToStatementRP converts a RightPadded of any variant to RightPadded[Statement].
+// Panics if the underlying element does not implement Statement (see coerceToExpressionRP).
 func coerceToStatementRP(rp any) tree.RightPadded[tree.Statement] {
 	if rp, ok := rp.(tree.RightPadded[tree.Statement]); ok {
 		return rp
@@ -313,7 +324,7 @@ func coerceToStatementRP(rp any) tree.RightPadded[tree.Statement] {
 	if stmt, ok := elem.(tree.Statement); ok {
 		return tree.RightPadded[tree.Statement]{Element: stmt, After: after, Markers: m}
 	}
-	return tree.RightPadded[tree.Statement]{After: after, Markers: m}
+	panic(fmt.Sprintf("coerceToStatementRP: element does not implement tree.Statement (rp=%T elem=%T nil=%v)", rp, elem, elem == nil))
 }
 
 // coerceRightPaddedIdent converts a RightPadded of any variant to RightPadded[*Identifier].
@@ -627,8 +638,11 @@ func updateContainer(c any, before tree.Space, elements []any, markers tree.Mark
 	return containerFromElements(before, elements, markers)
 }
 
-// containerFromElements creates a Container with the correct generic type
-// based on the elements' types.
+// containerFromElements creates a Container whose generic type is the most
+// specific interface satisfied by *every* element. Picking based on the first
+// element alone silently drops Statement-only entries (Return, If, …) when
+// the first element happens to be an Expression — that is the root cause of
+// the Case.Body corruption documented in the round-trip diagnostics.
 func containerFromElements(before tree.Space, elements []any, markers tree.Markers) any {
 	if len(elements) == 0 {
 		// Empty container — default to Expression since most containers
@@ -636,11 +650,24 @@ func containerFromElements(before tree.Space, elements []any, markers tree.Marke
 		return tree.Container[tree.Expression]{Before: before, Markers: markers}
 	}
 
-	// Detect from first element. Java may send mixed RightPadded variants in one
-	// container (e.g. switch-case bodies). Coerce every element to the detected
-	// variant rather than raw-casting — raw casts panic on heterogeneous lists.
-	switch elements[0].(type) {
-	case tree.RightPadded[*tree.Import]:
+	allImport := true
+	allExpr := true
+	allStmt := true
+	for _, e := range elements {
+		elem := rightPaddedElement(e)
+		if _, ok := elem.(*tree.Import); !ok {
+			allImport = false
+		}
+		if _, ok := elem.(tree.Expression); !ok {
+			allExpr = false
+		}
+		if _, ok := elem.(tree.Statement); !ok {
+			allStmt = false
+		}
+	}
+
+	switch {
+	case allImport:
 		elems := make([]tree.RightPadded[*tree.Import], len(elements))
 		for i, e := range elements {
 			if rp, ok := e.(tree.RightPadded[*tree.Import]); ok {
@@ -648,25 +675,38 @@ func containerFromElements(before tree.Space, elements []any, markers tree.Marke
 			}
 		}
 		return tree.Container[*tree.Import]{Before: before, Elements: elems, Markers: markers}
-	case tree.RightPadded[tree.Expression]:
+	case allExpr:
+		// All elements implement Expression — safe to fit into Container[Expression].
 		elems := make([]tree.RightPadded[tree.Expression], len(elements))
 		for i, e := range elements {
 			elems[i] = coerceToExpressionRP(e)
 		}
 		return tree.Container[tree.Expression]{Before: before, Elements: elems, Markers: markers}
-	case tree.RightPadded[tree.Statement]:
+	case allStmt:
+		// Some element does not implement Expression but all implement Statement
+		// (mixed Case.Body: method calls + return). Without this branch, the old
+		// first-element-only detection would pick Expression and silently drop the
+		// Statement-only entries via coerceToExpressionRP's fallback.
 		elems := make([]tree.RightPadded[tree.Statement], len(elements))
 		for i, e := range elements {
 			elems[i] = coerceToStatementRP(e)
 		}
 		return tree.Container[tree.Statement]{Before: before, Elements: elems, Markers: markers}
 	default:
-		// Coerce elements: try Expression first, then Statement
-		exprElems := make([]tree.RightPadded[tree.Expression], 0, len(elements))
-		for _, e := range elements {
-			rp := coerceToExpressionRP(e)
-			exprElems = append(exprElems, rp)
+		// Truly heterogeneous (nothing common beyond tree.J). Use Container[tree.J]
+		// so callers can decide how to coerce — coerceContainerStatement and
+		// coerceContainerExpression both already handle this variant element-wise.
+		elems := make([]tree.RightPadded[tree.J], len(elements))
+		for i, e := range elements {
+			elem := rightPaddedElement(e)
+			after := rightPaddedAfter(e).(tree.Space)
+			m := rightPaddedMarkers(e).(tree.Markers)
+			if j, ok := elem.(tree.J); ok {
+				elems[i] = tree.RightPadded[tree.J]{Element: j, After: after, Markers: m}
+			} else {
+				elems[i] = tree.RightPadded[tree.J]{After: after, Markers: m}
+			}
 		}
-		return tree.Container[tree.Expression]{Before: before, Elements: exprElems, Markers: markers}
+		return tree.Container[tree.J]{Before: before, Elements: elems, Markers: markers}
 	}
 }

--- a/rewrite-go/pkg/rpc/padding_rpc_test.go
+++ b/rewrite-go/pkg/rpc/padding_rpc_test.go
@@ -294,7 +294,8 @@ func TestContainerFromElements_HeterogeneousElements(t *testing.T) {
 }
 
 func TestContainerFromElements_HeterogeneousStatementFirst(t *testing.T) {
-	// given: opposite ordering — Statement detected first, Expression follows.
+	// given: opposite ordering — Statement-labelled RightPadded first, Expression follows.
+	// Both elements are MethodInvocations, which implement Expression AND Statement.
 	mi1, mi2 := makeMethodInvocation(), makeMethodInvocation()
 	elements := []any{
 		tree.RightPadded[tree.Statement]{Element: mi1, Markers: tree.Markers{}},
@@ -304,7 +305,48 @@ func TestContainerFromElements_HeterogeneousStatementFirst(t *testing.T) {
 	// when
 	got := containerFromElements(tree.EmptySpace, elements, tree.Markers{})
 
-	// then
+	// then: the variant is chosen by "most specific interface all elements satisfy",
+	// not by which slot's label appeared first. Both MIs satisfy Expression, so the
+	// container should be [Expression] — matching the sibling Expression-first test.
+	cont, ok := got.(tree.Container[tree.Expression])
+	if !ok {
+		t.Fatalf("want Container[Expression], got %T", got)
+	}
+	if len(cont.Elements) != 2 {
+		t.Fatalf("want 2 elements, got %d", len(cont.Elements))
+	}
+	if cont.Elements[0].Element.(*tree.MethodInvocation) != mi1 {
+		t.Errorf("element[0] identity lost")
+	}
+	if cont.Elements[1].Element.(*tree.MethodInvocation) != mi2 {
+		t.Errorf("element[1] identity lost")
+	}
+}
+
+// makeReturnStatement returns a *tree.Return — implements Statement but NOT Expression.
+// Used to exercise mixed Case.Body containers whose elements include statement-only nodes.
+func makeReturnStatement() *tree.Return {
+	return &tree.Return{ID: uuid.New()}
+}
+
+func TestContainerFromElements_StatementOnlyElementSurvives(t *testing.T) {
+	// given: a Case.Body-shaped list with a method call (Expression+Statement) and
+	// a return (Statement-only). Before the variant-detection fix, picking the
+	// Expression variant from the first element caused coerceToExpressionRP to
+	// silently drop the return statement — surfacing as truncated Go source after
+	// a round trip. See diagnostic findings in /tmp/rewrite-go-rpc-nil-debug-patches.md.
+	mi := makeMethodInvocation()
+	ret := makeReturnStatement()
+	elements := []any{
+		tree.RightPadded[tree.Expression]{Element: mi, Markers: tree.Markers{}},
+		tree.RightPadded[tree.Statement]{Element: ret, Markers: tree.Markers{}},
+	}
+
+	// when
+	got := containerFromElements(tree.EmptySpace, elements, tree.Markers{})
+
+	// then: both elements survive in a Container[Statement] — Statement is the
+	// most specific interface every element satisfies.
 	cont, ok := got.(tree.Container[tree.Statement])
 	if !ok {
 		t.Fatalf("want Container[Statement], got %T", got)
@@ -312,8 +354,11 @@ func TestContainerFromElements_HeterogeneousStatementFirst(t *testing.T) {
 	if len(cont.Elements) != 2 {
 		t.Fatalf("want 2 elements, got %d", len(cont.Elements))
 	}
-	if cont.Elements[1].Element.(*tree.MethodInvocation) != mi2 {
-		t.Errorf("element[1] identity lost — coerce dropped the Expression-variant entry")
+	if cont.Elements[0].Element.(*tree.MethodInvocation) != mi {
+		t.Errorf("element[0] (method invocation) identity lost")
+	}
+	if cont.Elements[1].Element.(*tree.Return) != ret {
+		t.Errorf("element[1] (return statement) identity lost — pre-fix this was silently dropped")
 	}
 }
 


### PR DESCRIPTION
## What's changed?

Stops `containerFromElements` (part of the RPC) from picking the container variant off the first element (which silently drops Statement-only entries like Return/If when the first element is an Expression).

## What's your motivation?

Otherwise, RPC failures are observed when running Go recipes. The symptoms might include:
```
org.openrewrite.internal.RecipeRunException: java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.J.getId()" because the return value of "org.openrewrite.java.tree.JRightPadded.getElement()" is null
        at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:278)
        at org.openrewrite.golang.internal.rpc.GolangSender$GolangSenderDelegate.visit(GolangSender.java:235)
        at org.openrewrite.golang.internal.rpc.GolangSender$GolangSenderDelegate.visit(GolangSender.java:223)
        at org.openrewrite.java.internal.rpc.JavaSender.lambda$visitRightPadded$296(JavaSender.java:606)
        at org.openrewrite.rpc.RpcSendQueue.lambda$getAndSend$0(RpcSendQueue.java:83)
```