### PR TITLE
Go: mutate objects in place in RPC receiver

### DIFF
--- a/rewrite-go/pkg/rpc/java_type_receiver.go
+++ b/rewrite-go/pkg/rpc/java_type_receiver.go
@@ -38,8 +38,6 @@ func NewJavaTypeReceiver() *JavaTypeReceiver {
 // VisitAnnotation mirrors JavaTypeReceiver.visitAnnotation
 func (r *JavaTypeReceiver) VisitAnnotation(a *tree.JavaTypeAnnotation, p any) tree.JavaType {
 	q := p.(*ReceiveQueue)
-	cc := *a
-	a = &cc
 	a.Type = receiveAsFullyQualified(r, q, a.Type)
 	a.Values = r.receiveAnnotationElementValueList(q, a.Values)
 	return a
@@ -65,44 +63,27 @@ func (r *JavaTypeReceiver) receiveAnnotationElementValueList(
 func (r *JavaTypeReceiver) receiveAnnotationElementValue(
 	q *ReceiveQueue, v tree.JavaTypeAnnotationElementValue,
 ) tree.JavaTypeAnnotationElementValue {
-	element := receiveAsType[tree.JavaType](r, q, v.GetElement())
 	switch ev := v.(type) {
 	case *tree.JavaTypeAnnotationArrayElementValue:
+		ev.Element = receiveAsType[tree.JavaType](r, q, ev.Element)
 		// Constant values arrive as whatever the JSON-RPC layer deserialized;
 		// numeric subtype and char/string distinctions are not preserved.
-		constantValues := q.ReceiveList(ev.ConstantValues, nil)
-		refValues := receiveTypeList(r, q, ev.ReferenceValues)
-		return &tree.JavaTypeAnnotationArrayElementValue{
-			Element:         element,
-			ConstantValues:  constantValues,
-			ReferenceValues: refValues,
-		}
+		ev.ConstantValues = q.ReceiveList(ev.ConstantValues, nil)
+		ev.ReferenceValues = receiveTypeList(r, q, ev.ReferenceValues)
+		return ev
+	case *tree.JavaTypeAnnotationSingleElementValue:
+		ev.Element = receiveAsType[tree.JavaType](r, q, ev.Element)
+		ev.ConstantValue = q.Receive(ev.ConstantValue, nil)
+		ev.ReferenceValue = receiveAsType[tree.JavaType](r, q, ev.ReferenceValue)
+		return ev
 	default:
-		var sev *tree.JavaTypeAnnotationSingleElementValue
-		if s, ok := v.(*tree.JavaTypeAnnotationSingleElementValue); ok {
-			sev = s
-		}
-		var beforeConstant any
-		var beforeRef tree.JavaType
-		if sev != nil {
-			beforeConstant = sev.ConstantValue
-			beforeRef = sev.ReferenceValue
-		}
-		constantValue := q.Receive(beforeConstant, nil)
-		refValue := receiveAsType[tree.JavaType](r, q, beforeRef)
-		return &tree.JavaTypeAnnotationSingleElementValue{
-			Element:        element,
-			ConstantValue:  constantValue,
-			ReferenceValue: refValue,
-		}
+		return v
 	}
 }
 
 // VisitMultiCatch mirrors JavaTypeReceiver.visitMultiCatch
 func (r *JavaTypeReceiver) VisitMultiCatch(mc *tree.JavaTypeMultiCatch, p any) tree.JavaType {
 	q := p.(*ReceiveQueue)
-	cc := *mc
-	mc = &cc
 	mc.ThrowableTypes = receiveTypeList(r, q, mc.ThrowableTypes)
 	return mc
 }
@@ -110,8 +91,6 @@ func (r *JavaTypeReceiver) VisitMultiCatch(mc *tree.JavaTypeMultiCatch, p any) t
 // VisitIntersection mirrors JavaTypeReceiver.visitIntersection
 func (r *JavaTypeReceiver) VisitIntersection(is *tree.JavaTypeIntersection, p any) tree.JavaType {
 	q := p.(*ReceiveQueue)
-	cc := *is
-	is = &cc
 	is.Bounds = receiveTypeList(r, q, is.Bounds)
 	return is
 }
@@ -121,18 +100,16 @@ func (r *JavaTypeReceiver) VisitIntersection(is *tree.JavaTypeIntersection, p an
 // annotations, interfaces, members, methods
 func (r *JavaTypeReceiver) VisitClass(c *tree.JavaTypeClass, p any) tree.JavaType {
 	q := p.(*ReceiveQueue)
-	cc := *c
-	r.receiveClassFields(&cc, q)
-	return &cc
+	r.receiveClassFields(c, q)
+	return c
 }
 
 // VisitShallowClass mirrors VisitClass — Java's ShallowClass extends Class
 // and uses the same field set; the discriminator is the wire valueType.
 func (r *JavaTypeReceiver) VisitShallowClass(sc *tree.JavaTypeShallowClass, p any) tree.JavaType {
 	q := p.(*ReceiveQueue)
-	cc := *sc
-	r.receiveClassFields(&cc.JavaTypeClass, q)
-	return &cc
+	r.receiveClassFields(&sc.JavaTypeClass, q)
+	return sc
 }
 
 func (r *JavaTypeReceiver) receiveClassFields(c *tree.JavaTypeClass, q *ReceiveQueue) {
@@ -151,8 +128,6 @@ func (r *JavaTypeReceiver) receiveClassFields(c *tree.JavaTypeClass, q *ReceiveQ
 // VisitParameterized mirrors JavaTypeReceiver.visitParameterized
 func (r *JavaTypeReceiver) VisitParameterized(pt *tree.JavaTypeParameterized, p any) tree.JavaType {
 	q := p.(*ReceiveQueue)
-	cc := *pt
-	pt = &cc
 	pt.Type = receiveAsFullyQualified(r, q, pt.Type)
 	pt.TypeParameters = receiveTypeList(r, q, pt.TypeParameters)
 	return pt
@@ -161,8 +136,6 @@ func (r *JavaTypeReceiver) VisitParameterized(pt *tree.JavaTypeParameterized, p 
 // VisitGenericTypeVariable mirrors JavaTypeReceiver.visitGenericTypeVariable
 func (r *JavaTypeReceiver) VisitGenericTypeVariable(g *tree.JavaTypeGenericTypeVariable, p any) tree.JavaType {
 	q := p.(*ReceiveQueue)
-	cc := *g
-	g = &cc
 	g.Name = receiveScalar[string](q, g.Name)
 	g.Variance = receiveScalar[string](q, g.Variance)
 	g.Bounds = receiveTypeList(r, q, g.Bounds)
@@ -172,8 +145,6 @@ func (r *JavaTypeReceiver) VisitGenericTypeVariable(g *tree.JavaTypeGenericTypeV
 // VisitArray mirrors JavaTypeReceiver.visitArray
 func (r *JavaTypeReceiver) VisitArray(a *tree.JavaTypeArray, p any) tree.JavaType {
 	q := p.(*ReceiveQueue)
-	cc := *a
-	a = &cc
 	a.ElemType = receiveAsType[tree.JavaType](r, q, a.ElemType)
 	a.Annotations = receiveClassList(r, q, a.Annotations)
 	return a
@@ -182,8 +153,6 @@ func (r *JavaTypeReceiver) VisitArray(a *tree.JavaTypeArray, p any) tree.JavaTyp
 // VisitPrimitive mirrors JavaTypeReceiver.visitPrimitive
 func (r *JavaTypeReceiver) VisitPrimitive(pr *tree.JavaTypePrimitive, p any) tree.JavaType {
 	q := p.(*ReceiveQueue)
-	cc := *pr
-	pr = &cc
 	pr.Keyword = receiveScalar[string](q, pr.Keyword)
 	return pr
 }
@@ -193,8 +162,6 @@ func (r *JavaTypeReceiver) VisitPrimitive(pr *tree.JavaTypePrimitive, p any) tre
 // thrownExceptions, annotations, defaultValue, declaredFormalTypeNames
 func (r *JavaTypeReceiver) VisitMethod(m *tree.JavaTypeMethod, p any) tree.JavaType {
 	q := p.(*ReceiveQueue)
-	cc := *m
-	m = &cc
 	m.DeclaringType = receiveAsFullyQualified(r, q, m.DeclaringType)
 	m.Name = receiveScalar[string](q, m.Name)
 	m.FlagsBitMap = receiveScalar[int64](q, m.FlagsBitMap)
@@ -211,8 +178,6 @@ func (r *JavaTypeReceiver) VisitMethod(m *tree.JavaTypeMethod, p any) tree.JavaT
 // VisitVariable mirrors JavaTypeReceiver.visitVariable
 func (r *JavaTypeReceiver) VisitVariable(v *tree.JavaTypeVariable, p any) tree.JavaType {
 	q := p.(*ReceiveQueue)
-	cc := *v
-	v = &cc
 	v.Name = receiveScalar[string](q, v.Name)
 	v.Owner = receiveAsType[tree.JavaType](r, q, v.Owner)
 	v.Type = receiveAsType[tree.JavaType](r, q, v.Type)

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangRecipeIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangRecipeIntegTest.java
@@ -189,6 +189,35 @@ class GolangRecipeIntegTest implements RewriteTest {
     }
 
     @Test
+    void selfReferencingMethodSurvivesAddRoundtrip() {
+        GoRewriteRpc rpc = GoRewriteRpc.getOrStart();
+        String source = """
+          package main
+
+          type Counter struct {
+          \tvalue int
+          }
+
+          func (c *Counter) Inc(x int) {
+          }
+          """;
+        SourceFile cu = GolangParser.builder().build()
+          .parse(source).findFirst().orElseThrow();
+
+        // Force ADD path on Java→Go: Go has no baseline for this tree, so the
+        // entire JavaType graph (incl. the Counter ↔ Inc self-cycle) is sent
+        // as ADD, triggering the receive-side ref cache on the Go side.
+        rpc.reset();
+        var recipe = rpc.prepareRecipe("org.openrewrite.golang.test.RenameXToFlag");
+        Tree result = recipe.getVisitor().visit(cu, new InMemoryExecutionContext());
+
+        // Before the fix, this throws
+        // `IllegalArgumentException: No enum constant ... JavaType.FullyQualified.Kind.`
+        // when Java deserializes the returned tree.
+        assertThat(result).isNotNull().isInstanceOf(SourceFile.class);
+    }
+
+    @Test
     void renameIdentifier() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new org.openrewrite.java.JavaIsoVisitor<>() {


### PR DESCRIPTION
## What's changed?

Change the RPC visitor implementation for Go. Mutate the objects in place, just like we do for other languages.

## What's your motivation?

Otherwise the recipe run might fail with:
```
java.lang.IllegalArgumentException: No enum constant org.openrewrite.java.tree.JavaType.FullyQualified.Kind.
  at org.openrewrite.java.tree.JavaType$FullyQualified$Kind.valueOf(JavaType.java:389)
  at org.openrewrite.java.internal.rpc.JavaTypeReceiver.lambda$visitClass$7(JavaTypeReceiver.java:74)
```
if you have a cycle in type attributions.