### PR TITLE
TypeTable: tolerate cross-JVM races when publishing per-artifact JARs

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -26,6 +26,8 @@ import org.openrewrite.java.JavaParserExecutionContextView;
 
 import java.io.*;
 import java.net.URL;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -422,10 +424,20 @@ public class TypeTable implements JavaParserClasspathLoader {
                         jos.closeEntry();
                     }
                 }
-                // Atomic publish: callers blocked on `future` see either the prior jar
-                // (if any) or the fully-written one — never a half-written file.
-                Files.move(tmpJar, jarPath,
-                        StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+                // Atomic publish: callers blocked on `future` see either no jar or the
+                // fully-written one — never a half-written file. If another JVM
+                // produced the same jar concurrently on a shared cache directory,
+                // keep its version and discard our temp file. Windows raises
+                // AccessDeniedException when the target is held open in another JVM,
+                // which we treat the same as FileAlreadyExistsException.
+                try {
+                    Files.move(tmpJar, jarPath, StandardCopyOption.ATOMIC_MOVE);
+                } catch (FileAlreadyExistsException | AccessDeniedException e) {
+                    Files.deleteIfExists(tmpJar);
+                    if (!Files.exists(jarPath)) {
+                        throw e;
+                    }
+                }
                 future.complete(jarPath);
             } catch (Exception e) {
                 future.completeExceptionally(e);

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTest.java
@@ -38,6 +38,7 @@ import javax.tools.ToolProvider;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.FileVisitResult;
@@ -46,6 +47,7 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.jar.JarEntry;
@@ -898,6 +900,65 @@ class TypeTableTest implements RewriteTest {
             } finally {
                 Thread.currentThread().setContextClassLoader(originalTccl);
             }
+        }
+    }
+
+    @Nested
+    class ConcurrentJarWriteTests {
+
+        /**
+         * Regression test for the Windows cross-JVM race introduced in #7528: when multiple
+         * test JVMs share the user's classpath cache, two JVMs may both produce a temp jar
+         * and try to publish it to the same path. With ATOMIC_MOVE + REPLACE_EXISTING,
+         * the second move can fail on Windows with AccessDeniedException if the target
+         * is held open by the first JVM. Here we simulate a fresh JVM by clearing the
+         * in-process {@code jarByArtifact} map between two reads — the second read must
+         * tolerate the target jar already being on disk.
+         */
+        @Test
+        void secondReadToleratesExistingJar() throws Exception {
+            //language=java
+            String source = """
+                package com.example;
+
+                public class SimpleClass {
+                    public static final String VALUE = "hello";
+                }
+                """;
+            Path classFile = compileToClassFile(source, "com.example.SimpleClass");
+            Path jarFile = createJarFromClasses("simple.jar", classFile);
+
+            try (TypeTable.Writer writer = TypeTable.newWriter(Files.newOutputStream(tsv))) {
+                writer.jar("com.example", "simple", "1.0").write(jarFile);
+            }
+
+            // First read: writes the jar to the classpath cache directory.
+            Path firstLoaded = new TypeTable(ctx, tsv.toUri().toURL(), List.of("simple"))
+                    .load("simple");
+            assertThat(firstLoaded).isNotNull();
+            assertThat(Files.exists(firstLoaded)).isTrue();
+
+            // Simulate a fresh JVM by clearing the in-process map. The jar remains on disk.
+            clearJarByArtifact();
+
+            // Second read: must not fail when the target jar already exists on disk.
+            Path secondLoaded = new TypeTable(ctx, tsv.toUri().toURL(), List.of("simple"))
+                    .load("simple");
+            assertThat(secondLoaded).isNotNull();
+            assertThat(Files.exists(secondLoaded)).isTrue();
+
+            // No stray temp files were left behind in the artifact directory.
+            try (var entries = Files.list(secondLoaded.getParent())) {
+                assertThat(entries.map(p -> p.getFileName().toString()))
+                        .noneMatch(name -> name.endsWith(".tmp"));
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private void clearJarByArtifact() throws Exception {
+            Field f = TypeTable.class.getDeclaredField("jarByArtifact");
+            f.setAccessible(true);
+            ((Map<?, ?>) f.get(null)).clear();
         }
     }
 


### PR DESCRIPTION
## Summary

- Since #7528 switched `TypeTable` from writing per-class files to publishing a single per-artifact JAR via `Files.move(tmpJar, jarPath, ATOMIC_MOVE, REPLACE_EXISTING)`, parallel Gradle test forks sharing `~/.rewrite/classpath/.tt/...` could crash on Windows with `AccessDeniedException` when one JVM tried to replace a jar that another JVM had open. This drops `REPLACE_EXISTING` (the jar contents are deterministic, so the existing file is fine) and catches `FileAlreadyExistsException` / `AccessDeniedException`, accepting the on-disk jar produced by the other process and cleaning up our temp file. A regression test simulates a fresh JVM by reflectively clearing the in-process `jarByArtifact` map between two reads.

## Test plan

- [x] `./gradlew :rewrite-java:test --tests TypeTableTest`