### PR TITLE
C#: preserve whitespace in nullable directives and widen IsPattern

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/TestHelpers.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/TestHelpers.cs
@@ -75,9 +75,9 @@ internal static class TestHelpers
         new(Guid.NewGuid(), Space.Empty, Markers.Empty,
             new JRightPadded<Expression>(expr, Space.Empty, Markers.Empty));
 
-    public static IsPattern MakeIsPattern(Expression expression, Pattern pattern) =>
+    public static IsPattern MakeIsPattern(Expression expression, Expression pattern) =>
         new(Guid.NewGuid(), Space.Empty, Markers.Empty, expression,
-            new JLeftPadded<Pattern>(Space.Empty, pattern));
+            new JLeftPadded<Expression>(Space.Empty, pattern));
 
     public static ConstantPattern MakeConstantPattern(Expression value) =>
         new(Guid.NewGuid(), Space.Empty, Markers.Empty, value);

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -2887,15 +2887,17 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var isPrefix = ExtractSpaceBefore(node.IsKeyword);
         _cursor = node.IsKeyword.Span.End;
 
-        // Visit the right-hand pattern
-        var pattern = Visit(node.Pattern)!;
+        // Visit the right-hand pattern. Use VisitPatternAsExpression so declaration patterns
+        // (which produce Statements) get wrapped, and parenthesized patterns (J.Parentheses<Expression>)
+        // are accepted via the Expression-typed IsPattern.Pattern field.
+        var pattern = VisitPatternAsExpression(node.Pattern);
 
         return new IsPattern(
             Guid.NewGuid(),
             prefix,
             Markers.Empty,
             expression,
-            new JLeftPadded<Pattern>(isPrefix, (Pattern)pattern)
+            new JLeftPadded<Expression>(isPrefix, pattern)
         );
     }
 
@@ -9066,7 +9068,11 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
     private NullableDirective ParseNullableDirective(Space prefix, string afterKeyword, string hashSpacing = "")
     {
+        // Preserve the original whitespace between "nullable" and the setting keyword
+        // (e.g. "  " in "#nullable  enable") so the LST round-trips byte-for-byte.
         var trimmed = afterKeyword.TrimStart();
+        var keywordSpacing = afterKeyword[..(afterKeyword.Length - trimmed.Length)];
+        if (keywordSpacing.Length == 0) keywordSpacing = " ";
 
         // Extract setting keyword
         var settingEnd = 0;
@@ -9104,7 +9110,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         // Capture any trailing comment (e.g., "// TODO: Fix this")
         var trailingComment = target != null ? remainder : (remainder.Length > 0 && settingEnd > 0 ? remainder : "");
 
-        return new NullableDirective(Guid.NewGuid(), prefix, Markers.Empty, setting, target, hashSpacing, trailingComment);
+        return new NullableDirective(Guid.NewGuid(), prefix, Markers.Empty, setting, target, hashSpacing, trailingComment, keywordSpacing);
     }
 
     private DefineDirective ParseDefineDirective(Space prefix, string afterKeyword)

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -3026,7 +3026,7 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
         p.Append('#');
         p.Append(nullableDirective.HashSpacing);
         p.Append("nullable");
-        p.Append(' ');
+        p.Append(nullableDirective.KeywordSpacing);
         p.Append(nullableDirective.Setting.ToString().ToLower());
         if (nullableDirective.Target != null)
         {

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
@@ -853,14 +853,15 @@ public sealed class IsPattern(
     Space prefix,
     Markers markers,
     Expression expression,
-    JLeftPadded<Pattern> pattern
+    JLeftPadded<Expression> pattern
 ) : Cs, Expression, IEquatable<IsPattern>
 {
     public Guid Id { get; } = id;
     public Space Prefix { get; } = prefix;
     public Markers Markers { get; } = markers;
     public Expression Expression { get; } = expression;
-    public JLeftPadded<Pattern> Pattern { get; } = pattern;
+    // Widened from Pattern to Expression so parenthesized patterns (J.Parentheses<Expression>) fit too.
+    public JLeftPadded<Expression> Pattern { get; } = pattern;
 
     public IsPattern WithId(Guid id) =>
         id == Id ? this : new(id, Prefix, Markers, Expression, Pattern);
@@ -870,7 +871,7 @@ public sealed class IsPattern(
         ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Expression, Pattern);
     public IsPattern WithExpression(Expression expression) =>
         ReferenceEquals(expression, Expression) ? this : new(Id, Prefix, Markers, expression, Pattern);
-    public IsPattern WithPattern(JLeftPadded<Pattern> pattern) =>
+    public IsPattern WithPattern(JLeftPadded<Expression> pattern) =>
         ReferenceEquals(pattern, Pattern) ? this : new(Id, Prefix, Markers, Expression, pattern);
 
     public JavaType? Type => JavaType.Primitive.Of(JavaType.PrimitiveKind.Boolean);
@@ -1372,7 +1373,8 @@ public sealed class NullableDirective(
     NullableSetting setting,
     NullableTarget? target,
     string hashSpacing = "",
-    string trailingComment = ""
+    string trailingComment = "",
+    string keywordSpacing = " "
 ) : Cs, Statement, IEquatable<NullableDirective>
 {
     public Guid Id { get; } = id;
@@ -1382,21 +1384,25 @@ public sealed class NullableDirective(
     public NullableTarget? Target { get; } = target;
     public string HashSpacing { get; } = hashSpacing;
     public string TrailingComment { get; } = trailingComment;
+    // Whitespace between the "nullable" keyword and the setting keyword (e.g. "  " in "#nullable  enable").
+    public string KeywordSpacing { get; } = keywordSpacing;
 
     public NullableDirective WithId(Guid id) =>
-        id == Id ? this : new(id, Prefix, Markers, Setting, Target, HashSpacing, TrailingComment);
+        id == Id ? this : new(id, Prefix, Markers, Setting, Target, HashSpacing, TrailingComment, KeywordSpacing);
     public NullableDirective WithPrefix(Space prefix) =>
-        ReferenceEquals(prefix, Prefix) ? this : new(Id, prefix, Markers, Setting, Target, HashSpacing, TrailingComment);
+        ReferenceEquals(prefix, Prefix) ? this : new(Id, prefix, Markers, Setting, Target, HashSpacing, TrailingComment, KeywordSpacing);
     public NullableDirective WithMarkers(Markers markers) =>
-        ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Setting, Target, HashSpacing, TrailingComment);
+        ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Setting, Target, HashSpacing, TrailingComment, KeywordSpacing);
     public NullableDirective WithSetting(NullableSetting setting) =>
-        setting == Setting ? this : new(Id, Prefix, Markers, setting, Target, HashSpacing, TrailingComment);
+        setting == Setting ? this : new(Id, Prefix, Markers, setting, Target, HashSpacing, TrailingComment, KeywordSpacing);
     public NullableDirective WithTarget(NullableTarget? target) =>
-        target == Target ? this : new(Id, Prefix, Markers, Setting, target, HashSpacing, TrailingComment);
+        target == Target ? this : new(Id, Prefix, Markers, Setting, target, HashSpacing, TrailingComment, KeywordSpacing);
     public NullableDirective WithHashSpacing(string hashSpacing) =>
-        string.Equals(hashSpacing, HashSpacing, StringComparison.Ordinal) ? this : new(Id, Prefix, Markers, Setting, Target, hashSpacing, TrailingComment);
+        string.Equals(hashSpacing, HashSpacing, StringComparison.Ordinal) ? this : new(Id, Prefix, Markers, Setting, Target, hashSpacing, TrailingComment, KeywordSpacing);
     public NullableDirective WithTrailingComment(string trailingComment) =>
-        string.Equals(trailingComment, TrailingComment, StringComparison.Ordinal) ? this : new(Id, Prefix, Markers, Setting, Target, HashSpacing, trailingComment);
+        string.Equals(trailingComment, TrailingComment, StringComparison.Ordinal) ? this : new(Id, Prefix, Markers, Setting, Target, HashSpacing, trailingComment, KeywordSpacing);
+    public NullableDirective WithKeywordSpacing(string keywordSpacing) =>
+        string.Equals(keywordSpacing, KeywordSpacing, StringComparison.Ordinal) ? this : new(Id, Prefix, Markers, Setting, Target, HashSpacing, TrailingComment, keywordSpacing);
 
     Tree Tree.WithId(Guid id) => WithId(id);
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
@@ -514,9 +514,11 @@ public class CSharpReceiver : CSharpVisitor<RpcReceiveQueue>
         };
         var hashSpacing = q.Receive(nd.HashSpacing)!;
         var trailingComment = q.Receive(nd.TrailingComment)!;
+        var keywordSpacing = q.Receive(nd.KeywordSpacing)!;
         return nd.WithId(PvId).WithPrefix(PvPrefix).WithMarkers(PvMarkers)
             .WithSetting(setting).WithTarget(target)
-            .WithHashSpacing(hashSpacing).WithTrailingComment(trailingComment);
+            .WithHashSpacing(hashSpacing).WithTrailingComment(trailingComment)
+            .WithKeywordSpacing(keywordSpacing);
     }
 
     // ---- RegionDirective ----

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpSender.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpSender.cs
@@ -507,6 +507,7 @@ public class CSharpSender : CSharpVisitor<RpcSendQueue>
         q.GetAndSend(nd, n => (object?)n.Target);
         q.GetAndSend(nd, n => (object)n.HashSpacing);
         q.GetAndSend(nd, n => (object)n.TrailingComment);
+        q.GetAndSend(nd, n => (object)n.KeywordSpacing);
         return nd;
     }
 

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpReceiver.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpReceiver.java
@@ -739,7 +739,8 @@ public class CSharpReceiver extends CSharpVisitor<RpcReceiveQueue> {
                 .withSetting(q.receiveAndGet(nullableDirective.getSetting(), toEnum(Cs.NullableDirective.NullableSetting.class)))
                 .withTarget(q.receiveAndGet(nullableDirective.getTarget(), toEnum(Cs.NullableDirective.NullableTarget.class)))
                 .withHashSpacing(q.receive(nullableDirective.getHashSpacing()))
-                .withTrailingComment(q.receive(nullableDirective.getTrailingComment()));
+                .withTrailingComment(q.receive(nullableDirective.getTrailingComment()))
+                .withKeywordSpacing(q.receive(nullableDirective.getKeywordSpacing()));
     }
 
     @Override

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpSender.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpSender.java
@@ -153,6 +153,7 @@ public class CSharpSender extends CSharpVisitor<RpcSendQueue> {
         q.getAndSend(nullableDirective, Cs.NullableDirective::getTarget);
         q.getAndSend(nullableDirective, Cs.NullableDirective::getHashSpacing);
         q.getAndSend(nullableDirective, Cs.NullableDirective::getTrailingComment);
+        q.getAndSend(nullableDirective, Cs.NullableDirective::getKeywordSpacing);
         return nullableDirective;
     }
 

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/tree/Cs.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/tree/Cs.java
@@ -4569,13 +4569,13 @@ public interface Cs extends J {
         @Getter
         Expression expression;
 
-        JLeftPadded<Pattern> pattern;
+        JLeftPadded<Expression> pattern;
 
-        public Pattern getPattern() {
+        public Expression getPattern() {
             return pattern.getElement();
         }
 
-        public IsPattern withPattern(Pattern pattern) {
+        public IsPattern withPattern(Expression pattern) {
             return getPadding().withPattern(this.pattern.withElement(pattern));
         }
 
@@ -4619,11 +4619,11 @@ public interface Cs extends J {
         public static class Padding {
             private final IsPattern t;
 
-            public JLeftPadded<Pattern> getPattern() {
+            public JLeftPadded<Expression> getPattern() {
                 return t.pattern;
             }
 
-            public IsPattern withPattern(JLeftPadded<Pattern> pattern) {
+            public IsPattern withPattern(JLeftPadded<Expression> pattern) {
                 return t.pattern == pattern ? t : new IsPattern(t.id, t.prefix, t.markers, t.expression, pattern);
             }
         }
@@ -7610,6 +7610,14 @@ public interface Cs extends J {
         @With
         @Getter
         String trailingComment;
+
+        /**
+         * Whitespace between the {@code nullable} keyword and the setting keyword
+         * (e.g. {@code "  "} in {@code "#nullable  enable"}).
+         */
+        @With
+        @Getter
+        String keywordSpacing;
 
         public enum NullableSetting {
             Enable,


### PR DESCRIPTION
## Summary
- Preserve the original whitespace between `#nullable` and the setting keyword (e.g. `#nullable  enable`) via a new `keywordSpacing` field on `Cs.NullableDirective`, threaded through the parser, printer, and RPC sender/receiver on both the Java and C# sides.
- Widen `Cs.IsPattern.Pattern` from `Pattern` to `Expression` so parenthesized patterns (`J.Parentheses<Expression>`) and wrapped declaration patterns fit too; parser now uses `VisitPatternAsExpression`.

## Test plan
- [ ] `./gradlew :rewrite-csharp:test`
- [ ] `dotnet test` against `rewrite-csharp/csharp`