### PR TITLE
C#: skip dotnet restore for unmodified csproj during attestation

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/MSBuildProjectAttestationTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/MSBuildProjectAttestationTests.cs
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.CSharp;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Tests.CSharp;
+
+public class MSBuildProjectAttestationTests
+{
+    [Fact]
+    public void FreshContextHasNoStaleAttestations()
+    {
+        var ctx = new ExecutionContext();
+        Assert.False(MSBuildProjectHelper.IsAttestationStale(ctx, "src/A/A.csproj"));
+    }
+
+    [Fact]
+    public void MarkStaleMakesIsStaleReturnTrue()
+    {
+        var ctx = new ExecutionContext();
+        MSBuildProjectHelper.MarkAttestationStale(ctx, "src/A/A.csproj");
+        Assert.True(MSBuildProjectHelper.IsAttestationStale(ctx, "src/A/A.csproj"));
+    }
+
+    [Fact]
+    public void StaleFlagIsScopedPerSourcePath()
+    {
+        var ctx = new ExecutionContext();
+        MSBuildProjectHelper.MarkAttestationStale(ctx, "src/A/A.csproj");
+        Assert.True(MSBuildProjectHelper.IsAttestationStale(ctx, "src/A/A.csproj"));
+        Assert.False(MSBuildProjectHelper.IsAttestationStale(ctx, "src/B/B.csproj"));
+    }
+
+    [Fact]
+    public void StaleFlagComparisonIsCaseInsensitive()
+    {
+        // Source paths come through the LST verbatim, and Windows-origin paths can
+        // differ in case from the mutation site to the EnsureCsprojAttestation step.
+        var ctx = new ExecutionContext();
+        MSBuildProjectHelper.MarkAttestationStale(ctx, "src/A/A.csproj");
+        Assert.True(MSBuildProjectHelper.IsAttestationStale(ctx, "SRC/a/A.CSPROJ"));
+    }
+
+    [Fact]
+    public void MarkStaleIsIdempotent()
+    {
+        var ctx = new ExecutionContext();
+        MSBuildProjectHelper.MarkAttestationStale(ctx, "src/A/A.csproj");
+        MSBuildProjectHelper.MarkAttestationStale(ctx, "src/A/A.csproj");
+        Assert.True(MSBuildProjectHelper.IsAttestationStale(ctx, "src/A/A.csproj"));
+    }
+
+    [Fact]
+    public void StaleFlagsAreIsolatedPerExecutionContext()
+    {
+        var ctx1 = new ExecutionContext();
+        var ctx2 = new ExecutionContext();
+        MSBuildProjectHelper.MarkAttestationStale(ctx1, "src/A/A.csproj");
+        Assert.False(MSBuildProjectHelper.IsAttestationStale(ctx2, "src/A/A.csproj"));
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
@@ -37,7 +37,60 @@ namespace OpenRewrite.CSharp;
 /// </summary>
 public static class MSBuildProjectHelper
 {
-    private static readonly TimeSpan RestoreTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan RestoreTimeout = TimeSpan.FromMinutes(5);
+
+    // Keyed off ExecutionContext: the set of .csproj source paths that have been
+    // structurally modified during this run and whose MSBuildProject marker is
+    // therefore stale until the next dotnet restore. Mutating visitors add to
+    // this set; RegenerateMarkerVisitor consumes from it so files no one touched
+    // skip the (expensive) restore.
+    private const string StaleAttestationsKey = "OpenRewrite.CSharp.StaleCsprojAttestations";
+
+    /// <summary>
+    /// Marks the given .csproj source path as having pending changes whose
+    /// MSBuildProject marker no longer reflects on-disk state. Call this from
+    /// any visitor after it mutates a project file (independent of whether the
+    /// visitor reattests immediately or defers to a trailing
+    /// <see cref="Recipes.EnsureCsprojAttestation"/>).
+    /// </summary>
+    public static void MarkAttestationStale(ExecutionContext ctx, string sourcePath)
+    {
+        var set = ctx.ComputeMessageIfAbsent(
+            StaleAttestationsKey,
+            _ => new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+        lock (set)
+        {
+            set.Add(sourcePath);
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the given .csproj source path has been marked stale and
+    /// has not yet been reattested in this execution.
+    /// </summary>
+    public static bool IsAttestationStale(ExecutionContext ctx, string sourcePath)
+    {
+        var set = ctx.GetMessage<HashSet<string>>(StaleAttestationsKey);
+        if (set == null) return false;
+        lock (set)
+        {
+            return set.Contains(sourcePath);
+        }
+    }
+
+    // Atomically removes the stale flag for this source path and returns whether
+    // it was set. Used by the marker-regen visitor so a stale flag drives exactly
+    // one reattestation regardless of whether it came from a mutating visitor's
+    // immediate DoAfterVisit or from a trailing EnsureCsprojAttestation pass.
+    private static bool TryConsumeStaleAttestation(ExecutionContext ctx, string sourcePath)
+    {
+        var set = ctx.GetMessage<HashSet<string>>(StaleAttestationsKey);
+        if (set == null) return false;
+        lock (set)
+        {
+            return set.Remove(sourcePath);
+        }
+    }
 
     #region Marker creation
 
@@ -468,9 +521,15 @@ public static class MSBuildProjectHelper
     {
         public override Xml.Xml VisitDocument(Document document, ExecutionContext ctx)
         {
-            if (document.Markers.FindFirst<MSBuildProject>() != null)
-                return RegenerateAndRefreshMarker(document, ctx);
-            return document;
+            if (document.Markers.FindFirst<MSBuildProject>() == null)
+                return document;
+            // Gate on the stale flag so files no mutating recipe touched don't
+            // trigger dotnet restore. Consuming clears the flag so a second
+            // reattestation pass (e.g., immediate + trailing
+            // EnsureCsprojAttestation) doesn't run restore twice.
+            if (!TryConsumeStaleAttestation(ctx, document.SourcePath))
+                return document;
+            return RegenerateAndRefreshMarker(document, ctx);
         }
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/AddFrameworkReferenceVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/AddFrameworkReferenceVisitor.cs
@@ -50,6 +50,7 @@ public class AddFrameworkReferenceVisitor(string frameworkName, string? triggerP
         var itemGroup = TagExtensions.BuildTag(
             $"<ItemGroup>\n    {tag}\n  </ItemGroup>");
         DoAfterVisit(new AddToTagVisitor<ExecutionContext>(d.Root, itemGroup));
+        MSBuildProjectHelper.MarkAttestationStale(ctx, d.SourcePath);
         if (regenerateMarker)
             DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
         return d;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/AddNuGetPackageReferenceVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/AddNuGetPackageReferenceVisitor.cs
@@ -76,6 +76,7 @@ public class AddNuGetPackageReferenceVisitor(string packageName, string? version
             DoAfterVisit(new AddToTagVisitor<ExecutionContext>(d.Root, itemGroup));
         }
 
+        MSBuildProjectHelper.MarkAttestationStale(ctx, d.SourcePath);
         if (regenerateMarker)
             DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
         return d;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetFrameworkVersionVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetFrameworkVersionVisitor.cs
@@ -37,8 +37,12 @@ public class ChangeDotNetFrameworkVersionVisitor(string oldVersion, string newVe
     {
         _modified = false;
         var d = (Document)base.VisitDocument(document, ctx);
-        if (_modified && regenerateMarker && d.Markers.FindFirst<MSBuildProject>() != null)
-            DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+        if (_modified && d.Markers.FindFirst<MSBuildProject>() != null)
+        {
+            MSBuildProjectHelper.MarkAttestationStale(ctx, d.SourcePath);
+            if (regenerateMarker)
+                DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+        }
         return d;
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetTargetFrameworkVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/ChangeDotNetTargetFrameworkVisitor.cs
@@ -35,8 +35,12 @@ public class ChangeDotNetTargetFrameworkVisitor(string oldTfm, string newTfm, bo
     {
         _modified = false;
         var d = (Document)base.VisitDocument(document, ctx);
-        if (_modified && regenerateMarker)
-            DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+        if (_modified)
+        {
+            MSBuildProjectHelper.MarkAttestationStale(ctx, d.SourcePath);
+            if (regenerateMarker)
+                DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+        }
         return d;
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/EnsureCsprojAttestation.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/EnsureCsprojAttestation.cs
@@ -21,10 +21,15 @@ using ExecutionContext = OpenRewrite.Core.ExecutionContext;
 namespace OpenRewrite.CSharp.Recipes;
 
 /// <summary>
-/// Regenerates the <see cref="MSBuildProject"/> marker on every .csproj that carries one,
-/// by running <c>dotnet restore</c> against the current (possibly modified) project state.
-/// Intended as the terminator step in a composite recipe that suppresses intermediate
-/// marker reattestation via <c>RegenerateMarker = false</c> on csproj-mutating sub-recipes.
+/// Re-runs <c>dotnet restore</c> against each .csproj whose
+/// <see cref="MSBuildProject"/> marker has been marked stale by an earlier
+/// mutating recipe in this run, and refreshes the marker from the resulting
+/// <c>project.assets.json</c>. Files that no recipe touched are skipped — the
+/// staleness flag is set by mutating visitors via
+/// <see cref="MSBuildProjectHelper.MarkAttestationStale"/>. Intended as the
+/// terminator step in a composite recipe that suppresses intermediate marker
+/// reattestation via <c>RegenerateMarker = false</c> on csproj-mutating
+/// sub-recipes.
 /// </summary>
 [Category, Csproj]
 public class EnsureCsprojAttestation : ScanningRecipe<DotNetBuildContext>
@@ -32,10 +37,12 @@ public class EnsureCsprojAttestation : ScanningRecipe<DotNetBuildContext>
     public override string DisplayName => "Ensure csproj attestation";
 
     public override string Description =>
-        "Re-runs `dotnet restore` against each .csproj that has an `MSBuildProject` marker and " +
-        "refreshes the marker from the resulting `project.assets.json`. Use this at the end of a " +
-        "composite recipe whose csproj-mutating sub-recipes have `RegenerateMarker = false`, " +
-        "so reattestation happens once on the final consistent state instead of after every edit.";
+        "Re-runs `dotnet restore` against each .csproj whose `MSBuildProject` marker " +
+        "is stale (set by any csproj-mutating recipe in the run) and refreshes the marker " +
+        "from the resulting `project.assets.json`. Use this at the end of a composite " +
+        "recipe whose csproj-mutating sub-recipes have `RegenerateMarker = false`, so " +
+        "reattestation happens once on the final consistent state instead of after every edit. " +
+        "Unmodified .csproj files incur no `dotnet restore` cost.";
 
     public override DotNetBuildContext GetInitialValue(ExecutionContext ctx) => DotNetBuildContext.GetOrCreate(ctx);
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveDotNetCliToolReferenceVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveDotNetCliToolReferenceVisitor.cs
@@ -31,8 +31,12 @@ public class RemoveDotNetCliToolReferenceVisitor(string toolName, bool regenerat
     {
         _modified = false;
         var d = (Document)base.VisitDocument(document, ctx);
-        if (_modified && regenerateMarker)
-            DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+        if (_modified)
+        {
+            MSBuildProjectHelper.MarkAttestationStale(ctx, d.SourcePath);
+            if (regenerateMarker)
+                DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+        }
         return d;
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveMSBuildPropertyVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveMSBuildPropertyVisitor.cs
@@ -32,8 +32,12 @@ public class RemoveMSBuildPropertyVisitor(string propertyName, bool regenerateMa
     {
         _modified = false;
         var d = (Document)base.VisitDocument(document, ctx);
-        if (_modified && regenerateMarker)
-            DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+        if (_modified)
+        {
+            MSBuildProjectHelper.MarkAttestationStale(ctx, d.SourcePath);
+            if (regenerateMarker)
+                DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+        }
         return d;
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveNuGetPackageReferenceVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/RemoveNuGetPackageReferenceVisitor.cs
@@ -32,8 +32,12 @@ public class RemoveNuGetPackageReferenceVisitor(string packageName, bool regener
     {
         _modified = false;
         var d = (Document)base.VisitDocument(document, ctx);
-        if (_modified && regenerateMarker)
-            DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+        if (_modified)
+        {
+            MSBuildProjectHelper.MarkAttestationStale(ctx, d.SourcePath);
+            if (regenerateMarker)
+                DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+        }
         return d;
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/UpgradeNuGetPackageVersionVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Recipes/UpgradeNuGetPackageVersionVisitor.cs
@@ -41,9 +41,11 @@ public class UpgradeNuGetPackageVersionVisitor(
         {
             _modified = true;
         }
-        if (_modified && regenerateMarker)
+        if (_modified)
         {
-            DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
+            MSBuildProjectHelper.MarkAttestationStale(ctx, d.SourcePath);
+            if (regenerateMarker)
+                DoAfterVisit(MSBuildProjectHelper.RegenerateMarkerVisitor());
         }
         return d;
     }


### PR DESCRIPTION
## Summary
- Tracks per-csproj staleness on the `ExecutionContext` so `EnsureCsprojAttestation` only re-runs `dotnet restore` against projects mutated this run.
- All csproj-mutating visitors (`AddNuGetPackageReferenceVisitor`, `AddFrameworkReferenceVisitor`, `Change{DotNetFrameworkVersion,DotNetTargetFramework}Visitor`, `Remove{DotNetCliToolReference,MSBuildProperty,NuGetPackageReference}Visitor`, `UpgradeNuGetPackageVersionVisitor`) call `MSBuildProjectHelper.MarkAttestationStale`; the regen visitor atomically consumes the flag so reattestation runs at most once per file.
- Also bumps `RestoreTimeout` from 2 to 5 minutes.

## Test plan
- [x] New `MSBuildProjectAttestationTests` (6 xUnit cases) cover the stale-flag API: fresh state, mark→is-stale, per-path scoping, case-insensitive compare, idempotency, per-`ExecutionContext` isolation.