### PR TITLE
Python: bump `ty-types` to 0.0.39, handle `EnumComplement`

### DIFF
--- a/rewrite-python/rewrite/pyproject.toml
+++ b/rewrite-python/rewrite/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "more_itertools>=10.0.0",
-    "ty-types>=0.0.31",  # Type inference CLI for Python type attribution
+    "ty-types>=0.0.39",  # Type inference CLI for Python type attribution
     "parso>=0.7.1,<0.8",  # Python 2/3 parser with CST support (0.8+ dropped Python 2.7 grammar)
 ]
 

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -548,7 +548,7 @@ class PythonTypeMapping:
         elif kind in ('dynamic', 'never'):
             return _UNKNOWN
 
-        elif kind == 'enumLiteral':
+        elif kind in ('enumLiteral', 'enumComplement'):
             class_name = descriptor.get('className', '')
             class_type = self._create_class_type(class_name)
             class_type._kind = JavaType.FullyQualified.Kind.Enum


### PR DESCRIPTION
## Motivation

ty-types v0.0.39 introduces a new `enumComplement` `TypeDescriptor` kind, representing an enum type narrowed by excluding specific members (e.g. the type of `c` after `if c is not Color.RED:` is `Color & ~Literal[Color.RED]`). Without explicit handling, the Python type mapper falls through to `_UNKNOWN`, dropping type attribution for narrowed enum variables.

Java's type system has no equivalent of literal or subtraction types, so mapping `enumComplement` follows the same approach as the existing `enumLiteral` handling: collapse to the underlying enum class type. The excluded-members information is intentionally not preserved on the LST — recipes that need that level of detail should consult the Python AST directly.

See https://github.com/openrewrite/ty-types/releases/tag/v0.0.39 for the upstream release notes.

## Summary

- Bump `ty-types` from `>=0.0.31` to `>=0.0.39`.
- Map the new `enumComplement` `TypeDescriptor` to the underlying enum `JavaType.Class` (same handling as `enumLiteral`).

## Test plan

- [x] `pytest tests/python/all/tree/import_test.py` (16/16 pass)