### PR TITLE
Python: fix DependencyWorkspace race on invalid leftover dir

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/template/dependency_workspace.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/dependency_workspace.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import logging
 import os
@@ -168,45 +169,48 @@ class DependencyWorkspace:
         """Create a new workspace, install dependencies, and move it into place."""
         os.makedirs(WORKSPACE_BASE, exist_ok=True)
 
-        tmp_dir = os.path.join(
-            WORKSPACE_BASE,
-            f".tmp-{os.getpid()}-{cache_key}",
-        )
         final_dir = os.path.join(WORKSPACE_BASE, cache_key)
+        lock_path = os.path.join(WORKSPACE_BASE, f".{cache_key}.lock")
 
-        try:
-            # Clean up any leftover temp directory from a previous crash
-            if os.path.exists(tmp_dir):
-                shutil.rmtree(tmp_dir)
-            os.makedirs(tmp_dir)
+        # Serialize concurrent creators for the same cache_key. Holding the lock
+        # across uv sync is intentional — only one process should build the same
+        # workspace at a time.
+        with open(lock_path, "w") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
 
-            # Write pyproject.toml
-            with open(os.path.join(tmp_dir, "pyproject.toml"), "w") as f:
-                f.write(pyproject_content)
+            # Another holder may have built it while we waited for the lock.
+            if cls._is_valid(final_dir):
+                return final_dir
 
-            # Run uv sync
-            cls._run_uv_sync(tmp_dir)
+            # Remove any half-built leftover at the target. macOS rename(2)
+            # refuses to replace a non-empty directory (ENOTEMPTY), so we must
+            # clear the target before renaming.
+            if os.path.exists(final_dir):
+                shutil.rmtree(final_dir)
 
-            # Write version marker
-            with open(os.path.join(tmp_dir, "version.txt"), "w") as f:
-                f.write(WORKSPACE_VERSION)
-
-            # Atomic rename
+            tmp_dir = os.path.join(
+                WORKSPACE_BASE,
+                f".tmp-{os.getpid()}-{cache_key}",
+            )
             try:
+                if os.path.exists(tmp_dir):
+                    shutil.rmtree(tmp_dir)
+                os.makedirs(tmp_dir)
+
+                with open(os.path.join(tmp_dir, "pyproject.toml"), "w") as f:
+                    f.write(pyproject_content)
+
+                cls._run_uv_sync(tmp_dir)
+
+                with open(os.path.join(tmp_dir, "version.txt"), "w") as f:
+                    f.write(WORKSPACE_VERSION)
+
                 os.rename(tmp_dir, final_dir)
-            except OSError:
-                # Another process may have won the race
-                if cls._is_valid(final_dir):
-                    shutil.rmtree(tmp_dir, ignore_errors=True)
-                else:
-                    raise
+                return final_dir
 
-            return final_dir
-
-        except Exception:
-            # Clean up on failure
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise
+            except Exception:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                raise
 
     _PEP508_COMPARATORS = ('>=', '<=', '==', '!=', '~=', '>', '<')
 

--- a/rewrite-python/rewrite/tests/python/template/test_dependency_workspace.py
+++ b/rewrite-python/rewrite/tests/python/template/test_dependency_workspace.py
@@ -185,3 +185,23 @@ class TestDependencyWorkspaceIntegration:
         ws1 = DependencyWorkspace.get_or_create_from_pyproject(content)
         ws2 = DependencyWorkspace.get_or_create_from_pyproject(content)
         assert ws1 == ws2
+
+    def test_get_or_create_recovers_from_invalid_leftover(self):
+        """If final_dir exists but is invalid (e.g. crashed mid-build), rebuild."""
+        deps = (("six", "1.17.0"),)
+        cache_key = DependencyWorkspace._hash_dependencies(deps)
+        final_dir = os.path.join(WORKSPACE_BASE, cache_key)
+
+        DependencyWorkspace.clear_cache()
+        if os.path.isdir(final_dir):
+            shutil.rmtree(final_dir)
+
+        os.makedirs(final_dir)
+        with open(os.path.join(final_dir, "stale.txt"), "w") as f:
+            f.write("leftover from a previous crash\n")
+        assert not DependencyWorkspace._is_valid(final_dir)
+
+        workspace = DependencyWorkspace.get_or_create(deps)
+
+        assert workspace == final_dir
+        assert DependencyWorkspace._is_valid(workspace)


### PR DESCRIPTION
## Motivation

`DependencyWorkspace._create_workspace_with_content` crashes with `OSError: [Errno 66] Directory not empty` when the target cache directory already exists but is invalid (missing `.venv` or `version.txt`, typically from a previous crashed build). The old logic tried `os.rename(tmp_dir, final_dir)` and only handled the race-loss case where another process had built a *valid* workspace at the destination — if the leftover was invalid, it re-raised.

There are two underlying problems:

1. **macOS `rename(2)` semantics.** On macOS, `rename` over a non-empty directory returns `ENOTEMPTY` (errno 66). Linux happens to allow it atomically, but macOS does not. Python's stdlib has no portable atomic-replace-directory primitive (`renameat2(RENAME_EXCHANGE)` is Linux-only and not exposed).
2. **No serialization between concurrent creators.** Two processes building the same `cache_key` simultaneously could both reach the rename step, with one observing the other's half-built result.

## Summary

- Acquire an `fcntl.flock(LOCK_EX)` on `.{cache_key}.lock` for the entire create operation. The lock is held across `uv sync` — intentional, since only one process should build the same workspace at a time.
- Inside the lock: re-check `_is_valid(final_dir)` (another holder may have built it while we waited), then `shutil.rmtree` any invalid leftover so the subsequent `os.rename` always targets a non-existent path.
- Drop the now-unreachable post-rename race-handling block.

## Test plan

- [x] New regression test `test_get_or_create_recovers_from_invalid_leftover` seeds an invalid `final_dir` and verifies `get_or_create` rebuilds rather than crashing.
- [x] `pytest tests/python/template/test_dependency_workspace.py` — 18/18 pass.
- [x] Full `pytest tests/python/` — 1441 passed, 6 skipped, 0 failed.