### PR TITLE
Scala: accept .sbt files and add sbt() test helper

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/Assertions.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/Assertions.java
@@ -60,6 +60,31 @@ public class Assertions {
         return scala;
     }
 
+    public static SourceSpecs sbt(@Language("scala") @Nullable String before) {
+        return sbt(before, s -> {
+        });
+    }
+
+    public static SourceSpecs sbt(@Language("scala") @Nullable String before, Consumer<SourceSpec<S.CompilationUnit>> spec) {
+        SourceSpec<S.CompilationUnit> sbt = new SourceSpec<>(S.CompilationUnit.class, null, scalaParser, before, null)
+                .path("build.sbt");
+        spec.accept(sbt);
+        return sbt;
+    }
+
+    public static SourceSpecs sbt(@Language("scala") @Nullable String before, @Language("scala") @Nullable String after) {
+        return sbt(before, after, s -> {
+        });
+    }
+
+    public static SourceSpecs sbt(@Language("scala") @Nullable String before, @Language("scala") @Nullable String after,
+                                  Consumer<SourceSpec<S.CompilationUnit>> spec) {
+        SourceSpec<S.CompilationUnit> sbt = new SourceSpec<>(S.CompilationUnit.class, null, scalaParser, before, s -> after)
+                .path("build.sbt");
+        spec.accept(sbt);
+        return sbt;
+    }
+
     public static SourceSpecs srcMainScala(Consumer<SourceSpec<SourceFile>> spec, SourceSpecs... scalaSources) {
         return dir("src/main/scala", spec, scalaSources);
     }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaParser.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaParser.java
@@ -53,12 +53,15 @@ public class ScalaParser implements Parser {
 
     private static String derivedRelativePath(String sourceCode) {
         Matcher packageMatcher = PACKAGE_PATTERN.matcher(sourceCode);
-        String pkg = packageMatcher.find() ? packageMatcher.group(1).replace('.', '/') + "/" : "";
+        boolean hasPackage = packageMatcher.find();
+        String pkg = hasPackage ? packageMatcher.group(1).replace('.', '/') + "/" : "";
 
         Matcher classMatcher = CLASS_PATTERN.matcher(sourceCode);
-        String simpleName = classMatcher.find() ? classMatcher.group(3) : Long.toString(System.nanoTime());
+        boolean hasClass = classMatcher.find();
+        String simpleName = hasClass ? classMatcher.group(3) : Long.toString(System.nanoTime());
 
-        return pkg + simpleName + ".scala";
+        String extension = (!hasPackage && !hasClass) ? ".sbt" : ".scala";
+        return pkg + simpleName + extension;
     }
 
     @Override
@@ -145,7 +148,8 @@ public class ScalaParser implements Parser {
 
     @Override
     public boolean accept(Path path) {
-        return path.toString().endsWith(".scala") || path.toString().endsWith(".sc");
+        String s = path.toString();
+        return s.endsWith(".scala") || s.endsWith(".sc") || s.endsWith(".sbt");
     }
 
     @Override

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaASTConverter.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaASTConverter.scala
@@ -15,7 +15,7 @@
  */
 package org.openrewrite.scala.internal
 
-import dotty.tools.dotc.ast.Trees
+import dotty.tools.dotc.ast.{Trees, untpd}
 import dotty.tools.dotc.core.Contexts.*
 import org.openrewrite.Tree
 import org.openrewrite.java.internal.JavaTypeFactory
@@ -60,12 +60,13 @@ class ScalaASTConverter {
     // Use the context from the parse result (carries type info from batch compilation)
     given Context = if (parseResult.context != null) parseResult.context else dotty.tools.dotc.core.Contexts.NoContext
 
-    // Calculate offset adjustment if content was wrapped
-    val offsetAdjustment = if (parseResult.wasWrapped) {
-      "object ExprWrapper { val result = ".length
-    } else {
-      0
-    }
+    // Calculate offset adjustment if content was wrapped before parsing.
+    // For `.sbt` content wrapped as `object __SbtScript__ { ... }`, spans in
+    // the parsed tree are offset by the wrapper prefix (`object __SbtScript__ {\n`).
+    val offsetAdjustment =
+      if (parseResult.wasObjectWrapped) ScalaParseResultConstants.ObjectScriptPrefix.length
+      else if (parseResult.wasWrapped) "object ExprWrapper { val result = ".length
+      else 0
 
     // Build type mapping from typed tree if available
     val mapping: Option[ScalaTypeMapping] = if (typeFactory != null) {
@@ -94,10 +95,26 @@ class ScalaASTConverter {
           packageDecl = createPackageDeclaration(pkgDef, visitor)
         }
 
+        // For `.sbt` content the bridge wrapped statements in
+        // `object __SbtScript__ { ... }` so Dotty would accept them at the
+        // file level. Lift the wrapper's body back up here so downstream
+        // visiting sees the original statements as direct children of the
+        // compilation unit. Filter out empty/synthetic trees Dotty may emit
+        // for the object's constructor — those carry no span and would crash
+        // visitUnknown.
+        val rawStats: Seq[Trees.Tree[?]] =
+          if (parseResult.wasObjectWrapped) {
+            pkgDef.stats.collectFirst {
+              case mod: untpd.ModuleDef
+                if mod.name.toString == ScalaParseResultConstants.ObjectScriptWrapperName =>
+                mod.impl.body.filter(s => !s.isEmpty && s.span.exists)
+            }.getOrElse(pkgDef.stats)
+          } else pkgDef.stats
+
         // Process the statements within the package.
         // Sort by source position to ensure source order is preserved —
         // the Dotty parser may reorder brace imports internally.
-        val sortedStats = pkgDef.stats.sortBy(s => if (s.span.exists) s.span.start else Int.MaxValue)
+        val sortedStats = rawStats.sortBy(s => if (s.span.exists) s.span.start else Int.MaxValue)
         sortedStats.foreach {
           case _: Trees.PackageDef[?] =>
           case imp: Trees.Import[?] =>

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
@@ -111,36 +111,14 @@ class ScalaCompilerBridge {
     val srcIter = sources.iterator()
     while (srcIter.hasNext) {
       val entry = srcIter.next()
-      val path = entry.path
-      val content = entry.content
+      val parsed = parseOne(entry.path, entry.content)
 
-      // Handle simple expression wrapping
-      val (adjustedContent, needsUnwrap) = if (isSimpleExpression(content)) {
-        (s"object ExprWrapper { val result = $content }", true)
-      } else {
-        (content, false)
-      }
+      results.put(entry.path, buildResult(parsed, new ArrayList[ScalaWarning]()))
 
-      val source = SourceFile.virtual(path, adjustedContent)
-      val unit = CompilationUnit(source)
-
-      // Parse using the parser (this always works)
-      val parser = new Parsers.Parser(source)(using ctx.fresh.setCompilationUnit(unit))
-      val tree = parser.parse()
-
-      // Unwrap if needed
-      val finalTree = if (needsUnwrap && !tree.isEmpty) {
-        extractExpression(tree).getOrElse(tree)
-      } else {
-        tree
-      }
-
-      // Store parse-only result initially
-      results.put(path, ScalaParseResult(finalTree, None, new ArrayList[ScalaWarning](), needsUnwrap, ctx))
-
-      // Track unit for batch type-checking
-      unit.untpdTree = tree
-      units.add(unit)
+      // Track unit for batch type-checking. The *raw* parsed tree (pre-unwrap)
+      // is what the typer needs — it's the form the parser actually produced.
+      parsed.unit.untpdTree = parsed.rawTree
+      units.add(parsed.unit)
       sourceEntries.add(entry)
     }
 
@@ -245,36 +223,53 @@ class ScalaCompilerBridge {
       case _: Throwable => configuredCtx
     }
 
-    // For simple expressions, wrap in a valid compilation unit
-    val (adjustedContent, needsUnwrap) = if (isSimpleExpression(content)) {
-      (s"object ExprWrapper { val result = $content }", true)
-    } else {
-      (content, false)
-    }
-
-    // Create source file
-    val source = SourceFile.virtual(path, adjustedContent)
-
-    // Parse the source
-    val unit = CompilationUnit(source)
-    val parser = new Parsers.Parser(source)(using ctx.fresh.setCompilationUnit(unit))
-
-    val tree = parser.parse()
-
-    // If we wrapped the expression, extract it
-    val finalTree = if (needsUnwrap && !tree.isEmpty) {
-      extractExpression(tree).getOrElse(tree)
-    } else {
-      tree
-    }
+    val parsed = parseOne(path, content)
 
     // Drain buffered diagnostics from the reporter so they're surfaced to the caller
     // instead of being silently dropped (or, with the default reporter, printed to stderr).
     val javaWarnings = new ArrayList[ScalaWarning]()
     storeReporter.removeBufferedMessages.foreach(d => javaWarnings.add(toScalaWarning(d)))
 
-    ScalaParseResult(finalTree, None, javaWarnings, needsUnwrap, ctx)
+    buildResult(parsed, javaWarnings)
   }
+
+  /**
+   * Pick a wrapping strategy, wrap the content, parse it, and (for the
+   * expression wrapper) unwrap the result. The raw and unwrapped trees are
+   * both returned: the typer wants the raw form (`compileUnits` walks
+   * `unit.untpdTree`), while downstream consumers want the unwrapped form.
+   *
+   * `.sbt` build definitions are sequences of top-level expressions — Dotty
+   * silently drops those at the file level, so we lift the content into an
+   * `object __SbtScript__ { ... }` body where statements are accepted. The
+   * single-line expression wrapper is the pre-existing path used by
+   * recipe/template machinery to coerce bare expressions through the parser.
+   */
+  private def parseOne(path: String, content: String)(using ctx: Context): ParsedUnit = {
+    val wrapping =
+      if (path != null && path.endsWith(".sbt")) Wrapping.ObjectScript
+      else if (isSimpleExpression(content)) Wrapping.Expression
+      else Wrapping.None
+
+    val source = SourceFile.virtual(path, wrapping.wrap(content))
+    val unit = CompilationUnit(source)
+    val parser = new Parsers.Parser(source)(using ctx.fresh.setCompilationUnit(unit))
+    val rawTree = parser.parse()
+
+    val finalTree = wrapping match {
+      case Wrapping.Expression if !rawTree.isEmpty => extractExpression(rawTree).getOrElse(rawTree)
+      case _ => rawTree
+    }
+    ParsedUnit(rawTree, finalTree, unit, wrapping)
+  }
+
+  private def buildResult(parsed: ParsedUnit, warnings: JList[ScalaWarning])(using ctx: Context): ScalaParseResult =
+    ScalaParseResult(
+      parsed.finalTree, None, warnings,
+      wasWrapped = parsed.wrapping == Wrapping.Expression,
+      wasObjectWrapped = parsed.wrapping == Wrapping.ObjectScript,
+      context = ctx
+    )
 
   private def extractExpression(tree: untpd.Tree)(using Context): Option[untpd.Tree] = tree match {
     case pkgDef: untpd.PackageDef =>
@@ -405,15 +400,59 @@ object ScalaCompilerBridge {
 case class SourceEntry(path: String, content: String)
 
 /**
+ * Output of the bridge's shared parsing path: the raw parsed tree (what Dotty
+ * produced — keeps the wrapper if there was one, needed by the typer), the
+ * unwrapped tree visible to downstream consumers, the underlying Dotty
+ * `CompilationUnit`, and the wrapping strategy that was applied.
+ */
+private[internal] case class ParsedUnit(
+  rawTree: untpd.Tree,
+  finalTree: untpd.Tree,
+  unit: dotty.tools.dotc.CompilationUnit,
+  wrapping: Wrapping
+)
+
+/**
+ * How the bridge transformed the source before parsing.
+ *
+ *  - `None`: passed verbatim.
+ *  - `Expression`: wrapped as `object ExprWrapper { val result = <content> }`
+ *    so a bare expression parses; the result tree is the expression itself.
+ *  - `ObjectScript`: wrapped as `object __SbtScript__ {\n<content>\n}` so a
+ *    sequence of top-level statements parses (used for `.sbt` build files).
+ *    The wrapper is left in the tree; downstream code lifts the body.
+ */
+private[internal] enum Wrapping:
+  case None, Expression, ObjectScript
+
+  def wrap(content: String): String = this match
+    case Wrapping.None => content
+    case Wrapping.Expression => s"object ExprWrapper { val result = $content }"
+    case Wrapping.ObjectScript => s"object __SbtScript__ {\n$content\n}"
+
+/**
  * Result of parsing (and optionally type-checking) a Scala source file.
+ *
+ * @param wasWrapped       true when the bridge wrapped a single-line
+ *                         expression as `object ExprWrapper { val result = ... }`
+ *                         and then unwrapped before returning the tree.
+ * @param wasObjectWrapped true when the bridge wrapped multi-statement content
+ *                         (e.g. a `.sbt` file) as `object __SbtScript__ { ... }`.
+ *                         The wrapper is still present in `tree`; the
+ *                         converter is responsible for lifting its body.
  */
 case class ScalaParseResult(
   tree: untpd.Tree,
   typedTree: Option[tpd.Tree],
   warnings: JList[ScalaWarning],
   wasWrapped: Boolean = false,
+  wasObjectWrapped: Boolean = false,
   context: Context
 )
+
+private[internal] object ScalaParseResultConstants:
+  val ObjectScriptPrefix: String = "object __SbtScript__ {\n"
+  val ObjectScriptWrapperName: String = "__SbtScript__"
 
 /**
  * Represents a warning or error from the Scala compiler.

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -2451,8 +2451,9 @@ class ScalaTreeVisitor(
     }
 
     if (tree.span.exists) {
-      val adjustedEnd = Math.max(0, tree.span.end - offsetAdjustment)
-      updateCursor(adjustedEnd)
+      // updateCursor takes a raw (un-adjusted) span position and applies
+      // offsetAdjustment itself; don't pre-subtract here.
+      updateCursor(tree.span.end)
     }
 
     qualid

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/SbtFileTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/SbtFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2026 the original author or authors.
  * <p>
  * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/SbtFileTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/SbtFileTest.java
@@ -45,4 +45,106 @@ class SbtFileTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void importsAdjacentToStatement() {
+        rewriteRun(
+          sbt(
+            """
+            import sbt._
+            import Keys._
+            libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % Test
+            """
+          )
+        );
+    }
+
+    @Test
+    void importsWithBlankLineBeforeStatement() {
+        rewriteRun(
+          sbt(
+            """
+            import sbt._
+            import Keys._
+
+            libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % Test
+            """
+          )
+        );
+    }
+
+    @Test
+    void thisBuildScopedSetting() {
+        rewriteRun(
+          sbt(
+            """
+            ThisBuild / scalaVersion := "3.3.1"
+            ThisBuild / organization := "com.example"
+            """
+          )
+        );
+    }
+
+    @Test
+    void crossScalaVersions() {
+        rewriteRun(
+          sbt(
+            """
+            crossScalaVersions := Seq("2.13.12", "3.3.1")
+            """
+          )
+        );
+    }
+
+    @Test
+    void lineComments() {
+        rewriteRun(
+          sbt(
+            """
+            // top of file comment
+            name := "demo" // trailing comment
+            // standalone comment between settings
+            version := "0.1.0"
+            """
+          )
+        );
+    }
+
+    @Test
+    void blockComment() {
+        rewriteRun(
+          sbt(
+            """
+            /* multi
+               line
+               comment */
+            name := "demo"
+            """
+          )
+        );
+    }
+
+    @Test
+    void valDeclaration() {
+        rewriteRun(
+          sbt(
+            """
+            val scala3 = "3.3.1"
+            scalaVersion := scala3
+            """
+          )
+        );
+    }
+
+    @Test
+    void multiProjectLazyVals() {
+        rewriteRun(
+          sbt(
+            """
+            lazy val core = project.in(file("core"))
+            lazy val root = project.in(file(".")).aggregate(core).dependsOn(core)
+            """
+          )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/SbtFileTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/SbtFileTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.scala.Assertions.sbt;
+
+class SbtFileTest implements RewriteTest {
+
+    @Test
+    void simpleSettings() {
+        rewriteRun(
+          sbt(
+            """
+            name := "demo"
+            version := "0.1.0"
+            scalaVersion := "3.3.1"
+            """
+          )
+        );
+    }
+
+    @Test
+    void libraryDependencies() {
+        rewriteRun(
+          sbt(
+            """
+            libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % Test
+            """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `ScalaParser.accept` now recognizes `.sbt` in addition to `.scala`/`.sc`, and `derivedRelativePath` emits a `.sbt` extension for source strings with no `package` or class/object/trait declaration so synthesized paths round-trip through `accept()`.
- Adds `Assertions.sbt(...)` overloads mirroring `scala(...)` that set the source path to `build.sbt`, plus a `SbtFileTest` covering common sbt DSL (`name := …`, `libraryDependencies += …`).

## Test plan
- [x] ./gradlew :rewrite-scala:test --tests "org.openrewrite.scala.SbtFileTest"