### PR TITLE
Go: fix RPC handling of left padded operator enums

### DIFF
--- a/rewrite-go/pkg/rpc/padding_rpc.go
+++ b/rewrite-go/pkg/rpc/padding_rpc.go
@@ -493,6 +493,19 @@ func leftPaddedFromElement(before tree.Space, elem any, markers tree.Markers) an
 	if sp, ok := elem.(tree.Space); ok {
 		return tree.LeftPadded[tree.Space]{Before: before, Element: sp, Markers: markers}
 	}
+	// Pre-typed operator enums (NO_CHANGE path passes the existing typed value through)
+	if op, ok := elem.(tree.BinaryOperator); ok {
+		return tree.LeftPadded[tree.BinaryOperator]{Before: before, Element: op, Markers: markers}
+	}
+	if op, ok := elem.(tree.UnaryOperator); ok {
+		return tree.LeftPadded[tree.UnaryOperator]{Before: before, Element: op, Markers: markers}
+	}
+	if op, ok := elem.(tree.AssignmentOperator); ok {
+		return tree.LeftPadded[tree.AssignmentOperator]{Before: before, Element: op, Markers: markers}
+	}
+	if op, ok := elem.(tree.AssignOp); ok {
+		return tree.LeftPadded[tree.AssignOp]{Before: before, Element: op, Markers: markers}
+	}
 	// Interface types — prefer Expression over Statement
 	if expr, ok := elem.(tree.Expression); ok {
 		return tree.LeftPadded[tree.Expression]{Before: before, Element: expr, Markers: markers}

--- a/rewrite-go/pkg/rpc/padding_rpc_test.go
+++ b/rewrite-go/pkg/rpc/padding_rpc_test.go
@@ -370,3 +370,93 @@ func TestRawCastPanics_HeterogeneousRightPadded(t *testing.T) {
 		_ = second.(tree.RightPadded[tree.Expression])
 	})
 }
+
+// ----- Group 6: leftPaddedFromElement preserves pre-typed operator enums -----
+//
+// On the NO_CHANGE path, ReceiveQueue.Receive returns the existing `before`
+// value unchanged. For Binary/Unary/Assignment operator slots that value is
+// the already-typed enum (BinaryOperator/UnaryOperator/AssignmentOperator/
+// AssignOp — all int-based), not the wire-format string. Pre-fix,
+// leftPaddedFromElement only matched the string spellings and fell through
+// to the catch-all `LeftPadded[tree.J]{Before, Markers}` with the element
+// dropped — then VisitBinary's `result.(LeftPadded[BinaryOperator])` cast
+// at java_receiver.go:149 panicked. See /tmp/rewrite-go-rpc-print-panics-round3.md.
+
+func TestLeftPaddedFromElement_PreTypedBinaryOperator(t *testing.T) {
+	// given: NO_CHANGE handed back an already-typed BinaryOperator
+	op := tree.Add
+
+	// when
+	got := leftPaddedFromElement(tree.EmptySpace, op, tree.Markers{})
+
+	// then: correctly-typed LeftPadded with element preserved
+	lp, ok := got.(tree.LeftPadded[tree.BinaryOperator])
+	if !ok {
+		t.Fatalf("want LeftPadded[BinaryOperator], got %T", got)
+	}
+	if lp.Element != op {
+		t.Errorf("Element lost: want %v, got %v", op, lp.Element)
+	}
+}
+
+func TestLeftPaddedFromElement_PreTypedUnaryOperator(t *testing.T) {
+	// given
+	op := tree.Negate
+
+	// when
+	got := leftPaddedFromElement(tree.EmptySpace, op, tree.Markers{})
+
+	// then
+	lp, ok := got.(tree.LeftPadded[tree.UnaryOperator])
+	if !ok {
+		t.Fatalf("want LeftPadded[UnaryOperator], got %T", got)
+	}
+	if lp.Element != op {
+		t.Errorf("Element lost: want %v, got %v", op, lp.Element)
+	}
+}
+
+func TestLeftPaddedFromElement_PreTypedAssignmentOperator(t *testing.T) {
+	// given
+	op := tree.AddAssign
+
+	// when
+	got := leftPaddedFromElement(tree.EmptySpace, op, tree.Markers{})
+
+	// then
+	lp, ok := got.(tree.LeftPadded[tree.AssignmentOperator])
+	if !ok {
+		t.Fatalf("want LeftPadded[AssignmentOperator], got %T", got)
+	}
+	if lp.Element != op {
+		t.Errorf("Element lost: want %v, got %v", op, lp.Element)
+	}
+}
+
+func TestLeftPaddedFromElement_PreTypedAssignOp(t *testing.T) {
+	// given
+	op := tree.AssignOpDefine
+
+	// when
+	got := leftPaddedFromElement(tree.EmptySpace, op, tree.Markers{})
+
+	// then
+	lp, ok := got.(tree.LeftPadded[tree.AssignOp])
+	if !ok {
+		t.Fatalf("want LeftPadded[AssignOp], got %T", got)
+	}
+	if lp.Element != op {
+		t.Errorf("Element lost: want %v, got %v", op, lp.Element)
+	}
+}
+
+func TestRawCastPanics_LeftPaddedJOnBinaryOperatorSlot(t *testing.T) {
+	// Lock in the receiver-side panic shape that surfaced pre-fix: without the
+	// pre-typed-enum branches in leftPaddedFromElement, the catch-all returned
+	// LeftPadded[tree.J]{Before, Markers} (element dropped). VisitBinary then
+	// raw-cast that to LeftPadded[BinaryOperator] and panicked.
+	var wire any = tree.LeftPadded[tree.J]{Before: tree.EmptySpace, Markers: tree.Markers{}}
+	expectPanic(t, "raw cast LP[J]->LP[BinaryOperator]", func() {
+		_ = wire.(tree.LeftPadded[tree.BinaryOperator])
+	})
+}


### PR DESCRIPTION
## What's changed?

Fix Go RPC logic to properly handle left-padded operator enums.

## What's your motivation?

Panics are raised when running Go recipes in Moderne CLI, e.g.
```
2026/05/27 11:40:25 PANIC in Print: interface conversion: interface {} is tree.LeftPadded[github.com/openrewrite/rewrite/rewrite-go/pkg/tree.J], not tree.LeftPadded[github.com/openrewrite/rewrite/rewrite-go/pkg/tree.BinaryOperator]
goroutine 1 [running]:
main.(*server).safeHandleRequest.func1()
        rewrite-recipe-workspace/cmd/rpc/main.go:404 +0x84
panic({0x103340820?, 0x140004492f0?})
        runtime/panic.go:783 +0x120
github.com/openrewrite/rewrite/rewrite-go/pkg/rpc.(*JavaReceiver).VisitBinary(0x14000350d40, 0x140003fc1e0, {0x103381700?, 0x1400049f980})
        github.com/openrewrite/rewrite/rewrite-go@v0.0.1/pkg/rpc/java_receiver.go:149 +0x2f0
github.com/openrewrite/rewrite/rewrite-go/pkg/visitor.(*GoVisitor).Visit(0x14000350d40, {0x103436940, 0x140004283c0}, {0x103381700, 0x1400049f980})
```