### PR TITLE
Scala: support for Scala 2 macro syntax

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -1857,6 +1857,10 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 p.append('\'');
                 visit(macro.getExpression(), p);
                 break;
+            case Scala2Macro:
+                p.append("macro");
+                visit(macro.getExpression(), p);
+                break;
         }
         afterSyntax(macro, p);
         return macro;

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -1931,7 +1931,9 @@ public interface S extends J {
             /** {@code '{expr}} */
             QuoteBlock,
             /** {@code 'name} (single-token quote) */
-            QuoteIdent
+            QuoteIdent,
+            /** Scala 2 macro implementation reference: {@code macro impl} */
+            Scala2Macro
         }
 
         @With @Getter @EqualsAndHashCode.Include

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7579,20 +7579,30 @@ class ScalaTreeVisitor(
 
   private def visitMacroTree(mac: untpd.MacroTree): S.Macro = {
     // Scala 3 inline/macro expressions: ${ ... }, '{ ... }, or 'name
-    val prefix = extractPrefix(mac.span)
     val startAdj = Math.max(0, mac.span.start - offsetAdjustment)
     val firstChar = if (startAdj < source.length) source.charAt(startAdj) else ' '
     val secondChar = if (startAdj + 1 < source.length) source.charAt(startAdj + 1) else ' '
     val kind: S.Macro.Kind =
       if (firstChar == '$' && secondChar == '{') S.Macro.Kind.Splice
       else if (firstChar == '\'' && secondChar == '{') S.Macro.Kind.QuoteBlock
-      else S.Macro.Kind.QuoteIdent
+      else if (firstChar == '\'') S.Macro.Kind.QuoteIdent
+      else S.Macro.Kind.Scala2Macro
+    val macroKeywordStart =
+      if (kind == S.Macro.Kind.Scala2Macro) source.lastIndexOf("macro", Math.max(0, startAdj - 1)) else -1
+    val prefix =
+      if (kind == S.Macro.Kind.Scala2Macro && macroKeywordStart >= cursor) {
+        Space.format(source, cursor, macroKeywordStart)
+      } else {
+        extractPrefix(mac.span)
+      }
 
     // Advance past the prefix tokens: `${`, `'{`, or `'`
-    cursor = startAdj + (kind match {
-      case S.Macro.Kind.Splice | S.Macro.Kind.QuoteBlock => 2
-      case S.Macro.Kind.QuoteIdent => 1
-    })
+    cursor = kind match {
+      case S.Macro.Kind.Splice | S.Macro.Kind.QuoteBlock => startAdj + 2
+      case S.Macro.Kind.QuoteIdent => startAdj + 1
+      case S.Macro.Kind.Scala2Macro if macroKeywordStart >= 0 => macroKeywordStart + "macro".length
+      case S.Macro.Kind.Scala2Macro => startAdj
+    }
 
     val expr: Expression = visitTree(mac.expr) match {
       case e: Expression => e

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -200,6 +200,21 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void scala2MacroImplementation() {
+        rewriteRun(
+            scala(
+                """
+                import scala.language.experimental.macros
+
+                class C {
+                  def q: T = macro macroimpl.M.f
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void methodWithTypeParameters() {
         rewriteRun(
             scala(


### PR DESCRIPTION
## What's changed?

Support for Scala 2 experimental `macro` syntax, e.g.
```
def q: T = macro macroimpl.M.f
```

## What's your motivation?

Currently it's not supported.