### PR TITLE
Fix `FindEndOfLifeImagesTest` to suggest Node 26 or 24

### DIFF
--- a/rewrite-docker/src/test/java/org/openrewrite/docker/search/FindEndOfLifeImagesTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/search/FindEndOfLifeImagesTest.java
@@ -182,7 +182,7 @@ class FindEndOfLifeImagesTest implements RewriteTest {
               RUN npm install
               """,
             """
-              ~~(EOL: node:14-slim (ended 2023-04-30, suggest 24 or 22))~~>FROM node:14-slim
+              ~~(EOL: node:14-slim (ended 2023-04-30, suggest 26 or 24))~~>FROM node:14-slim
               RUN npm install
               """
           )
@@ -198,7 +198,7 @@ class FindEndOfLifeImagesTest implements RewriteTest {
               RUN npm install
               """,
             """
-              ~~(EOL: node:16 (ended 2023-09-11, suggest 24 or 22))~~>FROM node:16
+              ~~(EOL: node:16 (ended 2023-09-11, suggest 26 or 24))~~>FROM node:16
               RUN npm install
               """
           )
@@ -296,7 +296,7 @@ class FindEndOfLifeImagesTest implements RewriteTest {
             //language=csv
             """
               sourceFile,stageName,imageName,tag,eolDate,suggestedReplacement
-              Dockerfile,builder,node,14,2023-04-30,"24 or 22"
+              Dockerfile,builder,node,14,2023-04-30,"26 or 24"
               Dockerfile,,debian,buster,2022-09-10,"trixie (13)"
               """
           ),
@@ -309,7 +309,7 @@ class FindEndOfLifeImagesTest implements RewriteTest {
               COPY --from=builder /app /app
               """,
             """
-              ~~(EOL: node:14 (ended 2023-04-30, suggest 24 or 22))~~>FROM node:14 AS builder
+              ~~(EOL: node:14 (ended 2023-04-30, suggest 26 or 24))~~>FROM node:14 AS builder
               RUN npm run build
 
               ~~(EOL: debian:buster (ended 2022-09-10, suggest trixie (13)))~~>FROM debian:buster


### PR DESCRIPTION
## What's changed?

Changing the test expectations in `FindEndOfLifeImagesTest` to mention Node 26.

## What's your motivation?

Fix broken CI after a77f82c599:
```diff
org.opentest4j.AssertionFailedError: [Unexpected result in "Dockerfile": |  
-- | --
diff --git a/Dockerfile b/Dockerfile |  
index ec10687..8d11f45 100644 |  
--- a/Dockerfile |  
+++ b/Dockerfile |  
@@ -1,2 +1,2 @@ |  
-~~(EOL: node:14-slim (ended 2023-04-30, suggest 24 or 22))~~>FROM node:14-slim |  
+~~(EOL: node:14-slim (ended 2023-04-30, suggest 26 or 24))~~>FROM node:14-slim |  
RUN npm install |  
\ No newline at end of file |  
]


```