### PR TITLE
Go: Add missing visitFallThrough to RPC

### DIFF
--- a/rewrite-go/pkg/rpc/go_receiver.go
+++ b/rewrite-go/pkg/rpc/go_receiver.go
@@ -196,6 +196,13 @@ func (r *GoReceiver) VisitGoto(g *tree.Goto, p any) tree.J {
 	return g
 }
 
+// VisitFallthrough mirrors GolangReceiver.visitFallthrough — the node has no
+// payload beyond the framework-handled id/prefix/markers, so this override
+// is intentionally a no-op. Present for sender/receiver symmetry.
+func (r *GoReceiver) VisitFallthrough(f *tree.Fallthrough, p any) tree.J {
+	return f
+}
+
 func (r *GoReceiver) VisitComposite(comp *tree.Composite, p any) tree.J {
 	q := p.(*ReceiveQueue)
 	c := *comp // shallow copy to avoid mutating remoteObjects baseline

--- a/rewrite-go/pkg/rpc/go_sender.go
+++ b/rewrite-go/pkg/rpc/go_sender.go
@@ -134,6 +134,13 @@ func (s *GoSender) VisitGoto(g *tree.Goto, p any) tree.J {
 	return g
 }
 
+// VisitFallthrough mirrors GolangSender.visitFallthrough — the node has no
+// payload beyond the framework-handled id/prefix/markers, so this override
+// is intentionally a no-op. Present for sender/receiver symmetry.
+func (s *GoSender) VisitFallthrough(f *tree.Fallthrough, p any) tree.J {
+	return f
+}
+
 func (s *GoSender) VisitComposite(c *tree.Composite, p any) tree.J {
 	q := p.(*SendQueue)
 	q.GetAndSend(c, func(v any) any { return v.(*tree.Composite).TypeExpr },


### PR DESCRIPTION
## What's changed?

The Go side of Go RPC missed the visitors for `FallThrough`. Adding.

## What's your motivation?

This might result in RPC desynchronization issues.