### PR TITLE
C#: preserve whitespace in auto-property accessors and null-conditional assignments

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/PropertyDeclarationTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/PropertyDeclarationTests.cs
@@ -34,6 +34,22 @@ public class PropertyDeclarationTests : RewriteTest
     }
 
     [Fact]
+    public void AutoPropertyWithSpaceBeforeSemicolon()
+    {
+        // The space between "get" and ";" must round-trip: stored as J.Empty.Prefix
+        // inside the AccessorDeclaration.ExpressionBody slot.
+        RewriteRun(
+            CSharp(
+                """
+                class Foo {
+                    public int X { get ; set; }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
     public void GetOnlyAutoProperty()
     {
         RewriteRun(

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/StatementTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/StatementTests.cs
@@ -52,6 +52,49 @@ public class ReturnTests : RewriteTest
     }
 }
 
+public class ConditionalAccessAssignmentReproTests : RewriteTest
+{
+    [Fact]
+    public void NullConditionalPropertyAssignmentPreservesLeadingNewline()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Foo {
+                    public string? Color;
+                    public string Bar() {
+                        var rgb = Color;
+                        rgb?.Length = 0;
+                        return rgb;
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void NullConditionalEventUnsubscribePreservesLeadingNewline()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                using System;
+                class Foo {
+                    public event EventHandler? Changed;
+                    public void Dispose() {
+                        Console.WriteLine("disposing");
+
+                        Changed -= OnChanged;
+                    }
+                    void OnChanged(object? s, EventArgs e) {}
+                }
+                """
+            )
+        );
+    }
+}
+
 public class IfTests : RewriteTest
 {
     [Fact]

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -2344,9 +2344,15 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
         else if (node.SemicolonToken != default)
         {
-            // Auto-implemented accessor - consume the semicolon
-            SkipTo(node.SemicolonToken.SpanStart);
-            SkipToken(node.SemicolonToken);
+            // Auto-implemented accessor (e.g. "get;" or "get ;"). Roslyn has no node for the
+            // implicit body; we model it as J.Empty so the whitespace between the keyword and
+            // the trailing ';' has a home. ExpressionBody.Element being Empty is the signal to
+            // the printer to emit ';' without '=>'.
+            var emptyPrefix = ExtractSpaceBefore(node.SemicolonToken);
+            _cursor = node.SemicolonToken.Span.End;
+            expressionBody = new JLeftPadded<Expression>(
+                Space.Empty,
+                new Empty(Guid.NewGuid(), emptyPrefix, Markers.Empty));
         }
 
         return new AccessorDeclaration(
@@ -6549,25 +6555,13 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         {
             // x?.b.c - member access chain (without further ?.)
             var segment = ParseConditionalAccessSegment(targetExpr, operatorSpace, whenMemberAccess);
-            return segment switch
-            {
-                FieldAccess fa => fa.WithPrefix(prefix),
-                MethodInvocation mi => mi.WithPrefix(prefix),
-                ArrayAccess aa => aa.WithPrefix(prefix),
-                _ => segment
-            };
+            return ApplyConditionalAccessPrefix(segment, prefix);
         }
         else if (node.WhenNotNull is ElementAccessExpressionSyntax elementAccess)
         {
             // x?.Items[0] - member access followed by indexer in null-conditional chain
             var segment = ParseConditionalAccessSegment(targetExpr, operatorSpace, elementAccess);
-            return segment switch
-            {
-                FieldAccess fa => fa.WithPrefix(prefix),
-                MethodInvocation mi => mi.WithPrefix(prefix),
-                ArrayAccess aa => aa.WithPrefix(prefix),
-                _ => segment
-            };
+            return ApplyConditionalAccessPrefix(segment, prefix);
         }
         else if (node.WhenNotNull is ConditionalAccessExpressionSyntax innerConditional)
         {
@@ -6652,15 +6646,23 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         // For all other WhenNotNull patterns, delegate to the general segment parser
         {
             var segment = ParseConditionalAccessSegment(targetExpr, operatorSpace, node.WhenNotNull);
-            return segment switch
-            {
-                FieldAccess fa => fa.WithPrefix(prefix),
-                MethodInvocation mi => mi.WithPrefix(prefix),
-                ArrayAccess aa => aa.WithPrefix(prefix),
-                _ => segment
-            };
+            return ApplyConditionalAccessPrefix(segment, prefix);
         }
     }
+
+    // Re-applies the outer ConditionalAccessExpression's prefix to the segment returned by
+    // ParseConditionalAccessSegment. The segment was built with Space.Empty prefix because
+    // the actual leading whitespace lives on the outer ConditionalAccessExpression.
+    private static Expression ApplyConditionalAccessPrefix(Expression segment, Space prefix) => segment switch
+    {
+        FieldAccess fa => fa.WithPrefix(prefix),
+        MethodInvocation mi => mi.WithPrefix(prefix),
+        ArrayAccess aa => aa.WithPrefix(prefix),
+        Assignment a => a.WithPrefix(prefix),
+        AssignmentOperation aop => aop.WithPrefix(prefix),
+        CsUnary cu => cu.WithPrefix(prefix),
+        _ => segment
+    };
 
     /// <summary>
     /// Helper method to parse a null-conditional element access (x?[0]).
@@ -6916,13 +6918,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         {
             // Terminal chain like ?.b.c at end
             var segment = ParseConditionalAccessSegment(target, operatorSpace, terminalMemberAccess);
-            return segment switch
-            {
-                FieldAccess fa => fa.WithPrefix(prefix),
-                MethodInvocation mi => mi.WithPrefix(prefix),
-                ArrayAccess aa => aa.WithPrefix(prefix),
-                _ => segment
-            };
+            return ApplyConditionalAccessPrefix(segment, prefix);
         }
         else if (whenNotNull is ConditionalAccessExpressionSyntax innerConditional)
         {
@@ -7000,13 +6996,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         // delegate to the general segment parser
         {
             var segment = ParseConditionalAccessSegment(target, operatorSpace, whenNotNull);
-            return segment switch
-            {
-                FieldAccess fa => fa.WithPrefix(prefix),
-                MethodInvocation mi => mi.WithPrefix(prefix),
-                ArrayAccess aa => aa.WithPrefix(prefix),
-                _ => segment
-            };
+            return ApplyConditionalAccessPrefix(segment, prefix);
         }
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -1155,13 +1155,23 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
         VisitSpace(accessor.Kind.Before, p);
         p.Append(GetAccessorKindString(accessor.Kind.Element));
 
-        // Print expression body, block body, or semicolon
+        // Print expression body, block body, or auto-implemented semicolon.
+        // For auto-impl, ExpressionBody.Element is J.Empty; its Prefix carries any
+        // whitespace between the keyword and the trailing ';' (e.g. "get ;").
         if (accessor.ExpressionBody != null)
         {
-            VisitSpace(accessor.ExpressionBody.Before, p);
-            p.Append("=>");
-            Visit(accessor.ExpressionBody.Element, p);
-            p.Append(';');
+            if (accessor.ExpressionBody.Element is Empty)
+            {
+                Visit(accessor.ExpressionBody.Element, p);
+                p.Append(';');
+            }
+            else
+            {
+                VisitSpace(accessor.ExpressionBody.Before, p);
+                p.Append("=>");
+                Visit(accessor.ExpressionBody.Element, p);
+                p.Append(';');
+            }
         }
         else if (accessor.Body != null)
         {
@@ -1169,6 +1179,7 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
         }
         else
         {
+            // Legacy fallback for LSTs created before the J.Empty change.
             p.Append(';');
         }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
@@ -229,6 +229,9 @@ public sealed class AccessorDeclaration(
     public IList<Modifier> Modifiers { get; } = modifiers;
     public JLeftPadded<AccessorKind> Kind { get; } = kind;
     public Block? Body { get; } = body;
+    // For auto-implemented accessors (e.g. "get ;"), Element is a J.Empty whose Prefix
+    // carries any whitespace between the keyword and the trailing ';'. For "get => x;" the
+    // Element is the body expression and Before is the space before '=>'.
     public JLeftPadded<Expression>? ExpressionBody { get; } = expressionBody;
 
     public AccessorDeclaration WithId(Guid id) =>


### PR DESCRIPTION
## Summary
- Auto-implemented accessors like `get ;` now round-trip: `AccessorDeclaration.ExpressionBody` holds a `J.Empty` whose `Prefix` carries the whitespace between the keyword and the trailing `;`. The printer treats an `Empty` body element as the auto-impl signal and emits `;` without `=>`.
- Null-conditional targets that resolve to `Assignment`, `AssignmentOperation`, or `CsUnary` (e.g. `rgb?.Length = 0`, `Changed -= OnChanged`) now keep their leading whitespace by routing through a shared `ApplyConditionalAccessPrefix` helper.

## Test plan
- [x] `dotnet test` covering the new `AutoPropertyWithSpaceBeforeSemicolon`, `NullConditionalPropertyAssignmentPreservesLeadingNewline`, and `NullConditionalEventUnsubscribePreservesLeadingNewline` cases