### PR TITLE
Go: don't parse `.moderne/` files

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -1808,7 +1808,7 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 			// Skip common non-source directories. vendor/ is handled by
 			// the (3-tier) ProjectImporter for symbol resolution; we
 			// don't want to parse vendored code as project sources.
-			if base == "vendor" || base == "node_modules" || base == ".git" || base == "testdata" {
+			if base == "vendor" || base == "node_modules" || base == ".git" || base == "testdata" || base == ".moderne" {
 				return filepath.SkipDir
 			}
 			for _, excl := range req.Exclusions {


### PR DESCRIPTION
## What's changed?

Excluding the `.moderne/` subdirectory from getting parsed in Go.

## What's your motivation?

We do that for other languages. And otherwise Moderne CLI walks into its own output, e.g.
```
  0% (1s)             Discovered 81 files to parse
  0% (1s)     .moderne/run/20260527102030-3IBvu/before/context.go
```
which doesn't make sense.