### PR TITLE
Fix DOCTYPE continuation indentation in XML TabsAndIndents

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/TabsAndIndentsVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/TabsAndIndentsVisitor.java
@@ -43,11 +43,17 @@ public class TabsAndIndentsVisitor<P> extends XmlIsoVisitor<P> {
             String prefix = x.getPrefix();
             if (prefix.contains("\n")) {
                 int indentMultiple = (int) getCursor().getPathAsStream().filter(Xml.Tag.class::isInstance).count() - 1;
+                boolean docTypeContinuation = isDocTypeContinuation(x);
+                boolean continuationIndent = x instanceof Xml.Attribute || docTypeContinuation;
                 if (getCursor().getValue() instanceof Xml.Attribute ||
                         getCursor().getValue() instanceof Xml.CharData ||
                         getCursor().getValue() instanceof Xml.Comment ||
-                        getCursor().getValue() instanceof Xml.ProcessingInstruction) {
+                        getCursor().getValue() instanceof Xml.ProcessingInstruction ||
+                        docTypeContinuation) {
                     indentMultiple++;
+                }
+                if (docTypeContinuation) {
+                    indentMultiple = Math.max(indentMultiple, 1);
                 }
 
                 StringBuilder shiftedPrefixBuilder = new StringBuilder(prefix.substring(0, prefix.lastIndexOf('\n') + 1));
@@ -55,7 +61,8 @@ public class TabsAndIndentsVisitor<P> extends XmlIsoVisitor<P> {
                     if(style.getUseTabCharacter()) {
                         shiftedPrefixBuilder.append("\t");
                     } else {
-                        for(int j = 0; j < (x instanceof Xml.Attribute ? style.getContinuationIndentSize() : style.getIndentSize()); j++) {
+                        int indentSize = continuationIndent ? style.getContinuationIndentSize() : style.getIndentSize();
+                        for(int j = 0; j < indentSize; j++) {
                             shiftedPrefixBuilder.append(" ");
                         }
                     }
@@ -68,6 +75,11 @@ public class TabsAndIndentsVisitor<P> extends XmlIsoVisitor<P> {
             }
         }
         return x;
+    }
+
+    private boolean isDocTypeContinuation(Xml x) {
+        return x instanceof Xml.Ident &&
+                getCursor().getPathAsStream().anyMatch(Xml.DocTypeDecl.class::isInstance);
     }
 
     @Override

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/format/TabsAndIndentsTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/format/TabsAndIndentsTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.xml.format;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.xml.style.TabsAndIndentsStyle;
 
@@ -47,6 +48,32 @@ class TabsAndIndentsTest implements RewriteTest {
                    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
                 <modelVersion>4.0.0</modelVersion>
                 <artifactId>quarkus-bootstrap-bom</artifactId>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4234")
+    @Test
+    void continuationIndentsWithinDOCTYPE() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new TabsAndIndentsVisitor<>(
+            TabsAndIndentsStyle.DEFAULT.withIndentSize(2).withContinuationIndentSize(5)
+          ))),
+          xml(
+            """
+              <!DOCTYPE module PUBLIC
+                "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+                "https://checkstyle.org/dtds/configuration_1_3.dtd">
+              <project>
+              </project>
+              """,
+            """
+              <!DOCTYPE module PUBLIC
+                   "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+                   "https://checkstyle.org/dtds/configuration_1_3.dtd">
+              <project>
               </project>
               """
           )


### PR DESCRIPTION
## What changed

- Closes #4234.

Updates XML `TabsAndIndentsVisitor` so line-broken identifiers inside a `<!DOCTYPE ...>` declaration use `continuationIndentSize`, matching how continued XML attributes are formatted.

## Why

`TabsAndIndents` previously treated DOCTYPE continuation lines as top-level XML identifiers, so their indentation was reduced to the start of the line instead of the configured continuation indent.

## Testing

- `./gradlew :rewrite-xml:test --tests org.openrewrite.xml.format.TabsAndIndentsTest.continuationIndentsWithinDOCTYPE`
- `./gradlew :rewrite-xml:test --tests org.openrewrite.xml.format.TabsAndIndentsTest`
- `./gradlew :rewrite-xml:test`
- `./gradlew :rewrite-xml:check`
- `git diff --check`
