### PR TITLE
Lazy single-recipe activation

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
@@ -590,13 +590,23 @@ public class ClasspathScanningLoader implements ResourceLoader {
     }
 
     /**
-     * Drain every remaining YAML loader and compute recipe descriptors. Descriptors
-     * require the complete recipe set to resolve cross-loader references, so the
-     * descriptor pass runs after all loaders are drained.
+     * Drain every remaining YAML loader so the shared maps are fully populated. Recipe
+     * descriptor extraction is intentionally separate — see {@link #extractYamlRecipeDescriptors()}.
      */
     private void drainAllYamlLoaders() {
         while (drainNextYamlLoader()) {
         }
+    }
+
+    /**
+     * Compute recipe descriptors for every drained YAML loader. Must be called after
+     * both the class scan and the full YAML drain, because the descriptor pass
+     * resolves cross-loader references through {@code recipes} — and that map only
+     * contains imperative entries once the class scan has run. Calling this before
+     * the class scan would yield declarative descriptors with empty recipeLists for
+     * any imperative sub-recipe.
+     */
+    private void extractYamlRecipeDescriptors() {
         if (!recipeDescriptorsExtracted) {
             recipeDescriptorsExtracted = true;
             for (YamlResourceLoader loader : yamlResourceLoaders) {
@@ -689,6 +699,7 @@ public class ClasspathScanningLoader implements ResourceLoader {
     @Override
     public Collection<RecipeDescriptor> listRecipeDescriptors() {
         ensureScanned();
+        extractYamlRecipeDescriptors();
         return recipeDescriptors;
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
@@ -55,9 +55,29 @@ public class ClasspathScanningLoader implements ResourceLoader {
 
     private final Map<String, List<RecipeExample>> recipeExamples = new HashMap<>();
 
+    private final List<YamlResourceLoader> yamlResourceLoaders = new ArrayList<>();
+    // Index of the next YAML loader to drain into the shared maps via progressive scan.
+    // Each loader is parsed at most once; subsequent loadRecipe calls hit the shared
+    // recipes map directly for any already-scanned name.
+    private int yamlScanIndex;
+    // Recipe descriptors require cross-loader recipe references to resolve, so they
+    // can only be computed after every YAML loader has been drained. This flag
+    // guards against duplicate descriptor extraction.
+    private boolean recipeDescriptorsExtracted;
+
     private final ClassLoader classLoader;
     private final RecipeLoader recipeLoader;
-    private @Nullable Runnable performScan;
+
+    // Scanning is split into independently triggerable phases so single-recipe
+    // activation pays only for what it needs:
+    //  - performClassScan: walks class bytecode to find Recipe subclasses and
+    //    instantiate them (most expensive — ~1 s for a large bundle).
+    //  - performYamlListing: enumerates META-INF/rewrite/*.yml and constructs
+    //    one YamlResourceLoader per file (cheap; no YAML parsing yet).
+    // YAML parsing happens progressively in loadRecipe — one file at a time —
+    // until either the requested recipe is found or all loaders are drained.
+    private @Nullable Runnable performClassScan;
+    private @Nullable Runnable performYamlListing;
 
     /**
      * Construct a ClasspathScanningLoader that scans the runtime classpath of the current java process for recipes,
@@ -73,7 +93,7 @@ public class ClasspathScanningLoader implements ResourceLoader {
         for (String pkg : acceptPackages) {
             packagePrefixes.add(pkg.replace('.', '/'));
         }
-        this.performScan = () -> {
+        this.performClassScan = () -> {
             Map<String, String> superclassMap = buildSuperclassMapFromClassLoader(classLoader);
             if (!packagePrefixes.isEmpty()) {
                 superclassMap.keySet().removeIf(name -> {
@@ -87,9 +107,8 @@ public class ClasspathScanningLoader implements ResourceLoader {
                 });
             }
             configureRecipesAndStyles(superclassMap, classLoader);
-            List<YamlResource> yaml = listYamlResourcesFromClassLoader(classLoader);
-            scanYaml(yaml, properties, emptyList(), null);
         };
+        this.performYamlListing = () -> listYamlLoaders(listYamlResourcesFromClassLoader(classLoader), properties, emptyList(), null);
     }
 
     /**
@@ -101,10 +120,8 @@ public class ClasspathScanningLoader implements ResourceLoader {
     public ClasspathScanningLoader(@Nullable Properties properties, ClassLoader classLoader) {
         this.classLoader = classLoader;
         this.recipeLoader = new RecipeLoader(classLoader);
-        this.performScan = () -> {
-            configureRecipesAndStyles(buildSuperclassMapFromClassLoader(classLoader), classLoader);
-            scanYaml(listYamlResourcesFromClassLoader(classLoader), properties, emptyList(), classLoader);
-        };
+        this.performClassScan = () -> configureRecipesAndStyles(buildSuperclassMapFromClassLoader(classLoader), classLoader);
+        this.performYamlListing = () -> listYamlLoaders(listYamlResourcesFromClassLoader(classLoader), properties, emptyList(), classLoader);
     }
 
     /**
@@ -124,10 +141,8 @@ public class ClasspathScanningLoader implements ResourceLoader {
         this.classLoader = classLoader;
         this.recipeLoader = new RecipeLoader(classLoader);
 
-        this.performScan = () -> {
-            configureRecipesAndStyles(sharedSuperclassMap.scan(jar), classLoader);
-            scanYaml(listYamlResourcesFromPath(jar), properties, dependencyResourceLoaders, classLoader);
-        };
+        this.performClassScan = () -> configureRecipesAndStyles(sharedSuperclassMap.scan(jar), classLoader);
+        this.performYamlListing = () -> listYamlLoaders(listYamlResourcesFromPath(jar), properties, dependencyResourceLoaders, classLoader);
     }
 
     /**
@@ -524,31 +539,69 @@ public class ClasspathScanningLoader implements ResourceLoader {
     }
 
     /**
+     * Convenience used by the {@code onlyYaml} factories that bypass the lazy scan
+     * machinery. Lists every YAML loader and drains them all into the shared maps.
+     * <p>
      * This must be called _after_ configureRecipesAndStyles or the descriptors of declarative recipes will be missing
      * any non-declarative recipes they depend on that would be discovered by class scanning.
      */
     private void scanYaml(List<YamlResource> yamlResources, @Nullable Properties properties,
                           Collection<? extends ResourceLoader> dependencyResourceLoaders,
                           @Nullable ClassLoader classLoader) {
-        List<YamlResourceLoader> yamlResourceLoaders = new ArrayList<>();
+        listYamlLoaders(yamlResources, properties, dependencyResourceLoaders, classLoader);
+        drainAllYamlLoaders();
+    }
+
+    /**
+     * Enumerate the YAML files and construct one {@link YamlResourceLoader} per
+     * file. The loader constructor only consumes the YAML input stream into a
+     * byte buffer; no YAML parsing happens here, so this remains cheap even for
+     * bundles with hundreds of files.
+     */
+    private void listYamlLoaders(List<YamlResource> yamlResources, @Nullable Properties properties,
+                                 Collection<? extends ResourceLoader> dependencyResourceLoaders,
+                                 @Nullable ClassLoader classLoader) {
         for (YamlResource resource : yamlResources) {
             try (InputStream input = resource.inputStreamSupplier.get()) {
                 yamlResourceLoaders.add(new YamlResourceLoader(input, resource.uri, properties, classLoader, dependencyResourceLoaders));
             } catch (IOException ignored) {
             }
         }
-        // Extract in two passes so that the full list of recipes from all sources are known when computing recipe descriptors
-        // Otherwise recipes which include recipes from other sources in their recipeList will have incomplete descriptors
-        for (YamlResourceLoader resourceLoader : yamlResourceLoaders) {
-            for (Recipe recipe : resourceLoader.listRecipes()) {
-                recipes.put(recipe.getName(), recipe);
-            }
-            categoryDescriptors.addAll(resourceLoader.listCategoryDescriptors());
-            styles.addAll(resourceLoader.listStyles());
-            recipeExamples.putAll(resourceLoader.listRecipeExamples());
+    }
+
+    /**
+     * Drain the next unscanned YAML loader into the shared maps. Each loader is
+     * parsed at most once across the lifetime of this instance.
+     *
+     * @return true if a loader was drained; false if every loader has already been processed.
+     */
+    private boolean drainNextYamlLoader() {
+        if (yamlScanIndex >= yamlResourceLoaders.size()) {
+            return false;
         }
-        for (YamlResourceLoader resourceLoader : yamlResourceLoaders) {
-            recipeDescriptors.addAll(resourceLoader.listRecipeDescriptors(recipes.values(), recipeExamples));
+        YamlResourceLoader loader = yamlResourceLoaders.get(yamlScanIndex++);
+        for (Recipe recipe : loader.listRecipes()) {
+            recipes.put(recipe.getName(), recipe);
+        }
+        categoryDescriptors.addAll(loader.listCategoryDescriptors());
+        styles.addAll(loader.listStyles());
+        recipeExamples.putAll(loader.listRecipeExamples());
+        return true;
+    }
+
+    /**
+     * Drain every remaining YAML loader and compute recipe descriptors. Descriptors
+     * require the complete recipe set to resolve cross-loader references, so the
+     * descriptor pass runs after all loaders are drained.
+     */
+    private void drainAllYamlLoaders() {
+        while (drainNextYamlLoader()) {
+        }
+        if (!recipeDescriptorsExtracted) {
+            recipeDescriptorsExtracted = true;
+            for (YamlResourceLoader loader : yamlResourceLoaders) {
+                recipeDescriptors.addAll(loader.listRecipeDescriptors(recipes.values(), recipeExamples));
+            }
         }
     }
 
@@ -556,15 +609,31 @@ public class ClasspathScanningLoader implements ResourceLoader {
 
     @Override
     public @Nullable Recipe loadRecipe(String recipeName, RecipeDetail... details) {
-        if (performScan != null) {
+        // Imperative fast path: try to load by FQCN directly. This succeeds for any
+        // imperative recipe whose name matches its class, without triggering any scan.
+        if (performClassScan != null) {
             try {
                 return recipeLoader.load(recipeName, null);
             } catch (NoClassDefFoundError | IllegalArgumentException ignored) {
                 // it's probably declarative
             }
         }
-        ensureScanned();
-        return recipes.get(recipeName);
+        // Progressive YAML scan: parse YAML files one at a time until the recipe
+        // turns up in the shared map or every loader has been drained. Subsequent
+        // lookups for already-scanned names hit the map directly without parsing
+        // any additional files.
+        Recipe recipe = recipes.get(recipeName);
+        if (recipe != null) {
+            return recipe;
+        }
+        ensureYamlListed();
+        while (drainNextYamlLoader()) {
+            recipe = recipes.get(recipeName);
+            if (recipe != null) {
+                return recipe;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -573,12 +642,48 @@ public class ClasspathScanningLoader implements ResourceLoader {
         return recipes.values();
     }
 
-    private void ensureScanned() {
-        if (performScan != null) {
-            Runnable scan = performScan;
-            performScan = null;
+    private void ensureClassesScanned() {
+        if (performClassScan != null) {
+            Runnable scan = performClassScan;
+            performClassScan = null;
             scan.run();
         }
+    }
+
+    private void ensureYamlListed() {
+        if (performYamlListing != null) {
+            Runnable listing = performYamlListing;
+            performYamlListing = null;
+            listing.run();
+        }
+    }
+
+    private void ensureYamlScanned() {
+        ensureYamlListed();
+        drainAllYamlLoaders();
+    }
+
+    private void ensureScanned() {
+        ensureClassesScanned();
+        ensureYamlScanned();
+    }
+
+    // ---- Package-private introspection for tests ----
+
+    boolean classScanTriggered() {
+        return performClassScan == null;
+    }
+
+    boolean yamlListingTriggered() {
+        return performYamlListing == null;
+    }
+
+    int yamlLoadersDrained() {
+        return yamlScanIndex;
+    }
+
+    int yamlLoadersListed() {
+        return yamlResourceLoaders.size();
     }
 
     @Override
@@ -589,19 +694,22 @@ public class ClasspathScanningLoader implements ResourceLoader {
 
     @Override
     public Collection<CategoryDescriptor> listCategoryDescriptors() {
-        ensureScanned();
+        // Categories come from YAML only; no need to walk class bytecode.
+        ensureYamlScanned();
         return categoryDescriptors;
     }
 
     @Override
     public Collection<NamedStyles> listStyles() {
+        // Styles can come from either imperative classes or YAML, so both phases are needed.
         ensureScanned();
         return styles;
     }
 
     @Override
     public Map<String, List<RecipeExample>> listRecipeExamples() {
-        ensureScanned();
+        // Examples are a YAML-only concept; the class scan does not populate this map.
+        ensureYamlScanned();
         return recipeExamples;
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -38,7 +38,6 @@ import static java.util.Comparator.comparingInt;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
-import static org.openrewrite.config.ResourceLoader.RecipeDetail.EXAMPLES;
 
 public class Environment {
     private final Collection<? extends ResourceLoader> resourceLoaders;
@@ -130,7 +129,7 @@ public class Environment {
         if (activeRecipes.isEmpty()) {
             recipes = emptyList();
         } else if (activeRecipes.size() == 1) {
-            Recipe recipe = loadRecipe(activeRecipes.iterator().next(), EXAMPLES);
+            Recipe recipe = loadRecipe(activeRecipes.iterator().next());
             if (recipe != null) {
                 return recipe;
             }

--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -204,29 +204,30 @@ public class Environment {
             }
         }
 
-        Map<String, Recipe> nameToRecipe = new HashMap<>();
-        for (ResourceLoader dependencyResourceLoader : dependencyResourceLoaders) {
-            for (Recipe listedRecipe : dependencyResourceLoader.listRecipes()) {
-                nameToRecipe.putIfAbsent(listedRecipe.getName(), listedRecipe);
-            }
-        }
-        for (Recipe dependency : nameToRecipe.values()) {
-            if (dependency instanceof DeclarativeRecipe) {
-                ((DeclarativeRecipe) dependency).initialize(nameToRecipe::get);
-            }
-        }
-
         if (includeExamples && recipeExamples.containsKey(recipe.getName())) {
             recipe.setExamples(recipeExamples.get(recipe.getName()));
         }
 
         if (recipe instanceof DeclarativeRecipe) {
+            Map<String, Recipe> nameToRecipe = new HashMap<>();
             Function<String, @Nullable Recipe> loadFunction = new Function<String, Recipe>() {
                 @Override
                 public @Nullable Recipe apply(String key) {
                     Recipe cached = nameToRecipe.get(key);
                     if (cached != null) {
                         return cached;
+                    }
+
+                    // Dependencies first to preserve "deps win on name conflicts" priority.
+                    for (ResourceLoader dependencyResourceLoader : dependencyResourceLoaders) {
+                        Recipe r = dependencyResourceLoader.loadRecipe(key, details);
+                        if (r != null) {
+                            nameToRecipe.put(key, r);
+                            if (r instanceof DeclarativeRecipe) {
+                                ((DeclarativeRecipe) r).initialize(this);
+                            }
+                            return r;
+                        }
                     }
 
                     for (ResourceLoader resourceLoader : resourceLoaders) {

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -225,7 +225,8 @@ public class YamlResourceLoader implements ResourceLoader {
             if (!recipeResource.containsKey("name") || !recipeName.equals(recipeResource.get("name"))) {
                 continue;
             }
-            return mapToRecipe(recipeResource, EnumSet.copyOf(Arrays.asList(details)));
+            return mapToRecipe(recipeResource,
+                    details.length == 0 ? EnumSet.noneOf(RecipeDetail.class) : EnumSet.copyOf(Arrays.asList(details)));
         }
         try {
             return recipeLoader.apply(recipeName, null);

--- a/rewrite-core/src/test/java/org/openrewrite/config/ClasspathScanningLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/ClasspathScanningLoaderTest.java
@@ -123,4 +123,82 @@ class ClasspathScanningLoaderTest {
                 .contains(AbstractRecipeFixtures.ConcreteRecipe.class.getName())
                 .doesNotContain(AbstractRecipeFixtures.AbstractlyMarkedRecipe.class.getName());
     }
+
+    @Test
+    void singleImperativeRecipeActivationDoesNotScan() {
+        ClasspathScanningLoader loader = new ClasspathScanningLoader(
+                new Properties(),
+                new String[]{AbstractRecipeFixtures.class.getPackageName()});
+        Environment env = new Environment(List.of(loader));
+
+        Recipe recipe = env.activateRecipes(AbstractRecipeFixtures.ConcreteRecipe.class.getName());
+
+        assertThat(recipe.getName()).isEqualTo(AbstractRecipeFixtures.ConcreteRecipe.class.getName());
+        // Neither the class hierarchy walk nor the YAML enumeration should have run.
+        assertThat(loader.classScanTriggered()).isFalse();
+        assertThat(loader.yamlListingTriggered()).isFalse();
+    }
+
+    @Test
+    void singleDeclarativeRecipeActivationDoesNotScanClasses(@TempDir Path tempDir) throws Exception {
+        Path resourcesDir = tempDir.resolve("resources");
+        Path metaInf = resourcesDir.resolve("META-INF/rewrite");
+        Files.createDirectories(metaInf);
+        Files.writeString(metaInf.resolve("recipe.yml"),
+                """
+                type: specs.openrewrite.org/v1beta/recipe
+                name: com.example.DeclarativeRecipe
+                displayName: Declarative
+                description: A declarative recipe.
+                recipeList:
+                  - org.openrewrite.text.ChangeText:
+                      toText: hello
+                """);
+        ClassLoader cl = new URLClassLoader(new URL[]{resourcesDir.toUri().toURL()}, Recipe.class.getClassLoader());
+        ClasspathScanningLoader loader = new ClasspathScanningLoader(
+                resourcesDir, new Properties(), List.of(), cl);
+        Environment env = new Environment(List.of(loader));
+
+        Recipe recipe = env.activateRecipes("com.example.DeclarativeRecipe");
+
+        assertThat(recipe.getName()).isEqualTo("com.example.DeclarativeRecipe");
+        // YAML listing necessarily happened (the recipe is declarative), but the
+        // class hierarchy walk should still be deferred.
+        assertThat(loader.classScanTriggered()).isFalse();
+        assertThat(loader.yamlListingTriggered()).isTrue();
+    }
+
+    @Test
+    void singleDeclarativeRecipeActivationDrainsOnlyUntilFirstMatch(@TempDir Path tempDir) throws Exception {
+        Path resourcesDir = tempDir.resolve("resources");
+        Path metaInf = resourcesDir.resolve("META-INF/rewrite");
+        Files.createDirectories(metaInf);
+        // Three YAML files, each defining the same recipe (with the same body). The
+        // progressive scan only needs to parse one of them to satisfy the lookup —
+        // it should not drain the remaining loaders regardless of file walk order.
+        String yaml = """
+                type: specs.openrewrite.org/v1beta/recipe
+                name: com.example.SharedRecipe
+                displayName: Shared
+                description: Shared recipe.
+                recipeList:
+                  - org.openrewrite.text.ChangeText:
+                      toText: shared
+                """;
+        Files.writeString(metaInf.resolve("aaa.yml"), yaml);
+        Files.writeString(metaInf.resolve("mmm.yml"), yaml);
+        Files.writeString(metaInf.resolve("zzz.yml"), yaml);
+        ClassLoader cl = new URLClassLoader(new URL[]{resourcesDir.toUri().toURL()}, Recipe.class.getClassLoader());
+        ClasspathScanningLoader loader = new ClasspathScanningLoader(
+                resourcesDir, new Properties(), List.of(), cl);
+        Environment env = new Environment(List.of(loader));
+
+        Recipe recipe = env.activateRecipes("com.example.SharedRecipe");
+
+        assertThat(recipe.getName()).isEqualTo("com.example.SharedRecipe");
+        assertThat(loader.yamlLoadersListed()).isEqualTo(3);
+        // Exactly one loader was drained — the short-circuit stopped iterating once
+        // the recipe turned up in the shared map.
+        assertThat(loader.yamlLoadersDrained()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
## Motivation

`Environment.activateRecipes(name)` is on the hot path of CLI startup. Wall-clock
profiling of `mod run --recipe=org.openrewrite.java.testing.assertj.Assertj`
(declarative recipe with 888 sub-recipes) showed the prepare() window takes
~2.5 s on the first repo, broken down as:

- ~1 s walking class bytecode to build a `className → superClassName` map for
  `isSubclassOf(name, Recipe)` filtering (78% of which is `Inflater.inflate` on
  class file bodies).
- ~870 ms instantiating every Recipe subclass found by the scan.
- ~520 ms parsing every YAML file in the bundle.

For a single-recipe activation almost none of that work is needed: only the
requested recipe and the YAML files transitively referenced by its `recipeList`
have to be touched.

## Summary

- Drop the `EXAMPLES` `RecipeDetail` from the single-recipe call site in
  `Environment.activateRecipes` so YAML example loading is skipped.
- Replace the eager `Map<String, Recipe> nameToRecipe` build over every
  `dependencyResourceLoader.listRecipes()` in `Environment.loadRecipe` with a
  lazy `Function<String, Recipe>` that searches dependency loaders by name on
  demand (deps still consulted first to preserve "deps win on name conflicts").
- Split `ClasspathScanningLoader.ensureScanned()` into independently triggerable
  `ensureClassesScanned()` and `ensureYamlScanned()` phases.
- `loadRecipe(name)` now tries an imperative fast path (`recipeLoader.load`),
  then progressively drains YAML loaders one at a time until either the recipe
  turns up in the shared map or every loader has been parsed.
- `listCategoryDescriptors` and `listRecipeExamples` are wired to the YAML phase
  only — no class scan needed for YAML-only data.
- `YamlResourceLoader.loadRecipe` no longer throws `IllegalArgumentException`
  on empty `RecipeDetail` varargs (exposed by dropping `EXAMPLES`).

Multi-recipe activation (`activateRecipes(Collection)` with more than one
entry) still goes through `listRecipes()` and is unchanged.

## Behavior changes

- Single-recipe activation returns a recipe with empty `getExamples()`; the
  multi-recipe path still attaches them. Affects marketplace `describe()`.
- Dependency declarative recipes can now resolve sub-recipes from primary
  `resourceLoaders` (previously sandboxed to deps).
- Dependency declaratives are loaded without `MAINTAINERS` detail on the
  activation path; `listRecipeDescriptors()` still surfaces maintainers via the
  full-descriptor flow.
- For duplicate recipe names across YAML files: progressive `loadRecipe`
  returns first-wins while a subsequent `listRecipes()` overwrites with
  last-wins (pre-PR was last-wins everywhere).

## Test plan

- [x] `./gradlew :rewrite-core:test` passes
- [x] `./gradlew :rewrite-java:test` passes
- [x] New tests in `ClasspathScanningLoaderTest`:
  - `singleImperativeRecipeActivationDoesNotScan` — single imperative
    activation triggers neither class scan nor YAML enumeration.
  - `singleDeclarativeRecipeActivationDoesNotScanClasses` — single declarative
    activation triggers YAML listing but not class scan.
  - `singleDeclarativeRecipeActivationDrainsOnlyUntilFirstMatch` — progressive
    scan stops at first YAML file containing the recipe.