### PR TITLE
Scala: fix parsing of curried constructor calls

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -1838,18 +1838,20 @@ class ScalaTreeVisitor(
   }
   
   private def visitNewClassWithArgs(newTree: Trees.New[?], app: Trees.Apply[?]): J = {
-    // The Apply node has the full span including "new", use its prefix
-    val prefix = extractPrefix(app.span)
-    
-    // Extract space between "new" and the type
-    // First, consume "new" keyword
-    val newPos = positionOfNext("new")
-    if (newPos >= 0 && newPos == cursor) {
-      cursor += 3 // Move past "new"
-    }
-    
-    // Extract space between "new" and type
+    // For curried constructor calls `new Foo(a)(b)`, the inner `Apply(Select(New(Foo), <init>), List(a))`
+    // has a span starting at `Foo` rather than `new`. Locate the `new` keyword explicitly so we don't
+    // swallow it as the NewClass prefix.
     val typeStart = Math.max(0, newTree.tpt.span.start - offsetAdjustment)
+    val newPos = positionOfNext("new")
+    val prefix = if (newPos >= cursor && newPos < typeStart) {
+      val spaceBeforeNew = if (newPos > cursor) Space.format(source, cursor, newPos) else Space.EMPTY
+      cursor = newPos + 3 // Move past "new"
+      spaceBeforeNew
+    } else {
+      extractPrefix(app.span)
+    }
+
+    // Extract space between "new" and type
     val typeSpace = if (cursor < typeStart && typeStart <= source.length) {
       val spaceStr = source.substring(cursor, typeStart)
       cursor = typeStart

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/NewClassTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/NewClassTest.java
@@ -296,4 +296,27 @@ class NewClassTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void curriedNewClass() {
+        rewriteRun(
+          scala(
+            """
+            val x = new Foo(a)(b)
+            """
+          )
+        );
+    }
+
+    @Test
+    void curriedNewClassAsDefBody() {
+        rewriteRun(
+          scala(
+            """
+            def make: Foo =
+              new Foo(0)(f)
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Scala: fix parsing of curried constructor calls, e.g. `new Foo(a)(b)`

## What's your motivation?

They suffer from idempotency issues.