### PR TITLE
Gradle: sync `version { strictly(...) }` constraints when upgrading dependencies

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleDependency.java
@@ -1375,6 +1375,28 @@ public class GradleDependency implements Trait<J.MethodInvocation> {
             }
         }
 
+        // Sync rich version constraints inside any trailing `version { ... }` closure
+        // so that calls like `strictly(...)`, `require(...)`, `prefer(...)` reference the new version.
+        J.MethodInvocation withSyncedConstraints = (J.MethodInvocation) new JavaVisitor<Integer>() {
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, Integer i) {
+                J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, i);
+                String name = mi.getSimpleName();
+                if (("strictly".equals(name) || "require".equals(name) || "prefer".equals(name)) &&
+                        withinBlock(getCursor(), "version")) {
+                    return mi.withArguments(ListUtils.map(mi.getArguments(), arg ->
+                            arg instanceof J.Literal ?
+                                    ChangeStringLiteral.withStringValue((J.Literal) arg, newVersion) :
+                                    arg));
+                }
+                return mi;
+            }
+        }.visitNonNull(updated, 0);
+
+        if (withSyncedConstraints != updated) {
+            updated = withSyncedConstraints;
+        }
+
         return updated == m ? this : new GradleDependency(new Cursor(cursor.getParent(), updated), resolvedDependency);
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -2928,4 +2928,162 @@ class UpgradeDependencyVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void upgradesStrictlyVersionConstraintInClosure() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  implementation('com.google.guava:guava:29.0-jre') {
+                      version { strictly('29.0-jre') }
+                  }
+              }
+              """,
+            """
+              plugins {
+                id 'java-library'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  implementation('com.google.guava:guava:30.1.1-jre') {
+                      version { strictly('30.1.1-jre') }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void upgradesRequireAndPreferVersionConstraintsInClosure() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  implementation('com.google.guava:guava:29.0-jre') {
+                      version {
+                          require('29.0-jre')
+                          prefer('29.0-jre')
+                      }
+                  }
+              }
+              """,
+            """
+              plugins {
+                id 'java-library'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  implementation('com.google.guava:guava:30.1.1-jre') {
+                      version {
+                          require('30.1.1-jre')
+                          prefer('30.1.1-jre')
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void upgradesStrictlyVersionConstraintInClosureWithMultiComponentNotation() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  implementation(group: 'com.google.guava', name: 'guava', version: '29.0-jre') {
+                      version { strictly('29.0-jre') }
+                  }
+              }
+              """,
+            """
+              plugins {
+                id 'java-library'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  implementation(group: 'com.google.guava', name: 'guava', version: '30.1.1-jre') {
+                      version { strictly('30.1.1-jre') }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void upgradesStrictlyVersionConstraintInKotlinClosure() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              plugins {
+                  `java-library`
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  implementation("com.google.guava:guava:29.0-jre") {
+                      version { strictly("29.0-jre") }
+                  }
+              }
+              """,
+            """
+              plugins {
+                  `java-library`
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  implementation("com.google.guava:guava:30.1.1-jre") {
+                      version { strictly("30.1.1-jre") }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotTouchConstraintsOnUnrelatedDependencies() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  implementation('com.google.guava:guava:29.0-jre')
+                  implementation('org.openrewrite:rewrite-core:8.0.0') {
+                      version { strictly('8.0.0') }
+                  }
+              }
+              """,
+            """
+              plugins {
+                id 'java-library'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  implementation('com.google.guava:guava:30.1.1-jre')
+                  implementation('org.openrewrite:rewrite-core:8.0.0') {
+                      version { strictly('8.0.0') }
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `UpgradeDependencyVersion` (and any other caller of `GradleDependency.withDeclaredVersion`) updated only the outer dependency notation. Any rich version constraint inside the trailing configuration closure — `version { strictly('…') }`, `require('…')`, or `prefer('…')` — kept pointing at the old version, producing Gradle resolution conflicts:

  ```gradle
  implementation('org.springframework:spring-context:6.2.18') {
      version { strictly('5.3.18') }  // ← left at old version
  }
  ```

- Extend `GradleDependency.withDeclaredVersion` to walk the resulting `J.MethodInvocation` and rewrite the literal argument of any `strictly` / `require` / `prefer` call whose cursor is enclosed by a `version { }` block. The check reuses the existing `withinBlock(cursor, "version")` helper and `ChangeStringLiteral.withStringValue` to stay consistent with the rest of the trait.

- `reject(...)` is intentionally left untouched — it lists versions to *exclude*, so auto-rewriting to the new target is not safe.

- Fixes [moderneinc/customer-requests#2454](https://github.com/moderneinc/customer-requests/issues/2454) (TIAA).

## Test plan

- [x] New tests in `UpgradeDependencyVersionTest`:
  - [x] `strictly` constraint in a Groovy DSL closure
  - [x] `require` + `prefer` constraints in a Groovy DSL closure
  - [x] multi-component `group:/name:/version:` notation with `strictly`
  - [x] Kotlin DSL with `strictly`
  - [x] negative: unrelated dependency's `strictly` block left alone
- [x] `./gradlew :rewrite-gradle:test` — BUILD SUCCESSFUL, no regressions.