### PR TITLE
Fix main CI: exclude build-time gradle-api jar from tooling-API test manifest

### DIFF
--- a/rewrite-gradle-tooling-model/model/build.gradle.kts
+++ b/rewrite-gradle-tooling-model/model/build.gradle.kts
@@ -67,7 +67,17 @@ val testManifestTask = tasks.register("testManifest") {
     inputs.files(pluginLocalTestClasspath)
     outputs.file(testManifestFile)
     doLast {
-        testManifestFile.get().asFile.writeText(pluginLocalTestClasspath.files.joinToString(separator = "\n") { it.absolutePath })
+        testManifestFile.get().asFile.writeText(
+            pluginLocalTestClasspath.files
+                // Exclude the build's own gradle-api jar (under "generated-gradle-jars"). It leaks in
+                // via `implementation(gradleApi())` on the plugin, but the embedded Gradle build that
+                // applies the plugin already provides its own Gradle API to init scripts. Injecting the
+                // build-time Gradle's gradle-api into an older embedded Gradle's initscript classpath
+                // breaks classpath instrumentation when the two target different Java bytecode versions
+                // (e.g. Gradle 9.5's gradle-api has Java 25 / v69 classes the embedded Gradle can't read).
+                .filter { !it.absolutePath.contains("generated-gradle-jars") }
+                .joinToString(separator = "\n") { it.absolutePath }
+        )
     }
 }
 


### PR DESCRIPTION
## Problem

Main CI broke after the `Update Gradle wrapper 9.5.1` commit (ecc0c6932). `AddDependencyGradle9CatalogTest` fails in `:rewrite-gradle:test` with:

```
org.gradle.api.internal.artifacts.transform.TransformException: Execution failed for
InstrumentationAnalysisTransform: .../caches/9.5.1/generated-gradle-jars/gradle-api-9.5.1.jar
  Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 69
```

(Failing [run](https://github.com/openrewrite/rewrite/actions/runs/26598832665/job/78376854623).)

## Root cause

Gradle 9.5.1's `gradle-api` jar contains Java 25 (major version 69) bytecode. The tooling-API tests write the plugin's full runtime classpath into `test-manifest.txt` and inject it into an **embedded, older Gradle** build's init-script classpath (the tests spin up Gradle 8.14.3 / 9.0.0 via the Tooling API). Because the plugin declares `implementation(gradleApi())`, the build-time Gradle's `gradle-api-9.5.1.jar` leaks into that manifest. The embedded older Gradle then runs classpath instrumentation (ASM) over it and cannot read v69 classes.

This only surfaced now because the previous wrapper (9.3.1) shipped a `gradle-api` jar with bytecode the embedded Gradle could still instrument.

## Fix

Exclude the build's own `gradle-api` jar (under `generated-gradle-jars`) when writing the test manifest. The embedded Gradle build already provides its own Gradle API to init scripts — matching how the plugin resolves in production, where `gradleApi()` is never on the published classpath — so removing it is both safe and more correct.

## Verification

- `./gradlew :rewrite-gradle:test --tests "org.openrewrite.gradle.AddDependencyGradle9CatalogTest"` → BUILD SUCCESSFUL
- `./gradlew :rewrite-gradle-tooling-model:model:test` → BUILD SUCCESSFUL