### PR TITLE
Go: Fix `nil` directive slices in `go.mod` producer

### DIFF
--- a/rewrite-go/pkg/parser/gomod_parser.go
+++ b/rewrite-go/pkg/parser/gomod_parser.go
@@ -107,7 +107,11 @@ var goSumLine = regexp.MustCompile(`^\s*(\S+)\s+(\S+?)(/go\.mod)?\s+h1:(\S+)\s*$
 // RPC where sources are passed as strings.
 func ParseGoSum(content string) []tree.GoResolvedDependency {
 	if content == "" {
-		return nil
+		// Return a non-nil empty slice: callers assign this directly to
+		// GoResolutionResult.ResolvedDependencies, and a nil slice would be
+		// serialized as a null list and break the LST write (see
+		// tree.NewGoResolutionResult).
+		return []tree.GoResolvedDependency{}
 	}
 	type slot struct{ module, gomod string }
 	order := []string{}

--- a/rewrite-go/pkg/tree/go_resolution_result.go
+++ b/rewrite-go/pkg/tree/go_resolution_result.go
@@ -97,12 +97,23 @@ type GoResolvedDependency struct {
 }
 
 // NewGoResolutionResult creates a GoResolutionResult marker with a fresh UUID.
+//
+// The directive slices are initialized to empty (non-nil) values. Go has no
+// way to declare a slice non-nullable at the type level, so this constructor is
+// the single chokepoint that guarantees it: a nil slice would be serialized by
+// the RPC send codec as a null list, which the Java receive side stores as a
+// null field and the Moderne reflective binary LST serializer then NPEs on.
 func NewGoResolutionResult(modulePath, goVersion, toolchain, path string) GoResolutionResult {
 	return GoResolutionResult{
-		Ident:      uuid.New(),
-		ModulePath: modulePath,
-		GoVersion:  goVersion,
-		Toolchain:  toolchain,
-		Path:       path,
+		Ident:                uuid.New(),
+		ModulePath:           modulePath,
+		GoVersion:            goVersion,
+		Toolchain:            toolchain,
+		Path:                 path,
+		Requires:             []GoRequire{},
+		Replaces:             []GoReplace{},
+		Excludes:             []GoExclude{},
+		Retracts:             []GoRetract{},
+		ResolvedDependencies: []GoResolvedDependency{},
 	}
 }

--- a/rewrite-go/test/gomod_parser_test.go
+++ b/rewrite-go/test/gomod_parser_test.go
@@ -165,8 +165,15 @@ github.com/c/d v2.0.0 h1:hashC=
 }
 
 func TestParseGoSumEmptyInput(t *testing.T) {
-	if got := parser.ParseGoSum(""); got != nil {
-		t.Errorf("want nil for empty input, got %+v", got)
+	// Empty input must yield a non-nil empty slice: callers assign the result
+	// directly to GoResolutionResult.ResolvedDependencies, and a nil slice
+	// would be serialized as a null list and break the LST write.
+	got := parser.ParseGoSum("")
+	if got == nil {
+		t.Error("want non-nil empty slice for empty input, got nil")
+	}
+	if len(got) != 0 {
+		t.Errorf("want empty slice for empty input, got %+v", got)
 	}
 }
 
@@ -210,5 +217,57 @@ func TestGoProjectMergesGoSumIntoGoModMarker(t *testing.T) {
 	}
 	if rd.ModuleHash == "" || rd.GoModHash == "" {
 		t.Errorf("expected both ModuleHash and GoModHash populated: %+v", rd)
+	}
+}
+
+// TestParseGoModDirectiveListsNeverNil guards the root cause of the Moderne CLI
+// Go build LST serialization failure: a go.mod that omits a directive must still
+// yield non-nil (empty) slices. The RPC send codec serializes a nil slice as a
+// null list, which the Java receive side stores as a null field, and the Moderne
+// reflective binary LST serializer then NPEs calling items.size() on it.
+func TestParseGoModDirectiveListsNeverNil(t *testing.T) {
+	mrr, err := parser.ParseGoMod("go.mod", "module example.com/foo\n\ngo 1.22\n")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if mrr.Requires == nil {
+		t.Error("Requires is nil; want non-nil empty slice")
+	}
+	if mrr.Replaces == nil {
+		t.Error("Replaces is nil; want non-nil empty slice")
+	}
+	if mrr.Excludes == nil {
+		t.Error("Excludes is nil; want non-nil empty slice")
+	}
+	if mrr.Retracts == nil {
+		t.Error("Retracts is nil; want non-nil empty slice")
+	}
+	if mrr.ResolvedDependencies == nil {
+		t.Error("ResolvedDependencies is nil; want non-nil empty slice")
+	}
+}
+
+// TestParseGoModRequireButNoReplace covers the gin/cobra/zap failure shape: a
+// require block is present but replace/exclude/retract/resolved are absent and
+// must still be non-nil empty slices.
+func TestParseGoModRequireButNoReplace(t *testing.T) {
+	mrr, err := parser.ParseGoMod("go.mod", "module example.com/foo\n\ngo 1.22\n\nrequire github.com/x/y v1.2.3\n")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if len(mrr.Requires) != 1 {
+		t.Fatalf("Requires len: want 1, got %d", len(mrr.Requires))
+	}
+	if mrr.Replaces == nil {
+		t.Error("Replaces is nil; want non-nil empty slice")
+	}
+	if mrr.Excludes == nil {
+		t.Error("Excludes is nil; want non-nil empty slice")
+	}
+	if mrr.Retracts == nil {
+		t.Error("Retracts is nil; want non-nil empty slice")
+	}
+	if mrr.ResolvedDependencies == nil {
+		t.Error("ResolvedDependencies is nil; want non-nil empty slice")
 	}
 }


### PR DESCRIPTION
## Motivation

Every Go module's LST failed to serialize when built via the Moderne CLI Go build step. Any repo containing a `go.mod` that omits a directive (e.g. only `module` + `go`, no `require`/`replace`) crashed the LST write:

```
java.lang.IllegalStateException: Failed writing field "replaces" (kind=POJO_LIST, nullable=false) of type "org.openrewrite.golang.marker.GoResolutionResult": value=null
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.List.size()" because "items" is null
```

The reported field varied (`requires`, `replaces`, …) — it's just whichever non-`@Nullable` list the reflective serializer reached first while still null.

The `GoResolutionResult` marker is produced **in Go**. `NewGoResolutionResult` left the five directive slices (`requires`, `replaces`, `excludes`, `retracts`, `resolvedDependencies`) as their zero value (`nil`), and `ParseGoMod` only `append`s when a directive is present, so any omitted directive stayed `nil`. `ResolvedDependencies` was set only when a sibling `go.sum` was read, and `ParseGoSum("")` returned `nil`. The RPC send codec faithfully serializes a `nil` slice as a null list, which the Java receive side stores as a null field, and the Moderne reflective binary LST serializer then NPEs calling `items.size()` on it.

Go has no way to declare a slice non-nullable at the type level, so the fix is applied at the source — the single construction chokepoint — rather than coalescing in the codec (which would mask the problem) or annotating the Java fields `@Nullable` (which pushes null checks onto every consumer; `findRequire`/`findResolved` iterate these lists without null guards).

The sibling markers were checked: `NodeResolutionResult`'s TypeScript producer already emits `[]` for every list, and `PythonResolutionResult` is only ever built Java-side with `Collections.emptyList()`/non-null lists — so neither actually manifests this bug, and both are left untouched.

## Summary

- `NewGoResolutionResult` now initializes all five directive slices to empty (non-nil) values.
- `ParseGoSum` returns an empty slice instead of `nil` for empty input, so assigning it to `ResolvedDependencies` can't reintroduce `nil`.

## Test plan

- [x] New `TestParseGoModDirectiveListsNeverNil` — go.mod with only `module` + `go` yields non-nil empty lists (the `google/uuid` shape).
- [x] New `TestParseGoModRequireButNoReplace` — require present, other directives absent, all non-nil empty (the `gin`/`cobra`/`zap` shape).
- [x] Updated `TestParseGoSumEmptyInput` — corrected the contract from `nil` to non-nil empty.
- [x] Full `rewrite-go` Go test suite green (`go test ./...`).