### PR TITLE
Go: send `dimensionsAfterName` in `MethodDeclaration` RPC codec

### DIFF
--- a/rewrite-go/pkg/rpc/java_receiver.go
+++ b/rewrite-go/pkg/rpc/java_receiver.go
@@ -343,6 +343,8 @@ func (r *JavaReceiver) VisitMethodDeclaration(md *tree.MethodDeclaration, p any)
 	if result := q.Receive(md.Parameters, func(v any) any { return receiveContainerAs(r, q, v, ContainerStatement) }); result != nil {
 		md.Parameters = result.(tree.Container[tree.Statement])
 	}
+	// dimensionsAfterName (empty for Go — no C-style array method returns)
+	q.ReceiveList(nil, nil)
 	// throws
 	q.Receive(nil, nil)
 	// body

--- a/rewrite-go/pkg/rpc/java_sender.go
+++ b/rewrite-go/pkg/rpc/java_sender.go
@@ -252,7 +252,7 @@ func (s *JavaSender) VisitMethodDeclaration(md *tree.MethodDeclaration, p any) t
 	q := p.(*SendQueue)
 	// Go's MethodDeclaration maps to parts of Java's MethodDeclaration
 	// Java sends: leadingAnnotations, modifiers, typeParameters, returnTypeExpression,
-	//   name annotations, name, parameters, throws, body, defaultValue, methodType
+	//   name annotations, name, parameters, dimensionsAfterName, throws, body, defaultValue, methodType
 	// Go: receiver, name, parameters, returnType, body, methodType
 
 	// leadingAnnotations (`//go:` directives modeled as J.Annotation)
@@ -282,6 +282,8 @@ func (s *JavaSender) VisitMethodDeclaration(md *tree.MethodDeclaration, p any) t
 	// parameters (container)
 	q.GetAndSend(md, func(v any) any { return v.(*tree.MethodDeclaration).Parameters },
 		func(v any) { sendContainer(s, v, q) })
+	// dimensionsAfterName (empty for Go — no C-style array method returns)
+	q.GetAndSendList(md, func(_ any) []any { return nil }, func(_ any) any { return nil }, nil)
 	// throws (nil for Go)
 	q.GetAndSend(md, func(_ any) any { return nil }, nil)
 	// body

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangParserIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangParserIntegTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.golang.tree.Go;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.openrewrite.test.TypeValidation;
@@ -28,6 +30,7 @@ import org.openrewrite.test.TypeValidation;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.openrewrite.golang.Assertions.expectMethodType;
 import static org.openrewrite.golang.Assertions.expectType;
@@ -131,6 +134,48 @@ class GolangParserIntegTest implements RewriteTest {
                                 }
                                 """,
                         spec -> spec.afterRecipe(cu -> expectType(cu, "p", "main.Point"))
+                )
+        );
+    }
+
+    /**
+     * Regression test for the {@code dimensionsAfterName} field added to
+     * {@code J.MethodDeclaration} in #6992. The Go RPC sender/receiver originally
+     * omitted this left-padded list (positioned between {@code parameters} and
+     * {@code throws}), desyncing the RPC stream by one field for every method
+     * declaration. The symptom was a {@code ClassCastException: J$Block cannot be
+     * cast to JContainer} in {@code JavaReceiver.visitMethodDeclaration}, which
+     * broke parsing of <em>any</em> Go source containing a function — not just
+     * C-style arrays (which don't exist in Go). This asserts a plain method
+     * declaration round-trips with its parameters and body intact.
+     */
+    @Test
+    void methodDeclarationRoundTrips() {
+        rewriteRun(
+                go(
+                        """
+                                package main
+
+                                func add(a int, b int) int {
+                                \treturn a + b
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            J.MethodDeclaration method = new JavaIsoVisitor<AtomicReference<J.MethodDeclaration>>() {
+                                @Override
+                                public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration m, AtomicReference<J.MethodDeclaration> found) {
+                                    if ("add".equals(m.getSimpleName())) {
+                                        found.set(m);
+                                    }
+                                    return super.visitMethodDeclaration(m, found);
+                                }
+                            }.reduce(cu, new AtomicReference<J.MethodDeclaration>()).get();
+
+                            assertThat(method).as("method declaration 'add' should be present").isNotNull();
+                            assertThat(method.getParameters()).as("parameters should survive the round-trip").hasSize(2);
+                            assertThat(method.getBody()).as("body should be a J.Block, not a desynced field").isNotNull();
+                            assertThat(method.getReturnTypeExpression()).as("return type should survive the round-trip").isNotNull();
+                        })
                 )
         );
     }


### PR DESCRIPTION
## Motivation

- PR #6992 added a `dimensionsAfterName` left-padded list to the RPC contract of `J.MethodDeclaration`, positioned in the stream **between `parameters` and `throws`**. That PR propagated the new field to the Java, JavaScript, Python, and C# RPC layers — but missed **rewrite-go**.

Because Go's `JavaSender`/`JavaReceiver` use a strictly positional protocol (they emit nil/empty placeholders for every Java-only field they don't model, e.g. `typeParameters`, `modifiers`, `throws`, `defaultValue`), omitting `dimensionsAfterName` desynced the stream by one field for **every** method declaration. The Java side then read the method `body` where it expected the `throws` container:

```
ClassCastException: class org.openrewrite.java.tree.J$Block cannot be cast to
class org.openrewrite.java.tree.JContainer
    at org.openrewrite.java.internal.rpc.JavaReceiver.visitMethodDeclaration(JavaReceiver.java:375)
```

This broke parsing of **any** Go source containing a function over RPC — not just the C-style array method returns the field was introduced for (which don't exist in Go syntax at all).

Go does not — and should not — model C-style array method returns, so the fix is purely in the codec: send an empty list / receive-and-discard at the correct stream position. No Go LST model change is required, matching how the other Java-only fields are already handled.

## Summary

- `rewrite-go/pkg/rpc/java_sender.go`: emit the `dimensionsAfterName` (empty list) placeholder between `parameters` and `throws` in `VisitMethodDeclaration`; fix the stale field-order comment.
- `rewrite-go/pkg/rpc/java_receiver.go`: receive-and-discard `dimensionsAfterName` between `parameters` and `throws` in `VisitMethodDeclaration`.
- `GolangParserIntegTest`: add `methodDeclarationRoundTrips`, a focused regression test asserting a plain method declaration round-trips through RPC with its parameters, body, and return type intact.

### Audit of the other language RPC implementations

- While here I audited every non-Java LST RPC implementation for the same field on both `J.MethodDeclaration` and `J.VariableDeclarations.NamedVariable`. All others were already correct (handled by #6992):

| Language | Method (sender / receiver) | NamedVariable | Status |
|----------|----------------------------|---------------|--------|
| Groovy / Kotlin | shared `JavaSender`/`JavaReceiver` + `J.java` | shared | ✅ auto |
| JavaScript / TypeScript | `rpc.ts` | `rpc.ts` | ✅ |
| C# | `JavaSender.cs` / `JavaReceiver.cs` | ✅ | ✅ |
| Python | `python_sender.py` / `python_receiver.py` | ✅ | ✅ |
| **Go** | **was missing on method** | already correct | ✅ fixed here |

- `dimensionsAfterName` is also the most recent field added to `JavaSender`/`JavaReceiver` (`git log` confirms #6992 is the latest change to those files), so no other recently-added field has an unpropagated gap.

## Test plan

- [x] `./gradlew :rewrite-go:integTest --tests "org.openrewrite.golang.rpc.GolangParserIntegTest"` — run via Gradle so `goBuild` rebuilds `build/rewrite-go-rpc` fresh (stale binaries mask the desync). **25/25 pass, 0 skipped.**
- [x] Confirmed the fix is load-bearing: reverting just the two codec files and rebuilding reproduces the exact `J$Block cannot be cast to JContainer` desync at `JavaReceiver.visitMethodDeclaration:375`; restoring the fix makes all tests pass.