### PR TITLE
Go: break import cycles in `ProjectImporter` to fix stack overflow

### DIFF
--- a/rewrite-go/pkg/parser/project_importer.go
+++ b/rewrite-go/pkg/parser/project_importer.go
@@ -295,12 +295,28 @@ func (p *ProjectImporter) parsePackage(importPath string, files []projectFile) (
 		Defs: make(map[*ast.Ident]types.Object),
 		Uses: make(map[*ast.Ident]types.Object),
 	}
-	// types.Config.Check's first argument becomes the resulting package's
-	// Path() — e.g. "github.com/x/y". This MUST be the full import path,
-	// not just the package name, because mapType sets a method's
-	// DeclaringType.FullyQualifiedName from pkg.Path() at type-mapping
-	// time. With "y" alone, vendored fmt-like methods would resolve to
-	// FQN "y" instead of "github.com/x/y".
-	pkg, _ := conf.Check(importPath, p.fset, asts, info)
+	// The package's Path() — here the full import path, e.g. "github.com/x/y"
+	// — MUST be the full import path, not just the package name, because
+	// mapType sets a method's DeclaringType.FullyQualifiedName from pkg.Path()
+	// at type-mapping time. With "y" alone, vendored fmt-like methods would
+	// resolve to FQN "y" instead of "github.com/x/y".
+	//
+	// Forward-declare the package in the cache BEFORE type-checking it. This
+	// is the standard go/types cycle-breaking pattern: type-checking calls
+	// back into Import for every dependency, so an import cycle
+	// (a -> b -> ... -> a, common in deep graphs like entgo.io/ent) would
+	// otherwise re-enter parsePackage for a path not yet in the cache and
+	// recurse until the goroutine stack overflows. Registering the
+	// not-yet-complete package up front lets the cycle resolve to it on
+	// re-entry instead; go/types tolerates importing an incomplete package
+	// for cycle resolution and completes it once Files returns.
+	//
+	// conf.Check(importPath, ...) is itself exactly NewPackage + NewChecker +
+	// Files; we spell it out only so the package object exists (and is cached)
+	// before the recursive type-check begins. The package name is left empty;
+	// the checker fills it in from the parsed files, same as conf.Check.
+	pkg := types.NewPackage(importPath, "")
+	p.cache[importPath] = pkg
+	_ = types.NewChecker(&conf, p.fset, pkg, info).Files(asts)
 	return pkg, nil
 }

--- a/rewrite-go/test/import_cycle_test.go
+++ b/rewrite-go/test/import_cycle_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"go/types"
+	"testing"
+	"time"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+)
+
+// importWithTimeout runs pi.Import(importPath) in a separate goroutine and
+// fails the test if it does not return within the deadline. Without an
+// in-progress cycle guard the import recurses unboundedly; this surfaces as
+// either a goroutine that never returns (caught by the timeout here) or a
+// `fatal error: stack overflow` that crashes the test binary outright.
+func importWithTimeout(t *testing.T, pi *parser.ProjectImporter, importPath string) *types.Package {
+	t.Helper()
+	type result struct {
+		pkg *types.Package
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		pkg, err := pi.Import(importPath)
+		ch <- result{pkg, err}
+	}()
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			t.Fatalf("Import(%q) returned error: %v", importPath, r.err)
+		}
+		if r.pkg == nil {
+			t.Fatalf("Import(%q) returned nil package", importPath)
+		}
+		return r.pkg
+	case <-time.After(15 * time.Second):
+		t.Fatalf("Import(%q) did not return within 15s — unbounded recursion (missing import-cycle guard)", importPath)
+		return nil
+	}
+}
+
+// A direct import cycle between two sibling source packages: a imports b and
+// b imports a. Each Import re-enters parsePackage for a path that hasn't been
+// cached yet (the cache is only populated after parsePackage returns), so
+// without an in-progress guard the type-checker recurses until the goroutine
+// stack overflows. The fix must break the cycle and return a usable package.
+func TestProjectImporter_DirectImportCycle(t *testing.T) {
+	pi := parser.NewProjectImporter("example.com/foo", nil)
+	pi.AddSource("a/a.go", "package a\n\nimport \"example.com/foo/b\"\n\nfunc A() string { return b.B() }\n")
+	pi.AddSource("b/b.go", "package b\n\nimport \"example.com/foo/a\"\n\nfunc B() string { return a.A() }\n")
+
+	pkg := importWithTimeout(t, pi, "example.com/foo/a")
+	if pkg.Path() != "example.com/foo/a" {
+		t.Errorf("expected package path %q, got %q", "example.com/foo/a", pkg.Path())
+	}
+}
+
+// A longer cycle (a -> b -> c -> a) exercises the same guard across more than
+// two hops, mirroring the deep, indirectly-cyclic import graphs in real-world
+// repositories such as entgo.io/ent that originally triggered the crash.
+func TestProjectImporter_TransitiveImportCycle(t *testing.T) {
+	pi := parser.NewProjectImporter("example.com/foo", nil)
+	pi.AddSource("a/a.go", "package a\n\nimport \"example.com/foo/b\"\n\nfunc A() string { return b.B() }\n")
+	pi.AddSource("b/b.go", "package b\n\nimport \"example.com/foo/c\"\n\nfunc B() string { return c.C() }\n")
+	pi.AddSource("c/c.go", "package c\n\nimport \"example.com/foo/a\"\n\nfunc C() string { return a.A() }\n")
+
+	pkg := importWithTimeout(t, pi, "example.com/foo/a")
+	if pkg.Path() != "example.com/foo/a" {
+		t.Errorf("expected package path %q, got %q", "example.com/foo/a", pkg.Path())
+	}
+}


### PR DESCRIPTION
## Motivation

Parsing certain real-world Go repositories (notably `entgo.io/ent`) crashed the Go RPC server with `fatal error: stack overflow` (process exit code 2), surfaced by the Moderne CLI as `IllegalStateException: RPC process shut down early with exit code 2`.

`ProjectImporter` is a `go/types.Importer`. Its `parsePackage` populated `p.cache[importPath]` only *after* `go/types` type-checking fully returned. Because type-checking synchronously calls back into `Import` for every dependency, a genuine import cycle (`a -> b -> ... -> a`, common in deep import graphs such as ent's `entc/integration/...` packages) re-entered `Import(a)` while `a` was still being checked. The cache still missed, so `parsePackage(a)` was invoked again, and the chain

```
parsePackage -> walkVendor/Check -> Import
  -> go/types type-check -> parsePackage -> Import -> ...   (unbounded)
```

recursed until the goroutine stack exceeded the 1 GB limit and the process died. There was no in-progress / cycle guard.

## Summary

- `parsePackage` now applies the standard `go/types` cycle-breaking pattern: it forward-declares the package with `types.NewPackage(importPath, "")` and registers it in `p.cache` **before** type-checking, then type-checks via `types.NewChecker(...).Files(...)`. A cyclic re-entry resolves to the not-yet-complete cached package instead of recursing into `parsePackage` again. `go/types` tolerates importing an incomplete package for cycle resolution and completes it once `Files` returns.
- `conf.Check(importPath, ...)` is internally exactly `NewPackage` + `NewChecker` + `Files`; spelling it out only changes *when* the package object is cached, so non-cyclic resolution (sibling sources, vendor walking, replace/require tiers, stub fallback) is unchanged.
- The cache key remains the import-path string `go/types` requests; `replace` / `resolveVendorDir` / require sub-path matching only affect *where on disk* sources are read, never the cache key, so the guard key always matches the lookup key.
- Real import errors are still not swallowed beyond the pre-existing `Error: func(error){}` handler — only cycles are broken.
- Adds focused regression tests for a direct (`a <-> b`) and a transitive (`a -> b -> c -> a`) import cycle in `rewrite-go/test/import_cycle_test.go`, each run in a goroutine guarded by a watchdog timeout.

## Test plan

- [x] Confirmed RED: the new `TestProjectImporter_DirectImportCycle` reproduces `fatal error: stack overflow` through the exact `parser.ParseFile <- go/types <- Import <- parsePackage` path on the unfixed code.
- [x] Confirmed GREEN: both new cycle tests pass after the fix.
- [x] No regression: all 9 existing `TestVendorWalker_*` tests still pass, including the syntax-error -> stub fallback case.
- [x] Full `go test ./...` for `rewrite-go` is green.
- [x] `gofmt -l` and `go vet ./pkg/parser/ ./test/` are clean.