### PR TITLE
Add optional `ecosystem` parameter to `ChangeType`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -2648,6 +2648,29 @@ class ChangeTypeTest implements RewriteTest {
     }
 
     @Test
+    void appliesToJavaFilesWhenEcosystemIsJvm() {
+        // A Java source file is in the "jvm" ecosystem, so a jvm-scoped change still applies.
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("java.lang.Integer", "java.lang.Long", true, "jvm")),
+          java(
+            "public class ThinkPositive { private Integer fred = 1;}",
+            "public class ThinkPositive { private Long fred = 1;}"
+          )
+        );
+    }
+
+    @Test
+    void skipsJavaFilesWhenEcosystemIsNonJvm() {
+        // Scoping to a non-JVM ecosystem must skip JVM (Java) source files entirely.
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("java.lang.Integer", "java.lang.Long", true, "python")),
+          java(
+            "public class ThinkPositive { private Integer fred = 1;}"
+          )
+        );
+    }
+
+    @Test
     void changeTypeAddsExplicitImportWhenStarImportsWouldBeAmbiguous() {
         rewriteRun(
           spec -> spec.recipe(new ChangeType("a.Ambiguous", "b.Ambiguous", true))

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
@@ -56,6 +57,18 @@ public class ChangeType extends Recipe {
     @Nullable
     Boolean ignoreDefinition;
 
+    @Option(displayName = "Ecosystem",
+            description = "Restrict the type change to source files of a given ecosystem: `jvm` (Java, Kotlin, " +
+                    "Groovy), `python`, or `javascript`. Python and JavaScript reuse the Java LST model (their " +
+                    "compilation units implement `JavaSourceFile`), so without this filter a change targeting one " +
+                    "ecosystem still scans the others' source files unnecessarily. Reference-based files (such as " +
+                    "XML and properties) are always processed because they may carry type references. When `null` " +
+                    "(the default), the change is applied to all source files.",
+            valid = {"jvm", "python", "javascript"},
+            required = false)
+    @Nullable
+    String ecosystem;
+
     String displayName = "Change type";
 
     @Override
@@ -82,6 +95,46 @@ public class ChangeType extends Recipe {
 
     String description = "Change a given type to another.";
 
+    public ChangeType(String oldFullyQualifiedTypeName, String newFullyQualifiedTypeName, @Nullable Boolean ignoreDefinition) {
+        this(oldFullyQualifiedTypeName, newFullyQualifiedTypeName, ignoreDefinition, null);
+    }
+
+    @JsonCreator
+    public ChangeType(String oldFullyQualifiedTypeName, String newFullyQualifiedTypeName, @Nullable Boolean ignoreDefinition, @Nullable String ecosystem) {
+        this.oldFullyQualifiedTypeName = oldFullyQualifiedTypeName;
+        this.newFullyQualifiedTypeName = newFullyQualifiedTypeName;
+        this.ignoreDefinition = ignoreDefinition;
+        this.ecosystem = ecosystem;
+    }
+
+    private boolean skipForEcosystem(JavaSourceFile cu) {
+        if (ecosystem == null || ecosystem.isEmpty()) {
+            return false;
+        }
+        String impl = cu.getClass().getName();
+        String fileEcosystem;
+        if (impl.startsWith("org.openrewrite.python.")) {
+            fileEcosystem = "python";
+        } else if (impl.startsWith("org.openrewrite.javascript.")) {
+            fileEcosystem = "javascript";
+        } else {
+            // java, kotlin, groovy, scala, ...
+            fileEcosystem = "jvm";
+        }
+        return !normalizeEcosystem(ecosystem).equals(fileEcosystem);
+    }
+
+    private static String normalizeEcosystem(String ecosystem) {
+        switch (ecosystem.toLowerCase()) {
+            case "js":
+                return "javascript";
+            case "py":
+                return "python";
+            default:
+                return ecosystem.toLowerCase();
+        }
+    }
+
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         TreeVisitor<?, ExecutionContext> condition = new TreeVisitor<Tree, ExecutionContext>() {
@@ -90,6 +143,9 @@ public class ChangeType extends Recipe {
                 stopAfterPreVisit();
                 if (tree instanceof JavaSourceFile) {
                     JavaSourceFile cu = (JavaSourceFile) tree;
+                    if (skipForEcosystem(cu)) {
+                        return tree;
+                    }
                     if (!Boolean.TRUE.equals(ignoreDefinition) && containsClassDefinition(cu, oldFullyQualifiedTypeName)) {
                         return SearchResult.found(cu);
                     }

--- a/rewrite-python/src/integTest/java/org/openrewrite/python/ChangeTypeIntegTest.java
+++ b/rewrite-python/src/integTest/java/org/openrewrite/python/ChangeTypeIntegTest.java
@@ -57,6 +57,24 @@ class ChangeTypeIntegTest implements RewriteTest {
         );
     }
 
+    @Test
+    void skippedWhenEcosystemIsJvm() {
+        // Python compilation units implement JavaSourceFile, so ChangeType would otherwise traverse them.
+        // Scoping the change to the "jvm" ecosystem must skip Python source files entirely (leaving them
+        // unchanged and avoiding the cost of scanning them).
+        rewriteRun(
+          spec -> spec
+            .typeValidationOptions(TypeValidation.none())
+            .recipe(new ChangeType("str", "String", false, "jvm")),
+          python(
+            """
+              result = "hello".upper()
+              """
+            // unchanged: skipped because this is a Python (non-JVM) source file
+          )
+        );
+    }
+
     // Note: ChangeType on module references (like os.path -> pathlib) requires
     // additional work to handle Python's module import structure properly.
     // Currently ChangeType works on type attribution but may not work on


### PR DESCRIPTION
- > **Draft for discussion** — opening this to gather maintainer feedback on the approach before polishing. Resolves moderneinc/customer-requests#2463.

## Problem

`org.openrewrite.java.ChangeType` applies to every `JavaSourceFile`:

```java
public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
    return sourceFile instanceof JavaSourceFile || sourceFile instanceof SourceFileWithReferences;
}
```

Python and JavaScript reuse the Java LST model — `Py.CompilationUnit` and `JS.CompilationUnit` both implement `JavaSourceFile`. So a JVM-targeted `ChangeType` accepts every Python/JS file and runs its `UsesType` precondition, walking the entire AST looking for a JVM fully-qualified type that can never appear there.

In telemetry from a single recipe run (see issue for the full table), `ChangeType` spent **423 s** on `finos/symphony-bdk-python` — which has **zero** Java files — and changed nothing. On Python-heavy repos this is enough to push recipe runs past the timeout.

## Proposal

Add an optional `ecosystem` option (`jvm`, `python`, `javascript`) that scopes the change to a single ecosystem:

- **Default (`null`)** — unchanged behavior: the recipe runs on all source files.
- When set, files whose compilation unit belongs to a different ecosystem are skipped before the `UsesType` scan.
- Reference-based files (XML, properties, …) are always processed, since they may carry type references.

The new constructor is annotated `@JsonCreator`; the prior 3-arg constructor is preserved for backward compatibility.

## Open questions for discussion

- **Detection mechanism** — the current draft infers a file's ecosystem from its implementing class package (`org.openrewrite.python.*`, `org.openrewrite.javascript.*`, else `jvm`). Is there a cleaner / more robust signal we'd prefer (e.g. a marker or a `SourceFile`-level capability)?
- **Scope** — the issue notes this affects *other* JVM type/usage recipes too (`ChangeMethodName`, `UsesType`-based recipes, …). Should this live on `ChangeType` alone, or be lifted into a shared precondition/utility so every affected recipe benefits?
- **Option shape** — single `ecosystem` string vs. a more general include/exclude list? Naming (`jvm` vs `java`)?

## Changes

- `ChangeType`: new optional `ecosystem` option + ecosystem-skip logic, backward-compatible constructor.
- Tests in `ChangeTypeTest` (jvm applies / non-jvm skips Java files) and `ChangeTypeIntegTest` (jvm scope skips Python files).

## Possible follow-up: roll this out broadly via a best-practices recipe

The per-recipe option above is only worthwhile if it actually gets *set* across the large meta-recipes that drive the cost (Spring Boot upgrades, `migrate-java`, etc.), where hundreds of `ChangeType` steps each scan every Python/JS file.

Rather than hand-editing each declarative recipe, we could add a recipe to **rewrite best practices** that infers the right `ecosystem` for an existing `ChangeType` step from indicators already present in the declarative YAML — e.g. the package of the changed class (`org.springframework.*`, `javax.*`, … → `jvm`) — and fills in the `ecosystem` option automatically.

Run across `rewrite-migrate-java`, `rewrite-spring`, and the other recipe libraries, that would scope every `ChangeType` (and ideally the other `UsesType`-based steps) to `jvm` in one sweep — turning this from a single-recipe opt-in into a broad win, where the biggest savings land precisely on the Python/JS-heavy repos that pay the most today.
