### PR TITLE
Go: collapse receiver `q.Receive` boilerplate via generic `receiveValue`

### DIFF
--- a/rewrite-go/pkg/rpc/go_receiver.go
+++ b/rewrite-go/pkg/rpc/go_receiver.go
@@ -144,9 +144,7 @@ func (r *GoReceiver) VisitCompilationUnit(cu *golang.CompilationUnit, p any) jav
 		}
 	}
 	// EOF
-	if result := q.Receive(cu.EOF, func(v any) any { return receiveSpace(v.(java.Space), q) }); result != nil {
-		cu.EOF = result.(java.Space)
-	}
+	cu.EOF = receiveValue(q, cu.EOF, func(e java.Space) any { return receiveSpace(e, q) })
 	return cu
 }
 
@@ -154,10 +152,7 @@ func (r *GoReceiver) VisitGoStmt(gs *golang.GoStmt, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *gs // shallow copy to avoid mutating remoteObjects baseline
 	gs = &c
-	result := q.Receive(gs.Expr, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		gs.Expr = result.(java.Expression)
-	}
+	gs.Expr = receiveValue(q, gs.Expr, func(e java.Expression) any { return r.Visit(e, q) })
 	return gs
 }
 
@@ -165,10 +160,7 @@ func (r *GoReceiver) VisitDefer(d *golang.Defer, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *d // shallow copy to avoid mutating remoteObjects baseline
 	d = &c
-	result := q.Receive(d.Expr, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		d.Expr = result.(java.Expression)
-	}
+	d.Expr = receiveValue(q, d.Expr, func(e java.Expression) any { return r.Visit(e, q) })
 	return d
 }
 
@@ -176,10 +168,7 @@ func (r *GoReceiver) VisitSend(sn *golang.Send, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *sn // shallow copy to avoid mutating remoteObjects baseline
 	sn = &c
-	result := q.Receive(sn.Channel, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		sn.Channel = result.(java.Expression)
-	}
+	sn.Channel = receiveValue(q, sn.Channel, func(e java.Expression) any { return r.Visit(e, q) })
 	if result := q.Receive(sn.Arrow, func(v any) any { return receiveLeftPadded(r, q, v) }); result != nil {
 		sn.Arrow = result.(java.LeftPadded[java.Expression])
 	}
@@ -190,10 +179,7 @@ func (r *GoReceiver) VisitGoto(g *golang.Goto, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *g // shallow copy to avoid mutating remoteObjects baseline
 	g = &c
-	result := q.Receive(g.Label, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		g.Label = result.(*java.Identifier)
-	}
+	g.Label = receiveValue(q, g.Label, func(e *java.Identifier) any { return r.Visit(e, q) })
 	return g
 }
 
@@ -208,10 +194,7 @@ func (r *GoReceiver) VisitComposite(comp *golang.Composite, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *comp // shallow copy to avoid mutating remoteObjects baseline
 	comp = &c
-	result := q.Receive(comp.TypeExpr, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		comp.TypeExpr = result.(java.Expression)
-	}
+	comp.TypeExpr = receiveValue(q, comp.TypeExpr, func(e java.Expression) any { return r.Visit(e, q) })
 	if result := q.Receive(comp.Elements, func(v any) any { return receiveContainerTyped[java.Expression](r, q, v) }); result != nil {
 		comp.Elements = result.(java.Container[java.Expression])
 	}
@@ -222,10 +205,7 @@ func (r *GoReceiver) VisitKeyValue(kv *golang.KeyValue, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *kv // shallow copy to avoid mutating remoteObjects baseline
 	kv = &c
-	result := q.Receive(kv.Key, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		kv.Key = result.(java.Expression)
-	}
+	kv.Key = receiveValue(q, kv.Key, func(e java.Expression) any { return r.Visit(e, q) })
 	if result := q.Receive(kv.Value, func(v any) any { return receiveLeftPadded(r, q, v) }); result != nil {
 		kv.Value = result.(java.LeftPadded[java.Expression])
 	}
@@ -236,26 +216,16 @@ func (r *GoReceiver) VisitSlice(sl *golang.Slice, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *sl // shallow copy to avoid mutating remoteObjects baseline
 	sl = &c
-	result := q.Receive(sl.Indexed, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		sl.Indexed = result.(java.Expression)
-	}
-	if result := q.Receive(sl.OpenBracket, func(v any) any { return receiveSpace(v.(java.Space), q) }); result != nil {
-		sl.OpenBracket = result.(java.Space)
-	}
+	sl.Indexed = receiveValue(q, sl.Indexed, func(e java.Expression) any { return r.Visit(e, q) })
+	sl.OpenBracket = receiveValue(q, sl.OpenBracket, func(e java.Space) any { return receiveSpace(e, q) })
 	if result := q.Receive(sl.Low, func(v any) any { return receiveRightPadded(r, q, v) }); result != nil {
 		sl.Low = coerceToExpressionRP(result)
 	}
 	if result := q.Receive(sl.High, func(v any) any { return receiveRightPadded(r, q, v) }); result != nil {
 		sl.High = coerceToExpressionRP(result)
 	}
-	max := q.Receive(sl.Max, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if max != nil {
-		sl.Max = max.(java.Expression)
-	}
-	if result := q.Receive(sl.CloseBracket, func(v any) any { return receiveSpace(v.(java.Space), q) }); result != nil {
-		sl.CloseBracket = result.(java.Space)
-	}
+	sl.Max = receiveValue(q, sl.Max, func(e java.Expression) any { return r.Visit(e, q) })
+	sl.CloseBracket = receiveValue(q, sl.CloseBracket, func(e java.Space) any { return receiveSpace(e, q) })
 	return sl
 }
 
@@ -263,16 +233,11 @@ func (r *GoReceiver) VisitMapType(mt *golang.MapType, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *mt // shallow copy to avoid mutating remoteObjects baseline
 	mt = &c
-	if result := q.Receive(mt.OpenBracket, func(v any) any { return receiveSpace(v.(java.Space), q) }); result != nil {
-		mt.OpenBracket = result.(java.Space)
-	}
+	mt.OpenBracket = receiveValue(q, mt.OpenBracket, func(e java.Space) any { return receiveSpace(e, q) })
 	if result := q.Receive(mt.Key, func(v any) any { return receiveRightPadded(r, q, v) }); result != nil {
 		mt.Key = coerceToExpressionRP(result)
 	}
-	result := q.Receive(mt.Value, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		mt.Value = result.(java.Expression)
-	}
+	mt.Value = receiveValue(q, mt.Value, func(e java.Expression) any { return r.Visit(e, q) })
 	return mt
 }
 
@@ -280,10 +245,7 @@ func (r *GoReceiver) VisitStatementExpression(se *golang.StatementExpression, p 
 	q := p.(*ReceiveQueue)
 	c := *se
 	se = &c
-	result := q.Receive(se.Statement, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		se.Statement = result.(java.Statement)
-	}
+	se.Statement = receiveValue(q, se.Statement, func(e java.Statement) any { return r.Visit(e, q) })
 	return se
 }
 
@@ -291,10 +253,7 @@ func (r *GoReceiver) VisitPointerType(pt *golang.PointerType, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *pt
 	pt = &c
-	result := q.Receive(pt.Elem, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		pt.Elem = result.(java.Expression)
-	}
+	pt.Elem = receiveValue(q, pt.Elem, func(e java.Expression) any { return r.Visit(e, q) })
 	return pt
 }
 
@@ -311,10 +270,7 @@ func (r *GoReceiver) VisitChannel(ch *golang.Channel, p any) java.J {
 	case "RECV_ONLY":
 		ch.Dir = golang.ChanRecvOnly
 	}
-	result := q.Receive(ch.Value, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		ch.Value = result.(java.Expression)
-	}
+	ch.Value = receiveValue(q, ch.Value, func(e java.Expression) any { return r.Visit(e, q) })
 	return ch
 }
 
@@ -325,10 +281,7 @@ func (r *GoReceiver) VisitFuncType(ft *golang.FuncType, p any) java.J {
 	if result := q.Receive(ft.Parameters, func(v any) any { return receiveContainerTyped[java.Statement](r, q, v) }); result != nil {
 		ft.Parameters = result.(java.Container[java.Statement])
 	}
-	result := q.Receive(ft.ReturnType, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		ft.ReturnType = result.(java.Expression)
-	}
+	ft.ReturnType = receiveValue(q, ft.ReturnType, func(e java.Expression) any { return r.Visit(e, q) })
 	return ft
 }
 
@@ -336,10 +289,7 @@ func (r *GoReceiver) VisitStructType(st *golang.StructType, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *st // shallow copy to avoid mutating remoteObjects baseline
 	st = &c
-	result := q.Receive(st.Body, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		st.Body = result.(*java.Block)
-	}
+	st.Body = receiveValue(q, st.Body, func(e *java.Block) any { return r.Visit(e, q) })
 	return st
 }
 
@@ -347,10 +297,7 @@ func (r *GoReceiver) VisitInterfaceType(it *golang.InterfaceType, p any) java.J 
 	q := p.(*ReceiveQueue)
 	c := *it // shallow copy to avoid mutating remoteObjects baseline
 	it = &c
-	result := q.Receive(it.Body, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		it.Body = result.(*java.Block)
-	}
+	it.Body = receiveValue(q, it.Body, func(e *java.Block) any { return r.Visit(e, q) })
 	return it
 }
 
@@ -386,10 +333,7 @@ func (r *GoReceiver) VisitUnderlyingType(ut *golang.UnderlyingType, p any) java.
 	q := p.(*ReceiveQueue)
 	c := *ut // shallow copy to avoid mutating remoteObjects baseline
 	ut = &c
-	result := q.Receive(ut.Element, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		ut.Element = result.(java.Expression)
-	}
+	ut.Element = receiveValue(q, ut.Element, func(e java.Expression) any { return r.Visit(e, q) })
 	return ut
 }
 
@@ -411,16 +355,9 @@ func (r *GoReceiver) VisitTypeDecl(td *golang.TypeDecl, p any) java.J {
 			}
 		}
 	}
-	result := q.Receive(td.Name, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		td.Name = result.(*java.Identifier)
-	}
+	td.Name = receiveValue(q, td.Name, func(e *java.Identifier) any { return r.Visit(e, q) })
 	// typeParameters
-	if tpResult := q.Receive(td.TypeParameters, func(v any) any { return r.Visit(v.(java.Tree), q) }); tpResult != nil {
-		td.TypeParameters = tpResult.(*java.TypeParameters)
-	} else {
-		td.TypeParameters = nil
-	}
+	td.TypeParameters = receiveValue(q, td.TypeParameters, func(e *java.TypeParameters) any { return r.Visit(e, q) })
 	var beforeAssign any
 	if td.Assign != nil {
 		beforeAssign = *td.Assign
@@ -431,10 +368,7 @@ func (r *GoReceiver) VisitTypeDecl(td *golang.TypeDecl, p any) java.J {
 	} else {
 		td.Assign = nil
 	}
-	defResult := q.Receive(td.Definition, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if defResult != nil {
-		td.Definition = defResult.(java.Expression)
-	}
+	td.Definition = receiveValue(q, td.Definition, func(e java.Expression) any { return r.Visit(e, q) })
 	var beforeSpecs any
 	if td.Specs != nil {
 		beforeSpecs = *td.Specs
@@ -487,13 +421,8 @@ func (r *GoReceiver) VisitCommClause(cc *golang.CommClause, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *cc // shallow copy to avoid mutating remoteObjects baseline
 	cc = &c
-	result := q.Receive(cc.Comm, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		cc.Comm = result.(java.Statement)
-	}
-	if result := q.Receive(cc.Colon, func(v any) any { return receiveSpace(v.(java.Space), q) }); result != nil {
-		cc.Colon = result.(java.Space)
-	}
+	cc.Comm = receiveValue(q, cc.Comm, func(e java.Statement) any { return r.Visit(e, q) })
+	cc.Colon = receiveValue(q, cc.Colon, func(e java.Space) any { return receiveSpace(e, q) })
 	// Body
 	beforeBody := make([]any, len(cc.Body))
 	for i, s := range cc.Body {
@@ -513,10 +442,7 @@ func (r *GoReceiver) VisitIndexList(il *golang.IndexList, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *il // shallow copy to avoid mutating remoteObjects baseline
 	il = &c
-	result := q.Receive(il.Target, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		il.Target = result.(java.Expression)
-	}
+	il.Target = receiveValue(q, il.Target, func(e java.Expression) any { return r.Visit(e, q) })
 	if result := q.Receive(il.Indices, func(v any) any { return receiveContainerTyped[java.Expression](r, q, v) }); result != nil {
 		il.Indices = result.(java.Container[java.Expression])
 	}

--- a/rewrite-go/pkg/rpc/java_receiver.go
+++ b/rewrite-go/pkg/rpc/java_receiver.go
@@ -141,15 +141,9 @@ func (r *JavaReceiver) VisitBinary(b *java.Binary, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *b // shallow copy to avoid mutating remoteObjects baseline
 	b = &c
-	result := q.Receive(b.Left, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		b.Left = result.(java.Expression)
-	}
+	b.Left = receiveValue(q, b.Left, func(e java.Expression) any { return r.Visit(e, q) })
 	b.Operator = receiveLeftPaddedEnum(r, q, b.Operator, java.ParseBinaryOperator)
-	rightResult := q.Receive(b.Right, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if rightResult != nil {
-		b.Right = rightResult.(java.Expression)
-	}
+	b.Right = receiveValue(q, b.Right, func(e java.Expression) any { return r.Visit(e, q) })
 	b.Type = r.receiveType(b.Type, q)
 	return b
 }
@@ -173,11 +167,7 @@ func (r *JavaReceiver) VisitBlock(b *java.Block, p any) java.J {
 		}
 	}
 	// end space
-	if result := q.Receive(b.End, func(v any) any {
-		return receiveSpace(v.(java.Space), q)
-	}); result != nil {
-		b.End = result.(java.Space)
-	}
+	b.End = receiveValue(q, b.End, func(e java.Space) any { return receiveSpace(e, q) })
 	return b
 }
 
@@ -187,9 +177,7 @@ func (r *JavaReceiver) VisitAnnotation(ann *java.Annotation, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *ann // shallow copy to avoid mutating remoteObjects baseline
 	ann = &c
-	if result := q.Receive(ann.AnnotationType, func(v any) any { return r.Visit(v.(java.Tree), q) }); result != nil {
-		ann.AnnotationType = result.(java.Expression)
-	}
+	ann.AnnotationType = receiveValue(q, ann.AnnotationType, func(e java.Expression) any { return r.Visit(e, q) })
 	var beforeArgs any
 	if ann.Arguments != nil {
 		beforeArgs = *ann.Arguments
@@ -208,10 +196,7 @@ func (r *JavaReceiver) VisitUnary(u *java.Unary, p any) java.J {
 	c := *u // shallow copy to avoid mutating remoteObjects baseline
 	u = &c
 	u.Operator = receiveLeftPaddedEnum(r, q, u.Operator, java.ParseUnaryOperator)
-	result := q.Receive(u.Operand, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		u.Operand = result.(java.Expression)
-	}
+	u.Operand = receiveValue(q, u.Operand, func(e java.Expression) any { return r.Visit(e, q) })
 	u.Type = r.receiveType(u.Type, q)
 	return u
 }
@@ -220,10 +205,7 @@ func (r *JavaReceiver) VisitFieldAccess(fa *java.FieldAccess, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *fa // shallow copy to avoid mutating remoteObjects baseline
 	fa = &c
-	result := q.Receive(fa.Target, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		fa.Target = result.(java.Expression)
-	}
+	fa.Target = receiveValue(q, fa.Target, func(e java.Expression) any { return r.Visit(e, q) })
 	if result := q.Receive(fa.Name, func(v any) any { return receiveLeftPadded(r, q, v) }); result != nil {
 		fa.Name = coerceLeftPaddedIdent(result)
 	}
@@ -249,10 +231,7 @@ func (r *JavaReceiver) VisitMethodInvocation(mi *java.MethodInvocation, p any) j
 	// typeParameters (nil for Go)
 	q.Receive(nil, nil)
 	// name
-	result := q.Receive(mi.Name, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		mi.Name = result.(*java.Identifier)
-	}
+	mi.Name = receiveValue(q, mi.Name, func(e *java.Identifier) any { return r.Visit(e, q) })
 	// arguments
 	if result := q.Receive(mi.Arguments, func(v any) any { return receiveContainerTyped[java.Expression](r, q, v) }); result != nil {
 		mi.Arguments = result.(java.Container[java.Expression])
@@ -271,10 +250,7 @@ func (r *JavaReceiver) VisitAssignment(a *java.Assignment, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *a // shallow copy to avoid mutating remoteObjects baseline
 	a = &c
-	result := q.Receive(a.Variable, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		a.Variable = result.(java.Expression)
-	}
+	a.Variable = receiveValue(q, a.Variable, func(e java.Expression) any { return r.Visit(e, q) })
 	if result := q.Receive(a.Value, func(v any) any { return receiveLeftPadded(r, q, v) }); result != nil {
 		a.Value = result.(java.LeftPadded[java.Expression])
 	}
@@ -286,15 +262,9 @@ func (r *JavaReceiver) VisitAssignmentOperation(a *java.AssignmentOperation, p a
 	q := p.(*ReceiveQueue)
 	c := *a // shallow copy to avoid mutating remoteObjects baseline
 	a = &c
-	result := q.Receive(a.Variable, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		a.Variable = result.(java.Expression)
-	}
+	a.Variable = receiveValue(q, a.Variable, func(e java.Expression) any { return r.Visit(e, q) })
 	a.Operator = receiveLeftPaddedEnum(r, q, a.Operator, java.ParseAssignmentOperator)
-	assignResult := q.Receive(a.Assignment, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if assignResult != nil {
-		a.Assignment = assignResult.(java.Expression)
-	}
+	a.Assignment = receiveValue(q, a.Assignment, func(e java.Expression) any { return r.Visit(e, q) })
 	a.Type = r.receiveType(a.Type, q)
 	return a
 }
@@ -320,23 +290,13 @@ func (r *JavaReceiver) VisitMethodDeclaration(md *java.MethodDeclaration, p any)
 	// modifiers
 	q.ReceiveList(nil, nil)
 	// typeParameters
-	if tpResult := q.Receive(md.TypeParameters, func(v any) any { return r.Visit(v.(java.Tree), q) }); tpResult != nil {
-		md.TypeParameters = tpResult.(*java.TypeParameters)
-	} else {
-		md.TypeParameters = nil
-	}
+	md.TypeParameters = receiveValue(q, md.TypeParameters, func(e *java.TypeParameters) any { return r.Visit(e, q) })
 	// returnTypeExpression
-	result := q.Receive(md.ReturnType, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		md.ReturnType = result.(java.Expression)
-	}
+	md.ReturnType = receiveValue(q, md.ReturnType, func(e java.Expression) any { return r.Visit(e, q) })
 	// name annotations
 	q.ReceiveList(nil, nil)
 	// name
-	nameResult := q.Receive(md.Name, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if nameResult != nil {
-		md.Name = nameResult.(*java.Identifier)
-	}
+	md.Name = receiveValue(q, md.Name, func(e *java.Identifier) any { return r.Visit(e, q) })
 	// parameters
 	if result := q.Receive(md.Parameters, func(v any) any { return receiveContainerTyped[java.Statement](r, q, v) }); result != nil {
 		md.Parameters = result.(java.Container[java.Statement])
@@ -346,10 +306,7 @@ func (r *JavaReceiver) VisitMethodDeclaration(md *java.MethodDeclaration, p any)
 	// throws
 	q.Receive(nil, nil)
 	// body
-	bodyResult := q.Receive(md.Body, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if bodyResult != nil {
-		md.Body = bodyResult.(*java.Block)
-	}
+	md.Body = receiveValue(q, md.Body, func(e *java.Block) any { return r.Visit(e, q) })
 	// defaultValue
 	q.Receive(nil, nil)
 	// methodType
@@ -392,9 +349,7 @@ func (r *JavaReceiver) VisitTypeParameter(tp *java.TypeParameter, p any) java.J 
 	// modifiers
 	q.ReceiveList(nil, nil)
 	// name
-	if result := q.Receive(tp.Name, func(v any) any { return r.Visit(v.(java.Tree), q) }); result != nil {
-		tp.Name = result.(java.Expression)
-	}
+	tp.Name = receiveValue(q, tp.Name, func(e java.Expression) any { return r.Visit(e, q) })
 	// bounds (container; nil when the parameter shares a sibling's constraint).
 	// Pass the value Container baseline (not the *Container) so the padding
 	// accessors recognize it.
@@ -432,17 +387,13 @@ func (r *JavaReceiver) VisitVariableDeclarations(vd *java.VariableDeclarations, 
 	// modifiers
 	q.ReceiveList(nil, nil)
 	// typeExpression
-	result := q.Receive(vd.TypeExpr, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		vd.TypeExpr = result.(java.Expression)
-	}
+	vd.TypeExpr = receiveValue(q, vd.TypeExpr, func(e java.Expression) any { return r.Visit(e, q) })
 	// varargs
 	var currentVarargs any
 	if vd.Varargs != nil {
 		currentVarargs = *vd.Varargs
 	}
-	varargsResult := q.Receive(currentVarargs, func(v any) any { return receiveSpace(v.(java.Space), q) })
-	if varargsResult != nil {
+	if varargsResult := q.Receive(currentVarargs, func(v any) any { return receiveSpace(v.(java.Space), q) }); varargsResult != nil {
 		sp := varargsResult.(java.Space)
 		vd.Varargs = &sp
 	}
@@ -466,10 +417,7 @@ func (r *JavaReceiver) VisitVariableDeclarator(vd *java.VariableDeclarator, p an
 	c := *vd // shallow copy to avoid mutating remoteObjects baseline
 	vd = &c
 	// declarator (name)
-	result := q.Receive(vd.Name, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		vd.Name = result.(*java.Identifier)
-	}
+	vd.Name = receiveValue(q, vd.Name, func(e *java.Identifier) any { return r.Visit(e, q) })
 	// dimensionsAfterName
 	q.ReceiveList(nil, nil)
 	// initializer
@@ -496,8 +444,7 @@ func (r *JavaReceiver) VisitReturn(ret *java.Return, p any) java.J {
 	if len(ret.Expressions) > 0 {
 		beforeExpr = ret.Expressions[0].Element
 	}
-	result := q.Receive(beforeExpr, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
+	if result := q.Receive(beforeExpr, func(v any) any { return r.Visit(v.(java.Tree), q) }); result != nil {
 		expr := result.(java.Expression)
 		if len(ret.Expressions) > 0 {
 			ret.Expressions[0] = java.RightPadded[java.Expression]{
@@ -531,8 +478,7 @@ func (r *JavaReceiver) VisitIf(i *java.If, p any) java.J {
 			Tree:    java.RightPadded[java.Expression]{Element: i.Condition},
 		}
 	}
-	cpResult := q.Receive(beforeCP, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if cpResult != nil {
+	if cpResult := q.Receive(beforeCP, func(v any) any { return r.Visit(v.(java.Tree), q) }); cpResult != nil {
 		if cp, ok := cpResult.(*java.ControlParentheses); ok {
 			i.ConditionCP = cp
 			i.Condition = cp.Tree.Element
@@ -548,8 +494,7 @@ func (r *JavaReceiver) VisitIf(i *java.If, p any) java.J {
 		}
 	}
 	// elsePart - Java sends Else node, convert to RightPadded
-	elseResult := q.Receive(nil, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if elseResult != nil {
+	if elseResult := q.Receive(nil, func(v any) any { return r.Visit(v.(java.Tree), q) }); elseResult != nil {
 		el := elseResult.(*java.Else)
 		i.ElsePart = &java.RightPadded[java.J]{
 			Element: el.Body.Element,
@@ -576,8 +521,7 @@ func (r *JavaReceiver) VisitForLoop(f *java.ForLoop, p any) java.J {
 	c := *f // shallow copy to avoid mutating remoteObjects baseline
 	f = &c
 	ctrl := &f.Control
-	result := q.Receive(ctrl, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
+	if result := q.Receive(ctrl, func(v any) any { return r.Visit(v.(java.Tree), q) }); result != nil {
 		f.Control = *result.(*java.ForControl)
 	}
 	// body - Java sends RightPadded<Statement> wrapping the Block
@@ -637,8 +581,7 @@ func (r *JavaReceiver) VisitForEachLoop(f *java.ForEachLoop, p any) java.J {
 	c := *f // shallow copy to avoid mutating remoteObjects baseline
 	f = &c
 	ctrl := &f.Control
-	result := q.Receive(ctrl, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
+	if result := q.Receive(ctrl, func(v any) any { return r.Visit(v.(java.Tree), q) }); result != nil {
 		f.Control = *result.(*java.ForEachControl)
 	}
 	// body - Java sends RightPadded<Statement> wrapping the Block
@@ -680,10 +623,7 @@ func (r *JavaReceiver) VisitForEachControl(fc *java.ForEachControl, p any) java.
 	// operator (left-padded AssignOp enum)
 	fc.Operator = receiveLeftPaddedEnum(r, q, fc.Operator, parseAssignOpDefaulting)
 	// iterable
-	result := q.Receive(fc.Iterable, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		fc.Iterable = result.(java.Expression)
-	}
+	fc.Iterable = receiveValue(q, fc.Iterable, func(e java.Expression) any { return r.Visit(e, q) })
 	return fc
 }
 
@@ -692,8 +632,7 @@ func (r *JavaReceiver) VisitSwitch(sw *java.Switch, p any) java.J {
 	c := *sw // shallow copy to avoid mutating remoteObjects baseline
 	sw = &c
 	// selector - Java sends ControlParentheses, extract inner Expression for Tag
-	cpResult := q.Receive(nil, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if cpResult != nil {
+	if cpResult := q.Receive(nil, func(v any) any { return r.Visit(v.(java.Tree), q) }); cpResult != nil {
 		if cp, ok := cpResult.(*java.ControlParentheses); ok {
 			if _, isEmpty := cp.Tree.Element.(*java.Empty); !isEmpty {
 				sw.Tag = &java.RightPadded[java.Expression]{
@@ -703,10 +642,7 @@ func (r *JavaReceiver) VisitSwitch(sw *java.Switch, p any) java.J {
 			}
 		}
 	}
-	result := q.Receive(sw.Body, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		sw.Body = result.(*java.Block)
-	}
+	sw.Body = receiveValue(q, sw.Body, func(e *java.Block) any { return r.Visit(e, q) })
 	return sw
 }
 
@@ -732,10 +668,7 @@ func (r *JavaReceiver) VisitBreak(b *java.Break, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *b // shallow copy to avoid mutating remoteObjects baseline
 	b = &c
-	result := q.Receive(b.Label, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		b.Label = result.(*java.Identifier)
-	}
+	b.Label = receiveValue(q, b.Label, func(e *java.Identifier) any { return r.Visit(e, q) })
 	return b
 }
 
@@ -743,10 +676,7 @@ func (r *JavaReceiver) VisitContinue(cont *java.Continue, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *cont // shallow copy to avoid mutating remoteObjects baseline
 	cont = &c
-	result := q.Receive(cont.Label, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		cont.Label = result.(*java.Identifier)
-	}
+	cont.Label = receiveValue(q, cont.Label, func(e *java.Identifier) any { return r.Visit(e, q) })
 	return cont
 }
 
@@ -757,10 +687,7 @@ func (r *JavaReceiver) VisitLabel(l *java.Label, p any) java.J {
 	if result := q.Receive(l.Name, func(v any) any { return receiveRightPadded(r, q, v) }); result != nil {
 		l.Name = coerceRightPaddedTyped[*java.Identifier](result)
 	}
-	result := q.Receive(l.Statement, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		l.Statement = result.(java.Statement)
-	}
+	l.Statement = receiveValue(q, l.Statement, func(e java.Statement) any { return r.Visit(e, q) })
 	return l
 }
 
@@ -768,10 +695,7 @@ func (r *JavaReceiver) VisitArrayType(at *java.ArrayType, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *at // shallow copy to avoid mutating remoteObjects baseline
 	at = &c
-	result := q.Receive(at.ElementType, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		at.ElementType = result.(java.Expression)
-	}
+	at.ElementType = receiveValue(q, at.ElementType, func(e java.Expression) any { return r.Visit(e, q) })
 	q.ReceiveList(nil, nil) // annotations
 	if result := q.Receive(at.Dimension, func(v any) any { return receiveLeftPadded(r, q, v) }); result != nil {
 		at.Dimension = result.(java.LeftPadded[java.Space])
@@ -784,9 +708,7 @@ func (r *JavaReceiver) VisitParameterizedType(pt *java.ParameterizedType, p any)
 	q := p.(*ReceiveQueue)
 	c := *pt
 	pt = &c
-	if result := q.Receive(pt.Clazz, func(v any) any { return r.Visit(v.(java.Tree), q) }); result != nil {
-		pt.Clazz = result.(java.Expression)
-	}
+	pt.Clazz = receiveValue(q, pt.Clazz, func(e java.Expression) any { return r.Visit(e, q) })
 	if result := q.Receive(pt.TypeParameters, func(v any) any { return receiveContainerTyped[java.Expression](r, q, v) }); result != nil {
 		container := result.(java.Container[java.Expression])
 		pt.TypeParameters = &container
@@ -799,14 +721,8 @@ func (r *JavaReceiver) VisitArrayAccess(aa *java.ArrayAccess, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *aa // shallow copy to avoid mutating remoteObjects baseline
 	aa = &c
-	result := q.Receive(aa.Indexed, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		aa.Indexed = result.(java.Expression)
-	}
-	dimResult := q.Receive(aa.Dimension, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if dimResult != nil {
-		aa.Dimension = dimResult.(*java.ArrayDimension)
-	}
+	aa.Indexed = receiveValue(q, aa.Indexed, func(e java.Expression) any { return r.Visit(e, q) })
+	aa.Dimension = receiveValue(q, aa.Dimension, func(e *java.ArrayDimension) any { return r.Visit(e, q) })
 	return aa
 }
 
@@ -834,14 +750,8 @@ func (r *JavaReceiver) VisitTypeCast(tc *java.TypeCast, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *tc // shallow copy to avoid mutating remoteObjects baseline
 	tc = &c
-	result := q.Receive(tc.Clazz, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		tc.Clazz = result.(*java.ControlParentheses)
-	}
-	exprResult := q.Receive(tc.Expr, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if exprResult != nil {
-		tc.Expr = exprResult.(java.Expression)
-	}
+	tc.Clazz = receiveValue(q, tc.Clazz, func(e *java.ControlParentheses) any { return r.Visit(e, q) })
+	tc.Expr = receiveValue(q, tc.Expr, func(e java.Expression) any { return r.Visit(e, q) })
 	return tc
 }
 
@@ -863,10 +773,7 @@ func (r *JavaReceiver) VisitImport(imp *java.Import, p any) java.J {
 	staticBefore := java.LeftPadded[bool]{Before: java.EmptySpace, Element: false}
 	q.Receive(staticBefore, func(v any) any { return receiveLeftPadded(r, q, v) })
 	// qualid (Expression - could be Literal or FieldAccess depending on direction)
-	result := q.Receive(imp.Qualid, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if result != nil {
-		imp.Qualid = result.(java.Expression)
-	}
+	imp.Qualid = receiveValue(q, imp.Qualid, func(e java.Expression) any { return r.Visit(e, q) })
 	// alias
 	var beforeAlias any
 	if imp.Alias != nil {

--- a/rewrite-go/pkg/rpc/java_type_receiver.go
+++ b/rewrite-go/pkg/rpc/java_type_receiver.go
@@ -185,67 +185,6 @@ func (r *JavaTypeReceiver) VisitVariable(v *java.JavaTypeVariable, p any) java.J
 	return v
 }
 
-// receiveScalar receives a simple value from the queue.
-func receiveScalar[T any](q *ReceiveQueue, before T) T {
-	result := q.Receive(before, nil)
-	if result == nil {
-		var zero T
-		return zero
-	}
-	// Handle numeric type conversions from JSON
-	return convertTo[T](result)
-}
-
-// receiveValue receives a field that needs a deserialization closure, returning the
-// typed value directly (the zero value — nil for pointer/interface T — on delete) so
-// call sites are a single branch-free assignment. This is the free-function analog of
-// the generic q.receive(before, onChange) in the Java/TS/Python receivers (Go forbids
-// type-parameterized methods).
-//
-// onChange receives the prior value already typed as T (receiveValue does the inbound
-// cast once) and returns the deserialized value; its result is narrowed back to T here,
-// so closure bodies need no casts, e.g.:
-//
-//	gs.Expr = receiveValue(q, gs.Expr, func(e java.Expression) any { return r.Visit(e, q) })
-//	b.End   = receiveValue(q, b.End,   func(s java.Space) any { return receiveSpace(s, q) })
-//
-// Semantics mirror Java's RpcReceiveQueue.receive: NO_CHANGE returns `before`, DELETE
-// returns the zero value (nil for the pointer/interface T of nullable fields — Java's
-// `return null`), ADD/CHANGE returns the deserialized value. q.Receive yields nil only
-// on DELETE or a nil `before`, so the zero return never produces a bogus empty value for
-// the mandatory value-typed fields (which are never deleted).
-func receiveValue[T any](q *ReceiveQueue, before T, onChange func(T) any) T {
-	result := q.Receive(before, func(v any) any { return onChange(v.(T)) })
-	if result == nil {
-		var zero T
-		return zero
-	}
-	return result.(T)
-}
-
-// convertTo converts a value to the desired type, handling JSON number conversions.
-func convertTo[T any](v any) T {
-	if t, ok := v.(T); ok {
-		return t
-	}
-	// Handle float64 -> int64 conversion (common with JSON)
-	var zero T
-	switch any(zero).(type) {
-	case int64:
-		switch n := v.(type) {
-		case float64:
-			return any(int64(n)).(T)
-		case int:
-			return any(int64(n)).(T)
-		}
-	case string:
-		if s, ok := v.(string); ok {
-			return any(s).(T)
-		}
-	}
-	return v.(T)
-}
-
 // receiveAsType receives a ref-tracked type from the queue.
 func receiveAsType[T java.JavaType](r *JavaTypeReceiver, q *ReceiveQueue, before T) T {
 	result := q.Receive(before, func(v any) any {

--- a/rewrite-go/pkg/rpc/java_type_receiver.go
+++ b/rewrite-go/pkg/rpc/java_type_receiver.go
@@ -196,6 +196,33 @@ func receiveScalar[T any](q *ReceiveQueue, before T) T {
 	return convertTo[T](result)
 }
 
+// receiveValue receives a field that needs a deserialization closure, returning the
+// typed value directly (the zero value — nil for pointer/interface T — on delete) so
+// call sites are a single branch-free assignment. This is the free-function analog of
+// the generic q.receive(before, onChange) in the Java/TS/Python receivers (Go forbids
+// type-parameterized methods).
+//
+// onChange receives the prior value already typed as T (receiveValue does the inbound
+// cast once) and returns the deserialized value; its result is narrowed back to T here,
+// so closure bodies need no casts, e.g.:
+//
+//	gs.Expr = receiveValue(q, gs.Expr, func(e java.Expression) any { return r.Visit(e, q) })
+//	b.End   = receiveValue(q, b.End,   func(s java.Space) any { return receiveSpace(s, q) })
+//
+// Semantics mirror Java's RpcReceiveQueue.receive: NO_CHANGE returns `before`, DELETE
+// returns the zero value (nil for the pointer/interface T of nullable fields — Java's
+// `return null`), ADD/CHANGE returns the deserialized value. q.Receive yields nil only
+// on DELETE or a nil `before`, so the zero return never produces a bogus empty value for
+// the mandatory value-typed fields (which are never deleted).
+func receiveValue[T any](q *ReceiveQueue, before T, onChange func(T) any) T {
+	result := q.Receive(before, func(v any) any { return onChange(v.(T)) })
+	if result == nil {
+		var zero T
+		return zero
+	}
+	return result.(T)
+}
+
 // convertTo converts a value to the desired type, handling JSON number conversions.
 func convertTo[T any](v any) T {
 	if t, ok := v.(T); ok {

--- a/rewrite-go/pkg/rpc/receive_queue.go
+++ b/rewrite-go/pkg/rpc/receive_queue.go
@@ -149,6 +149,69 @@ func (q *ReceiveQueue) ReceiveAndGet(before any, mapping func(any) any) any {
 	return after
 }
 
+// Typed free-function wrappers around Receive. The Java/TS/Python receivers expose a
+// generic q.receive(before, onChange) that returns the value already typed; Go forbids
+// type-parameterized methods, so the typed layer lives in these free functions instead.
+
+// receiveValue receives a field that needs a deserialization closure, returning the
+// typed value directly (the zero value — nil for pointer/interface T — on delete) so
+// call sites are a single branch-free assignment.
+//
+// onChange receives the prior value already typed as T (receiveValue does the inbound
+// cast once) and returns the deserialized value; its result is narrowed back to T here,
+// so closure bodies need no casts, e.g.:
+//
+//	gs.Expr = receiveValue(q, gs.Expr, func(e java.Expression) any { return r.Visit(e, q) })
+//	b.End   = receiveValue(q, b.End,   func(s java.Space) any { return receiveSpace(s, q) })
+//
+// Semantics mirror Java's RpcReceiveQueue.receive: NO_CHANGE returns `before`, DELETE
+// returns the zero value (nil for the pointer/interface T of nullable fields — Java's
+// `return null`), ADD/CHANGE returns the deserialized value. Receive yields nil only on
+// DELETE or a nil `before`, so the zero return never produces a bogus empty value for the
+// mandatory value-typed fields (which are never deleted).
+func receiveValue[T any](q *ReceiveQueue, before T, onChange func(T) any) T {
+	result := q.Receive(before, func(v any) any { return onChange(v.(T)) })
+	if result == nil {
+		var zero T
+		return zero
+	}
+	return result.(T)
+}
+
+// receiveScalar receives a simple leaf value (no nested deserialization, hence a nil
+// onChange) and applies convertTo to bridge JSON's numeric/string representations.
+func receiveScalar[T any](q *ReceiveQueue, before T) T {
+	result := q.Receive(before, nil)
+	if result == nil {
+		var zero T
+		return zero
+	}
+	return convertTo[T](result)
+}
+
+// convertTo converts a value to the desired type, handling JSON number conversions.
+func convertTo[T any](v any) T {
+	if t, ok := v.(T); ok {
+		return t
+	}
+	// Handle float64 -> int64 conversion (common with JSON)
+	var zero T
+	switch any(zero).(type) {
+	case int64:
+		switch n := v.(type) {
+		case float64:
+			return any(int64(n)).(T)
+		case int:
+			return any(int64(n)).(T)
+		}
+	case string:
+		if s, ok := v.(string); ok {
+			return any(s).(T)
+		}
+	}
+	return v.(T)
+}
+
 // ReceiveList reads a list from the queue with position-based tracking.
 func (q *ReceiveQueue) ReceiveList(before []any, onChange func(any) any) []any {
 	msg := q.Take()

--- a/rewrite-go/pkg/rpc/receive_value_test.go
+++ b/rewrite-go/pkg/rpc/receive_value_test.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// queueOf returns a ReceiveQueue that yields the given messages once.
+func queueOf(msgs ...RpcObjectData) *ReceiveQueue {
+	delivered := false
+	return NewReceiveQueue(make(map[int]any), func() []RpcObjectData {
+		if delivered {
+			return nil
+		}
+		delivered = true
+		return msgs
+	})
+}
+
+// receiveValue mirrors Java's RpcReceiveQueue.receive: NO_CHANGE returns `before`,
+// DELETE returns the zero value (nil for the nullable pointer/interface fields it is
+// used on). These lock in the semantics the call-site assignments rely on.
+
+func TestReceiveValue_NoChangeReturnsBefore(t *testing.T) {
+	before := makeIdent("x")
+	got := receiveValue(queueOf(RpcObjectData{State: NoChange}), java.Expression(before),
+		func(e java.Expression) any { return e })
+	if got != java.Expression(before) {
+		t.Errorf("NO_CHANGE: want before %p, got %v", before, got)
+	}
+}
+
+func TestReceiveValue_DeleteReturnsNil(t *testing.T) {
+	before := makeIdent("x")
+	got := receiveValue(queueOf(RpcObjectData{State: Delete}), java.Expression(before),
+		func(e java.Expression) any { return e })
+	if got != nil {
+		t.Errorf("DELETE: want nil, got %v", got)
+	}
+}


### PR DESCRIPTION
## Motivation

The Go RPC receiver wraps almost every field receive in a three-line guard:

```go
result := q.Receive(x.F, func(v any) any { return r.Visit(v.(java.Tree), q) })
if result != nil {
    x.F = result.(java.Expression)
}
```

The Java/TS/Python receivers don't — their `RpcReceiveQueue.receive` is generic and returns the typed value (incl. null on DELETE), so call sites assign it directly: `x.F = q.receive(x.F, onChange)`. Go can't make `q.Receive` a generic *method* (the language forbids type-parameterized methods), which is why the Go side fell back to `any` + a manual nil-check + a type assertion at every site.

A generic *free function* recovers the same ergonomics.

## Examples

```go
// generic free-function analog of Java/TS/Python q.receive(before, onChange)
func receiveValue[T any](q *ReceiveQueue, before T, onChange func(T) any) T {
    result := q.Receive(before, func(v any) any { return onChange(v.(T)) })
    if result == nil {
        var zero T // nil for the pointer/interface T of nullable fields
        return zero
    }
    return result.(T)
}
```

Call sites become a single branch-free assignment, with no casts in the closure body (the inbound cast happens once inside `receiveValue`, the result is narrowed back to `T`):

```go
gs.Expr = receiveValue(q, gs.Expr, func(e java.Expression) any { return r.Visit(e, q) })
b.End   = receiveValue(q, b.End,   func(s java.Space) any { return receiveSpace(s, q) })
```

## Summary

- Add `receiveValue[T]` next to the existing `receiveScalar[T]`. Semantics mirror Java's `RpcReceiveQueue.receive`: NO_CHANGE → `before`, DELETE → zero (nil for the nullable pointer/interface fields it is used on), ADD/CHANGE → the deserialized value.
- Convert the ~53 node- and space-receive sites in `go_receiver.go` and `java_receiver.go` to single-line assignments (net ~140 fewer lines).
- Container, right-padded, and left-padded sites are unchanged — they keep their coercers (`coerceTo*RP` panic-on-mismatch, container pointer handling, `receiveLeftPaddedEnum`), which encode behavior a blanket helper shouldn't flatten.
- Pure refactor: no behavior change.

## Test plan

- [x] New `pkg/rpc/receive_value_test.go`: locks in `receiveValue` semantics (NO_CHANGE returns `before`, DELETE returns nil).
- [x] The existing send→receive round-trip suite exercises `receiveValue` on the NO_CHANGE and ADD/CHANGE paths for every converted field.
- [x] `go test ./...` for `rewrite-go` green; `gofmt` and `go vet` clean.