### PR TITLE
Go: resolve composite recipes' `RecipeList()` children by name

### DIFF
--- a/rewrite-go/pkg/recipe/registry.go
+++ b/rewrite-go/pkg/recipe/registry.go
@@ -60,6 +60,13 @@ type Registry struct {
 	mu     sync.RWMutex
 	root   Category
 	byName map[string]*Registration
+
+	// subByName holds the children contributed by composite recipes'
+	// RecipeList(). These are resolvable by name (so the CLI can prepare a
+	// composite's children individually) but are intentionally kept out of
+	// byName / the category tree so they don't surface as standalone
+	// marketplace entries. FindRecipe falls back to this map.
+	subByName map[string]*Registration
 }
 
 // Activator is a function that registers recipes with a registry.
@@ -81,7 +88,8 @@ type Activator func(registry *Registry)
 // NewRegistry creates an empty registry.
 func NewRegistry() *Registry {
 	return &Registry{
-		byName: make(map[string]*Registration),
+		byName:    make(map[string]*Registration),
+		subByName: make(map[string]*Registration),
 	}
 }
 
@@ -114,6 +122,32 @@ func (r *Registry) Register(prototype Recipe, categories ...CategoryDescriptor) 
 		cat = r.findOrCreateSubcategory(cat, cd)
 	}
 	cat.Recipes = append(cat.Recipes, *reg)
+
+	// Composite recipes advertise their RecipeList() children in the
+	// descriptor (see Describe), so the CLI prepares each child by name.
+	// Register those children so FindRecipe can resolve them — but only into
+	// subByName, never byName or the category tree, so they don't appear as
+	// standalone marketplace recipes.
+	r.registerSubRecipes(prototype)
+}
+
+// registerSubRecipes recursively records a recipe's RecipeList() children in
+// subByName so they are resolvable by name. The traversal is guarded against
+// cycles (and shared sub-recipes) via the subByName presence check.
+func (r *Registry) registerSubRecipes(rec Recipe) {
+	for _, sub := range rec.RecipeList() {
+		name := sub.Name()
+		if _, exists := r.subByName[name]; !exists {
+			// A child that is also registered as a top-level recipe is
+			// already resolvable via byName; FindRecipe checks byName first.
+			child := sub
+			r.subByName[name] = &Registration{
+				Descriptor:  Describe(child),
+				Constructor: func(map[string]any) Recipe { return child },
+			}
+			r.registerSubRecipes(child)
+		}
+	}
 }
 
 // RegisterDescriptor registers a recipe from its descriptor (used for dynamically loaded recipes).
@@ -153,7 +187,12 @@ func (r *Registry) RegisterWithCategories(desc RecipeDescriptor, categories []Ca
 func (r *Registry) FindRecipe(name string) (*Registration, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	reg, ok := r.byName[name]
+	if reg, ok := r.byName[name]; ok {
+		return reg, true
+	}
+	// Fall back to composite children (e.g. "Parent$Keep") contributed via
+	// RecipeList(), which are not standalone marketplace recipes.
+	reg, ok := r.subByName[name]
 	return reg, ok
 }
 

--- a/rewrite-go/pkg/recipe/registry_test.go
+++ b/rewrite-go/pkg/recipe/registry_test.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package recipe
+
+import "testing"
+
+// leafRecipe is a minimal standalone recipe used as a composite child.
+type leafRecipe struct {
+	Base
+	name string
+}
+
+func (l *leafRecipe) Name() string        { return l.name }
+func (l *leafRecipe) DisplayName() string { return l.name }
+func (l *leafRecipe) Description() string { return "Leaf recipe " + l.name }
+
+// compositeRecipe composes child recipes via RecipeList, mirroring the Java
+// getRecipeList() composition pattern (and Go template.NewRecipe sub-recipes).
+type compositeRecipe struct {
+	Base
+	children []Recipe
+}
+
+func (c *compositeRecipe) Name() string         { return "com.example.Composite" }
+func (c *compositeRecipe) DisplayName() string  { return "Composite" }
+func (c *compositeRecipe) Description() string  { return "A composite recipe." }
+func (c *compositeRecipe) RecipeList() []Recipe { return c.children }
+
+func newComposite() *compositeRecipe {
+	return &compositeRecipe{
+		children: []Recipe{
+			&leafRecipe{name: "com.example.Composite$Keep"},
+			&leafRecipe{name: "com.example.Composite$Negate"},
+		},
+	}
+}
+
+// TestRegisterResolvesCompositeChildren verifies that the children returned by
+// a recipe's RecipeList() are resolvable by FindRecipe (so the CLI can prepare
+// them by name) even though only the prototype is registered via Register.
+func TestRegisterResolvesCompositeChildren(t *testing.T) {
+	r := NewRegistry()
+	r.Register(newComposite(), CategoryDescriptor{DisplayName: "Example"})
+
+	// Parent resolves.
+	if _, ok := r.FindRecipe("com.example.Composite"); !ok {
+		t.Fatal("expected parent recipe to resolve")
+	}
+
+	// Children with '$' in their names resolve and round-trip correctly.
+	for _, child := range []string{"com.example.Composite$Keep", "com.example.Composite$Negate"} {
+		reg, ok := r.FindRecipe(child)
+		if !ok {
+			t.Fatalf("expected child recipe %q to resolve via FindRecipe", child)
+		}
+		inst := reg.Constructor(nil)
+		if inst == nil {
+			t.Fatalf("expected child recipe %q constructor to return an instance", child)
+		}
+		if inst.Name() != child {
+			t.Errorf("child %q resolved to instance with name %q", child, inst.Name())
+		}
+	}
+}
+
+// TestCompositeChildrenNotInMarketplace verifies that composite children are not
+// surfaced as standalone marketplace entries: they must not appear in
+// AllRegistrations/AllRecipes nor in the category tree.
+func TestCompositeChildrenNotInMarketplace(t *testing.T) {
+	r := NewRegistry()
+	r.Register(newComposite(), CategoryDescriptor{DisplayName: "Example"})
+
+	childNames := map[string]bool{
+		"com.example.Composite$Keep":   true,
+		"com.example.Composite$Negate": true,
+	}
+
+	for _, reg := range r.AllRegistrations() {
+		if childNames[reg.Descriptor.Name] {
+			t.Errorf("child recipe %q must not appear in AllRegistrations (marketplace)", reg.Descriptor.Name)
+		}
+	}
+	for _, desc := range r.AllRecipes() {
+		if childNames[desc.Name] {
+			t.Errorf("child recipe %q must not appear in AllRecipes", desc.Name)
+		}
+	}
+
+	// And not in the category tree.
+	var walk func(c *Category)
+	walk = func(c *Category) {
+		for _, reg := range c.Recipes {
+			if childNames[reg.Descriptor.Name] {
+				t.Errorf("child recipe %q must not appear in the category tree", reg.Descriptor.Name)
+			}
+		}
+		for _, sub := range c.Subcategories {
+			walk(sub)
+		}
+	}
+	for _, cat := range r.Categories() {
+		walk(cat)
+	}
+}


### PR DESCRIPTION
## Motivation

Composite Go recipes — those that return child recipes from `RecipeList()`, the Go analogue of Java's `getRecipeList()` — cannot currently be run via the Moderne CLI. For example:

```
mod run . --recipe org.openrewrite.golang.codequality.SimplifyBooleanExpression
```

fails with:

```
io.moderne.jsonrpc.JsonRpcException: {code=-32602, message='Unknown recipe: org.openrewrite.golang.codequality.SimplifyBooleanExpression$Keep'}
  at org.openrewrite.rpc.RewriteRpc.prepareRecipe(RewriteRpc.java:379)
```

The root cause is an internal inconsistency in `rewrite-go`'s recipe registry:

- `Describe` recurses `RecipeList()` into `RecipeDescriptor.RecipeList`, so the descriptor the CLI receives lists the `$Keep`/`$Negate` children, and the CLI then calls `prepareRecipe` for each child **by name**.
- But `Registry.Register` only inserts the prototype into `byName`; it never registers the `RecipeList()` children.
- `handlePrepareRecipe` resolves names via `FindRecipe` (a plain `byName` lookup), so the children miss → `Unknown recipe: …$Keep`.

`RecipeList()` children are a first-class composition pattern, so authors should not have to register them individually — the framework should resolve them.

## Summary

- Added a dedicated `subByName` map to `Registry` for composite children.
- `Register` now recursively records each `RecipeList()` child (via `registerSubRecipes`) into `subByName` only — never `byName` or the category tree. The recursion is cycle-guarded by the `subByName` presence check, which also handles shared sub-recipe instances.
- `FindRecipe` checks `byName` first, then falls back to `subByName`, so the prepare handler resolves children by name with no other changes.
- `AllRecipes` / `AllRegistrations` / `Categories` are untouched, so the marketplace and category listings still expose only top-level recipes — children are resolvable for preparation but do **not** surface as standalone marketplace entries.

### Why a separate map instead of `byName`

The marketplace listing (`handleGetMarketplace`) and the installer both iterate `AllRegistrations()`, which walks `byName`. Registering children directly into `byName` would make `$Keep`/`$Negate` appear as standalone marketplace recipes. The separate `subByName` map keeps children resolvable for `prepareRecipe` while keeping them out of the marketplace/category listing.

Each child's constructor returns the shared `RecipeList()` instance directly (no clone). This matches how a parent already runs its children — it hands out those same package-level `template.NewRecipe` instances, whose configuration is immutable and whose work happens in per-visit visitor state.

## Test plan

- [x] New `rewrite-go/pkg/recipe/registry_test.go`:
  - `TestRegisterResolvesCompositeChildren` — registers a composite recipe whose `RecipeList()` returns `Parent$Keep` / `Parent$Negate`, asserts both resolve via `FindRecipe` (names with `$` round-trip) and that the constructor returns an instance with the matching name.
  - `TestCompositeChildrenNotInMarketplace` — asserts the children are absent from `AllRegistrations`, `AllRecipes`, and the category tree.
- [x] `go test ./pkg/recipe/...` passes (including the existing installer tests).
- [x] `go build ./...` and `go vet ./pkg/recipe/` pass.
