### PR TITLE
Go: fix `Print` panic on pointer-typed `*Container` NO_CHANGE receive (follow-up to #7831)

### DIFF
--- a/rewrite-go/pkg/rpc/container_pointer_rpc_test.go
+++ b/rewrite-go/pkg/rpc/container_pointer_rpc_test.go
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// These tests cover the pointer-typed *Container Print round-trip on the NO_CHANGE
+// path — the direct continuation of #7831. On NO_CHANGE, q.Receive returns the
+// `before` value verbatim. For a nullable *Container[T] field that before-value is
+// the *Container[T] pointer, so a raw `result.(java.Container[T])` value-cast panics
+// with "interface conversion: ... is *java.Container[...], not java.Container[...]"
+// (a pointer-vs-value mismatch, not an element-type mismatch). The fix derefs the
+// before-pointer to a value baseline so the NO_CHANGE path returns an assertable
+// value Container[T]; receivePointerContainer / receiveContainer centralize that so
+// the class can't recur.
+
+// roundTripNodeWithBefore is like roundTripNode but drives the sender with a distinct
+// `before` baseline, so fields whose after-value is identical to the before-value emit
+// NO_CHANGE messages (the sender diffs each field against q.before). This is what a
+// real session produces when a subtree is unchanged since the last GET_OBJECT cycle.
+func roundTripNodeWithBefore(t *testing.T, after, before, seed java.Tree) any {
+	t.Helper()
+	var messages []RpcObjectData
+	sendQ := NewSendQueue(1000, func(batch []RpcObjectData) {
+		messages = append(messages, batch...)
+	}, make(map[uintptr]int))
+	// Diff `after` against `before`; identical field pointers/values emit NO_CHANGE.
+	sendQ.before = before
+	NewGoSender().Visit(after, sendQ)
+	sendQ.Flush()
+
+	delivered := false
+	recvQ := NewReceiveQueue(make(map[int]any), func() []RpcObjectData {
+		if delivered {
+			return nil
+		}
+		delivered = true
+		return messages
+	})
+	return NewGoReceiver().Visit(seed, recvQ)
+}
+
+func TestParameterizedTypeRoundTrip_TypeParametersNoChange(t *testing.T) {
+	// given: a ParameterizedType whose TypeParameters container is unchanged
+	// (after and before share the same *Container pointer) but whose Clazz differs,
+	// so the container field receives a NO_CHANGE message while the node is a change.
+	ptID := uuid.New()
+	typeParams := &java.Container[java.Expression]{
+		Elements: []java.RightPadded[java.Expression]{
+			{Element: makeIdent("string"), Markers: java.Markers{}},
+		},
+	}
+	before := &java.ParameterizedType{
+		ID:             ptID,
+		Clazz:          makeIdent("List"),
+		TypeParameters: typeParams,
+	}
+	after := &java.ParameterizedType{
+		ID:             ptID,
+		Clazz:          makeIdent("Map"), // changed so the node itself is a change
+		TypeParameters: typeParams,       // SAME pointer -> NO_CHANGE for this field
+	}
+	// seed mirrors a baseline from a prior receive: TypeParameters is a non-nil
+	// *Container, which is the before-value the NO_CHANGE path hands back.
+	seed := &java.ParameterizedType{
+		ID:             ptID,
+		TypeParameters: &java.Container[java.Expression]{Elements: typeParams.Elements},
+	}
+
+	// when: the round-trip must not panic on the container field's NO_CHANGE message.
+	got := roundTripNodeWithBefore(t, after, before, seed).(*java.ParameterizedType)
+
+	// then: TypeParameters stays a *Container[Expression] with its element intact.
+	if got.TypeParameters == nil {
+		t.Fatal("TypeParameters: got nil, want non-nil *Container[Expression]")
+	}
+	if len(got.TypeParameters.Elements) != 1 {
+		t.Fatalf("TypeParameters.Elements: got %d, want 1", len(got.TypeParameters.Elements))
+	}
+	if id, ok := got.TypeParameters.Elements[0].Element.(*java.Identifier); !ok || id.Name != "string" {
+		t.Errorf("TypeParameters[0]: got %+v, want Identifier{string}", got.TypeParameters.Elements[0].Element)
+	}
+}
+
+func TestParameterizedTypeRoundTrip_TypeParametersChange(t *testing.T) {
+	// given: a fresh ParameterizedType (Add path) with one type argument.
+	ptID := uuid.New()
+	before := &java.ParameterizedType{
+		ID:    ptID,
+		Clazz: makeIdent("List"),
+		TypeParameters: &java.Container[java.Expression]{
+			Elements: []java.RightPadded[java.Expression]{
+				{Element: makeIdent("int"), Markers: java.Markers{}},
+			},
+		},
+	}
+	seed := &java.ParameterizedType{ID: ptID}
+
+	got := roundTripNode(t, before, seed).(*java.ParameterizedType)
+
+	if got.TypeParameters == nil {
+		t.Fatal("TypeParameters: got nil, want non-nil")
+	}
+	if len(got.TypeParameters.Elements) != 1 {
+		t.Fatalf("TypeParameters.Elements: got %d, want 1", len(got.TypeParameters.Elements))
+	}
+	if id, ok := got.TypeParameters.Elements[0].Element.(*java.Identifier); !ok || id.Name != "int" {
+		t.Errorf("TypeParameters[0]: got %+v, want Identifier{int}", got.TypeParameters.Elements[0].Element)
+	}
+}
+
+func TestParameterizedTypeRoundTrip_NilTypeParameters(t *testing.T) {
+	// given: a ParameterizedType with no type arguments (nil container) — must stay nil.
+	ptID := uuid.New()
+	before := &java.ParameterizedType{ID: ptID, Clazz: makeIdent("string")}
+	seed := &java.ParameterizedType{ID: ptID}
+
+	got := roundTripNode(t, before, seed).(*java.ParameterizedType)
+	if got.TypeParameters != nil {
+		t.Errorf("TypeParameters: got %+v, want nil", got.TypeParameters)
+	}
+}
+
+func TestCompositeRoundTrip_ElementsNoChange(t *testing.T) {
+	// given: a Go Composite whose Elements is a VALUE Container[Expression]. The
+	// value-container NO_CHANGE path returns the value baseline directly; this guards
+	// that routing value containers through receiveContainer keeps that behavior.
+	compID := uuid.New()
+	elements := java.Container[java.Expression]{
+		Elements: []java.RightPadded[java.Expression]{
+			{Element: makeIdent("a"), Markers: java.Markers{}},
+		},
+	}
+	before := &golang.Composite{
+		ID:       compID,
+		TypeExpr: makeIdent("T"),
+		Elements: elements,
+	}
+	after := &golang.Composite{
+		ID:       compID,
+		TypeExpr: makeIdent("U"), // changed so the node is a change
+		Elements: elements,       // identical value -> NO_CHANGE for this field
+	}
+	seed := &golang.Composite{
+		ID:       compID,
+		Elements: java.Container[java.Expression]{Elements: elements.Elements},
+	}
+
+	got := roundTripNodeWithBefore(t, after, before, seed).(*golang.Composite)
+
+	if len(got.Elements.Elements) != 1 {
+		t.Fatalf("Elements: got %d, want 1", len(got.Elements.Elements))
+	}
+	if id, ok := got.Elements.Elements[0].Element.(*java.Identifier); !ok || id.Name != "a" {
+		t.Errorf("Elements[0]: got %+v, want Identifier{a}", got.Elements.Elements[0].Element)
+	}
+}

--- a/rewrite-go/pkg/rpc/go_receiver.go
+++ b/rewrite-go/pkg/rpc/go_receiver.go
@@ -118,19 +118,7 @@ func (r *GoReceiver) VisitCompilationUnit(cu *golang.CompilationUnit, p any) jav
 		cu.PackageDecl = nil
 	}
 	// imports (container)
-	var beforeImports any
-	if cu.Imports != nil {
-		beforeImports = *cu.Imports
-	}
-	if result := q.Receive(beforeImports, func(v any) any { return receiveContainerTyped[*java.Import](r, q, v) }); result != nil {
-		// Safe by construction: the onChange path returns Container[*Import] from
-		// receiveContainerTyped, and the NoChange path returns beforeImports, which
-		// is the field's own Container[*Import] value (or nil, handled by the else).
-		c := result.(java.Container[*java.Import])
-		cu.Imports = &c
-	} else {
-		cu.Imports = nil
-	}
+	cu.Imports = receivePointerContainer[*java.Import](r, q, cu.Imports)
 	// statements
 	beforeStmts := make([]any, len(cu.Statements))
 	for i, s := range cu.Statements {
@@ -195,9 +183,7 @@ func (r *GoReceiver) VisitComposite(comp *golang.Composite, p any) java.J {
 	c := *comp // shallow copy to avoid mutating remoteObjects baseline
 	comp = &c
 	comp.TypeExpr = receiveValue(q, comp.TypeExpr, func(e java.Expression) any { return r.Visit(e, q) })
-	if result := q.Receive(comp.Elements, func(v any) any { return receiveContainerTyped[java.Expression](r, q, v) }); result != nil {
-		comp.Elements = result.(java.Container[java.Expression])
-	}
+	comp.Elements = receiveContainer[java.Expression](r, q, comp.Elements)
 	return comp
 }
 
@@ -278,9 +264,7 @@ func (r *GoReceiver) VisitFuncType(ft *golang.FuncType, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *ft // shallow copy to avoid mutating remoteObjects baseline
 	ft = &c
-	if result := q.Receive(ft.Parameters, func(v any) any { return receiveContainerTyped[java.Statement](r, q, v) }); result != nil {
-		ft.Parameters = result.(java.Container[java.Statement])
-	}
+	ft.Parameters = receiveContainer[java.Statement](r, q, ft.Parameters)
 	ft.ReturnType = receiveValue(q, ft.ReturnType, func(e java.Expression) any { return r.Visit(e, q) })
 	return ft
 }
@@ -305,9 +289,7 @@ func (r *GoReceiver) VisitTypeList(tl *golang.TypeList, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *tl // shallow copy to avoid mutating remoteObjects baseline
 	tl = &c
-	if result := q.Receive(tl.Types, func(v any) any { return receiveContainerTyped[java.Statement](r, q, v) }); result != nil {
-		tl.Types = result.(java.Container[java.Statement])
-	}
+	tl.Types = receiveContainer[java.Statement](r, q, tl.Types)
 	return tl
 }
 
@@ -369,16 +351,7 @@ func (r *GoReceiver) VisitTypeDecl(td *golang.TypeDecl, p any) java.J {
 		td.Assign = nil
 	}
 	td.Definition = receiveValue(q, td.Definition, func(e java.Expression) any { return r.Visit(e, q) })
-	var beforeSpecs any
-	if td.Specs != nil {
-		beforeSpecs = *td.Specs
-	}
-	if result := q.Receive(beforeSpecs, func(v any) any { return receiveContainerTyped[java.Statement](r, q, v) }); result != nil {
-		c := result.(java.Container[java.Statement])
-		td.Specs = &c
-	} else {
-		td.Specs = nil
-	}
+	td.Specs = receivePointerContainer[java.Statement](r, q, td.Specs)
 	return td
 }
 
@@ -443,8 +416,6 @@ func (r *GoReceiver) VisitIndexList(il *golang.IndexList, p any) java.J {
 	c := *il // shallow copy to avoid mutating remoteObjects baseline
 	il = &c
 	il.Target = receiveValue(q, il.Target, func(e java.Expression) any { return r.Visit(e, q) })
-	if result := q.Receive(il.Indices, func(v any) any { return receiveContainerTyped[java.Expression](r, q, v) }); result != nil {
-		il.Indices = result.(java.Container[java.Expression])
-	}
+	il.Indices = receiveContainer[java.Expression](r, q, il.Indices)
 	return il
 }

--- a/rewrite-go/pkg/rpc/java_receiver.go
+++ b/rewrite-go/pkg/rpc/java_receiver.go
@@ -178,16 +178,7 @@ func (r *JavaReceiver) VisitAnnotation(ann *java.Annotation, p any) java.J {
 	c := *ann // shallow copy to avoid mutating remoteObjects baseline
 	ann = &c
 	ann.AnnotationType = receiveValue(q, ann.AnnotationType, func(e java.Expression) any { return r.Visit(e, q) })
-	var beforeArgs any
-	if ann.Arguments != nil {
-		beforeArgs = *ann.Arguments
-	}
-	if result := q.Receive(beforeArgs, func(v any) any { return receiveContainerTyped[java.Expression](r, q, v) }); result != nil {
-		container := result.(java.Container[java.Expression])
-		ann.Arguments = &container
-	} else {
-		ann.Arguments = nil
-	}
+	ann.Arguments = receivePointerContainer[java.Expression](r, q, ann.Arguments)
 	return ann
 }
 
@@ -233,9 +224,7 @@ func (r *JavaReceiver) VisitMethodInvocation(mi *java.MethodInvocation, p any) j
 	// name
 	mi.Name = receiveValue(q, mi.Name, func(e *java.Identifier) any { return r.Visit(e, q) })
 	// arguments
-	if result := q.Receive(mi.Arguments, func(v any) any { return receiveContainerTyped[java.Expression](r, q, v) }); result != nil {
-		mi.Arguments = result.(java.Container[java.Expression])
-	}
+	mi.Arguments = receiveContainer[java.Expression](r, q, mi.Arguments)
 	// methodType
 	mt := r.receiveType(mi.MethodType, q)
 	if mt != nil {
@@ -298,9 +287,7 @@ func (r *JavaReceiver) VisitMethodDeclaration(md *java.MethodDeclaration, p any)
 	// name
 	md.Name = receiveValue(q, md.Name, func(e *java.Identifier) any { return r.Visit(e, q) })
 	// parameters
-	if result := q.Receive(md.Parameters, func(v any) any { return receiveContainerTyped[java.Statement](r, q, v) }); result != nil {
-		md.Parameters = result.(java.Container[java.Statement])
-	}
+	md.Parameters = receiveContainer[java.Statement](r, q, md.Parameters)
 	// dimensionsAfterName (empty for Go — no C-style array method returns)
 	q.ReceiveList(nil, nil)
 	// throws
@@ -350,19 +337,8 @@ func (r *JavaReceiver) VisitTypeParameter(tp *java.TypeParameter, p any) java.J 
 	q.ReceiveList(nil, nil)
 	// name
 	tp.Name = receiveValue(q, tp.Name, func(e java.Expression) any { return r.Visit(e, q) })
-	// bounds (container; nil when the parameter shares a sibling's constraint).
-	// Pass the value Container baseline (not the *Container) so the padding
-	// accessors recognize it.
-	var boundsBefore any
-	if tp.Bounds != nil {
-		boundsBefore = *tp.Bounds
-	}
-	if result := q.Receive(boundsBefore, func(v any) any { return receiveContainerTyped[java.Expression](r, q, v) }); result != nil {
-		container := result.(java.Container[java.Expression])
-		tp.Bounds = &container
-	} else {
-		tp.Bounds = nil
-	}
+	// bounds (container; nil when the parameter shares a sibling's constraint)
+	tp.Bounds = receivePointerContainer[java.Expression](r, q, tp.Bounds)
 	return tp
 }
 
@@ -651,9 +627,7 @@ func (r *JavaReceiver) VisitCase(cs *java.Case, p any) java.J {
 	c := *cs // shallow copy to avoid mutating remoteObjects baseline
 	cs = &c
 	q.Receive(nil, nil) // type enum
-	if result := q.Receive(cs.Expressions, func(v any) any { return receiveContainerTyped[java.Expression](r, q, v) }); result != nil {
-		cs.Expressions = result.(java.Container[java.Expression])
-	}
+	cs.Expressions = receiveContainer[java.Expression](r, q, cs.Expressions)
 	// statements - Java sends Container<RightPadded<Statement>>, extract to Go's []RightPadded[Statement]
 	if result := q.Receive(nil, func(v any) any { return receiveContainerTyped[java.Statement](r, q, v) }); result != nil {
 		cont := result.(java.Container[java.Statement])
@@ -709,10 +683,7 @@ func (r *JavaReceiver) VisitParameterizedType(pt *java.ParameterizedType, p any)
 	c := *pt
 	pt = &c
 	pt.Clazz = receiveValue(q, pt.Clazz, func(e java.Expression) any { return r.Visit(e, q) })
-	if result := q.Receive(pt.TypeParameters, func(v any) any { return receiveContainerTyped[java.Expression](r, q, v) }); result != nil {
-		container := result.(java.Container[java.Expression])
-		pt.TypeParameters = &container
-	}
+	pt.TypeParameters = receivePointerContainer[java.Expression](r, q, pt.TypeParameters)
 	pt.Type = r.receiveType(pt.Type, q)
 	return pt
 }

--- a/rewrite-go/pkg/rpc/java_sender.go
+++ b/rewrite-go/pkg/rpc/java_sender.go
@@ -649,8 +649,15 @@ func (s *JavaSender) VisitParameterizedType(pt *java.ParameterizedType, p any) j
 	q := p.(*SendQueue)
 	q.GetAndSend(pt, func(v any) any { return v.(*java.ParameterizedType).Clazz },
 		func(v any) { s.Visit(v.(java.Tree), q) })
-	q.GetAndSend(pt, func(v any) any { return v.(*java.ParameterizedType).TypeParameters },
-		func(v any) { sendContainer(s, v, q) })
+	// TypeParameters is a *Container; dereference so sendContainer (containerElements
+	// et al.) sees a value Container rather than the pointer (which sends as empty).
+	q.GetAndSend(pt, func(v any) any {
+		tp := v.(*java.ParameterizedType).TypeParameters
+		if tp == nil {
+			return nil
+		}
+		return *tp
+	}, func(v any) { sendContainer(s, v, q) })
 	q.GetAndSend(pt, func(v any) any { return AsRef(v.(*java.ParameterizedType).Type) },
 		func(v any) { s.visitType(GetValueNonNull(v).(java.JavaType), q) })
 	return pt

--- a/rewrite-go/pkg/rpc/padding_rpc.go
+++ b/rewrite-go/pkg/rpc/padding_rpc.go
@@ -595,3 +595,38 @@ func receiveContainerTyped[T any](r Receiver, q *ReceiveQueue, before any) java.
 	}
 	return java.Container[T]{Before: beforeSpace.(java.Space), Elements: elems, Markers: markers.(java.Markers)}
 }
+
+// receiveContainer receives a value-typed Container[T] field. NO_CHANGE returns the
+// before value (a Container[T], which the cast matches); ADD/CHANGE returns the typed
+// container from receiveContainerTyped; DELETE leaves the field unchanged (value-typed
+// container fields are never deleted).
+//
+// Unlike receiveValue, the onChange closure forwards `before` to receiveContainerTyped
+// as a bare `any` — it must NOT cast to Container[T] first. On the ADD path the wire's
+// erased "JContainer" type makes the queue materialize a Container[java.J] baseline
+// (newObj can't know the element type T); receiveContainerTyped tolerates that via
+// containerElements, but a `v.(Container[T])` cast would panic on it. This is the same
+// reason receivePointerContainer keeps the closure untyped.
+func receiveContainer[T any](r Receiver, q *ReceiveQueue, before java.Container[T]) java.Container[T] {
+	if result := q.Receive(before, func(v any) any { return receiveContainerTyped[T](r, q, v) }); result != nil {
+		return result.(java.Container[T])
+	}
+	return before
+}
+
+// receivePointerContainer receives a nullable *Container[T] field. The before-pointer is
+// dereferenced to a value baseline before q.Receive so the NO_CHANGE path returns an
+// assertable value Container[T] rather than the *Container[T] pointer (a raw value-cast
+// of which panics — the #7831 / pointer-vs-value bug class). DELETE (nil result) clears
+// the field; ADD/CHANGE rewraps the typed container as a pointer.
+func receivePointerContainer[T any](r Receiver, q *ReceiveQueue, before *java.Container[T]) *java.Container[T] {
+	var beforeVal any
+	if before != nil {
+		beforeVal = *before
+	}
+	if result := q.Receive(beforeVal, func(v any) any { return receiveContainerTyped[T](r, q, v) }); result != nil {
+		c := result.(java.Container[T])
+		return &c
+	}
+	return nil
+}


### PR DESCRIPTION
## Motivation

- [#7831](https://github.com/openrewrite/rewrite/pull/7831) fixed the empty-imports `Container` panic by dereferencing a nullable `*Container` field's before-value before `q.Receive`, so the NO_CHANGE path returns a value `Container[T]` the receive can assert. That deref pattern was not propagated to every `*Container`-field receive site — most notably `ParameterizedType.TypeParameters`, which still passed the pointer directly:

```
PANIC in Print: interface conversion: interface {} is *java.Container[…/java.Expression], not java.Container[…/java.Expression]
  rpc.(*JavaReceiver).VisitParameterizedType  java_receiver.go
```

On a NO_CHANGE message `q.Receive` returns its `before` argument verbatim — for a pointer field that is the `*Container[Expression]` pointer, so the raw value-cast `result.(java.Container[Expression])` panics. This was the single largest remaining source of Print-path panics (~200 occurrences in one recipe run across 8 repos).

The same field was **also** broken on the send side: `sendContainer` (via `containerElements`/`containerBefore`/`containerMarkers`) only matches a value `Container[T]`, so passing the `*Container` pointer sent an empty element list — silently dropping type arguments. The four sibling pointer-container send sites already dereference; `ParameterizedType.TypeParameters` was the lone exception.

## Summary

- Add two generic helpers in `padding_rpc.go` — the container analog of #7836's `receiveValue`:
  - `receiveContainer[T]` for value `Container[T]` fields
  - `receivePointerContainer[T]` for nullable `*Container[T]` fields (derefs the before-pointer so NO_CHANGE yields an assertable value `Container[T]`)
  - Both forward `before` to `receiveContainerTyped` as a bare `any` rather than casting it, so an ADD-path `Container[java.J]` baseline (materialized by `newObj` from the erased `JContainer` wire type) is tolerated.
- Route **all 12** container receive sites in `java_receiver.go` / `go_receiver.go` through the helpers, collapsing four hand-written deref blocks and removing every raw `result.(Container[T])` cast — so the pointer-vs-value panic class can no longer recur.
- Dereference `ParameterizedType.TypeParameters` in `JavaSender`, matching the existing `Annotation.Arguments` / `TypeParameter.Bounds` / `CompilationUnit.Imports` / `TypeDecl.Specs` send sites.
- Audited the `*RightPadded` / `*LeftPadded` pointer-field receive sites too (`If`, `For`, `RangeFor`, `Switch`, `MethodInvocation.Select`, `VariableDeclarator.Initializer`, `Import.Alias`): all already dereference or reconstruct, so none were affected.

Net diff is a reduction (+57/−73 in the source files): the helpers remove more boilerplate than they add.

## Test plan

- [x] New `rewrite-go/pkg/rpc/container_pointer_rpc_test.go`:
  - `TestParameterizedTypeRoundTrip_TypeParametersNoChange` — the repro: a `*Container` field receiving a NO_CHANGE message; asserts no panic and `TypeParameters` stays a `*Container[Expression]` with its element intact. (Confirmed it panics with the production stack before the fix.)
  - `TestCompositeRoundTrip_ElementsNoChange` — value-container NO_CHANGE path.
  - `TestParameterizedTypeRoundTrip_TypeParametersChange` / `_NilTypeParameters` — ADD and nil paths.
- [x] `go build ./...`, `go vet ./...`, and the full `rewrite-go` test suite (incl. `pkg/rpc` and the generics RPC round-trip tests) pass.