### PR TITLE
Go: isolate reverse-RPC receive state so a mid-receive panic can't cascade

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -848,22 +848,47 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 	q := rpc.NewReceiveQueue(s.reverseRemoteRefs, fetchBatch)
 
 	receiver := rpc.NewGoReceiver()
-	obj := q.Receive(before, func(v any) any {
-		// ExecutionContext uses an empty-body codec (matches JS execution.ts):
-		// the type tag arrives via the queue envelope; no field messages follow.
-		if ctx, ok := v.(*recipe.ExecutionContext); ok {
-			return ctx
-		}
-		if t, ok := v.(java.Tree); ok {
-			return receiver.Visit(t, q)
-		}
-		return v
-	})
 
-	// Consume the END_OF_OBJECT sentinel if present
-	if len(q.PeekBatch()) > 0 && q.PeekBatch()[0].State == rpc.EndOfObject {
-		q.Take()
-	}
+	var obj any
+	func() {
+		// A panic mid-receive leaves Go's per-id baseline diverged from Java's:
+		// Java records remoteObjects[id] when it generates the diff, so its next
+		// send would be a CHANGE delta against a baseline Go never finished
+		// applying — desyncing the wire and cascading "expected CHANGE with
+		// positions" / position panics into unrelated later requests. Drop our
+		// baseline so the next GetObject for this id re-syncs as a full ADD.
+		// Mirrors the getObject recovery in RewriteRpc (Java) and rewrite-rpc.ts
+		// (JS): on failure they `remoteObjects.remove(id)` and rethrow.
+		//
+		// The shared ref table is intentionally left intact. Java's
+		// reverse-direction send refs are connection-scoped (cleared only on
+		// Reset), so discarding ours would make Java's bare {ref:N} look-ups
+		// fail with "received reference to unknown object: N" — turning a single
+		// failed request into a fresh cascade.
+		defer func() {
+			if r := recover(); r != nil {
+				delete(s.reverseRemoteObjects, id)
+				panic(r) // surface as one clear error via safeHandleRequest
+			}
+		}()
+
+		obj = q.Receive(before, func(v any) any {
+			// ExecutionContext uses an empty-body codec (matches JS execution.ts):
+			// the type tag arrives via the queue envelope; no field messages follow.
+			if ctx, ok := v.(*recipe.ExecutionContext); ok {
+				return ctx
+			}
+			if t, ok := v.(java.Tree); ok {
+				return receiver.Visit(t, q)
+			}
+			return v
+		})
+
+		// Consume the END_OF_OBJECT sentinel if present
+		if len(q.PeekBatch()) > 0 && q.PeekBatch()[0].State == rpc.EndOfObject {
+			q.Take()
+		}
+	}()
 
 	if obj != nil {
 		s.reverseRemoteObjects[id] = obj

--- a/rewrite-go/cmd/rpc/receive_resilience_test.go
+++ b/rewrite-go/cmd/rpc/receive_resilience_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// frameReverseGetObjectReply renders one Content-Length framed JSON-RPC
+// response carrying `result` — the shape Java sends back when Go issues a
+// reverse GetObject during Print/Visit.
+func frameReverseGetObjectReply(t *testing.T, result any) []byte {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "go-GetObject",
+		"result":  result,
+	})
+	if err != nil {
+		t.Fatalf("marshal reply: %v", err)
+	}
+	return append([]byte(fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))), body...)
+}
+
+// TestGetObjectFromJavaPanicResetsBaselineButKeepsRefs reproduces the
+// receive-stream cascade and pins down the containment contract.
+//
+// When a reverse GetObject panics mid-receive, the per-id baseline must be
+// dropped (so the next transfer of that id re-syncs as a full ADD rather than
+// a CHANGE delta against a baseline Go never finished applying — the source of
+// the "expected CHANGE with positions" cascade). The shared ref table must NOT
+// be wiped: Java's reverse-direction send refs are connection-scoped (cleared
+// only on Reset), so discarding Go's would make Java's bare {ref:N} look-ups
+// fail with "received reference to unknown object: N".
+func TestGetObjectFromJavaPanicResetsBaselineButKeepsRefs(t *testing.T) {
+	dir := t.TempDir()
+	s := newServer(serverConfig{logFile: filepath.Join(dir, "server.log")})
+	t.Cleanup(s.closeMetrics)
+
+	// Java's two scripted replies on the reverse GetObject stream:
+	//  1) a bare reference to an object Go never received -> panics mid-receive
+	//     ("received reference to unknown object: 7"), a documented cascade
+	//     signature.
+	//  2) a clean full ADD of a simple value -> the follow-up request.
+	stream := append(
+		frameReverseGetObjectReply(t, []map[string]any{{"state": "ADD", "ref": 7}}),
+		frameReverseGetObjectReply(t, []map[string]any{
+			{"state": "ADD", "value": "package main\n"},
+			{"state": "END_OF_OBJECT"},
+		})...,
+	)
+	s.reader = bufio.NewReader(bytes.NewReader(stream))
+	s.writer = &bytes.Buffer{} // the GetObject requests Go writes are irrelevant here
+
+	const id = "tree-X"
+	// Pre-seed state a live session would hold from prior successful cycles:
+	//  - a baseline that diverges from Java's once the receive panics, and
+	//  - a shared ref the panic must NOT wipe.
+	s.reverseRemoteObjects[id] = "STALE-BASELINE"
+	s.reverseRemoteRefs[5] = "shared-value-from-earlier-transfer"
+
+	// Transfer 1: must panic mid-receive.
+	panicked := func() (p bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				p = true
+			}
+		}()
+		s.getObjectFromJava(id, "")
+		return false
+	}()
+	if !panicked {
+		t.Fatal("transfer 1: expected a panic mid-receive, got none")
+	}
+
+	// Containment: the diverged per-id baseline is dropped.
+	if v, ok := s.reverseRemoteObjects[id]; ok {
+		t.Errorf("reverseRemoteObjects[%q] should be deleted after a receive panic, still present: %v", id, v)
+	}
+	// ...but the shared ref table survives.
+	if got := s.reverseRemoteRefs[5]; got != "shared-value-from-earlier-transfer" {
+		t.Errorf("reverseRemoteRefs[5] should survive a receive panic, got %v", got)
+	}
+
+	// Transfer 2: a fresh request on the same server must succeed cleanly,
+	// with no leftover state poisoning the receive.
+	got := s.getObjectFromJava(id, "")
+	if got != "package main\n" {
+		t.Errorf("transfer 2: want clean ADD value %q, got %#v", "package main\n", got)
+	}
+	if s.reverseRemoteObjects[id] != "package main\n" {
+		t.Errorf("transfer 2: baseline should be repopulated, got %#v", s.reverseRemoteObjects[id])
+	}
+}


### PR DESCRIPTION
## Motivation

Running a recipe over a multi-file Go repo produced a burst of RPC panics where most were not independent bugs — they were cascade fallout. When one `handlePrint`/`handleVisit` panicked partway through reading the reverse `GetObject` stream, `safeHandleRequest` recovered and kept the server alive, but the per-request receive state was left misaligned, so subsequent requests threw spurious assertion/consistency panics:

```
PANIC in Print: expected CHANGE with positions, got NO_CHANGE/ADD   (receive_queue.go)
PANIC in Print: interface conversion: interface {} is []interface {} (…)
PANIC in Print: received reference to unknown object: N             (receive_queue.go)
```

In one run across 8 repos this cascade accounted for well over a hundred panics after the first genuine failure.

The root of the cascade is the per-id baseline. `getObjectFromJava` had **no panic recovery**: when `q.Receive` panicked mid-transfer it never reached the line that updates `reverseRemoteObjects[id]`. Java records its baseline (`remoteObjects[id]`) as soon as it generates the diff, so Go's baseline diverged — the next transfer of that id applied a CHANGE delta against a baseline Go never finished applying, desyncing the wire.

The bidirectional byte stream itself does **not** desync (Go only reads batches it explicitly requests, and the `ReceiveQueue` cursor/pending batch are already per-transfer). The only state shared across requests on the connection is two maps: `reverseRemoteObjects` (per-id baselines) and `reverseRemoteRefs` (refs). Only the baseline needs resetting.

## Summary

- Wrap the receive in `getObjectFromJava` with a deferred recover that, on panic, drops `reverseRemoteObjects[id]` so the next `GetObject` for that id re-syncs as a full ADD instead of a doomed CHANGE delta, then re-panics so the failed request still surfaces a single clear error via `safeHandleRequest`.
- Leave the shared ref table (`reverseRemoteRefs`) **intact**. Java's reverse-direction send refs are connection-scoped (cleared only on `Reset`), so discarding Go's would make Java's bare `{ref:N}` look-ups fail with `received reference to unknown object: N` — manufacturing a fresh cascade rather than containing one.
- This mirrors the `getObject` recovery contract shared by the other clients — Java (`RewriteRpc.getObject`), JS/TS (`rewrite-rpc.ts`), and Python (`server.py`) all drop the per-id baseline, keep refs, and rethrow; C# keeps refs too.

- This is the **containment** half. The genuine root panics that trigger the cascade are fixed separately (e.g. #7831 / #7838 for the `*Container` Print panics); this change ensures whatever genuine failures remain stay isolated, with no downstream cascade. There is no file overlap with those PRs.

## Test plan

- [x] New `rewrite-go/cmd/rpc/receive_resilience_test.go`: drives `getObjectFromJava` twice on one server with a scripted in-memory stream. Transfer 1 replies a bare reference to a never-received object (`received reference to unknown object: 7`, a mid-receive panic); transfer 2 is a clean follow-up ADD. Asserts the diverged baseline is dropped, the shared ref **survives**, and the follow-up succeeds with no cascade. (Confirmed red before the fix: the baseline survived the panic.)
- [x] `go build ./...`, `go vet ./...`, `gofmt`, and the full `rewrite-go` test suite (9 packages) pass.