### PR TITLE
JavaSourceSet: add @JsonIdentityInfo so Jackson dedups instance across CUs

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.java.marker;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfo;
 import io.github.classgraph.ClassInfoList;
@@ -47,6 +49,7 @@ import static org.openrewrite.internal.StringUtils.matchesGlob;
 @Value
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @With
+@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
 public class JavaSourceSet implements SourceSet {
     @EqualsAndHashCode.Include
     UUID id;


### PR DESCRIPTION
## Summary

- Adds `@JsonIdentityInfo(IntSequenceGenerator)` to `JavaSourceSet`, mirroring the pattern already used on `MavenResolutionResult`, `ResolvedPom`, `ResolvedDependency`, `ManagedDependency`, `MavenRepository`, and `MSBuildProject.ResolvedPackage`.
- The same `JavaSourceSet` instance is attached to every `CompilationUnit` in a source set, but without this annotation Jackson Smile writes the full payload (classpath list, gavToTypes map) once per CU. With the annotation the payload is written once and back-referenced from the rest, materially reducing LST bytes on source sets with non-trivial classpaths.

## Test plan
- [ ] `./gradlew :rewrite-java:check` passes locally
- [ ] Existing round-trip / serialization tests in `rewrite-java-test` exercise the JavaSourceSet marker path