### PR TITLE
.gitignore .kotlin/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ CLAUDE.local.md
 # Moderne CLI
 .moderne/*
 !.moderne/context/
+
+# Kotlin compiler daemon session files
+.kotlin/


### PR DESCRIPTION
## What's changed?

Remove an accidentally committed file: `.kotlin/sessions/kotlin-compiler-9121149630670752279.salive`
and add a .gitignore entry to prevent the same from happening again.

## What's your motivation?

Clean up junk.
