### PR TITLE
Scala: Introduce `S.Binding`

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -637,6 +637,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return visitXmlLiteral((S.XmlLiteral) tree, p);
         } else if (tree instanceof S.Alternative) {
             return visitAlternative((S.Alternative) tree, p);
+        } else if (tree instanceof S.Binding) {
+            return visitBinding((S.Binding) tree, p);
         } else if (tree instanceof S.QualifiedSuper) {
             return visitQualifiedSuper((S.QualifiedSuper) tree, p);
         } else if (tree instanceof S.AnnotatedExpression) {
@@ -1744,6 +1746,16 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         visitContainer("", alternative.getPadding().getPatterns(), JContainer.Location.LANGUAGE_EXTENSION, "|", "", p);
         afterSyntax(alternative, p);
         return alternative;
+    }
+
+    public J visitBinding(S.Binding binding, PrintOutputCapture<P> p) {
+        beforeSyntax(binding, Space.Location.LANGUAGE_EXTENSION, p);
+        visit(binding.getName(), p);
+        visitSpace(binding.getBeforeAt(), Space.Location.LANGUAGE_EXTENSION, p);
+        p.append('@');
+        visit(binding.getPattern(), p);
+        afterSyntax(binding, p);
+        return binding;
     }
 
     public J visitQualifiedSuper(S.QualifiedSuper qualifiedSuper, PrintOutputCapture<P> p) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -285,6 +285,16 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         return a;
     }
 
+    public J visitBinding(S.Binding binding, P p) {
+        S.Binding b = binding;
+        b = b.withPrefix(visitSpace(b.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        b = b.withMarkers(visitMarkers(b.getMarkers(), p));
+        b = b.withName(visitAndCast(b.getName(), p));
+        b = b.withBeforeAt(visitSpace(b.getBeforeAt(), Space.Location.LANGUAGE_EXTENSION, p));
+        b = b.withPattern(visitAndCast(b.getPattern(), p));
+        return b;
+    }
+
     public J visitQualifiedSuper(S.QualifiedSuper qualifiedSuper, P p) {
         S.QualifiedSuper q = qualifiedSuper;
         q = q.withPrefix(visitSpace(q.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -1859,6 +1859,63 @@ public interface S extends J {
         }
     }
 
+    /**
+     * Represents a Scala pattern binding (at-binding): {@code p @ Person(name, _)},
+     * {@code all @ List(head, _*)}, or {@code msg @ (_: String)}. The bound variable
+     * {@code name} is matched against {@code pattern}.
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    final class Binding implements S, Expression {
+
+        @With @Getter @EqualsAndHashCode.Include
+        UUID id;
+
+        @With @Getter
+        Space prefix;
+
+        @With @Getter
+        Markers markers;
+
+        @With @Getter
+        J.Identifier name;
+
+        /**
+         * Space before the {@code @} separator.
+         */
+        @With @Getter
+        Space beforeAt;
+
+        @With @Getter
+        Expression pattern;
+
+        @With @Getter
+        @Nullable
+        JavaType type;
+
+        public Binding(UUID id, Space prefix, Markers markers,
+                       J.Identifier name, Space beforeAt, Expression pattern,
+                       @Nullable JavaType type) {
+            this.id = id;
+            this.prefix = prefix;
+            this.markers = markers;
+            this.name = name;
+            this.beforeAt = beforeAt;
+            this.pattern = pattern;
+            this.type = type;
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitBinding(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+    }
+
 
     /**
      * Represents a Scala refined (structural) type:

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7412,12 +7412,23 @@ class ScalaTreeVisitor(
       JLeftPadded.build(arg).withBefore(beforeEq), typeFor(namedArg.span))
   }
 
-  private def visitBind(bind: Trees.Bind[?]): J.Identifier = {
-    // At-binding pattern: `all@List(head, _*)` — preserve as identifier with source text
+  private def visitBind(bind: Trees.Bind[?]): S.Binding = {
+    // At-binding pattern: `p@Person(name, _)`, `all@List(head, _*)`, `msg@(_: String)`.
     val prefix = extractPrefix(bind.span)
-    val text = extractSource(bind.span)
+    val nameStr = bind.name.toString
+    val name = ident(nameStr)
+    cursor = cursor + nameStr.length
+    val atPos = positionOfNext("@", cursor)
+    val beforeAt = if (atPos >= cursor) Space.format(source, cursor, atPos) else Space.EMPTY
+    if (atPos >= 0) cursor = atPos + 1
+    val pattern: Expression = visitTree(bind.body) match {
+      case e: Expression => e
+      case j: J => new S.StatementExpression(Tree.randomId(), j)
+      case _ => throw new UnsupportedOperationException(
+        s"Bind body did not produce an Expression: ${bind.body.getClass.getSimpleName}")
+    }
     updateCursor(bind.span.end)
-    ident(text, prefix)
+    new S.Binding(Tree.randomId(), prefix, Markers.EMPTY, name, beforeAt, pattern, typeFor(bind.span))
   }
 
   private def visitAlternative(alt: Trees.Alternative[?]): S.Alternative = {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
@@ -16,11 +16,59 @@
 package org.openrewrite.scala.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.scala.ScalaIsoVisitor;
+import org.openrewrite.scala.tree.S;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.scala.Assertions.scala;
 
 class MatchTest implements RewriteTest {
+
+    @Test
+    void atBindingIsNotCollapsedIntoSingleIdentifier() {
+        AtomicReference<S.Binding> binding = new AtomicReference<>();
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              case class Person(name: String, age: Int)
+              def handle(x: Any): String = x match {
+                case p@Person(name, _) => name
+                case _ => ""
+              }
+            }
+            """,
+            spec -> spec.afterRecipe(cu -> {
+                new ScalaIsoVisitor<Integer>() {
+                    @Override
+                    public J.Identifier visitIdentifier(J.Identifier identifier, Integer p) {
+                        // the whole pattern must never be stuffed into one identifier name
+                        assertThat(identifier.getSimpleName()).doesNotContain("@", "(");
+                        return identifier;
+                    }
+
+                    @Override
+                    public J visitBinding(S.Binding b, Integer p) {
+                        binding.set(b);
+                        return super.visitBinding(b, p);
+                    }
+                }.visit(cu, 0);
+
+                assertThat(binding.get()).isNotNull();
+                assertThat(binding.get().getName().getSimpleName()).isEqualTo("p");
+                assertThat(binding.get().getPattern()).isInstanceOf(J.MethodInvocation.class);
+                J.MethodInvocation pattern = (J.MethodInvocation) binding.get().getPattern();
+                assertThat(pattern.getSelect()).isInstanceOf(J.Identifier.class);
+                assertThat(((J.Identifier) pattern.getSelect()).getSimpleName()).isEqualTo("Person");
+                assertThat(pattern.getArguments()).hasSize(2);
+            })
+          )
+        );
+    }
 
     @Test
     void emptyCaseBodyWithGuardPreservesAlignmentBeforeArrow() {


### PR DESCRIPTION
## What's changed?

Adding a new LST element to Scala for holding the named bindings in pattern matches, e.g.
```
def describe(expr: Expr): String =
  expr match {
    case whole @ Add(Number(a), Number(b)) =>
      s"Found addition $whole with values $a and $b"

    case Number(n) =>
      s"Number: $n"
  }
```
See the `whole @` part.

## What's your motivation?

Currently they are not parsed at all. And their text is just stuffed into an identifier.