### PR TITLE
Scala: add support for interpolated strings

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaIsoVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaIsoVisitor.java
@@ -214,6 +214,16 @@ public class ScalaIsoVisitor<P> extends ScalaVisitor<P> {
     }
 
     @Override
+    public S.InterpolatedString visitInterpolatedString(S.InterpolatedString interpolatedString, P p) {
+        return (S.InterpolatedString) super.visitInterpolatedString(interpolatedString, p);
+    }
+
+    @Override
+    public S.Interpolation visitInterpolation(S.Interpolation interpolation, P p) {
+        return (S.Interpolation) super.visitInterpolation(interpolation, p);
+    }
+
+    @Override
     public J.InstanceOf visitInstanceOf(J.InstanceOf instanceOf, P p) {
         return (J.InstanceOf) super.visitInstanceOf(instanceOf, p);
     }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -637,6 +637,10 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return visitXmlLiteral((S.XmlLiteral) tree, p);
         } else if (tree instanceof S.Alternative) {
             return visitAlternative((S.Alternative) tree, p);
+        } else if (tree instanceof S.InterpolatedString) {
+            return visitInterpolatedString((S.InterpolatedString) tree, p);
+        } else if (tree instanceof S.Interpolation) {
+            return visitInterpolation((S.Interpolation) tree, p);
         } else if (tree instanceof S.QualifiedSuper) {
             return visitQualifiedSuper((S.QualifiedSuper) tree, p);
         } else if (tree instanceof S.AnnotatedExpression) {
@@ -1744,6 +1748,33 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         visitContainer("", alternative.getPadding().getPatterns(), JContainer.Location.LANGUAGE_EXTENSION, "|", "", p);
         afterSyntax(alternative, p);
         return alternative;
+    }
+
+    public J visitInterpolatedString(S.InterpolatedString interpolatedString, PrintOutputCapture<P> p) {
+        beforeSyntax(interpolatedString, Space.Location.LANGUAGE_EXTENSION, p);
+        visit(interpolatedString.getInterpolator(), p);
+        p.append(interpolatedString.getDelimiter());
+        for (Expression part : interpolatedString.getParts()) {
+            visit(part, p);
+        }
+        p.append(interpolatedString.getDelimiter());
+        afterSyntax(interpolatedString, p);
+        return interpolatedString;
+    }
+
+    public J visitInterpolation(S.Interpolation interpolation, PrintOutputCapture<P> p) {
+        beforeSyntax(interpolation, Space.Location.LANGUAGE_EXTENSION, p);
+        p.append('$');
+        if (interpolation.isBraces()) {
+            p.append('{');
+        }
+        visit(interpolation.getExpression(), p);
+        visitSpace(interpolation.getAfterExpression(), Space.Location.LANGUAGE_EXTENSION, p);
+        if (interpolation.isBraces()) {
+            p.append('}');
+        }
+        afterSyntax(interpolation, p);
+        return interpolation;
     }
 
     public J visitQualifiedSuper(S.QualifiedSuper qualifiedSuper, PrintOutputCapture<P> p) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -285,6 +285,24 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         return a;
     }
 
+    public J visitInterpolatedString(S.InterpolatedString interpolatedString, P p) {
+        S.InterpolatedString i = interpolatedString;
+        i = i.withPrefix(visitSpace(i.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        i = i.withMarkers(visitMarkers(i.getMarkers(), p));
+        i = i.withInterpolator(visitAndCast(i.getInterpolator(), p));
+        i = i.withParts(ListUtils.map(i.getParts(), e -> visitAndCast(e, p)));
+        return i;
+    }
+
+    public J visitInterpolation(S.Interpolation interpolation, P p) {
+        S.Interpolation i = interpolation;
+        i = i.withPrefix(visitSpace(i.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        i = i.withMarkers(visitMarkers(i.getMarkers(), p));
+        i = i.withExpression(visitAndCast(i.getExpression(), p));
+        i = i.withAfterExpression(visitSpace(i.getAfterExpression(), Space.Location.LANGUAGE_EXTENSION, p));
+        return i;
+    }
+
     public J visitQualifiedSuper(S.QualifiedSuper qualifiedSuper, P p) {
         S.QualifiedSuper q = qualifiedSuper;
         q = q.withPrefix(visitSpace(q.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -2408,4 +2408,119 @@ public interface S extends J {
             return new CoordinateBuilder.Statement(this);
         }
     }
+
+    /**
+     * A Scala string interpolation such as {@code s"Hello, $name"}, {@code f"$x%2.2f"}, or
+     * {@code raw"a\nb"}. The {@code interpolator} identifier captures the {@code s}/{@code f}/{@code raw}
+     * (or any custom {@link StringContext} extension) prefix. {@code parts} interleaves
+     * {@link J.Literal} text chunks with {@link Interpolation} nodes, so the embedded
+     * expressions are first-class, visitable LST elements rather than opaque source text.
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    final class InterpolatedString implements S, Expression, TypedTree {
+
+        @With @Getter @EqualsAndHashCode.Include
+        UUID id;
+
+        @With @Getter
+        Space prefix;
+
+        @With @Getter
+        Markers markers;
+
+        @With @Getter
+        J.Identifier interpolator;
+
+        @With @Getter
+        String delimiter;
+
+        @With @Getter
+        List<Expression> parts;
+
+        @With @Getter
+        @Nullable
+        JavaType type;
+
+        public InterpolatedString(UUID id, Space prefix, Markers markers, J.Identifier interpolator,
+                                  String delimiter, List<Expression> parts, @Nullable JavaType type) {
+            this.id = id;
+            this.prefix = prefix;
+            this.markers = markers;
+            this.interpolator = interpolator;
+            this.delimiter = delimiter;
+            this.parts = parts;
+            this.type = type;
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitInterpolatedString(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+    }
+
+    /**
+     * A single interpolation inside an {@link InterpolatedString}: {@code $name} (no braces) or
+     * {@code ${expr}} (braces). The wrapped {@code expression} is a real LST {@link Expression}.
+     * When {@code braces} is {@code true}, {@code afterExpression} holds any whitespace before the
+     * closing {@code }} (e.g. {@code ${ x }}).
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    final class Interpolation implements S, Expression {
+
+        @With @Getter @EqualsAndHashCode.Include
+        UUID id;
+
+        @With @Getter
+        Space prefix;
+
+        @With @Getter
+        Markers markers;
+
+        @With @Getter
+        boolean braces;
+
+        @With @Getter
+        Expression expression;
+
+        @With @Getter
+        Space afterExpression;
+
+        public Interpolation(UUID id, Space prefix, Markers markers, boolean braces,
+                             Expression expression, Space afterExpression) {
+            this.id = id;
+            this.prefix = prefix;
+            this.markers = markers;
+            this.braces = braces;
+            this.expression = expression;
+            this.afterExpression = afterExpression;
+        }
+
+        @Override
+        public @Nullable JavaType getType() {
+            return expression.getType();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Interpolation withType(@Nullable JavaType type) {
+            return withExpression(expression.withType(type));
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitInterpolation(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+    }
 }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7366,12 +7366,98 @@ class ScalaTreeVisitor(
     )
   }
 
-  private def visitInterpolatedString(interp: untpd.InterpolatedString): J.Identifier = {
-    // String interpolation like s"Hello, $name" — preserve as identifier (Statement + Expression)
+  private def visitInterpolatedString(interp: untpd.InterpolatedString): S.InterpolatedString = {
+    // String interpolation like s"Hello, $name", f"$x%2.2f", raw"a\nb". The dotty AST models
+    // this as InterpolatedString(id, segments) where each segment is either a Thicket(literalPart,
+    // expr) pair or a trailing bare Literal. We map the literal text chunks to J.Literal and each
+    // embedded `$expr` / `${expr}` to S.Interpolation, so the expressions stay first-class.
     val prefix = extractPrefix(interp.span)
-    val sourceText = extractSource(interp.span)
+    val interpStart = Math.max(0, interp.span.start - offsetAdjustment)
+    val interpName = interp.id.toString
+    val interpolator = ident(interpName)
+    cursor = Math.max(cursor, interpStart + interpName.length)
+    val delimiter = if (source.startsWith("\"\"\"", cursor)) "\"\"\"" else "\""
+    cursor = Math.min(source.length, cursor + delimiter.length)
+
+    val parts = new util.ArrayList[Expression]()
+
+    def addLiteral(litTree: Trees.Literal[?]): Unit = {
+      val ls = Math.max(0, litTree.span.start - offsetAdjustment)
+      val le = Math.max(0, litTree.span.end - offsetAdjustment)
+      if (le > ls && le <= source.length) {
+        val text = source.substring(ls, le)
+        if (text.nonEmpty) {
+          parts.add(new J.Literal(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+            litTree.const.value, text, Collections.emptyList(), JavaType.Primitive.String))
+        }
+        cursor = le
+      }
+    }
+
+    def asExpression(j: J): Expression = j match {
+      case e: Expression => e
+      case s: Statement => new S.StatementExpression(Tree.randomId(), s)
+      case other => throw new UnsupportedOperationException(
+        s"Interpolation expression did not produce an Expression: ${other.getClass.getName}")
+    }
+
+    // A `${...}` block that wraps a single expression is unwrapped so the printer can re-add the
+    // braces; a multi-statement block (rare, e.g. `${ val x = 1; x }`) keeps its own braces.
+    def singleExpr(b: untpd.Block): Option[untpd.Tree] = {
+      val all = b.stats ++ (if (b.expr.isEmpty) Nil else List(b.expr))
+      all match {
+        case single :: Nil => Some(single)
+        case _ => None
+      }
+    }
+
+    interp.segments.foreach {
+      case th: untpd.Thicket =>
+        val trees = th.trees
+        trees.head match {
+          case lit: Trees.Literal[?] => addLiteral(lit)
+          case _ =>
+        }
+        val exprTree = trees(1)
+        val dollarPos = cursor
+        val braces = dollarPos + 1 < source.length && source.charAt(dollarPos + 1) == '{'
+        if (braces) {
+          val inner = exprTree match {
+            case b: untpd.Block => singleExpr(b)
+            case t => Some(t)
+          }
+          inner match {
+            case Some(innerExpr) =>
+              cursor = dollarPos + 2 // past `${`
+              val exprJ = asExpression(visitTree(innerExpr))
+              val blockEnd = Math.max(0, exprTree.span.end - offsetAdjustment)
+              val bracePos = blockEnd - 1
+              val afterExpr =
+                if (bracePos > cursor && bracePos <= source.length) Space.format(source.substring(cursor, bracePos))
+                else Space.EMPTY
+              cursor = Math.max(cursor, blockEnd)
+              parts.add(new S.Interpolation(Tree.randomId(), Space.EMPTY, Markers.EMPTY, true, exprJ, afterExpr))
+            case None =>
+              cursor = dollarPos + 1 // at `{`, let the block self-print its braces
+              val exprJ = asExpression(visitTree(exprTree))
+              parts.add(new S.Interpolation(Tree.randomId(), Space.EMPTY, Markers.EMPTY, false, exprJ, Space.EMPTY))
+          }
+        } else {
+          cursor = dollarPos + 1 // past `$`, at the identifier
+          val exprJ = asExpression(visitTree(exprTree))
+          parts.add(new S.Interpolation(Tree.randomId(), Space.EMPTY, Markers.EMPTY, false, exprJ, Space.EMPTY))
+        }
+      case lit: Trees.Literal[?] =>
+        addLiteral(lit)
+      case other =>
+        throw new UnsupportedOperationException(
+          s"Unexpected interpolated string segment: ${other.getClass.getName}")
+    }
+
+    cursor = Math.min(source.length, cursor + delimiter.length) // closing quote
     updateCursor(interp.span.end)
-    ident(sourceText, prefix)
+    new S.InterpolatedString(Tree.randomId(), prefix, Markers.EMPTY, interpolator, delimiter, parts,
+      JavaType.Primitive.String)
   }
 
   private def visitSymbolLit(sym: untpd.SymbolLit): J.Identifier = {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InterpolatedStringTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InterpolatedStringTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.scala.ScalaIsoVisitor;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.scala.Assertions.scala;
+
+class InterpolatedStringTest implements RewriteTest {
+
+    @Test
+    void simpleInterpolation() {
+        rewriteRun(
+          scala("val greeting = s\"Hello, I'm $name\"")
+        );
+    }
+
+    @Test
+    void multipleInterpolations() {
+        rewriteRun(
+          scala("val msg = s\"$name is $age\"")
+        );
+    }
+
+    @Test
+    void bracedInterpolation() {
+        rewriteRun(
+          scala("val x = s\"sum is ${a + b}!\"")
+        );
+    }
+
+    @Test
+    void bracedInterpolationWithInnerSpaces() {
+        rewriteRun(
+          scala("val x = s\"${ a + b }\"")
+        );
+    }
+
+    @Test
+    void fInterpolatorWithFormat() {
+        rewriteRun(
+          scala("val x = f\"${pi}%2.2f is pi\"")
+        );
+    }
+
+    @Test
+    void rawInterpolator() {
+        rewriteRun(
+          scala("val x = raw\"a\\nb $name\"")
+        );
+    }
+
+    @Test
+    void noInterpolations() {
+        rewriteRun(
+          scala("val x = s\"just text\"")
+        );
+    }
+
+    @Test
+    void memberAccessInterpolation() {
+        rewriteRun(
+          scala("val x = s\"name: ${person.name}\"")
+        );
+    }
+
+    /**
+     * The embedded expressions must be first-class LST nodes, not text stuffed into a J.Identifier.
+     * This is the assertion that fails against the old behavior (the whole {@code s"..."} was a
+     * single J.Identifier whose simpleName held the raw source).
+     */
+    @Test
+    void interpolationsAreStructured() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(sources -> {
+              List<S.InterpolatedString> strings = new ArrayList<>();
+              List<String> interpolatedIdentifiers = new ArrayList<>();
+              ScalaIsoVisitor<Integer> visitor = new ScalaIsoVisitor<Integer>() {
+                  @Override
+                  public S.InterpolatedString visitInterpolatedString(S.InterpolatedString is, Integer i) {
+                      strings.add(is);
+                      return super.visitInterpolatedString(is, i);
+                  }
+
+                  @Override
+                  public S.Interpolation visitInterpolation(S.Interpolation in, Integer i) {
+                      if (in.getExpression() instanceof J.Identifier) {
+                          interpolatedIdentifiers.add(((J.Identifier) in.getExpression()).getSimpleName());
+                      }
+                      return super.visitInterpolation(in, i);
+                  }
+              };
+              sources.forEach(source -> visitor.visit(source, 0));
+
+              assertThat(strings).hasSize(1);
+              S.InterpolatedString is = strings.get(0);
+              assertThat(is.getInterpolator().getSimpleName()).isEqualTo("s");
+              assertThat(is.getDelimiter()).isEqualTo("\"");
+              assertThat(interpolatedIdentifiers).containsExactly("name", "age");
+          }),
+          scala("val msg = s\"$name is $age\"")
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?

Adding support for one of the basic Scala features, the interpolated strings, e.g.
```
s"Hello, I'm $name"
```

## What's your motivation?

They are currently mishandled and squeezedd into `J.Identifier`s instead.