### PR TITLE
Scala: parse by-name types into S.FunctionType

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7946,12 +7946,25 @@ class ScalaTreeVisitor(
     buildSFor(prefix, forYield.enums.asInstanceOf[List[Trees.Tree[?]]], forYield.expr, yielding = true, endPos)
   }
 
-  private def visitByNameTypeTree(bnt: Trees.ByNameTypeTree[?]): J.Identifier = {
-    // By-name parameter type: `=> Int` — preserve as identifier with source text
+  /**
+   * By-name parameter type `=> Int`. Modeled as a degenerate `S.FunctionType`:
+   * no parameters, unparenthesized. The printer renders empty + unparenthesized
+   * params as just `=>`, so this round-trips to `=> Int` without a dedicated type.
+   * It stays distinguishable from `() => Int` (empty params, but parenthesized).
+   */
+  private def visitByNameTypeTree(bnt: Trees.ByNameTypeTree[?]): S.FunctionType = {
     val prefix = extractPrefix(bnt.span)
-    val text = extractSource(bnt.span)
-    updateCursor(bnt.span.end)
-    ident(text, prefix)
+    val beforeArrow = sourceBefore("=>")
+    val returnType = visitTypeTree(bnt.result)
+    S.FunctionType.build(
+      Tree.randomId(),
+      prefix,
+      Markers.EMPTY,
+      false,
+      JContainer.empty[TypeTree](),
+      new JLeftPadded(beforeArrow, returnType, Markers.EMPTY),
+      typeOfTree(bnt)
+    )
   }
 
   private def visitTypeBoundsTree(tbt: Trees.TypeBoundsTree[?]): J.Identifier = {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/FunctionTypeTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/FunctionTypeTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.scala.ScalaIsoVisitor;
+import org.openrewrite.scala.tree.S;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.scala.Assertions.scala;
+
+class FunctionTypeTest implements RewriteTest {
+
+    @Test
+    void functionType() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              def apply(f: Int => Int, x: Int): Int = f(x)
+            }
+            """,
+            spec -> spec.afterRecipe(cu -> {
+                S.FunctionType ft = firstFunctionType(cu);
+                assertThat(ft.isParenthesized()).isFalse();
+                assertThat(ft.getParameters()).hasSize(1);
+                assertThat(((J.Identifier) ft.getParameters().get(0)).getSimpleName()).isEqualTo("Int");
+                assertThat(((J.Identifier) ft.getReturnType()).getSimpleName()).isEqualTo("Int");
+            })
+          )
+        );
+    }
+
+    @Test
+    void byNameParameterIsAnEmptyUnparenthesizedFunctionType() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              def foo(x: => Int): Int = x
+            }
+            """,
+            spec -> spec.afterRecipe(cu -> {
+                S.FunctionType ft = firstFunctionType(cu);
+                assertThat(ft.getParameters()).isEmpty();
+                assertThat(ft.isParenthesized()).isFalse();
+                assertThat(((J.Identifier) ft.getReturnType()).getSimpleName()).isEqualTo("Int");
+            })
+          )
+        );
+    }
+
+    @Test
+    void byNameTypeParameterIsAnEmptyUnparenthesizedFunctionType() {
+        rewriteRun(
+          scala(
+            """
+            class Lazy[A](value: => A) {
+              lazy val get: A = value
+            }
+            """,
+            spec -> spec.afterRecipe(cu -> {
+                S.FunctionType ft = firstFunctionType(cu);
+                assertThat(ft.getParameters()).isEmpty();
+                assertThat(ft.isParenthesized()).isFalse();
+                assertThat(((J.Identifier) ft.getReturnType()).getSimpleName()).isEqualTo("A");
+            })
+          )
+        );
+    }
+
+    private static S.FunctionType firstFunctionType(J tree) {
+        AtomicReference<S.FunctionType> ref = new AtomicReference<>();
+        new ScalaIsoVisitor<Integer>() {
+            @Override
+            public J visitFunctionType(S.FunctionType functionType, Integer p) {
+                ref.compareAndSet(null, functionType);
+                return super.visitFunctionType(functionType, p);
+            }
+        }.visit(tree, 0);
+        assertThat(ref.get()).as("should find an S.FunctionType").isNotNull();
+        return ref.get();
+    }
+}


### PR DESCRIPTION
## What's changed?

In Scala parse the by-name types into `S.FunctionType`, e.g. `value: => A`

## What's your motivation?

They are currently stuffed into `J.Identifier` which is wrong.