### PR TITLE
Go: add `MaybeAddImport` convenience function

### DIFF
--- a/rewrite-go/doc/recipe-authoring.md
+++ b/rewrite-go/doc/recipe-authoring.md
@@ -222,11 +222,15 @@ func (v *replaceTimeSinceVisitor) VisitMethodInvocation(mi *tree.MethodInvocatio
 
     // Side-effect: queue an `import "xerrors"` to land after the main
     // visit completes. The harness drains the queue automatically.
-    svc := recipe.Service[*golang.ImportService](nil)
-    v.DoAfterVisit(svc.AddImportVisitor("xerrors", nil, false /* unconditional */))
+    golang.MaybeAddImport(v, "xerrors", nil, false /* unconditional */)
     return mi
 }
 ```
+
+`MaybeAddImport(v, path, alias, onlyIfReferenced)` is the convenience
+form for add-import side effects. It queues the same `AddImport` visitor
+and de-duplicates equivalent pending requests before the after-visit
+drain runs.
 
 `ImportService` exposes four visitors:
 

--- a/rewrite-go/pkg/recipe/golang/import_service.go
+++ b/rewrite-go/pkg/recipe/golang/import_service.go
@@ -18,6 +18,7 @@ package golang
 
 import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
 
 // ImportService exposes the Go-side import-manipulation primitives as
@@ -50,6 +51,47 @@ import (
 //	    return mi
 //	}
 type ImportService struct{}
+
+// MaybeAddImport queues an AddImport visitor on v unless an equivalent
+// AddImport is already pending. It mirrors JavaVisitor.maybeAddImport
+// and TypeScript maybeAddImport: the import edit is deferred until the
+// recipe runner drains after-visits.
+func MaybeAddImport(v visitor.AfterVisitsProvider, packagePath string, alias *string, onlyIfReferenced bool) {
+	if v == nil {
+		return
+	}
+	if pending, ok := v.(visitor.PendingAfterVisitsProvider); ok {
+		for _, after := range pending.PendingAfterVisits() {
+			if samePendingAddImport(after, packagePath, alias, onlyIfReferenced) {
+				return
+			}
+		}
+	}
+	v.DoAfterVisit((&AddImport{
+		PackagePath:      packagePath,
+		Alias:            alias,
+		OnlyIfReferenced: onlyIfReferenced,
+	}).Editor())
+}
+
+func samePendingAddImport(after visitor.AfterVisitor, packagePath string, alias *string, onlyIfReferenced bool) bool {
+	v, ok := after.(*addImportVisitor)
+	if !ok || v.cfg == nil {
+		return false
+	}
+	return v.cfg.PackagePath == packagePath &&
+		sameAlias(v.cfg.Alias, alias) &&
+		v.cfg.OnlyIfReferenced == onlyIfReferenced
+}
+
+func sameAlias(a, b *string) bool {
+	switch {
+	case a == nil || b == nil:
+		return a == b
+	default:
+		return *a == *b
+	}
+}
 
 // AddImportVisitor returns a visitor that adds `import [alias] "packagePath"`
 // to the visited compilation unit. No-op if the import is already

--- a/rewrite-go/pkg/recipe/golang/internal/imports.go
+++ b/rewrite-go/pkg/recipe/golang/internal/imports.go
@@ -269,11 +269,17 @@ func AddToBlock(cu *golang.CompilationUnit, imp *java.Import, modulePath string)
 		}
 		// Wire the leading-space convention onto the new import: the
 		// space between `import` and the path lives on the Qualid
-		// literal's Prefix.
-		if lit, ok := imp.Qualid.(*java.Literal); ok {
-			cloned := *lit
-			cloned.Prefix = java.Space{Whitespace: " "}
-			imp.Qualid = &cloned
+		// literal's Prefix for regular imports. For aliased imports, the
+		// space after `import` lives on Import.Prefix and the space between
+		// alias and path lives on the literal.
+		if imp.Alias != nil {
+			imp.Prefix = java.Space{Whitespace: " "}
+		} else {
+			if lit, ok := imp.Qualid.(*java.Literal); ok {
+				cloned := *lit
+				cloned.Prefix = java.Space{Whitespace: " "}
+				imp.Qualid = &cloned
+			}
 		}
 	}
 	imps := *c.Imports
@@ -309,7 +315,7 @@ func promoteToGrouped(imps *java.Container[*java.Import]) {
 	if rp.Element != nil {
 		imp := *rp.Element
 		imp.Prefix = java.Space{Whitespace: "\n\t"}
-		if lit, ok := imp.Qualid.(*java.Literal); ok {
+		if lit, ok := imp.Qualid.(*java.Literal); ok && imp.Alias == nil {
 			cloned := *lit
 			cloned.Prefix = java.EmptySpace
 			imp.Qualid = &cloned
@@ -421,6 +427,11 @@ func NewImport(path string, alias *string) *java.Import {
 		Qualid: &java.Literal{ID: uuid.New(), Source: `"` + path + `"`, Value: path, Kind: java.StringLiteral},
 	}
 	if alias != nil {
+		if lit, ok := imp.Qualid.(*java.Literal); ok {
+			cloned := *lit
+			cloned.Prefix = java.Space{Whitespace: " "}
+			imp.Qualid = &cloned
+		}
 		imp.Alias = &java.LeftPadded[*java.Identifier]{
 			Before: java.Space{Whitespace: " "},
 			Element: &java.Identifier{

--- a/rewrite-go/pkg/template/PARITY-AUDIT.md
+++ b/rewrite-go/pkg/template/PARITY-AUDIT.md
@@ -12,7 +12,7 @@ present, what was added in this PR, and what is intentionally deferred.
 |---|---|---|---|
 | Builder | `JavaTemplate.builder(code)` | `template.ExpressionTemplate(code)` / `StatementTemplate(code)` / `TopLevelTemplate(code)` | ✓ shipped (kind-explicit factories preferred over a single overloaded builder) |
 | Build the template | `.build()` | `.Build()` | ✓ shipped |
-| Required imports | `.imports(String...)` | `.Imports(...string)` | ✓ shipped |
+| Parse-context imports | `.imports(String...)` | `.Imports(...string)` | ✓ shipped |
 | Static imports | `.staticImports(String...)` | n/a | not applicable — Go has no static-import concept |
 | Coordinate-based substitution | `.apply(JavaCoordinates, params...)` | `.Apply(cursor, *MatchResult)` | ✓ shipped via match captures (see deferred note below) |
 | Pattern → template rewrite | `JavaIsoVisitor` + `JavaTemplate.apply` per visit | `template.Rewrite(before, after)` returns a `RewriteVisitor` | ✓ shipped (single-call ergonomic that matches and replaces in one step — Go-side delta over Java) |
@@ -84,6 +84,14 @@ For inserting a fresh statement (no before-match):
 ```go
 tmpl := template.StatementTemplate(`fmt.Println("hi")`).Imports("fmt").Build()
 result := tmpl.Apply(cursor, nil)
+```
+
+`Imports(...)` is parse context only, matching `JavaTemplate.imports(...)`.
+Declarative template recipes that should edit source imports must say so
+explicitly:
+
+```go
+template.WithAfter(`strconv.Itoa(#{N})`, template.Imports("strconv"), template.SourceImports("strconv"))
 ```
 
 The Java →  Go porting cheat-sheet:

--- a/rewrite-go/pkg/template/go_template.go
+++ b/rewrite-go/pkg/template/go_template.go
@@ -99,7 +99,8 @@ func (b *TemplateBuilder) Captures(caps ...*Capture) *TemplateBuilder {
 	return b
 }
 
-// Imports adds required imports for the template code.
+// Imports adds imports to the synthetic source used to parse the template.
+// It does not edit imports in the source file being rewritten.
 func (b *TemplateBuilder) Imports(pkgs ...string) *TemplateBuilder {
 	b.imports = append(b.imports, pkgs...)
 	return b

--- a/rewrite-go/pkg/template/template_recipe.go
+++ b/rewrite-go/pkg/template/template_recipe.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+	recipegolang "github.com/openrewrite/rewrite/rewrite-go/pkg/recipe/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
@@ -34,22 +35,31 @@ type RecipeOption func(*templateRecipeConfig)
 type BeforeOption func(*beforeSpec)
 
 type beforeSpec struct {
-	code    string
-	imports []string
-	kind    *ScaffoldKind // nil = auto-detect
+	code          string
+	imports       []string
+	sourceImports []SourceImportSpec
+	kind          *ScaffoldKind // nil = auto-detect
+}
+
+// SourceImportSpec describes an import that should be added to the source file
+// when an after template is applied.
+type SourceImportSpec struct {
+	Path  string
+	Alias *string
 }
 
 type templateRecipeConfig struct {
-	name         string
-	displayName  string
-	description  string
-	tags         []string
-	befores      []beforeSpec
-	afterCode    string
-	afterImports []string
-	afterKind    *ScaffoldKind
-	captures     []*Capture
-	kind         *ScaffoldKind // global override
+	name          string
+	displayName   string
+	description   string
+	tags          []string
+	befores       []beforeSpec
+	afterCode     string
+	afterImports  []string
+	sourceImports []SourceImportSpec
+	afterKind     *ScaffoldKind
+	captures      []*Capture
+	kind          *ScaffoldKind // global override
 }
 
 // RecipeName sets the fully qualified recipe name.
@@ -93,6 +103,7 @@ func WithAfter(code string, opts ...BeforeOption) RecipeOption {
 			opt(&spec)
 		}
 		c.afterImports = spec.imports
+		c.sourceImports = spec.sourceImports
 		c.afterKind = spec.kind
 	}
 }
@@ -118,9 +129,29 @@ func AsStatement() RecipeOption {
 	}
 }
 
-// Imports adds required imports for a before or after template.
+// Imports adds imports to the synthetic source used to parse a before or
+// after template. It does not edit imports in the source file being rewritten.
 func Imports(pkgs ...string) BeforeOption {
 	return func(s *beforeSpec) { s.imports = append(s.imports, pkgs...) }
+}
+
+// SourceImports declares regular imports to add to the source file when an
+// after template is applied. It is only meaningful on WithAfter.
+func SourceImports(pkgs ...string) BeforeOption {
+	return func(s *beforeSpec) {
+		for _, pkg := range pkgs {
+			s.sourceImports = append(s.sourceImports, SourceImportSpec{Path: pkg})
+		}
+	}
+}
+
+// SourceImport declares an import with optional alias to add to the source file
+// when an after template is applied. Pass "_" for blank imports or "." for dot
+// imports.
+func SourceImport(path string, alias *string) BeforeOption {
+	return func(s *beforeSpec) {
+		s.sourceImports = append(s.sourceImports, SourceImportSpec{Path: path, Alias: alias})
+	}
 }
 
 // NewRecipe creates a recipe.Recipe from declarative before/after templates.
@@ -157,7 +188,7 @@ func buildRecipe(cfg *templateRecipeConfig) recipe.Recipe {
 	afterKind := resolveKind(cfg.afterKind, cfg.kind, cfg.afterCode)
 	after := buildTemplate(cfg.afterCode, caps, cfg.afterImports, afterKind)
 
-	v := newTemplateRecipeVisitor(befores, after)
+	v := newTemplateRecipeVisitor(befores, after, cfg.sourceImports)
 
 	return &builtTemplateRecipe{
 		name:        cfg.name,
@@ -224,12 +255,13 @@ func detectScaffoldKind(code string) ScaffoldKind {
 // templateRecipeVisitor tries each before pattern in order; first match wins.
 type templateRecipeVisitor struct {
 	visitor.GoVisitor
-	befores []*GoPattern
-	after   *GoTemplate
+	befores       []*GoPattern
+	after         *GoTemplate
+	sourceImports []SourceImportSpec
 }
 
-func newTemplateRecipeVisitor(befores []*GoPattern, after *GoTemplate) *templateRecipeVisitor {
-	v := &templateRecipeVisitor{befores: befores, after: after}
+func newTemplateRecipeVisitor(befores []*GoPattern, after *GoTemplate, sourceImports []SourceImportSpec) *templateRecipeVisitor {
+	v := &templateRecipeVisitor{befores: befores, after: after, sourceImports: sourceImports}
 	v.Self = v
 	return v
 }
@@ -252,6 +284,12 @@ func (v *templateRecipeVisitor) Visit(t java.Tree, p any) java.Tree {
 		}
 		replaced := v.after.Apply(nil, match)
 		if replaced != nil {
+			if len(v.sourceImports) > 0 {
+				for _, imp := range v.sourceImports {
+					recipegolang.MaybeAddImport(v, imp.Path, imp.Alias, false)
+				}
+				v.DoAfterVisit(recipe.Service[*recipegolang.ImportService](nil).RemoveUnusedImportsVisitor())
+			}
 			return setLeadingPrefix(replaced, getLeadingPrefix(j))
 		}
 	}
@@ -325,7 +363,7 @@ func (tr *TemplateRecipe) InitTemplate(opts ...RecipeOption) {
 	afterKind := resolveKind(cfg.afterKind, cfg.kind, cfg.afterCode)
 	after := buildTemplate(cfg.afterCode, caps, cfg.afterImports, afterKind)
 
-	tr.editor = newTemplateRecipeVisitor(befores, after)
+	tr.editor = newTemplateRecipeVisitor(befores, after, cfg.sourceImports)
 }
 
 // Editor returns the auto-generated visitor.

--- a/rewrite-go/pkg/template/template_recipe_test.go
+++ b/rewrite-go/pkg/template/template_recipe_test.go
@@ -162,8 +162,9 @@ func TestNewRecipeMultipleBeforeSecondMatches(t *testing.T) {
 	)
 }
 
-func TestNewRecipeWithImports(t *testing.T) {
-	// Replace `fmt.Sprintf("%d", n)` with `strconv.Itoa(n)`
+func TestNewRecipeImportsAreTemplateContextOnly(t *testing.T) {
+	// Imports on the after template let `strconv.Itoa(n)` parse, but callers
+	// are responsible for source-file import edits via SourceImports.
 	n := Expr("n")
 	r := NewRecipe(
 		RecipeName("test.SprintfToItoa"),
@@ -191,6 +192,67 @@ func TestNewRecipeWithImports(t *testing.T) {
 			func f(n int) string {
 				return strconv.Itoa(n)
 			}
+		`),
+	)
+}
+
+func TestNewRecipeWithSourceImports(t *testing.T) {
+	// SourceImports explicitly adds "strconv" to the file; the import cleanup
+	// pass removes "fmt" once the replacement no longer uses it.
+	n := Expr("n")
+	r := NewRecipe(
+		RecipeName("test.SprintfToItoa"),
+		WithDisplayName("Use strconv.Itoa"),
+		WithBefore(fmt.Sprintf(`fmt.Sprintf("%%d", %s)`, n), Imports("fmt")),
+		WithAfter(fmt.Sprintf(`strconv.Itoa(%s)`, n), Imports("strconv"), SourceImports("strconv")),
+		WithCaptures(n),
+	)
+
+	spec := test.NewRecipeSpec().WithRecipe(r)
+	spec.RewriteRun(t,
+		test.Golang(`
+			package main
+
+			import "fmt"
+
+			func f(n int) string {
+				return fmt.Sprintf("%d", n)
+			}
+		`, `
+			package main
+
+			import (
+				"strconv"
+			)
+
+			func f(n int) string {
+				return strconv.Itoa(n)
+			}
+		`),
+	)
+}
+
+func TestNewRecipeWithAliasedSourceImport(t *testing.T) {
+	blank := "_"
+	r := NewRecipe(
+		RecipeName("test.AddPprofImport"),
+		WithDisplayName("Add pprof import"),
+		WithBefore(`x`),
+		WithAfter(`y`, SourceImport("net/http/pprof", &blank)),
+	)
+
+	spec := test.NewRecipeSpec().WithRecipe(r)
+	spec.RewriteRun(t,
+		test.Golang(`
+			package main
+
+			var a = x
+		`, `
+			package main
+
+			import _ "net/http/pprof"
+
+			var a = y
 		`),
 	)
 }

--- a/rewrite-go/pkg/visitor/drain.go
+++ b/rewrite-go/pkg/visitor/drain.go
@@ -26,6 +26,12 @@ type AfterVisitsProvider interface {
 	DoAfterVisit(AfterVisitor)
 }
 
+// PendingAfterVisitsProvider is implemented by visitors that can expose
+// their queued after-visits without draining them.
+type PendingAfterVisitsProvider interface {
+	PendingAfterVisits() []AfterVisitor
+}
+
 // DrainAfterVisits applies any visitors that `editor` queued via
 // GoVisitor.DoAfterVisit. After-visits can themselves queue more
 // after-visits (transitive); this loops until no provider has anything

--- a/rewrite-go/pkg/visitor/go_visitor.go
+++ b/rewrite-go/pkg/visitor/go_visitor.go
@@ -83,6 +83,15 @@ func (v *GoVisitor) AfterVisits() []AfterVisitor {
 	return out
 }
 
+// PendingAfterVisits returns the currently queued follow-up visitors
+// without clearing the queue. Helper APIs use this to keep convenience
+// methods like MaybeAddImport idempotent before the drain runs.
+func (v *GoVisitor) PendingAfterVisits() []AfterVisitor {
+	out := make([]AfterVisitor, len(v.afterVisits))
+	copy(out, v.afterVisits)
+	return out
+}
+
 // Visit dispatches to the appropriate visit method based on the node's concrete type.
 //
 // Lifecycle:

--- a/rewrite-go/test/import_recipes_test.go
+++ b/rewrite-go/test/import_recipes_test.go
@@ -82,6 +82,45 @@ func TestAddImport_AddsToFileWithNoImports(t *testing.T) {
 	spec.RewriteRun(t, Golang(before, after))
 }
 
+func TestAddImport_AddsAliasedImportToFileWithNoImports(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&recipes.AddImport{PackagePath: "net/http/pprof", Alias: strPtr("_")})
+	before := `
+		package main
+
+		func main() {}
+	`
+	after := `
+		package main
+
+		import _ "net/http/pprof"
+
+		func main() {}
+	`
+	spec.RewriteRun(t, Golang(before, after))
+}
+
+func TestAddImport_PromotesAliasedImportToGroupedBlock(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&recipes.AddImport{PackagePath: "fmt"})
+	before := `
+		package main
+
+		import _ "net/http/pprof"
+
+		func main() {}
+	`
+	after := `
+		package main
+
+		import (
+			_ "net/http/pprof"
+			"fmt"
+		)
+
+		func main() {}
+	`
+	spec.RewriteRun(t, Golang(before, after))
+}
+
 func TestAddImport_OnlyIfReferenced_NoOpWhenNotReferenced(t *testing.T) {
 	spec := NewRecipeSpec().WithRecipe(&recipes.AddImport{
 		PackagePath:      "github.com/x/y",

--- a/rewrite-go/test/import_service_test.go
+++ b/rewrite-go/test/import_service_test.go
@@ -92,6 +92,52 @@ func TestImportService_AddImportViaDoAfterVisit(t *testing.T) {
 	spec.RewriteRun(t, Golang(before, after))
 }
 
+func TestMaybeAddImport_DeduplicatesPendingVisitors(t *testing.T) {
+	v := visitor.Init(&maybeAddImportPendingVisitor{})
+	recipes.MaybeAddImport(v, "fmt", nil, false)
+	recipes.MaybeAddImport(v, "fmt", nil, false)
+
+	if got := len(v.PendingAfterVisits()); got != 1 {
+		t.Fatalf("expected one pending AddImport visitor, got %d", got)
+	}
+}
+
+type maybeAddImportPendingVisitor struct{ visitor.GoVisitor }
+
+func TestMaybeAddImport_AddsImportViaDoAfterVisit(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&maybeAddFmtImportRecipe{})
+	before := `
+		package main
+
+		func main() {}
+	`
+	after := `
+		package main
+
+		import "fmt"
+
+		func main() {}
+	`
+	spec.RewriteRun(t, Golang(before, after))
+}
+
+type maybeAddFmtImportRecipe struct{ recipe.Base }
+
+func (r *maybeAddFmtImportRecipe) Name() string        { return "test.MaybeAddFmtImport" }
+func (r *maybeAddFmtImportRecipe) DisplayName() string { return "Add fmt import via MaybeAddImport" }
+func (r *maybeAddFmtImportRecipe) Description() string { return "Test recipe." }
+func (r *maybeAddFmtImportRecipe) Editor() recipe.TreeVisitor {
+	return visitor.Init(&maybeAddFmtVisitor{})
+}
+
+type maybeAddFmtVisitor struct{ visitor.GoVisitor }
+
+func (v *maybeAddFmtVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p any) java.J {
+	cu = v.GoVisitor.VisitCompilationUnit(cu, p).(*golang.CompilationUnit)
+	recipes.MaybeAddImport(v, "fmt", nil, false)
+	return cu
+}
+
 // TestImportService_RemoveImport via DoAfterVisit.
 func TestImportService_RemoveImportViaDoAfterVisit(t *testing.T) {
 	spec := NewRecipeSpec().WithRecipe(&removeFmtImportRecipe{})


### PR DESCRIPTION
## What's changed?

Go: add `MaybeAddImport` convenience function (just like we have for other languages).
And add `SourceImports` support to Go template recipes.

## What's your motivation?

To be used in recipes.