### PR TITLE
Fix implement interface double space

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ImplementInterfaceTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ImplementInterfaceTest.java
@@ -95,6 +95,46 @@ class ImplementInterfaceTest implements RewriteTest {
     }
 
     @Test
+    void firstImplementedInterfaceWithTypeParameters() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                  doAfterVisit(new ImplementInterface<>(
+                    classDecl,
+                    "b.B",
+                    List.of(
+                      new J.Identifier(
+                        randomId(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        emptyList(),
+                        "String",
+                        ShallowClass.build("java.lang.String"),
+                        null
+                      )
+                    )
+                  ));
+                  return classDecl;
+              }
+          })),
+          java(b, SourceSpec::skip),
+          java(
+            """
+              class A {
+              }
+              """,
+            """
+              import b.B;
+
+              class A implements B<String> {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void addAnImplementedInterfaceWithTypeParameters() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/ImplementInterface.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ImplementInterface.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
 import static org.openrewrite.Tree.randomId;
-import static org.openrewrite.java.tree.Space.format;
 
 public class ImplementInterface<P> extends JavaIsoVisitor<P> {
     private final J.ClassDeclaration scope;
@@ -66,8 +65,7 @@ public class ImplementInterface<P> extends JavaIsoVisitor<P> {
 
             TypeTree impl = TypeTree.build(classDecl.getSimpleName().equals(interfaceType.getClassName()) ?
                             interfaceType.getFullyQualifiedName() : interfaceType.getClassName())
-                    .withType(interfaceType)
-                    .withPrefix(c.getImplements() == null ? Space.EMPTY : format(" "));
+                    .withType(interfaceType);
 
             if (typeParameters != null && !typeParameters.isEmpty()) {
                 typeParameters.stream()
@@ -82,7 +80,7 @@ public class ImplementInterface<P> extends JavaIsoVisitor<P> {
 
                 J.ParameterizedType typedImpl = new J.ParameterizedType(
                         randomId(),
-                        Space.EMPTY,
+                        Space.SINGLE_SPACE,
                         Markers.EMPTY,
                         interfaceType instanceof JavaType.Parameterized ? impl.withType(((JavaType.Parameterized) interfaceType).getType()) : impl,
                         JContainer.build(Space.EMPTY, elements, Markers.EMPTY),
@@ -91,7 +89,8 @@ public class ImplementInterface<P> extends JavaIsoVisitor<P> {
 
                 c = c.withImplements(ListUtils.concat(c.getImplements(), typedImpl));
             } else {
-                c = c.withImplements(ListUtils.concat(c.getImplements(), impl));
+                TypeTree spacedImpl = impl.withPrefix(Space.SINGLE_SPACE);
+                c = c.withImplements(ListUtils.concat(c.getImplements(), spacedImpl));
             }
         }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/ImplementInterface.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ImplementInterface.java
@@ -67,7 +67,7 @@ public class ImplementInterface<P> extends JavaIsoVisitor<P> {
             TypeTree impl = TypeTree.build(classDecl.getSimpleName().equals(interfaceType.getClassName()) ?
                             interfaceType.getFullyQualifiedName() : interfaceType.getClassName())
                     .withType(interfaceType)
-                    .withPrefix(format(" "));
+                    .withPrefix(c.getImplements() == null ? Space.EMPTY : format(" "));
 
             if (typeParameters != null && !typeParameters.isEmpty()) {
                 typeParameters.stream()


### PR DESCRIPTION
## What's changed?
Add a regression test for `ImplementInterface` when adding the first parameterized interface to a class.

Update `ImplementInterface` so the generated type uses an empty prefix when creating a new `implements` clause. When appending to an existing list, it keeps the existing single-space prefix needed after the comma.

## What's your motivation?
This is a regression introduced between `v8.83.1` and `v8.83.2`.

- The behavior still worked correctly in [`v8.83.1`](https://github.com/openrewrite/rewrite/releases/tag/v8.83.1). It changed in [`v8.83.2`](https://github.com/openrewrite/rewrite/releases/tag/v8.83.2) after [#7769](https://github.com/openrewrite/rewrite/pull/7769), commit [`59c7f99a6`](https://github.com/openrewrite/rewrite/commit/59c7f99a698e7c9f4fbb21a390342e5854db7d5e), added default whitespace for keyword-prefixed `JContainer`s in `withX(...)` mutators.

`ClassDeclaration.withImplements(..)` now supplies spacing when it creates an `implements` container. `ImplementInterface` still added a leading prefix to the generated type.

For a parameterized interface, whitespace was then present at two AST levels:

```java
class A implements  B<String> { // two whitespaces after implements keyword
}
```
The outer `J.ParameterizedType` received the default prefix from `withImplements(..)`, while its nested class type still had the prefix added by `ImplementInterface`.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
