### PR TITLE
Scala: parse classOf[Something] as MethodInvocation

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5583,11 +5583,26 @@ class ScalaTreeVisitor(
         return visitMethodInvocationFromTypeApply(ta, sel, savedCursor)
 
       case id: Trees.Ident[?] if id.name.toString == "classOf" && ta.args.size == 1 =>
-        // classOf[String] — preserve as identifier (Statement + Expression)
+        // classOf[String] is a type application with no value argument list.
         val prefix = extractPrefix(ta.span)
-        val text = extractSource(ta.span)
+        val nameEnd = if (id.span.exists) Math.max(0, id.span.end - offsetAdjustment) else cursor + "classOf".length
+        if (nameEnd > cursor && nameEnd <= source.length) {
+          cursor = nameEnd
+        }
+        val typeParams = parseTypeApplyArgs(ta)
+        val omitParens = Markers.build(Collections.singletonList(new OmitParentheses(Tree.randomId())))
+        val args = JContainer.build(Space.EMPTY, Collections.emptyList[JRightPadded[Expression]](), omitParens)
         updateCursor(ta.span.end)
-        return ident(text, prefix)
+        return new J.MethodInvocation(
+          Tree.randomId(),
+          prefix,
+          Markers.EMPTY,
+          null,
+          typeParams,
+          ident("classOf"),
+          args,
+          methodTypeOfTree(ta)
+        )
 
       case _ =>
         // Other TypeApply (e.g., Array[Int]): preserve as identifier with source text.

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TypeApplyTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TypeApplyTest.java
@@ -16,8 +16,14 @@
 package org.openrewrite.scala.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.marker.OmitParentheses;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.scala.ScalaIsoVisitor;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.scala.Assertions.scala;
 
 class TypeApplyTest implements RewriteTest {
@@ -144,6 +150,51 @@ class TypeApplyTest implements RewriteTest {
                 val x = Outer.Inner.empty[Int]()
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void classOfTypeApplyIsMethodInvocation() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                val x = classOf[String]
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                AtomicReference<J.Identifier> misparsedIdentifier = new AtomicReference<>();
+                AtomicReference<J.MethodInvocation> classOf = new AtomicReference<>();
+                new ScalaIsoVisitor<Integer>() {
+                    @Override
+                    public J.Identifier visitIdentifier(J.Identifier identifier, Integer p) {
+                        if ("classOf[String]".equals(identifier.getSimpleName())) {
+                            misparsedIdentifier.set(identifier);
+                        }
+                        return super.visitIdentifier(identifier, p);
+                    }
+
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer p) {
+                        if ("classOf".equals(method.getSimpleName())) {
+                            classOf.set(method);
+                        }
+                        return super.visitMethodInvocation(method, p);
+                    }
+                }.visit(cu, 0);
+
+                assertThat(misparsedIdentifier.get())
+                  .as("classOf[String] should not be parsed as a single identifier")
+                  .isNull();
+                assertThat(classOf.get()).isNotNull();
+                assertThat(classOf.get().getArguments()).isEmpty();
+                assertThat(classOf.get().getPadding().getArguments().getMarkers().findFirst(OmitParentheses.class)).isPresent();
+                assertThat(classOf.get().getTypeParameters()).singleElement().satisfies(typeParameter -> {
+                    assertThat(typeParameter).isInstanceOf(J.Identifier.class);
+                    assertThat(((J.Identifier) typeParameter).getSimpleName()).isEqualTo("String");
+                });
+            })
           )
         );
     }


### PR DESCRIPTION
## What's changed?

Parsing Scala's `classOf[String]` as MethodInvocation, similar to Java's `String.class` being parsed as FieldAccess.

## What's your motivation?

Currently it's parsed into a single J.Identifier, which doesn't make sense.