### PR TITLE
Groovy: Fix parsing of generated code that contains ternery operator  

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -3009,6 +3009,13 @@ public class GroovyParserVisitor {
 
         @Override
         public void visitTernaryExpression(TernaryExpression ternary) {
+            // AST transformations like @Slf4j create synthetic ternary guards (e.g. log.isInfoEnabled() ? log.info(...) : null)
+            // whose boolean condition has no source position. Only the true-branch exists in the original source, so skip
+            // the synthetic wrapper and visit only the true expression to avoid corrupting the cursor.
+            if (ternary.getBooleanExpression().getLineNumber() < 0) {
+                queue.add(doVisit(ternary.getTrueExpression()));
+                return;
+            }
             queue.add(insideParentheses(ternary, fmt -> new J.Ternary(randomId(), fmt, Markers.EMPTY,
                     doVisit(ternary.getBooleanExpression()),
                     padLeft(sourceBefore("?"), doVisit(ternary.getTrueExpression())),
@@ -3940,8 +3947,10 @@ public class GroovyParserVisitor {
                 MethodCallExpression expr = (MethodCallExpression) node;
                 // The trait AST transformation rewrites implicit-this calls inside trait method bodies to use a synthetic
                 // $self variable expression that has no source position; without a valid object position there's nothing
-                // to scan, so skip the parenthesis-level computation.
-                if (expr.getObjectExpression().getLineNumber() < 0) {
+                // to scan, so skip the parenthesis-level computation. Similarly, AST transformations like @Slf4j can
+                // produce synthetic MethodCallExpressions (e.g. log.isInfoEnabled()) whose own line number is -1 even
+                // though the object expression has a valid position; guard against that to avoid a negative array index.
+                if (expr.getObjectExpression().getLineNumber() < 0 || expr.getLineNumber() < 0) {
                     return null;
                 }
                 return determineParenthesisLevel(expr, expr.getObjectExpression().getLineNumber(), expr.getLineNumber(), expr.getObjectExpression().getColumnNumber(), expr.getColumnNumber());

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovySlf4jTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovySlf4jTest.java
@@ -40,7 +40,7 @@ class GroovySlf4jTest implements RewriteTest {
     }
 
     @Test
-    void slf4jWithCConcatenation() {
+    void slf4jWithConcatenation() {
         rewriteRun(
           groovy(
             """

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovySlf4jTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovySlf4jTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.groovy.Assertions.groovy;
+
+class GroovySlf4jTest implements RewriteTest {
+
+    @Test
+    void slf4jWithoutArguments() {
+        rewriteRun(
+          groovy(
+            """
+              import groovy.util.logging.Slf4j
+              @Slf4j
+              class A {
+                void method() {
+                     log.info("Hello World")
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void slf4jWithCConcatenation() {
+        rewriteRun(
+          groovy(
+            """
+              import groovy.util.logging.Slf4j
+              @Slf4j
+              class A {
+                void method() {
+                     def a = "A"
+                     log.info("Hello World" + A)
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void slf4jWithStringTemplate() {
+        rewriteRun(
+          groovy(
+            """
+              import groovy.util.logging.Slf4j
+              @Slf4j
+              class A {
+                void method() {
+                     def a = "A"
+                     log.info("Hello World ${A}")
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void slf4jWithDifferentLogLevel() {
+        rewriteRun(
+          groovy(
+            """
+              import groovy.util.logging.Slf4j
+              @Slf4j
+              class A {
+                void method() {
+                     def msg = "World"
+                     log.warn("Hello " + msg)
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void slf4jWithMultipleCalls() {
+        rewriteRun(
+          groovy(
+            """
+              import groovy.util.logging.Slf4j
+              @Slf4j
+              class A {
+                void method() {
+                     def a = "A"
+                     log.info("Hello " + a)
+                     log.debug("World ${a}")
+                }
+              }
+              """
+          )
+        );
+    }
+
+}


### PR DESCRIPTION
Im fixing the parsing error as described on the repo: https://github.com/gtiwari333/openrewrite-groovy-bug#error-3-cant-parse-conditional-statements-from-generated-code-eg-slf4j

The following code was failing to parse during code migration.

```
def a = "A"

//this fails to parse
log.info("Headers ${a}")
log.info("Headers " + a)

//this won't complain
log.info("Headers ")
```


## What's changed?
<!-- A brief description of the changes in this pull request -->
Added defensive checks in `GroovyParserVisitor` to detect and skip synthetic nodes:
- **Ternary expressions**: Check if `boolean expression.getLineNumber() < 0`, and if so, visit only 
  the true branch directly, bypassing the synthetic wrapper.
- **Method call expressions**: Check if either the method or its object has `lineNumber < 0` to
  avoid negative array index access during parenthesis level computation.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Working on using openrewrite to migrate groovy based repositories. Blocked by this bug.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
N/A

## Anyone you would like to review specifically?
<!-- @mention them here -->
N/A

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
No.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files



Full stacktrace

```
Error during rewrite run
org.openrewrite.groovy.GroovyParsingException: Failed to parse src/main/groovy/com/example/demo/LogTestWithConcatenatedArg.groovy at cursor position 149. The surrounding characters in the original source are:
package com.example.demo

import groovy.util.logging.Slf4j

@Slf4j
class LogTestWithConcatenatedArg {

    void test() {
        def a = "A"
        ~cursor~>log.info("Headers " + a)
    }
}

        at org.openrewrite.groovy.GroovyParserVisitor.visit(GroovyParserVisitor.java:248)
        at org.openrewrite.groovy.GroovyParser.lambda$parseInputs$3(GroovyParser.java:155)
        at java.base@21.0.11/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
        at java.base@21.0.11/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base@21.0.11/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
        at java.base@21.0.11/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base@21.0.11/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
        at java.base@21.0.11/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:276)
        at java.base@21.0.11/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
        at java.base@21.0.11/java.util.stream.Streams$StreamBuilderImpl.forEachRemaining(Streams.java:411)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base@21.0.11/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
        at java.base@21.0.11/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base@21.0.11/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
        at java.base@21.0.11/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base@21.0.11/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
        at java.base@21.0.11/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:734)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base@21.0.11/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
        at java.base@21.0.11/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base@21.0.11/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
        at java.base@21.0.11/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:734)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base@21.0.11/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
        at java.base@21.0.11/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:734)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base@21.0.11/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
        at java.base@21.0.11/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:734)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base@21.0.11/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
        at java.base@21.0.11/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base@21.0.11/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
        at java.base@21.0.11/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base@21.0.11/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
        at org.openrewrite.gradle.isolated.DefaultProjectParser.listResults(DefaultProjectParser.java:1437)
        at org.openrewrite.gradle.isolated.DefaultProjectParser.run(DefaultProjectParser.java:453)
        at org.openrewrite.gradle.DelegatingProjectParser.lambda$run$2(DelegatingProjectParser.java:116)
        at org.openrewrite.gradle.DelegatingProjectParser.unwrapInvocationException(DelegatingProjectParser.java:166)
        at org.openrewrite.gradle.DelegatingProjectParser.run(DelegatingProjectParser.java:115)
        at org.openrewrite.gradle.RewriteRunTask.run(RewriteRunTask.java:36)
        at java.base@21.0.11/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base@21.0.11/java.lang.reflect.Method.invoke(Method.java:580)
        at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:125)
        at org.gradle.api.internal.project.taskfactory.StandardTaskAction.doExecute(StandardTaskAction.java:58)
        at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:51)
        at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:29)
        at org.gradle.api.internal.tasks.execution.TaskExecution$3.run(TaskExecution.java:259)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:30)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:27)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:67)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:60)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:167)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:60)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.run(DefaultBuildOperationRunner.java:48)
        at org.gradle.api.internal.tasks.execution.TaskExecution.executeAction(TaskExecution.java:244)
        at org.gradle.api.internal.tasks.execution.TaskExecution.executeActions(TaskExecution.java:227)
        at org.gradle.api.internal.tasks.execution.TaskExecution.executeWithPreviousOutputFiles(TaskExecution.java:210)
        at org.gradle.api.internal.tasks.execution.TaskExecution.execute(TaskExecution.java:176)
        at org.gradle.internal.execution.steps.ExecuteStep.executeInternal(ExecuteStep.java:167)
        at org.gradle.internal.execution.steps.ExecuteStep.access$000(ExecuteStep.java:47)
        at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:137)
        at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:134)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:210)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:205)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:67)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:60)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:167)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:60)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:54)
        at org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:134)
        at org.gradle.internal.execution.steps.ExecuteStep$Mutable.execute(ExecuteStep.java:80)
        at org.gradle.internal.execution.steps.CancelExecutionStep.execute(CancelExecutionStep.java:42)
        at org.gradle.internal.execution.steps.TimeoutStep.executeWithoutTimeout(TimeoutStep.java:75)
        at org.gradle.internal.execution.steps.TimeoutStep.execute(TimeoutStep.java:55)
        at org.gradle.internal.execution.steps.PreCreateOutputParentsStep.execute(PreCreateOutputParentsStep.java:51)
        at org.gradle.internal.execution.steps.PreCreateOutputParentsStep.execute(PreCreateOutputParentsStep.java:29)
        at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.executeMutable(RemovePreviousOutputsStep.java:67)
        at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.executeMutable(RemovePreviousOutputsStep.java:39)
        at org.gradle.internal.execution.steps.MutableStep.execute(MutableStep.java:26)
        at org.gradle.internal.execution.steps.BroadcastChangingOutputsStep.execute(BroadcastChangingOutputsStep.java:42)
        at org.gradle.internal.execution.steps.BroadcastChangingOutputsStep.execute(BroadcastChangingOutputsStep.java:24)
        at org.gradle.internal.execution.steps.CaptureOutputsAfterExecutionStep.execute(CaptureOutputsAfterExecutionStep.java:69)
        at org.gradle.internal.execution.steps.CaptureOutputsAfterExecutionStep.execute(CaptureOutputsAfterExecutionStep.java:46)
        at org.gradle.internal.execution.steps.ResolveInputChangesStep.executeMutable(ResolveInputChangesStep.java:39)
        at org.gradle.internal.execution.steps.ResolveInputChangesStep.executeMutable(ResolveInputChangesStep.java:28)
        at org.gradle.internal.execution.steps.MutableStep.execute(MutableStep.java:26)
        at org.gradle.internal.execution.steps.BuildCacheStep.executeWithoutCache(BuildCacheStep.java:189)
        at org.gradle.internal.execution.steps.BuildCacheStep.lambda$execute$1(BuildCacheStep.java:76)
        at org.gradle.internal.Either$Right.fold(Either.java:176)
        at org.gradle.internal.execution.caching.CachingState.fold(CachingState.java:62)
        at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:74)
        at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:49)
        at org.gradle.internal.execution.steps.StoreExecutionStateStep.executeMutable(StoreExecutionStateStep.java:46)
        at org.gradle.internal.execution.steps.StoreExecutionStateStep.executeMutable(StoreExecutionStateStep.java:35)
        at org.gradle.internal.execution.steps.MutableStep.execute(MutableStep.java:26)
        at org.gradle.internal.execution.steps.SkipUpToDateStep.executeBecause(SkipUpToDateStep.java:75)
        at org.gradle.internal.execution.steps.SkipUpToDateStep.lambda$execute$2(SkipUpToDateStep.java:53)
        at java.base@21.0.11/java.util.Optional.orElseGet(Optional.java:364)
        at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:53)
        at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:35)
        at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:37)
        at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:27)
        at org.gradle.internal.execution.steps.ResolveMutableCachingStateStep.executeDelegate(ResolveMutableCachingStateStep.java:70)
        at org.gradle.internal.execution.steps.ResolveMutableCachingStateStep.executeDelegate(ResolveMutableCachingStateStep.java:32)
        at org.gradle.internal.execution.steps.AbstractResolveCachingStateStep.execute(AbstractResolveCachingStateStep.java:69)
        at org.gradle.internal.execution.steps.AbstractResolveCachingStateStep.execute(AbstractResolveCachingStateStep.java:37)
        at org.gradle.internal.execution.steps.ResolveChangesStep.executeMutable(ResolveChangesStep.java:63)
        at org.gradle.internal.execution.steps.ResolveChangesStep.executeMutable(ResolveChangesStep.java:34)
        at org.gradle.internal.execution.steps.MutableStep.execute(MutableStep.java:26)
        at org.gradle.internal.execution.steps.ValidateStep$Mutable.executeDelegate(ValidateStep.java:79)
        at org.gradle.internal.execution.steps.ValidateStep$Mutable.executeDelegate(ValidateStep.java:65)
        at org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:99)
        at org.gradle.internal.execution.steps.ValidateStep$Mutable.execute(ValidateStep.java:65)
        at org.gradle.internal.execution.steps.CaptureMutableStateBeforeExecutionStep.executeMutable(CaptureMutableStateBeforeExecutionStep.java:86)
        at org.gradle.internal.execution.steps.CaptureMutableStateBeforeExecutionStep.execute(CaptureMutableStateBeforeExecutionStep.java:65)
        at org.gradle.internal.execution.steps.CaptureMutableStateBeforeExecutionStep.execute(CaptureMutableStateBeforeExecutionStep.java:45)
        at org.gradle.internal.execution.steps.SkipEmptyMutableWorkStep.executeWithNonEmptySources(SkipEmptyMutableWorkStep.java:210)
        at org.gradle.internal.execution.steps.SkipEmptyMutableWorkStep.executeMutable(SkipEmptyMutableWorkStep.java:85)
        at org.gradle.internal.execution.steps.SkipEmptyMutableWorkStep.executeMutable(SkipEmptyMutableWorkStep.java:53)
        at org.gradle.internal.execution.steps.MutableStep.execute(MutableStep.java:26)
        at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsStartedStep.execute(MarkSnapshottingInputsStartedStep.java:38)
        at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.executeMutable(LoadPreviousExecutionStateStep.java:36)
        at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.executeMutable(LoadPreviousExecutionStateStep.java:23)
        at org.gradle.internal.execution.steps.MutableStep.execute(MutableStep.java:26)
        at org.gradle.internal.execution.steps.HandleStaleOutputsStep.executeMutable(HandleStaleOutputsStep.java:77)
        at org.gradle.internal.execution.steps.HandleStaleOutputsStep.executeMutable(HandleStaleOutputsStep.java:43)
        at org.gradle.internal.execution.steps.MutableStep.execute(MutableStep.java:26)
        at org.gradle.internal.execution.steps.AssignMutableWorkspaceStep.lambda$executeMutable$0(AssignMutableWorkspaceStep.java:34)
        at org.gradle.api.internal.tasks.execution.TaskExecution$4.withWorkspace(TaskExecution.java:305)
        at org.gradle.internal.execution.steps.AssignMutableWorkspaceStep.executeMutable(AssignMutableWorkspaceStep.java:30)
        at org.gradle.internal.execution.steps.AssignMutableWorkspaceStep.executeMutable(AssignMutableWorkspaceStep.java:21)
        at org.gradle.internal.execution.steps.MutableStep.execute(MutableStep.java:26)
        at org.gradle.internal.execution.steps.ChoosePipelineStep.execute(ChoosePipelineStep.java:40)
        at org.gradle.internal.execution.steps.ChoosePipelineStep.execute(ChoosePipelineStep.java:23)
        at org.gradle.internal.execution.steps.ExecuteWorkBuildOperationFiringStep.lambda$execute$2(ExecuteWorkBuildOperationFiringStep.java:67)
        at java.base@21.0.11/java.util.Optional.orElseGet(Optional.java:364)
        at org.gradle.internal.execution.steps.ExecuteWorkBuildOperationFiringStep.execute(ExecuteWorkBuildOperationFiringStep.java:67)
        at org.gradle.internal.execution.steps.ExecuteWorkBuildOperationFiringStep.execute(ExecuteWorkBuildOperationFiringStep.java:39)
        at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:46)
        at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:34)
        at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:56)
        at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:38)
        at org.gradle.internal.execution.impl.DefaultExecutionEngine$1.execute(DefaultExecutionEngine.java:68)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:132)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:121)
        at org.gradle.api.internal.tasks.execution.ProblemsTaskPathTrackingTaskExecuter.execute(ProblemsTaskPathTrackingTaskExecuter.java:41)
        at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:51)
        at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
        at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
        at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:74)
        at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:210)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:205)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:67)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:60)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:167)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:60)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:54)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
        at org.gradle.execution.plan.DefaultNodeExecutor.executeLocalTaskNode(DefaultNodeExecutor.java:55)
        at org.gradle.execution.plan.DefaultNodeExecutor.execute(DefaultNodeExecutor.java:34)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:355)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:343)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.lambda$execute$0(DefaultTaskExecutionGraph.java:339)
        at org.gradle.internal.operations.CurrentBuildOperationRef.with(CurrentBuildOperationRef.java:84)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:339)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:328)
        at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:459)
        at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:376)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
        at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
        at java.base@21.0.11/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base@21.0.11/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base@21.0.11/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -2 out of bounds for length 12
        at org.openrewrite.groovy.GroovyParserVisitor.determineParenthesisLevel(GroovyParserVisitor.java:3991)
        at org.openrewrite.groovy.GroovyParserVisitor.getInsideParenthesesLevel(GroovyParserVisitor.java:3946)
        at org.openrewrite.groovy.GroovyParserVisitor.access$2600(GroovyParserVisitor.java:82)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyVisitor.insideParentheses(GroovyParserVisitor.java:1280)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyVisitor.visitMethodCallExpression(GroovyParserVisitor.java:2643)
        at org.codehaus.groovy.ast.expr.MethodCallExpression.visit(MethodCallExpression.java:77)
        at org.codehaus.groovy.ast.CodeVisitorSupport.visitBooleanExpression(CodeVisitorSupport.java:229)
        at org.codehaus.groovy.ast.expr.BooleanExpression.visit(BooleanExpression.java:41)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyVisitor.doVisit(GroovyParserVisitor.java:1251)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyVisitor.lambda$visitTernaryExpression$24(GroovyParserVisitor.java:3012)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyVisitor.insideParentheses(GroovyParserVisitor.java:1293)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyVisitor.visitTernaryExpression(GroovyParserVisitor.java:3011)
        at org.codehaus.groovy.ast.expr.TernaryExpression.visit(TernaryExpression.java:44)
        at org.codehaus.groovy.ast.CodeVisitorSupport.visitExpressionStatement(CodeVisitorSupport.java:117)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyVisitor.lambda$visitExpressionStatement$13(GroovyParserVisitor.java:2336)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyVisitor.labeled(GroovyParserVisitor.java:1308)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyVisitor.visitExpressionStatement(GroovyParserVisitor.java:2335)
        at org.codehaus.groovy.ast.stmt.ExpressionStatement.visit(ExpressionStatement.java:41)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyVisitor.doVisit(GroovyParserVisitor.java:1251)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyVisitor.visitBlockStatement(GroovyParserVisitor.java:1756)
        at org.codehaus.groovy.ast.stmt.BlockStatement.visit(BlockStatement.java:72)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyVisitor.doVisit(GroovyParserVisitor.java:1251)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyVisitor.access$1900(GroovyParserVisitor.java:1234)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyClassVisitor.visitMethod(GroovyParserVisitor.java:1191)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyClassVisitor.lambda$visitClassBlock$2(GroovyParserVisitor.java:813)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
        at java.base/java.util.TreeMap$ValueSpliterator.forEachRemaining(TreeMap.java:3250)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyClassVisitor.visitClassBlock(GroovyParserVisitor.java:822)
        at org.openrewrite.groovy.GroovyParserVisitor$RewriteGroovyClassVisitor.visitClass(GroovyParserVisitor.java:408)
        at org.openrewrite.groovy.GroovyParserVisitor.convertTopLevelStatement(GroovyParserVisitor.java:3436)
        at org.openrewrite.groovy.GroovyParserVisitor.visit(GroovyParserVisitor.java:234)
        ... 192 more
There were problems parsing src/main/groovy/com/example/demo/LogTestWithConcatenatedArg.groovy
```
