### PR TITLE
Scala: fix parsing of array types

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -51,6 +51,7 @@ import org.openrewrite.scala.tree.S
 
 import java.util
 import java.util.{Collections, Arrays}
+import scala.jdk.CollectionConverters.*
 
 /**
  * Visitor that traverses the Scala compiler AST and builds OpenRewrite LST nodes.
@@ -5792,16 +5793,7 @@ class ScalaTreeVisitor(
       Markers.EMPTY
     )
     
-    // Resolve type: try span-based first, then derive from the base clazz type
-    var paramType: JavaType = typeOfTree(at)
-    if (paramType == null) {
-      // Fall back to the type of the base class identifier (e.g., List → java.util.List)
-      paramType = clazz match {
-        case id: J.Identifier => id.getType
-        case fa: J.FieldAccess => fa.getType
-        case _ => null
-      }
-    }
+    val paramType = parameterizedTypeForAppliedTypeTree(clazz, typeArgs, typeOfTree(at))
 
     new J.ParameterizedType(
       Tree.randomId(),
@@ -5811,6 +5803,42 @@ class ScalaTreeVisitor(
       typeParameters,
       paramType
     )
+  }
+
+  private def parameterizedTypeForAppliedTypeTree(
+    clazz: NameTree,
+    typeArgs: util.List[JRightPadded[Expression]],
+    mappedType: JavaType
+  ): JavaType = mappedType match {
+    case pt: JavaType.Parameterized => pt
+    case _ =>
+      val fallbackType =
+        if (mappedType == null || mappedType.isInstanceOf[JavaType.Unknown]) clazz.getType
+        else mappedType
+
+      fallbackType match {
+        case pt: JavaType.Parameterized if !typeArgs.isEmpty =>
+          new JavaType.Parameterized(null, pt.getType, typeArgs.asScala.map(typeArgType).asJava)
+        case fq: JavaType.FullyQualified if !fq.isInstanceOf[JavaType.Unknown] && !typeArgs.isEmpty =>
+          new JavaType.Parameterized(null, fq, typeArgs.asScala.map(typeArgType).asJava)
+        case _ =>
+          mappedType
+      }
+  }
+
+  private def typeArgType(arg: JRightPadded[Expression]): JavaType = {
+    arg.getElement.getType match {
+      case null | _: JavaType.Unknown =>
+      case t => return t
+    }
+
+    arg.getElement match {
+      case id: J.Identifier =>
+        val mapped = typeForName(id.getSimpleName)
+        if (mapped != null) mapped else JavaType.Unknown.getInstance()
+      case _ =>
+        JavaType.Unknown.getInstance()
+    }
   }
 
   /**

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTypeMapping.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTypeMapping.scala
@@ -118,13 +118,31 @@ class ScalaTypeMapping(typeFactory: JavaTypeFactory, typedTree: tpd.Tree)(using 
       case Some(sym) =>
         try {
           val tpe = sym.info
-          if (tpe == null || tpe == NoType) null
-          else mapType(tpe)
+          val mapped = if (tpe == null || tpe == NoType) null else mapType(tpe)
+          if (mapped == null || mapped.isInstanceOf[JavaType.Unknown]) typeForPredefAlias(name)
+          else mapped
         } catch {
-          case _: Throwable => null
+          case _: Throwable => typeForPredefAlias(name)
         }
-      case None => null
+      case None => typeForPredefAlias(name)
     }
+  }
+
+  private def typeForPredefAlias(name: String): JavaType = name match {
+    case "String" => JavaType.ShallowClass.build("java.lang.String")
+    case "Int" => JavaType.Primitive.Int
+    case "Long" => JavaType.Primitive.Long
+    case "Short" => JavaType.Primitive.Short
+    case "Byte" => JavaType.Primitive.Byte
+    case "Char" => JavaType.Primitive.Char
+    case "Float" => JavaType.Primitive.Float
+    case "Double" => JavaType.Primitive.Double
+    case "Boolean" => JavaType.Primitive.Boolean
+    case "Unit" => JavaType.Primitive.Void
+    case "Any" | "AnyRef" => JavaType.ShallowClass.build("java.lang.Object")
+    case "Null" => JavaType.Primitive.Null
+    case "Nothing" => JavaType.ShallowClass.build("scala.Nothing")
+    case _ => null
   }
 
   /** Look up JavaType.Method by span start position. */

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ParameterizedTypeTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ParameterizedTypeTest.java
@@ -16,8 +16,15 @@
 package org.openrewrite.scala.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeTree;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.scala.Assertions.scala;
 
 class ParameterizedTypeTest implements RewriteTest {
@@ -31,6 +38,52 @@ class ParameterizedTypeTest implements RewriteTest {
               val list: List[String] = List("a", "b", "c")
             }
             """
+          )
+        );
+    }
+
+    @Test
+    void arrayTypeAnnotationIsParameterizedType() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              val args: Array[String] = Array.empty[String]
+            }
+            """,
+            spec -> spec.afterRecipe(cu -> {
+                AtomicReference<TypeTree> typeExpression = new AtomicReference<>();
+
+                new JavaIsoVisitor<Integer>() {
+                    @Override
+                    public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, Integer p) {
+                        J.VariableDeclarations.NamedVariable variable = multiVariable.getVariables().get(0);
+                        if ("args".equals(variable.getSimpleName())) {
+                            typeExpression.set(multiVariable.getTypeExpression());
+                        }
+                        return super.visitVariableDeclarations(multiVariable, p);
+                    }
+                }.visit(cu, 0);
+
+                assertThat(typeExpression.get())
+                  .as("Array[String] should parse as a parameterized type annotation")
+                  .isInstanceOf(J.ParameterizedType.class);
+
+                J.ParameterizedType arrayType = (J.ParameterizedType) typeExpression.get();
+                assertThat(arrayType.getClazz()).isInstanceOf(J.Identifier.class);
+                assertThat(((J.Identifier) arrayType.getClazz()).getSimpleName()).isEqualTo("Array");
+                assertThat(arrayType.getTypeParameters()).hasSize(1);
+                assertThat(arrayType.getTypeParameters().get(0)).isInstanceOf(J.Identifier.class);
+                assertThat(((J.Identifier) arrayType.getTypeParameters().get(0)).getSimpleName()).isEqualTo("String");
+                assertThat(arrayType.getType()).isInstanceOf(JavaType.Parameterized.class);
+                JavaType.Parameterized attributedType = (JavaType.Parameterized) arrayType.getType();
+                assertThat(attributedType.getType().getFullyQualifiedName()).isEqualTo("scala.Array");
+                assertThat(attributedType.getTypeParameters()).hasSize(1);
+                assertThat(attributedType.getTypeParameters().get(0))
+                  .isInstanceOf(JavaType.FullyQualified.class);
+                assertThat(((JavaType.FullyQualified) attributedType.getTypeParameters().get(0)).getFullyQualifiedName())
+                  .isEqualTo("java.lang.String");
+            })
           )
         );
     }


### PR DESCRIPTION
## What's changed?

Fixing parsing of Scala array types, e.g. `Array[String]`.

## What's your motivation?

They are currently stuffed into a `J.Identifier`, which is wrong.