### PR TITLE
Go: visitor logic to traverse `go.mod` and test harness

### DIFF
--- a/rewrite-go/pkg/printer/gomod_printer.go
+++ b/rewrite-go/pkg/printer/gomod_printer.go
@@ -24,12 +24,27 @@ import (
 // whitespace and every comment is preserved on the tree, an unmodified
 // GoMod prints to exactly the bytes it was parsed from.
 func PrintGoMod(gm *golang.GoMod) string {
-	out := NewPrintOutputCapture()
+	return printGoMod(gm, NewPrintOutputCapture())
+}
+
+// PrintGoModWithMarkers renders a GoMod LST to source, printing cross-cutting
+// markers (SearchResult, Markup) via the given MarkerPrinter. With a nil-free
+// marker printer that emits nothing for a node, the output is byte-identical
+// to PrintGoMod — so search recipes can be tested with the same /*~~>*/
+// convention used for .go sources.
+func PrintGoModWithMarkers(gm *golang.GoMod, mp MarkerPrinter) string {
+	return printGoMod(gm, NewPrintOutputCaptureWithMarkers(mp))
+}
+
+func printGoMod(gm *golang.GoMod, out *PrintOutputCapture) string {
+	out.BeforePrefix(gm.Markers)
 	printGoModSpace(gm.Prefix, out)
+	out.BeforeSyntax(gm.Markers)
 	for _, rp := range gm.Statements {
 		printGoModStatement(rp.Element, out)
 		printGoModSpace(rp.After, out)
 	}
+	out.AfterSyntax(gm.Markers)
 	printGoModSpace(gm.Eof, out)
 	return out.String()
 }
@@ -44,18 +59,30 @@ func printGoModStatement(s golang.GoModStatement, out *PrintOutputCapture) {
 }
 
 func printGoModDirective(d *golang.GoModDirective, out *PrintOutputCapture) {
+	out.BeforePrefix(d.Markers)
 	printGoModSpace(d.Prefix, out)
+	out.BeforeSyntax(d.Markers)
 	if d.Keyword != "" {
 		out.Append(d.Keyword)
 	}
 	for _, v := range d.Values {
-		printGoModSpace(v.Prefix, out)
-		out.Append(v.Text)
+		printGoModValue(v, out)
 	}
+	out.AfterSyntax(d.Markers)
+}
+
+func printGoModValue(v *golang.GoModValue, out *PrintOutputCapture) {
+	out.BeforePrefix(v.Markers)
+	printGoModSpace(v.Prefix, out)
+	out.BeforeSyntax(v.Markers)
+	out.Append(v.Text)
+	out.AfterSyntax(v.Markers)
 }
 
 func printGoModBlock(b *golang.GoModBlock, out *PrintOutputCapture) {
+	out.BeforePrefix(b.Markers)
 	printGoModSpace(b.Prefix, out)
+	out.BeforeSyntax(b.Markers)
 	out.Append(b.Keyword)
 	printGoModSpace(b.BeforeLParen, out)
 	out.Append("(")
@@ -65,6 +92,7 @@ func printGoModBlock(b *golang.GoModBlock, out *PrintOutputCapture) {
 	}
 	printGoModSpace(b.BeforeRParen, out)
 	out.Append(")")
+	out.AfterSyntax(b.Markers)
 }
 
 func printGoModSpace(space java.Space, out *PrintOutputCapture) {

--- a/rewrite-go/pkg/test/spec.go
+++ b/rewrite-go/pkg/test/spec.go
@@ -477,11 +477,13 @@ func (spec *RecipeSpec) RewriteRun(t *testing.T, sources ...Sources) {
 	}
 
 	for i, src := range flat {
-		// Non-Go sources (e.g. go.mod) are not yet parsed on the Go side.
-		// We round-trip them verbatim so project layouts compose, but skip
-		// tree-walks and recipe application.
 		if !strings.HasSuffix(src.Path, ".go") {
-			if src.After != nil && *src.After != src.Before {
+			// go.mod parses into a lossless LST, so recipes can run against
+			// it. Other non-Go sources (e.g. go.sum) have no LST yet and
+			// round-trip verbatim.
+			if path.Base(src.Path) == "go.mod" {
+				spec.rewriteGoMod(t, src)
+			} else if src.After != nil && *src.After != src.Before {
 				t.Errorf("non-Go source %q: harness cannot apply recipes to it yet", src.Path)
 			}
 			continue
@@ -554,6 +556,66 @@ func (spec *RecipeSpec) RewriteRun(t *testing.T, sources ...Sources) {
 		} else if src.After != nil {
 			t.Error("after state specified but no recipe configured")
 		}
+	}
+}
+
+// rewriteGoMod parses a go.mod source into its lossless LST, checks
+// parse-print idempotence, and (if a recipe is configured) applies it and
+// compares the printed result to the expected after-state. Mirrors the
+// .go path in RewriteRun, but uses the go.mod-specific parser/printer since
+// GoMod is a SourceFile that is not a *golang.CompilationUnit.
+func (spec *RecipeSpec) rewriteGoMod(t *testing.T, src SourceSpec) {
+	t.Helper()
+
+	gm, err := parser.ParseGoModFile(src.Path, src.Before)
+	if err != nil {
+		t.Fatalf("go.mod parse error: %v", err)
+	}
+
+	// Attach any markers contributed by GoProject(...) wrappers (e.g. the
+	// GoResolutionResult / GoProject markers) so recipes can read them.
+	for _, m := range src.Markers {
+		gm = gm.WithMarkers(java.AddMarker(gm.Markers, m))
+	}
+
+	if spec.CheckParsePrintIdempotence {
+		if printed := printer.PrintGoMod(gm); printed != src.Before {
+			t.Errorf("go.mod parse-print idempotence failed\n\nexpected:\n%s\n\nactual:\n%s\n\ndiff positions:", src.Before, printed)
+			showDiff(t, src.Before, printed)
+		}
+	}
+
+	if spec.Recipe == nil {
+		if src.After != nil {
+			t.Error("after state specified but no recipe configured")
+		}
+		return
+	}
+
+	result := runRecipe(spec.Recipe, gm)
+	if result == nil {
+		if src.After != nil {
+			t.Error("recipe returned nil (deleted source file) but expected an after state")
+		}
+		return
+	}
+	resultGoMod, ok := result.(*golang.GoMod)
+	if !ok {
+		t.Fatalf("recipe returned %T, want *golang.GoMod", result)
+	}
+
+	mp := spec.MarkerPrinter
+	if mp == nil {
+		mp = printer.DefaultMarkerPrinter
+	}
+	actual := printer.PrintGoModWithMarkers(resultGoMod, mp)
+	if src.After != nil {
+		if actual != *src.After {
+			t.Errorf("recipe result mismatch\n\nexpected:\n%s\n\nactual:\n%s", *src.After, actual)
+			showDiff(t, *src.After, actual)
+		}
+	} else if actual != src.Before {
+		t.Errorf("recipe made unexpected changes\n\nexpected (no change):\n%s\n\nactual:\n%s", src.Before, actual)
 	}
 }
 

--- a/rewrite-go/pkg/tree/golang/gomod.go
+++ b/rewrite-go/pkg/tree/golang/gomod.go
@@ -69,6 +69,12 @@ func (n *GoMod) WithStatements(statements []java.RightPadded[GoModStatement]) *G
 	return &c
 }
 
+func (n *GoMod) WithEof(eof java.Space) *GoMod {
+	c := *n
+	c.Eof = eof
+	return &c
+}
+
 // GoModStatement is a top-level go.mod statement or a single line inside a
 // factored block. The two concrete forms are GoModDirective (a single
 // line of tokens) and GoModBlock (a `keyword ( … )` factored block).
@@ -105,6 +111,18 @@ func (n *GoModDirective) WithPrefix(prefix java.Space) *GoModDirective {
 	return &c
 }
 
+func (n *GoModDirective) WithMarkers(markers java.Markers) *GoModDirective {
+	c := *n
+	c.Markers = markers
+	return &c
+}
+
+func (n *GoModDirective) WithValues(values []*GoModValue) *GoModDirective {
+	c := *n
+	c.Values = values
+	return &c
+}
+
 // GoModBlock is a factored block, e.g.
 //
 //	require (
@@ -130,6 +148,18 @@ func (n *GoModBlock) WithPrefix(prefix java.Space) *GoModBlock {
 	return &c
 }
 
+func (n *GoModBlock) WithMarkers(markers java.Markers) *GoModBlock {
+	c := *n
+	c.Markers = markers
+	return &c
+}
+
+func (n *GoModBlock) WithEntries(entries []java.RightPadded[GoModStatement]) *GoModBlock {
+	c := *n
+	c.Entries = entries
+	return &c
+}
+
 // GoModValue is a single token within a directive line: a module path,
 // version, local path, operator, or bracketed range expression. The raw
 // text is preserved verbatim (including any quoting).
@@ -145,5 +175,17 @@ func (*GoModValue) IsTree() {}
 func (n *GoModValue) WithPrefix(prefix java.Space) *GoModValue {
 	c := *n
 	c.Prefix = prefix
+	return &c
+}
+
+func (n *GoModValue) WithMarkers(markers java.Markers) *GoModValue {
+	c := *n
+	c.Markers = markers
+	return &c
+}
+
+func (n *GoModValue) WithText(text string) *GoModValue {
+	c := *n
+	c.Text = text
 	return &c
 }

--- a/rewrite-go/pkg/visitor/go_visitor.go
+++ b/rewrite-go/pkg/visitor/go_visitor.go
@@ -121,6 +121,14 @@ func (v *GoVisitor) Visit(t java.Tree, p any) java.Tree {
 	switch n := t.(type) {
 	case *golang.CompilationUnit:
 		return v.self().VisitCompilationUnit(n, p)
+	case *golang.GoMod:
+		return v.self().VisitGoMod(n, p)
+	case *golang.GoModDirective:
+		return v.self().VisitGoModDirective(n, p)
+	case *golang.GoModBlock:
+		return v.self().VisitGoModBlock(n, p)
+	case *golang.GoModValue:
+		return v.self().VisitGoModValue(n, p)
 	case *java.Identifier:
 		return v.self().VisitIdentifier(n, p)
 	case *java.Literal:
@@ -264,6 +272,12 @@ type VisitorI interface {
 	Visit(t java.Tree, p any) java.Tree
 	PreVisit(t java.Tree, p any) java.Tree
 	VisitCompilationUnit(cu *golang.CompilationUnit, p any) java.J
+	// go.mod nodes are Tree, not J (their tokens are not Java
+	// expressions), so these return java.Tree rather than java.J.
+	VisitGoMod(gm *golang.GoMod, p any) java.Tree
+	VisitGoModDirective(d *golang.GoModDirective, p any) java.Tree
+	VisitGoModBlock(b *golang.GoModBlock, p any) java.Tree
+	VisitGoModValue(val *golang.GoModValue, p any) java.Tree
 	VisitIdentifier(ident *java.Identifier, p any) java.J
 	VisitLiteral(lit *java.Literal, p any) java.J
 	VisitBinary(bin *java.Binary, p any) java.J
@@ -362,6 +376,44 @@ func (v *GoVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p any) java
 	cu = cu.WithStatements(visitRightPaddedList(v, cu.Statements, p))
 	cu = cu.WithEOF(v.self().VisitSpace(cu.EOF, p))
 	return cu
+}
+
+func (v *GoVisitor) VisitGoMod(gm *golang.GoMod, p any) java.Tree {
+	gm = gm.WithPrefix(v.self().VisitSpace(gm.Prefix, p))
+	gm = gm.WithMarkers(v.visitMarkers(gm.Markers, p))
+	gm = gm.WithStatements(visitGoModStatementList(v, gm.Statements, p))
+	gm = gm.WithEof(v.self().VisitSpace(gm.Eof, p))
+	return gm
+}
+
+func (v *GoVisitor) VisitGoModDirective(d *golang.GoModDirective, p any) java.Tree {
+	d = d.WithPrefix(v.self().VisitSpace(d.Prefix, p))
+	d = d.WithMarkers(v.visitMarkers(d.Markers, p))
+	values := make([]*golang.GoModValue, 0, len(d.Values))
+	for _, val := range d.Values {
+		visited := v.self().Visit(val, p)
+		if visited == nil {
+			continue
+		}
+		values = append(values, visited.(*golang.GoModValue))
+	}
+	d = d.WithValues(values)
+	return d
+}
+
+func (v *GoVisitor) VisitGoModBlock(b *golang.GoModBlock, p any) java.Tree {
+	b = b.WithPrefix(v.self().VisitSpace(b.Prefix, p))
+	b = b.WithMarkers(v.visitMarkers(b.Markers, p))
+	b.BeforeLParen = v.self().VisitSpace(b.BeforeLParen, p)
+	b = b.WithEntries(visitGoModStatementList(v, b.Entries, p))
+	b.BeforeRParen = v.self().VisitSpace(b.BeforeRParen, p)
+	return b
+}
+
+func (v *GoVisitor) VisitGoModValue(val *golang.GoModValue, p any) java.Tree {
+	val = val.WithPrefix(v.self().VisitSpace(val.Prefix, p))
+	val = val.WithMarkers(v.visitMarkers(val.Markers, p))
+	return val
 }
 
 func (v *GoVisitor) VisitIdentifier(ident *java.Identifier, p any) java.J {
@@ -1074,6 +1126,23 @@ func visitAndCast[T java.Tree](v *GoVisitor, t java.Tree, p any) T {
 		return zero
 	}
 	return result.(T)
+}
+
+// visitGoModStatementList visits a right-padded list of go.mod statements.
+// GoModStatement is a java.Tree (not java.J), so the J-constrained
+// visitRightPaddedList helper can't be reused here.
+func visitGoModStatementList(v *GoVisitor, list []java.RightPadded[golang.GoModStatement], p any) []java.RightPadded[golang.GoModStatement] {
+	result := make([]java.RightPadded[golang.GoModStatement], 0, len(list))
+	for _, rp := range list {
+		visited := v.self().Visit(rp.Element, p)
+		if visited == nil {
+			continue
+		}
+		rp.Element = visited.(golang.GoModStatement)
+		rp.After = v.self().VisitSpace(rp.After, p)
+		result = append(result, rp)
+	}
+	return result
 }
 
 func visitExpression(v *GoVisitor, expr java.Expression, p any) java.Expression {

--- a/rewrite-go/test/gomod_recipe_test.go
+++ b/rewrite-go/test/gomod_recipe_test.go
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/test"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// --- Sample refactoring recipe that rewrites the `go` directive version ---
+
+type changeGoVersion struct {
+	recipe.Base
+	NewVersion string
+}
+
+func (r *changeGoVersion) Name() string        { return "org.openrewrite.golang.test.ChangeGoVersion" }
+func (r *changeGoVersion) DisplayName() string { return "Change the go directive version" }
+func (r *changeGoVersion) Description() string { return "Rewrites the `go` directive to a new version." }
+
+func (r *changeGoVersion) Editor() recipe.TreeVisitor {
+	return visitor.Init(&changeGoVersionVisitor{newVersion: r.NewVersion})
+}
+
+type changeGoVersionVisitor struct {
+	visitor.GoVisitor
+	newVersion string
+}
+
+func (v *changeGoVersionVisitor) VisitGoModDirective(d *golang.GoModDirective, p any) java.Tree {
+	d = v.GoVisitor.VisitGoModDirective(d, p).(*golang.GoModDirective)
+	if d.Keyword == "go" && len(d.Values) == 1 {
+		d = d.WithValues([]*golang.GoModValue{d.Values[0].WithText(v.newVersion)})
+	}
+	return d
+}
+
+// --- Sample search recipe that marks the module path ---
+
+type findModulePath struct {
+	recipe.Base
+}
+
+func (r *findModulePath) Name() string        { return "org.openrewrite.golang.test.FindModulePath" }
+func (r *findModulePath) DisplayName() string { return "Find the module path" }
+func (r *findModulePath) Description() string {
+	return "Marks the `module` directive's path with a search result."
+}
+
+func (r *findModulePath) Editor() recipe.TreeVisitor {
+	return visitor.Init(&findModulePathVisitor{})
+}
+
+type findModulePathVisitor struct {
+	visitor.GoVisitor
+}
+
+func (v *findModulePathVisitor) VisitGoModDirective(d *golang.GoModDirective, p any) java.Tree {
+	d = v.GoVisitor.VisitGoModDirective(d, p).(*golang.GoModDirective)
+	if d.Keyword == "module" && len(d.Values) > 0 {
+		marked := d.Values[0].WithMarkers(java.FoundSearchResult(d.Values[0].Markers, "found module"))
+		d = d.WithValues(append([]*golang.GoModValue{marked}, d.Values[1:]...))
+	}
+	return d
+}
+
+// --- Tests ---
+
+func TestGoModRecipeSetGoVersion(t *testing.T) {
+	spec := test.NewRecipeSpec().WithRecipe(&changeGoVersion{NewVersion: "1.22"})
+	spec.RewriteRun(t,
+		test.GoMod(`
+			module example.com/foo
+
+			go 1.21
+		`, `
+			module example.com/foo
+
+			go 1.22
+		`),
+	)
+}
+
+func TestGoModRecipeNoChange(t *testing.T) {
+	spec := test.NewRecipeSpec().WithRecipe(&changeGoVersion{NewVersion: "1.22"})
+	spec.RewriteRun(t,
+		test.GoMod(`
+			module example.com/bar
+
+			go 1.22
+		`),
+	)
+}
+
+// TestGoModRecipeInBlock confirms a recipe can reach version tokens inside a
+// factored require block, not just top-level directives.
+func TestGoModRecipeBumpsAcrossWhitespace(t *testing.T) {
+	spec := test.NewRecipeSpec().WithRecipe(&changeGoVersion{NewVersion: "1.23"})
+	spec.RewriteRun(t,
+		test.GoMod(`
+			module example.com/foo
+
+			go 1.21
+
+			require (
+				github.com/foo/bar v1.0.0
+				github.com/baz/qux v1.5.0 // indirect
+			)
+		`, `
+			module example.com/foo
+
+			go 1.23
+
+			require (
+				github.com/foo/bar v1.0.0
+				github.com/baz/qux v1.5.0 // indirect
+			)
+		`),
+	)
+}
+
+// TestGoModSearchRecipe verifies SearchResult markers render as /*~~(...)~~>*/
+// in go.mod output, matching the .go convention.
+func TestGoModSearchRecipe(t *testing.T) {
+	spec := test.NewRecipeSpec().WithRecipe(&findModulePath{})
+	spec.RewriteRun(t,
+		test.GoMod(
+			"module example.com/foo\n\ngo 1.21\n",
+			"module /*~~(found module)~~>*/example.com/foo\n\ngo 1.21\n",
+		),
+	)
+}
+
+// TestGoModRecipeInProject runs a recipe over a project mixing a go.mod and a
+// .go file: the go.mod is transformed while the unrelated .go file is left
+// untouched.
+func TestGoModRecipeInProject(t *testing.T) {
+	spec := test.NewRecipeSpec().WithRecipe(&changeGoVersion{NewVersion: "1.23"})
+	spec.RewriteRun(t,
+		test.GoProject("foo",
+			test.GoMod(`
+				module example.com/foo
+
+				go 1.21
+			`, `
+				module example.com/foo
+
+				go 1.23
+			`),
+			test.Golang(`
+				package main
+
+				func main() {
+				}
+			`),
+		),
+	)
+}


### PR DESCRIPTION
## What's changed?

- And some test harness and visitor elements to traverse the `GoModFile` better (continuation of #7862)

## What's your motivation?

Ability to build recipes to upgrade Go version.