### PR TITLE
Groovy: parse untyped parameters whose names start with a modifier keyword

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -4097,19 +4097,32 @@ public class GroovyParserVisitor {
 
     private List<J.Modifier> getModifiers() {
         List<J.Modifier> modifiers = new ArrayList<>();
-        Set<String> possibleModifiers = new LinkedHashSet<>(modifierNameToType.keySet());
-        String currentModifier = possibleModifiers.stream().filter(this::sourceStartsWith).findFirst().orElse(null);
-        while (currentModifier != null) {
-            possibleModifiers.remove(currentModifier);
-            modifiers.add(new J.Modifier(randomId(), whitespace(), Markers.EMPTY, currentModifier, modifierNameToType.get(currentModifier), emptyList()));
-            skip(currentModifier);
-            currentModifier = possibleModifiers.stream()
-                    // Try to avoid confusing a variable name with an incidentally similar modifier keyword like `def defaultPublicStaticFinal = 0`
-                    .filter(modifierName -> sourceStartsWith(modifierName, "\n", " ", ")"))
-                    .findFirst()
-                    .orElse(null);
+        String keyword;
+        while ((keyword = nextModifierKeyword()) != null) {
+            modifiers.add(new J.Modifier(randomId(), whitespace(), Markers.EMPTY, keyword, modifierNameToType.get(keyword), emptyList()));
+            skip(keyword);
         }
         return modifiers;
+    }
+
+    /**
+     * Peeks at the next token without consuming it and returns it only if it is a modifier keyword whose end falls
+     * on an identifier boundary. Requiring the character after the keyword to not be an identifier part keeps a
+     * variable name from being mistaken for an incidentally similar keyword (e.g. {@code defaultValue} is not the
+     * {@code def} keyword), while still recognizing a keyword that is immediately followed by punctuation such as
+     * {@code def(key, value)} destructuring.
+     */
+    private @Nullable String nextModifierKeyword() {
+        int start = indexOfNextNonWhitespace(cursor, source);
+        for (String keyword : modifierNameToType.keySet()) {
+            if (source.startsWith(keyword, start)) {
+                int after = start + keyword.length();
+                if (after >= source.length() || !isJavaIdentifierPart(source.charAt(after))) {
+                    return keyword;
+                }
+            }
+        }
+        return null;
     }
 
     private <G2 extends J> JRightPadded<G2> maybeSemicolon(G2 g) {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
@@ -128,6 +128,33 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void dynamicTypedArgumentsNamedLikeModifiers() {
+        rewriteRun(
+          groovy(
+            """
+              class T {
+                  private String fromEnv(template, id, defaultValue) {
+                      return defaultValue
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                J.MethodDeclaration fromEnv = (J.MethodDeclaration) ((J.ClassDeclaration) cu.getStatements().getFirst())
+                  .getBody().getStatements().getFirst();
+                for (var param : fromEnv.getParameters()) {
+                    assertThat(((J.VariableDeclarations) param).getModifiers()).isEmpty();
+                }
+                assertThat(fromEnv.getParameters()).satisfiesExactly(
+                  p -> assertThat(((J.VariableDeclarations) p).getVariables().getFirst().getSimpleName()).isEqualTo("template"),
+                  p -> assertThat(((J.VariableDeclarations) p).getVariables().getFirst().getSimpleName()).isEqualTo("id"),
+                  p -> assertThat(((J.VariableDeclarations) p).getVariables().getFirst().getSimpleName()).isEqualTo("defaultValue")
+                );
+            })
+          )
+        );
+    }
+
+    @Test
     void varargsArguments() {
         rewriteRun(
           groovy(


### PR DESCRIPTION
## Motivation

A dynamic-typed Groovy parameter whose name begins with a modifier keyword was parsed incorrectly. For example, `defaultValue` begins with `def`, so the parser greedily matched the leading `def` as the `def` modifier and corrupted the parameter name when printing the LST back to source — failing the print-idempotency check. This was found in real-world Groovy (a Gradle `buildSrc` script with `private String fromEnv(template, id, defaultValue)`).

The root cause: `GroovyParserVisitor.getModifiers()` detected modifier keywords with a prefix match (`sourceStartsWith`), so a parameter named `defaultValue` matched the `def` keyword. The first detection had no word-boundary guard at all, and the loop's guard (an enumerated suffix list `"\n"`, `" "`, `")"`) was brittle.

## Examples

Before this change, the following round-tripped incorrectly:

```groovy
class T {
    private String fromEnv(template, id, defaultValue) {
        return defaultValue
    }
}
```

The parameter `defaultValue` printed back as `defdefaultValueaultValue` (the leading `def` was consumed as a modifier, leaving the name misaligned).

## Summary

- Replaced the prefix-based modifier detection in `GroovyParserVisitor.getModifiers()` with a new `nextModifierKeyword()` helper that recognizes a keyword only when the character immediately after it is **not** an identifier part (an identifier boundary).
- This keeps a variable name from being mistaken for an incidentally similar keyword (`defaultValue` is not `def`, `staticThing` is not `static`, etc.), while still:
  - recognizing a keyword immediately followed by punctuation, e.g. `def(key, value)` destructuring;
  - handling the hyphenated `non-sealed` keyword (only the character after the full keyword is checked).
- Removed the previous `possibleModifiers` set-removal bookkeeping and the enumerated-suffix `sourceStartsWith` calls from modifier detection.

## Test plan

- [x] New test `MethodDeclarationTest.dynamicTypedArgumentsNamedLikeModifiers` asserts the parameters round-trip and carry no spurious modifiers.
- [x] Existing related tests still pass (`parameterWithConflictingTypeName`, `defIsNotReturnType`, `dynamicTypedArguments`, the destructuring-assignment tests).
- [x] Full `rewrite-groovy` test suite passes (648 tests, 0 failures).