### PR TITLE
Exclude synthetic parameters from constructor parameterNames in `JavaReflectionTypeMapping`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
@@ -287,14 +287,18 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
 
         String[] paramNames = null;
         if (method.getParameters().length > 0) {
-            paramNames = new String[method.getParameters().length];
-            Parameter[] parameters = method.getParameters();
-            for (int i = 0; i < parameters.length; i++) {
-                Parameter p = parameters[i];
+            // Exclude synthetic parameters (e.g. the leading name/ordinal params
+            // of an enum constructor) so parameterNames stays aligned with
+            // parameterTypes below, which also skips synthetic parameters. Sizing
+            // the array to all parameters and filling only the non-synthetic
+            // slots left null holes and a length mismatch between the two lists.
+            List<String> names = new ArrayList<>();
+            for (Parameter p : method.getParameters()) {
                 if (!p.isSynthetic()) {
-                    paramNames[i] = p.getName();
+                    names.add(p.getName());
                 }
             }
+            paramNames = names.isEmpty() ? null : names.toArray(new String[0]);
         }
 
         String[] finalParamNames = paramNames;

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/JavaReflectionTypeMappingTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/JavaReflectionTypeMappingTest.java
@@ -74,4 +74,23 @@ class JavaReflectionTypeMappingTest implements JavaTypeMappingTest {
         );
     }
 
+    @Test
+    void syntheticEnumConstructorParametersAreExcluded() {
+        JavaType.FullyQualified roundingMode = TypeUtils.asFullyQualified(typeMapping.type(java.math.RoundingMode.class));
+        JavaType.Method constructor = null;
+        for (JavaType.Method method : roundingMode.getMethods()) {
+            if (method.isConstructor()) {
+                constructor = method;
+                break;
+            }
+        }
+        assertThat(constructor).isNotNull();
+        // An enum constructor carries synthetic name/ordinal parameters in the byte
+        // code. They are excluded from parameterTypes, so they must also be excluded
+        // from parameterNames -- otherwise the names list has null holes for the
+        // synthetic slots and a different length than the types list.
+        assertThat(constructor.getParameterNames()).doesNotContainNull();
+        assertThat(constructor.getParameterNames()).hasSameSizeAs(constructor.getParameterTypes());
+    }
+
 }


### PR DESCRIPTION
## Motivation

`JavaReflectionTypeMapping.method(Constructor, …)` sized the `parameterNames`
array to *all* constructor parameters but only populated the non-synthetic
slots:

```java
paramNames = new String[method.getParameters().length];
for (int i = 0; i < parameters.length; i++) {
    if (!parameters[i].isSynthetic()) {
        paramNames[i] = parameters[i].getName();
    }
}
```

For constructors with synthetic parameters — e.g. the implicit `name`/`ordinal`
parameters an enum constructor carries in byte code — this left `null` elements
in `parameterNames`. It also diverged from the `parameterTypes` loop just below,
which *skips* synthetic parameters, so the two parallel lists ended up with
different lengths (`parameterNames` longer than `parameterTypes`).

Any consumer that zips `parameterNames` with `parameterTypes`, or assumes
parameter names are non-null, gets wrong data. We hit it serializing the
`JavaType.Method` for `sun.invoke.util.Wrapper` (an enum), whose
`parameterNames` came back as `[null, null, arg2, …]`.

## Summary

- Collect only non-synthetic parameter names into `parameterNames`, mirroring
  the existing `parameterTypes` filter, so the list has no `null` holes and
  `parameterNames.size() == parameterTypes.size()`.

## Test plan

- Added `JavaReflectionTypeMappingTest#syntheticEnumConstructorParametersAreExcluded`:
  maps `java.math.RoundingMode` (an enum with a declared constructor) and asserts
  the constructor's `parameterNames` contains no nulls and is the same length as
  `parameterTypes`.
- Verified the test fails without the change and passes with it.
