### PR TITLE
JavaScript: Normalize `@types/<pkg>` to the importable specifier in transitively-resolved type names

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -627,22 +627,36 @@ export class JavaScriptTypeMapping {
             return undefined;
         }
 
-        // Remove @types/ prefix and decode DefinitelyTyped scoped package encoding
-        // DefinitelyTyped encodes scoped packages using __ instead of /
-        // Example: @types/testing-library__react -> @testing-library/react
-        if (moduleName.startsWith('@types/')) {
-            moduleName = moduleName.substring('@types/'.length);
-            // Decode __ encoding for scoped packages
-            // testing-library__react -> @testing-library/react
-            if (moduleName.includes('__')) {
-                const parts = moduleName.split('__');
+        return this.normalizePackageName(moduleName);
+    }
+
+    /**
+     * Normalize a node_modules package name to the specifier consumers actually import.
+     *
+     * DefinitelyTyped packages (`@types/<pkg>`) are never importable under that name — the
+     * importable specifier is `<pkg>`, with DefinitelyTyped's `__` scoped-package encoding
+     * decoded back to a `@scope/name` form. Using the importable specifier keeps attributed
+     * fully qualified names consistent regardless of whether a type is reached through a direct
+     * import (which already resolves via the module specifier) or transitively (e.g. a call's
+     * return type), which falls back to the declaration file's `node_modules` path.
+     *
+     * Examples:
+     * - `@types/express-serve-static-core` -> `express-serve-static-core`
+     * - `@types/node`                      -> `node`
+     * - `@types/testing-library__react`    -> `@testing-library/react`
+     */
+    private normalizePackageName(packageName: string): string {
+        if (packageName.startsWith('@types/')) {
+            packageName = packageName.substring('@types/'.length);
+            // Decode __ encoding for scoped packages: testing-library__react -> @testing-library/react
+            if (packageName.includes('__')) {
+                const parts = packageName.split('__');
                 if (parts.length === 2) {
-                    moduleName = `@${parts[0]}/${parts[1]}`;
+                    packageName = `@${parts[0]}/${parts[1]}`;
                 }
             }
         }
-
-        return moduleName;
+        return packageName;
     }
 
     /**
@@ -1143,6 +1157,11 @@ export class JavaScriptTypeMapping {
                 if (packageName.startsWith('@') && pathParts.length > 1) {
                     packageName = `${packageName}/${pathParts[1]}`;
                 }
+
+                // Normalize `@types/<pkg>` to the importable specifier `<pkg>` so that types
+                // reached transitively (e.g. a call's return type, resolved via the declaration
+                // file's node_modules path) match the names used for directly imported types.
+                packageName = this.normalizePackageName(packageName);
 
                 // Find the symbol name (everything after the last dot in the original cleaned name)
                 const lastDotIndex = cleanedName.lastIndexOf('.');

--- a/rewrite-javascript/rewrite/test/javascript/type-mapping-types-package.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/type-mapping-types-package.test.ts
@@ -1,0 +1,138 @@
+// noinspection JSUnusedLocalSymbols
+
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {RecipeSpec} from "../../src/test";
+import {javascript, JavaScriptVisitor, npm, packageJson, typescript} from "../../src/javascript";
+import {J, Type} from "../../src/java";
+import {ExecutionContext, Recipe} from "../../src";
+import {withDir} from "tmp-promise";
+
+/**
+ * Captures the resolved FQN of the value type attributed to identifiers with the
+ * given names. The FQN of an identifier's type is what downstream recipes gate on
+ * when detecting framework objects (e.g. an Express `Application`/`Router`).
+ */
+function captureIdentifierTypes(names: string[], sink: Map<string, string>): Recipe {
+    class CaptureRecipe extends Recipe {
+        name = 'org.openrewrite.javascript.test.CaptureIdentifierTypes';
+        displayName = 'Capture identifier types';
+        description = 'Records the resolved type FQN of selected identifiers.';
+
+        async editor(): Promise<JavaScriptVisitor<ExecutionContext>> {
+            return new class extends JavaScriptVisitor<ExecutionContext> {
+                async visitIdentifier(ident: J.Identifier, p: ExecutionContext): Promise<J.Identifier> {
+                    const visited = await super.visitIdentifier(ident, p) as J.Identifier;
+                    if (names.includes(visited.simpleName)) {
+                        const type = visited.type;
+                        sink.set(visited.simpleName, Type.isClass(type) ? type.fullyQualifiedName : Type.signature(type));
+                    }
+                    return visited;
+                }
+            };
+        }
+    }
+
+    return new CaptureRecipe();
+}
+
+const TS_SNIPPET = `
+import express from 'express';
+const app = express();
+const router = express.Router();
+app.get('/users', (req, res) => res.send('ok'));
+router.post('/items', (req, res) => res.send('ok'));
+`;
+
+const JS_SNIPPET = `
+const express = require('express');
+const app = express();
+const router = express.Router();
+app.get('/users', (req, res) => res.send('ok'));
+router.post('/items', (req, res) => res.send('ok'));
+`;
+
+function expressPackageJson(version: string, typesVersion: string): string {
+    return `{
+  "name": "express-fqn-fixture",
+  "version": "1.0.0",
+  "dependencies": { "express": "${version}" },
+  "devDependencies": { "@types/express": "${typesVersion}" }
+}`;
+}
+
+describe('@types package FQN normalization', () => {
+    // Express's runtime functions return the interfaces declared in
+    // `express-serve-static-core` (e.g. `function e(): core.Express`,
+    // `Router(): core.Router`). The declaration package is the correct FQN root
+    // (OpenRewrite names types by their declaration site), but it must be the
+    // importable specifier `express-serve-static-core`, NOT `@types/express-serve-static-core`,
+    // which is never something you can `import ... from`.
+
+    test('@types/express v4: receivers resolve to express-serve-static-core.*', async () => {
+        const captured = new Map<string, string>();
+        const spec = new RecipeSpec();
+        spec.recipe = captureIdentifierTypes(['app', 'router'], captured);
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    //language=typescript
+                    typescript(TS_SNIPPET),
+                    //language=json
+                    packageJson(expressPackageJson('^4.18.2', '^4.17.21'))
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        expect(captured.get('app')).toBe('express-serve-static-core.Express');
+        expect(captured.get('router')).toBe('express-serve-static-core.Router');
+    }, 120000);
+
+    test('@types/express v5: receivers resolve to express-serve-static-core.*', async () => {
+        const captured = new Map<string, string>();
+        const spec = new RecipeSpec();
+        spec.recipe = captureIdentifierTypes(['app', 'router'], captured);
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    //language=typescript
+                    typescript(TS_SNIPPET),
+                    //language=json
+                    packageJson(expressPackageJson('^5.0.0', '^5.0.0'))
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        expect(captured.get('app')).toBe('express-serve-static-core.Express');
+        expect(captured.get('router')).toBe('express-serve-static-core.Router');
+    }, 120000);
+
+    test('plain JS without @types stays <unknown> (no synthetic type invented)', async () => {
+        const captured = new Map<string, string>();
+        const spec = new RecipeSpec();
+        spec.recipe = captureIdentifierTypes(['app', 'router'], captured);
+
+        //language=javascript
+        await spec.rewriteRun(javascript(JS_SNIPPET));
+
+        expect(captured.get('app')).toBe('<unknown>');
+        expect(captured.get('router')).toBe('<unknown>');
+    }, 60000);
+});


### PR DESCRIPTION
## Motivation

The rewrite-javascript TypeScript parser names a `JavaType` by the npm package where the type is *declared*. For types reached **transitively** — e.g. the return type of a call rather than a directly-imported symbol — the package name is extracted from the declaration file's `node_modules/...` path. That branch never stripped the DefinitelyTyped `@types/` prefix, even though the sibling helper `extractModuleNameFromPath` already did.

The result is an inconsistency: a type imported directly is named by its module specifier (`react-spinners.ClipLoader`), but the same kind of type reached transitively keeps the `@types/` prefix. Concretely, for Express:

```ts
import express from 'express';
const app = express();              // app: returns express-serve-static-core.Express
const router = express.Router();    // router: returns express-serve-static-core.Router
```

`app` was attributed `@types/express-serve-static-core.Express` and `router` `@types/express-serve-static-core.Router`. `@types/X` is never a name you can `import ... from`, so the prefixed form is not a useful or valid module specifier.

(Note: `express-serve-static-core` is the genuine declaration site — `@types/express` declares `function e(): core.Express` and `Router(): core.Router`, where `core` is `import * as core from "express-serve-static-core"`. So the *type* the value has is correct; only the package-name prefix was wrong.)

## Examples

After this change, transitively-resolved types from `@types`-only packages use the importable specifier:

| Expression | Before | After |
|---|---|---|
| `const app = express()` | `@types/express-serve-static-core.Express` | `express-serve-static-core.Express` |
| `const router = express.Router()` | `@types/express-serve-static-core.Router` | `express-serve-static-core.Router` |

This matches how directly-imported types are already named, and is stable across `@types/express` v4 and v5.

## Summary

- Extract a shared `normalizePackageName` helper (`@types/<pkg>` → `<pkg>`, decoding the `__` scoped-package encoding, e.g. `@types/testing-library__react` → `@testing-library/react`).
- Apply it in `getFullyQualifiedNameFromSymbol`'s `node_modules` path-extraction branch (the transitive-resolution path that previously skipped it).
- Refactor `extractModuleNameFromPath` to reuse the same helper instead of duplicating the logic.

## Test plan

- [x] New `test/javascript/type-mapping-types-package.test.ts`:
  - `@types/express` v4 — `app`/`router` resolve to `express-serve-static-core.Express`/`.Router`
  - `@types/express` v5 — same (version-stability)
  - plain JS without `@types` — both stay `<unknown>` (no synthetic type is invented)
- [x] Full `test/javascript` suite: 1566 passed, 21 skipped
- [x] `npm run typecheck` clean