### PR TITLE
Scala: add public canonical all-args constructors to 6 S LST types

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -501,6 +501,7 @@ public interface S extends J {
      */
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     final class TupleType implements S, TypeTree, Expression {
 
@@ -1174,6 +1175,7 @@ public interface S extends J {
      */
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     final class Export implements S, Statement {
 
@@ -1667,6 +1669,7 @@ public interface S extends J {
      */
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     final class Alternative implements S, Expression {
 
@@ -2041,6 +2044,7 @@ public interface S extends J {
      */
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     final class ExtensionMethods implements S, Statement {
 
@@ -2129,6 +2133,7 @@ public interface S extends J {
      */
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     final class For implements S, Expression, Statement {
 
@@ -2310,6 +2315,7 @@ public interface S extends J {
      */
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     final class FunctionType implements S, TypeTree, Expression {
 


### PR DESCRIPTION
## Motivation

The universal OpenRewrite LST convention is that every concrete `Tree` node exposes a **public canonical all-args constructor** over its non-transient fields, in field-declaration order. Tooling relies on this — notably the Moderne CLI's V3 tree-serialization code generator, which reflects over every concrete `Tree` subclass and only includes a type if it can find a constructor whose parameter count equals the number of non-transient instance fields (it then reconstructs nodes via `new Type(field1, field2, …)`).

Six newer `rewrite-scala` `S` types violate this convention. They were annotated only with `@AllArgsConstructor(access = AccessLevel.PRIVATE)`, which generates a *private*, padding-inclusive constructor (arity N+1, where the extra arg is the `@NonFinal transient WeakReference<Padding> padding`); construction goes through a hand-written `public static X build(...)` factory. As a result they have no public constructor at arity N (the non-transient field count), so the V3 codegen skips them:

```
Skipping org.openrewrite.scala.tree.S$Alternative (no matching constructor)
Skipping org.openrewrite.scala.tree.S$Export (no matching constructor)
...
```

and they are silently dropped from V3 serialization (becoming lossy when the Scala LST is persisted in V3 format). `@RequiredArgsConstructor` was never present on these types — it is a consistent omission relative to the older `S` types (`Import`, `FunctionCall`, `ImportSelector`), which carry **both** `@RequiredArgsConstructor` and `@AllArgsConstructor(access = PRIVATE)`.

## Summary

Add `@RequiredArgsConstructor` alongside the existing `@AllArgsConstructor(access = AccessLevel.PRIVATE)` on:

- `Alternative`
- `Export`
- `ExtensionMethods`
- `For`
- `FunctionType`
- `TupleType`

`@RequiredArgsConstructor` expands to a public constructor over the `final` fields (the `@NonFinal transient padding` is excluded) in declaration order — exactly the canonical all-args constructor the convention requires. The change is purely additive and semantically identical to what the existing `build(...)` factories already do (pure delegation passing `null` for `padding`); the `build(...)` factories are left in place.

There is no constructor-signature collision: the generated public constructor's arity (N) differs from the private padding-inclusive one (N+1) and from `Export`'s hand-written 4-arg convenience constructor.

## Test plan

- [x] `./gradlew :rewrite-scala:compileJava` succeeds.
- [x] `./gradlew :rewrite-scala:test` passes — parsing/printing round-trips are unchanged (the change is purely additive).
- [x] Verified via `javap` that each type now has a public constructor at arity N (non-transient field count), distinct from the private padding-inclusive N+1 constructor, and that `Export`'s new 6-arg constructor `(UUID, Space, Markers, Expression, Space, JContainer<ImportSelector>)` matches the declared field order `id, prefix, markers, exportClause, beforeBrace, selectors`.