### PR TITLE
Groovy: Disable AST transformations on the classpath that influence the shape of the code 

### DIFF
--- a/rewrite-groovy/build.gradle.kts
+++ b/rewrite-groovy/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     testImplementation("org.junit-pioneer:junit-pioneer:latest.release")
     testRuntimeOnly("org.antlr:antlr4-runtime:4.13.2")
     testRuntimeOnly("org.apache.groovy:groovy-all:4.+")
+    testRuntimeOnly("org.spockframework:spock-core:2.4-groovy-4.0")
     testRuntimeOnly(project(":rewrite-java-21"))
 }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
@@ -99,8 +99,7 @@ public class GroovyParser implements Parser {
 
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sources, @Nullable Path relativeTo, ExecutionContext ctx) {
-        // pass system properties so that users have flexibility to change behavior of groovy compiler
-        CompilerConfiguration configuration = new CompilerConfiguration(System.getProperties());
+        CompilerConfiguration configuration = new CompilerConfiguration();
         configuration.setTolerance(Integer.MAX_VALUE);
         configuration.setWarningLevel(WarningMessage.NONE);
         configuration.setClasspathList(classpath == null ? emptyList() : classpath.stream()
@@ -198,8 +197,7 @@ public class GroovyParser implements Parser {
      * <p>
      * This intentionally only targets <em>global</em> transformations. Annotation-driven <em>local</em>
      * transformations (e.g. {@code @Builder}, {@code @Memoize}) are unaffected and continue to contribute
-     * type attribution. Any names already configured (for example via the
-     * {@code groovy.disabled.global.ast.transformations} system property) are preserved.
+     * type attribution. Any names already configured (for example by a compiler customizer) are preserved.
      */
     private void disableGlobalAstTransformations(CompilerConfiguration configuration) {
         Set<String> disabled = configuration.getDisabledGlobalASTTransformations() == null ?

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
@@ -38,9 +38,13 @@ import org.openrewrite.style.NamedStyles;
 import org.openrewrite.tree.ParseError;
 import org.openrewrite.tree.ParsingExecutionContextView;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -112,6 +116,7 @@ public class GroovyParser implements Parser {
         for (Consumer<CompilerConfiguration> compilerCustomizer : compilerCustomizers) {
             compilerCustomizer.accept(configuration);
         }
+        disableGlobalAstTransformations(configuration);
 
         ParsingExecutionContextView pctx = ParsingExecutionContextView.view(ctx);
         return StreamSupport.stream(sources.spliterator(), false)
@@ -178,6 +183,46 @@ public class GroovyParser implements Parser {
                         }
                     }
                 });
+    }
+
+    private static final String AST_TRANSFORMATION_SERVICE = "META-INF/services/org.codehaus.groovy.transform.ASTTransformation";
+
+    /**
+     * OpenRewrite parses Groovy only to build a source-faithful LST; it never executes the parsed code.
+     * Global AST transformations (Spock, {@code @Grab}, instrumentation agents, Gradle plugins, ...) are
+     * discovered from whatever happens to be on the classpath and rewrite the AST <em>away</em> from the
+     * original source text. That desynchronizes the position-based {@link GroovyParserVisitor} and surfaces
+     * as "Failed to parse ... at cursor position N". Since they serve no purpose for parsing, disable every
+     * global transformation we can discover so that the same source always produces the same LST regardless
+     * of which transformations happen to be present in the runtime.
+     * <p>
+     * This intentionally only targets <em>global</em> transformations. Annotation-driven <em>local</em>
+     * transformations (e.g. {@code @Builder}, {@code @Memoize}) are unaffected and continue to contribute
+     * type attribution. Any names already configured (for example via the
+     * {@code groovy.disabled.global.ast.transformations} system property) are preserved.
+     */
+    private void disableGlobalAstTransformations(CompilerConfiguration configuration) {
+        Set<String> disabled = configuration.getDisabledGlobalASTTransformations() == null ?
+                new HashSet<>() : new HashSet<>(configuration.getDisabledGlobalASTTransformations());
+        // Enumerate through a loader configured exactly like the per-source loaders below, so that
+        // transformations registered on the configured classpath and on the runtime classpath are both found.
+        try (GroovyClassLoader transformLoader = new GroovyClassLoader(getClass().getClassLoader(), configuration, true)) {
+            Enumeration<URL> services = transformLoader.getResources(AST_TRANSFORMATION_SERVICE);
+            while (services.hasMoreElements()) {
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(services.nextElement().openStream(), StandardCharsets.UTF_8))) {
+                    for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+                        int comment = line.indexOf('#');
+                        String name = (comment >= 0 ? line.substring(0, comment) : line).trim();
+                        if (!name.isEmpty()) {
+                            disabled.add(name);
+                        }
+                    }
+                }
+            }
+        } catch (IOException ignored) {
+            // If discovery fails, fall back to whatever was already configured; never worse than before.
+        }
+        configuration.setDisabledGlobalASTTransformations(disabled);
     }
 
     @Override

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
@@ -95,7 +95,8 @@ public class GroovyParser implements Parser {
 
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sources, @Nullable Path relativeTo, ExecutionContext ctx) {
-        CompilerConfiguration configuration = new CompilerConfiguration();
+        // pass system properties so that users have flexibility to change behavior of groovy compiler
+        CompilerConfiguration configuration = new CompilerConfiguration(System.getProperties());
         configuration.setTolerance(Integer.MAX_VALUE);
         configuration.setWarningLevel(WarningMessage.NONE);
         configuration.setClasspathList(classpath == null ? emptyList() : classpath.stream()

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GradleSnippetGlobalTransformReproTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GradleSnippetGlobalTransformReproTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
+import org.openrewrite.tree.ParseError;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards against the failure mode behind "Failed to parse build.gradle at cursor position N" in
+ * {@code UpgradeTransitiveDependencyVersion} (and openrewrite/rewrite#7870): a <em>global</em> Groovy AST
+ * transformation present on the classpath the parser discovers transformations from rewrites the AST away
+ * from the source, breaking the position-coupled {@link GroovyParserVisitor}.
+ *
+ * <p>{@code GroovyParser} now disables every discoverable global AST transformation, so parsing is
+ * independent of which transformations happen to be on the classpath.
+ */
+class GradleSnippetGlobalTransformReproTest {
+
+    // The exact snippet UpgradeTransitiveDependencyVersion.parseAsGradle() compiles at runtime.
+    private static final String SNIPPET =
+            "plugins { id 'java' }\n" +
+            "dependencies {\n" +
+            "    constraints {\n" +
+            "    }\n" +
+            "}\n";
+
+    @Test
+    void parsesCleanlyWithNoGlobalTransformOnClasspath() {
+        SourceFile parsed = parse(null);
+        assertThat(parsed).isNotInstanceOf(ParseError.class);
+    }
+
+    @Test
+    void parsesCleanlyEvenWhenAnAstMutatingGlobalTransformIsOnTheClasspath(@TempDir Path tmp) throws Exception {
+        // Register a global AST transformation exactly as a real library (Spock, a Gradle plugin, ...) would.
+        Path services = tmp.resolve("META-INF/services");
+        Files.createDirectories(services);
+        Files.write(services.resolve("org.codehaus.groovy.transform.ASTTransformation"),
+                InjectClosureStatementTransformation.class.getName().getBytes(StandardCharsets.UTF_8));
+        // Sanity: the registration is wired up, so this test cannot pass vacuously.
+        assertThat(Files.readString(services.resolve("org.codehaus.groovy.transform.ASTTransformation")))
+                .isEqualTo(InjectClosureStatementTransformation.class.getName());
+
+        InjectClosureStatementTransformation.executed = false;
+
+        SourceFile parsed = parse(tmp);
+
+        // Before the fix this produced a ParseError: "Failed to parse build.gradle at cursor position N".
+        assertThat(parsed).isNotInstanceOf(ParseError.class);
+        // The transformation was discoverable on the classpath but the parser disabled it.
+        assertThat(InjectClosureStatementTransformation.executed)
+                .as("global AST transformation should have been disabled by GroovyParser")
+                .isFalse();
+    }
+
+    private static SourceFile parse(@org.jspecify.annotations.Nullable Path classpathEntry) {
+        GroovyParser.Builder builder = GroovyParser.builder();
+        if (classpathEntry != null) {
+            builder = builder.classpath(singletonList(classpathEntry));
+        }
+        List<SourceFile> result = builder.build()
+                .parseInputs(singletonList(new Parser.Input(
+                        Path.of("build.gradle"),
+                        () -> new ByteArrayInputStream(SNIPPET.getBytes(StandardCharsets.UTF_8)))),
+                        null,
+                        new InMemoryExecutionContext())
+                .toList();
+        return result.get(0);
+    }
+}

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/InjectClosureStatementTransformation.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/InjectClosureStatementTransformation.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.expr.*;
+import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.ExpressionStatement;
+import org.codehaus.groovy.ast.stmt.Statement;
+import org.codehaus.groovy.control.CompilePhase;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.transform.ASTTransformation;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+
+import java.util.List;
+
+/**
+ * A stand-in for the kind of <em>global</em> Groovy AST transformation that real
+ * libraries register via {@code META-INF/services/org.codehaus.groovy.transform.ASTTransformation}
+ * (Spock, various Gradle plugins, instrumentation agents, ...).
+ * <p>
+ * Groovy discovers it from the compilation classpath and runs it on <em>every</em> compilation,
+ * including the synthetic snippets OpenRewrite recipes parse at runtime. This particular one
+ * injects a synthetic statement (with no real source coordinates) into the first closure it finds —
+ * e.g. the body of {@code plugins { ... }} — which is exactly the situation that desynchronizes
+ * the position-coupled {@link GroovyParserVisitor} from the original source text.
+ */
+@GroovyASTTransformation(phase = CompilePhase.SEMANTIC_ANALYSIS)
+public class InjectClosureStatementTransformation implements ASTTransformation {
+
+    /** Set whenever this transformation actually runs, so tests can assert whether it was suppressed. */
+    public static volatile boolean executed = false;
+
+    @Override
+    public void visit(ASTNode[] nodes, SourceUnit source) {
+        executed = true;
+        if (source.getAST() == null) {
+            return;
+        }
+        for (ClassNode classNode : source.getAST().getClasses()) {
+            for (MethodNode method : classNode.getMethods()) {
+                if (method.getCode() instanceof BlockStatement) {
+                    injectIntoFirstClosure(((BlockStatement) method.getCode()).getStatements());
+                }
+            }
+            // Script bodies live in the synthetic run() method too, but also scan the module statements
+        }
+        if (source.getAST().getStatementBlock() != null) {
+            injectIntoFirstClosure(source.getAST().getStatementBlock().getStatements());
+        }
+    }
+
+    private void injectIntoFirstClosure(List<Statement> statements) {
+        for (Statement statement : statements) {
+            if (statement instanceof ExpressionStatement &&
+                ((ExpressionStatement) statement).getExpression() instanceof MethodCallExpression) {
+                MethodCallExpression call = (MethodCallExpression) ((ExpressionStatement) statement).getExpression();
+                if (call.getArguments() instanceof ArgumentListExpression) {
+                    for (Expression arg : ((ArgumentListExpression) call.getArguments()).getExpressions()) {
+                        if (arg instanceof ClosureExpression && ((ClosureExpression) arg).getCode() instanceof BlockStatement) {
+                            BlockStatement body = (BlockStatement) ((ClosureExpression) arg).getCode();
+                            // A synthetic statement with no source position, as transforms routinely emit.
+                            ExpressionStatement injected = new ExpressionStatement(
+                                    new MethodCallExpression(new VariableExpression("this"), "__injectedBySpockLikeTransform", new ArgumentListExpression()));
+                            injected.setLineNumber(-1);
+                            injected.setColumnNumber(-1);
+                            injected.getExpression().setLineNumber(-1);
+                            injected.getExpression().setColumnNumber(-1);
+                            body.getStatements().add(0, injected);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RealWorldGroovyTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RealWorldGroovyTest.java
@@ -160,26 +160,31 @@ class RealWorldGroovyTest implements RewriteTest {
     @Issue("https://github.com/spring-projects/spring-ldap/blob/v3.4.1/buildSrc/src/test/resources/samples/integrationtest/withgroovy/src/integration-test/groovy/sample/TheTest.groovy")
     @Test
     void springLdapTheTest() {
-        rewriteRun(
-          groovy(
-            """
-              import org.springframework.core.Ordered
-              import spock.lang.Specification
-
-              class TheTest extends Specification {
-                  def "has Ordered"() {
-                      expect: 'Loads Ordered fine'
-                      Ordered ordered = new Ordered() {
-                          @Override
-                          int getOrder() {
-                              return 0
+        try {
+            System.setProperty("groovy.disabled.global.ast.transformations", "org.spockframework.compiler.SpockTransform");
+            rewriteRun(
+              groovy(
+                """
+                  import org.springframework.core.Ordered
+                  import spock.lang.Specification
+    
+                  class TheTest extends Specification {
+                      def "has Ordered"() {
+                          expect: 'Loads Ordered fine'
+                          Ordered ordered = new Ordered() {
+                              @Override
+                              int getOrder() {
+                                  return 0
+                              }
                           }
                       }
                   }
-              }
-              """
-          )
-        );
+                  """
+              )
+            );
+        } finally {
+            System.clearProperty("groovy.disabled.global.ast.transformations");
+        }
     }
 
     @Issue("https://github.com/spring-projects/spring-session-data-geode/blob/v3.4.1/buildSrc/src/main/groovy/io/spring/gradle/convention/SchemaZipPlugin.groovy")

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RealWorldGroovyTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RealWorldGroovyTest.java
@@ -160,31 +160,29 @@ class RealWorldGroovyTest implements RewriteTest {
     @Issue("https://github.com/spring-projects/spring-ldap/blob/v3.4.1/buildSrc/src/test/resources/samples/integrationtest/withgroovy/src/integration-test/groovy/sample/TheTest.groovy")
     @Test
     void springLdapTheTest() {
-        try {
-            System.setProperty("groovy.disabled.global.ast.transformations", "org.spockframework.compiler.SpockTransform");
-            rewriteRun(
-              groovy(
-                """
-                  import org.springframework.core.Ordered
-                  import spock.lang.Specification
-    
-                  class TheTest extends Specification {
-                      def "has Ordered"() {
-                          expect: 'Loads Ordered fine'
-                          Ordered ordered = new Ordered() {
-                              @Override
-                              int getOrder() {
-                                  return 0
-                              }
+        // spock-core is on the test classpath, so Spock's global SpockTransform would normally run during
+        // parsing and corrupt this Specification. GroovyParser disables all global AST transformations, so
+        // this parses cleanly without any per-test or environment-specific configuration.
+        rewriteRun(
+          groovy(
+            """
+              import org.springframework.core.Ordered
+              import spock.lang.Specification
+
+              class TheTest extends Specification {
+                  def "has Ordered"() {
+                      expect: 'Loads Ordered fine'
+                      Ordered ordered = new Ordered() {
+                          @Override
+                          int getOrder() {
+                              return 0
                           }
                       }
                   }
-                  """
-              )
-            );
-        } finally {
-            System.clearProperty("groovy.disabled.global.ast.transformations");
-        }
+              }
+              """
+          )
+        );
     }
 
     @Issue("https://github.com/spring-projects/spring-session-data-geode/blob/v3.4.1/buildSrc/src/main/groovy/io/spring/gradle/convention/SchemaZipPlugin.groovy")


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->
Updated GroovyParser's `CompilerConfiguration` initialiation code to pass System Properties  so that users have flexibility to configure/override groovy compiler. This will fix https://github.com/openrewrite/rewrite/issues/7870 and allow users to suppress any AST transform that's causing errors.

## What's changed?
<!-- A brief description of the changes in this pull request -->
Updated GroovyParser's CompilerConfiguration initialiation code to pass System Properties 


## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- This will fix https://github.com/openrewrite/rewrite/issues/7870 . Allow users to migrate codebase that has Spock in classpath.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
N/A
## Anyone you would like to review specifically?
<!-- @mention them here -->
N/A
## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
There's no workaround.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
N/A
### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
