### PR TITLE
Return -1 for blank or null Java compatibility without throwing

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaVersion.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaVersion.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.marker;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.With;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
@@ -34,25 +35,28 @@ public class JavaVersion implements Marker {
     String targetCompatibility;
 
     public int getMajorVersion() {
-        try {
-            return Integer.parseInt(normalize(sourceCompatibility));
-        } catch (NumberFormatException e) {
-            return -1;
-        }
+        return majorVersionOf(sourceCompatibility);
     }
 
     /**
      * @return The major --release version.
      */
     public int getMajorReleaseVersion() {
+        return majorVersionOf(targetCompatibility);
+    }
+
+    private static int majorVersionOf(@Nullable String version) {
+        if (version == null || version.trim().isEmpty()) {
+            return -1;
+        }
         try {
-            return Integer.parseInt(normalize(targetCompatibility));
+            return Integer.parseInt(normalize(version));
         } catch (NumberFormatException e) {
             return -1;
         }
     }
 
-    private String normalize(String version) {
+    private static String normalize(String version) {
         if (!version.contains(".")) {
             return version;
         }

--- a/rewrite-java/src/test/java/org/openrewrite/java/marker/JavaVersionTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/marker/JavaVersionTest.java
@@ -40,4 +40,25 @@ class JavaVersionTest {
         var javaVersion = new JavaVersion(UUID.randomUUID(), "", "", "11.0.11+x", "").getMajorVersion();
         assertThat(javaVersion).isEqualTo(11);
     }
+
+    @Test
+    void emptyCompatibilityReturnsMinusOne() {
+        var javaVersion = new JavaVersion(UUID.randomUUID(), "", "", "", "");
+        assertThat(javaVersion.getMajorVersion()).isEqualTo(-1);
+        assertThat(javaVersion.getMajorReleaseVersion()).isEqualTo(-1);
+    }
+
+    @Test
+    void blankCompatibilityReturnsMinusOne() {
+        var javaVersion = new JavaVersion(UUID.randomUUID(), "", "", "  ", "  ");
+        assertThat(javaVersion.getMajorVersion()).isEqualTo(-1);
+        assertThat(javaVersion.getMajorReleaseVersion()).isEqualTo(-1);
+    }
+
+    @Test
+    void nullCompatibilityReturnsMinusOneWithoutThrowing() {
+        var javaVersion = new JavaVersion(UUID.randomUUID(), "", "", null, null);
+        assertThat(javaVersion.getMajorVersion()).isEqualTo(-1);
+        assertThat(javaVersion.getMajorReleaseVersion()).isEqualTo(-1);
+    }
 }


### PR DESCRIPTION
## What's changed

`JavaVersion.getMajorVersion()` and `getMajorReleaseVersion()` parse `sourceCompatibility`/`targetCompatibility` and return `-1` when the value is unparseable. However, a **null** value threw a `NullPointerException` instead, because `normalize()` dereferenced the string without a guard (only `NumberFormatException` was caught).

This routes both accessors through a single `majorVersionOf()` helper that treats `null` and blank strings as an unknown version (`-1`), consistent with how an unparseable string is already handled.

## Why

The build-tool plugins (Maven, Gradle) construct `JavaVersion` markers from build metadata. When a project does not declare a compiler source/target level (e.g. a toolchain-only Gradle build, or an unresolved `${...}` property), they can hand an empty — or, in some paths, null — compatibility string to the marker. An empty string already yields `-1`; a null string crashed. After this change both degrade gracefully to `-1`.

## Testing

Added `JavaVersionTest` cases for empty, blank, and null compatibility on both accessors.