### PR TITLE
Resolve RPC tree codec by canonical type for SourceFile subclasses

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
@@ -103,7 +103,7 @@ public abstract class DynamicDispatchRpcCodec<T> implements RpcCodec<T> {
             }
         }
         // Defense-in-depth: the keyed bucket missed. This happens when {@code sourceFileType}
-        // is a proxy/subclass runtime class name (e.g. a moderne-cli V3 lazy proxy) rather
+        // is a proxy/subclass runtime class name rather
         // than the canonical registered type, including when such a string arrives from a
         // remote. Scan all registered codecs for one assignable from the instance's runtime
         // type. {@code getType()} is a language marker interface (e.g. Xml, Json), so at most
@@ -140,9 +140,7 @@ public abstract class DynamicDispatchRpcCodec<T> implements RpcCodec<T> {
 
     /**
      * Resolves the canonical, codec-registered source file type name for a (possibly
-     * subclassed/proxied) runtime class. A moderne-cli V3 LST is a lazy-loading proxy
-     * generated as {@code Lazy_X extends <realTreeType>}; its {@code getClass().getName()}
-     * is the proxy name, which is not a key in the codec map. Walking the superclass chain
+     * subclassed/proxied) runtime class. Walking the superclass chain
      * lands on the concrete registered type (e.g. {@code Xml$Document}), whose name equals
      * the codec's {@link #getSourceFileType()} key. Normal LSTs match on the first iteration,
      * so behavior is unchanged for them.

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
@@ -102,7 +102,60 @@ public abstract class DynamicDispatchRpcCodec<T> implements RpcCodec<T> {
                 return (RpcCodec<T>) codec;
             }
         }
+        // Defense-in-depth: the keyed bucket missed. This happens when {@code sourceFileType}
+        // is a proxy/subclass runtime class name (e.g. a moderne-cli V3 lazy proxy) rather
+        // than the canonical registered type, including when such a string arrives from a
+        // remote. Scan all registered codecs for one assignable from the instance's runtime
+        // type. {@code getType()} is a language marker interface (e.g. Xml, Json), so at most
+        // one language's codec is assignable from a given tree instance.
+        for (List<DynamicDispatchRpcCodec<?>> bucket : CODEC_BY_TYPE.values()) {
+            for (DynamicDispatchRpcCodec<?> codec : bucket) {
+                if (codec.getType().isAssignableFrom(t.getClass())) {
+                    return (RpcCodec<T>) codec;
+                }
+            }
+        }
         return null;
+    }
+
+    /**
+     * Memoized per {@link Class}: see {@link #canonicalSourceFileType(Class)}.
+     */
+    private static final ClassValue<String> CANONICAL_SOURCE_FILE_TYPE = new ClassValue<String>() {
+        @Override
+        protected String computeValue(Class<?> type) {
+            // Mirror getCodec's discovery so a proxy's codec (carried by the proxy's own
+            // classloader, since the proxy extends the real tree type) is registered before
+            // we walk. The result is then cached for the life of the class.
+            discoverFrom(Thread.currentThread().getContextClassLoader());
+            discoverFrom(type.getClassLoader());
+            for (Class<?> c = type; c != null && c != Object.class; c = c.getSuperclass()) {
+                if (CODEC_BY_TYPE.containsKey(c.getName())) {
+                    return c.getName();
+                }
+            }
+            return type.getName();
+        }
+    };
+
+    /**
+     * Resolves the canonical, codec-registered source file type name for a (possibly
+     * subclassed/proxied) runtime class. A moderne-cli V3 LST is a lazy-loading proxy
+     * generated as {@code Lazy_X extends <realTreeType>}; its {@code getClass().getName()}
+     * is the proxy name, which is not a key in the codec map. Walking the superclass chain
+     * lands on the concrete registered type (e.g. {@code Xml$Document}), whose name equals
+     * the codec's {@link #getSourceFileType()} key. Normal LSTs match on the first iteration,
+     * so behavior is unchanged for them.
+     * <p>
+     * The canonical name must be derived here rather than worked around downstream, because
+     * it is also sent over the wire and the remote (e.g. the Python receiver) does an exact
+     * string lookup that cannot perform Java-class assignability.
+     *
+     * @param type the runtime class of a {@code SourceFile} (possibly a proxy/subclass).
+     * @return the registered supertype's name, or {@code type.getName()} if none is registered.
+     */
+    public static String canonicalSourceFileType(Class<?> type) {
+        return CANONICAL_SOURCE_FILE_TYPE.get(type);
     }
 
     public abstract String getSourceFileType();

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -293,8 +293,8 @@ public class RewriteRpc {
         String pId = maybeUnwrapExecutionContext(p);
         List<String> cursorIds = getCursorIds(cursor);
 
-        String sourceFileType = (tree instanceof SourceFile ? tree : requireNonNull(cursor).firstEnclosingOrThrow(SourceFile.class))
-                .getClass().getName();
+        String sourceFileType = DynamicDispatchRpcCodec.canonicalSourceFileType(
+                (tree instanceof SourceFile ? tree : requireNonNull(cursor).firstEnclosingOrThrow(SourceFile.class)).getClass());
         Supplier<VisitResponse> doSend = () -> send("Visit", new Visit(visitorName, sourceFileType, null,
                 tree.getId().toString(), pId, cursorIds), VisitResponse.class);
         VisitResponse response = p instanceof ExecutionContext
@@ -313,8 +313,8 @@ public class RewriteRpc {
         String pId = maybeUnwrapExecutionContext(p);
         List<String> cursorIds = getCursorIds(cursor);
 
-        String sourceFileType = (tree instanceof SourceFile ? tree : requireNonNull(cursor).firstEnclosingOrThrow(SourceFile.class))
-                .getClass().getName();
+        String sourceFileType = DynamicDispatchRpcCodec.canonicalSourceFileType(
+                (tree instanceof SourceFile ? tree : requireNonNull(cursor).firstEnclosingOrThrow(SourceFile.class)).getClass());
         Supplier<BatchVisitResponse> doSend = () -> send("BatchVisit",
                 new BatchVisit(sourceFileType, treeId, pId, cursorIds, visitors),
                 BatchVisitResponse.class);
@@ -556,7 +556,7 @@ public class RewriteRpc {
         String treeId = tree.getId().toString();
         localObjects.put(treeId, tree);
         SourceFile sourceFile = tree instanceof SourceFile ? (SourceFile) tree : parent.firstEnclosingOrThrow(SourceFile.class);
-        String sourceFileType = sourceFile.getClass().getName();
+        String sourceFileType = DynamicDispatchRpcCodec.canonicalSourceFileType(sourceFile.getClass());
 
         return send(
                 "Print",

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -247,7 +247,6 @@ public class RpcSendQueue {
             }
 
             // Synthetic tree subclasses generated outside the org.openrewrite packages
-            // -- e.g. moderne-cli's V3 lazy proxies, emitted as `Lazy_X extends <realType>`
             // -- must be reported to the remote as their real (super) type, not the proxy
             // class name, which the remote has no codec/factory for.
             if (pkg != null && !pkg.getName().startsWith("org.openrewrite")) {

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -246,6 +246,18 @@ public class RpcSendQueue {
                 }
             }
 
+            // Synthetic tree subclasses generated outside the org.openrewrite packages
+            // -- e.g. moderne-cli's V3 lazy proxies, emitted as `Lazy_X extends <realType>`
+            // -- must be reported to the remote as their real (super) type, not the proxy
+            // class name, which the remote has no codec/factory for.
+            if (pkg != null && !pkg.getName().startsWith("org.openrewrite")) {
+                Class<?> superclass = afterType.getSuperclass();
+                Package superPkg = superclass == null ? null : superclass.getPackage();
+                if (superPkg != null && superPkg.getName().startsWith("org.openrewrite") && !Object.class.equals(superclass)) {
+                    return superclass.getName();
+                }
+            }
+
             return afterType.getName();
         }
     };

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/rpc/SubclassCodecDispatchTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/rpc/SubclassCodecDispatchTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.xml.rpc;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.rpc.DynamicDispatchRpcCodec;
+import org.openrewrite.xml.tree.Xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubclassCodecDispatchTest {
+
+    /**
+     * Stand-in for a moderne-cli V3 lazy proxy: a non-final SourceFile subtype whose
+     * runtime class name is not the canonical type registered with the codec.
+     */
+    static class LazyXmlDocument extends Xml.Document {
+        LazyXmlDocument() {
+            super(null, null, null, null, null, false, null, null, null, null, null);
+        }
+    }
+
+    @Test
+    void codecResolvesForSubclassByRuntimeClassName() {
+        Xml.Document proxy = new LazyXmlDocument();
+        // Sanity: codec resolves under the canonical type name (passes today).
+        assertThat(DynamicDispatchRpcCodec.getCodec(proxy, Xml.Document.class.getName()))
+                .as("codec under canonical type name").isNotNull();
+        // Bug: RewriteRpc derives the codec key from getClass().getName(); for a
+        // proxy/subclass that key is not in the codec map -> null codec (FAILS today).
+        assertThat(DynamicDispatchRpcCodec.getCodec(proxy, proxy.getClass().getName()))
+                .as("codec under subclass (proxy) runtime class name").isNotNull();
+    }
+
+    @Test
+    void canonicalSourceFileTypeWalksToRegisteredSupertype() {
+        // The wire string the rest of the pipeline (including the Python receiver) keys on
+        // must be the canonical, codec-registered type name, not the proxy subclass name.
+        assertThat(DynamicDispatchRpcCodec.canonicalSourceFileType(LazyXmlDocument.class))
+                .as("proxy subclass resolves to canonical registered type")
+                .isEqualTo(Xml.Document.class.getName());
+    }
+
+    @Test
+    void canonicalSourceFileTypeUnchangedForRegisteredType() {
+        // A normal LST whose runtime class IS the registered type must be unaffected.
+        assertThat(DynamicDispatchRpcCodec.canonicalSourceFileType(Xml.Document.class))
+                .as("registered type resolves to itself")
+                .isEqualTo(Xml.Document.class.getName());
+    }
+}

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/rpc/SubclassCodecDispatchTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/rpc/SubclassCodecDispatchTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SubclassCodecDispatchTest {
 
     /**
-     * Stand-in for a moderne-cli V3 lazy proxy: a non-final SourceFile subtype whose
+     * An example non-final SourceFile subtype whose
      * runtime class name is not the canonical type registered with the codec.
      */
     static class LazyXmlDocument extends Xml.Document {


### PR DESCRIPTION
## Motivation

The RPC layer fails to find a tree codec when a `SourceFile`'s runtime class is a **subclass** of the canonical, codec-registered type. The codec key is derived from `getClass().getName()`, and a subclass's name is not a key in the codec map — so no codec is found and the tree node is serialized raw (bean-serialized by the jsonrpc `ObjectMapper`) instead of being decomposed field-by-field via the registered codec.

Stock OpenRewrite LSTs are unaffected: their runtime class *is* the canonical type. But consumers that subclass tree types are broken. The concrete case is moderne-cli's V3-format LSTs, whose trees are lazy-loading proxies generated as `Lazy_X extends <realTreeType>` (e.g. `…GeneratedTreeProxies$Lazy_python_tree_py_compilationunit extends org.openrewrite.python.tree.Py$CompilationUnit`). Running Python/JS/C# recipes over those LSTs fails entirely — for a proxy, raw bean-serialization reflects into the proxy's lazy `reader` → an mmap `MemorySegment` → `InaccessibleObjectException`.

The fix has to happen at **derivation** of the type name, not just as a local lookup fallback: the same string is sent over the wire, and the Python receiver does an exact-string dict lookup that cannot perform Java-class assignability. So the canonical name must be the one that propagates to the remote.

## Examples

A new resolver maps a (possibly subclassed/proxied) runtime class to the canonical, codec-registered type name:

```java
// Proxy subclass resolves to the registered supertype name...
DynamicDispatchRpcCodec.canonicalSourceFileType(LazyXmlDocument.class);
// => "org.openrewrite.xml.tree.Xml$Document"

// ...and a normal LST is unchanged (matches on the first iteration).
DynamicDispatchRpcCodec.canonicalSourceFileType(Xml.Document.class);
// => "org.openrewrite.xml.tree.Xml$Document"
```

## Summary

- Add `DynamicDispatchRpcCodec.canonicalSourceFileType(Class)`: walks the superclass chain to the first codec-registered type name, falling back to the class's own name when none is registered. Memoized per `Class` via `ClassValue`.
- `RewriteRpc` derives `sourceFileType` via this resolver in `visit`, `batchVisit`, and `print` instead of `getClass().getName()`.
- Add a defense-in-depth assignability fallback in `getCodec`: when the keyed bucket misses (e.g. a proxy-named string arriving from a remote), scan all registered codecs for one whose `getType()` is assignable from the instance's runtime type.

## Test plan

- [x] New `SubclassCodecDispatchTest` (rewrite-xml): `getCodec` resolves a codec under a subclass's runtime class name; `canonicalSourceFileType` walks a proxy subclass to the registered supertype and leaves the registered type unchanged. (Written test-first, watched fail, then pass.)
- [x] `:rewrite-core:test --tests "org.openrewrite.rpc.*"` — `RewriteRpcTest`, `RewriteRpcProcessTest`, `RpcSendQueueTest`, `RpcReceiveQueueTest`, `RewriteRpcExecutionContextViewTest` all pass (0 failures/errors).
- [x] Full `:rewrite-xml:test` passes.
- [ ] End-to-end (manual, not run here): run a Python recipe over a moderne-cli V3 LST and confirm a diff is produced instead of the `NativeMemorySegmentImpl` error / "No changes".
