### PR TITLE
Set DOTNET_ROOT for the C# RPC apphost from the resolved dotnet

### DIFF
--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -30,9 +30,12 @@ import org.openrewrite.rpc.RewriteRpcProcessManager;
 import org.openrewrite.tree.ParsingEventListener;
 import org.openrewrite.tree.ParsingExecutionContextView;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -321,10 +324,10 @@ public class CSharpRewriteRpc extends RewriteRpc {
                 cmd = buildToolPathCommand(dotnetPath, version);
             }
 
-            return startProcess(cmd);
+            return startProcess(cmd, dotnetPath);
         }
 
-        private CSharpRewriteRpc startProcess(Stream<@Nullable String> cmd) {
+        private CSharpRewriteRpc startProcess(Stream<@Nullable String> cmd, Path dotnetPath) {
             String[] cmdArr = cmd.filter(Objects::nonNull).toArray(String[]::new);
             RewriteRpcProcess process = new RewriteRpcProcess(cmdArr);
 
@@ -334,6 +337,21 @@ public class CSharpRewriteRpc extends RewriteRpc {
             process.setStderrRedirect(log);
 
             process.environment().putAll(environment);
+
+            // The tool is launched as a self-contained apphost (not via the `dotnet`
+            // muxer), so it must locate the shared runtime itself. When DOTNET_ROOT is
+            // unset and the runtime isn't at a registered install location for the
+            // apphost's architecture, launch fails ("You must install .NET ..."). This
+            // bites on hosts where `dotnet` lives in a bin/ dir separate from the runtime
+            // (e.g. Homebrew, where the binary is under bin/ but the runtime under
+            // libexec/), and on arm64 machines using an x64 dotnet. Derive DOTNET_ROOT
+            // from the resolved dotnet and set it if the caller hasn't.
+            if (!process.environment().containsKey("DOTNET_ROOT")) {
+                Path dotnetRoot = resolveDotnetRoot(dotnetPath);
+                if (dotnetRoot != null) {
+                    process.environment().put("DOTNET_ROOT", dotnetRoot.toString());
+                }
+            }
 
             if (profileOutputPath != null) {
                 Map<String, String> env = process.environment();
@@ -358,6 +376,44 @@ public class CSharpRewriteRpc extends RewriteRpc {
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+        }
+
+        /**
+         * Derive the {@code DOTNET_ROOT} (the directory containing {@code shared/}) for a
+         * resolved {@code dotnet} executable by parsing {@code dotnet --list-runtimes}, whose
+         * lines look like {@code Microsoft.NETCore.App 10.0.2 [/path/to/dotnet/shared/Microsoft.NETCore.App]}.
+         * The root is two levels up from that path ({@code .../shared/Microsoft.NETCore.App} →
+         * {@code .../shared} → root). Returns {@code null} if it can't be determined; callers
+         * then fall back to the apphost's own resolution.
+         */
+        private static @Nullable Path resolveDotnetRoot(Path dotnetPath) {
+            Path resolved = null;
+            try {
+                Process p = new ProcessBuilder(dotnetPath.toString(), "--list-runtimes")
+                        .redirectErrorStream(false)
+                        .start();
+                try (BufferedReader br = new BufferedReader(
+                        new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = br.readLine()) != null) {
+                        int lb = line.indexOf('[');
+                        int rb = line.lastIndexOf(']');
+                        if (lb >= 0 && rb > lb) {
+                            Path sharedAppDir = Paths.get(line.substring(lb + 1, rb).trim());
+                            Path shared = sharedAppDir.getParent();
+                            Path root = shared == null ? null : shared.getParent();
+                            if (root != null && Files.isDirectory(root)) {
+                                resolved = root;
+                                break;
+                            }
+                        }
+                    }
+                }
+                p.waitFor();
+            } catch (IOException | InterruptedException ignored) {
+                // Best effort: leave DOTNET_ROOT unset and let the apphost resolve.
+            }
+            return resolved;
         }
 
         private Stream<@Nullable String> buildCsprojCommand(Path dotnetPath, Path csproj) {


### PR DESCRIPTION
- **Draft / checkpoint.** The C# tool is launched as a self-contained apphost (not via the `dotnet` muxer), so it must locate the shared runtime itself. When `DOTNET_ROOT` is unset and the runtime isn't at a registered install location for the apphost's architecture, launch fails ("You must install .NET ...", exit 131). This bites where `dotnet` lives in a `bin/` dir separate from the runtime (Homebrew: binary under `bin/`, runtime under `libexec/`) and on arm64 machines using an x64 `dotnet`. `CSharpRewriteRpc.startProcess` now derives `DOTNET_ROOT` from the resolved `dotnet` via `dotnet --list-runtimes` (root = two levels up from the `Microsoft.NETCore.App` path) and sets it on the process env when the caller hasn't. Java 8 compatible. Found while running .NET migration recipes via the Moderne CLI on an arm64 mac with an x64 Homebrew dotnet. Pairs with moderneinc/moderne-cli#4045.