### PR TITLE
Kotlin recipe DSL v2 dispatch: route all-Java bodies to JavaVisitor

### DIFF
--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
@@ -472,26 +472,36 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         templates: RewriteTemplates,
         ctx: RecipeIrGenContext,
     ): IrSimpleFunctionSymbol? {
-        // v1: always dispatch to the Kotlin helper. Plan §Design.4 reasoned
-        // about which SOURCES the visitor walks (JavaVisitor walks both .java
-        // and .kt via TreeVisitorAdapter), but the TEMPLATE engine must match
-        // the recipe author's source language. Recipes authored in Kotlin
-        // carry Kotlin syntax in their before/after templates — trailing
-        // lambdas, `<Type>` arg lists, extension calls, `..<` — none of which
-        // JavaTemplate can parse. Always-Kotlin works because recipes
-        // authored under this DSL are by definition in .kt source.
+        // v2: route all-Java method-invocation bodies through the Java helper
+        // (JavaVisitor + JavaTemplate). The LST-structural classifier decides
+        // "all-Java": if the before/after lambdas don't structurally reference
+        // any K.* tree node, JavaVisitor matches the same call sites against
+        // both Java and Kotlin sources (via TreeVisitorAdapter) and
+        // JavaTemplate can parse the after template — none of the after-
+        // template syntax that's Kotlin-only (trailing lambdas, `<Type>` arg
+        // lists, extension calls, `..<`) can appear without dragging a K.*
+        // reference into the lambdas. So the classifier is sufficient.
         //
-        // `methodInvocationRewriteJava` exists for a future cross-language
-        // path (`java { rewrite { } to { } }` explicit shape) and for recipes
-        // authored in Java someday; v1 has no way to reach it from the DSL.
-        // The LST-structural classifier still computes [usesKotlinTreeNode]
-        // — it's plumbing for the eventual third helper (JavaVisitor +
-        // KotlinTemplate) the plan deferred.
-        @Suppress("UNUSED_VARIABLE")
+        // Three Kotlin-only shapes are never safe to route to Java:
+        //   - property access (`d.inHours` is Kotlin property syntax;
+        //     the Java visitor walks `J.FieldAccess`, a different LST node)
+        //   - wrapped-in-not-null (`!!` is a Kotlin-only operator)
+        //   - chained calls (the chain encoding's `\t`-separated spec is only
+        //     parsed by the Kotlin helper; the Java helper splits on `\n` only)
+        //
+        // The Java symbol may legitimately be null when authors compile
+        // against a rewrite-kotlin without [GeneratedRecipeSupport.methodInvocationRewriteJava]
+        // (i.e. older snapshots) — fall back to the Kotlin helper in that case
+        // so the recipe still compiles, even though it won't match Java
+        // sources without TreeVisitorAdapter glue.
         val classifierResult = templates.usesKotlinTreeNode
+        val isChain = templates.matcherSpecs.any { it.contains('\t') }
+        val canRouteToJava = !classifierResult && !isChain
         return when {
             templates.propertyAccess -> ctx.propertyAccessRewriteKotlinSymbol
             templates.wrappedInNotNull -> ctx.methodInvocationRewriteKotlinNotNullSymbol
+            canRouteToJava -> ctx.methodInvocationRewriteJavaSymbol
+                ?: ctx.methodInvocationRewriteKotlinSymbol
             else -> ctx.methodInvocationRewriteKotlinSymbol
         }
     }
@@ -628,14 +638,22 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
     }
 
     /**
-     * LST-structural classifier. Scans all type references inside the before
-     * + after lambdas; returns true if ANY references a Kotlin-specific tree
-     * node (FQN starts with `org.openrewrite.kotlin.tree.K.`).
+     * LST-structural classifier. Scans the before + after lambdas; returns
+     * true if ANY of:
+     *  - a value-parameter type references a Kotlin-specific tree node
+     *    (FQN starts with `org.openrewrite.kotlin.tree.K.`)
+     *  - a call expression resolves to a callee in the `kotlin.*` package
+     *    namespace (Kotlin stdlib function or extension — `String.lowercase`,
+     *    `StringBuilder.appendLine`, `kotlin.enumValues`, etc.)
      *
-     * Per plan §Design.4: method-name / callee-package / API-level signals are
-     * NOT used. The MethodMatcher spec, resolved at FIR time pre-inline,
-     * already encodes the Kotlin-extension target correctly even when the
-     * generated visitor is Java-rooted.
+     * The call-FQN check exists because v2 dispatch routes the non-Kotlin
+     * case through `JavaTemplate`, which can't parse Kotlin-extension call
+     * syntax in the after-template. If a Kotlin-stdlib callee appears
+     * anywhere in the lambdas, the recipe stays on the Kotlin helper.
+     *
+     * Per plan §Design.4: only LST-structural and callee-namespace signals
+     * drive promotion. The MethodMatcher spec built at FIR time pre-inline
+     * still works against either visitor's matched node.
      */
     private fun classifyKotlinPromotion(lambdas: List<IrFunctionExpression>): Boolean {
         var found = false
@@ -653,6 +671,21 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
                         found = true
                         return
                     }
+                }
+                expression.acceptChildrenVoid(this)
+            }
+
+            override fun visitCall(expression: IrCall) {
+                if (found) return
+                // Callee FQN in the `kotlin.*` namespace promotes to Kotlin:
+                // JavaTemplate can't parse Kotlin-extension call syntax in
+                // the after-template (`s.lowercase()`, `sb.appendLine("x")`,
+                // `enumValues<E>()` all resolve to `kotlin.text.lowercase`,
+                // `kotlin.text.StringsKt.appendLine`, `kotlin.enumValues`).
+                val fqn = expression.symbol.owner.kotlinFqName.asString()
+                if (fqn == "kotlin" || fqn.startsWith("kotlin.")) {
+                    found = true
+                    return
                 }
                 expression.acceptChildrenVoid(this)
             }

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/JavaKotlinClassifierTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/JavaKotlinClassifierTest.kt
@@ -21,16 +21,23 @@ import org.junit.jupiter.api.Test
 import org.openrewrite.Preconditions
 import org.openrewrite.Recipe
 import org.openrewrite.TreeVisitor
+import org.openrewrite.java.JavaVisitor
 import org.openrewrite.kotlin.KotlinVisitor
 
 /**
- * v1 dispatch coverage for the IR pass's helper selection. The
- * LST-structural classifier still runs (it computes `usesKotlinTreeNode`)
- * but v1 always dispatches to the Kotlin helper — see
- * `RecipeIrGenerationExtension.pickHelperSymbol` for the reasoning. These
- * tests pin that v1 behavior so a future change that re-enables the
- * Java-template path doesn't accidentally regress recipes authored in
- * Kotlin (every recipe in Kotlin1To2.kt today).
+ * v2 dispatch coverage for the IR pass's helper selection. The
+ * LST-structural classifier promotes a recipe to the Kotlin helper when
+ * either a value-parameter type references a `K.*` tree node OR a call
+ * expression resolves into the `kotlin.*` namespace (Kotlin stdlib
+ * function / extension that `JavaTemplate` can't parse). All-Java bodies
+ * — no K.* tree nodes, no `kotlin.*` calls — dispatch to the Java helper
+ * (`JavaVisitor` + `JavaTemplate`), which still matches both Java and
+ * Kotlin sources via `TreeVisitorAdapter` but parses the after-template
+ * as Java.
+ *
+ * Property-access and not-null shapes stay Kotlin-only — `J.FieldAccess`
+ * is a different LST node than Kotlin property access, and `!!` has no
+ * Java analogue.
  *
  * Test strategy: compile each recipe via the K2 plugin, load the synthesized
  * `<Name>$KtRecipe` class through the compilation result's classloader, and
@@ -39,7 +46,7 @@ import org.openrewrite.kotlin.KotlinVisitor
 class JavaKotlinClassifierTest {
 
     @Test
-    fun `all-Java body still dispatches to KotlinVisitor in v1`() {
+    fun `kotlin lowercase uppercase stdlib extensions dispatch to KotlinVisitor`() {
         val r = compileRecipe(
             """
             import org.openrewrite.recipe
@@ -55,7 +62,7 @@ class JavaKotlinClassifierTest {
     }
 
     @Test
-    fun `kotlin stdlib extension call dispatches to KotlinVisitor`() {
+    fun `kotlin appendLine extension dispatches to KotlinVisitor`() {
         val r = compileRecipe(
             """
             import org.openrewrite.recipe
@@ -71,7 +78,7 @@ class JavaKotlinClassifierTest {
     }
 
     @Test
-    fun `reified-generic stdlib call dispatches to KotlinVisitor`() {
+    fun `reified-generic Kotlin builtin dispatches to KotlinVisitor`() {
         val r = compileRecipe(
             """
             import org.openrewrite.recipe
@@ -85,6 +92,30 @@ class JavaKotlinClassifierTest {
             propertyName = "EnumEntriesRename",
         )
         assertThat(unwrap(r.getVisitor())).isInstanceOf(KotlinVisitor::class.java)
+    }
+
+    @Test
+    fun `all-Java body dispatches to JavaVisitor in v2`() {
+        // Pure-Java callees on both sides: `StringBuilder.appendCodePoint(I)`
+        // matcher and `StringBuilder.append(String)` after-template. Both
+        // resolve to `java.lang.{AbstractStringBuilder,StringBuilder}` members
+        // — no `K.*` LST node references, no `kotlin.*` callees in the
+        // lambdas. JavaTemplate parses the after; JavaVisitor matches the
+        // call sites against both Java and Kotlin sources (TreeVisitorAdapter
+        // glue). This is the dispatch path that unlocks the Kotlin DSL for
+        // Java-source migrations like adopt-jdk-9plus-idioms.
+        val r = compileRecipe(
+            """
+            import org.openrewrite.recipe
+            val ReplaceCodePoint = recipe("d", "desc") {
+                edit {
+                    rewrite { sb: StringBuilder -> sb.appendCodePoint(65) } to { sb -> sb.append("A") }
+                }
+            }
+            """.trimIndent(),
+            propertyName = "ReplaceCodePoint",
+        )
+        assertThat(unwrap(r.getVisitor())).isInstanceOf(JavaVisitor::class.java)
     }
 
     /**


### PR DESCRIPTION
## Summary

`rewrite { } to { }` clauses whose before/after lambdas don't structurally reference any `K.*` tree node AND don't call any `kotlin.*` function or extension now lower to `methodInvocationRewriteJava` (`JavaVisitor` + `JavaTemplate`) instead of the Kotlin helper.

Two pieces:

### 1. `pickHelperSymbol` consults the classifier

`RecipeIrGenerationExtension.pickHelperSymbol` was pinning every dispatch to the Kotlin helper with an explicit comment that the path was deferred. v1 left the classifier wired up (`templates.usesKotlinTreeNode`) and the Java helper symbol resolved (`methodInvocationRewriteJavaSymbol`) — this PR just connects them.

```kotlin
val canRouteToJava = !classifierResult && !isChain
return when {
    templates.propertyAccess -> ctx.propertyAccessRewriteKotlinSymbol
    templates.wrappedInNotNull -> ctx.methodInvocationRewriteKotlinNotNullSymbol
    canRouteToJava -> ctx.methodInvocationRewriteJavaSymbol
        ?: ctx.methodInvocationRewriteKotlinSymbol
    else -> ctx.methodInvocationRewriteKotlinSymbol
}
```

Kotlin-only shapes still route to Kotlin:
- `propertyAccess` (`d.inHours` — Kotlin property syntax, walks `J.FieldAccess` differently)
- `wrappedInNotNull` (`!!` — Kotlin-only operator)
- Chain shapes (`xs.filter(p).any()` — the chain encoding's `\t`-separated spec is only parsed by the Kotlin helper)
- Any `K.*` LST-node reference in the lambdas

Java symbol-null fallback to the Kotlin helper handles consumers compiled against older rewrite-kotlin without `methodInvocationRewriteJava`.

### 2. `classifyKotlinPromotion` strengthened

The previous classifier only inspected value-parameter types for `K.*` tree-node references. That misses the common case where the lambda body calls a Kotlin stdlib extension on a Java type (`sb: StringBuilder -> sb.appendLine("x")`). Under (1) alone, those would wrongly route to Java, and `JavaTemplate` would fail to parse the after-template at runtime.

Added an `visitCall` override that promotes to Kotlin if any callee FQN sits in the `kotlin.*` namespace. Covers:
- `s.lowercase()`, `s.uppercase()` — `kotlin.text.*`
- `sb.appendLine("x")` — `kotlin.text.StringsKt.appendLine`
- `enumValues<E>()` — `kotlin.enumValues`

## Tests

`JavaKotlinClassifierTest` updated to pin v2 behavior:

| Test | Before lambda | After lambda | Expected visitor |
|---|---|---|---|
| `kotlin lowercase uppercase stdlib extensions` | `s.lowercase()` | `s.uppercase()` | KotlinVisitor |
| `kotlin appendLine extension` | `sb.append("x")` | `sb.appendLine("x")` | KotlinVisitor |
| `reified-generic Kotlin builtin` | `enumValues<E>()` | `enumValues<E>()` | KotlinVisitor |
| **`all-Java body dispatches to JavaVisitor in v2`** (new) | `sb.appendCodePoint(65)` | `sb.append("A")` | **JavaVisitor** |

Full `:rewrite-kotlin:test` suite (1195 tests) green.

## Why

Unlocks the Kotlin DSL for Java-source migrations. Until v2 dispatch, the only way to author a recipe that matched Java callsites was Refaster — a heavier, annotation-driven authoring surface that LLMs in particular struggle with. With v2 the same `rewrite { } to { }` shape used for Kotlin migrations is also viable for Java migrations like `adopt-jdk-9plus-idioms` (`Arrays.asList` → `List.of`, `Charset.forName("UTF-8")` → `StandardCharsets.UTF_8`, etc.) — Kotlin-DSL-authored recipes finally reach the Java callsites that dominate real-world refactor work.

## Test plan

- [x] `:rewrite-kotlin:test` green (1195 tests)
- [x] New `all-Java body dispatches to JavaVisitor in v2` case asserts the v2 path
- [x] All 3 previously-pinned `KotlinVisitor` cases still pin to `KotlinVisitor` (strengthened classifier catches their `kotlin.*` callees)