### PR TITLE
Build data table descriptors from the cached recipe descriptor

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -247,7 +247,7 @@ public abstract class Recipe implements Cloneable {
         }
 
         return new RecipeDescriptor(getName(), getDisplayName(), getInstanceName(), getDescription(), getTags(),
-                getEstimatedEffortPerOccurrence(), options, preconditionDescriptors, recipeDescriptors, getDataTableDescriptors(),
+                getEstimatedEffortPerOccurrence(), options, preconditionDescriptors, recipeDescriptors, aggregateDataTableDescriptors(recipeDescriptors),
                 getMaintainers(), getContributors(), getExamples(), recipeSource);
     }
 
@@ -347,15 +347,38 @@ public abstract class Recipe implements Cloneable {
         GLOBAL_DATA_TABLE_NAMES = names;
     }
 
+    /**
+     * The descriptors of every data table reachable from this recipe: this recipe's own data
+     * tables, those of its sub-recipes (recursively), and the data tables that the framework
+     * contributes to every recipe run. The result is derived from the (cached)
+     * {@link #getDescriptor()}, so repeated calls on the same instance do not re-walk the recipe
+     * tree.
+     *
+     * @return The descriptors of every data table reachable from this recipe.
+     */
     public List<DataTableDescriptor> getDataTableDescriptors() {
+        return getDescriptor().getDataTables();
+    }
+
+    /**
+     * Unions this recipe's own data tables with those of its already-described sub-recipes and the
+     * data tables that the framework contributes to every run, de-duplicating by name. Sub-recipe
+     * data tables are read from the {@link RecipeDescriptor}s that {@link #createRecipeDescriptor()}
+     * has already built for this recipe's children, so the recipe tree is walked exactly once per
+     * descriptor rather than once per level of nesting.
+     *
+     * @param subRecipeDescriptors The descriptors of this recipe's direct sub-recipes.
+     * @return The unioned, de-duplicated data table descriptors for this recipe.
+     */
+    protected List<DataTableDescriptor> aggregateDataTableDescriptors(List<RecipeDescriptor> subRecipeDescriptors) {
         Map<String, DataTableDescriptor> byName = new LinkedHashMap<>();
         if (dataTables != null) {
             for (DataTableDescriptor dt : dataTables) {
                 byName.putIfAbsent(dt.getName(), dt);
             }
         }
-        for (Recipe sub : getRecipeList()) {
-            for (DataTableDescriptor dt : sub.getDataTableDescriptors()) {
+        for (RecipeDescriptor sub : subRecipeDescriptors) {
+            for (DataTableDescriptor dt : sub.getDataTables()) {
                 if (!GLOBAL_DATA_TABLE_NAMES.contains(dt.getName())) {
                     byName.putIfAbsent(dt.getName(), dt);
                 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -701,7 +701,7 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
         }
         return new RecipeDescriptor(getName(), getDisplayName(), getInstanceName(), getDescription() != null ? getDescription() : "",
                 getTags(), getEstimatedEffortPerOccurrence(),
-                emptyList(), preconditionDescriptors, recipeDescriptors, getDataTableDescriptors(), getMaintainers(), getContributors(),
+                emptyList(), preconditionDescriptors, recipeDescriptors, aggregateDataTableDescriptors(recipeDescriptors), getMaintainers(), getContributors(),
                 getExamples(), source);
     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/DataTableTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/DataTableTest.java
@@ -25,6 +25,7 @@ import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.test.RewriteTest.toRecipe;
@@ -170,6 +171,38 @@ class DataTableTest implements RewriteTest {
     }
 
     @Test
+    void dataTableDescriptorsDeriveFromCachedDescriptorAndWalkTreeOnce() {
+        Recipe leaf = toRecipe();
+        new TableC(leaf);
+
+        // A chain of nested composites, deep enough that an O(n^2) re-walk would be obvious.
+        Recipe top = leaf;
+        int depth = 6;
+        for (int i = 0; i < depth; i++) {
+            top = new CountingComposite(List.of(top));
+        }
+
+        CountingComposite.recipeListCalls.set(0);
+        List<DataTableDescriptor> descriptors = top.getDataTableDescriptors();
+
+        // The leaf's data table propagates all the way up.
+        assertThat(descriptors).extracting(DataTableDescriptor::getName).contains(TableC.class.getName());
+
+        // Each composite contributes exactly one getRecipeList() call: the tree is walked once,
+        // not once per nesting level. This is what makes a per-class/static introspection cache
+        // unnecessary.
+        assertThat(CountingComposite.recipeListCalls.get()).isEqualTo(depth);
+
+        // getDataTableDescriptors() is just a view over the cached descriptor.
+        assertThat(top.getDataTableDescriptors()).isEqualTo(top.getDescriptor().getDataTables());
+
+        // Repeated descriptor loads on the same instance do not re-walk the tree.
+        top.getDataTableDescriptors();
+        top.getDescriptor();
+        assertThat(CountingComposite.recipeListCalls.get()).isEqualTo(depth);
+    }
+
+    @Test
     void recipeUsedInPreconditionDoesNotEmitDataTableRows() {
         Recipe preconditionRecipe = toRecipe(r -> new PlainTextVisitor<>() {
             final WordTable wordTable = new WordTable(r);
@@ -201,6 +234,36 @@ class DataTableTest implements RewriteTest {
               .containsExactly("main")),
           text("test", "changed")
         );
+    }
+
+    /**
+     * A composite recipe that counts how many times {@link #getRecipeList()} is invoked, so tests
+     * can assert the recipe tree is walked once per descriptor rather than once per nesting level.
+     */
+    static class CountingComposite extends Recipe {
+        static final AtomicInteger recipeListCalls = new AtomicInteger();
+
+        private final List<Recipe> children;
+
+        CountingComposite(List<Recipe> children) {
+            this.children = children;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Counting composite";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Counts the number of getRecipeList() invocations.";
+        }
+
+        @Override
+        public List<Recipe> getRecipeList() {
+            recipeListCalls.incrementAndGet();
+            return children;
+        }
     }
 
     @JsonIgnoreType


### PR DESCRIPTION
## Summary

Reworks the fix for slow recipe-descriptor loading on deeply nested composites (e.g. `io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0`, a ~50-recipe pipeline) **without** introducing any static or per-class cache.

### Root cause

`getDataTableDescriptors()` did an independent recursive `getRecipeList()` walk *at every level* of `createRecipeDescriptor()`. Because `getRecipeList()` rebuilds fresh sub-recipe instances on every call — each one re-registering its data tables via reflective column introspection — a tree of N nodes was instantiated and walked roughly O(N²) times. That churn (the `ColumnDescriptor` / `Field` / `Validated$Invalid` allocations seen while profiling) is what made descriptor loading expensive.

The key observation: `createRecipeDescriptor()` already feeds `getDataTableDescriptors()` straight into the cached `RecipeDescriptor`, and each child descriptor it builds already carries that child's aggregated data tables. The aggregation just wasn't reusing them.

### Change

- Fold the union/dedup/global logic into `createRecipeDescriptor()` (`aggregateDataTableDescriptors`), sourcing sub-recipe data tables from the child `RecipeDescriptor`s already built in the same method — so the recipe tree is walked **once per descriptor**.
- Make `getDataTableDescriptors()` a thin view over the cached `getDescriptor()`.

The only cache is the **existing per-instance `descriptor` field** — GC'd with the recipe, so a long-lived process (RPC server, MCP) accumulates nothing. No new field; no `ClassValue`/`ConcurrentHashMap` keyed by `Class<?>`. Output is byte-identical: same union, same name-dedup, same global-table append, same order.

This also makes `recipe.getDataTableDescriptors()` and `recipe.getDescriptor().getDataTables()` consistent (they could previously diverge).

## Test plan

- [x] `./gradlew :rewrite-core:test` — `DataTableTest`, `DeclarativeRecipeTest` (incl. the concurrent `getDataTableDescriptorsThreadSafe`), `DataTableStoreTest`, `RecipeRunTest`, descriptor/serializer tests, `RewriteRpcTest` all pass
- [x] `:rewrite-java` `FindDeprecatedUsesDataTablesTest` passes
- [x] New `dataTableDescriptorsDeriveFromCachedDescriptorAndWalkTreeOnce`: a depth-6 nested composite asserts `getRecipeList()` fires exactly once per node (not once per level) and a second descriptor load triggers zero additional walks — the evidence that no introspection cache is needed