### PR TITLE
Break self-referential JavaType.Method attribution cycles via the type cache

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTypeMapping.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTypeMapping.java
@@ -27,6 +27,7 @@ import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -205,11 +206,12 @@ class GroovyTypeMapping implements JavaTypeMapping<ASTNode> {
         }
 
         String[] finalParamNames = paramNames;
-        return typeFactory.methodFor(signature, () -> {
-            JavaType.Method method = new JavaType.Method(
+        return typeFactory.methodFor(signature,
+                () -> new JavaType.Method(
                     null, node.getModifiers(), null,
                     node instanceof ConstructorNode ? "<constructor>" : node.getName(),
-                    null, finalParamNames, null, null, null, null, null);
+                    null, finalParamNames, null, null, null, null, null),
+                method -> {
             List<JavaType> parameterTypes = null;
             if (node.getParameters().length > 0) {
                 parameterTypes = new ArrayList<>(node.getParameters().length);
@@ -235,7 +237,6 @@ class GroovyTypeMapping implements JavaTypeMapping<ASTNode> {
                     thrownExceptions,
                     annotations
             );
-            return method;
         });
     }
 

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
@@ -30,6 +30,7 @@ import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeMirror;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
@@ -452,11 +453,12 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
         Type finalSelectType = selectType;
         JavaType.FullyQualified finalDeclaringType = resolvedDeclaringType;
         String[] finalParamNames = paramNames;
-        return typeFactory.methodFor(signature, () -> {
-            JavaType.Method method = new JavaType.Method(
+        return typeFactory.methodFor(signature,
+                () -> new JavaType.Method(
                     null, methodSymbol.flags_field, null,
                     methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
-                    null, finalParamNames, null, null, null, null, null);
+                    null, finalParamNames, null, null, null, null, null),
+                method -> {
             JavaType returnType = null;
             List<JavaType> parameterTypes = null;
             List<JavaType> exceptionTypes = null;
@@ -492,7 +494,6 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
             method.unsafeSet(finalDeclaringType,
                     methodSymbol.isConstructor() ? finalDeclaringType : returnType,
                     parameterTypes, exceptionTypes, listAnnotations(methodSymbol));
-            return method;
         });
     }
 
@@ -561,11 +562,12 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
             String[] finalParamNames = paramNames;
             List<String> finalDefaultValues = defaultValues;
             String[] finalFormalTypeNames = declaredFormalTypeNames == null ? null : declaredFormalTypeNames.toArray(new String[0]);
-            return typeFactory.methodFor(signature, () -> {
-                JavaType.Method method = new JavaType.Method(
+            return typeFactory.methodFor(signature,
+                    () -> new JavaType.Method(
                         null, methodSymbol.flags_field, null,
                         methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
-                        null, finalParamNames, null, null, null, finalDefaultValues, finalFormalTypeNames);
+                        null, finalParamNames, null, null, null, finalDefaultValues, finalFormalTypeNames),
+                    method -> {
                 Type signatureType = methodSymbol.type instanceof Type.ForAll ?
                         ((Type.ForAll) methodSymbol.type).qtype :
                         methodSymbol.type;
@@ -615,7 +617,6 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
                 method.unsafeSet(finalDeclaringType,
                         methodSymbol.isConstructor() ? finalDeclaringType : returnType,
                         parameterTypes, exceptionTypes, listAnnotations(methodSymbol));
-                return method;
             });
         }
 

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
@@ -32,6 +32,7 @@ import javax.lang.model.type.TypeMirror;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
@@ -461,11 +462,12 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
         }
 
         String[] finalParamNames = paramNames;
-        return typeFactory.methodFor(signature, () -> {
-            JavaType.Method method = new JavaType.Method(
+        return typeFactory.methodFor(signature,
+                () -> new JavaType.Method(
                     null, methodSymbol.flags_field, null,
                     methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
-                    null, finalParamNames, null, null, null, null, null);
+                    null, finalParamNames, null, null, null, null, null),
+                method -> {
             JavaType returnType = null;
             List<JavaType> parameterTypes = null;
             List<JavaType> exceptionTypes = null;
@@ -501,7 +503,6 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
             method.unsafeSet(resolvedDeclaringType,
                     methodSymbol.isConstructor() ? resolvedDeclaringType : returnType,
                     parameterTypes, exceptionTypes, listAnnotations(methodSymbol));
-            return method;
         });
     }
 
@@ -572,11 +573,12 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
         String[] finalParamNames = paramNames;
         List<String> finalDefaultValues = defaultValues;
         String[] finalFormalTypeNames = declaredFormalTypeNames == null ? null : declaredFormalTypeNames.toArray(new String[0]);
-        return typeFactory.methodFor(signature, () -> {
-            JavaType.Method method = new JavaType.Method(
+        return typeFactory.methodFor(signature,
+                () -> new JavaType.Method(
                     null, methodSymbol.flags_field, null,
                     methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
-                    null, finalParamNames, null, null, null, finalDefaultValues, finalFormalTypeNames);
+                    null, finalParamNames, null, null, null, finalDefaultValues, finalFormalTypeNames),
+                method -> {
             Type signatureType = methodSymbol.type instanceof Type.ForAll ?
                     ((Type.ForAll) methodSymbol.type).qtype :
                     methodSymbol.type;
@@ -626,7 +628,6 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
             method.unsafeSet(finalDeclaringType,
                     methodSymbol.isConstructor() ? finalDeclaringType : returnType,
                     parameterTypes, exceptionTypes, listAnnotations(methodSymbol));
-            return method;
         });
     }
 

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
@@ -456,11 +456,12 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
         }
 
         String[] finalParamNames = paramNames;
-        return typeFactory.methodFor(signature, () -> {
-            JavaType.Method method = new JavaType.Method(
-                    null, methodSymbol.flags_field, null,
-                    methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
-                    null, finalParamNames, null, null, null, null, null);
+        return typeFactory.methodFor(signature,
+                () -> new JavaType.Method(
+                        null, methodSymbol.flags_field, null,
+                        methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
+                        null, finalParamNames, null, null, null, null, null),
+                method -> {
             JavaType returnType = null;
             List<JavaType> parameterTypes = null;
             List<JavaType> exceptionTypes = null;
@@ -496,7 +497,6 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
             method.unsafeSet(resolvedDeclaringType,
                     methodSymbol.isConstructor() ? resolvedDeclaringType : returnType,
                     parameterTypes, exceptionTypes, listAnnotations(methodSymbol));
-            return method;
         });
     }
 
@@ -566,11 +566,12 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
         String[] finalParamNames = paramNames;
         List<String> finalDefaultValues = defaultValues;
         String[] finalFormalTypeNames = declaredFormalTypeNames == null ? null : declaredFormalTypeNames.toArray(new String[0]);
-        return typeFactory.methodFor(signature, () -> {
-            JavaType.Method method = new JavaType.Method(
-                    null, methodSymbol.flags_field, null,
-                    methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
-                    null, finalParamNames, null, null, null, finalDefaultValues, finalFormalTypeNames);
+        return typeFactory.methodFor(signature,
+                () -> new JavaType.Method(
+                        null, methodSymbol.flags_field, null,
+                        methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
+                        null, finalParamNames, null, null, null, finalDefaultValues, finalFormalTypeNames),
+                method -> {
             Type signatureType = methodSymbol.type instanceof Type.ForAll ?
                     ((Type.ForAll) methodSymbol.type).qtype :
                     methodSymbol.type;
@@ -620,7 +621,6 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
             method.unsafeSet(finalDeclaringType,
                     methodSymbol.isConstructor() ? finalDeclaringType : returnType,
                     parameterTypes, exceptionTypes, listAnnotations(methodSymbol));
-            return method;
         });
     }
 

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25TypeMapping.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25TypeMapping.java
@@ -459,11 +459,12 @@ class ReloadableJava25TypeMapping implements JavaTypeMapping<Tree> {
         }
 
         String[] finalParamNames = paramNames;
-        return typeFactory.methodFor(signature, () -> {
-            JavaType.Method method = new JavaType.Method(
-                    null, methodSymbol.flags_field, null,
-                    methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
-                    null, finalParamNames, null, null, null, null, null);
+        return typeFactory.methodFor(signature,
+                () -> new JavaType.Method(
+                        null, methodSymbol.flags_field, null,
+                        methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
+                        null, finalParamNames, null, null, null, null, null),
+                method -> {
             JavaType returnType = null;
             List<JavaType> parameterTypes = null;
             List<JavaType> exceptionTypes = null;
@@ -497,7 +498,6 @@ class ReloadableJava25TypeMapping implements JavaTypeMapping<Tree> {
             method.unsafeSet(resolvedDeclaringType,
                     methodSymbol.isConstructor() ? resolvedDeclaringType : returnType,
                     parameterTypes, exceptionTypes, listAnnotations(methodSymbol));
-            return method;
         });
     }
 
@@ -567,11 +567,12 @@ class ReloadableJava25TypeMapping implements JavaTypeMapping<Tree> {
         String[] finalParamNames = paramNames;
         List<String> finalDefaultValues = defaultValues;
         String[] finalFormalTypeNames = declaredFormalTypeNames == null ? null : declaredFormalTypeNames.toArray(new String[0]);
-        return typeFactory.methodFor(signature, () -> {
-            JavaType.Method method = new JavaType.Method(
-                    null, methodSymbol.flags_field, null,
-                    methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
-                    null, finalParamNames, null, null, null, finalDefaultValues, finalFormalTypeNames);
+        return typeFactory.methodFor(signature,
+                () -> new JavaType.Method(
+                        null, methodSymbol.flags_field, null,
+                        methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
+                        null, finalParamNames, null, null, null, finalDefaultValues, finalFormalTypeNames),
+                method -> {
             Type signatureType = methodSymbol.type instanceof Type.ForAll ?
                     ((Type.ForAll) methodSymbol.type).qtype :
                     methodSymbol.type;
@@ -621,7 +622,6 @@ class ReloadableJava25TypeMapping implements JavaTypeMapping<Tree> {
             method.unsafeSet(finalDeclaringType,
                     methodSymbol.isConstructor() ? finalDeclaringType : returnType,
                     parameterTypes, exceptionTypes, listAnnotations(methodSymbol));
-            return method;
         });
     }
 

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
@@ -29,6 +29,7 @@ import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeMirror;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
@@ -446,11 +447,12 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
         Type finalSelectType = selectType;
         JavaType.FullyQualified finalDeclaringType = resolvedDeclaringType;
         String[] finalParamNames = paramNames;
-        return typeFactory.methodFor(signature, () -> {
-            JavaType.Method method = new JavaType.Method(
+        return typeFactory.methodFor(signature,
+                () -> new JavaType.Method(
                     null, methodSymbol.flags_field, null,
                     methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
-                    null, finalParamNames, null, null, null, null, null);
+                    null, finalParamNames, null, null, null, null, null),
+                method -> {
             JavaType returnType = null;
             List<JavaType> parameterTypes = null;
             List<JavaType> exceptionTypes = null;
@@ -486,7 +488,6 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
             method.unsafeSet(finalDeclaringType,
                     methodSymbol.isConstructor() ? finalDeclaringType : returnType,
                     parameterTypes, exceptionTypes, listAnnotations(methodSymbol));
-            return method;
         });
     }
 
@@ -556,11 +557,12 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
             String[] finalParamNames = paramNames;
             List<String> finalDefaultValues = defaultValues;
             String[] finalFormalTypeNames = declaredFormalTypeNames == null ? null : declaredFormalTypeNames.toArray(new String[0]);
-            return typeFactory.methodFor(signature, () -> {
-                JavaType.Method method = new JavaType.Method(
+            return typeFactory.methodFor(signature,
+                    () -> new JavaType.Method(
                         null, methodSymbol.flags_field, null,
                         methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
-                        null, finalParamNames, null, null, null, finalDefaultValues, finalFormalTypeNames);
+                        null, finalParamNames, null, null, null, finalDefaultValues, finalFormalTypeNames),
+                    method -> {
                 Type signatureType = methodSymbol.type instanceof Type.ForAll ?
                         ((Type.ForAll) methodSymbol.type).qtype :
                         methodSymbol.type;
@@ -610,7 +612,6 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
                 method.unsafeSet(finalDeclaringType,
                         methodSymbol.isConstructor() ? finalDeclaringType : returnType,
                         parameterTypes, exceptionTypes, listAnnotations(methodSymbol));
-                return method;
             });
         }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/DefaultJavaTypeFactory.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/DefaultJavaTypeFactory.java
@@ -107,14 +107,20 @@ public class DefaultJavaTypeFactory implements JavaTypeFactory {
     // ---------------------------------------------------------------------
 
     @Override
-    public JavaType.Method methodFor(String signature, Supplier<JavaType.Method> builder) {
+    public JavaType.Method methodFor(String signature, Supplier<JavaType.Method> stub,
+                                     Consumer<JavaType.Method> initializer) {
         JavaType.Method cached = cache.get(signature);
         if (cached != null) {
             return cached;
         }
-        JavaType.Method built = builder.get();
-        cache.put(signature, built);
-        return built;
+        // Cache the bare stub before running the initializer so a re-entrant
+        // lookup on the same signature (e.g. the @AliasFor annotation-element
+        // cycle) resolves to this in-progress instance instead of recursing.
+        // Same cycle-breaking contract as computeClass.
+        JavaType.Method method = stub.get();
+        cache.put(signature, method);
+        initializer.accept(method);
+        return method;
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -302,10 +303,11 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
         }
 
         String[] finalParamNames = paramNames;
-        return typeFactory.methodFor(signature, () -> {
-            JavaType.Method mappedMethod = new JavaType.Method(
-                    null, method.getModifiers(), null, "<constructor>",
-                    null, finalParamNames, null, null, null, null, null);
+        return typeFactory.methodFor(signature,
+                () -> new JavaType.Method(
+                        null, method.getModifiers(), null, "<constructor>",
+                        null, finalParamNames, null, null, null, null, null),
+                mappedMethod -> {
             List<JavaType> thrownExceptions = null;
             if (method.getExceptionTypes().length > 0) {
                 thrownExceptions = new ArrayList<>(method.getExceptionTypes().length);
@@ -336,7 +338,6 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
             }
 
             mappedMethod.unsafeSet(declaringType, declaringType, parameterTypes, thrownExceptions, annotations);
-            return mappedMethod;
         });
     }
 
@@ -410,10 +411,11 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
         String[] finalParamNames = paramNames;
         List<String> finalDefaultValues = defaultValues;
         String[] finalFormalTypeNames = declaredFormalTypeNames == null ? null : declaredFormalTypeNames.toArray(new String[0]);
-        return typeFactory.methodFor(signature, () -> {
-            JavaType.Method mappedMethod = new JavaType.Method(
-                    null, method.getModifiers(), null, method.getName(),
-                    null, finalParamNames, null, null, null, finalDefaultValues, finalFormalTypeNames);
+        return typeFactory.methodFor(signature,
+                () -> new JavaType.Method(
+                        null, method.getModifiers(), null, method.getName(),
+                        null, finalParamNames, null, null, null, finalDefaultValues, finalFormalTypeNames),
+                mappedMethod -> {
             List<JavaType> thrownExceptions = null;
             if (method.getExceptionTypes().length > 0) {
                 thrownExceptions = new ArrayList<>(method.getExceptionTypes().length);
@@ -441,7 +443,6 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
 
             JavaType returnType = type(method.getGenericReturnType());
             mappedMethod.unsafeSet(declaringType, returnType, parameterTypes, thrownExceptions, annotations);
-            return mappedMethod;
         });
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaTypeFactory.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaTypeFactory.java
@@ -154,6 +154,35 @@ public interface JavaTypeFactory {
             JavaType.GenericTypeVariable.Variance variance,
             Consumer<JavaType.GenericTypeVariable> initializer);
 
+    /**
+     * Build for {@link JavaType.Method} with cycle-breaking on the same key.
+     * Unlike {@link #variableFor}/{@link #arrayFor}/{@link #intersectionFor},
+     * a method's attribution can recurse back to its own signature: an
+     * annotation-element method whose own annotations reference an annotation
+     * whose element is that same method (the Spring {@code @AliasFor} shape &mdash;
+     * {@code value()} is annotated {@code @AliasFor}, and {@code @AliasFor}'s
+     * element is {@code value()}). So this mirrors {@link #computeClass}:
+     * {@code stub} constructs the bare instance from non-recursive header fields,
+     * which is cached <em>before</em> {@code initializer} runs the (possibly
+     * self-referential) attribution onto that same instance. A re-entrant lookup
+     * on the same signature then hits the cached stub instead of recursing &mdash;
+     * the signature and cache are the cycle-breaker, the same way they are for
+     * {@link #computeClass}.
+     *
+     * @param signature   an opaque per-factory key from a {@link JavaTypeSignatureBuilder}
+     *                    &mdash; canonical shape
+     *                    {@code com.MyThing{name=add,return=void,parameters=[Integer]}}.
+     * @param stub        constructs the bare method from non-recursive header fields
+     *                    (name, flags, parameter names, default value, declared
+     *                    formal type names); must not resolve any type that could
+     *                    recurse to this signature.
+     * @param initializer populates the cached stub's recursive attribution
+     *                    (declaring type, return type, parameter types, thrown
+     *                    exceptions, annotations) via {@code unsafeSet}.
+     */
+    JavaType.Method methodFor(String signature, Supplier<JavaType.Method> stub,
+                              Consumer<JavaType.Method> initializer);
+
     // ---------------------------------------------------------------------
     // Atomic build ({@code *For})
     //
@@ -161,15 +190,6 @@ public interface JavaTypeFactory {
     // constructs the instance fully before the factory caches it; no
     // half-built object is ever observable through the cache.
     // ---------------------------------------------------------------------
-
-    /**
-     * Atomic build for {@link JavaType.Method}.
-     *
-     * @param signature an opaque per-factory key from a {@link JavaTypeSignatureBuilder}
-     *                  &mdash; canonical shape
-     *                  {@code com.MyThing{name=add,return=void,parameters=[Integer]}}.
-     */
-    JavaType.Method methodFor(String signature, Supplier<JavaType.Method> builder);
 
     /**
      * Atomic build for {@link JavaType.Variable}.

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/DefaultJavaTypeFactoryTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/DefaultJavaTypeFactoryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultJavaTypeFactoryTest {
+
+    /**
+     * A method's attribution can recurse back to its own signature: an
+     * annotation-element method whose own annotations reference an annotation
+     * whose element is that same method — the Spring {@code @AliasFor} shape,
+     * where {@code value()} is annotated {@code @AliasFor} and {@code @AliasFor}'s
+     * element is {@code value()}.
+     * <p>
+     * {@link DefaultJavaTypeFactory#methodFor} must cache the in-progress stub
+     * before running the initializer so the re-entrant lookup on the same
+     * signature resolves to that stub instead of recursing until the stack
+     * overflows — the same signature+cache cycle-breaking {@code computeClass}
+     * relies on.
+     */
+    @Test
+    void selfReferentialMethodResolvesToInProgressStub() {
+        DefaultJavaTypeFactory factory = new DefaultJavaTypeFactory(new JavaTypeCache());
+        String signature = "com.Example{name=value,return=int,parameters=[]}";
+
+        JavaType.Method method = factory.methodFor(signature,
+                () -> new JavaType.Method(null, 0, null, "value", null,
+                        (List<String>) null, null, null, null, null, null),
+                m -> {
+                    // Re-enter for the same signature mid-attribution. The cache must
+                    // hand back the in-progress stub; neither the stub supplier nor the
+                    // initializer may run again (that re-entry is the stack overflow).
+                    JavaType.Method reentrant = factory.methodFor(signature,
+                            () -> {
+                                throw new AssertionError("stub supplier must not run on re-entry");
+                            },
+                            again -> {
+                                throw new AssertionError("initializer must not run on re-entry");
+                            });
+                    assertThat(reentrant).isSameAs(m);
+                    m.unsafeSet(null, JavaType.Primitive.Int, (List<JavaType>) null, null, null);
+                });
+
+        // The same canonical, fully-attributed instance is served from cache afterward.
+        JavaType.Method cached = factory.methodFor(signature,
+                () -> {
+                    throw new AssertionError("should be served from cache");
+                },
+                m -> {
+                    throw new AssertionError("should be served from cache");
+                });
+        assertThat(cached).isSameAs(method);
+        assertThat(method.getReturnType()).isEqualTo(JavaType.Primitive.Int);
+    }
+}

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinIrTypeMapping.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinIrTypeMapping.kt
@@ -360,8 +360,9 @@ class KotlinIrTypeMapping(private val typeFactory: JavaTypeFactory) : JavaTypeMa
         }
         val name = if (function is IrConstructor) "<constructor>" else function.name.asString()
         val finalParamNames = paramNamesArr
-        return typeFactory.methodFor(signature) {
-            val method = JavaType.Method(null, methodFlags, null, name, null, finalParamNames, null, null, null, null, null)
+        return typeFactory.methodFor(signature, {
+            JavaType.Method(null, methodFlags, null, name, null, finalParamNames, null, null, null, null, null)
+        }) { method ->
             var declaringType = when (val irParent = function.parent) {
                 is IrField -> TypeUtils.asFullyQualified(type(irParent.parent))
                 else -> TypeUtils.asFullyQualified(type(irParent))
@@ -386,7 +387,6 @@ class KotlinIrTypeMapping(private val typeFactory: JavaTypeFactory) : JavaTypeMa
                 (if (function is IrConstructor) declaringType else returnType) ?: JavaType.Unknown.getInstance(),
                 paramTypes, null, listAnnotations(function.annotations)
             )
-            method
         }
     }
 
@@ -407,8 +407,9 @@ class KotlinIrTypeMapping(private val typeFactory: JavaTypeFactory) : JavaTypeMa
         val paramNamesArr: kotlin.Array<String> = kotlin.Array(ownerRegularParams.size) { ownerRegularParams[it].name.asString() }
         val flags = mapToFlagsBitmap(type.symbol.owner.visibility)
         val name = type.symbol.owner.name.asString()
-        return typeFactory.methodFor(signature) {
-            val method = JavaType.Method(null, flags, null, name, null, paramNamesArr, null, null, null, null, null)
+        return typeFactory.methodFor(signature, {
+            JavaType.Method(null, flags, null, name, null, paramNamesArr, null, null, null, null, null)
+        }) { method ->
             var declaringType = TypeUtils.asFullyQualified(type(type.symbol.owner.parent))
             if (declaringType is JavaType.Parameterized) {
                 declaringType = declaringType.type
@@ -429,7 +430,6 @@ class KotlinIrTypeMapping(private val typeFactory: JavaTypeFactory) : JavaTypeMa
                 returnType,
                 paramTypes, null, listAnnotations(type.symbol.owner.annotations)
             )
-            method
         }
     }
 
@@ -437,8 +437,9 @@ class KotlinIrTypeMapping(private val typeFactory: JavaTypeFactory) : JavaTypeMa
         val ownerRegularParams = type.symbol.owner.parameters.filter { it.kind == IrParameterKind.Regular }
         val paramNamesArr: kotlin.Array<String> = kotlin.Array(ownerRegularParams.size) { ownerRegularParams[it].name.asString() }
         val flags = mapToFlagsBitmap(type.symbol.owner.visibility)
-        return typeFactory.methodFor(signature) {
-            val method = JavaType.Method(null, flags, null, "<constructor>", null, paramNamesArr, null, null, null, null, null)
+        return typeFactory.methodFor(signature, {
+            JavaType.Method(null, flags, null, "<constructor>", null, paramNamesArr, null, null, null, null, null)
+        }) { method ->
             var declaringType = TypeUtils.asFullyQualified(type(type.symbol.owner.parent))
             if (declaringType is JavaType.Parameterized) {
                 declaringType = declaringType.type
@@ -459,7 +460,6 @@ class KotlinIrTypeMapping(private val typeFactory: JavaTypeFactory) : JavaTypeMa
                 returnType ?: JavaType.Unknown.getInstance(),
                 paramTypes, null, listAnnotations(type.symbol.owner.annotations)
             )
-            method
         }
     }
 

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -635,10 +635,11 @@ class KotlinTypeMapping(
         }
         val name = if (function.symbol is FirConstructorSymbol) "<constructor>" else methodName(function)
         val finalParamNames = paramNamesArr
-        return typeFactory.methodFor(signature) {
-            val method = Method(
+        return typeFactory.methodFor(signature, {
+            Method(
                     null, methodFlags, null, name,
                     null, finalParamNames, null, null, null, null, null)
+        }) { method ->
             var parentType: JavaType? = when {
                 function.symbol is FirConstructorSymbol -> type(function.returnTypeRef)
                 function.dispatchReceiverType is ConeClassLikeType ->
@@ -700,7 +701,6 @@ class KotlinTypeMapping(
                 returnType,
                 parameterTypes, null, listAnnotations(function.annotations)
             )
-            method
         }
     }
 
@@ -764,10 +764,11 @@ class KotlinTypeMapping(
         val finalParamNames = paramNamesArr
         val finalDefaultValues = defaultValues
         val finalMethodFlags = methodFlags
-        return typeFactory.methodFor(signature) {
-            val method = Method(
+        return typeFactory.methodFor(signature, {
+            Method(
                     null, finalMethodFlags, null, javaMethod.name.asString(),
                     null, finalParamNames, null, null, null, finalDefaultValues, null)
+        }) { method ->
             val exceptionTypes: List<JavaType>? = null
             val returnType = type(javaMethod.returnType)
             var parameterTypes: MutableList<JavaType>? = null
@@ -782,7 +783,6 @@ class KotlinTypeMapping(
                 returnType,
                 parameterTypes, exceptionTypes, listAnnotations(javaMethod.annotations)
             )
-            method
         }
     }
 
@@ -841,10 +841,11 @@ class KotlinTypeMapping(
         }
         val finalParamNames = paramNamesArr
         val finalInvocationFlags = invocationFlags
-        return typeFactory.methodFor(signature) {
-            val method = Method(
+        return typeFactory.methodFor(signature, {
+            Method(
                     null, finalInvocationFlags, null, name,
                     null, finalParamNames, null, null, null, null, null)
+        }) { method ->
             var paramTypes: MutableList<JavaType>? = if (paramNamesArr != null) ArrayList(paramNamesArr.size) else null
             var declaringType: FullyQualified? = null
             if (function.calleeReference is FirResolvedNamedReference &&
@@ -944,7 +945,6 @@ class KotlinTypeMapping(
                 returnType,
                 paramTypes, null, listAnnotations(function.annotations)
             )
-            method
         }
     }
 
@@ -1435,10 +1435,11 @@ class KotlinTypeMapping(
         constructorFlags = constructorFlags and (1L shl 4).inv()
         val finalParamNames = paramNamesArr
         val finalConstructorFlags = constructorFlags
-        return typeFactory.methodFor(signature) {
-            val method = Method(
+        return typeFactory.methodFor(signature, {
+            Method(
                     null, finalConstructorFlags, null, "<constructor>",
                     null, finalParamNames, null, null, null, null, null)
+        }) { method ->
             val exceptionTypes: List<JavaType>? = null
             var parameterTypes: MutableList<JavaType>? = null
             if (constructor.valueParameters.isNotEmpty()) {
@@ -1452,7 +1453,6 @@ class KotlinTypeMapping(
                 finalDeclaringType,
                 parameterTypes, exceptionTypes, listAnnotations(constructor.annotations)
             )
-            method
         }
     }
 

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTypeMapping.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTypeMapping.scala
@@ -510,33 +510,33 @@ class ScalaTypeMapping(typeFactory: JavaTypeFactory, typedTree: tpd.Tree)(using 
     }
 
     val finalParamNames = paramNamesArr
-    typeFactory.methodFor(sig, () => {
-      val method = new JavaType.Method(null, flagsBits, null, name, null, finalParamNames, null, null, null, null, null)
-      val paramTypes: util.List[JavaType] = sym.info match {
-        case mt: MethodType =>
-          val pts = new ArrayList[JavaType]()
-          mt.paramInfos.foreach(pt => pts.add(mapType(pt)))
-          pts
-        case pt: PolyType => pt.resultType match {
+    typeFactory.methodFor(sig,
+      () => new JavaType.Method(null, flagsBits, null, name, null, finalParamNames, null, null, null, null, null),
+      (method: JavaType.Method) => {
+        val paramTypes: util.List[JavaType] = sym.info match {
           case mt: MethodType =>
             val pts = new ArrayList[JavaType]()
-            mt.paramInfos.foreach(pt2 => pts.add(mapType(pt2)))
+            mt.paramInfos.foreach(pt => pts.add(mapType(pt)))
             pts
+          case pt: PolyType => pt.resultType match {
+            case mt: MethodType =>
+              val pts = new ArrayList[JavaType]()
+              mt.paramInfos.foreach(pt2 => pts.add(mapType(pt2)))
+              pts
+            case _ => null
+          }
           case _ => null
         }
-        case _ => null
-      }
 
-      val declaringType = try {
-        TypeUtils.asFullyQualified(mapType(sym.owner.info))
-      } catch {
-        case _: Throwable => null
-      }
-      val returnType = mapType(sym.info.finalResultType)
+        val declaringType = try {
+          TypeUtils.asFullyQualified(mapType(sym.owner.info))
+        } catch {
+          case _: Throwable => null
+        }
+        val returnType = mapType(sym.info.finalResultType)
 
-      method.unsafeSet(declaringType, returnType, paramTypes, null, null)
-      method
-    })
+        method.unsafeSet(declaringType, returnType, paramTypes, null, null)
+      })
   }
 
   def mapVariableType(sym: Symbol): JavaType.Variable = {
@@ -556,12 +556,12 @@ class ScalaTypeMapping(typeFactory: JavaTypeFactory, typedTree: tpd.Tree)(using 
   /** Create a constructor method type for a given class type. */
   def mapConstructorType(fq: JavaType.FullyQualified): JavaType.Method = {
     val sig = fq.getFullyQualifiedName + "{name=<constructor>,return=" + fq.getFullyQualifiedName + ",parameters=[]}"
-    typeFactory.methodFor(sig, () => {
-      val method = new JavaType.Method(null, Flag.Public.getBitMask, null, "<constructor>",
-        null, null.asInstanceOf[Array[String]], null, null, null, null, null)
-      method.unsafeSet(fq, fq, java.util.Collections.emptyList[JavaType](), null, null)
-      method
-    })
+    typeFactory.methodFor(sig,
+      () => new JavaType.Method(null, Flag.Public.getBitMask, null, "<constructor>",
+        null, null.asInstanceOf[Array[String]], null, null, null, null, null),
+      (method: JavaType.Method) => {
+        method.unsafeSet(fq, fq, java.util.Collections.emptyList[JavaType](), null, null)
+      })
   }
 
   // --- Helpers ---


### PR DESCRIPTION
## What's changed?

`DefaultJavaTypeFactory.methodFor` now takes a stub supplier plus an initializer (the same shape as `computeClass`), caching the bare `JavaType.Method` **before** running the initializer. A re-entrant lookup on the same signature then resolves to the in-progress instance instead of recursing.

## What's your motivation?

Parsing source with self-referential method-attribution graphs throws `StackOverflowError`. The canonical trigger is the Spring `@AliasFor` shape: `value()` is annotated `@AliasFor`, and `@AliasFor`'s element is `value()`. Attributing `value()` lists its annotations → resolves `@AliasFor`'s element method → lists *its* annotations → back to `value()`, with no cached placeholder to break the cycle.

- The #7861 `JavaTypeFactory` redesign moved method construction into a `Supplier<JavaType.Method>` that builds-then-caches. That dropped the cache-as-cycle-breaker the prior `ReloadableJavaNNTypeMapping` code provided by putting a placeholder in the `JavaTypeCache` **before** resolving the method body. `computeClass` / `computeParameterized` / `computeGenericTypeVariable` kept the stub-then-initialize shape; `methodFor` did not. This restores it for `methodFor`.

## Anything in particular you'd like reviewers to focus on?

- This is an **alternative to #7865**. Per the review feedback there ("isn't that why we have the signature and the cache already?"), this uses the existing signature + `JavaTypeCache` as the cycle-breaker — mirroring `computeClass` — rather than adding a separate `methodsInProgress` map.

All `JavaTypeMapping` callers are updated to the 3-arg shape: javac `8/11/17/21/25`, `JavaReflectionTypeMapping`, Groovy, Kotlin, and Scala.

### Checklist
- [x] I've added a regression test (`DefaultJavaTypeFactoryTest`) covering the self-referential cycle.
