### PR TITLE
Make `AdaptiveRadixTree` stack-safe (iterative search, insert, and copy)

### DIFF
--- a/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/core/AdaptiveRadixTreeBenchmark.java
+++ b/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/core/AdaptiveRadixTreeBenchmark.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.core;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.internal.AdaptiveRadixTree;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Compares {@link AdaptiveRadixTree} insert/search throughput and per-operation allocation.
+ * <p>
+ * Two key shapes are exercised:
+ * <ul>
+ *   <li><b>signatures</b> — synthetic Java type signatures with heavy shared prefixes, modelling
+ *       the {@code JavaTypeCache} workload (the only production user of this structure).</li>
+ *   <li><b>deepChain</b> — strict extensions ("a", "aa", "aaa", ...), which build a chain of
+ *       {@code keyLength==0} internal nodes one level per byte. This isolates the per-descent-level
+ *       cost, which is where the recursive→iterative rewrite differs most.</li>
+ * </ul>
+ * Run with the {@code gc} profiler to compare {@code ·gc.alloc.rate.norm} (bytes/op).
+ */
+@Fork(1)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class AdaptiveRadixTreeBenchmark {
+
+    @State(Scope.Benchmark)
+    public static class Data {
+        List<byte[]> signatures;
+        List<byte[]> deepChain;
+
+        AdaptiveRadixTree<Integer> prebuiltSignatures;
+        AdaptiveRadixTree<Integer> prebuiltDeepChain;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            signatures = generateSignatures();
+            deepChain = generateDeepChain(2_000);
+
+            prebuiltSignatures = build(signatures);
+            prebuiltDeepChain = build(deepChain);
+        }
+
+        private static AdaptiveRadixTree<Integer> build(List<byte[]> keys) {
+            AdaptiveRadixTree<Integer> tree = new AdaptiveRadixTree<>();
+            for (int i = 0; i < keys.size(); i++) {
+                tree.insert(keys.get(i), i);
+            }
+            return tree;
+        }
+
+        private static List<byte[]> generateSignatures() {
+            String[] roots = {
+                    "java.lang", "java.util", "java.util.concurrent", "java.util.stream",
+                    "java.io", "java.nio.file", "com.example.app.service", "com.example.app.model",
+                    "org.openrewrite.java.tree", "org.openrewrite.java.internal",
+            };
+            String[] returns = {"void", "boolean", "int", "java.lang.String", "java.util.List", "java.lang.Object"};
+            List<byte[]> keys = new ArrayList<>();
+            for (String root : roots) {
+                for (int c = 0; c < 25; c++) {
+                    String cls = root + ".Class" + c;
+                    keys.add(cls.getBytes(StandardCharsets.UTF_8));
+                    for (int f = 0; f < 6; f++) {
+                        keys.add((cls + " field" + f).getBytes(StandardCharsets.UTF_8));
+                    }
+                    for (int m = 0; m < 12; m++) {
+                        String ret = returns[m % returns.length];
+                        String params = m % 3 == 0 ? "" :
+                                m % 3 == 1 ? "java.lang.String" :
+                                        "java.lang.String,int,java.util.List";
+                        keys.add((cls + "{name=method" + m + ",return=" + ret +
+                                  ",parameters=[" + params + "]}").getBytes(StandardCharsets.UTF_8));
+                    }
+                }
+            }
+            return keys;
+        }
+
+        private static List<byte[]> generateDeepChain(int depth) {
+            List<byte[]> keys = new ArrayList<>(depth);
+            StringBuilder sb = new StringBuilder(depth);
+            for (int i = 0; i < depth; i++) {
+                sb.append('a');
+                keys.add(sb.toString().getBytes(StandardCharsets.UTF_8));
+            }
+            return keys;
+        }
+    }
+
+    @Benchmark
+    public AdaptiveRadixTree<Integer> insertSignatures(Data data) {
+        AdaptiveRadixTree<Integer> tree = new AdaptiveRadixTree<>();
+        List<byte[]> keys = data.signatures;
+        for (int i = 0; i < keys.size(); i++) {
+            tree.insert(keys.get(i), i);
+        }
+        return tree;
+    }
+
+    @Benchmark
+    public void searchSignatures(Data data, Blackhole bh) {
+        List<byte[]> keys = data.signatures;
+        for (int i = 0; i < keys.size(); i++) {
+            bh.consume(data.prebuiltSignatures.search(keys.get(i)));
+        }
+    }
+
+    @Benchmark
+    public AdaptiveRadixTree<Integer> insertDeepChain(Data data) {
+        AdaptiveRadixTree<Integer> tree = new AdaptiveRadixTree<>();
+        List<byte[]> keys = data.deepChain;
+        for (int i = 0; i < keys.size(); i++) {
+            tree.insert(keys.get(i), i);
+        }
+        return tree;
+    }
+
+    @Benchmark
+    public void searchDeepChain(Data data, Blackhole bh) {
+        List<byte[]> keys = data.deepChain;
+        for (int i = 0; i < keys.size(); i++) {
+            bh.consume(data.prebuiltDeepChain.search(keys.get(i)));
+        }
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(AdaptiveRadixTreeBenchmark.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/internal/AdaptiveRadixTree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/AdaptiveRadixTree.java
@@ -19,7 +19,9 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Incubating;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 @Incubating(since = "8.38.0")
 public class AdaptiveRadixTree<V> {
@@ -201,57 +203,93 @@ public class AdaptiveRadixTree<V> {
 
         @Override
         Node<V> insert(byte[] key, int depth, V value, KeyTable keyTable) {
-            if (!matchesPartialKey(key, depth, keyTable)) {
-                // Find common prefix length
-                int commonPrefix = 0;
-                int maxLength = Math.min(key.length - depth, keyLength);
-                while (commonPrefix < maxLength && key[depth + commonPrefix] == keyTable.get(keyOffset + commonPrefix)) {
-                    commonPrefix++;
+            // Iterative descent: each step strictly advances `depth`, so we bound work
+            // by the key length rather than the JVM stack. We push every internal node
+            // we pass through onto a path stack and, after performing the terminal
+            // action, walk back up rewriting child slots only as far as a node's
+            // identity actually changes.
+            List<InternalNode<V>> pathNodes = new ArrayList<>();
+            List<Byte> pathSlots = new ArrayList<>();
+            InternalNode<V> current = this;
+            Node<V> replacement;
+
+            while (true) {
+                if (current.keyLength != 0) {
+                    if (!current.matchesPartialKey(key, depth, keyTable)) {
+                        int commonPrefix = 0;
+                        int maxLength = Math.min(key.length - depth, current.keyLength);
+                        while (commonPrefix < maxLength &&
+                               key[depth + commonPrefix] == keyTable.get(current.keyOffset + commonPrefix)) {
+                            commonPrefix++;
+                        }
+
+                        Node4<V> newNode = current.split(commonPrefix, keyTable);
+
+                        int remainingNewLength = key.length - (depth + commonPrefix);
+                        if (remainingNewLength > 0) {
+                            byte firstByte = key[depth + commonPrefix];
+                            Node<V> leafNode = LeafNode.create(
+                                    key, depth + commonPrefix + 1, remainingNewLength - 1,
+                                    value, keyTable);
+                            InternalNode<V> grown = newNode.addChild(firstByte, leafNode, keyTable);
+                            replacement = grown != null ? grown : newNode;
+                        } else {
+                            newNode.value = value;
+                            replacement = newNode;
+                        }
+                        break;
+                    }
+                    depth += current.keyLength;
                 }
 
-                Node4<V> newNode = split(commonPrefix, keyTable);
-
-                // Handle remaining parts of new key
-                int remainingNewLength = key.length - (depth + commonPrefix);
-                if (remainingNewLength > 0) {
-                    byte firstByte = key[depth + commonPrefix];
-                    Node<V> leafNode = LeafNode.create(
-                            key, depth + commonPrefix + 1, remainingNewLength - 1,
-                            value, keyTable);
-                    InternalNode<V> grown = newNode.addChild(firstByte, leafNode, keyTable);
-                    return grown != null ? grown : newNode;
-                } else {
-                    newNode.value = value;
-                    return newNode;
+                if (depth == key.length) {
+                    current.value = value;
+                    replacement = current;
+                    break;
                 }
+
+                byte nextByte = key[depth];
+                Node<V> child = current.getChild(nextByte);
+
+                if (child == null) {
+                    Node<V> newChild = LeafNode.create(key, depth + 1, key.length - (depth + 1), value, keyTable);
+                    InternalNode<V> grown = current.addChild(nextByte, newChild, keyTable);
+                    replacement = grown != null ? grown : current;
+                    break;
+                }
+
+                if (!(child instanceof InternalNode)) {
+                    // LeafNode.insert is non-recursive and may return a new node.
+                    Node<V> newChild = child.insert(key, depth + 1, value, keyTable);
+                    if (newChild != child) {
+                        InternalNode<V> grown = current.addChild(nextByte, newChild, keyTable);
+                        replacement = grown != null ? grown : current;
+                    } else {
+                        replacement = current;
+                    }
+                    break;
+                }
+
+                pathNodes.add(current);
+                pathSlots.add(nextByte);
+                current = (InternalNode<V>) child;
+                depth++;
             }
 
-            depth += keyLength;
-
-            // We've reached the end of the key
-            if (depth == key.length) {
-                this.value = value;
-                return this;
+            // Walk back up. At each ancestor, point its slot at `replacement`. If the
+            // ancestor itself grew, that grown node becomes the next iteration's
+            // replacement; otherwise the ancestor's identity is preserved and nothing
+            // above needs touching, since their child pointers still resolve to it.
+            for (int i = pathNodes.size() - 1; i >= 0; i--) {
+                InternalNode<V> ancestor = pathNodes.get(i);
+                byte slot = pathSlots.get(i);
+                InternalNode<V> grown = ancestor.addChild(slot, replacement, keyTable);
+                if (grown == null) {
+                    return this;
+                }
+                replacement = grown;
             }
-
-            // Continue with child node
-            byte nextByte = key[depth];
-            Node<V> child = getChild(nextByte);
-
-            if (child == null) {
-                // Create new leaf node
-                Node<V> newChild = LeafNode.create(key, depth + 1, key.length - (depth + 1), value, keyTable);
-                InternalNode<V> grown = addChild(nextByte, newChild, keyTable);
-                return grown != null ? grown : this;
-            }
-
-            // Recursively insert into child node
-            Node<V> newChild = child.insert(key, depth + 1, value, keyTable);
-            if (newChild != child) {
-                InternalNode<V> grown = addChild(nextByte, newChild, keyTable);
-                return grown != null ? grown : this;
-            }
-            return this;
+            return replacement;
         }
 
         private Node4<V> split(int commonPrefix, KeyTable keyTable) {

--- a/rewrite-core/src/main/java/org/openrewrite/internal/AdaptiveRadixTree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/AdaptiveRadixTree.java
@@ -19,9 +19,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Incubating;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 @Incubating(since = "8.38.0")
 public class AdaptiveRadixTree<V> {
@@ -204,12 +202,14 @@ public class AdaptiveRadixTree<V> {
         @Override
         Node<V> insert(byte[] key, int depth, V value, KeyTable keyTable) {
             // Iterative descent: each step strictly advances `depth`, so we bound work
-            // by the key length rather than the JVM stack. We push every internal node
-            // we pass through onto a path stack and, after performing the terminal
-            // action, walk back up rewriting child slots only as far as a node's
-            // identity actually changes.
-            List<InternalNode<V>> pathNodes = new ArrayList<>();
-            List<Byte> pathSlots = new ArrayList<>();
+            // by the key length rather than the JVM stack. Only the immediate parent of
+            // the node where the terminal action happens can ever need its child slot
+            // repointed: every slot we descend through already exists in its node, so
+            // `addChild` replaces it in place (returning null) and never grows an
+            // ancestor. Ancestors above that parent keep their identity, so the original
+            // root is returned unchanged.
+            InternalNode<V> parent = null;
+            byte parentSlot = 0;
             InternalNode<V> current = this;
             Node<V> replacement;
 
@@ -270,26 +270,23 @@ public class AdaptiveRadixTree<V> {
                     break;
                 }
 
-                pathNodes.add(current);
-                pathSlots.add(nextByte);
+                parent = current;
+                parentSlot = nextByte;
                 current = (InternalNode<V>) child;
                 depth++;
             }
 
-            // Walk back up. At each ancestor, point its slot at `replacement`. If the
-            // ancestor itself grew, that grown node becomes the next iteration's
-            // replacement; otherwise the ancestor's identity is preserved and nothing
-            // above needs touching, since their child pointers still resolve to it.
-            for (int i = pathNodes.size() - 1; i >= 0; i--) {
-                InternalNode<V> ancestor = pathNodes.get(i);
-                byte slot = pathSlots.get(i);
-                InternalNode<V> grown = ancestor.addChild(slot, replacement, keyTable);
-                if (grown == null) {
-                    return this;
-                }
-                replacement = grown;
+            // No ancestor was traversed: `replacement` is the new root of this subtree.
+            if (parent == null) {
+                return replacement;
             }
-            return replacement;
+            // Point the immediate parent's existing slot at `replacement`. Because the
+            // slot already exists, this replaces in place without growing the parent, so
+            // every ancestor above keeps its identity and the original root stays valid.
+            if (replacement != current) {
+                parent.addChild(parentSlot, replacement, keyTable);
+            }
+            return this;
         }
 
         private Node4<V> split(int commonPrefix, KeyTable keyTable) {

--- a/rewrite-core/src/main/java/org/openrewrite/internal/AdaptiveRadixTree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/AdaptiveRadixTree.java
@@ -19,7 +19,9 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Incubating;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Deque;
 
 @Incubating(since = "8.38.0")
 public class AdaptiveRadixTree<V> {
@@ -50,7 +52,12 @@ public class AdaptiveRadixTree<V> {
 
         abstract Node<V> insert(byte[] key, int depth, V value, KeyTable keyTable);
 
-        abstract Node<V> copy(); // New abstract method
+        /**
+         * Clone this node without recursing into children: child references are copied
+         * as-is. Whole-tree deep copies are assembled iteratively by
+         * {@link AdaptiveRadixTree#deepCopy} so they are bounded by heap, not the JVM stack.
+         */
+        abstract Node<V> shallowCopy();
 
         protected boolean matchesPartialKey(byte[] key, int depth, KeyTable keyTable) {
             return keyTable.matches(key, depth, keyOffset, keyLength);
@@ -147,7 +154,7 @@ public class AdaptiveRadixTree<V> {
         }
 
         @Override
-        Node<V> copy() {
+        Node<V> shallowCopy() {
             return new LeafNode<>(keyOffset, keyLength, value);
         }
     }
@@ -164,6 +171,21 @@ public class AdaptiveRadixTree<V> {
 
         // Return the new node if growth occurred, otherwise null
         abstract @Nullable InternalNode<V> addChild(byte key, Node<V> child, KeyTable keyTable);
+
+        /**
+         * Replace each child reference (initially shared with the source node after a
+         * {@link #shallowCopy()}) with a shallow clone of it, pushing any internal clone
+         * onto {@code work} so its own children get cloned in turn.
+         */
+        abstract void cloneChildrenInto(Deque<InternalNode<V>> work);
+
+        static <V> Node<V> pushClone(Node<V> child, Deque<InternalNode<V>> work) {
+            Node<V> clone = child.shallowCopy();
+            if (clone instanceof InternalNode) {
+                work.push((InternalNode<V>) clone);
+            }
+            return clone;
+        }
 
         void adjustKey(int newKeyOffset, int newKeyLength) {
             this.keyOffset = newKeyOffset;
@@ -424,9 +446,8 @@ public class AdaptiveRadixTree<V> {
             return null;
         }
 
-        @SuppressWarnings("DataFlowIssue")
         @Override
-        Node<V> copy() {
+        Node<V> shallowCopy() {
             Node4<V> clone = new Node4<>(keyOffset, keyLength);
             clone.value = this.value;
             clone.size = this.size;
@@ -434,11 +455,20 @@ public class AdaptiveRadixTree<V> {
             clone.k1 = this.k1;
             clone.k2 = this.k2;
             clone.k3 = this.k3;
-            if (size > 0) clone.c0 = c0.copy();
-            if (size > 1) clone.c1 = c1.copy();
-            if (size > 2) clone.c2 = c2.copy();
-            if (size > 3) clone.c3 = c3.copy();
+            clone.c0 = this.c0;
+            clone.c1 = this.c1;
+            clone.c2 = this.c2;
+            clone.c3 = this.c3;
             return clone;
+        }
+
+        @SuppressWarnings("DataFlowIssue")
+        @Override
+        void cloneChildrenInto(Deque<InternalNode<V>> work) {
+            if (size > 0) c0 = pushClone(c0, work);
+            if (size > 1) c1 = pushClone(c1, work);
+            if (size > 2) c2 = pushClone(c2, work);
+            if (size > 3) c3 = pushClone(c3, work);
         }
     }
 
@@ -529,18 +559,21 @@ public class AdaptiveRadixTree<V> {
         }
 
         @Override
-        Node<V> copy() {
+        Node<V> shallowCopy() {
             Node16<V> clone = new Node16<>(keyOffset, keyLength);
             clone.value = this.value;
             clone.size = this.size;
             clone.keys = Arrays.copyOf(this.keys, this.keys.length);
             clone.children = Arrays.copyOf(this.children, this.children.length);
-            // Deep copy children
+            return clone;
+        }
+
+        @Override
+        void cloneChildrenInto(Deque<InternalNode<V>> work) {
             for (int i = 0; i < size; i++) {
                 //noinspection DataFlowIssue
-                clone.children[i] = children[i].copy();
+                children[i] = pushClone(children[i], work);
             }
-            return clone;
         }
     }
 
@@ -728,23 +761,23 @@ public class AdaptiveRadixTree<V> {
         }
 
         @Override
-        Node<V> copy() {
+        Node<V> shallowCopy() {
             Node64<V> clone = new Node64<>(keyOffset, keyLength);
             clone.value = this.value;
             clone.bitmap0 = this.bitmap0;
             clone.bitmap1 = this.bitmap1;
             clone.bitmap2 = this.bitmap2;
             clone.bitmap3 = this.bitmap3;
-
-            clone.children = new Node[this.children.length];
-
-            // Deep copy children
-            for (int i = 0; i < this.children.length; i++) {
-                //noinspection DataFlowIssue
-                clone.children[i] = this.children[i].copy();
-            }
-
+            clone.children = Arrays.copyOf(this.children, this.children.length);
             return clone;
+        }
+
+        @Override
+        void cloneChildrenInto(Deque<InternalNode<V>> work) {
+            for (int i = 0; i < children.length; i++) {
+                //noinspection DataFlowIssue
+                children[i] = pushClone(children[i], work);
+            }
         }
     }
 
@@ -772,18 +805,20 @@ public class AdaptiveRadixTree<V> {
         }
 
         @Override
-        Node<V> copy() {
+        Node<V> shallowCopy() {
             Node256<V> clone = new Node256<>(keyOffset, keyLength);
             clone.value = this.value;
             System.arraycopy(this.children, 0, clone.children, 0, this.children.length);
-            // Deep copy children
+            return clone;
+        }
+
+        @Override
+        void cloneChildrenInto(Deque<InternalNode<V>> work) {
             for (int i = 0; i < 256; i++) {
-                Node<V> child = children[i];
-                if (child != null) {
-                    clone.children[i] = child.copy();
+                if (children[i] != null) {
+                    children[i] = pushClone(children[i], work);
                 }
             }
-            return clone;
         }
     }
 
@@ -812,9 +847,24 @@ public class AdaptiveRadixTree<V> {
     public AdaptiveRadixTree<V> copy() {
         AdaptiveRadixTree<V> newTree = new AdaptiveRadixTree<>(keyTable.copy());
         if (root != null) {
-            newTree.root = root.copy();
+            newTree.root = deepCopy(root);
         }
         return newTree;
+    }
+
+    // Iterative deep copy: clone the root shallowly, then repeatedly replace each cloned
+    // node's child references with shallow clones of their own. An explicit stack bounds
+    // the work by heap rather than the JVM call stack, matching insert/search.
+    private static <V> Node<V> deepCopy(Node<V> root) {
+        Node<V> rootClone = root.shallowCopy();
+        if (rootClone instanceof InternalNode) {
+            Deque<InternalNode<V>> work = new ArrayDeque<>();
+            work.push((InternalNode<V>) rootClone);
+            while (!work.isEmpty()) {
+                work.pop().cloneChildrenInto(work);
+            }
+        }
+        return rootClone;
     }
 
     public void clear() {

--- a/rewrite-core/src/main/java/org/openrewrite/internal/AdaptiveRadixTree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/AdaptiveRadixTree.java
@@ -173,26 +173,30 @@ public class AdaptiveRadixTree<V> {
         @Override
         @Nullable
         V search(byte[] key, int depth, KeyTable keyTable) {
-            // Fast path for empty partial key
-            if (keyLength == 0) {
-                if (depth == key.length) {
-                    return value;
+            // Iterative descent: each step strictly advances `depth`, so we bound work
+            // by the key length rather than the JVM stack. LeafNode.search remains
+            // non-recursive and is delegated to when we land on one.
+            InternalNode<V> node = this;
+            while (true) {
+                if (node.keyLength != 0) {
+                    if (!node.matchesPartialKey(key, depth, keyTable)) return null;
+                    depth += node.keyLength;
                 }
-                Node<V> child = getChild(key[depth]);
-                return child != null ? child.search(key, depth + 1, keyTable) : null;
+
+                if (depth == key.length) {
+                    return node.value;
+                }
+
+                Node<V> child = node.getChild(key[depth]);
+                if (child == null) return null;
+                depth++;
+
+                if (child instanceof InternalNode) {
+                    node = (InternalNode<V>) child;
+                } else {
+                    return child.search(key, depth, keyTable);
+                }
             }
-
-            if (!matchesPartialKey(key, depth, keyTable)) return null;
-            depth += keyLength;
-
-            // We've reached the end of the search key
-            if (depth == key.length) {
-                return value;
-            }
-
-            // If there's more key to search but we've found a value, keep searching
-            Node<V> child = getChild(key[depth]);
-            return child != null ? child.search(key, depth + 1, keyTable) : null;
         }
 
         @Override

--- a/rewrite-core/src/test/java/org/openrewrite/internal/AdaptiveRadixTreeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/AdaptiveRadixTreeTest.java
@@ -82,6 +82,39 @@ class AdaptiveRadixTreeTest {
     }
 
     @Test
+    void copySurvivesDeepChainOnSmallStack() throws Exception {
+        // A deep chain of keyLength=0 internal nodes makes a recursive copy() walk one
+        // frame per level. Build the tree on the main thread (insert is iterative), then
+        // copy on a small-stack thread so the regression is caught regardless of
+        // JVM/platform defaults. The copy must be both complete and independent.
+        int depth = 20_000;
+        AdaptiveRadixTree<Integer> tree = new AdaptiveRadixTree<>();
+        StringBuilder sb = new StringBuilder(depth);
+        for (int i = 1; i <= depth; i++) {
+            sb.append('a');
+            tree.insert(sb.toString(), i);
+        }
+        String longest = sb.toString();
+
+        Throwable[] error = new Throwable[1];
+        Thread t = new Thread(null, () -> {
+            AdaptiveRadixTree<Integer> copy = tree.copy();
+            assertThat(copy.search(longest)).isEqualTo(depth);
+            assertThat(copy.search("a")).isEqualTo(1);
+            // A deep copy must be independent: mutating it must not affect the original.
+            copy.insert(longest, -1);
+            assertThat(copy.search(longest)).isEqualTo(-1);
+            assertThat(tree.search(longest)).isEqualTo(depth);
+        }, "AdaptiveRadixTreeTest-copySmallStack", 128 * 1024);
+        t.setUncaughtExceptionHandler((thr, ex) -> error[0] = ex);
+        t.start();
+        t.join();
+        if (error[0] != null) {
+            throw new AssertionError("copy() failed on 128KB stack", error[0]);
+        }
+    }
+
+    @Test
     void insertAndSearch_MultipleKeys() {
         AdaptiveRadixTree<Integer> tree = new AdaptiveRadixTree<>();
         tree.insert("cat", 1);

--- a/rewrite-core/src/test/java/org/openrewrite/internal/AdaptiveRadixTreeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/AdaptiveRadixTreeTest.java
@@ -34,20 +34,30 @@ class AdaptiveRadixTreeTest {
     }
 
     @Test
-    void searchSurvivesDeepChain() {
+    void surviveDeepChainOnSmallStack() throws Exception {
         // Inserting a family of strict-extension keys ("a", "aa", "aaa", ...) builds
         // a chain of keyLength=0 internal nodes — one per extension. A recursive
-        // search walks one stack frame per byte of the longest key. With JVM defaults
-        // ~10k frames blows the stack; with the iterative implementation, even much
-        // longer keys are bounded by memory rather than the stack.
-        AdaptiveRadixTree<Integer> tree = new AdaptiveRadixTree<>();
-        int depth = 20_000;
-        StringBuilder sb = new StringBuilder(depth);
-        for (int i = 1; i <= depth; i++) {
-            sb.append('a');
-            tree.insert(sb.toString(), i);
+        // insert/search would walk one frame per byte; with the iterative
+        // implementation, even much longer keys are bounded by memory rather than the
+        // stack. Run on a small-stack thread so that the regression catches the bug
+        // regardless of JVM/platform defaults.
+        Throwable[] error = new Throwable[1];
+        Thread t = new Thread(null, () -> {
+            AdaptiveRadixTree<Integer> tree = new AdaptiveRadixTree<>();
+            int depth = 20_000;
+            StringBuilder sb = new StringBuilder(depth);
+            for (int i = 1; i <= depth; i++) {
+                sb.append('a');
+                tree.insert(sb.toString(), i);
+            }
+            assertThat(tree.search(sb.toString())).isEqualTo(depth);
+        }, "AdaptiveRadixTreeTest-smallStack", 128 * 1024);
+        t.setUncaughtExceptionHandler((thr, ex) -> error[0] = ex);
+        t.start();
+        t.join();
+        if (error[0] != null) {
+            throw new AssertionError("Failed on 128KB stack", error[0]);
         }
-        assertThat(tree.search(sb.toString())).isEqualTo(depth);
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/internal/AdaptiveRadixTreeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/AdaptiveRadixTreeTest.java
@@ -34,6 +34,23 @@ class AdaptiveRadixTreeTest {
     }
 
     @Test
+    void searchSurvivesDeepChain() {
+        // Inserting a family of strict-extension keys ("a", "aa", "aaa", ...) builds
+        // a chain of keyLength=0 internal nodes — one per extension. A recursive
+        // search walks one stack frame per byte of the longest key. With JVM defaults
+        // ~10k frames blows the stack; with the iterative implementation, even much
+        // longer keys are bounded by memory rather than the stack.
+        AdaptiveRadixTree<Integer> tree = new AdaptiveRadixTree<>();
+        int depth = 20_000;
+        StringBuilder sb = new StringBuilder(depth);
+        for (int i = 1; i <= depth; i++) {
+            sb.append('a');
+            tree.insert(sb.toString(), i);
+        }
+        assertThat(tree.search(sb.toString())).isEqualTo(depth);
+    }
+
+    @Test
     void fullInternaNode() {
         AdaptiveRadixTree<Integer> tree = new AdaptiveRadixTree<>();
         tree.insert("cat", 1);


### PR DESCRIPTION
## Motivation

`AdaptiveRadixTree` traversed and duplicated its nodes recursively: `InternalNode.search`, `InternalNode.insert`, and `copy()` each consumed one JVM stack frame per tree level. For normal keys that depth is bounded by the key length, but a chain of `keyLength == 0` internal nodes — which `LeafNode.insert` builds when you insert a strict-extension family like `"a"`, `"aa"`, `"aaa"`, … (one link per extension) — makes the depth unbounded by the data. Searching, inserting, or copying the longest such key then walks one frame per byte and throws `StackOverflowError` once the path exceeds the JVM's default stack (~10k frames).

This PR makes all three traversals iterative (heap-bounded) and removes a per-insert allocation regression that the first iterative `insert` draft had introduced.

## Summary

- **`search`** — rewritten as a `while`-loop. Each iteration strictly advances `depth` (consuming the node's partial key plus one slot byte, or just a slot byte for `keyLength == 0` nodes), and the descent delegates to the already-non-recursive `LeafNode.search` on reaching a leaf. Semantics are unchanged: same partial-key matching, same termination on `depth == key.length`, same null-on-missing-child behavior.
- **`insert`** — rewritten iteratively. The terminal action (split / value set / new leaf / leaf delegation) produces the new subtree root; because every slot descended through already exists in its node, `addChild` always replaces in place and never grows an ancestor, so only the **immediate parent** needs its slot repointed and the original root is returned unchanged. This is tracked with a single `parent`+`slot` pair, so there is **no per-insert heap allocation** — an earlier draft kept the full descent path in two `ArrayList`s (one boxing every slot byte), which this removes.
- **`copy()`** — converted from a recursive deep-copy to an iterative one. Each node now exposes a non-recursive `shallowCopy()` (clones its own fields and child references) plus `cloneChildrenInto()`, and a driver walks an explicit work stack bounded by heap rather than the call stack.
- Added `AdaptiveRadixTreeBenchmark` (JMH) covering insert/search for realistic shared-prefix type signatures and for deep chains, gc-profiled.

## Performance

Iterative + single-parent `insert`/`search` vs. the recursive baseline (local JMH, 2 forks × 10 iterations, `gc` profiler):

| Benchmark | Baseline (recursive) | This PR |
|---|---|---|
| insert (type signatures) | 2.02 ops/ms · 843,266 B/op | 2.09 ops/ms · 843,266 B/op |
| insert (deep chain) | 0.060 ops/ms · 190,410 B/op | 0.125 ops/ms · 190,380 B/op |
| search (type signatures) | 1.77 ops/ms | 2.18 ops/ms |
| search (deep chain) | 0.062 ops/ms | 0.116 ops/ms |

Insert allocation is byte-for-byte identical to the recursive baseline (the draft's regression is eliminated), deep-chain insert/search are ~2× faster, and the realistic workloads are at parity or better.

## Test plan

- `surviveDeepChainOnSmallStack` inserts and searches a 20,000-deep chain on a 128 KB-stack thread; it `StackOverflowError`s on the recursive code and passes here.
- `copySurvivesDeepChainOnSmallStack` copies a 20,000-deep chain on a 128 KB-stack thread and asserts the copy is complete and independent of the original.
- Existing `AdaptiveRadixTreeTest` cases (including `copy`) pass unchanged.
- `./gradlew :rewrite-core:test` green.
