### PR TITLE
Resolve RPC wire type names through the codec (SourceFile subclasses + JavaType)

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -90,33 +91,53 @@ public abstract class DynamicDispatchRpcCodec<T> implements RpcCodec<T> {
 
     @SuppressWarnings("unchecked")
     public static <T> @Nullable RpcCodec<T> getCodec(Object t, @Nullable String sourceFileType) {
-        if (sourceFileType == null) {
-            return null;
-        }
         // Discover codecs from any classloader we haven't seen yet. Covers plugin/recipe
         // classloaders that weren't visible when this class's static initializer ran.
         discoverFrom(Thread.currentThread().getContextClassLoader());
         discoverFrom(t.getClass().getClassLoader());
-        for (DynamicDispatchRpcCodec<?> codec : CODEC_BY_TYPE.getOrDefault(sourceFileType, emptyList())) {
-            if (codec.getType().isAssignableFrom(t.getClass())) {
-                return (RpcCodec<T>) codec;
-            }
-        }
-        // Defense-in-depth: the keyed bucket missed. This happens when {@code sourceFileType}
-        // is a proxy/subclass runtime class name rather
-        // than the canonical registered type, including when such a string arrives from a
-        // remote. Scan all registered codecs for one assignable from the instance's runtime
-        // type. {@code getType()} is a language marker interface (e.g. Xml, Json), so at most
-        // one language's codec is assignable from a given tree instance.
-        for (List<DynamicDispatchRpcCodec<?>> bucket : CODEC_BY_TYPE.values()) {
-            for (DynamicDispatchRpcCodec<?> codec : bucket) {
+        // The source-file-keyed lookup is an override hook for language-specific codecs; it needs
+        // a key. A cross-cutting value (e.g. JavaType) has no enclosing source file type, so it is
+        // resolved purely by assignability below, which is why the keyed lookup is skipped (not
+        // short-circuited to null) when sourceFileType is absent.
+        if (sourceFileType != null) {
+            for (DynamicDispatchRpcCodec<?> codec : CODEC_BY_TYPE.getOrDefault(sourceFileType, emptyList())) {
                 if (codec.getType().isAssignableFrom(t.getClass())) {
                     return (RpcCodec<T>) codec;
                 }
             }
         }
-        return null;
+        // The keyed bucket missed. This happens when {@code sourceFileType} is a proxy/subclass
+        // runtime class name rather than the canonical registered type (including when such a
+        // string arrives from a remote), or when {@code t} is a cross-cutting value type (e.g.
+        // JavaType) whose codec is not registered under the enclosing source file's type. Resolve
+        // by assignability, cached per value class so this stays off the per-node hot path.
+        return (RpcCodec<T>) FALLBACK_CODEC.get(t.getClass()).orElse(null);
     }
+
+    /**
+     * Caches, per value class, the codec resolved by scanning all registered codecs for one
+     * whose {@link #getType()} is assignable from that class. {@code getType()} is a language
+     * marker (e.g. {@code Xml}, {@code Json}, {@code JavaType}), so at most one codec matches a
+     * given value. The scan runs once per value class; the result is then memoized for the life
+     * of the class.
+     */
+    private static final ClassValue<Optional<DynamicDispatchRpcCodec<?>>> FALLBACK_CODEC =
+            new ClassValue<Optional<DynamicDispatchRpcCodec<?>>>() {
+                @Override
+                protected Optional<DynamicDispatchRpcCodec<?>> computeValue(Class<?> valueClass) {
+                    // Mirror getCodec's discovery so a value's own codec (carried by its
+                    // classloader) is registered before we scan, then cache the result.
+                    discoverFrom(valueClass.getClassLoader());
+                    for (List<DynamicDispatchRpcCodec<?>> bucket : CODEC_BY_TYPE.values()) {
+                        for (DynamicDispatchRpcCodec<?> codec : bucket) {
+                            if (codec.getType().isAssignableFrom(valueClass)) {
+                                return Optional.of(codec);
+                            }
+                        }
+                    }
+                    return Optional.empty();
+                }
+            };
 
     /**
      * Memoized per {@link Class}: see {@link #canonicalSourceFileType(Class)}.

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
@@ -156,6 +156,29 @@ public abstract class DynamicDispatchRpcCodec<T> implements RpcCodec<T> {
         return CANONICAL_SOURCE_FILE_TYPE.get(type);
     }
 
+    /**
+     * Canonicalizes a (possibly subclassed) value's runtime type to the topmost class still
+     * assignable to this codec's {@link #getType()} language marker. When a tree is represented
+     * at runtime by a synthetic subclass generated outside the {@code org.openrewrite} packages,
+     * its {@code getClass().getName()} is a name the remote cannot reconstruct, because the
+     * remote resolves codecs by exact string match. Walking up while the superclass remains
+     * assignable to {@link #getType()} strips the synthetic layer and lands on the real tree
+     * node class (e.g. {@code J$Literal}).
+     * <p>
+     * This relies on real tree nodes sitting directly on {@link Object} (they {@code implement}
+     * their language interfaces rather than {@code extend} a base class), so for a value that is
+     * not subclassed the loop never advances and the result equals {@code value.getClass().getName()}
+     * -- behavior is unchanged. Only a synthetic subclass advances the walk.
+     */
+    @Override
+    public String valueType(Object value) {
+        Class<?> type = value.getClass();
+        for (Class<?> s = type.getSuperclass(); s != null && getType().isAssignableFrom(s); s = s.getSuperclass()) {
+            type = s;
+        }
+        return type.getName();
+    }
+
     public abstract String getSourceFileType();
 
     public abstract Class<? extends T> getType();

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcCodec.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcCodec.java
@@ -45,6 +45,21 @@ public interface RpcCodec<T> {
      */
     T rpcReceive(T before, RpcReceiveQueue q);
 
+    /**
+     * The wire type name the remote uses to reconstruct {@code value}. Defaults to the
+     * value's concrete runtime class name, which is correct for a value that encodes
+     * itself (a {@code value instanceof RpcCodec}), since such values are not represented
+     * by a generated subclass for transport. {@link DynamicDispatchRpcCodec} overrides this
+     * to canonicalize a subclassed runtime type back to the registered tree type, which is
+     * the name the remote can actually reconstruct.
+     *
+     * @param value the value being sent; its runtime type may be a generated subclass.
+     * @return the fully-qualified type name the remote should reconstruct.
+     */
+    default String valueType(Object value) {
+        return value.getClass().getName();
+    }
+
     static <T> @Nullable RpcCodec<T> forInstance(T t, @Nullable String sourceFileType) {
         // First check for a dynamic dispatch codec (allows language-specific overrides)
         RpcCodec<T> dynamicCodec = DynamicDispatchRpcCodec.getCodec(t, sourceFileType);

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -208,55 +208,25 @@ public class RpcSendQueue {
         }
     }
 
-    private static final String JAVA_TYPE_PACKAGE = "org.openrewrite.java.tree";
-    private static final String JAVA_TYPE_NAME = JAVA_TYPE_PACKAGE + ".JavaType";
-
     private static final ClassValue<@Nullable String> VALUE_TYPE_CACHE = new ClassValue<String>() {
-        private @Nullable Class<?> javaTypeClass;
-        private boolean javaTypeResolved;
-
-        private @Nullable Class<?> getJavaTypeClass(Class<?> from) {
-            if (!javaTypeResolved) {
-                try {
-                    javaTypeClass = Class.forName(JAVA_TYPE_NAME, false, from.getClassLoader());
-                } catch (ClassNotFoundException ignored) {
-                }
-                javaTypeResolved = true;
-            }
-            return javaTypeClass;
-        }
-
         @Override
         protected @Nullable String computeValue(Class<?> afterType) {
             Package pkg = afterType.getPackage();
             if (afterType.isPrimitive() || afterType.isArray() || (pkg != null && pkg.getName().startsWith("java.lang")) ||
                 afterType.equals(UUID.class) || Iterable.class.isAssignableFrom(afterType)) {
                 return null;
-            } else if (Enum.class.isAssignableFrom(afterType) && !JAVA_TYPE_NAME.concat("$Primitive").equals(afterType.getName())) {
-                // FIXME special case for `JavaType.Primitive` here
+            } else if (Enum.class.isAssignableFrom(afterType)) {
                 return null;
             }
-
-            // If the class is a subtype of JavaType but in a different package,
-            // return the superclass name instead
-            Class<?> jt = getJavaTypeClass(afterType);
-            if (jt != null && pkg != null && !pkg.getName().equals(JAVA_TYPE_PACKAGE) && jt.isAssignableFrom(afterType)) {
-                Class<?> superclass = afterType.getSuperclass();
-                if (superclass != null && !Object.class.equals(superclass)) {
-                    return superclass.getName();
-                }
-            }
-
             return afterType.getName();
         }
     };
 
     /**
-     * The wire type name for {@code after}. When a codec handles the value, the codec
-     * decides (a {@link DynamicDispatchRpcCodec} canonicalizes a proxied/subclassed runtime
-     * type back to its registered tree type); otherwise we fall back to the static
-     * {@link #getValueType(Object)} which filters out java.lang/collection/{@code JavaType}
-     * cases that have no codec.
+     * The wire type name for {@code after}. When a codec handles the value, the codec decides
+     * (a {@link DynamicDispatchRpcCodec} canonicalizes a proxied/subclassed runtime type back to
+     * its registered type); otherwise we fall back to {@link #getValueType(Object)}, which filters
+     * out the java.lang/collection/enum cases that travel as raw inlined values with no codec.
      */
     private static @Nullable String valueType(@Nullable Object after, @Nullable RpcCodec<?> codec) {
         if (after == null) {

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -121,7 +121,7 @@ public class RpcSendQueue {
             put(new RpcObjectData(DELETE, null, null, null, trace));
         } else {
             RpcCodec<Object> afterCodec = RpcCodec.forInstance(afterVal, sourceFileType);
-            put(new RpcObjectData(CHANGE, getValueType(afterVal), onChange == null && afterCodec == null ? afterVal : null, null, trace));
+            put(new RpcObjectData(CHANGE, valueType(afterVal, afterCodec), onChange == null && afterCodec == null ? afterVal : null, null, trace));
             doChange(afterVal, beforeVal, onChange, afterCodec);
         }
     }
@@ -149,8 +149,9 @@ public class RpcSendQueue {
                         // Type changed - treat as ADD
                         add(asRef ? Reference.asRef(anAfter) : anAfter, onChangeRun);
                     } else {
-                        put(new RpcObjectData(CHANGE, getValueType(anAfter), null, null, trace));
-                        doChange(anAfter, aBefore, onChangeRun, RpcCodec.forInstance(anAfter, sourceFileType));
+                        RpcCodec<Object> anAfterCodec = RpcCodec.forInstance((Object) anAfter, sourceFileType);
+                        put(new RpcObjectData(CHANGE, valueType(anAfter, anAfterCodec), null, null, trace));
+                        doChange(anAfter, aBefore, onChangeRun, anAfterCodec);
                     }
                 }
             }
@@ -186,7 +187,7 @@ public class RpcSendQueue {
             refs.put(afterVal, ref);
         }
         RpcCodec<Object> afterCodec = RpcCodec.forInstance(afterVal, sourceFileType);
-        put(new RpcObjectData(ADD, getValueType(afterVal),
+        put(new RpcObjectData(ADD, valueType(afterVal, afterCodec),
                 onChange == null && afterCodec == null ? afterVal : null, ref, trace));
         doChange(afterVal, null, onChange, afterCodec);
     }
@@ -246,20 +247,23 @@ public class RpcSendQueue {
                 }
             }
 
-            // Synthetic tree subclasses generated outside the org.openrewrite packages
-            // -- must be reported to the remote as their real (super) type, not the proxy
-            // class name, which the remote has no codec/factory for.
-            if (pkg != null && !pkg.getName().startsWith("org.openrewrite")) {
-                Class<?> superclass = afterType.getSuperclass();
-                Package superPkg = superclass == null ? null : superclass.getPackage();
-                if (superPkg != null && superPkg.getName().startsWith("org.openrewrite") && !Object.class.equals(superclass)) {
-                    return superclass.getName();
-                }
-            }
-
             return afterType.getName();
         }
     };
+
+    /**
+     * The wire type name for {@code after}. When a codec handles the value, the codec
+     * decides (a {@link DynamicDispatchRpcCodec} canonicalizes a proxied/subclassed runtime
+     * type back to its registered tree type); otherwise we fall back to the static
+     * {@link #getValueType(Object)} which filters out java.lang/collection/{@code JavaType}
+     * cases that have no codec.
+     */
+    private static @Nullable String valueType(@Nullable Object after, @Nullable RpcCodec<?> codec) {
+        if (after == null) {
+            return null;
+        }
+        return codec != null ? codec.valueType(after) : getValueType(after);
+    }
 
     private static @Nullable String getValueType(@Nullable Object after) {
         return after == null ? null : VALUE_TYPE_CACHE.get(after.getClass());

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/DynamicDispatchRpcCodecTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/DynamicDispatchRpcCodecTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DynamicDispatchRpcCodecTest {
+
+    /**
+     * A language marker interface, plus a concrete tree node that sits directly on
+     * {@link Object} -- the shape every real LST node has. {@code Generated*} stand in for
+     * synthetic subclasses produced at runtime (e.g. by a lazy-loading proxy generator),
+     * whose {@code getClass().getName()} the remote has no codec for.
+     */
+    interface TestTree {
+    }
+
+    static class TestLeaf implements TestTree {
+    }
+
+    static class GeneratedLeaf extends TestLeaf {
+    }
+
+    static class GeneratedLeaf2 extends GeneratedLeaf {
+    }
+
+    static class TestTreeCodec extends DynamicDispatchRpcCodec<TestTree> {
+        @Override
+        public String getSourceFileType() {
+            return TestLeaf.class.getName();
+        }
+
+        @Override
+        public Class<? extends TestTree> getType() {
+            return TestTree.class;
+        }
+
+        @Override
+        public void rpcSend(TestTree after, RpcSendQueue q) {
+        }
+
+        @Override
+        public TestTree rpcReceive(TestTree before, RpcReceiveQueue q) {
+            return before;
+        }
+    }
+
+    private final TestTreeCodec codec = new TestTreeCodec();
+
+    @Test
+    void realNodeKeepsItsOwnType() {
+        assertThat(codec.valueType(new TestLeaf())).isEqualTo(TestLeaf.class.getName());
+    }
+
+    @Test
+    void syntheticSubclassResolvesToRegisteredType() {
+        assertThat(codec.valueType(new GeneratedLeaf())).isEqualTo(TestLeaf.class.getName());
+    }
+
+    @Test
+    void multiLevelSyntheticSubclassResolvesToRegisteredType() {
+        assertThat(codec.valueType(new GeneratedLeaf2())).isEqualTo(TestLeaf.class.getName());
+    }
+
+    @Test
+    void defaultValueTypeIsRuntimeClassName() {
+        RpcCodec<String> selfEncoding = new RpcCodec<String>() {
+            @Override
+            public void rpcSend(String after, RpcSendQueue q) {
+            }
+
+            @Override
+            public String rpcReceive(String before, RpcReceiveQueue q) {
+                return before;
+            }
+        };
+        assertThat(selfEncoding.valueType("x")).isEqualTo(String.class.getName());
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaTypeRpcCodec.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaTypeRpcCodec.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal.rpc;
+
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.rpc.DynamicDispatchRpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+public class JavaTypeRpcCodec extends DynamicDispatchRpcCodec<JavaType> {
+
+    private static final String JAVA_TYPE_PACKAGE = "org.openrewrite.java.tree";
+
+    /**
+     * {@code JavaType} is not a source file; it is a cross-language attribution model that
+     * appears under every JVM-language source file type. There is therefore no meaningful
+     * source-file key for it — it is registered under its own type name and resolved through
+     * {@link DynamicDispatchRpcCodec#getCodec} by assignability rather than by key.
+     */
+    @Override
+    public String getSourceFileType() {
+        return JavaType.class.getName();
+    }
+
+    @Override
+    public Class<? extends JavaType> getType() {
+        return JavaType.class;
+    }
+
+    /**
+     * Canonicalizes a (possibly subclassed/proxied) {@code JavaType} runtime type to the wire
+     * name the remote can reconstruct. Unlike LST tree nodes — which implement their language
+     * interface and sit directly on {@link Object} — {@code JavaType} is a real class hierarchy
+     * (e.g. {@code ShallowClass extends Class extends FullyQualified}). So we must NOT use the
+     * inherited "walk up while assignable to {@link #getType()}" default, which would collapse
+     * {@code JavaType.Class} all the way to {@code FullyQualified}. Instead we strip only the
+     * synthetic layers — classes outside the canonical {@code org.openrewrite.java.tree} package,
+     * such as a proxy generated for lazy loading — landing on the first real {@code JavaType} class.
+     * A value already in the canonical package is returned unchanged.
+     */
+    @Override
+    public String valueType(Object value) {
+        Class<?> type = value.getClass();
+        while (isSynthetic(type) &&
+               type.getSuperclass() != null &&
+               JavaType.class.isAssignableFrom(type.getSuperclass())) {
+            type = type.getSuperclass();
+        }
+        return type.getName();
+    }
+
+    private static boolean isSynthetic(Class<?> type) {
+        Package pkg = type.getPackage();
+        return pkg == null || !JAVA_TYPE_PACKAGE.equals(pkg.getName());
+    }
+
+    @Override
+    public void rpcSend(JavaType after, RpcSendQueue q) {
+        new JavaTypeSender().visit(after, q);
+    }
+
+    @Override
+    public JavaType rpcReceive(JavaType before, RpcReceiveQueue q) {
+        return new JavaTypeReceiver().visitNonNull(before, q);
+    }
+}

--- a/rewrite-java/src/main/resources/META-INF/services/org.openrewrite.rpc.DynamicDispatchRpcCodec
+++ b/rewrite-java/src/main/resources/META-INF/services/org.openrewrite.rpc.DynamicDispatchRpcCodec
@@ -1,4 +1,5 @@
 org.openrewrite.java.internal.rpc.JavaRpcCodec
+org.openrewrite.java.internal.rpc.JavaTypeRpcCodec
 org.openrewrite.java.internal.rpc.JavaRightPaddedRpcCodec
 org.openrewrite.java.internal.rpc.JavaLeftPaddedRpcCodec
 org.openrewrite.java.internal.rpc.JavaContainerRpcCodec

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/rpc/JavaTypeRpcCodecTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/rpc/JavaTypeRpcCodecTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal.rpc;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.rpc.DynamicDispatchRpcCodec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JavaTypeRpcCodecTest {
+
+    /**
+     * Stand-in for a runtime-generated proxy: a {@code JavaType} subtype living outside the
+     * canonical {@code org.openrewrite.java.tree} package (this test class's package is foreign).
+     */
+    static class LazyShallowClass extends JavaType.ShallowClass {
+        LazyShallowClass() {
+            super(null, 0, "java.lang.String", JavaType.FullyQualified.Kind.Class,
+                    null, null, null, null, null, null, null);
+        }
+    }
+
+    @Test
+    void codecResolvesForJavaTypeValues() {
+        JavaType type = JavaType.ShallowClass.build("java.lang.String");
+        // JavaType is cross-language and is never the enclosing source file type, so it resolves
+        // through the assignability fallback rather than the source-file-keyed bucket.
+        assertThat(DynamicDispatchRpcCodec.getCodec(type, J.CompilationUnit.class.getName()))
+                .isInstanceOf(JavaTypeRpcCodec.class);
+    }
+
+    @Test
+    void valueTypeDoesNotCollapseRealSubtypes() {
+        // JavaType is a real class hierarchy (ShallowClass -> Class -> FullyQualified). The
+        // canonicalization must NOT walk up it (that would lose the concrete type); a value
+        // already in the canonical package is returned unchanged.
+        assertThat(new JavaTypeRpcCodec().valueType(JavaType.ShallowClass.build("java.lang.String")))
+                .isEqualTo("org.openrewrite.java.tree.JavaType$ShallowClass");
+    }
+
+    @Test
+    void valueTypeStripsSyntheticSubclassLayer() {
+        // A proxy/subclass outside the canonical package canonicalizes back to the real type.
+        assertThat(new JavaTypeRpcCodec().valueType(new LazyShallowClass()))
+                .isEqualTo("org.openrewrite.java.tree.JavaType$ShallowClass");
+    }
+}


### PR DESCRIPTION
## Motivation

- [#7873](https://github.com/openrewrite/rewrite/pull/7873) made the wire-level `sourceFileType` canonical for `SourceFile` subclasses, but `RpcSendQueue` still reported each value's *runtime* class name as its `valueType`. When a tree (or its attribution) is represented at runtime by a synthetic subclass generated outside the `org.openrewrite` packages — e.g. a moderne-cli V3 lazy-loading proxy — that runtime name is one the remote has no codec/factory for, so the remote (e.g. the Python receiver) fails with *"No RPC codec registered … for '\<runtime class name>'"* and the RPC queues desynchronize.

- #7873 worked around this with a package-prefix heuristic in `getValueType` (report the superclass name when a value's package is not `org.openrewrite` but its superclass's is). That heuristic had no codec/type guard, only stripped a single subclass level, and — together with the `JavaType`-specific reflective lookup — meant `rewrite-core` hardcoded knowledge of `org.openrewrite.java.tree.JavaType` by string.

This PR makes **the codec decide the wire type name**, for every decomposable value, so `RpcSendQueue` no longer special-cases any language type.

## Examples

`RpcCodec.valueType(Object)` is the new hook (defaulting to the runtime class name, correct for self-encoding values). Codecs override it to canonicalize:

```java
// DynamicDispatchRpcCodec (tree nodes): walk up while the superclass is still assignable to
// the language marker — strips synthetic proxy layers, lands on the registered tree type.
//   Lazy_j_literal extends J.Literal           -> "org.openrewrite.java.tree.J$Literal"

// JavaTypeRpcCodec: JavaType is a *real* class hierarchy, so a marker-walk would over-collapse
// (JavaType.Class -> FullyQualified). It strips only synthetic (foreign-package) layers instead.
new JavaTypeRpcCodec().valueType(JavaType.ShallowClass.build("java.lang.String"));
//   -> "org.openrewrite.java.tree.JavaType$ShallowClass"   (real subtype preserved)
//   a foreign-package proxy of it                          -> "...JavaType$ShallowClass"
```

## Summary

- **`RpcCodec.valueType(Object)`** — new default method returning the runtime class name; the codec owns the wire type name.
- **`DynamicDispatchRpcCodec`** — overrides `valueType` with the marker-assignability walk for tree nodes. `getCodec` now resolves cross-cutting codecs by assignability even when `sourceFileType` is null, and caches that resolution per value class via `ClassValue` (replacing the per-node cross-bucket scan — also takes self-encoding `Markers`/`Checksum` off the scan path).
- **`JavaTypeRpcCodec`** (new, `rewrite-java`) — `DynamicDispatchRpcCodec<JavaType>` registered via `ServiceLoader`. Standalone (not a self-codec) to keep the `JavaType` model RPC-free and avoid a tree↔`internal.rpc` cycle. Overrides `valueType` with a **package-gated** walk (stripping only synthetic foreign-package layers) because `JavaType` is a real class hierarchy; `rpcSend`/`rpcReceive` delegate to the existing `JavaTypeSender`/`JavaTypeReceiver`.
- **`RpcSendQueue`** — deletes the `JavaType` special-case: the `JAVA_TYPE_PACKAGE`/`JAVA_TYPE_NAME` constants, the reflective `Class.forName` lookup, the single-level superclass branch, and the `JavaType.Primitive` enum-guard. `valueType` flows through the codec; `core` no longer references `rewrite-java` by string.

`JavaType` decomposition is unchanged — it is still driven by `JavaTypeSender` via the existing `onChange` callbacks; the codec only supplies the wire type name (its `rpcSend`/`rpcReceive` are an off-hot-path fallback, since `JavaType` is always reached as a child with an `onChange`).

## Test plan

- [x] New `JavaTypeRpcCodecTest`: codec resolves for `JavaType` values; `valueType` does **not** collapse real subtypes (`ShallowClass` stays `ShallowClass`, guarding the over-collapse hazard); strips a synthetic foreign-package subclass layer. (TDD — watched the marker-walk fail before adding the package-gated override.)
- [x] `DynamicDispatchRpcCodecTest` (from the SourceFile commit) — green.
- [x] `JavaTypeAnnotationRpcTest` (full `JavaType` round-trip incl. `Primitive`), `JavaReceiverTest`, `SubclassCodecDispatchTest`, and all `rewrite-core` `rpc.*` tests — 0 failures.
- [ ] The pre-existing `@Disabled` `JavaSendReceiveTest.sendReceiveIdempotence` ("until we've cleaned up the enum serialization") still times out — a real tree has other raw enums (`J.ClassDeclaration.Kind`, modifiers, …) beyond `JavaType.Primitive`. This PR is a step toward that, not the completion; left disabled.
