### PR TITLE
Recover the declaring package for bare top-level type names in the TypeScript parser

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -1180,6 +1180,24 @@ export class JavaScriptTypeMapping {
             if (this.sourceRoot) {
                 cleanedName = path.relative(this.sourceRoot, cleanedName);
             }
+        } else if (!cleanedName.includes('.') &&
+            (symbol.flags & (ts.SymbolFlags.Class | ts.SymbolFlags.Interface | ts.SymbolFlags.Enum))) {
+            // Bare class/interface/enum name whose declaring package was dropped (e.g. `Logger`
+            // from a package that does `export = Logger`). TypeScript's getFullyQualifiedName drops
+            // the package here because the symbol has no `parent`, so the package would otherwise be
+            // lost. Recover it from the symbol's declaration file — but only for genuine module
+            // exports from node_modules. Excluded by construction:
+            //  - namespace/module objects (e.g. the `React` namespace), whose bare name is intentional
+            //    and which are not Class/Interface/Enum symbols;
+            //  - local declarations (extractModuleNameFromPath returns undefined);
+            //  - ambient globals (which are `global.`-qualified, hence not bare).
+            const declarationFile = symbol.declarations?.[0]?.getSourceFile();
+            if (declarationFile && ts.isExternalModule(declarationFile)) {
+                const packageName = this.extractModuleNameFromPath(declarationFile.fileName);
+                if (packageName) {
+                    cleanedName = `${packageName}.${cleanedName}`;
+                }
+            }
         }
 
         return cleanedName.endsWith('Constructor') ?

--- a/rewrite-javascript/rewrite/test/javascript/type-mapping-package-recovery.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/type-mapping-package-recovery.test.ts
@@ -1,0 +1,95 @@
+// noinspection JSUnusedLocalSymbols
+
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {RecipeSpec} from "../../src/test";
+import {JavaScriptVisitor, npm, packageJson, typescript} from "../../src/javascript";
+import {J, Type} from "../../src/java";
+import {ExecutionContext, Recipe} from "../../src";
+import {withDir} from "tmp-promise";
+
+function fqn(t: Type | undefined): string {
+    if (!t) return "none";
+    if (Type.isClass(t)) return t.fullyQualifiedName;
+    return Type.signature(t);
+}
+
+function captureIdentifierTypes(names: string[], sink: Map<string, string>): Recipe {
+    class CaptureRecipe extends Recipe {
+        name = 'org.openrewrite.javascript.test.CapturePackageRecovery';
+        displayName = 'Capture identifier types';
+        description = 'Records the resolved type FQN of selected identifiers.';
+
+        async editor(): Promise<JavaScriptVisitor<ExecutionContext>> {
+            return new class extends JavaScriptVisitor<ExecutionContext> {
+                async visitIdentifier(ident: J.Identifier, p: ExecutionContext): Promise<J.Identifier> {
+                    const visited = await super.visitIdentifier(ident, p) as J.Identifier;
+                    if (names.includes(visited.simpleName)) {
+                        sink.set(visited.simpleName, fqn(visited.type));
+                    }
+                    return visited;
+                }
+            };
+        }
+    }
+
+    return new CaptureRecipe();
+}
+
+describe('node_modules package recovery for bare FQNs', () => {
+    // Some @types packages (e.g. @types/bunyan) `export = Logger` a single top-level class.
+    // TypeScript's getFullyQualifiedName drops the package for such symbols (they have no
+    // `parent`), yielding a bare `Logger` with the declaring package lost. Recover it from
+    // the declaration file so the FQN identifies the package it actually came from.
+    test('bare top-level export gets its declaring package prefixed (bunyan)', async () => {
+        const captured = new Map<string, string>();
+        const spec = new RecipeSpec();
+        spec.recipe = captureIdentifierTypes(['log', 'queue'], captured);
+
+        const src = `
+import bunyan from 'bunyan';
+import Bull from 'bull';
+const log = bunyan.createLogger({name: 'svc'});
+const queue = new Bull('q');
+log.info('hi');
+queue.add('job', {});
+`;
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    //language=typescript
+                    typescript(src),
+                    //language=json
+                    packageJson(`{
+                      "name": "pkg-recovery-fixture",
+                      "version": "1.0.0",
+                      "dependencies": { "bunyan": "^1.8.15", "bull": "^4.12.0" },
+                      "devDependencies": { "@types/bunyan": "^1.8.11", "@types/bull": "^3.15.9" }
+                    }`)
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        // The fix: bare `Logger` becomes `bunyan.Logger`.
+        expect(captured.get('log')).toBe('bunyan.Logger');
+
+        // Guard: a namespace-qualified FQN must NOT be rewritten to the package name.
+        // `new Bull('q')` is `Bull.Queue` (internal namespace) — this change is bare-name only,
+        // so it stays `Bull.Queue` rather than becoming `bull.Queue`.
+        expect(captured.get('queue')).toMatch(/^Bull\.Queue/);
+    }, 180000);
+});


### PR DESCRIPTION
## Motivation

Some type packages export a single top-level declaration directly — e.g. `@types/bunyan` does `export = Logger`, where `Logger` is a `declare class`. For such symbols TypeScript's `getFullyQualifiedName` returns a **bare** `Logger` (the symbol has no `parent`), so the declaring package was dropped entirely. As a result a value like `const log = bunyan.createLogger(...)` was attributed the package-less FQN `Logger` instead of `bunyan.Logger`, which is not useful for recipes that match on a package-qualified type name.

This is the same class of problem the ts-morph maintainers document for `getFullyQualifiedName` (a bare name is returned for symbols without a `parent`); their workaround is to recover the location from the symbol's first declaration. This change does the equivalent for npm packages.

## Examples

```ts
import bunyan from 'bunyan';
const log = bunyan.createLogger({name: 'svc'}); // log: Logger  ->  bunyan.Logger
```

| receiver | before | after |
|---|---|---|
| `bunyan.createLogger(...)` | `Logger` | `bunyan.Logger` |

## Summary

- In `getFullyQualifiedNameFromSymbol`, when the resolved name is a **bare identifier** (no `.`, no `node_modules/` path, not absolute), recover the declaring package from the symbol's declaration file (reusing `extractModuleNameFromPath`, which already normalizes `@types/<pkg>` → `<pkg>`).
- Scoped narrowly to avoid disturbing existing behavior — it only applies when **all** of the following hold:
  - the symbol is a `Class`, `Interface`, or `Enum` (so namespace/module objects such as the `React` namespace, intentionally attributed as `React`, are excluded);
  - the declaration lives in an **external module** under `node_modules` (so ambient globals — which are `global.`-qualified, hence not bare — and local declarations are excluded).

Cases deliberately **not** changed (verified): `React.Component`/the `React` namespace, Node globals (`global.Buffer`), and namespace-qualified leak cases like `Bull.Queue` / `request.SuperAgentStatic` (these carry a qualifier and would need a separate, UMD-global-aware change to address safely).

## Test plan

- [x] New `test/javascript/type-mapping-package-recovery.test.ts`:
  - `bunyan` (`export = Logger`) — receiver resolves to `bunyan.Logger`
  - guard: `new Bull('q')` stays `Bull.Queue` (namespace-qualified names are not rewritten)
- [x] Regression guard: `templating/lenient-type-matching.test.ts` ("namespace imports result in consistent type attribution FQN") still attributes the `React` namespace as `React`
- [x] Full `test/javascript` suite passes (1567 passed / 21 skipped); `npm run typecheck` clean