### PR TITLE
Attribute internal export= namespaces by their importable package name (TypeScript parser)

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -1198,11 +1198,48 @@ export class JavaScriptTypeMapping {
                     cleanedName = `${packageName}.${cleanedName}`;
                 }
             }
+        } else if (cleanedName.includes('.')) {
+            // Namespace-qualified name such as `Bull.Queue` or `request.SuperAgentStatic`, where
+            // the leading segment is the package's internal `export =` namespace rather than the
+            // importable package name. Replace it with the declaring package so the FQN identifies
+            // the package the type actually comes from.
+            //
+            // Preserved as-is:
+            //  - UMD globals (`export as namespace X`, e.g. React, lodash `_`, jQuery `$`): the
+            //    namespace name is the conventional public identifier;
+            //  - `global.*` (TypeScript's marker for ambient globals);
+            //  - namespaces that already match the package name, and any non-node_modules type.
+            const namespaceName = cleanedName.substring(0, cleanedName.indexOf('.'));
+            if (namespaceName !== 'global') {
+                const declarationFile = symbol.declarations?.[0]?.getSourceFile();
+                if (declarationFile && ts.isExternalModule(declarationFile)) {
+                    const packageName = this.extractModuleNameFromPath(declarationFile.fileName);
+                    if (packageName && packageName !== namespaceName &&
+                        !this.isUmdGlobalNamespace(declarationFile, namespaceName)) {
+                        cleanedName = packageName + cleanedName.substring(cleanedName.indexOf('.'));
+                    }
+                }
+            }
         }
 
         return cleanedName.endsWith('Constructor') ?
             cleanedName.substring(0, cleanedName.length - 'Constructor'.length) :
             cleanedName;
+    }
+
+    /**
+     * Whether {@code namespaceName} is exposed as a UMD global from the given declaration file
+     * (e.g. `export as namespace React`). The namespace name of a UMD global is the conventional
+     * public identifier (React, lodash `_`, jQuery `$`) and must be preserved rather than replaced
+     * with the package name.
+     */
+    private isUmdGlobalNamespace(sourceFile: ts.SourceFile, namespaceName: string): boolean {
+        for (const statement of sourceFile.statements) {
+            if (ts.isNamespaceExportDeclaration(statement) && statement.name.text === namespaceName) {
+                return true;
+            }
+        }
+        return false;
     }
 
 

--- a/rewrite-javascript/rewrite/test/javascript/type-mapping-namespace-replacement.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/type-mapping-namespace-replacement.test.ts
@@ -1,0 +1,93 @@
+// noinspection JSUnusedLocalSymbols
+import {RecipeSpec} from "../../src/test";
+import {JavaScriptVisitor, npm, packageJson, tsx, typescript} from "../../src/javascript";
+import {J, Type} from "../../src/java";
+import {ExecutionContext, Recipe} from "../../src";
+import {withDir} from "tmp-promise";
+
+function sig(t: Type | undefined): string {
+    if (!t) return "none";
+    if (Type.isClass(t)) return t.fullyQualifiedName;
+    return Type.signature(t);
+}
+
+function captureIdentifierTypes(names: string[], sink: Map<string, string>): Recipe {
+    class C extends Recipe {
+        name = 'org.openrewrite.javascript.test.CaptureNamespaceReplacement';
+        displayName = 'capture';
+        description = 'capture';
+        async editor(): Promise<JavaScriptVisitor<ExecutionContext>> {
+            return new class extends JavaScriptVisitor<ExecutionContext> {
+                async visitIdentifier(ident: J.Identifier, p: ExecutionContext): Promise<J.Identifier> {
+                    const v = await super.visitIdentifier(ident, p) as J.Identifier;
+                    if (names.includes(v.simpleName)) {
+                        sink.set(v.simpleName, sig(v.type));
+                    }
+                    return v;
+                }
+            };
+        }
+    }
+    return new C();
+}
+
+describe('internal namespace replaced with importable package name', () => {
+    test('Bull.Queue -> bull.Queue, request.SuperAgentStatic -> superagent.*', async () => {
+        const captured = new Map<string, string>();
+        const spec = new RecipeSpec();
+        spec.recipe = captureIdentifierTypes(['queue', 'sa'], captured);
+
+        const src = `
+import Bull from 'bull';
+import superagent from 'superagent';
+const queue = new Bull('q');
+const sa = superagent;
+queue.add('job', {});
+sa.get('/x');
+`;
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(repo.path,
+                    //language=typescript
+                    typescript(src),
+                    //language=json
+                    packageJson(`{
+                      "name": "ns-fixture", "version": "1.0.0",
+                      "dependencies": { "bull": "^4.12.0", "superagent": "^8.1.2" },
+                      "devDependencies": { "@types/bull": "^3.15.9", "@types/superagent": "^8.1.0" }
+                    }`)
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        expect(captured.get('queue')).toMatch(/^bull\.Queue/);
+        expect(captured.get('sa')).toMatch(/^superagent\.SuperAgentStatic/);
+    }, 180000);
+
+    test('UMD global namespace (React) is preserved', async () => {
+        const captured = new Map<string, string>();
+        const spec = new RecipeSpec();
+        spec.recipe = captureIdentifierTypes(['comp'], captured);
+
+        const src = `
+import * as React from 'react';
+const comp: React.Component = null as any;
+`;
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(repo.path,
+                    //language=tsx
+                    tsx(src),
+                    //language=json
+                    packageJson(`{
+                      "name": "react-fixture", "version": "1.0.0",
+                      "devDependencies": { "@types/react": "^18.2.0" }
+                    }`)
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        // UMD guard: must stay `React.*`, NOT become `react.*`.
+        expect(captured.get('comp')).toMatch(/^React\.Component/);
+    }, 180000);
+});

--- a/rewrite-javascript/rewrite/test/javascript/type-mapping-package-recovery.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/type-mapping-package-recovery.test.ts
@@ -87,9 +87,9 @@ queue.add('job', {});
         // The fix: bare `Logger` becomes `bunyan.Logger`.
         expect(captured.get('log')).toBe('bunyan.Logger');
 
-        // Guard: a namespace-qualified FQN must NOT be rewritten to the package name.
-        // `new Bull('q')` is `Bull.Queue` (internal namespace) — this change is bare-name only,
-        // so it stays `Bull.Queue` rather than becoming `bull.Queue`.
-        expect(captured.get('queue')).toMatch(/^Bull\.Queue/);
+        // `new Bull('q')` is declared in bull's internal `Bull` namespace; the importable
+        // package name is `bull`, so the FQN is rewritten to `bull.Queue` (see
+        // type-mapping-namespace-replacement.test.ts for the dedicated coverage).
+        expect(captured.get('queue')).toMatch(/^bull\.Queue/);
     }, 180000);
 });


### PR DESCRIPTION
## Motivation

Some type packages expose all their declarations through a single internal namespace via `export = <Namespace>`. TypeScript's `getFullyQualifiedName` reports that **internal namespace** as the FQN root, which is neither the package the type comes from nor anything a recipe author would write:

| package | declared via | attributed FQN (before) |
|---|---|---|
| `bull` | `declare namespace Bull { class Queue }` + `export = Bull` | `Bull.Queue` |
| `superagent` | `@types/superagent` does `export = request` | `request.SuperAgentStatic` |

`request.SuperAgentStatic` is especially problematic: `request` is also a real (different, well-known) npm package, so a recipe matching the `request` package's types would false-match superagent and vice-versa.

- This is the "namespace-leak" sibling of the bare-name package loss fixed in #7881 — there the package was dropped entirely (`Logger`); here it is replaced by an internal namespace name.

## Examples

```ts
import Bull from 'bull';
import superagent from 'superagent';
const queue = new Bull('q'); // Bull.Queue            -> bull.Queue
const sa = superagent;       // request.SuperAgentStatic -> superagent.SuperAgentStatic
```

## Summary

- In `getFullyQualifiedNameFromSymbol`, when the FQN is namespace-qualified (`<NS>.<Name>`) and the symbol is declared in an external module under `node_modules`, rewrite the leading `<NS>` to the declaring package's importable name (via `extractModuleNameFromPath`, which already normalizes `@types/<pkg>` → `<pkg>`).
- New `isUmdGlobalNamespace` helper preserves **UMD globals** (`export as namespace X`) — their namespace name is the conventional public identifier.

### Deliberately preserved (verified)

- **UMD globals**: `React.Component`, lodash `_.LoDashStatic`, jQuery `$.*` — the namespace name is the public API.
- **Ambient globals**: `global.Buffer`, `global.NodeJS.ProcessEnv` — TypeScript marks these with a `global.` root, which is excluded.
- **Already package-named** namespaces and any non-`node_modules` type.

## Test plan

- [x] New `test/javascript/type-mapping-namespace-replacement.test.ts`:
  - `new Bull('q')` → `bull.Queue`; `superagent` → `superagent.SuperAgentStatic`
  - UMD guard: `React.Component` stays `React.*` (not `react.*`)
- [x] Updated the `bull` guard in `type-mapping-package-recovery.test.ts` (from #7881) to reflect the new `bull.Queue` attribution
- [x] Full `test/javascript` suite passes (1569 passed / 21 skipped); `npm run typecheck` clean. The existing lodash test (`_.LoDashStatic`) and React tsx tests confirm UMD/global preservation.

## Notes / follow-ups

- `isUmdGlobalNamespace` scans the type's declaration file for `export as namespace`; for multi-file packages whose `export as namespace` lives only in the entry `.d.ts`, this could under-detect — none surfaced in the suite, but the module-symbol `globalExports` table would be a more robust signal.
- The scan runs per namespace-qualified type and is a candidate for per-`SourceFile` caching if it shows up in parse profiling.