### PR TITLE
Richer TypeScript type attribution: decorators and type-alias names

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -1073,6 +1073,10 @@ export class JavaScriptParserVisitor {
         let annotationType: NameTree | TypeTree;
         let _arguments: J.Container<Expression> | undefined = undefined;
 
+        // The identifier/qualified name that names the decorator — the call target for
+        // `@Entity()` / `@Entity<T>()`, or the bare reference for `@Entity`.
+        const nameNode = ts.isCallExpression(node.expression) ? node.expression.expression : node.expression;
+
         if (ts.isCallExpression(node.expression) && node.expression.typeArguments) {
             annotationType = {
                 kind: JS.Kind.ExpressionWithTypeArguments,
@@ -1094,6 +1098,16 @@ export class JavaScriptParserVisitor {
             annotationType = this.mapTypeTree(node.expression);
         } else {
             return this.visitUnknown(node);
+        }
+
+        // Attribute the decorator's fully qualified type (e.g. `typeorm.Entity`) so it is matchable
+        // by name, like Java annotations — rather than the generic function type of the decorator
+        // factory that the callee identifier otherwise resolves to.
+        const type = this.mapAnnotationType(nameNode);
+        if (type) {
+            // Identifier, FieldAccess and ExpressionWithTypeArguments (the decorator name forms)
+            // all declare an optional `type`; cast through `unknown` since the union itself does not.
+            annotationType = {...annotationType, type} as unknown as NameTree | TypeTree;
         }
 
         return {
@@ -4449,6 +4463,10 @@ export class JavaScriptParserVisitor {
 
     private mapMethodType(node: ts.Node): Type.Method | undefined {
         return this.typeMapping?.methodType(node);
+    }
+
+    private mapAnnotationType(node: ts.Node): Type.FullyQualified | undefined {
+        return this.typeMapping?.annotationType(node);
     }
 
     private mapCommaSeparatedList<T extends J>(nodes: readonly ts.Node[]): J.Container<T> {

--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -207,6 +207,49 @@ export class JavaScriptTypeMapping {
             }
         }
 
+        // A type alias to an intersection or a plain anonymous object (e.g. kafkajs's
+        // `export type Producer = Sender & {...}`, or `export type Consumer = {...}`) loses its name
+        // when TypeScript resolves the structure, leaving an unnamed intersection / `<unknown>`.
+        // TypeScript still records the originating alias via `aliasSymbol`; use it to attribute the
+        // nominal name (e.g. `kafkajs.Producer`) so the type is matchable. Unions keep their
+        // structural Union mapping (recipes rely on it), and mapped / instantiated utility types
+        // (`Partial<T>`, `Record<K, V>`, ...) are intentionally left untouched.
+        if (type.aliasSymbol) {
+            let nameableAlias = !!(type.flags & ts.TypeFlags.Intersection);
+            if (!nameableAlias && (type.flags & ts.TypeFlags.Object)) {
+                const objectFlags = (type as ts.ObjectType).objectFlags;
+                nameableAlias = !!(objectFlags & ts.ObjectFlags.Anonymous) &&
+                    !(objectFlags & ts.ObjectFlags.Mapped) &&
+                    !(objectFlags & ts.ObjectFlags.Instantiated);
+            }
+            if (nameableAlias) {
+                const fullyQualifiedName = this.getFullyQualifiedNameFromSymbol(type.aliasSymbol);
+                if (fullyQualifiedName && fullyQualifiedName !== 'unknown') {
+                    const aliasSignature = this.getSignature(type);
+                    const cached = this.typeCache.get(aliasSignature);
+                    if (cached) {
+                        return cached;
+                    }
+                    const aliasType: Type.Class = {
+                        kind: Type.Kind.Class,
+                        flags: 0,
+                        classKind: Type.Class.Kind.Interface,
+                        fullyQualifiedName,
+                        typeParameters: [],
+                        annotations: [],
+                        interfaces: [],
+                        members: [],
+                        methods: [],
+                        toJSON: function () {
+                            return Type.signature(this);
+                        }
+                    } as Type.Class;
+                    this.typeCache.set(aliasSignature, aliasType);
+                    return aliasType;
+                }
+            }
+        }
+
         // Skip problematic type constructs EARLY - before any caching or recursion
         // These can cause deep recursion and are often computed/structural types
         if (type.flags & ts.TypeFlags.Object) {

--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -84,6 +84,40 @@ export class JavaScriptTypeMapping {
     }
 
     /**
+     * Resolve the type of a decorator from the symbol it references, naming it by the decorator's
+     * fully qualified name (e.g. `typeorm.Entity`) rather than the generic function type of the
+     * decorator factory. Decorators are the JavaScript/TypeScript analogue of Java annotations, so
+     * — like {@code J.Annotation} in the Java LST — they are typed as a {@link Type.FullyQualified}
+     * with {@code classKind = Annotation}, which lets recipes match them by fully qualified name.
+     *
+     * @param node the identifier or qualified name naming the decorator (e.g. `Entity` in `@Entity()`)
+     */
+    annotationType(node: ts.Node): Type.FullyQualified | undefined {
+        const symbol = this.checker.getSymbolAtLocation(node);
+        if (!symbol) {
+            return undefined;
+        }
+        const fullyQualifiedName = this.getFullyQualifiedNameFromSymbol(symbol);
+        if (!fullyQualifiedName || fullyQualifiedName === 'unknown') {
+            return undefined;
+        }
+        return {
+            kind: Type.Kind.Class,
+            flags: 0,
+            classKind: Type.Class.Kind.Annotation,
+            fullyQualifiedName,
+            typeParameters: [],
+            annotations: [],
+            interfaces: [],
+            members: [],
+            methods: [],
+            toJSON: function () {
+                return Type.signature(this);
+            }
+        } as Type.Class;
+    }
+
+    /**
      * Resolve the declared type of a class / interface / enum / class-expression.
      *
      * Using {@code getTypeAtLocation} on these declaration nodes is unsafe: TypeScript returns

--- a/rewrite-javascript/rewrite/test/javascript/type-mapping-alias.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/type-mapping-alias.test.ts
@@ -1,0 +1,87 @@
+// noinspection JSUnusedLocalSymbols
+
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {RecipeSpec} from "../../src/test";
+import {JavaScriptVisitor, npm, packageJson, typescript} from "../../src/javascript";
+import {J, Type} from "../../src/java";
+import {ExecutionContext, Recipe} from "../../src";
+import {withDir} from "tmp-promise";
+
+function fqn(t: Type | undefined): string {
+    if (!t) return "none";
+    if (Type.isFullyQualified(t)) return Type.FullyQualified.getFullyQualifiedName(t);
+    return Type.signature(t);
+}
+
+function captureIdentifierTypes(names: string[], sink: Map<string, string>): Recipe {
+    class C extends Recipe {
+        name = 'org.openrewrite.javascript.test.CaptureAliasTypes';
+        displayName = 'capture';
+        description = 'capture';
+        async editor(): Promise<JavaScriptVisitor<ExecutionContext>> {
+            return new class extends JavaScriptVisitor<ExecutionContext> {
+                async visitIdentifier(ident: J.Identifier, p: ExecutionContext): Promise<J.Identifier> {
+                    const v = await super.visitIdentifier(ident, p) as J.Identifier;
+                    if (names.includes(v.simpleName)) {
+                        sink.set(v.simpleName, fqn(v.type));
+                    }
+                    return v;
+                }
+            };
+        }
+    }
+    return new C();
+}
+
+describe('type-alias name recovery via aliasSymbol', () => {
+    // kafkajs declares `producer(): Producer` / `consumer(): Consumer`, where
+    // `export type Producer = Sender & {...}` and `Consumer` are type aliases to an intersection /
+    // an anonymous object. TypeScript erases the alias name from the resolved return type, but
+    // preserves `type.aliasSymbol`, which we use to attribute the nominal `kafkajs.Producer` /
+    // `kafkajs.Consumer` instead of an unnamed intersection / `<unknown>`.
+    test('kafkajs producer()/consumer() recover their aliased type names', async () => {
+        const captured = new Map<string, string>();
+        const spec = new RecipeSpec();
+        // Use binding names distinct from the `producer`/`consumer` method names so the capture
+        // isn't overwritten by the method-name identifiers in `kafka.producer()`/`kafka.consumer()`.
+        spec.recipe = captureIdentifierTypes(['kafka', 'prod', 'cons'], captured);
+
+        const src = `
+import {Kafka} from 'kafkajs';
+const kafka = new Kafka({clientId: 'a', brokers: ['b']});
+const prod = kafka.producer();
+const cons = kafka.consumer({groupId: 'g'});
+`;
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(repo.path,
+                    //language=typescript
+                    typescript(src),
+                    //language=json
+                    packageJson(`{
+                      "name": "kafka-fixture", "version": "1.0.0",
+                      "dependencies": { "kafkajs": "^2.2.4" }
+                    }`)
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        expect(captured.get('kafka')).toBe('kafkajs.Kafka');
+        expect(captured.get('prod')).toBe('kafkajs.Producer');
+        expect(captured.get('cons')).toBe('kafkajs.Consumer');
+    }, 240000);
+});

--- a/rewrite-javascript/rewrite/test/javascript/type-mapping-decorator.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/type-mapping-decorator.test.ts
@@ -1,0 +1,83 @@
+// noinspection JSUnusedLocalSymbols
+
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {RecipeSpec} from "../../src/test";
+import {JavaScriptVisitor, npm, packageJson, typescript} from "../../src/javascript";
+import {J, Type} from "../../src/java";
+import {ExecutionContext, Recipe} from "../../src";
+import {withDir} from "tmp-promise";
+
+function fqn(t: Type | undefined): string {
+    if (!t) return "none";
+    if (Type.isFullyQualified(t)) return Type.FullyQualified.getFullyQualifiedName(t);
+    return Type.signature(t);
+}
+
+function captureAnnotationTypes(sink: Map<string, string>): Recipe {
+    class C extends Recipe {
+        name = 'org.openrewrite.javascript.test.CaptureAnnotationTypes';
+        displayName = 'capture';
+        description = 'capture';
+        async editor(): Promise<JavaScriptVisitor<ExecutionContext>> {
+            return new class extends JavaScriptVisitor<ExecutionContext> {
+                async visitAnnotation(a: J.Annotation, p: ExecutionContext): Promise<J.Annotation> {
+                    const v = await super.visitAnnotation(a, p) as J.Annotation;
+                    const at = v.annotationType as J.Identifier;
+                    if (at && at.simpleName) {
+                        sink.set(at.simpleName, fqn(at.type));
+                    }
+                    return v;
+                }
+            };
+        }
+    }
+    return new C();
+}
+
+describe('decorator type attribution', () => {
+    test('typeorm decorators resolve to their fully qualified package name', async () => {
+        const captured = new Map<string, string>();
+        const spec = new RecipeSpec();
+        spec.recipe = captureAnnotationTypes(captured);
+
+        const src = `
+import {Entity, Column} from 'typeorm';
+
+@Entity()
+class User {
+    @Column()
+    name: string = '';
+}
+`;
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(repo.path,
+                    //language=typescript
+                    typescript(src),
+                    //language=json
+                    packageJson(`{
+                      "name": "decorator-fixture", "version": "1.0.0",
+                      "dependencies": { "typeorm": "^0.3.20", "reflect-metadata": "^0.2.1" }
+                    }`)
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        expect(captured.get('Entity')).toBe('typeorm.Entity');
+        expect(captured.get('Column')).toBe('typeorm.Column');
+    }, 240000);
+});


### PR DESCRIPTION
Two independent, additive improvements to TypeScript type attribution (one commit each). Both only *add* identity that was previously discarded — no existing FQN is changed.

## 1. Attribute decorators by their fully qualified name

A decorator such as `@Entity()` (typeorm) was typed by the TypeScript type of its callee identifier — and a decorator factory is a *function*, so it resolved to the generic function type (`𝑓` / `FUNCTION_TYPE_NAME`). That discards the decorator's identity, so `@Entity` and `@Column` were indistinguishable by type and unmatchable by recipes.

Now the decorator is resolved from the symbol it references and typed as a `Type.Class` with `classKind = Annotation`, named by its fully qualified name — the JS/TS analogue of how `J.Annotation` is typed in the Java LST.

```ts
import {Entity, Column} from 'typeorm';
@Entity()                 // @Entity  -> typeorm.Entity
class User {
  @Column() name = '';    // @Column  -> typeorm.Column
}
```

## 2. Recover type-alias names for intersection / anonymous-object types

A `type` alias to an intersection or a plain anonymous object loses its name when TypeScript resolves the structure. kafkajs declares `producer(): Producer` / `consumer(): Consumer` where `export type Producer = Sender & {…}` and `export type Consumer = {…}`, so `kafka.producer()` / `kafka.consumer()` were attributed an unnamed intersection / `<unknown>`.

TypeScript still records the originating alias on `type.aliasSymbol`, so we use it to attribute the nominal name:

| expression | before | after |
|---|---|---|
| `kafka.producer()` | `<unknown> & <unknown>` | `kafkajs.Producer` |
| `kafka.consumer({…})` | `<unknown>` | `kafkajs.Consumer` |

Scoped to **intersection** and **plain anonymous-object** types so that:
- **unions** keep their structural `Type.Union` mapping (e.g. `React.Ref`, recursive `Json` — covered by existing tests);
- **inline** `A & B` / `string | number` (no `aliasSymbol`) are unaffected;
- **mapped/instantiated utility types** (`Partial<T>`, `Record<K, V>`, …) are left untouched.

## Test plan

- [x] New `test/javascript/type-mapping-decorator.test.ts`: `@Entity`/`@Column` → `typeorm.Entity`/`typeorm.Column`.
- [x] New `test/javascript/type-mapping-alias.test.ts`: kafkajs `producer()`/`consumer()` → `kafkajs.Producer`/`kafkajs.Consumer` (and `kafka` stays `kafkajs.Kafka`).
- [x] Existing union/intersection tests (`type-mapping.test.ts`, incl. `React.Ref` union and inline `A & B`) still pass — confirms the alias scoping.
- [x] `npm run typecheck` clean. Full `test/javascript` regression running (decorator commit already verified green at 1570 passed); will confirm the combined run.