### PR TITLE
npm-publish: also publish for manual `ci` dispatches on main

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,8 @@
 ---
 name: npm-publish
 
-# Publishes only after `ci` succeeds for a push to main or `publish` succeeds
-# for a version tag. `ci` also runs for PRs, schedules, and manual dispatches;
+# Publishes after `ci` succeeds for a push to (or manual dispatch on) main, or
+# `publish` succeeds for a version tag. `ci` also runs for PRs and schedules;
 # those must not publish to npm.
 on:
   workflow_run:
@@ -24,7 +24,8 @@ jobs:
       (
         (
           github.event.workflow_run.name == 'ci' &&
-          github.event.workflow_run.event == 'push' &&
+          (github.event.workflow_run.event == 'push' ||
+           github.event.workflow_run.event == 'workflow_dispatch') &&
           github.event.workflow_run.head_branch == 'main'
         ) ||
         (


### PR DESCRIPTION
## Problem

`npm-publish` only proceeds for **`push`**-triggered `ci` runs on `main`:

```yaml
github.event.workflow_run.name == 'ci' &&
github.event.workflow_run.event == 'push' &&
github.event.workflow_run.head_branch == 'main'
```

So a green `ci` started via **`workflow_dispatch`** on `main` triggers `npm-publish` (the `workflow_run` fires) but the job is **skipped**.

That matters because of how the parser is resolved downstream. The `rewrite-javascript` jar bundles `rewrite-javascript-version.txt` = `8.84.0-<git-commit-timestamp>`, and consumers launch the parser via `npx --package=@openrewrite/rewrite@<that-version> rewrite-rpc`. The npm package is published with the **same** commit-timestamp version. So a commit whose only green `ci` came from a manual dispatch (e.g. after re-running a flaky build to green) **never gets its parser published to npm** — and any consumer resolving that commit's Maven snapshot then fails with `RPC process shut down early with exit code 1` (the `npx` 404).

## Change

Allow `workflow_dispatch`-triggered `ci` runs on `main` to publish, in addition to `push`:

```yaml
github.event.workflow_run.name == 'ci' &&
(github.event.workflow_run.event == 'push' ||
 github.event.workflow_run.event == 'workflow_dispatch') &&
github.event.workflow_run.head_branch == 'main'
```

The `conclusion == 'success'` and `head_branch == 'main'` guards are unchanged, so PRs and non-`main` dispatches remain excluded, and a red `ci` still won't publish. The existing "version already published → skip" guard makes re-dispatching a no-op.

## Notes

- `workflow_run` workflows execute the **default-branch** copy of the YAML, so this takes effect once merged to `main` (it won't retroactively publish already-skipped runs).
- This is the minimal first step; it does **not** address the separate case where an unrelated failing test elsewhere in `ci` skips the JS publish even though the JS build is green.