### PR TITLE
8.83.5 regression: RocksdbMavenPomCache fails to deserialize stale POM cache entries

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
@@ -60,7 +60,7 @@ public class Pom {
      */
     public static int getModelVersion() {
         //NOTE: This value should be incremented if there are any model changes to Pom (or one of its referenced types)
-        return 2;
+        return 3;
     }
 
     @Nullable

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/cache/RocksdbMavenCacheTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/cache/RocksdbMavenCacheTest.java
@@ -15,12 +15,19 @@
  */
 package org.openrewrite.maven.cache;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.maven.internal.RawPom;
+import org.openrewrite.maven.tree.GroupArtifactVersion;
 import org.openrewrite.maven.tree.Pom;
+import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
 
 import java.io.ByteArrayInputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -65,6 +72,45 @@ class RocksdbMavenCacheTest {
 
 
     @Test
+    void invalidateCacheWhenReferencedPomTypeSerializationChanges(@TempDir Path tempDir) throws Exception {
+        String pathString = tempDir.resolve(".rewrite-cache").toString();
+
+        try {
+            new RocksdbMavenPomCache(tempDir);
+
+            Pom pom = parsePomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.foo</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.2</version>
+                    <name>test</name>
+                </project>
+                """);
+
+            ObjectMapper previousPomMapper = RocksdbMavenPomCache.mapper.copy()
+                    .addMixIn(GroupArtifactVersion.class, NoObjectId.class)
+                    .addMixIn(ResolvedGroupArtifactVersion.class, NoObjectId.class);
+
+            RocksdbMavenPomCache.RocksCache cache = RocksdbMavenPomCache.getCache(pathString);
+            putRaw(cache,
+                    RocksdbMavenPomCache.serialize("org.openrewrite.maven.internal.Pom.version"),
+                    RocksdbMavenPomCache.serialize(2));
+            putRaw(cache,
+                    RocksdbMavenPomCache.serialize(pom.getGav().toString().getBytes(StandardCharsets.UTF_8)),
+                    previousPomMapper.writeValueAsBytes(pom));
+            RocksdbMavenPomCache.closeCache(pathString);
+
+            RocksdbMavenPomCache mavenCache = new RocksdbMavenPomCache(tempDir);
+            assertThat(mavenCache.getPom(pom.getGav())).isNull();
+        } finally {
+            RocksdbMavenPomCache.closeCache(pathString);
+        }
+    }
+
+
+    @Test
     void entryPersistedInExistingDatabase(@TempDir Path tempDir) throws Exception {
 
         String pathString = tempDir.resolve(".rewrite-cache").toString();
@@ -101,5 +147,15 @@ class RocksdbMavenCacheTest {
 
     private Pom parsePomXml(String pom) {
         return RawPom.parse(new ByteArrayInputStream(pom.getBytes()), null).toPom(null, null);
+    }
+
+    private void putRaw(RocksdbMavenPomCache.RocksCache cache, byte[] key, byte[] value) throws Exception {
+        Method put = RocksdbMavenPomCache.RocksCache.class.getDeclaredMethod("put", byte[].class, byte[].class);
+        put.setAccessible(true);
+        put.invoke(cache, key, value);
+    }
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.None.class)
+    private interface NoObjectId {
     }
 }


### PR DESCRIPTION
### Problem

After upgrading from OpenRewrite `8.83.4` to `8.83.5`, Maven resolution failed while reading from `RocksdbMavenPomCache`:

```text
No Object Id found for an instance of `org.openrewrite.maven.tree.GroupArtifactVersion` to assign to property '@ref'
```

Deleting ~/.rewrite-cache fixed the issue locally.

### Version
Regression observed after upgrading from 8.83.4 to 8.83.5.

### How are you running OpenRewrite?
Via the build plugin with Maven recipes enabled.

### Expected behavior
Existing RocksDB Maven POM cache entries written by 8.83.4 should either deserialize correctly or be invalidated automatically after upgrading.

### Actual behavior
8.83.5 attempts to deserialize stale cached POM data and fails with the Jackson @ref object-id error.

### Possible cause
8.83.5 introduced Jackson `@JsonIdentityInfo(... property = "@ref")` on Maven model types such as `GroupArtifactVersion` and `ResolvedGroupArtifactVersion`, changing the serialized form of cached Pom objects.

- The relevant change appears to have been introduced in openrewrite/rewrite@8dfd30b60 as part of PR #7845:

However, `Pom.getModelVersion()` was not incremented, so old RocksDB cache entries are still treated as compatible.

### Workaround
Delete ~/.rewrite-cache.

### Suggested fix
Increment `Pom.getModelVersion()` so stale RocksDB POM cache entries are invalidated after the Maven model serialization change.