### PR TITLE
rewrite-kotlin: extend recipe DSL `rewrite { } to { }` arity from 2 to 12

### DIFF
--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/RecipeDsl.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/RecipeDsl.kt
@@ -504,6 +504,56 @@ public open class EditScope internal constructor() : LanguageHost() {
     @Suppress("UNUSED_PARAMETER")
     public fun <P1, P2, R> rewrite(first: (P1, P2) -> R, vararg rest: (P1, P2) -> R): RewriteAdvice2<P1, P2, R> = pluginRequired()
 
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, R> rewrite(before: (P1, P2, P3) -> R): RewriteAdvice3<P1, P2, P3, R> = pluginRequired()
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, R> rewrite(first: (P1, P2, P3) -> R, vararg rest: (P1, P2, P3) -> R): RewriteAdvice3<P1, P2, P3, R> = pluginRequired()
+
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, R> rewrite(before: (P1, P2, P3, P4) -> R): RewriteAdvice4<P1, P2, P3, P4, R> = pluginRequired()
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, R> rewrite(first: (P1, P2, P3, P4) -> R, vararg rest: (P1, P2, P3, P4) -> R): RewriteAdvice4<P1, P2, P3, P4, R> = pluginRequired()
+
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, R> rewrite(before: (P1, P2, P3, P4, P5) -> R): RewriteAdvice5<P1, P2, P3, P4, P5, R> = pluginRequired()
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, R> rewrite(first: (P1, P2, P3, P4, P5) -> R, vararg rest: (P1, P2, P3, P4, P5) -> R): RewriteAdvice5<P1, P2, P3, P4, P5, R> = pluginRequired()
+
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, R> rewrite(before: (P1, P2, P3, P4, P5, P6) -> R): RewriteAdvice6<P1, P2, P3, P4, P5, P6, R> = pluginRequired()
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, R> rewrite(first: (P1, P2, P3, P4, P5, P6) -> R, vararg rest: (P1, P2, P3, P4, P5, P6) -> R): RewriteAdvice6<P1, P2, P3, P4, P5, P6, R> = pluginRequired()
+
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, P7, R> rewrite(before: (P1, P2, P3, P4, P5, P6, P7) -> R): RewriteAdvice7<P1, P2, P3, P4, P5, P6, P7, R> = pluginRequired()
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, P7, R> rewrite(first: (P1, P2, P3, P4, P5, P6, P7) -> R, vararg rest: (P1, P2, P3, P4, P5, P6, P7) -> R): RewriteAdvice7<P1, P2, P3, P4, P5, P6, P7, R> = pluginRequired()
+
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, P7, P8, R> rewrite(before: (P1, P2, P3, P4, P5, P6, P7, P8) -> R): RewriteAdvice8<P1, P2, P3, P4, P5, P6, P7, P8, R> = pluginRequired()
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, P7, P8, R> rewrite(first: (P1, P2, P3, P4, P5, P6, P7, P8) -> R, vararg rest: (P1, P2, P3, P4, P5, P6, P7, P8) -> R): RewriteAdvice8<P1, P2, P3, P4, P5, P6, P7, P8, R> = pluginRequired()
+
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, R> rewrite(before: (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R): RewriteAdvice9<P1, P2, P3, P4, P5, P6, P7, P8, P9, R> = pluginRequired()
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, R> rewrite(first: (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R, vararg rest: (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R): RewriteAdvice9<P1, P2, P3, P4, P5, P6, P7, P8, P9, R> = pluginRequired()
+
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> rewrite(before: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R): RewriteAdvice10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> = pluginRequired()
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> rewrite(first: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R, vararg rest: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R): RewriteAdvice10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> = pluginRequired()
+
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> rewrite(before: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R): RewriteAdvice11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> = pluginRequired()
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> rewrite(first: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R, vararg rest: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R): RewriteAdvice11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> = pluginRequired()
+
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> rewrite(before: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R): RewriteAdvice12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> = pluginRequired()
+    @Suppress("UNUSED_PARAMETER")
+    public fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> rewrite(first: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R, vararg rest: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R): RewriteAdvice12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> = pluginRequired()
+
     private fun <T> pluginRequired(): T = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin. " +
             "Add rewrite-kotlin to `kotlinCompilerPluginClasspath` (plugin id `org.openrewrite.kotlin.recipe`)."
@@ -544,6 +594,76 @@ public open class GenerateScope internal constructor(public val ctx: ExecutionCo
 @RecipeDsl public class RewriteAdvice2<P1, P2, R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
     public infix fun <R2> to(after: (P1, P2) -> R2): Unit = error(
+        "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
+    )
+}
+
+@RecipeDsl public class RewriteAdvice3<P1, P2, P3, R> internal constructor() {
+    @Suppress("UNUSED_PARAMETER")
+    public infix fun <R2> to(after: (P1, P2, P3) -> R2): Unit = error(
+        "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
+    )
+}
+
+@RecipeDsl public class RewriteAdvice4<P1, P2, P3, P4, R> internal constructor() {
+    @Suppress("UNUSED_PARAMETER")
+    public infix fun <R2> to(after: (P1, P2, P3, P4) -> R2): Unit = error(
+        "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
+    )
+}
+
+@RecipeDsl public class RewriteAdvice5<P1, P2, P3, P4, P5, R> internal constructor() {
+    @Suppress("UNUSED_PARAMETER")
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5) -> R2): Unit = error(
+        "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
+    )
+}
+
+@RecipeDsl public class RewriteAdvice6<P1, P2, P3, P4, P5, P6, R> internal constructor() {
+    @Suppress("UNUSED_PARAMETER")
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6) -> R2): Unit = error(
+        "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
+    )
+}
+
+@RecipeDsl public class RewriteAdvice7<P1, P2, P3, P4, P5, P6, P7, R> internal constructor() {
+    @Suppress("UNUSED_PARAMETER")
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7) -> R2): Unit = error(
+        "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
+    )
+}
+
+@RecipeDsl public class RewriteAdvice8<P1, P2, P3, P4, P5, P6, P7, P8, R> internal constructor() {
+    @Suppress("UNUSED_PARAMETER")
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8) -> R2): Unit = error(
+        "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
+    )
+}
+
+@RecipeDsl public class RewriteAdvice9<P1, P2, P3, P4, P5, P6, P7, P8, P9, R> internal constructor() {
+    @Suppress("UNUSED_PARAMETER")
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R2): Unit = error(
+        "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
+    )
+}
+
+@RecipeDsl public class RewriteAdvice10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> internal constructor() {
+    @Suppress("UNUSED_PARAMETER")
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R2): Unit = error(
+        "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
+    )
+}
+
+@RecipeDsl public class RewriteAdvice11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> internal constructor() {
+    @Suppress("UNUSED_PARAMETER")
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R2): Unit = error(
+        "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
+    )
+}
+
+@RecipeDsl public class RewriteAdvice12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> internal constructor() {
+    @Suppress("UNUSED_PARAMETER")
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R2): Unit = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
@@ -123,11 +123,7 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         val RECIPE_FQN: FqName = FqName("org.openrewrite.recipe")
         val RECIPES_FQN: FqName = FqName("org.openrewrite.recipes")
 
-        const val REWRITE_ADVICE_0_TO = "org.openrewrite.RewriteAdvice0.to"
-        const val REWRITE_ADVICE_1_TO = "org.openrewrite.RewriteAdvice1.to"
-        const val REWRITE_ADVICE_2_TO = "org.openrewrite.RewriteAdvice2.to"
-
-        val REWRITE_ADVICE_TO_FQNS = setOf(REWRITE_ADVICE_0_TO, REWRITE_ADVICE_1_TO, REWRITE_ADVICE_2_TO)
+        val REWRITE_ADVICE_TO_FQNS: Set<String> = (0..12).map { "org.openrewrite.RewriteAdvice$it.to" }.toSet()
 
         const val EDIT_SCOPE_REWRITE_FQN = "org.openrewrite.EditScope.rewrite"
         const val RECIPE_BUILDER_EDIT_FQN = "org.openrewrite.RecipeBuilder.edit"


### PR DESCRIPTION
## Summary

Adds `rewrite` overloads + `RewriteAdviceN` carriers for arities 3 through 12, and registers the corresponding `RewriteAdviceN.to` FQNs with the K2 IR generation pass.

## Why

The DSL's two-parameter ceiling forced anyone generating Kotlin recipes — including LLM agents that synthesize templates from natural-language prompts — to either skip higher-arity patterns or split them into separate templates per arity. A single `Arrays.asList(a, b, c)` → `List.of(a, b, c)` pattern couldn't be expressed, because:

```kotlin
rewrite { a: Any, b: Any, c: Any -> java.util.Arrays.asList(a, b, c) } to { a, b, c -> java.util.List.of(a, b, c) }
```

fails to resolve — no 3-param `rewrite` overload exists. K2 reports `none of the following candidates is applicable` and the whole `recipe(...) { edit { ... } }` block fails to compile, taking the valid 1- and 2-arg rewrites in the same edit block down with it.

The agent-tools-bench copilot sweeps that exercise the Kotlin DSL produce templates with arities up to 6 routinely; arities 7–12 are uncommon but cheap to add while the change is fresh, and head off the same failure for `String.format(...)`-shape patterns where the format-arg count drives the rewrite arity.

## What changed

- **`RecipeDsl.kt`** — 9 new `rewrite(...)` overload pairs (single + vararg) for arities 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, plus matching `RewriteAdviceN<P1..Pn, R>` carriers with `infix fun to(after: (P1..Pn) -> R2)`. Follows the same `pluginRequired()` stub pattern as the existing arities 0/1/2.
- **`RecipeIrGenerationExtension.kt`** — `REWRITE_ADVICE_TO_FQNS` switches from a hand-enumerated set of three constants to ``(0..12).map { "org.openrewrite.RewriteAdvice$it.to" }.toSet()``.

The IR-walking code in `validateBeforeLambda` and the `to`-call dispatch in `processRecipeBuilder` already read parameter counts off `fn.valueParameters` generically — the only arity-bound location in the plugin was the FQN allow-list.

## Test plan

- [x] `:rewrite-kotlin:compileKotlin` — clean against the new arities
- [x] `:rewrite-kotlin:test --tests "*RecipeDsl*"` — existing surface tests pass
- [ ] End-to-end: compile an arity-3 recipe in a downstream consumer (moderne-cli's pattern_replace tool) and confirm it produces changes against a target codebase