### PR TITLE
JavaScript: tolerate MethodDeclarations without dimensionsAfterName

### DIFF
--- a/rewrite-javascript/rewrite/src/java/visitor.ts
+++ b/rewrite-javascript/rewrite/src/java/visitor.ts
@@ -712,7 +712,7 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
             nameAnnotations: await mapAsync(method.nameAnnotations, a => this.visitDefined<J.Annotation>(a, p)),
             name: await this.visitDefined(method.name, p),
             parameters: await this.visitContainer(method.parameters, p),
-            dimensionsAfterName: await mapAsync(method.dimensionsAfterName, dim => this.visitLeftPadded(dim, p)),
+            dimensionsAfterName: await mapAsync(method.dimensionsAfterName ?? [], dim => this.visitLeftPadded(dim, p)),
             throws: method.throws && await this.visitContainer(method.throws, p),
             body: method.body && await this.visitDefined(method.body, p) as J.Block,
             defaultValue: await this.visitOptionalLeftPadded(method.defaultValue, p),

--- a/rewrite-javascript/rewrite/test/javascript/parser/method.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/method.test.ts
@@ -15,9 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {RecipeSpec} from "../../../src/test";
+import {fromVisitor, RecipeSpec} from "../../../src/test";
 import {JavaScriptVisitor, JS, npm, packageJson, typescript} from "../../../src/javascript";
 import {J} from "../../../src/java";
+import {ExecutionContext} from "../../../src";
 import {withDir} from "tmp-promise";
 
 describe('method mapping', () => {
@@ -293,5 +294,26 @@ describe('method mapping', () => {
                 )
             );
         }, {unsafeCleanup: true});
+    });
+
+    test('tolerates a MethodDeclaration with undefined dimensionsAfterName (pre-#6992 LST)', () => {
+        // given a visitor that strips dimensionsAfterName, simulating a legacy LST deserialized
+        // without the field (Java backfills it via @JsonCreator, the JS side previously did not)
+        const legacyVisitor = class extends JavaScriptVisitor<ExecutionContext> {
+            protected async visitMethodDeclaration(method: J.MethodDeclaration, p: ExecutionContext): Promise<J | undefined> {
+                const legacy = {...method, dimensionsAfterName: undefined as unknown as J.MethodDeclaration["dimensionsAfterName"]};
+                return super.visitMethodDeclaration(legacy, p);
+            }
+        };
+        const legacySpec = new RecipeSpec();
+        legacySpec.recipe = fromVisitor(new legacyVisitor());
+        legacySpec.allowEmptyDiff = true;
+
+        // when the method (inside an object literal) is visited, then it must not throw
+        // "Cannot read properties of undefined (reading 'length')"
+        return legacySpec.rewriteRun(
+            //language=typescript
+            typescript('const o = { foo() {} };')
+        );
     });
 });


### PR DESCRIPTION
## What's changed?

Adding a defensive mechanism for dealing with LST models for `MethodDeclaration`s which don't have the `dimensionsAfterName` property set.
The property has been added recently in #6992. And there still might be LSTs without the field populated.

## What's your motivation?

Fix crashes like:
```
Error: TypeError: Cannot read properties of undefined (reading 'length')
    at mapAsync (src/util.ts:19:29)
    at legacyVisitor.visitMethodDeclaration (src/java/visitor.ts:715:40)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at legacyVisitor.visit (src/visitor.ts:68:29)
    at legacyVisitor.visitDefined (src/visitor.ts:43:17)
    at legacyVisitor.visitRightPadded (src/java/visitor.ts:1220:49)
    at mapAsync (src/util.ts:20:24)
    at legacyVisitor.visitBlock (src/java/visitor.ts:236:25)
    at legacyVisitor.visit (src/visitor.ts:68:29)
    at legacyVisitor.visitDefined (src/visitor.ts:43:17)
```