### PR TITLE
JavaScript: don't try to install RPC recipes

### DIFF
--- a/rewrite-javascript/rewrite/fixtures/example-recipe.ts
+++ b/rewrite-javascript/rewrite/fixtures/example-recipe.ts
@@ -19,6 +19,7 @@ import {CreateText} from "./create-text";
 import {ChangeText} from "./change-text";
 import {ChangeVersion} from "./change-version";
 import {RecipeWithRecipeList} from "./recipe-with-recipe-list";
+import {RecipeWithRpcSubRecipe} from "./recipe-with-rpc-sub-recipe";
 import {ReplaceId} from "./replace-id";
 import {FindIdentifierWithRemotePathPrecondition} from "./remote-path-precondition";
 import {FindIdentifierWithPathPrecondition} from "./path-precondition";
@@ -35,6 +36,7 @@ export async function activate(marketplace: RecipeMarketplace): Promise<void> {
     await marketplace.install(CreateText, JavaScript);
     await marketplace.install(ChangeVersion, JavaScript);
     await marketplace.install(RecipeWithRecipeList, JavaScript);
+    await marketplace.install(RecipeWithRpcSubRecipe, JavaScript);
     await marketplace.install(ReplaceId, JavaScript);
     await marketplace.install(FindIdentifier, JavaScript);
     await marketplace.install(FindIdentifierWithRemotePathPrecondition, JavaScript);

--- a/rewrite-javascript/rewrite/fixtures/recipe-with-rpc-sub-recipe.ts
+++ b/rewrite-javascript/rewrite/fixtures/recipe-with-rpc-sub-recipe.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Recipe, RecipeDescriptor} from "@openrewrite/rewrite";
+import {RewriteRpc, RpcRecipe} from "@openrewrite/rewrite/rpc";
+import {ChangeText} from "./change-text";
+
+/**
+ * Mirrors the shape of a real-world composite recipe (e.g. Angular's
+ * `UpgradeToAngular21`) whose `recipeList()` mixes locally-defined recipes with
+ * recipes that were prepared on a remote RPC peer (via `prepareJavaRecipe` /
+ * `rpc.prepareRecipe`, which return {@link RpcRecipe} instances).
+ *
+ * The remote sub-recipe must not be re-installed by its constructor during
+ * `PrepareRecipe` — `RpcRecipe` is a proxy that cannot be constructed without
+ * arguments.
+ */
+export class RecipeWithRpcSubRecipe extends Recipe {
+    name = "org.openrewrite.example.text.with-rpc-sub-recipe";
+    displayName = "A recipe whose recipe list contains a remote (RPC) recipe";
+    description = "To verify that an already-prepared remote recipe can sit in a recipe list.";
+
+    async recipeList(): Promise<Recipe[]> {
+        const descriptor: RecipeDescriptor = {
+            name: "org.openrewrite.example.text.remote-change-text",
+            displayName: "Remote change text",
+            instanceName: "Remote change text",
+            description: "A stand-in for a recipe prepared on a remote RPC peer.",
+            tags: [],
+            estimatedEffortPerOccurrence: 5,
+            options: [],
+            preconditions: [],
+            recipeList: [],
+            dataTables: [],
+            maintainers: [],
+            contributors: [],
+            examples: []
+        };
+        return [
+            new ChangeText({text: "hello"}),
+            new RpcRecipe(RewriteRpc.get()!, "remote-id", descriptor, "")
+        ];
+    }
+}

--- a/rewrite-javascript/rewrite/src/rpc/index.ts
+++ b/rewrite-javascript/rewrite/src/rpc/index.ts
@@ -22,6 +22,7 @@ import {updateIfChanged} from "../util";
 export * from "./queue";
 export * from "../reference";
 export {RewriteRpc} from "./rewrite-rpc";
+export {RpcRecipe, RpcVisitor} from "./recipe";
 export {prepareJavaRecipe} from "./java-recipe";
 
 RpcCodecs.registerCodec(TreeKind.Checksum, {

--- a/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
@@ -84,6 +84,12 @@ export class PrepareRecipe {
 
     private static async installSubRecipes(recipe: Recipe, marketplace: RecipeMarketplace) {
         for (const subRecipe of await recipe.recipeList()) {
+            // An RpcRecipe is a proxy for a recipe already prepared on a remote
+            // peer; it has no no-arg constructor to install and its sub-recipes
+            // live remotely, so there is nothing to register locally.
+            if (subRecipe instanceof RpcRecipe) {
+                continue;
+            }
             if (!marketplace.findRecipe(subRecipe.name)) {
                 await marketplace.install(subRecipe.constructor as any, []);
                 await this.installSubRecipes(subRecipe, marketplace);

--- a/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
@@ -252,6 +252,19 @@ describe("Rewrite RPC", () => {
         );
     });
 
+    test("prepareRecipeWithRpcSubRecipeInRecipeList", async () => {
+        // A composite recipe whose recipeList() mixes a local recipe with an
+        // already-prepared remote (RpcRecipe) sub-recipe — the shape of e.g.
+        // Angular's UpgradeToAngular21, which lists upgradeDependencyVersion()
+        // (a Java recipe prepared over RPC). Preparing it must not try to
+        // re-install the RpcRecipe by its (no-arg-incompatible) constructor.
+        const recipe = await client.prepareRecipe("org.openrewrite.example.text.with-rpc-sub-recipe");
+        const descriptor = await recipe.descriptor();
+        expect(descriptor.recipeList.map(r => r.name)).toContain(
+            "org.openrewrite.example.text.remote-change-text"
+        );
+    });
+
     test("runRecipeWithCrossModuleRecipeList", async () => {
         spec.recipe = await client.prepareRecipe("org.openrewrite.example.text.cross-module-recipe-list");
         await spec.rewriteRun(


### PR DESCRIPTION
## What's changed?

Amending the JavaScript's RPC engine not to attempt to install recipes which are a RPC Recipe. I.e. a remote one. 
This might happen when a JavaScript recipe includes a Java recipe in its recipe list.

## What's your motivation?

Otherwise:
```
>{code=-32603, message='Request PrepareRecipe failed with message: Failed to install recipe 'RpcRecipe'. Ensure the constructor can be called without any arguments.'}
```
is observed