### PR TITLE
C#: decompose CsDocComment.DocComment over RPC via a proper visitor

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
@@ -1093,6 +1093,31 @@ public class CSharpReceiver : CSharpVisitor<RpcReceiveQueue>
         public new void ConsumePreVisit(J j, RpcReceiveQueue q) => base.ConsumePreVisit(j, q);
         public new void PopPreVisit() => base.PopPreVisit();
 
+        public override Space VisitSpace(Space space, RpcReceiveQueue q)
+        {
+            var comments = q.ReceiveList(space.Comments, c =>
+            {
+                // The Java side decomposes a structured CsDocComment.DocComment tree; the C#
+                // side has no such model, so drain it and re-flatten to a raw XmlDocComment.
+                if (c is StructuredDocComment)
+                {
+                    return CsDocCommentReceiver.ReceiveDocComment(q);
+                }
+                var multiline = q.Receive(c.Multiline);
+                var text = q.Receive(c.Text);
+                var suffix = q.Receive(c.Suffix);
+                // C# Comment doesn't have Markers; consume and discard
+                q.Receive<Markers>(Markers.Empty);
+                if (c is XmlDocComment)
+                {
+                    return new XmlDocComment(text!, suffix!, multiline);
+                }
+                return new TextComment(text!, suffix!, multiline);
+            });
+            var whitespace = q.Receive(space.Whitespace);
+            return space.WithComments(comments!).WithWhitespace(whitespace!);
+        }
+
         public override J? Visit(Tree? tree, RpcReceiveQueue q)
         {
             // DeconstructionPattern is a J type whose visit method lives in JavaReceiver,

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CsDocCommentReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CsDocCommentReceiver.cs
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Text;
+using OpenRewrite.Core;
+using OpenRewrite.Core.Rpc;
+using OpenRewrite.Java;
+
+namespace OpenRewrite.CSharp.Rpc;
+
+/// <summary>
+/// The Java side models a C# XML documentation comment as a structured
+/// <c>CsDocComment.DocComment</c> tree and decomposes it over RPC. The C# side has no
+/// equivalent structured model — it stores doc comments as raw <see cref="XmlDocComment"/>
+/// text — so this receiver consumes the decomposed tree and re-flattens it to the textual
+/// form, exactly mirroring the Java <c>CsDocCommentPrinter</c>.
+/// </summary>
+internal static class CsDocCommentReceiver
+{
+    /// <summary>
+    /// Consume a decomposed <c>CsDocComment.DocComment</c> (id, markers, body, suffix) and
+    /// rebuild the raw <see cref="XmlDocComment"/>. The shell ADD message has already been
+    /// consumed by the caller, so the queue is positioned at the first field (id).
+    /// </summary>
+    public static XmlDocComment ReceiveDocComment(RpcReceiveQueue q)
+    {
+        ConsumeId(q);
+        q.Receive<Markers>(Markers.Empty);
+        string body = ReceiveNodeList(q);
+        string? suffix = q.Receive<string>(null);
+        // The printer emits "///" then the body; XmlDocComment.Text is everything after the
+        // leading "//", i.e. a single "/" followed by the printed body.
+        return new XmlDocComment("/" + body, suffix ?? "", true);
+    }
+
+    private static void ConsumeId(RpcReceiveQueue q) => q.Receive<object?>(null);
+
+    /// <summary>Concatenate the printed text of a (non-null) node list field.</summary>
+    private static string ReceiveNodeList(RpcReceiveQueue q)
+    {
+        var nodes = q.ReceiveList<DocNode>(new List<DocNode>(), null);
+        if (nodes == null)
+        {
+            return "";
+        }
+        var sb = new StringBuilder();
+        foreach (var node in nodes)
+        {
+            sb.Append(node.Text);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Receive a nullable node list field, returning whether it was non-null, its element
+    /// count, and its concatenated text. The list is always consumed to keep the queue in sync.
+    /// </summary>
+    private static (bool present, int count, string text) ReceiveNodeListNullable(RpcReceiveQueue q)
+    {
+        var nodes = q.ReceiveList<DocNode>(new List<DocNode>(), null);
+        if (nodes == null)
+        {
+            return (false, 0, "");
+        }
+        var sb = new StringBuilder();
+        foreach (var node in nodes)
+        {
+            sb.Append(node.Text);
+        }
+        return (true, nodes.Count, sb.ToString());
+    }
+
+    /// <summary>Replicates the printer's attribute body: "name[ space[=value]]".</summary>
+    private static string ReceiveAttributeBody(RpcReceiveQueue q, string name)
+    {
+        var spaceBeforeEquals = ReceiveNodeListNullable(q);
+        var value = ReceiveNodeListNullable(q);
+        if (spaceBeforeEquals.present && spaceBeforeEquals.count > 0)
+        {
+            string equalsAndValue = value.present ? "=" + value.text : "";
+            return name + spaceBeforeEquals.text + equalsAndValue;
+        }
+        return name;
+    }
+
+    // ---- Sentinel node types: not part of the C# LST, used only to drain the decomposed
+    //      tree and rebuild text. Each implements IRpcCodec so the receive queue dispatches
+    //      to RpcReceive. They are intentionally NOT Tree types. ----
+
+    internal abstract class DocNode : IRpcCodec<DocNode>
+    {
+        public string Text = "";
+
+        public void RpcSend(DocNode after, RpcSendQueue q) =>
+            throw new NotSupportedException("C# never sends structured doc comments");
+
+        public abstract DocNode RpcReceive(DocNode before, RpcReceiveQueue q);
+    }
+
+    internal sealed class DocXmlText : DocNode
+    {
+        public override DocNode RpcReceive(DocNode before, RpcReceiveQueue q)
+        {
+            ConsumeId(q);
+            q.Receive<Markers>(Markers.Empty);
+            Text = q.Receive<string>(null) ?? "";
+            return this;
+        }
+    }
+
+    internal sealed class DocLineBreak : DocNode
+    {
+        public override DocNode RpcReceive(DocNode before, RpcReceiveQueue q)
+        {
+            // Field order on the Java side is id, margin, markers.
+            ConsumeId(q);
+            Text = q.Receive<string>(null) ?? "";
+            q.Receive<Markers>(Markers.Empty);
+            return this;
+        }
+    }
+
+    internal sealed class DocXmlElement : DocNode
+    {
+        public override DocNode RpcReceive(DocNode before, RpcReceiveQueue q)
+        {
+            ConsumeId(q);
+            q.Receive<Markers>(Markers.Empty);
+            string name = q.Receive<string>(null) ?? "";
+            string attributes = ReceiveNodeList(q);
+            string spaceBeforeClose = ReceiveNodeList(q);
+            string content = ReceiveNodeList(q);
+            string closingTagSpaceBeforeClose = ReceiveNodeList(q);
+            Text = "<" + name + attributes + spaceBeforeClose + ">" +
+                   content +
+                   "</" + name + closingTagSpaceBeforeClose + ">";
+            return this;
+        }
+    }
+
+    internal sealed class DocXmlEmptyElement : DocNode
+    {
+        public override DocNode RpcReceive(DocNode before, RpcReceiveQueue q)
+        {
+            ConsumeId(q);
+            q.Receive<Markers>(Markers.Empty);
+            string name = q.Receive<string>(null) ?? "";
+            string attributes = ReceiveNodeList(q);
+            string spaceBeforeSlashClose = ReceiveNodeList(q);
+            Text = "<" + name + attributes + spaceBeforeSlashClose + "/>";
+            return this;
+        }
+    }
+
+    internal sealed class DocXmlAttribute : DocNode
+    {
+        public override DocNode RpcReceive(DocNode before, RpcReceiveQueue q)
+        {
+            ConsumeId(q);
+            q.Receive<Markers>(Markers.Empty);
+            string name = q.Receive<string>(null) ?? "";
+            Text = ReceiveAttributeBody(q, name);
+            return this;
+        }
+    }
+
+    internal sealed class DocXmlCrefAttribute : DocNode
+    {
+        public override DocNode RpcReceive(DocNode before, RpcReceiveQueue q)
+        {
+            ConsumeId(q);
+            q.Receive<Markers>(Markers.Empty);
+            Text = ReceiveAttributeBody(q, "cref");
+            // Consume the optional type-attributed J reference.
+            q.Receive<J?>(null);
+            return this;
+        }
+    }
+
+    internal sealed class DocXmlNameAttribute : DocNode
+    {
+        public override DocNode RpcReceive(DocNode before, RpcReceiveQueue q)
+        {
+            ConsumeId(q);
+            q.Receive<Markers>(Markers.Empty);
+            Text = ReceiveAttributeBody(q, "name");
+            // Consume the optional bound parameter/type-parameter reference.
+            q.Receive<J?>(null);
+            return this;
+        }
+    }
+}
+
+/// <summary>
+/// Sentinel <see cref="Comment"/> subtype used purely so the receive queue can instantiate a
+/// shell when it encounters a decomposed <c>CsDocComment.DocComment</c>. It never appears in a
+/// finished LST — <see cref="CsDocCommentReceiver.ReceiveDocComment"/> replaces it with an
+/// <see cref="XmlDocComment"/>.
+/// </summary>
+internal sealed class StructuredDocComment() : Comment("", "", true);

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
@@ -462,6 +462,26 @@ public class RpcReceiveQueue
             "org.openrewrite.java.tree.J$VariableDeclarations$NamedVariable" =>
                 typeof(NamedVariable),
 
+            // Structured XML doc-comment tree (Java-only model). The C# side has no
+            // equivalent, so these map to sentinel shells that CsDocCommentReceiver drains
+            // and re-flattens into a raw XmlDocComment.
+            "org.openrewrite.csharp.tree.CsDocComment$DocComment" =>
+                typeof(OpenRewrite.CSharp.Rpc.StructuredDocComment),
+            "org.openrewrite.csharp.tree.CsDocComment$XmlElement" =>
+                typeof(OpenRewrite.CSharp.Rpc.CsDocCommentReceiver.DocXmlElement),
+            "org.openrewrite.csharp.tree.CsDocComment$XmlEmptyElement" =>
+                typeof(OpenRewrite.CSharp.Rpc.CsDocCommentReceiver.DocXmlEmptyElement),
+            "org.openrewrite.csharp.tree.CsDocComment$XmlText" =>
+                typeof(OpenRewrite.CSharp.Rpc.CsDocCommentReceiver.DocXmlText),
+            "org.openrewrite.csharp.tree.CsDocComment$XmlAttribute" =>
+                typeof(OpenRewrite.CSharp.Rpc.CsDocCommentReceiver.DocXmlAttribute),
+            "org.openrewrite.csharp.tree.CsDocComment$XmlCrefAttribute" =>
+                typeof(OpenRewrite.CSharp.Rpc.CsDocCommentReceiver.DocXmlCrefAttribute),
+            "org.openrewrite.csharp.tree.CsDocComment$XmlNameAttribute" =>
+                typeof(OpenRewrite.CSharp.Rpc.CsDocCommentReceiver.DocXmlNameAttribute),
+            "org.openrewrite.csharp.tree.CsDocComment$LineBreak" =>
+                typeof(OpenRewrite.CSharp.Rpc.CsDocCommentReceiver.DocLineBreak),
+
             // Marker type overrides
             "org.openrewrite.java.marker.Semicolon" =>
                 typeof(Semicolon),

--- a/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
@@ -33,9 +33,9 @@
     <PackageReference Include="NuGet.Frameworks" Version="6.12.4" />
     <PackageReference Include="NuGet.Versioning" Version="6.12.4" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" PrivateAssets="none" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpReceiver.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpReceiver.java
@@ -19,6 +19,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Tree;
 import org.openrewrite.csharp.CSharpVisitor;
 import org.openrewrite.csharp.tree.Cs;
+import org.openrewrite.csharp.tree.CsDocComment;
 import org.openrewrite.csharp.tree.CsDocCommentRawComment;
 import org.openrewrite.csharp.tree.Linq;
 import org.openrewrite.java.internal.rpc.JavaReceiver;
@@ -885,6 +886,9 @@ public class CSharpReceiver extends CSharpVisitor<RpcReceiveQueue> {
         public Space visitSpace(Space space, RpcReceiveQueue q) {
             return space
                     .withComments(q.receiveList(space.getComments(), c -> {
+                        if (c instanceof CsDocComment.DocComment) {
+                            return (Comment) new CsDocCommentReceiver(delegate).visit((CsDocComment.DocComment) c, q);
+                        }
                         if (c instanceof CsDocCommentRawComment) {
                             CsDocCommentRawComment dc = (CsDocCommentRawComment) c;
                             q.receive(dc.isMultiline()); // consume; always true

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpSender.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpSender.java
@@ -16,11 +16,16 @@
 package org.openrewrite.csharp.rpc;
 
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.Tree;
 import org.openrewrite.csharp.CSharpVisitor;
+import org.openrewrite.csharp.CsDocCommentPrinter;
 import org.openrewrite.csharp.tree.Cs;
+import org.openrewrite.csharp.tree.CsDocComment;
 import org.openrewrite.csharp.tree.CsDocCommentRawComment;
 import org.openrewrite.csharp.tree.Linq;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.internal.rpc.JavaSender;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.rpc.RpcSendQueue;
@@ -873,12 +878,24 @@ public class CSharpSender extends CSharpVisitor<RpcSendQueue> {
 
         @Override
         public void visitSpace(Space space, RpcSendQueue q) {
-            q.getAndSendList(space, Space::getComments,
+            // Structured doc-comment trees are not transmitted over the wire; flatten them
+            // back to their raw textual form. The receiver (and lazy re-parse in
+            // CSharpVisitor.visitSpace) will reconstruct a DocComment when a visitor needs one.
+            List<Comment> originalComments = space.getComments();
+            List<Comment> wireComments = ListUtils.map(originalComments, c ->
+                    c instanceof CsDocComment.DocComment ? toRawComment((CsDocComment.DocComment) c) : c);
+            Space spaceForSend = wireComments == originalComments ? space : space.withComments(wireComments);
+
+            q.getAndSendList(spaceForSend, Space::getComments,
                     c -> {
                         if (c instanceof TextComment) {
                             return ((TextComment) c).getText() + c.getSuffix();
                         } else if (c instanceof CsDocCommentRawComment) {
                             return ((CsDocCommentRawComment) c).getText() + c.getSuffix();
+                        } else if (c instanceof CsDocComment.DocComment) {
+                            // A DocComment may appear in the "before" snapshot on incremental sends
+                            // even though the "after" list is always flattened to raw comments.
+                            return toRawComment((CsDocComment.DocComment) c).getText() + c.getSuffix();
                         }
                         throw new IllegalArgumentException("Unexpected comment type " + c.getClass().getName());
                     },
@@ -898,6 +915,16 @@ public class CSharpSender extends CSharpVisitor<RpcSendQueue> {
                         q.getAndSend(c, Comment::getMarkers);
                     });
             q.getAndSend(space, Space::getWhitespace);
+        }
+
+        private static CsDocCommentRawComment toRawComment(CsDocComment.DocComment d) {
+            PrintOutputCapture<Integer> out = new PrintOutputCapture<>(0);
+            new CsDocCommentPrinter<Integer>().visit(d, out, new Cursor(null, Cursor.ROOT_VALUE));
+            String printed = out.getOut();
+            // CsDocCommentPrinter emits the leading "///"; CsDocCommentRawComment.printComment
+            // prepends "//", so the raw text starts after the first two slashes.
+            String rawText = printed.startsWith("//") ? printed.substring(2) : printed;
+            return new CsDocCommentRawComment(rawText, d.getSuffix(), d.getMarkers());
         }
     }
 }

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpSender.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpSender.java
@@ -16,21 +16,15 @@
 package org.openrewrite.csharp.rpc;
 
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.Cursor;
-import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.Tree;
 import org.openrewrite.csharp.CSharpVisitor;
-import org.openrewrite.csharp.CsDocCommentPrinter;
 import org.openrewrite.csharp.tree.Cs;
 import org.openrewrite.csharp.tree.CsDocComment;
 import org.openrewrite.csharp.tree.CsDocCommentRawComment;
 import org.openrewrite.csharp.tree.Linq;
-import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.internal.rpc.JavaSender;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.rpc.RpcSendQueue;
-
-import java.util.List;
 
 import static org.openrewrite.rpc.Reference.asRef;
 import static org.openrewrite.rpc.Reference.getValueNonNull;
@@ -878,53 +872,39 @@ public class CSharpSender extends CSharpVisitor<RpcSendQueue> {
 
         @Override
         public void visitSpace(Space space, RpcSendQueue q) {
-            // Structured doc-comment trees are not transmitted over the wire; flatten them
-            // back to their raw textual form. The receiver (and lazy re-parse in
-            // CSharpVisitor.visitSpace) will reconstruct a DocComment when a visitor needs one.
-            List<Comment> originalComments = space.getComments();
-            List<Comment> wireComments = ListUtils.map(originalComments, c ->
-                    c instanceof CsDocComment.DocComment ? toRawComment((CsDocComment.DocComment) c) : c);
-            Space spaceForSend = wireComments == originalComments ? space : space.withComments(wireComments);
-
-            q.getAndSendList(spaceForSend, Space::getComments,
+            q.getAndSendList(space, Space::getComments,
                     c -> {
                         if (c instanceof TextComment) {
                             return ((TextComment) c).getText() + c.getSuffix();
                         } else if (c instanceof CsDocCommentRawComment) {
                             return ((CsDocCommentRawComment) c).getText() + c.getSuffix();
                         } else if (c instanceof CsDocComment.DocComment) {
-                            // A DocComment may appear in the "before" snapshot on incremental sends
-                            // even though the "after" list is always flattened to raw comments.
-                            return toRawComment((CsDocComment.DocComment) c).getText() + c.getSuffix();
+                            // A structured doc comment is a proper tree, so it is keyed by its id
+                            // (like Javadoc.DocComment on the Java side) and decomposed over RPC.
+                            return ((CsDocComment.DocComment) c).getId();
                         }
                         throw new IllegalArgumentException("Unexpected comment type " + c.getClass().getName());
                     },
                     c -> {
-                        if (c instanceof TextComment) {
-                            TextComment tc = (TextComment) c;
-                            q.getAndSend(tc, TextComment::isMultiline);
-                            q.getAndSend(tc, TextComment::getText);
-                        } else if (c instanceof CsDocCommentRawComment) {
-                            CsDocCommentRawComment dc = (CsDocCommentRawComment) c;
-                            q.getAndSend(dc, CsDocCommentRawComment::isMultiline);
-                            q.getAndSend(dc, CsDocCommentRawComment::getText);
+                        if (c instanceof CsDocComment.DocComment) {
+                            new CsDocCommentSender(delegate).visit((CsDocComment.DocComment) c, q);
                         } else {
-                            throw new IllegalArgumentException("Unexpected comment type " + c.getClass().getName());
+                            if (c instanceof TextComment) {
+                                TextComment tc = (TextComment) c;
+                                q.getAndSend(tc, TextComment::isMultiline);
+                                q.getAndSend(tc, TextComment::getText);
+                            } else if (c instanceof CsDocCommentRawComment) {
+                                CsDocCommentRawComment dc = (CsDocCommentRawComment) c;
+                                q.getAndSend(dc, CsDocCommentRawComment::isMultiline);
+                                q.getAndSend(dc, CsDocCommentRawComment::getText);
+                            } else {
+                                throw new IllegalArgumentException("Unexpected comment type " + c.getClass().getName());
+                            }
+                            q.getAndSend(c, Comment::getSuffix);
+                            q.getAndSend(c, Comment::getMarkers);
                         }
-                        q.getAndSend(c, Comment::getSuffix);
-                        q.getAndSend(c, Comment::getMarkers);
                     });
             q.getAndSend(space, Space::getWhitespace);
-        }
-
-        private static CsDocCommentRawComment toRawComment(CsDocComment.DocComment d) {
-            PrintOutputCapture<Integer> out = new PrintOutputCapture<>(0);
-            new CsDocCommentPrinter<Integer>().visit(d, out, new Cursor(null, Cursor.ROOT_VALUE));
-            String printed = out.getOut();
-            // CsDocCommentPrinter emits the leading "///"; CsDocCommentRawComment.printComment
-            // prepends "//", so the raw text starts after the first two slashes.
-            String rawText = printed.startsWith("//") ? printed.substring(2) : printed;
-            return new CsDocCommentRawComment(rawText, d.getSuffix(), d.getMarkers());
         }
     }
 }

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CsDocCommentReceiver.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CsDocCommentReceiver.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.rpc;
+
+import org.openrewrite.csharp.CSharpVisitor;
+import org.openrewrite.csharp.CsDocCommentVisitor;
+import org.openrewrite.csharp.tree.CsDocComment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.rpc.RpcReceiveQueue;
+
+import java.util.UUID;
+
+/**
+ * Reconstructs a {@link CsDocComment} tree decomposed by {@link CsDocCommentSender}. The
+ * field order here must mirror the sender exactly so the queue stays in sync.
+ */
+class CsDocCommentReceiver extends CsDocCommentVisitor<RpcReceiveQueue> {
+
+    CsDocCommentReceiver(CSharpVisitor<RpcReceiveQueue> csharpVisitor) {
+        super(csharpVisitor);
+    }
+
+    @Override
+    public CsDocComment visitDocComment(CsDocComment.DocComment docComment, RpcReceiveQueue q) {
+        return docComment
+                .withId(q.receiveAndGet(docComment.getId(), UUID::fromString))
+                .withMarkers(q.receive(docComment.getMarkers()))
+                .withBody(q.receiveList(docComment.getBody(), b -> visit(b, q)))
+                .withSuffix(q.receive(docComment.getSuffix()));
+    }
+
+    @Override
+    public CsDocComment visitXmlElement(CsDocComment.XmlElement element, RpcReceiveQueue q) {
+        return element
+                .withId(q.receiveAndGet(element.getId(), UUID::fromString))
+                .withMarkers(q.receive(element.getMarkers()))
+                .withName(q.receive(element.getName()))
+                .withAttributes(q.receiveList(element.getAttributes(), a -> visit(a, q)))
+                .withSpaceBeforeClose(q.receiveList(element.getSpaceBeforeClose(), s -> visit(s, q)))
+                .withContent(q.receiveList(element.getContent(), c -> visit(c, q)))
+                .withClosingTagSpaceBeforeClose(q.receiveList(element.getClosingTagSpaceBeforeClose(), s -> visit(s, q)));
+    }
+
+    @Override
+    public CsDocComment visitXmlEmptyElement(CsDocComment.XmlEmptyElement element, RpcReceiveQueue q) {
+        return element
+                .withId(q.receiveAndGet(element.getId(), UUID::fromString))
+                .withMarkers(q.receive(element.getMarkers()))
+                .withName(q.receive(element.getName()))
+                .withAttributes(q.receiveList(element.getAttributes(), a -> visit(a, q)))
+                .withSpaceBeforeSlashClose(q.receiveList(element.getSpaceBeforeSlashClose(), s -> visit(s, q)));
+    }
+
+    @Override
+    public CsDocComment visitXmlText(CsDocComment.XmlText text, RpcReceiveQueue q) {
+        return text
+                .withId(q.receiveAndGet(text.getId(), UUID::fromString))
+                .withMarkers(q.receive(text.getMarkers()))
+                .withText(q.receive(text.getText()));
+    }
+
+    @Override
+    public CsDocComment visitXmlAttribute(CsDocComment.XmlAttribute attribute, RpcReceiveQueue q) {
+        return attribute
+                .withId(q.receiveAndGet(attribute.getId(), UUID::fromString))
+                .withMarkers(q.receive(attribute.getMarkers()))
+                .withName(q.receive(attribute.getName()))
+                .withSpaceBeforeEquals(q.receiveList(attribute.getSpaceBeforeEquals(), s -> visit(s, q)))
+                .withValue(q.receiveList(attribute.getValue(), v -> visit(v, q)));
+    }
+
+    @Override
+    public CsDocComment visitXmlCrefAttribute(CsDocComment.XmlCrefAttribute attribute, RpcReceiveQueue q) {
+        return attribute
+                .withId(q.receiveAndGet(attribute.getId(), UUID::fromString))
+                .withMarkers(q.receive(attribute.getMarkers()))
+                .withSpaceBeforeEquals(q.receiveList(attribute.getSpaceBeforeEquals(), s -> visit(s, q)))
+                .withValue(q.receiveList(attribute.getValue(), v -> visit(v, q)))
+                .withReference((J) q.receive(attribute.getReference(), ref -> csharpVisitorVisit(ref, q)));
+    }
+
+    @Override
+    public CsDocComment visitXmlNameAttribute(CsDocComment.XmlNameAttribute attribute, RpcReceiveQueue q) {
+        return attribute
+                .withId(q.receiveAndGet(attribute.getId(), UUID::fromString))
+                .withMarkers(q.receive(attribute.getMarkers()))
+                .withSpaceBeforeEquals(q.receiveList(attribute.getSpaceBeforeEquals(), s -> visit(s, q)))
+                .withValue(q.receiveList(attribute.getValue(), v -> visit(v, q)))
+                .withParamName((J) q.receive(attribute.getParamName(), name -> csharpVisitorVisit(name, q)));
+    }
+
+    @Override
+    public CsDocComment visitLineBreak(CsDocComment.LineBreak lineBreak, RpcReceiveQueue q) {
+        return lineBreak
+                .withId(q.receiveAndGet(lineBreak.getId(), UUID::fromString))
+                .withMargin(q.receive(lineBreak.getMargin()))
+                .withMarkers(q.receive(lineBreak.getMarkers()));
+    }
+}

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CsDocCommentSender.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CsDocCommentSender.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.rpc;
+
+import org.openrewrite.Tree;
+import org.openrewrite.csharp.CSharpVisitor;
+import org.openrewrite.csharp.CsDocCommentVisitor;
+import org.openrewrite.csharp.tree.CsDocComment;
+import org.openrewrite.rpc.RpcSendQueue;
+
+/**
+ * Decomposes a {@link CsDocComment} tree over RPC, mirroring the way {@link CSharpSender}
+ * decomposes the rest of the C# LST. Each node sends its {@code id}, {@code markers}, and
+ * remaining fields so that {@link CsDocCommentReceiver} can faithfully reconstruct the tree
+ * on the other side rather than flattening it back to raw text.
+ */
+class CsDocCommentSender extends CsDocCommentVisitor<RpcSendQueue> {
+
+    CsDocCommentSender(CSharpVisitor<RpcSendQueue> csharpVisitor) {
+        super(csharpVisitor);
+    }
+
+    @Override
+    public CsDocComment visitDocComment(CsDocComment.DocComment docComment, RpcSendQueue q) {
+        q.getAndSend(docComment, Tree::getId);
+        q.getAndSend(docComment, CsDocComment.DocComment::getMarkers);
+        q.getAndSendList(docComment, CsDocComment.DocComment::getBody, Tree::getId, b -> visit(b, q));
+        q.getAndSend(docComment, CsDocComment.DocComment::getSuffix);
+        return docComment;
+    }
+
+    @Override
+    public CsDocComment visitXmlElement(CsDocComment.XmlElement element, RpcSendQueue q) {
+        q.getAndSend(element, Tree::getId);
+        q.getAndSend(element, CsDocComment.XmlElement::getMarkers);
+        q.getAndSend(element, CsDocComment.XmlElement::getName);
+        q.getAndSendList(element, CsDocComment.XmlElement::getAttributes, Tree::getId, a -> visit(a, q));
+        q.getAndSendList(element, CsDocComment.XmlElement::getSpaceBeforeClose, Tree::getId, s -> visit(s, q));
+        q.getAndSendList(element, CsDocComment.XmlElement::getContent, Tree::getId, c -> visit(c, q));
+        q.getAndSendList(element, CsDocComment.XmlElement::getClosingTagSpaceBeforeClose, Tree::getId, s -> visit(s, q));
+        return element;
+    }
+
+    @Override
+    public CsDocComment visitXmlEmptyElement(CsDocComment.XmlEmptyElement element, RpcSendQueue q) {
+        q.getAndSend(element, Tree::getId);
+        q.getAndSend(element, CsDocComment.XmlEmptyElement::getMarkers);
+        q.getAndSend(element, CsDocComment.XmlEmptyElement::getName);
+        q.getAndSendList(element, CsDocComment.XmlEmptyElement::getAttributes, Tree::getId, a -> visit(a, q));
+        q.getAndSendList(element, CsDocComment.XmlEmptyElement::getSpaceBeforeSlashClose, Tree::getId, s -> visit(s, q));
+        return element;
+    }
+
+    @Override
+    public CsDocComment visitXmlText(CsDocComment.XmlText text, RpcSendQueue q) {
+        q.getAndSend(text, Tree::getId);
+        q.getAndSend(text, CsDocComment.XmlText::getMarkers);
+        q.getAndSend(text, CsDocComment.XmlText::getText);
+        return text;
+    }
+
+    @Override
+    public CsDocComment visitXmlAttribute(CsDocComment.XmlAttribute attribute, RpcSendQueue q) {
+        q.getAndSend(attribute, Tree::getId);
+        q.getAndSend(attribute, CsDocComment.XmlAttribute::getMarkers);
+        q.getAndSend(attribute, CsDocComment.XmlAttribute::getName);
+        q.getAndSendList(attribute, CsDocComment.XmlAttribute::getSpaceBeforeEquals, Tree::getId, s -> visit(s, q));
+        q.getAndSendList(attribute, CsDocComment.XmlAttribute::getValue, Tree::getId, v -> visit(v, q));
+        return attribute;
+    }
+
+    @Override
+    public CsDocComment visitXmlCrefAttribute(CsDocComment.XmlCrefAttribute attribute, RpcSendQueue q) {
+        q.getAndSend(attribute, Tree::getId);
+        q.getAndSend(attribute, CsDocComment.XmlCrefAttribute::getMarkers);
+        q.getAndSendList(attribute, CsDocComment.XmlCrefAttribute::getSpaceBeforeEquals, Tree::getId, s -> visit(s, q));
+        q.getAndSendList(attribute, CsDocComment.XmlCrefAttribute::getValue, Tree::getId, v -> visit(v, q));
+        q.getAndSend(attribute, CsDocComment.XmlCrefAttribute::getReference, ref -> csharpVisitorVisit(ref, q));
+        return attribute;
+    }
+
+    @Override
+    public CsDocComment visitXmlNameAttribute(CsDocComment.XmlNameAttribute attribute, RpcSendQueue q) {
+        q.getAndSend(attribute, Tree::getId);
+        q.getAndSend(attribute, CsDocComment.XmlNameAttribute::getMarkers);
+        q.getAndSendList(attribute, CsDocComment.XmlNameAttribute::getSpaceBeforeEquals, Tree::getId, s -> visit(s, q));
+        q.getAndSendList(attribute, CsDocComment.XmlNameAttribute::getValue, Tree::getId, v -> visit(v, q));
+        q.getAndSend(attribute, CsDocComment.XmlNameAttribute::getParamName, name -> csharpVisitorVisit(name, q));
+        return attribute;
+    }
+
+    @Override
+    public CsDocComment visitLineBreak(CsDocComment.LineBreak lineBreak, RpcSendQueue q) {
+        q.getAndSend(lineBreak, Tree::getId);
+        q.getAndSend(lineBreak, CsDocComment.LineBreak::getMargin);
+        q.getAndSend(lineBreak, CsDocComment.LineBreak::getMarkers);
+        return lineBreak;
+    }
+}

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/CSharpRecipeTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/CSharpRecipeTest.java
@@ -184,6 +184,34 @@ class CSharpRecipeTest implements RewriteTest {
     }
 
     @Test
+    void structuredDocCommentSurvivesPrintRoundTrip() throws Exception {
+        // A CSharpVisitor pass converts the raw doc comment into a structured CsDocComment tree.
+        // When the modified tree is printed (serialized back to the C# side), the structured
+        // comment is decomposed over RPC and the C# side re-flattens it to text. This used to
+        // throw "Unexpected comment type ...$DocComment" / fail to map the type on the C# side.
+        String source = "class Foo {\n    /// <summary>Does <c>x</c>.</summary>\n    void Test() {\n    }\n}\n";
+        CSharpRewriteRpc rpc = CSharpRewriteRpc.getOrStart();
+        Path tempDir = Files.createTempDirectory("csharp-doc-test-");
+        try (OutputStream os = Files.newOutputStream(tempDir.resolve("Test.cs"))) {
+            os.write(source.getBytes(StandardCharsets.UTF_8));
+        }
+        Path csproj = tempDir.resolve("Test.csproj");
+        try (OutputStream os = Files.newOutputStream(csproj)) {
+            os.write(("<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n" +
+              "    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>\n")
+              .getBytes(StandardCharsets.UTF_8));
+        }
+        SourceFile sf = rpc.parseSolution(csproj, tempDir, new InMemoryExecutionContext())
+          .filter(f -> f instanceof Cs.CompilationUnit).toList().getFirst();
+
+        SourceFile modified = (SourceFile) new CSharpIsoVisitor<InMemoryExecutionContext>()
+          .visit(sf, new InMemoryExecutionContext());
+
+        String printed = rpc.print(modified);
+        assertThat(printed).contains("<summary>Does <c>x</c>.</summary>");
+    }
+
+    @Test
     void directRecipeApplication() throws Exception {
         String source = "using Newtonsoft.Json;\nclass Foo {\n    void Test() {\n        var json = JsonConvert.SerializeObject(\"test\");\n    }\n}\n";
         CSharpRewriteRpc rpc = CSharpRewriteRpc.getOrStart();

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/rpc/CSharpSenderDocCommentTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/rpc/CSharpSenderDocCommentTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.rpc;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Tree;
+import org.openrewrite.csharp.CsDocCommentParser;
+import org.openrewrite.csharp.tree.CsDocComment;
+import org.openrewrite.csharp.tree.CsDocCommentRawComment;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.rpc.RpcObjectData;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.util.IdentityHashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Regression: {@link CsDocComment.DocComment} can end up in {@link Space#getComments()} after
+ * a {@code CSharpVisitor} pass parses a {@link CsDocCommentRawComment} into a structured tree.
+ * The sender used to only know about {@link CsDocCommentRawComment} and {@code TextComment},
+ * so it threw {@code IllegalArgumentException: Unexpected comment type ...$DocComment} as soon
+ * as the LST was sent (e.g. when {@code mod run} re-serialized a tree post-visit).
+ */
+class CSharpSenderDocCommentTest {
+
+    @Test
+    void visitSpaceWithDocCommentDoesNotThrow() {
+        CsDocCommentRawComment raw = new CsDocCommentRawComment(
+                "/ <summary>doc</summary>", "\n", Markers.EMPTY);
+        CsDocComment.DocComment parsed = CsDocCommentParser.parse(raw);
+        Space space = Space.EMPTY.withComments(List.<Comment>of(parsed));
+
+        CSharpSender sender = new CSharpSender();
+        RpcSendQueue queue = new RpcSendQueue(64, batch -> {}, new IdentityHashMap<>(), null, false);
+
+        assertThatNoException().isThrownBy(() -> sender.visitSpace(space, queue));
+    }
+
+    @Test
+    void docCommentIsTransmittedAsRawCommentValueType() {
+        CsDocCommentRawComment raw = new CsDocCommentRawComment(
+                "/ <summary>doc</summary>", "\n", Markers.EMPTY);
+        CsDocComment.DocComment parsed = CsDocCommentParser.parse(raw);
+        Space space = Space.EMPTY.withComments(List.<Comment>of(parsed));
+
+        CSharpSender sender = new CSharpSender();
+        List<RpcObjectData> emitted = new java.util.ArrayList<>();
+        RpcSendQueue queue = new RpcSendQueue(1024, emitted::addAll, new IdentityHashMap<>(), null, false);
+
+        sender.visitSpace(space, queue);
+        queue.flush();
+
+        // The value type announced over the wire for the comment ADD must be
+        // CsDocCommentRawComment, never CsDocComment$DocComment.
+        boolean addedRaw = emitted.stream()
+                .filter(d -> d.getState() == RpcObjectData.State.ADD)
+                .anyMatch(d -> CsDocCommentRawComment.class.getName().equals(d.getValueType()));
+        boolean addedDoc = emitted.stream()
+                .filter(d -> d.getState() == RpcObjectData.State.ADD)
+                .anyMatch(d -> d.getValueType() != null && d.getValueType().endsWith("$DocComment"));
+        assertThat(addedRaw).as("CsDocCommentRawComment should be sent over the wire").isTrue();
+        assertThat(addedDoc).as("Structured DocComment should not leak onto the wire").isFalse();
+    }
+
+    @Test
+    void preservesIdsOnRawComment() {
+        // Sanity check that the helper produces a well-formed raw comment whose
+        // round-trip through the existing C# parser yields equivalent text.
+        String original = "/ <summary>hello</summary>";
+        CsDocCommentRawComment raw = new CsDocCommentRawComment(original, "\n", Markers.EMPTY);
+        CsDocComment.DocComment parsed = CsDocCommentParser.parse(raw);
+        assertThat(parsed.getId()).isNotEqualTo(Tree.randomId()); // distinct id
+        assertThat(parsed.getSuffix()).isEqualTo("\n");
+    }
+}

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/rpc/CSharpSenderDocCommentTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/rpc/CSharpSenderDocCommentTest.java
@@ -16,78 +16,128 @@
 package org.openrewrite.csharp.rpc;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.Tree;
+import org.openrewrite.Cursor;
+import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.csharp.CsDocCommentParser;
+import org.openrewrite.csharp.CsDocCommentPrinter;
+import org.openrewrite.csharp.tree.Cs;
 import org.openrewrite.csharp.tree.CsDocComment;
 import org.openrewrite.csharp.tree.CsDocCommentRawComment;
 import org.openrewrite.java.tree.Comment;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.rpc.RpcObjectData;
+import org.openrewrite.rpc.RpcReceiveQueue;
 import org.openrewrite.rpc.RpcSendQueue;
 
-import java.util.IdentityHashMap;
-import java.util.List;
+import java.nio.file.Path;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
- * Regression: {@link CsDocComment.DocComment} can end up in {@link Space#getComments()} after
- * a {@code CSharpVisitor} pass parses a {@link CsDocCommentRawComment} into a structured tree.
- * The sender used to only know about {@link CsDocCommentRawComment} and {@code TextComment},
- * so it threw {@code IllegalArgumentException: Unexpected comment type ...$DocComment} as soon
- * as the LST was sent (e.g. when {@code mod run} re-serialized a tree post-visit).
+ * A {@link CsDocComment.DocComment} can end up in {@link Space#getComments()} after a
+ * {@code CSharpVisitor} pass parses a {@link CsDocCommentRawComment} into a structured tree.
+ * Rather than flattening it back to raw text, {@link CSharpSender} decomposes the structured
+ * tree over RPC (mirroring {@code Javadoc.DocComment} on the Java side) and {@link CSharpReceiver}
+ * reconstructs it, so the tree survives a round trip with full fidelity.
  */
 class CSharpSenderDocCommentTest {
 
+    private static final String SOURCE_FILE_TYPE = Cs.CompilationUnit.class.getName();
+
     @Test
     void visitSpaceWithDocCommentDoesNotThrow() {
-        CsDocCommentRawComment raw = new CsDocCommentRawComment(
-                "/ <summary>doc</summary>", "\n", Markers.EMPTY);
-        CsDocComment.DocComment parsed = CsDocCommentParser.parse(raw);
-        Space space = Space.EMPTY.withComments(List.<Comment>of(parsed));
+        Space space = spaceWithDocComment("/ <summary>doc</summary>");
 
         CSharpSender sender = new CSharpSender();
-        RpcSendQueue queue = new RpcSendQueue(64, batch -> {}, new IdentityHashMap<>(), null, false);
+        RpcSendQueue queue = new RpcSendQueue(64, batch -> {}, new IdentityHashMap<>(), SOURCE_FILE_TYPE, false);
 
         assertThatNoException().isThrownBy(() -> sender.visitSpace(space, queue));
     }
 
     @Test
-    void docCommentIsTransmittedAsRawCommentValueType() {
-        CsDocCommentRawComment raw = new CsDocCommentRawComment(
-                "/ <summary>doc</summary>", "\n", Markers.EMPTY);
-        CsDocComment.DocComment parsed = CsDocCommentParser.parse(raw);
-        Space space = Space.EMPTY.withComments(List.<Comment>of(parsed));
+    void docCommentIsDecomposedAsStructuredTree() {
+        Space space = spaceWithDocComment("/ <summary>doc</summary>");
 
+        List<RpcObjectData> emitted = new ArrayList<>();
         CSharpSender sender = new CSharpSender();
-        List<RpcObjectData> emitted = new java.util.ArrayList<>();
-        RpcSendQueue queue = new RpcSendQueue(1024, emitted::addAll, new IdentityHashMap<>(), null, false);
+        RpcSendQueue queue = new RpcSendQueue(1024, emitted::addAll, new IdentityHashMap<>(), SOURCE_FILE_TYPE, false);
 
         sender.visitSpace(space, queue);
         queue.flush();
 
-        // The value type announced over the wire for the comment ADD must be
-        // CsDocCommentRawComment, never CsDocComment$DocComment.
-        boolean addedRaw = emitted.stream()
-                .filter(d -> d.getState() == RpcObjectData.State.ADD)
-                .anyMatch(d -> CsDocCommentRawComment.class.getName().equals(d.getValueType()));
+        // The structured DocComment tree must travel over the wire, never the flattened raw form.
         boolean addedDoc = emitted.stream()
                 .filter(d -> d.getState() == RpcObjectData.State.ADD)
                 .anyMatch(d -> d.getValueType() != null && d.getValueType().endsWith("$DocComment"));
-        assertThat(addedRaw).as("CsDocCommentRawComment should be sent over the wire").isTrue();
-        assertThat(addedDoc).as("Structured DocComment should not leak onto the wire").isFalse();
+        boolean addedRaw = emitted.stream()
+                .filter(d -> d.getState() == RpcObjectData.State.ADD)
+                .anyMatch(d -> CsDocCommentRawComment.class.getName().equals(d.getValueType()));
+        assertThat(addedDoc).as("Structured DocComment should be decomposed over the wire").isTrue();
+        assertThat(addedRaw).as("DocComment should not be flattened to a raw comment").isFalse();
     }
 
     @Test
-    void preservesIdsOnRawComment() {
-        // Sanity check that the helper produces a well-formed raw comment whose
-        // round-trip through the existing C# parser yields equivalent text.
-        String original = "/ <summary>hello</summary>";
-        CsDocCommentRawComment raw = new CsDocCommentRawComment(original, "\n", Markers.EMPTY);
+    void docCommentRoundTripsThroughSenderAndReceiver() {
+        roundTripPreservesStructure("/ <summary>doc</summary>");
+    }
+
+    @Test
+    void multilineDocCommentWithNestedElementsRoundTrips() {
+        roundTripPreservesStructure(
+                "/ <summary>\n" +
+                "/// Adds <paramref name=\"a\"/> to <c>b</c>.\n" +
+                "/// </summary>\n" +
+                "/// <param name=\"a\">first</param>");
+    }
+
+    private void roundTripPreservesStructure(String rawText) {
+        Space space = spaceWithDocComment(rawText);
+        CsDocComment.DocComment original = (CsDocComment.DocComment) space.getComments().get(0);
+
+        Deque<List<RpcObjectData>> batches = new ArrayDeque<>();
+        RpcSendQueue sq = new RpcSendQueue(1, e -> batches.addLast(encode(e)), new IdentityHashMap<>(), SOURCE_FILE_TYPE, false);
+        RpcReceiveQueue rq = new RpcReceiveQueue(new HashMap<>(), batches::removeFirst, SOURCE_FILE_TYPE, null);
+
+        new CSharpSender().visitSpace(space, sq);
+        sq.flush();
+        Space received = new CSharpReceiver().visitSpace(Space.EMPTY, rq);
+
+        assertThat(received.getComments()).hasSize(1);
+        Comment receivedComment = received.getComments().get(0);
+        assertThat(receivedComment).isInstanceOf(CsDocComment.DocComment.class);
+
+        CsDocComment.DocComment roundTripped = (CsDocComment.DocComment) receivedComment;
+        assertThat(roundTripped.getId()).isEqualTo(original.getId());
+        assertThat(roundTripped.getSuffix()).isEqualTo(original.getSuffix());
+        // Printing exercises the entire reconstructed subtree, so identical output proves
+        // the structure (and ids) survived the round trip.
+        assertThat(print(roundTripped)).isEqualTo(print(original));
+    }
+
+    private static Space spaceWithDocComment(String rawText) {
+        CsDocCommentRawComment raw = new CsDocCommentRawComment(rawText, "\n", Markers.EMPTY);
         CsDocComment.DocComment parsed = CsDocCommentParser.parse(raw);
-        assertThat(parsed.getId()).isNotEqualTo(Tree.randomId()); // distinct id
-        assertThat(parsed.getSuffix()).isEqualTo("\n");
+        return Space.EMPTY.withComments(List.<Comment>of(parsed));
+    }
+
+    private static String print(CsDocComment.DocComment d) {
+        PrintOutputCapture<Integer> out = new PrintOutputCapture<>(0);
+        new CsDocCommentPrinter<Integer>().visit(d, out, new Cursor(null, Cursor.ROOT_VALUE));
+        return out.getOut();
+    }
+
+    private static List<RpcObjectData> encode(List<RpcObjectData> batch) {
+        List<RpcObjectData> encoded = new ArrayList<>();
+        for (RpcObjectData data : batch) {
+            if (data.getValue() instanceof UUID || data.getValue() instanceof Path) {
+                encoded.add(new RpcObjectData(data.getState(), data.getValueType(), data.getValue().toString(), data.getRef(), false));
+            } else {
+                encoded.add(data);
+            }
+        }
+        return encoded;
     }
 }


### PR DESCRIPTION
## Summary
- A `CSharpVisitor` pass parses a raw `CsDocCommentRawComment` into a structured `CsDocComment.DocComment` tree. Previously the RPC sender flattened that tree back to raw text; this PR instead adds a proper doc-comment tree visitor pair (`CsDocCommentSender` / `CsDocCommentReceiver`) that decomposes and reconstructs the tree over RPC, mirroring how the Java side keys `Javadoc.DocComment` by id. The comment is now keyed by its id in `Space`'s comment list and each node transmits its id, markers, and fields (including embedded `J` cref/name references).
- The C# side has no structured doc-comment model (it stores raw `XmlDocComment` text), so `CsDocCommentReceiver.cs` consumes the decomposed tree and re-flattens it to text, mirroring `CsDocCommentPrinter`. Without this the C# receiver threw `Cannot map Java type name: CsDocComment$DocComment` when a recipe-modified tree was serialized back for printing.
- Also bumps `Microsoft.CodeAnalysis.*` packages from 5.0.0 to 5.3.0.

## Test plan
- New Java sender→receiver round-trip tests in `CSharpSenderDocCommentTest`, including a multiline/nested-element case.
- New end-to-end regression test in `CSharpRecipeTest` that forces structuring via a `CSharpVisitor` pass then `print()`s through the real C# RPC process (the path that previously crashed).
- Full `rewrite-csharp` Java suite passes; all 1945 C# xUnit tests pass.