### PR TITLE
rewrite-kotlin: variadic-by-default matching in the recipe DSL

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
@@ -79,11 +79,12 @@ public final class GeneratedRecipeSupport {
      * literal {@code (kind, value)} at each position).
      */
     public static TreeVisitor<?, ExecutionContext> methodInvocationRewrite(
-            String matcherSpecsLines, String afterTemplate, String substitutionSourcesCsv) {
+            String matcherSpecsLines, String afterTemplate, String substitutionSourcesCsv, int strictArgCount) {
         // Chain mode: a single matcher spec line containing a tab encodes a
         // two-segment chain <outerSpec>\t<innerSpec>. Substitution-source CSV
         // is segment-tagged ("o:N" / "i:N"). v1 supports single-before chains
-        // only; multi-before chains are rejected at IR-pass time.
+        // only; multi-before chains are rejected at IR-pass time. Chains never
+        // carry a variadic run, so strictArgCount is irrelevant there.
         if (matcherSpecsLines.indexOf('\t') >= 0) {
             return chainMethodInvocationRewrite(matcherSpecsLines, afterTemplate, substitutionSourcesCsv);
         }
@@ -92,7 +93,7 @@ public final class GeneratedRecipeSupport {
         for (int i = 0; i < specs.length; i++) {
             matchers[i] = new MethodMatcher(specs[i]);
         }
-        int[][] substitutionSourcesByMatcher = parseCsvPerMatcher(substitutionSourcesCsv, specs.length);
+        SubSource[][] substitutionSourcesByMatcher = parseSourcesPerMatcher(substitutionSourcesCsv, specs.length);
         TreeVisitor<?, ExecutionContext> walker = new KotlinVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
@@ -104,23 +105,13 @@ public final class GeneratedRecipeSupport {
                     }
                 }
                 if (matchedIdx >= 0) {
-                    int[] substitutionSources = substitutionSourcesByMatcher[matchedIdx];
-                    Object[] substitutions = new Object[substitutionSources.length];
-                    for (int i = 0; i < substitutionSources.length; i++) {
-                        int src = substitutionSources[i];
-                        if (src < 0) {
-                            if (method.getSelect() == null) {
-                                return super.visitMethodInvocation(method, ctx);
-                            }
-                            substitutions[i] = method.getSelect();
-                        } else {
-                            if (src >= method.getArguments().size()) {
-                                return super.visitMethodInvocation(method, ctx);
-                            }
-                            substitutions[i] = method.getArguments().get(src);
-                        }
+                    Applied applied = prepareSubstitutions(
+                            method, substitutionSourcesByMatcher[matchedIdx], afterTemplate, strictArgCount);
+                    if (applied == null) {
+                        return super.visitMethodInvocation(method, ctx);
                     }
-                    J result = KotlinTemplate.builder(afterTemplate).build()
+                    Object[] substitutions = applied.substitutions;
+                    J result = KotlinTemplate.builder(applied.template).build()
                             .apply(getCursor(), method.getCoordinates().replace(), substitutions);
                     // Preserve the matched call's reified type arguments. The
                     // after-template's type args (if any) are placeholders the
@@ -491,13 +482,13 @@ public final class GeneratedRecipeSupport {
      * dance is Kotlin-specific.
      */
     public static TreeVisitor<?, ExecutionContext> methodInvocationRewriteJava(
-            String matcherSpecsLines, String afterTemplate, String substitutionSourcesCsv) {
+            String matcherSpecsLines, String afterTemplate, String substitutionSourcesCsv, int strictArgCount) {
         String[] specs = matcherSpecsLines.isEmpty() ? new String[0] : matcherSpecsLines.split("\n");
         MethodMatcher[] matchers = new MethodMatcher[specs.length];
         for (int i = 0; i < specs.length; i++) {
             matchers[i] = new MethodMatcher(specs[i]);
         }
-        int[][] substitutionSourcesByMatcher = parseCsvPerMatcher(substitutionSourcesCsv, specs.length);
+        SubSource[][] substitutionSourcesByMatcher = parseSourcesPerMatcher(substitutionSourcesCsv, specs.length);
         TreeVisitor<?, ExecutionContext> walker = new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
@@ -509,23 +500,13 @@ public final class GeneratedRecipeSupport {
                     }
                 }
                 if (matchedIdx >= 0) {
-                    int[] substitutionSources = substitutionSourcesByMatcher[matchedIdx];
-                    Object[] substitutions = new Object[substitutionSources.length];
-                    for (int i = 0; i < substitutionSources.length; i++) {
-                        int src = substitutionSources[i];
-                        if (src < 0) {
-                            if (method.getSelect() == null) {
-                                return super.visitMethodInvocation(method, ctx);
-                            }
-                            substitutions[i] = method.getSelect();
-                        } else {
-                            if (src >= method.getArguments().size()) {
-                                return super.visitMethodInvocation(method, ctx);
-                            }
-                            substitutions[i] = method.getArguments().get(src);
-                        }
+                    Applied applied = prepareSubstitutions(
+                            method, substitutionSourcesByMatcher[matchedIdx], afterTemplate, strictArgCount);
+                    if (applied == null) {
+                        return super.visitMethodInvocation(method, ctx);
                     }
-                    J result = JavaTemplate.builder(afterTemplate).build()
+                    Object[] substitutions = applied.substitutions;
+                    J result = JavaTemplate.builder(applied.template).build()
                             .apply(getCursor(), method.getCoordinates().replace(), substitutions);
                     if (result instanceof J.MethodInvocation) {
                         JContainer<Expression> matchedTypeArgs = method.getPadding().getTypeParameters();
@@ -715,6 +696,146 @@ public final class GeneratedRecipeSupport {
             result[i] = parseCsv(lines[i]);
         }
         return result;
+    }
+
+    /**
+     * Marks the variadic-run position in an after template. Must stay
+     * byte-identical to {@code RecipeIrGenerationExtension.VARARGS_SENTINEL}.
+     * Control-char-fenced so it can never collide with real source text.
+     */
+    private static final String VARARGS_SENTINEL = "VARARGS";
+
+    /**
+     * A single substitution source parsed from the CSV. {@link #SELECT} pulls
+     * the matched call's receiver; {@link #ARG} pulls one positional argument;
+     * {@link #VARARG} expands to {@code getArguments()[pos..end]} — the
+     * variadic-by-default run.
+     */
+    private static final class SubSource {
+        static final int SELECT = 0;
+        static final int ARG = 1;
+        static final int VARARG = 2;
+        final int kind;
+        final int pos;
+        SubSource(int kind, int pos) { this.kind = kind; this.pos = pos; }
+    }
+
+    private static SubSource parseSource(String token) {
+        if (!token.isEmpty() && token.charAt(0) == 'V') {
+            return new SubSource(SubSource.VARARG, Integer.parseInt(token.substring(1)));
+        }
+        int n = Integer.parseInt(token);
+        return n < 0 ? new SubSource(SubSource.SELECT, -1) : new SubSource(SubSource.ARG, n);
+    }
+
+    /**
+     * Parse a per-matcher substitution-source CSV (same shared / {@code \n}-
+     * delimited shape as {@link #parseCsvPerMatcher}) into {@link SubSource}
+     * rows, supporting the {@code V<k>} variadic token.
+     */
+    private static SubSource[][] parseSourcesPerMatcher(String csv, int matcherCount) {
+        if (matcherCount == 0) {
+            return new SubSource[0][];
+        }
+        if (csv.indexOf('\n') < 0) {
+            SubSource[] shared = parseSourceRow(csv);
+            SubSource[][] result = new SubSource[matcherCount][];
+            for (int i = 0; i < matcherCount; i++) {
+                result[i] = shared;
+            }
+            return result;
+        }
+        String[] lines = csv.split("\n", -1);
+        if (lines.length != matcherCount) {
+            throw new IllegalStateException(
+                    "expected " + matcherCount + " per-matcher CSVs but got " + lines.length);
+        }
+        SubSource[][] result = new SubSource[matcherCount][];
+        for (int i = 0; i < matcherCount; i++) {
+            result[i] = parseSourceRow(lines[i]);
+        }
+        return result;
+    }
+
+    private static SubSource[] parseSourceRow(String row) {
+        if (row.isEmpty()) {
+            return new SubSource[0];
+        }
+        String[] parts = row.split(",");
+        SubSource[] out = new SubSource[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            out[i] = parseSource(parts[i]);
+        }
+        return out;
+    }
+
+    /** Expanded after template + the substitution array it aligns with. */
+    private static final class Applied {
+        final String template;
+        final Object[] substitutions;
+        Applied(String template, Object[] substitutions) {
+            this.template = template;
+            this.substitutions = substitutions;
+        }
+    }
+
+    /**
+     * Build the substitution array for a matched invocation and, when the
+     * recipe is variadic, expand the {@link #VARARGS_SENTINEL} in the after
+     * template to one {@code #{any()}} placeholder per matched run argument.
+     * Returns {@code null} (caller should skip) when the arity guard fails or a
+     * source can't be satisfied (missing receiver / out-of-range arg).
+     *
+     * <p>Placeholders bind positionally, so expanding the sentinel in place and
+     * splicing the run args at the same ordinal keeps template and array
+     * aligned.
+     */
+    private static @Nullable Applied prepareSubstitutions(
+            J.MethodInvocation method, SubSource[] sources, String afterTemplate, int strictArgCount) {
+        List<Expression> args = method.getArguments();
+        // The canonical zero-arg call is a single J.Empty — treat as 0 args so a
+        // variadic run collapses to `()` rather than splicing the placeholder.
+        boolean noArgs = args.size() == 1 && args.get(0) instanceof J.Empty;
+        int argCount = noArgs ? 0 : args.size();
+        if (strictArgCount >= 0 && argCount != strictArgCount) {
+            return null;
+        }
+        List<Object> substitutions = new ArrayList<>(sources.length);
+        int varargCount = -1;
+        for (SubSource s : sources) {
+            switch (s.kind) {
+                case SubSource.SELECT:
+                    if (method.getSelect() == null) {
+                        return null;
+                    }
+                    substitutions.add(method.getSelect());
+                    break;
+                case SubSource.ARG:
+                    if (s.pos >= argCount) {
+                        return null;
+                    }
+                    substitutions.add(args.get(s.pos));
+                    break;
+                case SubSource.VARARG:
+                    varargCount = Math.max(0, argCount - s.pos);
+                    for (int i = s.pos; i < s.pos + varargCount; i++) {
+                        substitutions.add(args.get(i));
+                    }
+                    break;
+            }
+        }
+        String template = afterTemplate;
+        if (varargCount >= 0) {
+            StringBuilder placeholders = new StringBuilder();
+            for (int i = 0; i < varargCount; i++) {
+                if (i > 0) {
+                    placeholders.append(", ");
+                }
+                placeholders.append("#{any()}");
+            }
+            template = afterTemplate.replace(VARARGS_SENTINEL, placeholders.toString());
+        }
+        return new Applied(template, substitutions.toArray());
     }
 
 /**

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/RecipeDsl.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/RecipeDsl.kt
@@ -577,93 +577,109 @@ public open class GenerateScope internal constructor(public val ctx: ExecutionCo
 // rewrite { } to { } type stubs — populated at IR time by the K2 plugin.
 // ---------------------------------------------------------------------------
 
+/**
+ * The result of a `rewrite { } to { }` clause. Exists so the optional
+ * `.strictArity()` opt-out can chain off it: by default a clause whose before
+ * targets a varargs method matches call sites with any number of trailing
+ * arguments (variadic-by-default); `(rewrite { } to { }).strictArity()` pins it
+ * to the exact arity the author wrote. Like the rest of the declarative shape
+ * this is an `error(...)` stub — the K2 plugin rewrites the whole clause at IR
+ * time and this body never runs.
+ */
+@RecipeDsl public class RewriteRule internal constructor() {
+    @Suppress("UNUSED_PARAMETER")
+    public fun strictArity(): Unit = error(
+        "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
+    )
+}
+
 @RecipeDsl public class RewriteAdvice0<R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
-    public infix fun <R2> to(after: () -> R2): Unit = error(
+    public infix fun <R2> to(after: () -> R2): RewriteRule = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }
 
 @RecipeDsl public class RewriteAdvice1<P, R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
-    public infix fun <R2> to(after: (P) -> R2): Unit = error(
+    public infix fun <R2> to(after: (P) -> R2): RewriteRule = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }
 
 @RecipeDsl public class RewriteAdvice2<P1, P2, R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
-    public infix fun <R2> to(after: (P1, P2) -> R2): Unit = error(
+    public infix fun <R2> to(after: (P1, P2) -> R2): RewriteRule = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }
 
 @RecipeDsl public class RewriteAdvice3<P1, P2, P3, R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
-    public infix fun <R2> to(after: (P1, P2, P3) -> R2): Unit = error(
+    public infix fun <R2> to(after: (P1, P2, P3) -> R2): RewriteRule = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }
 
 @RecipeDsl public class RewriteAdvice4<P1, P2, P3, P4, R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
-    public infix fun <R2> to(after: (P1, P2, P3, P4) -> R2): Unit = error(
+    public infix fun <R2> to(after: (P1, P2, P3, P4) -> R2): RewriteRule = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }
 
 @RecipeDsl public class RewriteAdvice5<P1, P2, P3, P4, P5, R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
-    public infix fun <R2> to(after: (P1, P2, P3, P4, P5) -> R2): Unit = error(
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5) -> R2): RewriteRule = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }
 
 @RecipeDsl public class RewriteAdvice6<P1, P2, P3, P4, P5, P6, R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
-    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6) -> R2): Unit = error(
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6) -> R2): RewriteRule = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }
 
 @RecipeDsl public class RewriteAdvice7<P1, P2, P3, P4, P5, P6, P7, R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
-    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7) -> R2): Unit = error(
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7) -> R2): RewriteRule = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }
 
 @RecipeDsl public class RewriteAdvice8<P1, P2, P3, P4, P5, P6, P7, P8, R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
-    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8) -> R2): Unit = error(
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8) -> R2): RewriteRule = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }
 
 @RecipeDsl public class RewriteAdvice9<P1, P2, P3, P4, P5, P6, P7, P8, P9, R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
-    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R2): Unit = error(
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R2): RewriteRule = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }
 
 @RecipeDsl public class RewriteAdvice10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
-    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R2): Unit = error(
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R2): RewriteRule = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }
 
 @RecipeDsl public class RewriteAdvice11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
-    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R2): Unit = error(
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R2): RewriteRule = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }
 
 @RecipeDsl public class RewriteAdvice12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> internal constructor() {
     @Suppress("UNUSED_PARAMETER")
-    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R2): Unit = error(
+    public infix fun <R2> to(after: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R2): RewriteRule = error(
         "Recipe DSL: `rewrite { } to { }` requires the rewrite-kotlin K2 compiler plugin.",
     )
 }

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeFirDslCheckers.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeFirDslCheckers.kt
@@ -86,6 +86,7 @@ internal object RecipeFirDslCheckers : FirPropertyChecker(MppCheckerKind.Common)
     private val NAME_EDIT = Name.identifier("edit")
     private val NAME_GENERATE = Name.identifier("generate")
     private val NAME_REWRITE = Name.identifier("rewrite")
+    private val NAME_STRICT_ARITY = Name.identifier("strictArity")
 
     /** Classification of a top-level statement inside the `recipe { … }` block. */
     private sealed interface StatementKind {
@@ -238,7 +239,9 @@ internal object RecipeFirDslCheckers : FirPropertyChecker(MppCheckerKind.Common)
         // receiver is `scan(…) { … }`. We classify by what the chain DOES.
         val chain = unwindChain(call)
         return when {
-            chain.head?.callableSimpleName() == NAME_REWRITE && chain.outermost.callableSimpleName() != NAME_TO ->
+            chain.head?.callableSimpleName() == NAME_REWRITE &&
+                chain.outermost.callableSimpleName() != NAME_TO &&
+                chain.outermost.callableSimpleName() != NAME_STRICT_ARITY ->
                 StatementKind.OrphanRewrite
             chain.head?.callableSimpleName() == NAME_SCAN -> {
                 val hasEdit = chain.tailNames.contains(NAME_EDIT)
@@ -326,7 +329,8 @@ internal object RecipeFirDslCheckers : FirPropertyChecker(MppCheckerKind.Common)
                     ?: continue
                 val chain = unwindChain(call)
                 if (chain.head?.callableSimpleName() == NAME_REWRITE &&
-                    chain.outermost.callableSimpleName() != NAME_TO
+                    chain.outermost.callableSimpleName() != NAME_TO &&
+                    chain.outermost.callableSimpleName() != NAME_STRICT_ARITY
                 ) {
                     reportError(
                         stmt.source ?: declaration.source ?: return,

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeFirMappedTypeFallbackExtension.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeFirMappedTypeFallbackExtension.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.fir.extensions.FirDeclarationGenerationExtension
 import org.jetbrains.kotlin.fir.plugin.createTopLevelFunction
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.ConeKotlinTypeProjectionOut
 import org.jetbrains.kotlin.fir.types.constructClassLikeType
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
@@ -174,10 +175,9 @@ internal class RecipeFirMappedTypeFallbackExtension(session: FirSession) :
                 if (method.isSynthetic) continue
                 if (method.isBridge) continue
                 // Note: vararg methods like `String.formatted(Object... args)`
-                // are emitted as plain Array<out Any?> parameters below
-                // (see generateExtensionFor). Authors lose the trailing-vararg
-                // convenience syntax (must pass a literal array) for these
-                // entries — acceptable for the recipe DSL use case.
+                // are re-exposed as real Kotlin `vararg` parameters below
+                // (see generateExtensionFor), so authors keep the natural
+                // `x.formatted(a, b, c)` call syntax.
                 // Skip methods whose name collides with an existing kotlin
                 // member of the same arity to avoid `equals/hashCode/toString`
                 // double-declaration in the generated facade.
@@ -293,25 +293,21 @@ internal class RecipeFirMappedTypeFallbackExtension(session: FirSession) :
         ) {
             extensionReceiverType(receiverType)
             for ((idx, p) in entry.method.parameters.withIndex()) {
-                // Java vararg: declare an `Array<Any?>` parameter (non-vararg
-                // from Kotlin's POV) so authors call the extension with an
-                // explicit `arrayOf(...)`. We don't surface `isVararg=true`
-                // here because the FIR-builder + IR-backend pair has a
-                // round-tripping bug with synthesized varargs whose element
-                // type is `Any?` (the call-side IR construction emits a
-                // `vararg(...)` expression whose element type doesn't match
-                // the param's declared element type, tripping
+                // Java vararg (`Object... args`): surface as a real Kotlin
+                // `vararg args: Any?` so authors write `x.formatted(a, b, c)`
+                // naturally and the recipe DSL's variadic machinery sees the
+                // varargs nature. The parameter's declared type must be the
+                // OUT-projected `Array<out Any?>` (what Kotlin uses for a
+                // vararg) — an invariant `Array<Any?>` here is what tripped
                 // `IllegalStateException: Vararg expression has incorrect type`
-                // during fir2ir).
-                val paramType = if (p.isVarArgs && p.type.isArray) {
-                    arrayOfAny()
-                } else {
-                    mapJavaTypeToKotlin(p.type)
-                }
+                // during fir2ir (the call-side `vararg(...)` element type
+                // mismatched the param's declared element type).
+                val isVarargParam = p.isVarArgs && p.type.isArray
+                val paramType = if (isVarargParam) arrayOfOutAny() else mapJavaTypeToKotlin(p.type)
                 valueParameter(
                     name = Name.identifier(p.name ?: "p$idx"),
                     type = paramType,
-                    isVararg = false,
+                    isVararg = isVarargParam,
                 )
             }
             // Default body — IR phase replaces this with a direct invokevirtual.
@@ -358,11 +354,16 @@ internal class RecipeFirMappedTypeFallbackExtension(session: FirSession) :
     private fun stdLibClass(packageName: String, className: String): ClassId =
         ClassId(FqName(packageName), Name.identifier(className))
 
-    /** Construct `Array<Any?>` as a ConeKotlinType for vararg-Object methods. */
-    private fun arrayOfAny(): ConeKotlinType {
+    /**
+     * Construct `Array<out Any?>` as a ConeKotlinType — the declared type of a
+     * Kotlin `vararg args: Any?` parameter. The `out` projection is essential:
+     * an invariant `Array<Any?>` mismatches the element type K2 derives when
+     * building the call-side vararg expression, crashing fir2ir.
+     */
+    private fun arrayOfOutAny(): ConeKotlinType {
         val any = stdLibClass("kotlin", "Any").constructClassLikeType(emptyArray(), true)
         val arrayCls = stdLibClass("kotlin", "Array")
-        return arrayCls.constructClassLikeType(arrayOf(any), false)
+        return arrayCls.constructClassLikeType(arrayOf(ConeKotlinTypeProjectionOut(any)), false)
     }
 
     private val ConeKotlinType.classId: ClassId?

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
@@ -38,6 +38,7 @@ import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irDelegatingConstructorCall
+import org.jetbrains.kotlin.ir.builders.irInt
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.declarations.IrClass
@@ -58,6 +59,9 @@ import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
 import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
 import org.jetbrains.kotlin.ir.expressions.IrReturn
+import org.jetbrains.kotlin.ir.expressions.IrSpreadElement
+import org.jetbrains.kotlin.ir.expressions.IrVararg
+import org.jetbrains.kotlin.ir.expressions.IrVarargElement
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
@@ -125,6 +129,9 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
 
         val REWRITE_ADVICE_TO_FQNS: Set<String> = (0..12).map { "org.openrewrite.RewriteAdvice$it.to" }.toSet()
 
+        /** The `.strictArity()` opt-out modifier wrapping a `to` call. */
+        const val REWRITE_RULE_STRICT_ARITY_FQN = "org.openrewrite.RewriteRule.strictArity"
+
         const val EDIT_SCOPE_REWRITE_FQN = "org.openrewrite.EditScope.rewrite"
         const val RECIPE_BUILDER_EDIT_FQN = "org.openrewrite.RecipeBuilder.edit"
 
@@ -135,6 +142,35 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
          * `FirNotNullableTransformer` in the Kotlin compiler.
          */
         const val CHECK_NOT_NULL_FQN = "kotlin.internal.ir.CHECK_NOT_NULL"
+
+        /**
+         * Sentinel that marks the variadic-run position in a generated after
+         * template. The runtime ([GeneratedRecipeSupport]) replaces it with the
+         * right number of `#{any()}` placeholders for the matched call's args.
+         * Control-char-fenced so it can never collide with real source text.
+         */
+        const val VARARGS_SENTINEL = "VARARGS"
+
+        /**
+         * Kotlin builtin → Java FQN, for typing the fixed prefix params of a
+         * varargs MethodMatcher spec. `JavaType.Method` carries Java types even
+         * for Kotlin sources, so `kotlin.String` must be spelled
+         * `java.lang.String` for the matcher to fire.
+         */
+        val KOTLIN_BUILTIN_TO_JAVA_FQN: Map<String, String> = mapOf(
+            "kotlin.String" to "java.lang.String",
+            "kotlin.CharSequence" to "java.lang.CharSequence",
+            "kotlin.Any" to "java.lang.Object",
+            "kotlin.Throwable" to "java.lang.Throwable",
+            "kotlin.Int" to "int",
+            "kotlin.Long" to "long",
+            "kotlin.Short" to "short",
+            "kotlin.Byte" to "byte",
+            "kotlin.Boolean" to "boolean",
+            "kotlin.Char" to "char",
+            "kotlin.Float" to "float",
+            "kotlin.Double" to "double",
+        )
     }
 
     override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
@@ -223,10 +259,13 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
 
         val supportClassId = ClassId.topLevel(FqName("org.openrewrite.kotlin.recipe.GeneratedRecipeSupport"))
         val supportClassSymbol = pluginContext.referenceClass(supportClassId)
+        // Resolve by name (each helper name is unique). Arity varies: the two
+        // method-invocation helpers carry a 4th `strictArgCount` param; the
+        // not-null / property helpers stay at 3.
         val supportFns = supportClassSymbol
             ?.owner?.declarations
             ?.filterIsInstance<IrSimpleFunction>()
-            ?.filter { it.dispatchReceiverParameter == null && it.valueParameters.size == 3 }
+            ?.filter { it.dispatchReceiverParameter == null }
             .orEmpty()
         val kotlinHelper = supportFns.firstOrNull { it.name.asString() == "methodInvocationRewrite" }?.symbol
         val javaHelper = supportFns.firstOrNull { it.name.asString() == "methodInvocationRewriteJava" }?.symbol
@@ -468,6 +507,13 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
          * Routes the helper selection to a `J.FieldAccess`-walking visitor.
          */
         val propertyAccess: Boolean,
+        /**
+         * For `.strictArity()` recipes on a varargs callee: the exact number of
+         * call-site arguments to require at runtime (the matcher is still `..`
+         * because a varargs method can only be matched by `..`). -1 disables the
+         * guard (variadic-by-default, or a non-varargs callee).
+         */
+        val strictArgCount: Int,
     )
 
     private fun pickHelperSymbol(
@@ -539,11 +585,27 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         val editBlockArg = editCall.getValueArgument(0) as? IrFunctionExpression ?: return null
         val editStmts = (editBlockArg.function.body as? IrBlockBody)?.statements ?: return null
 
-        // The edit block's sole statement should be the `rewrite { } to { }` call.
+        // The edit block's sole statement should be the `rewrite { } to { }`
+        // call, optionally wrapped in a trailing `.strictArity()` opt-out.
+        // Since `to` returns `RewriteRule` (non-Unit), a bare clause is wrapped
+        // by K2 in an IMPLICIT_COERCION_TO_UNIT when the edit lambda returns
+        // Unit — peel that so we see the underlying call.
         val rewriteStmt = editStmts.singleOrNull() ?: return null
-        val toCall = (rewriteStmt as? IrReturn)?.value as? IrCall
-            ?: rewriteStmt as? IrCall
-            ?: return null
+        val rawStmt = (rewriteStmt as? IrReturn)?.value ?: rewriteStmt
+        val unwrappedStmt = if (rawStmt is IrTypeOperatorCall &&
+            rawStmt.operator == IrTypeOperator.IMPLICIT_COERCION_TO_UNIT
+        ) {
+            rawStmt.argument
+        } else {
+            rawStmt
+        }
+        val outermostCall = unwrappedStmt as? IrCall ?: return null
+        val strict = outermostCall.symbol.owner.kotlinFqName.asString() == REWRITE_RULE_STRICT_ARITY_FQN
+        val toCall = if (strict) {
+            outermostCall.dispatchReceiver as? IrCall ?: return null
+        } else {
+            outermostCall
+        }
         val toCallFqn = toCall.symbol.owner.kotlinFqName.asString()
         if (toCallFqn !in REWRITE_ADVICE_TO_FQNS) return null
         val rewriteCall = toCall.dispatchReceiver as? IrCall ?: return null
@@ -587,16 +649,41 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             // recipe must pick one or the other.
             if (beforeLambdas[i].propertyAccess != propertyAccessForAll) return null
         }
+        // Variadic groups only flow through the plain method-invocation helpers;
+        // not-null / chain shapes use visitor entries without run support.
+        if (beforeLambdas.any { it.varargGroup != null && (it.wrappedInNotNull || it.inner != null) }) return null
+        // `.strictArity()` is incompatible with the spread form (a spread has no
+        // fixed count to pin). Compute the exact arg count for the runtime guard
+        // — only meaningful for varargs callees; -1 disables it.
+        if (strict && beforeLambdas.any { it.varargGroup?.isSpread == true }) return null
+        val strictArgCount = if (strict) {
+            val counts = beforeLambdas.filter { it.varargGroup != null }.map { it.argSignatures.size }.toSet()
+            when {
+                counts.isEmpty() -> -1
+                counts.size == 1 -> counts.single()
+                else -> return null
+            }
+        } else {
+            -1
+        }
         // Mixed-shape multi-before: each before gets its own
         // substitution-source CSV (since the after-lambda params bind to
         // different positions in each before — receiver in one, arg-N in
         // another). The after TEMPLATE is required to be identical across
         // all befores; if it isn't, the after lambda's IR was somehow
         // different per-before, which the runtime helper can't dispatch on.
-        val firstTemplate = buildAfterTemplate(afterArg, sourceText, beforeLambdas[0]) ?: return null
+        // Whether the generated visitor will use JavaTemplate (vs KotlinTemplate)
+        // — mirrors `pickHelperSymbol`. Drives placeholder type spelling: Java
+        // templates need `java.lang.String`, Kotlin templates `kotlin.String`.
+        val isChain = beforeLambdas.any { it.inner != null }
+        val usesKotlinTreeNode = classifyKotlinPromotion(beforeExprs + afterArg)
+        val javaTemplate = !usesKotlinTreeNode && !notNullForAll && !propertyAccessForAll &&
+            !isChain && ctx.methodInvocationRewriteJavaSymbol != null
+
+        val firstTemplate = buildAfterTemplate(afterArg, sourceText, beforeLambdas[0], strict, javaTemplate) ?: return null
         val csvs = mutableListOf(firstTemplate.second)
         for (i in 1 until beforeLambdas.size) {
-            val nextTemplate = buildAfterTemplate(afterArg, sourceText, beforeLambdas[i]) ?: return null
+            val nextTemplate = buildAfterTemplate(afterArg, sourceText, beforeLambdas[i], strict, javaTemplate) ?: return null
             if (nextTemplate.first != firstTemplate.first) return null
             csvs += nextTemplate.second
         }
@@ -621,7 +708,6 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         // the delimiter and dispatch per-matcher.
         val csvField = if (csvs.size == 1) csvs[0] else csvs.joinToString("\n")
 
-        val usesKotlinTreeNode = classifyKotlinPromotion(beforeExprs + afterArg)
         return RewriteTemplates(
             matcherSpecs = matcherSpecs,
             afterTemplate = firstTemplate.first,
@@ -629,6 +715,7 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             usesKotlinTreeNode = usesKotlinTreeNode,
             wrappedInNotNull = notNullForAll,
             propertyAccess = propertyAccessForAll,
+            strictArgCount = strictArgCount,
         )
     }
 
@@ -708,7 +795,34 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
     private sealed class ArgSig {
         class ParamRef(val symbol: IrValueSymbol) : ArgSig()
         class LiteralConst(val kind: org.jetbrains.kotlin.ir.expressions.IrConstKind, val value: Any?) : ArgSig()
+
+        /**
+         * A Kotlin spread (`*args`) of an array-typed param into a callee's
+         * varargs slot. Only valid as the trailing flattened sig of a varargs
+         * callee. Carries the array param symbol — the whole run is captured as
+         * one group (see [VarargGroup]).
+         */
+        class VarargSpread(val symbol: IrValueSymbol) : ArgSig()
     }
+
+    /**
+     * The variadic capture of a before-lambda whose root call targets a method
+     * whose declared last parameter is varargs (`Object...`). Built from the
+     * args the author placed into that slot — either plain "by example" element
+     * refs (`asList(a, b, c)`) or a single spread (`asList(*args)`).
+     *
+     * [startArgIndex] (`k`) is the flattened position where the varargs run
+     * begins — i.e. the number of fixed declared prefix params. At a matched
+     * call site the group absorbs `getArguments()[k..end]`. [memberSymbols] are
+     * the param symbols bound to the slot, in source order (one entry for the
+     * spread form; N for the by-example form). The after-template references
+     * them as a single contiguous run that expands to the matched args.
+     */
+    private class VarargGroup(
+        val startArgIndex: Int,
+        val memberSymbols: List<IrValueSymbol>,
+        val isSpread: Boolean,
+    )
 
     private class BeforeLambda(
         val params: List<IrValueParameter>,
@@ -760,6 +874,14 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
          * — those routes use different visitor entries.
          */
         val inner: BeforeLambda? = null,
+        /**
+         * Set when the root call targets a varargs method and the author placed
+         * ≥1 arg into the varargs slot. Drives variadic-by-default matching: the
+         * matcher becomes `prefix…, ..` and the after-template carries the group
+         * as one expandable run. Null for non-varargs callees (or chain/not-null/
+         * property shapes, which keep the fixed-arity path). See [VarargGroup].
+         */
+        val varargGroup: VarargGroup? = null,
     )
 
     private fun validateBeforeLambda(
@@ -899,9 +1021,51 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             else -> return null
         }
 
+        val isVarargsCallee = rootCall.symbol.owner.valueParameters.lastOrNull()?.varargElementType != null
         val sigs = mutableListOf<ArgSig>()
+        var varargGroup: VarargGroup? = null
         for (i in 0 until rootCall.valueArgumentsCount) {
-            val arg = unwrapImplicitCasts(rootCall.getValueArgument(i)) ?: continue
+            val rawArg = rootCall.getValueArgument(i) ?: continue
+            // A call to a varargs method lowers the trailing args into a single
+            // IrVararg at the varargs param's slot. Flatten its elements: plain
+            // refs are "by example" run members; a lone `*args` is a spread
+            // capturing the whole run. Either way they form a VarargGroup that
+            // drives variadic-by-default matching downstream.
+            if (rawArg is IrVararg) {
+                val k = sigs.size
+                val members = mutableListOf<IrValueSymbol>()
+                var sawSpread = false
+                for (element: IrVarargElement in rawArg.elements) {
+                    if (element is IrSpreadElement) {
+                        // `*args` — one lone spread of an array param. v1 rejects
+                        // mixing a spread with other elements in the same slot.
+                        if (rawArg.elements.size != 1) return null
+                        val spreadExpr = unwrapImplicitCasts(element.expression)
+                        if (spreadExpr !is IrGetValue || spreadExpr.symbol !in paramSyms) return null
+                        sigs += ArgSig.VarargSpread(spreadExpr.symbol)
+                        members += spreadExpr.symbol
+                        sawSpread = true
+                    } else {
+                        when (val elemExpr = unwrapImplicitCasts(element as? IrExpression)) {
+                            is IrGetValue -> {
+                                if (elemExpr.symbol !in paramSyms) return null
+                                sigs += ArgSig.ParamRef(elemExpr.symbol)
+                                members += elemExpr.symbol
+                            }
+                            // A literal in the varargs slot can't anchor a
+                            // pass-through run — reject for v1.
+                            else -> return null
+                        }
+                    }
+                }
+                // Only a genuinely varargs callee forms a group; an empty
+                // by-example slot has nothing to carry.
+                if (isVarargsCallee && members.isNotEmpty()) {
+                    varargGroup = VarargGroup(startArgIndex = k, memberSymbols = members, isSpread = sawSpread)
+                }
+                continue
+            }
+            val arg = unwrapImplicitCasts(rawArg) ?: continue
             when (arg) {
                 is IrGetValue -> {
                     if (arg.symbol !in paramSyms) return null
@@ -914,7 +1078,8 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         // Property accessors take 0 value args; a non-empty arg signature here
         // means the IR is method-style despite a getter-shaped symbol.
         val finalPropertyAccess = propertyAccess && sigs.isEmpty()
-        return BeforeLambda(params, rootCall, sigs, receiverParamSymbol, wrappedInNotNull, finalPropertyAccess)
+        return BeforeLambda(params, rootCall, sigs, receiverParamSymbol, wrappedInNotNull, finalPropertyAccess,
+            varargGroup = varargGroup)
     }
 
     /**
@@ -1012,6 +1177,10 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
                     CanonicalArgSig.ParamIdx(idx)
                 }
                 is ArgSig.LiteralConst -> CanonicalArgSig.Literal(sig.kind, sig.value)
+                is ArgSig.VarargSpread -> {
+                    val idx = paramIdxBySymbol[sig.symbol] ?: return@map CanonicalArgSig.Unknown
+                    CanonicalArgSig.Vararg(idx)
+                }
             }
         }
         return CanonicalSignature(receiverIdx, args)
@@ -1024,6 +1193,7 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
 
     private sealed class CanonicalArgSig {
         data class ParamIdx(val idx: Int) : CanonicalArgSig()
+        data class Vararg(val idx: Int) : CanonicalArgSig()
         data class Literal(val kind: org.jetbrains.kotlin.ir.expressions.IrConstKind, val value: Any?) : CanonicalArgSig()
         object Unknown : CanonicalArgSig()
     }
@@ -1121,9 +1291,35 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
     private fun computeArgsPattern(owner: IrSimpleFunction): String {
         val isDispatched = owner.dispatchReceiverParameter != null
         val extReceiverArg = if (!isDispatched && owner.extensionReceiverParameter != null) 1 else 0
-        val jvmArgCount = owner.valueParameters.size + extReceiverArg
+        val params = owner.valueParameters
+        if (params.lastOrNull()?.varargElementType != null) {
+            // Varargs callee: a `JavaType.Method` declares the varargs slot as a
+            // single array parameter, so only a trailing `..` can ever match it
+            // (a fixed `*,*,*` spec never will — `MethodMatcherTest
+            // .varargsMatchesArrayType`). Type the fixed prefix params so we
+            // don't also match a same-named sibling overload such as
+            // `String.format(Locale, String, Object...)`.
+            val tokens = mutableListOf<String>()
+            repeat(extReceiverArg) { tokens += "*" }
+            for (i in 0 until params.size - 1) {
+                tokens += matcherParamType(params[i].type)
+            }
+            tokens += ".."
+            return tokens.joinToString(",")
+        }
+        val jvmArgCount = params.size + extReceiverArg
         if (jvmArgCount == 0) return ""
         return List(jvmArgCount) { "*" }.joinToString(",")
+    }
+
+    /**
+     * Render a fixed prefix parameter's type as a MethodMatcher type token,
+     * mapping Kotlin builtins back to the Java FQN the matcher resolves against.
+     * Falls back to `*` when the type can't be named.
+     */
+    private fun matcherParamType(type: IrType): String {
+        val fqn = type.classFqName?.asString() ?: return "*"
+        return KOTLIN_BUILTIN_TO_JAVA_FQN[fqn] ?: fqn
     }
 
     private fun computeJvmFacadeFqn(fn: IrSimpleFunction): String? {
@@ -1184,6 +1380,8 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         fnExpr: IrFunctionExpression,
         sourceText: String,
         before: BeforeLambda,
+        strict: Boolean,
+        javaTemplate: Boolean,
     ): Pair<String, String>? {
         val fn = fnExpr.function
         val afterParams = fn.valueParameters
@@ -1194,6 +1392,21 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             is IrReturn -> singleStmt.value
             is IrExpression -> singleStmt
             else -> return null
+        }
+
+        // Variadic run: when the before targets a varargs method (and the
+        // recipe didn't opt into strict arity) the args placed in the varargs
+        // slot are carried as ONE expandable run, not fixed captures.
+        // `groupAfterSyms` are the after-lambda param symbols (positional twins
+        // of the before's group members) that make up that run — they're
+        // excluded from normal placeholder mapping and re-emitted as a single
+        // sentinel the runtime expands per matched call.
+        val group = if (strict) null else before.varargGroup
+        val groupBeforeSyms: Set<IrValueSymbol> = group?.memberSymbols?.toSet() ?: emptySet()
+        val groupAfterSyms: Set<IrValueSymbol> = if (group == null) emptySet() else buildSet {
+            for (i in before.params.indices) {
+                if (before.params[i].symbol in groupBeforeSyms) add(afterParams[i].symbol)
+            }
         }
 
         // Substitution source encoding:
@@ -1212,6 +1425,8 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
 
         val paramSymToSource = HashMap<IrValueSymbol, String>(afterParams.size)
         for (i in 0 until afterParams.size) {
+            val afterSym = afterParams[i].symbol
+            if (afterSym in groupAfterSyms) continue  // emitted as the variadic run below
             val beforeParamSym = before.params[i].symbol
             val source: String = when {
                 beforeParamSym == before.receiverParamSymbol -> outerSrc(-1)
@@ -1233,7 +1448,7 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
                     } else return null
                 }
             }
-            paramSymToSource[afterParams[i].symbol] = source
+            paramSymToSource[afterSym] = source
         }
 
         data class LiteralSlot(val src: String, val sig: ArgSig.LiteralConst, var consumed: Boolean = false)
@@ -1286,9 +1501,14 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             val startOffset: Int,
             val endOffset: Int,
             val source: String,
-            val typeFqn: String?,
+            // The exact text to splice in at this span: a `#{any(T)}` placeholder
+            // for a normal capture, or the variadic sentinel for the run.
+            val render: String,
         )
         val spots = mutableListOf<Spot>()
+        // Group-member references in the after body, folded into one run below.
+        data class GroupRef(val startOffset: Int, val endOffset: Int, val symbol: IrValueSymbol)
+        val groupRefs = mutableListOf<GroupRef>()
 
         // `accept(visitor, null)` includes `expr` itself; `acceptChildrenVoid`
         // would only visit its children. The distinction matters for after
@@ -1300,12 +1520,16 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             override fun visitElement(element: IrElement) { element.acceptChildrenVoid(this) }
 
             override fun visitGetValue(expression: IrGetValue) {
+                if (expression.symbol in groupAfterSyms) {
+                    groupRefs += GroupRef(expression.startOffset, expression.endOffset, expression.symbol)
+                    return
+                }
                 val src = paramSymToSource[expression.symbol] ?: return
                 spots += Spot(
                     startOffset = expression.startOffset,
                     endOffset = expression.endOffset,
                     source = src,
-                    typeFqn = renderPlaceholderType(expression.symbol.owner.type),
+                    render = renderPlaceholder(renderPlaceholderType(expression.symbol.owner.type, javaTemplate)),
                 )
             }
 
@@ -1317,10 +1541,34 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
                     startOffset = expression.startOffset,
                     endOffset = expression.endOffset,
                     source = slot.src,
-                    typeFqn = renderPlaceholderType(expression.type),
+                    render = renderPlaceholder(renderPlaceholderType(expression.type, javaTemplate)),
                 )
             }
         }, null)
+
+        // Fold the group-member references into one run spot. The runtime
+        // expands the sentinel to one `#{any()}` per matched arg and splices
+        // `getArguments()[k..end]` at this ordinal (source `V<k>`).
+        if (group != null) {
+            if (groupRefs.isEmpty()) return null                       // after must reference the run
+            val seen = groupRefs.map { it.symbol }.toSet()
+            if (seen.size != groupRefs.size) return null               // a member used twice
+            if (seen != groupAfterSyms) return null                    // missing / extra members
+            val runStartRaw = groupRefs.minOf { it.startOffset }
+            val runEnd = groupRefs.maxOf { it.endOffset }
+            // Spread form (`*args`): swallow the leading `*` (and any horizontal
+            // whitespace) so the sentinel replaces the whole spread expression.
+            val runStart = if (group.isSpread) {
+                var s = runStartRaw
+                while (s > 0 && (sourceText[s - 1] == ' ' || sourceText[s - 1] == '\t')) s--
+                if (s > 0 && sourceText[s - 1] == '*') s - 1 else runStartRaw
+            } else {
+                runStartRaw
+            }
+            // Contiguity: no normal capture may sit inside the run span.
+            if (spots.any { it.startOffset < runEnd && it.endOffset > runStart }) return null
+            spots += Spot(runStart, runEnd, "V${group.startArgIndex}", VARARGS_SENTINEL)
+        }
 
         val inSliceSpots = mutableListOf<Spot>()
         val prependSpots = mutableListOf<Spot>()
@@ -1348,13 +1596,13 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             templateBuilder.replace(
                 spot.startOffset - sliceStart,
                 spot.endOffset - sliceStart,
-                renderPlaceholder(spot.typeFqn),
+                spot.render,
             )
         }
         val template = if (prependSpots.isEmpty()) {
             templateBuilder.toString()
         } else {
-            "${renderPlaceholder(prependSpots.single().typeFqn)}.$templateBuilder"
+            "${prependSpots.single().render}.$templateBuilder"
         }
 
         val orderedSources = mutableListOf<String>()
@@ -1365,8 +1613,17 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         return template to csv
     }
 
-    private fun renderPlaceholderType(type: IrType): String? =
-        type.classFqName?.asString()
+    private fun renderPlaceholderType(type: IrType, javaTemplate: Boolean): String? {
+        val fqn = type.classFqName?.asString() ?: return null
+        // On the JavaTemplate path, map Kotlin builtin reference types to their
+        // Java FQN so the placeholder (`#{any(java.lang.String)}`) resolves the
+        // templated call's method type. Only remap reference FQNs (those with a
+        // dot); leave primitives (`int`) and non-builtins alone. KotlinTemplate
+        // keeps the Kotlin spelling, which is what it resolves against.
+        if (!javaTemplate) return fqn
+        val mapped = KOTLIN_BUILTIN_TO_JAVA_FQN[fqn]
+        return if (mapped != null && mapped.contains('.')) mapped else fqn
+    }
 
     private fun renderPlaceholder(typeFqn: String?): String =
         if (typeFqn != null) "#{any($typeFqn)}" else "#{any()}"
@@ -1496,6 +1753,11 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
                 factoryCall.arguments[0] = irString(templates.matcherSpecs.joinToString("\n"))
                 factoryCall.arguments[1] = irString(templates.afterTemplate)
                 factoryCall.arguments[2] = irString(templates.substitutionSourcesCsv)
+                // The method-invocation helpers take a 4th `strictArgCount`;
+                // the not-null / property helpers don't.
+                if (helperSymbol.owner.valueParameters.size >= 4) {
+                    factoryCall.arguments[3] = irInt(templates.strictArgCount)
+                }
                 +irReturn(factoryCall)
             }
         }

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipeMappedTypeFallbackTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipeMappedTypeFallbackTest.kt
@@ -60,19 +60,18 @@ class RecipeMappedTypeFallbackTest {
     }
 
     /**
-     * `String.formatted(Object... args)` is the vararg case. We currently
-     * surface it as a plain `Array<Any?>` parameter (not Kotlin's `vararg`
-     * — see comment in `RecipeFirMappedTypeFallbackExtension.generateExtensionFor`),
-     * so authors must call it with an explicit `arrayOf(...)`.
+     * `String.formatted(Object... args)` is the vararg case. It is re-exposed
+     * as a real Kotlin `vararg`, so authors call it with natural trailing
+     * arguments (`f.formatted("x", "y")`) — no explicit array required.
      */
     @Test
-    fun `String#formatted accepts explicit array argument`() {
+    fun `String#formatted accepts natural vararg arguments`() {
         val result = RecipePluginCompileFixture.compile(
             """
             import org.openrewrite.recipe
             val r = recipe("d", "desc") {
                 edit {
-                    rewrite { f: String -> java.lang.String.format(f) } to { f -> f.formatted(arrayOf<Any?>("x")) }
+                    rewrite { f: String -> java.lang.String.format(f) } to { f -> f.formatted("x", "y") }
                 }
             }
             """.trimIndent(),

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
@@ -24,7 +24,9 @@ import org.openrewrite.java.search.UsesField
 import org.openrewrite.java.search.UsesMethod
 import org.openrewrite.test.RecipeSpec
 import org.openrewrite.test.RewriteTest
+import org.openrewrite.test.TypeValidation
 import org.openrewrite.kotlin.Assertions.kotlin
+import org.openrewrite.java.Assertions.java
 
 /**
  * End-to-end recipe execution for the canonical Phase 3 shape:
@@ -1039,6 +1041,256 @@ class RecipePluginRewriteTest : RewriteTest {
         assertThat(r.description).isEqualTo("Test description")
         assertThat(r.getTags()).containsExactlyInAnyOrder("test", "smoke")
         assertThat(r.estimatedEffortPerOccurrence?.toMinutes()).isEqualTo(3L)
+    }
+
+    @Test
+    fun `variadic by-example — asList to List_of matches any arity`() {
+        // The author writes a representative 3-arg shape; because `asList` is a
+        // varargs method the recipe generalizes to ANY arity (2, 4, even 0).
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseListOf = recipe(
+                    displayName = "Use List.of",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { a: Any, b: Any, c: Any -> java.util.Arrays.asList(a, b, c) } to { a, b, c -> java.util.List.of(a, b, c) }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseListOf",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            java(
+                """
+                import java.util.Arrays;
+                import java.util.List;
+                class A {
+                    List<Object> two = Arrays.asList(1, 2);
+                    List<Object> four = Arrays.asList(1, 2, 3, 4);
+                    List<Object> none = Arrays.asList();
+                }
+                """.trimIndent(),
+                """
+                import java.util.Arrays;
+                import java.util.List;
+                class A {
+                    List<Object> two = java.util.List.of(1, 2);
+                    List<Object> four = java.util.List.of(1, 2, 3, 4);
+                    List<Object> none = java.util.List.of();
+                }
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `variadic by-example — Kotlin source fixture`() {
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseListOf = recipe(
+                    displayName = "Use List.of",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { a: Any, b: Any, c: Any -> java.util.Arrays.asList(a, b, c) } to { a, b, c -> java.util.List.of(a, b, c) }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseListOf",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            kotlin(
+                """
+                fun use() {
+                    java.util.Arrays.asList(1, 2, 3, 4, 5)
+                }
+                """.trimIndent(),
+                """
+                fun use() {
+                    java.util.List.of(1, 2, 3, 4, 5)
+                }
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `variadic spread — asList(star args) to List_of(star args)`() {
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseListOf = recipe(
+                    displayName = "Use List.of",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { args: Array<Any> -> java.util.Arrays.asList(*args) } to { args -> java.util.List.of(*args) }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseListOf",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            java(
+                """
+                import java.util.Arrays;
+                import java.util.List;
+                class A {
+                    List<Object> xs = Arrays.asList(1, 2, 3);
+                }
+                """.trimIndent(),
+                """
+                import java.util.Arrays;
+                import java.util.List;
+                class A {
+                    List<Object> xs = java.util.List.of(1, 2, 3);
+                }
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `prefix plus variadic — String_format to formatted`() {
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseFormatted = recipe(
+                    displayName = "Use String.formatted",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { fmt: String, a: Any, b: Any -> java.lang.String.format(fmt, a, b) } to { fmt, a, b -> fmt.formatted(a, b) }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseFormatted",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            java(
+                """
+                class A {
+                    String s = String.format("%s %s %s", 1, 2, 3);
+                }
+                """.trimIndent(),
+                """
+                class A {
+                    String s = "%s %s %s".formatted(1, 2, 3);
+                }
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `reorder — move trailing exception ahead of the varargs run`() {
+        // The slf4j-style migration: internal `log(msg, throwable, params...)`
+        // becomes `error(msg, params..., throwable)` — the fixed Throwable
+        // jumps from before the varargs run to after it.
+        val r = loadCompiledRecipe(
+            source = """
+                package demo
+                import org.openrewrite.recipe
+                class Log {
+                    fun internal(msg: String, t: Throwable, vararg params: Any) {}
+                    fun error(msg: String, vararg params: Any) {}
+                }
+                val ReorderLog = recipe(
+                    displayName = "Reorder log args",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { log: Log, msg: String, t: Throwable, a: Any, b: Any -> log.internal(msg, t, a, b) } to { log, msg, t, a, b -> log.error(msg, a, b, t) }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "ReorderLog",
+            packageName = "demo",
+        )
+        rewriteRun(
+            // `Log` is a full source so the before is properly typed and matched.
+            // The rewritten `log.error(...)` still needs method-invocation type
+            // validation relaxed: the generated recipe's JavaTemplate parses the
+            // after template with a JDK-only classpath, so it can't re-attribute
+            // a method on the test's own `demo.Log` (a real recipe targeting a
+            // classpath type like org.slf4j.Logger resolves fine). Same reason
+            // ~9 other tests in this file use TypeValidation.none(); the reorder
+            // itself is asserted by the before/after text.
+            { spec -> spec.recipe(r).typeValidationOptions(TypeValidation.builder().methodInvocations(false).build()) },
+            java(
+                """
+                package demo;
+                class Log {
+                    void internal(String msg, Throwable t, Object... params) {}
+                    void error(String msg, Object... params) {}
+                }
+                """.trimIndent(),
+            ),
+            java(
+                """
+                package demo;
+                class Use {
+                    void m(Log log, RuntimeException ex) {
+                        log.internal("boom", ex, 1, 2, 3);
+                    }
+                }
+                """.trimIndent(),
+                """
+                package demo;
+                class Use {
+                    void m(Log log, RuntimeException ex) {
+                        log.error("boom", 1, 2, 3, ex);
+                    }
+                }
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `strictArity — opt out of variadic matching`() {
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseListOfExactly2 = recipe(
+                    displayName = "Use List.of for exactly 2 args",
+                    description = "..."
+                ) {
+                    edit {
+                        (rewrite { a: Any, b: Any -> java.util.Arrays.asList(a, b) } to { a, b -> java.util.List.of(a, b) }).strictArity()
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseListOfExactly2",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            java(
+                """
+                import java.util.Arrays;
+                import java.util.List;
+                class A {
+                    List<Object> two = Arrays.asList(1, 2);
+                    List<Object> three = Arrays.asList(1, 2, 3);
+                }
+                """.trimIndent(),
+                """
+                import java.util.Arrays;
+                import java.util.List;
+                class A {
+                    List<Object> two = java.util.List.of(1, 2);
+                    List<Object> three = Arrays.asList(1, 2, 3);
+                }
+                """.trimIndent(),
+            ),
+        )
     }
 
     private fun loadCompiledRecipe(source: String, propertyName: String, packageName: String = ""): Recipe {


### PR DESCRIPTION
## What

Teaches the `rewrite { } to { }` recipe DSL to treat varargs methods as **variadic by default**. When the before pattern targets a method whose declared last parameter is varargs, the args the author places in that slot become a *representative group* rather than a literal count — so the recipe matches call sites of **any** arity and carries them all through. The author writes the natural shape; no `*args` ceremony required.

```kotlin
// matches Arrays.asList(...) of any arity (2, 4, even 0 -> List.of())
rewrite { a: Any, b: Any, c: Any -> java.util.Arrays.asList(a, b, c) } to { a, b, c -> java.util.List.of(a, b, c) }

// natural String.format -> String.formatted (JDK 15+)
rewrite { fmt: String, a: Any, b: Any -> java.lang.String.format(fmt, a, b) } to { fmt, a, b -> fmt.formatted(a, b) }
```

The variadic group can be **repositioned** in the after template — the motivating slf4j case moves a trailing `Throwable` from before the varargs run to after them (`log(msg, t, params…)` → `error(msg, params…, t)`). An explicit `.strictArity()` modifier opts out into exact-arity matching, and the explicit spread form `{ args: Array<Any> -> asList(*args) }` is also supported.

## How

- **Matcher**: a varargs callee is always matched with `prefix…, ..` — a `MethodMatcher` matches the *declared* signature, where varargs is a single array param, so a fixed `(*,*,*)` spec can never match it. Fixed prefix params are typed (Kotlin builtins → Java FQN) to avoid sibling-overload matches like `String.format(Locale, String, Object...)`.
- **After template**: carries a control-char sentinel + a `V<k>` substitution source. At apply time the runtime expands the sentinel to one `#{any()}` per matched arg and splices `getArguments()[k..end]` (the canonical zero-arg `[J.Empty]` collapses to count 0). Placeholders bind positionally, so in-place expansion keeps template and substitution array aligned. This handles pass-through, reorder, and `.strictArity()` (a runtime exact-count guard) uniformly.
- **Surface**: `to` now returns a `RewriteRule` so `(rewrite { } to { }).strictArity()` chains off it; the FIR checker accepts `strictArity` as a valid rewrite terminal.

### Bonus: the mapped-type fallback customizer now preserves varargs

- Re-exposed Java varargs methods like `String.formatted(Object...)` (surfaced by #7893) now appear as a real Kotlin `vararg args: Any?` instead of a plain `Array<Any?>`. #7893 deliberately punted on this because surfacing `isVararg = true` tripped `IllegalStateException: Vararg expression has incorrect type` in fir2ir — the cause was declaring the param as an **invariant** `Array<Any?>`; a Kotlin vararg's type is the **out-projected** `Array<out Any?>`. With that fix authors call `x.formatted("x", "y")` naturally, and `formatted` becomes a first-class variadic callee that the DSL handles for free.

## Testing

New cases in `RecipePluginRewriteTest` (compile-and-run via the K2 plugin + `rewriteRun`): by-example pass-through (Java + Kotlin sources), explicit spread, `String.format` → `formatted`, the slf4j reorder, and `.strictArity()`. `RecipeMappedTypeFallbackTest` updated to assert the natural `formatted("x", "y")` call. Full `:rewrite-kotlin:test` is green.