### PR TITLE
rewrite-csharp: preserve pragma whitespace and modifier-only lambda params

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/LambdaTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/LambdaTests.cs
@@ -217,6 +217,59 @@ public class LambdaTests : RewriteTest
         );
     }
 
+    // Parameters with modifiers but no explicit type (ref/out/in)
+
+    [Fact]
+    public void UntypedRefParameter()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Foo {
+                    delegate void D(ref int x);
+                    void Bar() {
+                        D f = (ref x) => x++;
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void UntypedRefParameters()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Foo {
+                    delegate void D(ref int a, ref int b);
+                    void Bar() {
+                        D f = static (ref a, ref b) => a += b;
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void UntypedOutParameter()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Foo {
+                    delegate void D(out int x);
+                    void Bar() {
+                        D f = (out x) => x = 1;
+                    }
+                }
+                """
+            )
+        );
+    }
+
     // Block body lambdas
 
     [Fact]

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/MethodDeclarationTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/MethodDeclarationTests.cs
@@ -170,6 +170,40 @@ public class MethodDeclarationTests : RewriteTest
         );
     }
 
+    [Fact]
+    public void ExpressionBodiedMethodWithCommentBeforeSemicolon()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Foo {
+                    int Bar()
+                        => 42
+                            // trailing comment
+                            ;
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void ExpressionBodiedConstructorWithCommentBeforeSemicolon()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                class Foo {
+                    int _x;
+                    Foo()
+                        => _x = 1 // set default
+                        ;
+                }
+                """
+            )
+        );
+    }
+
     /// <summary>
     /// Verifies that the printer does not crash with an InvalidCastException when a recipe
     /// transforms the Return statement inside an expression-bodied method into a different

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/PragmaDirectiveTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/PragmaDirectiveTests.cs
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Test;
+
+namespace OpenRewrite.Tests.Tree;
+
+public class PragmaDirectiveTests : RewriteTest
+{
+    [Fact]
+    public void PragmaWarningDisable()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                #pragma warning disable CS0168
+                class Foo {
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void PragmaWarningDisableRestore()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                #pragma warning disable CS0168, CS0219
+                class Foo {
+                }
+                #pragma warning restore CS0168, CS0219
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void PragmaWarningExtraSpaceBeforeWarning()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                #pragma  warning disable RS0026
+                class Foo {
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void PragmaWarningExtraSpaceBeforeAction()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                #pragma warning  disable RS0026
+                class Foo {
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void PragmaWarningExtraSpacesEverywhere()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                #pragma   warning   restore   RS0026
+                class Foo {
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void PragmaChecksum()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                #pragma checksum "file.cs" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "ab007f1d23d9"
+                class Foo {
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void PragmaChecksumExtraSpaceBeforeKeyword()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                #pragma   checksum "file.cs" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "ab007f1d23d9"
+                class Foo {
+                }
+                """
+            )
+        );
+    }
+
+    [Fact]
+    public void PragmaBeforeConditionalDirectiveWithAssembly()
+    {
+        RewriteRun(
+            CSharp(
+                """
+                #pragma warning disable SA1403 // single namespace
+
+                #if NET
+                // context
+                [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.CompilerServices.IsExternalInit))]
+                #endif
+                """
+            )
+        );
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -310,25 +310,18 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         // Leading directives go into the first non-empty printed list so the printer
         // emits them before any real content (print order: externs → usings → members)
-        if (leadingDirectives.Count > 0)
+        if (leadingDirectives.Count > 0 && node.Externs.Count > 0)
         {
-            var leadingTarget = node.Externs.Count > 0 ? externAliases : null;
-            // if target is null, defer to usingDirectives (declared below) or members
-            if (leadingTarget != null)
-            {
-                foreach (var d in leadingDirectives)
-                    leadingTarget.Add(new JRightPadded<Statement>(d, Space.Empty, Markers.Empty));
-                leadingDirectives.Clear();
-            }
-            else if (node.Usings.Count == 0)
-            {
-                // No externs, no usings — put in members
-                foreach (var d in leadingDirectives)
-                    members.Add(new JRightPadded<Statement>(d, Space.Empty, Markers.Empty));
-                leadingDirectives.Clear();
-            }
-            // else: leadingDirectives remain, will be prepended to usingDirectives below
+            // externAliases is the first list the printer emits, so leading directives belong
+            // ahead of the extern aliases when any exist.
+            foreach (var d in leadingDirectives)
+                externAliases.Add(new JRightPadded<Statement>(d, Space.Empty, Markers.Empty));
+            leadingDirectives.Clear();
         }
+        // Otherwise leadingDirectives remain and are prepended to usingDirectives below. The
+        // usings list prints before attributeLists and members, so a top-of-file directive
+        // (e.g. "#pragma warning disable" ahead of an "[assembly: ...]" attribute) keeps its
+        // position even when there are no usings.
 
         foreach (var externAlias in node.Externs)
         {
@@ -1449,17 +1442,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         else if (node.ExpressionBody != null)
         {
             // Expression-bodied method: syntactic sugar for a single return statement
-            var arrowPrefix = ExtractSpaceBefore(node.ExpressionBody.ArrowToken);
-            _cursor = node.ExpressionBody.ArrowToken.Span.End;
-            var expr = (Expression)Visit(node.ExpressionBody.Expression)!;
-
-            var returnStmt = new Return(Guid.NewGuid(), Space.Empty, Markers.Empty, expr);
-            body = new Block(Guid.NewGuid(), arrowPrefix, Markers.Empty,
-                new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
-                [new JRightPadded<Statement>(returnStmt, Space.Empty, Markers.Empty)],
-                Space.Empty);
-
-            _cursor = node.SemicolonToken.Span.End;
+            body = BuildExpressionBodiedBlock(node.ExpressionBody, node.SemicolonToken);
         }
         else if (node.SemicolonToken != default)
         {
@@ -1620,17 +1603,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         Markers methodMarkers = Markers.Empty;
         if (node.ExpressionBody != null)
         {
-            var arrowPrefix = ExtractSpaceBefore(node.ExpressionBody.ArrowToken);
-            _cursor = node.ExpressionBody.ArrowToken.Span.End;
-            var expr = (Expression)Visit(node.ExpressionBody.Expression)!;
-
-            var returnStmt = new Return(Guid.NewGuid(), Space.Empty, Markers.Empty, expr);
-            body = new Block(Guid.NewGuid(), arrowPrefix, Markers.Empty,
-                new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
-                [new JRightPadded<Statement>(returnStmt, Space.Empty, Markers.Empty)],
-                Space.Empty);
-
-            _cursor = node.SemicolonToken.Span.End;
+            body = BuildExpressionBodiedBlock(node.ExpressionBody, node.SemicolonToken);
             methodMarkers = Markers.Build([new ExpressionBodied(Guid.NewGuid())]);
         }
         else if (node.Body != null)
@@ -1711,15 +1684,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         Markers methodMarkers = Markers.Empty;
         if (node.ExpressionBody != null)
         {
-            var arrowPrefix = ExtractSpaceBefore(node.ExpressionBody.ArrowToken);
-            _cursor = node.ExpressionBody.ArrowToken.Span.End;
-            var expr = (Expression)Visit(node.ExpressionBody.Expression)!;
-            var returnStmt = new Return(Guid.NewGuid(), Space.Empty, Markers.Empty, expr);
-            body = new Block(Guid.NewGuid(), arrowPrefix, Markers.Empty,
-                new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
-                [new JRightPadded<Statement>(returnStmt, Space.Empty, Markers.Empty)],
-                Space.Empty);
-            _cursor = node.SemicolonToken.Span.End;
+            body = BuildExpressionBodiedBlock(node.ExpressionBody, node.SemicolonToken);
             methodMarkers = Markers.Build([new ExpressionBodied(Guid.NewGuid())]);
         }
         else if (node.Body != null)
@@ -2078,17 +2043,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         else if (node.ExpressionBody != null)
         {
             // Expression-bodied operator: => expr;
-            var arrowPrefix = ExtractSpaceBefore(node.ExpressionBody.ArrowToken);
-            _cursor = node.ExpressionBody.ArrowToken.Span.End;
-            var expr = (Expression)Visit(node.ExpressionBody.Expression)!;
-
-            var returnStmt = new Return(Guid.NewGuid(), Space.Empty, Markers.Empty, expr);
-            body = new Block(Guid.NewGuid(), arrowPrefix, Markers.Empty,
-                new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
-                [new JRightPadded<Statement>(returnStmt, Space.Empty, Markers.Empty)],
-                Space.Empty);
-
-            _cursor = node.SemicolonToken.Span.End;
+            body = BuildExpressionBodiedBlock(node.ExpressionBody, node.SemicolonToken);
         }
         else
         {
@@ -5951,8 +5906,10 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
     {
         var prefix = ExtractPrefix(node);
 
-        // If parameter has no type, return just an identifier
-        if (node.Type == null)
+        // If parameter has no type and no modifiers, return just an identifier.
+        // Lambda parameters can carry modifiers without a type (e.g. "(ref reader) => ..."),
+        // so those must fall through to the VariableDeclarations path to preserve the modifier.
+        if (node.Type == null && node.Modifiers.Count == 0)
         {
             _cursor = node.Identifier.Span.End;
             var lambdaParamVarType = _typeMapping?.VariableType(node);
@@ -5977,8 +5934,8 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             modifiers.Add(CreateModifier(modPrefix, mod));
         }
 
-        // Parse the type
-        var typeExpr = VisitType(node.Type);
+        // Parse the type (may be null for modifier-only lambda parameters like "ref reader")
+        var typeExpr = node.Type != null ? VisitType(node.Type) : null;
 
         // Parse the parameter name
         var namePrefix = ExtractSpaceBefore(node.Identifier);
@@ -8391,17 +8348,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
         else if (node.ExpressionBody != null)
         {
-            var arrowPrefix = ExtractSpaceBefore(node.ExpressionBody.ArrowToken);
-            _cursor = node.ExpressionBody.ArrowToken.Span.End;
-            var expr = (Expression)Visit(node.ExpressionBody.Expression)!;
-
-            var returnStmt = new Return(Guid.NewGuid(), Space.Empty, Markers.Empty, expr);
-            body = new Block(Guid.NewGuid(), arrowPrefix, Markers.Empty,
-                new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
-                [new JRightPadded<Statement>(returnStmt, Space.Empty, Markers.Empty)],
-                Space.Empty);
-
-            _cursor = node.SemicolonToken.Span.End;
+            body = BuildExpressionBodiedBlock(node.ExpressionBody, node.SemicolonToken);
         }
 
         return new MethodDeclaration(
@@ -9014,17 +8961,22 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
     private Statement? ParsePragmaDirective(Space prefix, string afterKeyword)
     {
+        // Whitespace between "#pragma" and the next keyword (e.g. the two spaces in "#pragma  warning").
+        var keywordSpacing = Space.Format(afterKeyword[..(afterKeyword.Length - afterKeyword.TrimStart().Length)]);
         var rest = afterKeyword.TrimStart();
 
         if (rest.StartsWith("checksum"))
         {
             var arguments = rest[8..]; // text after "checksum"
-            return new PragmaChecksumDirective(Guid.NewGuid(), prefix, Markers.Empty, arguments);
+            return new PragmaChecksumDirective(Guid.NewGuid(), prefix, Markers.Empty, keywordSpacing, arguments);
         }
 
         if (!rest.StartsWith("warning")) return null;
 
-        rest = rest[7..].TrimStart(); // skip "warning"
+        rest = rest[7..]; // skip "warning" (keep trailing whitespace to capture action spacing)
+        // Whitespace between "warning" and the action keyword (e.g. "warning  disable").
+        var actionSpacing = Space.Format(rest[..(rest.Length - rest.TrimStart().Length)]);
+        rest = rest.TrimStart();
 
         PragmaWarningAction action;
         string afterAction;
@@ -9058,7 +9010,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             }
         }
 
-        return new PragmaWarningDirective(Guid.NewGuid(), prefix, Markers.Empty, action, codes);
+        return new PragmaWarningDirective(Guid.NewGuid(), prefix, Markers.Empty, action, codes, keywordSpacing, actionSpacing);
     }
 
     private NullableDirective ParseNullableDirective(Space prefix, string afterKeyword, string hashSpacing = "")
@@ -9544,6 +9496,30 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             SyntaxKind.LogicalAndExpression => Binary.OperatorType.And,
             _ => throw new InvalidOperationException($"Unsupported binary operator: {kind}")
         };
+    }
+
+    /// <summary>
+    /// Builds the synthetic Block used to model an expression-bodied member ("=&gt; expr;").
+    /// The space (and any comment trivia) between the expression and the terminating semicolon
+    /// is captured as the "After" of the wrapped Return statement so the LST round-trips. The
+    /// cursor is advanced past the semicolon.
+    /// </summary>
+    private Block BuildExpressionBodiedBlock(ArrowExpressionClauseSyntax expressionBody, SyntaxToken semicolonToken)
+    {
+        var arrowPrefix = ExtractSpaceBefore(expressionBody.ArrowToken);
+        _cursor = expressionBody.ArrowToken.Span.End;
+        var expr = (Expression)Visit(expressionBody.Expression)!;
+
+        // Trivia between the expression and the ';' (e.g. a trailing comment) lives in the
+        // After space of the wrapped Return so it is not lost when round-tripping.
+        var beforeSemicolon = ExtractSpaceBefore(semicolonToken);
+        _cursor = semicolonToken.Span.End;
+
+        var returnStmt = new Return(Guid.NewGuid(), Space.Empty, Markers.Empty, expr);
+        return new Block(Guid.NewGuid(), arrowPrefix, Markers.Empty,
+            new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
+            [new JRightPadded<Statement>(returnStmt, beforeSemicolon, Markers.Empty)],
+            Space.Empty);
     }
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -1565,6 +1565,8 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
             VisitSpace(method.Body.Prefix, p);
             p.Append("=>");
             Visit(returnStmt.Expression, p);
+            // Trivia between the expression and ';' (e.g. a trailing comment) is held in After.
+            VisitSpace(method.Body.Statements[0].After, p);
             p.Append(';');
         }
         else if (method.Body != null && method.Body.Markers.FindFirst<Semicolon>() != null)
@@ -3015,8 +3017,13 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
     public override J VisitPragmaWarningDirective(PragmaWarningDirective pragmaWarningDirective, PrintOutputCapture<P> p)
     {
         BeforeSyntax(pragmaWarningDirective, p);
-        p.Append("#pragma warning");
-        p.Append(pragmaWarningDirective.Action == PragmaWarningAction.Disable ? " disable" : " restore");
+        p.Append("#pragma");
+        // Preserve the original inter-keyword whitespace (e.g. "#pragma  warning"); fall back to a
+        // single space for LSTs constructed without it so output stays valid.
+        VisitSpace(pragmaWarningDirective.KeywordSpacing.IsEmpty ? Space.SingleSpace : pragmaWarningDirective.KeywordSpacing, p);
+        p.Append("warning");
+        VisitSpace(pragmaWarningDirective.ActionSpacing.IsEmpty ? Space.SingleSpace : pragmaWarningDirective.ActionSpacing, p);
+        p.Append(pragmaWarningDirective.Action == PragmaWarningAction.Disable ? "disable" : "restore");
         VisitRightPadded(pragmaWarningDirective.WarningCodes, ",", p);
         AfterSyntax(pragmaWarningDirective, p);
         return pragmaWarningDirective;
@@ -3025,7 +3032,9 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
     public override J VisitPragmaChecksumDirective(PragmaChecksumDirective pragmaChecksumDirective, PrintOutputCapture<P> p)
     {
         BeforeSyntax(pragmaChecksumDirective, p);
-        p.Append("#pragma checksum");
+        p.Append("#pragma");
+        VisitSpace(pragmaChecksumDirective.KeywordSpacing.IsEmpty ? Space.SingleSpace : pragmaChecksumDirective.KeywordSpacing, p);
+        p.Append("checksum");
         p.Append(pragmaChecksumDirective.Arguments);
         AfterSyntax(pragmaChecksumDirective, p);
         return pragmaChecksumDirective;
@@ -3774,6 +3783,7 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
             VisitSpace(operatorDeclaration.Body.Prefix, p);
             p.Append("=>");
             Visit(opReturnStmt.Expression, p);
+            VisitSpace(operatorDeclaration.Body.Statements[0].After, p);
             p.Append(';');
         }
         else

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
@@ -1308,7 +1308,9 @@ public sealed class PragmaWarningDirective(
     Space prefix,
     Markers markers,
     PragmaWarningAction action,
-    IList<JRightPadded<Expression>> warningCodes
+    IList<JRightPadded<Expression>> warningCodes,
+    Space keywordSpacing,
+    Space actionSpacing
 ) : Cs, Statement, IEquatable<PragmaWarningDirective>
 {
     public Guid Id { get; } = id;
@@ -1317,16 +1319,26 @@ public sealed class PragmaWarningDirective(
     public PragmaWarningAction Action { get; } = action;
     public IList<JRightPadded<Expression>> WarningCodes { get; } = warningCodes;
 
+    /// <summary>Whitespace between <c>#pragma</c> and <c>warning</c> (usually a single space).</summary>
+    public Space KeywordSpacing { get; } = keywordSpacing;
+
+    /// <summary>Whitespace between <c>warning</c> and the action keyword (<c>disable</c>/<c>restore</c>).</summary>
+    public Space ActionSpacing { get; } = actionSpacing;
+
     public PragmaWarningDirective WithId(Guid id) =>
-        id == Id ? this : new(id, Prefix, Markers, Action, WarningCodes);
+        id == Id ? this : new(id, Prefix, Markers, Action, WarningCodes, KeywordSpacing, ActionSpacing);
     public PragmaWarningDirective WithPrefix(Space prefix) =>
-        ReferenceEquals(prefix, Prefix) ? this : new(Id, prefix, Markers, Action, WarningCodes);
+        ReferenceEquals(prefix, Prefix) ? this : new(Id, prefix, Markers, Action, WarningCodes, KeywordSpacing, ActionSpacing);
     public PragmaWarningDirective WithMarkers(Markers markers) =>
-        ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Action, WarningCodes);
+        ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Action, WarningCodes, KeywordSpacing, ActionSpacing);
     public PragmaWarningDirective WithAction(PragmaWarningAction action) =>
-        action == Action ? this : new(Id, Prefix, Markers, action, WarningCodes);
+        action == Action ? this : new(Id, Prefix, Markers, action, WarningCodes, KeywordSpacing, ActionSpacing);
     public PragmaWarningDirective WithWarningCodes(IList<JRightPadded<Expression>> warningCodes) =>
-        ReferenceEquals(warningCodes, WarningCodes) ? this : new(Id, Prefix, Markers, Action, warningCodes);
+        ReferenceEquals(warningCodes, WarningCodes) ? this : new(Id, Prefix, Markers, Action, warningCodes, KeywordSpacing, ActionSpacing);
+    public PragmaWarningDirective WithKeywordSpacing(Space keywordSpacing) =>
+        ReferenceEquals(keywordSpacing, KeywordSpacing) ? this : new(Id, Prefix, Markers, Action, WarningCodes, keywordSpacing, ActionSpacing);
+    public PragmaWarningDirective WithActionSpacing(Space actionSpacing) =>
+        ReferenceEquals(actionSpacing, ActionSpacing) ? this : new(Id, Prefix, Markers, Action, WarningCodes, KeywordSpacing, actionSpacing);
 
     Tree Tree.WithId(Guid id) => WithId(id);
 
@@ -1342,22 +1354,30 @@ public sealed class PragmaChecksumDirective(
     Guid id,
     Space prefix,
     Markers markers,
+    Space keywordSpacing,
     string arguments
 ) : Cs, Statement, IEquatable<PragmaChecksumDirective>
 {
     public Guid Id { get; } = id;
     public Space Prefix { get; } = prefix;
     public Markers Markers { get; } = markers;
+
+    /// <summary>Whitespace between <c>#pragma</c> and <c>checksum</c> (usually a single space).</summary>
+    public Space KeywordSpacing { get; } = keywordSpacing;
+
+    /// <summary>The raw text following <c>checksum</c> (file/guid/hash), whitespace preserved verbatim.</summary>
     public string Arguments { get; } = arguments;
 
     public PragmaChecksumDirective WithId(Guid id) =>
-        id == Id ? this : new(id, Prefix, Markers, Arguments);
+        id == Id ? this : new(id, Prefix, Markers, KeywordSpacing, Arguments);
     public PragmaChecksumDirective WithPrefix(Space prefix) =>
-        ReferenceEquals(prefix, Prefix) ? this : new(Id, prefix, Markers, Arguments);
+        ReferenceEquals(prefix, Prefix) ? this : new(Id, prefix, Markers, KeywordSpacing, Arguments);
     public PragmaChecksumDirective WithMarkers(Markers markers) =>
-        ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, Arguments);
+        ReferenceEquals(markers, Markers) ? this : new(Id, Prefix, markers, KeywordSpacing, Arguments);
+    public PragmaChecksumDirective WithKeywordSpacing(Space keywordSpacing) =>
+        ReferenceEquals(keywordSpacing, KeywordSpacing) ? this : new(Id, Prefix, Markers, keywordSpacing, Arguments);
     public PragmaChecksumDirective WithArguments(string arguments) =>
-        arguments == Arguments ? this : new(Id, Prefix, Markers, arguments);
+        arguments == Arguments ? this : new(Id, Prefix, Markers, KeywordSpacing, arguments);
 
     Tree Tree.WithId(Guid id) => WithId(id);
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
@@ -496,8 +496,11 @@ public class CSharpReceiver : CSharpVisitor<RpcReceiveQueue>
     public override J VisitPragmaWarningDirective(PragmaWarningDirective pwd, RpcReceiveQueue q)
     {
         var action = q.ReceiveAndGet(pwd.Action, RpcReceiveQueue.ToEnum<PragmaWarningAction>());
+        var keywordSpacing = q.Receive(pwd.KeywordSpacing, space => VisitSpace(space, q))!;
+        var actionSpacing = q.Receive(pwd.ActionSpacing, space => VisitSpace(space, q))!;
         var warningCodes = q.ReceiveList(pwd.WarningCodes, rp => _delegate.VisitRightPadded(rp, q));
-        return pwd.WithId(PvId).WithPrefix(PvPrefix).WithMarkers(PvMarkers).WithAction(action).WithWarningCodes(warningCodes!);
+        return pwd.WithId(PvId).WithPrefix(PvPrefix).WithMarkers(PvMarkers).WithAction(action)
+            .WithWarningCodes(warningCodes!).WithKeywordSpacing(keywordSpacing).WithActionSpacing(actionSpacing);
     }
 
     // ---- NullableDirective ----
@@ -568,8 +571,10 @@ public class CSharpReceiver : CSharpVisitor<RpcReceiveQueue>
     // ---- PragmaChecksumDirective ----
     public override J VisitPragmaChecksumDirective(PragmaChecksumDirective pcd, RpcReceiveQueue q)
     {
+        var keywordSpacing = q.Receive(pcd.KeywordSpacing, space => VisitSpace(space, q))!;
         var arguments = q.Receive<string>(pcd.Arguments);
-        return pcd.WithId(PvId).WithPrefix(PvPrefix).WithMarkers(PvMarkers).WithArguments(arguments!);
+        return pcd.WithId(PvId).WithPrefix(PvPrefix).WithMarkers(PvMarkers)
+            .WithKeywordSpacing(keywordSpacing).WithArguments(arguments!);
     }
 
     // ---- LineDirective ----

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpSender.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpSender.cs
@@ -495,6 +495,8 @@ public class CSharpSender : CSharpVisitor<RpcSendQueue>
     public override J VisitPragmaWarningDirective(PragmaWarningDirective pwd, RpcSendQueue q)
     {
         q.GetAndSend(pwd, p => (object)p.Action);
+        q.GetAndSend(pwd, p => p.KeywordSpacing, space => VisitSpace(space, q));
+        q.GetAndSend(pwd, p => p.ActionSpacing, space => VisitSpace(space, q));
         q.GetAndSendList(pwd, p => p.WarningCodes,
             r => (object)r.Element.Id, r => VisitRightPadded(r, q));
         return pwd;
@@ -558,6 +560,7 @@ public class CSharpSender : CSharpVisitor<RpcSendQueue>
     // ---- PragmaChecksumDirective ----
     public override J VisitPragmaChecksumDirective(PragmaChecksumDirective pcd, RpcSendQueue q)
     {
+        q.GetAndSend(pcd, p => p.KeywordSpacing, space => VisitSpace(space, q));
         q.GetAndSend(pcd, p => (object)p.Arguments);
         return pcd;
     }

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpReceiver.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpReceiver.java
@@ -145,6 +145,7 @@ public class CSharpReceiver extends CSharpVisitor<RpcReceiveQueue> {
     @Override
     public J visitPragmaChecksumDirective(Cs.PragmaChecksumDirective pragmaChecksumDirective, RpcReceiveQueue q) {
         return pragmaChecksumDirective
+                .withKeywordSpacing(q.receive(pragmaChecksumDirective.getKeywordSpacing(), space -> visitSpace(space, q)))
                 .withArguments(q.receiveAndGet(pragmaChecksumDirective.getArguments(), (String s) -> s));
     }
 
@@ -730,6 +731,8 @@ public class CSharpReceiver extends CSharpVisitor<RpcReceiveQueue> {
     public J visitPragmaWarningDirective(Cs.PragmaWarningDirective pragmaWarningDirective, RpcReceiveQueue q) {
         return pragmaWarningDirective
                 .withAction(q.receiveAndGet(pragmaWarningDirective.getAction(), toEnum(Cs.PragmaWarningDirective.PragmaWarningAction.class)))
+                .withKeywordSpacing(q.receive(pragmaWarningDirective.getKeywordSpacing(), space -> visitSpace(space, q)))
+                .withActionSpacing(q.receive(pragmaWarningDirective.getActionSpacing(), space -> visitSpace(space, q)))
                 .getPadding().withWarningCodes(q.receiveList(pragmaWarningDirective.getPadding().getWarningCodes(), el -> visitRightPadded(el, q)));
     }
 

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpSender.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpSender.java
@@ -143,6 +143,7 @@ public class CSharpSender extends CSharpVisitor<RpcSendQueue> {
 
     @Override
     public J visitPragmaChecksumDirective(Cs.PragmaChecksumDirective pragmaChecksumDirective, RpcSendQueue q) {
+        q.getAndSend(pragmaChecksumDirective, Cs.PragmaChecksumDirective::getKeywordSpacing, space -> visitSpace(space, q));
         q.getAndSend(pragmaChecksumDirective, Cs.PragmaChecksumDirective::getArguments);
         return pragmaChecksumDirective;
     }
@@ -188,6 +189,8 @@ public class CSharpSender extends CSharpVisitor<RpcSendQueue> {
     @Override
     public J visitPragmaWarningDirective(Cs.PragmaWarningDirective pragmaWarningDirective, RpcSendQueue q) {
         q.getAndSend(pragmaWarningDirective, Cs.PragmaWarningDirective::getAction);
+        q.getAndSend(pragmaWarningDirective, Cs.PragmaWarningDirective::getKeywordSpacing, space -> visitSpace(space, q));
+        q.getAndSend(pragmaWarningDirective, Cs.PragmaWarningDirective::getActionSpacing, space -> visitSpace(space, q));
         q.getAndSendList(pragmaWarningDirective, p -> p.getPadding().getWarningCodes(), el -> el.getElement().getId(), el -> visitRightPadded(el, q));
         return pragmaWarningDirective;
     }

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/tree/Cs.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/tree/Cs.java
@@ -7471,6 +7471,20 @@ public interface Cs extends J {
 
         List<JRightPadded<Expression>> warningCodes;
 
+        /**
+         * Whitespace between {@code #pragma} and {@code warning} (usually a single space).
+         */
+        @With
+        @Getter
+        Space keywordSpacing;
+
+        /**
+         * Whitespace between {@code warning} and the action keyword ({@code disable}/{@code restore}).
+         */
+        @With
+        @Getter
+        Space actionSpacing;
+
         public List<Expression> getWarningCodes() {
             return JRightPadded.getElements(warningCodes);
         }
@@ -7519,7 +7533,7 @@ public interface Cs extends J {
             }
 
             public PragmaWarningDirective withWarningCodes(List<JRightPadded<Expression>> warningCodes) {
-                return t.warningCodes == warningCodes ? t : new PragmaWarningDirective(t.id, t.prefix, t.markers, t.action, warningCodes);
+                return t.warningCodes == warningCodes ? t : new PragmaWarningDirective(t.id, t.prefix, t.markers, t.action, warningCodes, t.keywordSpacing, t.actionSpacing);
             }
         }
     }
@@ -7549,6 +7563,13 @@ public interface Cs extends J {
         @With
         @Getter
         Markers markers;
+
+        /**
+         * Whitespace between {@code #pragma} and {@code checksum} (usually a single space).
+         */
+        @With
+        @Getter
+        Space keywordSpacing;
 
         @With
         @Getter


### PR DESCRIPTION
Capture the inter-keyword whitespace of `#pragma warning`/`#pragma checksum` directives via new `keywordSpacing`/`actionSpacing` fields so source like `#pragma  warning disable` round-trips verbatim, wiring the fields through the C#/Java models, RPC sender/receiver, and printer. Map lambda parameters that carry modifiers but no type (e.g. `(ref reader) => ...`) to `VariableDeclarations` instead of dropping the modifier. Extract the expression-bodied member construction into a shared `BuildExpressionBodiedBlock` helper that preserves trivia before the terminating semicolon, and fix leading-directive placement at the top of a compilation unit. Adds `PragmaDirectiveTests` plus new `LambdaTests`/`MethodDeclarationTests` cases covering these fidelity scenarios.