### PR TITLE
Gradle: surface the real parse failure instead of an opaque ClassCastException

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyConstraintToRule.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyConstraintToRule.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
+import static org.openrewrite.gradle.internal.GradleParseUtils.requireParsed;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -207,7 +208,7 @@ public class DependencyConstraintToRule extends Recipe {
                         p + ".requested.name == '" + groupArtifactVersion.getArtifactId() + "') {\n}";
                 newIf = GroovyParser.builder().build()
                         .parse(ctx, snippet)
-                        .map(G.CompilationUnit.class::cast)
+                        .map(requireParsed(G.CompilationUnit.class))
                         .map(cu -> cu.getStatements().get(1))
                         .map(J.If.class::cast)
                         .findFirst()
@@ -218,7 +219,7 @@ public class DependencyConstraintToRule extends Recipe {
                         p + ".requested.name == \"" + groupArtifactVersion.getArtifactId() + "\") {\n}";
                 newIf = KotlinParser.builder().isKotlinScript(true).build()
                         .parse(ctx, snippet)
-                        .map(K.CompilationUnit.class::cast)
+                        .map(requireParsed(K.CompilationUnit.class))
                         .map(cu -> (J.Block) cu.getStatements().get(0))
                         .map(block -> (J.If) block.getStatements().get(1))
                         .findFirst()
@@ -303,7 +304,7 @@ public class DependencyConstraintToRule extends Recipe {
                     newStatements = GroovyParser.builder()
                             .build()
                             .parse(ctx, snippet)
-                            .map(G.CompilationUnit.class::cast)
+                            .map(requireParsed(G.CompilationUnit.class))
                             .map(G.CompilationUnit::getStatements)
                             .findFirst()
                             .orElseThrow(() -> new IllegalStateException("Unable to produce a new block statement"));
@@ -317,7 +318,7 @@ public class DependencyConstraintToRule extends Recipe {
                             .isKotlinScript(true)
                             .build()
                             .parse(ctx, snippet)
-                            .map(K.CompilationUnit.class::cast)
+                            .map(requireParsed(K.CompilationUnit.class))
                             .map(cu -> (J.Block) cu.getStatements().get(0))
                             .map(J.Block::getStatements)
                             .findFirst()
@@ -374,7 +375,7 @@ public class DependencyConstraintToRule extends Recipe {
                                             "    resolutionStrategy.eachDependency { details ->\n" +
                                             "    }\n" +
                                             "}")
-                            .map(G.CompilationUnit.class::cast)
+                            .map(requireParsed(G.CompilationUnit.class))
                             .map(G.CompilationUnit::getStatements)
                             .map(it -> it.get(0))
                             .map(J.MethodInvocation.class::cast)
@@ -411,7 +412,7 @@ public class DependencyConstraintToRule extends Recipe {
                                                             "    resolutionStrategy.eachDependency { details ->}\n" +
                                                             "}").getBytes(StandardCharsets.UTF_8)))
                             ), null, ctx)
-                            .map(K.CompilationUnit.class::cast)
+                            .map(requireParsed(K.CompilationUnit.class))
                             .map(k -> (J.Block) k.getStatements().get(0))
                             .map(J.Block::getStatements)
                             .map(it -> it.get(0))

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/EnableDevelocityBuildCache.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/EnableDevelocityBuildCache.java
@@ -27,6 +27,8 @@ import org.openrewrite.java.tree.J;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.openrewrite.gradle.internal.GradleParseUtils.requireParsed;
+
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class EnableDevelocityBuildCache extends Recipe {
@@ -103,7 +105,7 @@ public class EnableDevelocityBuildCache extends Recipe {
                 "}";
         return (J.MethodInvocation) GradleParser.builder().build()
                 .parse(ctx, conf)
-                .map(G.CompilationUnit.class::cast)
+                .map(requireParsed(G.CompilationUnit.class))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"))
                 .getStatements()

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -61,6 +61,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.openrewrite.Preconditions.not;
 import static org.openrewrite.gradle.UpgradeDependencyVersion.getGradleProjectKey;
+import static org.openrewrite.gradle.internal.GradleParseUtils.requireParsed;
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 @Incubating(since = "8.18.0")
@@ -634,7 +635,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                                 //language=groovy
                                 "dependencies {\n" +
                                 "}\n", false, ctx)
-                                .map(G.CompilationUnit.class::cast)
+                                .map(requireParsed(G.CompilationUnit.class))
                                 .map(parsed -> (J.MethodInvocation) parsed.getStatements().get(0))
                                 .orElseThrow(() -> new IllegalStateException("Unable to parse dependencies block"))
                                 .withPrefix(Space.format("\n\n"));
@@ -652,7 +653,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                                 //language=kotlin
                                 "dependencies {\n" +
                                 "}\n", true, ctx)
-                                .map(K.CompilationUnit.class::cast)
+                                .map(requireParsed(K.CompilationUnit.class))
                                 .map(parsed -> (J.Block) parsed.getStatements().get(0))
                                 .map(block -> (J.MethodInvocation) block.getStatements().get(0))
                                 .map(m -> m.withArguments(ListUtils.mapFirst(m.getArguments(), arg -> {
@@ -987,7 +988,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
             J.MethodInvocation constraint;
             if (!isKotlinDsl) {
                 constraint = parseAsGradle(because == null ? INDIVIDUAL_CONSTRAINT_SNIPPET_GROOVY : INDIVIDUAL_CONSTRAINT_BECAUSE_SNIPPET_GROOVY, false, ctx)
-                        .map(G.CompilationUnit.class::cast)
+                        .map(requireParsed(G.CompilationUnit.class))
                         .map(it -> (J.MethodInvocation) it.getStatements().get(1))
                         .map(dependenciesMethod -> (J.Lambda) dependenciesMethod.getArguments().get(0))
                         .map(dependenciesClosure -> (J.Block) dependenciesClosure.getBody())
@@ -1019,7 +1020,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                         .orElseThrow(() -> new IllegalStateException("Unable to find constraint"));
             } else {
                 constraint = parseAsGradle(because == null ? INDIVIDUAL_CONSTRAINT_SNIPPET_KOTLIN : INDIVIDUAL_CONSTRAINT_BECAUSE_SNIPPET_KOTLIN, true, ctx)
-                        .map(K.CompilationUnit.class::cast)
+                        .map(requireParsed(K.CompilationUnit.class))
                         .map(it -> (J.Block) it.getStatements().get(0))
                         .map(it -> (J.MethodInvocation) it.getStatements().get(1))
                         .map(dependenciesMethod -> (J.Lambda) dependenciesMethod.getArguments().get(0))
@@ -1183,7 +1184,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
             J.Lambda becauseArg;
             if (!isKotlinDsl) {
                 becauseArg = parseAsGradle(INDIVIDUAL_CONSTRAINT_BECAUSE_SNIPPET_GROOVY, false, ctx)
-                        .map(G.CompilationUnit.class::cast)
+                        .map(requireParsed(G.CompilationUnit.class))
                         .map(cu -> (J.MethodInvocation) cu.getStatements().get(1))
                         .map(dependencies -> (J.Lambda) dependencies.getArguments().get(0))
                         .map(dependenciesClosure -> ((J.Block) dependenciesClosure.getBody()).getStatements().get(0))
@@ -1204,7 +1205,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                         .orElseThrow(() -> new IllegalStateException("Unable to parse because text"));
             } else {
                 becauseArg = parseAsGradle(INDIVIDUAL_CONSTRAINT_BECAUSE_SNIPPET_KOTLIN, true, ctx)
-                        .map(K.CompilationUnit.class::cast)
+                        .map(requireParsed(K.CompilationUnit.class))
                         .map(cu -> (J.Block) cu.getStatements().get(0))
                         .map(block -> (J.MethodInvocation) block.getStatements().get(1))
                         .map(dependencies -> (J.Lambda) dependencies.getArguments().get(0))

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseMainClassPropertyForApplication.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseMainClassPropertyForApplication.java
@@ -29,6 +29,8 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 
+import static org.openrewrite.gradle.internal.GradleParseUtils.requireParsed;
+
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class UseMainClassPropertyForApplication extends Recipe {
@@ -110,7 +112,7 @@ public class UseMainClassPropertyForApplication extends Recipe {
                     Statement statement = GradleParser.builder().build()
                             .parseInputs(Collections.singletonList(
                                     Parser.Input.fromString(Paths.get("build.gradle.kts"), snippet)), null, ctx)
-                            .map(K.CompilationUnit.class::cast)
+                            .map(requireParsed(K.CompilationUnit.class))
                             .findFirst()
                             .orElseThrow(() -> new IllegalStateException("Could not parse application block"))
                             .getStatements()
@@ -119,7 +121,7 @@ public class UseMainClassPropertyForApplication extends Recipe {
                 }
                 return ((J) GradleParser.builder().build()
                         .parse(ctx, snippet)
-                        .map(G.CompilationUnit.class::cast)
+                        .map(requireParsed(G.CompilationUnit.class))
                         .findFirst()
                         .orElseThrow(() -> new IllegalStateException("Could not parse application block"))
                         .getStatements()

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/AddDependencyVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/AddDependencyVisitor.java
@@ -57,6 +57,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 import static org.openrewrite.gradle.AddDependencyVisitor.DependencyModifier.ENFORCED_PLATFORM;
 import static org.openrewrite.gradle.AddDependencyVisitor.DependencyModifier.PLATFORM;
+import static org.openrewrite.gradle.internal.GradleParseUtils.requireParsed;
 
 @RequiredArgsConstructor
 public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
@@ -348,13 +349,13 @@ public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
                 if (isKotlinDsl) {
                     dependencies = (J.MethodInvocation) ((J.Block) GRADLE_PARSER.parseInputs(singletonList(new GradleParser.Input(Paths.get("build.gradle.kts"), () -> new ByteArrayInputStream(template.getBytes(StandardCharsets.UTF_8)))), null, ctx)
                             .findFirst()
-                            .map(K.CompilationUnit.class::cast)
+                            .map(requireParsed(K.CompilationUnit.class))
                             .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"))
                             .getStatements().get(0)).getStatements().get(0);
                 } else {
                     dependencies = (J.MethodInvocation) GRADLE_PARSER.parse(ctx, template)
                             .findFirst()
-                            .map(G.CompilationUnit.class::cast)
+                            .map(requireParsed(G.CompilationUnit.class))
                             .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"))
                             .getStatements().get(0);
                 }
@@ -375,13 +376,13 @@ public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
                 if (isKotlinDsl) {
                     dependency = (J.MethodInvocation) ((J.Block) GRADLE_PARSER.parseInputs(singletonList(new GradleParser.Input(Paths.get("build.gradle.kts"), () -> new ByteArrayInputStream(template.getBytes(StandardCharsets.UTF_8)))), null, ctx)
                             .findFirst()
-                            .map(K.CompilationUnit.class::cast)
+                            .map(requireParsed(K.CompilationUnit.class))
                             .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"))
                             .getStatements().get(0)).getStatements().get(0);
                 } else {
                     dependency = (J.MethodInvocation) GRADLE_PARSER.parse(ctx, template)
                             .findFirst()
-                            .map(G.CompilationUnit.class::cast)
+                            .map(requireParsed(G.CompilationUnit.class))
                             .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"))
                             .getStatements().get(0);
                 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/GradleParseUtils.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/GradleParseUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.internal;
+
+import org.openrewrite.SourceFile;
+import org.openrewrite.tree.ParseError;
+
+import java.util.function.Function;
+
+public final class GradleParseUtils {
+    private GradleParseUtils() {
+    }
+
+    /**
+     * A mapping {@link Function} for use in a {@code stream.map(...)} / {@code optional.map(...)} chain over the
+     * result of parsing a generated Gradle code snippet, in place of {@code SomeType.class::cast}.
+     * <p>
+     * Recipes parse constant, valid Gradle snippets, so a {@link ParseError} here means the underlying Groovy or
+     * Kotlin parser threw while parsing the snippet. Rethrow that real cause — its
+     * {@link org.openrewrite.ParseExceptionResult} carries the full stack trace — instead of letting the cast mask
+     * it with an opaque {@link ClassCastException} ("Cannot cast ParseError to ...").
+     *
+     * @param expected the {@link SourceFile} subtype the snippet is expected to parse into
+     * @return a function that casts to {@code expected}, or throws with the underlying parse failure as its cause
+     */
+    public static <S extends SourceFile> Function<SourceFile, S> requireParsed(Class<S> expected) {
+        return sourceFile -> {
+            if (sourceFile instanceof ParseError) {
+                throw new IllegalStateException(
+                        "Failed to parse generated Gradle code as " + expected.getSimpleName(),
+                        ((ParseError) sourceFile).toException());
+            }
+            return expected.cast(sourceFile);
+        };
+    }
+}

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.singletonList;
+import static org.openrewrite.gradle.internal.GradleParseUtils.requireParsed;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -395,7 +396,7 @@ public class AddDevelocityGradlePlugin extends Recipe {
         G.CompilationUnit cu = GradleParser.builder().build()
                 .parseInputs(singletonList(
                         Parser.Input.fromString(Paths.get("settings.gradle"), ge.toString())), null, ctx)
-                .map(G.CompilationUnit.class::cast)
+                .map(requireParsed(G.CompilationUnit.class))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"));
 
@@ -463,7 +464,7 @@ public class AddDevelocityGradlePlugin extends Recipe {
         K.CompilationUnit cu = GradleParser.builder().build()
                 .parseInputs(singletonList(
                         Parser.Input.fromString(Paths.get("settings.gradle.kts"), ge.toString())), null, ctx)
-                .map(K.CompilationUnit.class::cast)
+                .map(requireParsed(K.CompilationUnit.class))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"));
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.util.Collections.singletonList;
+import static org.openrewrite.gradle.internal.GradleParseUtils.requireParsed;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -245,7 +246,7 @@ public class MigrateGradleEnterpriseToDevelocity extends Recipe {
             G.CompilationUnit cu = GradleParser.builder().build()
                     .parseInputs(singletonList(
                             Parser.Input.fromString(Paths.get("settings.gradle"), ge.toString())), null, ctx)
-                    .map(G.CompilationUnit.class::cast)
+                    .map(requireParsed(G.CompilationUnit.class))
                     .findFirst()
                     .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"));
 
@@ -264,7 +265,7 @@ public class MigrateGradleEnterpriseToDevelocity extends Recipe {
             G.CompilationUnit cu = GradleParser.builder().build()
                     .parseInputs(singletonList(
                             Parser.Input.fromString(Paths.get("settings.gradle"), ge.toString())), null, ctx)
-                    .map(G.CompilationUnit.class::cast)
+                    .map(requireParsed(G.CompilationUnit.class))
                     .findFirst()
                     .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"));
 


### PR DESCRIPTION
## What's changed

Gradle recipes that synthesize code parse a constant, valid snippet (e.g. `dependencies { implementation("…") }`) and immediately cast the parse result to `G.CompilationUnit`/`K.CompilationUnit`:

```java
.map(K.CompilationUnit.class::cast)
```

When the snippet parser instead yields a `ParseError` — i.e. the underlying Groovy/Kotlin parser **threw** while parsing the snippet — that cast fails with an uninformative:

```
java.lang.ClassCastException: Cannot cast org.openrewrite.tree.ParseError to org.openrewrite.kotlin.tree.K$CompilationUnit
    at org.openrewrite.gradle.internal.AddDependencyVisitor.lambda$dependenciesDeclaration$9(...)
```

The real cause is recorded on the `ParseError`'s `ParseExceptionResult` marker (which carries the full underlying stack trace), but the blind cast throws it away — so the actual reason the snippet failed to parse is invisible in the recipe run result.

## The change

A small shared helper, `GradleParseUtils.requireParsed(Class)`, returns a checked-cast `Function` for use in the existing `.map(...)` chains in place of `SomeType.class::cast`. On a `ParseError` it rethrows with `ParseError.toException()` as the cause, so the underlying Groovy/Kotlin parse failure (type, message, and full stack trace) shows up in the run result instead of the opaque cast error.

- **Happy path is unchanged** — when parsing succeeds it returns the same `CompilationUnit` the cast did.
- Minimal, uniform diff at each site: only the cast function is swapped; every existing chain structure is preserved.

Applied to every `*.CompilationUnit.class::cast` site over a parse stream across the Gradle recipes:

- `internal/AddDependencyVisitor`
- `UpgradeTransitiveDependencyVersion`
- `DependencyConstraintToRule`
- `EnableDevelocityBuildCache`
- `gradle9/UseMainClassPropertyForApplication`
- `plugins/AddDevelocityGradlePlugin`
- `plugins/MigrateGradleEnterpriseToDevelocity`

## Why

Seen in the wild as `Cannot cast ParseError to K$CompilationUnit` on `settings.gradle.kts`/`.gradle.kts` files during a Spring Boot upgrade. The CCE is a tombstone that hides why the internal snippet parse failed; this makes recipes report the real cause so such failures are diagnosable.

## Testing

`./gradlew :rewrite-gradle:test` for all seven affected recipes' test classes passes (no behavior change on success paths).