### PR TITLE
Renew expired OWASP suppressions to 2026-07-01

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
            file name: launcher-interface-1.4.4.jar
            reason: false positive on the regex pattern of impacted modules → sbt tool is at 1.10.4 whereas this vulnerability has been patched in version 1.9.7.
@@ -8,7 +8,7 @@
         <packageUrl regex="true">^pkg:maven/org\.scala-sbt/launcher-interface@.*$</packageUrl>
         <cve>CVE-2023-46122</cve>
     </suppress>
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
            file name: sbinary_2.13-0.5.1.jar
            reason: false positive on the regex pattern of impacted modules → sbt tool is at 1.10.4 whereas this vulnerability has been patched in version 1.9.7.


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1085

The `CVE-2023-46122` suppressions for the sbt artifacts expired on 2026-06-01 and resurfaced in the 2026-06-03 OpenRewrite vulnerability report:
- `launcher-interface-1.4.4.jar`
- `sbinary_2.13-0.5.1.jar`

False positive on the impacted-modules regex — the sbt tool in use is at 1.10.4, while this vulnerability was patched in sbt/io 1.9.7. Renewed to `2026-07-01Z`.