### PR TITLE
C#: Share `JavaType` cache across documents within a project

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/CSharpTypeMappingTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/CSharpTypeMappingTests.cs
@@ -412,4 +412,45 @@ public class CSharpTypeMappingTests : RewriteTest
         var stringArg = Assert.IsType<JavaType.Class>(Assert.Single(paramType.TypeParameters!));
         Assert.Equal("System.String", stringArg.FullyQualifiedName);
     }
+
+    [Fact]
+    public async Task SharedTypeCache_DedupesTypeInstancesAcrossDocumentsInProject()
+    {
+        // Two documents in ONE compilation both reference the same user type `Shared`.
+        // Roslyn interns symbols per Compilation, so the `Shared` ISymbol is identical
+        // across both documents' semantic models. A per-project shared type cache must
+        // therefore yield the SAME JavaType instance for `Shared` in both documents, so
+        // RPC asRef() can serialize it once instead of re-serializing it per file.
+        var refs = await Assemblies.Net90.ResolveAsync(LanguageNames.CSharp, CancellationToken.None);
+        const string sharedSrc = "public class Shared { }";
+        const string srcA = "class A { Shared f; }";
+        const string srcB = "class B { Shared g; }";
+        var treeShared = CSharpSyntaxTree.ParseText(sharedSrc, path: "shared.cs");
+        var treeA = CSharpSyntaxTree.ParseText(srcA, path: "a.cs");
+        var treeB = CSharpSyntaxTree.ParseText(srcB, path: "b.cs");
+        var compilation = CSharpCompilation.Create("TestCompilation")
+            .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddReferences(refs)
+            .AddSyntaxTrees(ImplicitUsingsSyntaxTree, treeShared, treeA, treeB);
+        var smA = compilation.GetSemanticModel(treeA);
+        var smB = compilation.GetSemanticModel(treeB);
+
+        var parser = new CSharpParser();
+
+        // Baseline: parsed independently (no shared cache), each document builds its own
+        // JavaType instance for `Shared` — this is the per-document duplication.
+        var indepA = FindVariableDeclaration(parser.Parse(srcA, "a.cs", smA), "f")!.TypeExpression?.Type;
+        var indepB = FindVariableDeclaration(parser.Parse(srcB, "b.cs", smB), "g")!.TypeExpression?.Type;
+        Assert.NotNull(indepA);
+        Assert.NotNull(indepB);
+        Assert.NotSame(indepA, indepB);
+
+        // With a shared per-project cache, both documents resolve `Shared` to the SAME instance.
+        var sharedCache = new Dictionary<ISymbol, JavaType>(SymbolEqualityComparer.Default);
+        var typeA = FindVariableDeclaration(parser.Parse(srcA, "a.cs", smA, typeCache: sharedCache), "f")!.TypeExpression?.Type;
+        var typeB = FindVariableDeclaration(parser.Parse(srcB, "b.cs", smB, typeCache: sharedCache), "g")!.TypeExpression?.Type;
+        Assert.NotNull(typeA);
+        Assert.NotNull(typeB);
+        Assert.Same(typeA, typeB);
+    }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -29,14 +29,15 @@ public class CSharpParser
     private bool _charsetBomMarked;
 
     public CompilationUnit Parse(string source, string sourcePath = "source.cs",
-        SemanticModel? semanticModel = null, bool charsetBomMarked = false)
+        SemanticModel? semanticModel = null, bool charsetBomMarked = false,
+        Dictionary<ISymbol, JavaType>? typeCache = null)
     {
         _charsetBomMarked = charsetBomMarked;
         var symbols = PreprocessorSourceTransformer.ExtractSymbols(source);
         if (symbols.Count == 0)
-            return ParseSingle(source, sourcePath, semanticModel);
+            return ParseSingle(source, sourcePath, semanticModel, typeCache);
 
-        return ParseMulti(source, sourcePath, semanticModel, symbols);
+        return ParseMulti(source, sourcePath, semanticModel, symbols, typeCache);
     }
 
     /// <summary>
@@ -48,13 +49,14 @@ public class CSharpParser
     /// </summary>
     public CompilationUnit ParseWithConfigurations(string source, string sourcePath,
         SemanticModel? semanticModel, List<HashSet<string>> configSymbolSets,
-        bool charsetBomMarked = false)
+        bool charsetBomMarked = false, Dictionary<ISymbol, JavaType>? typeCache = null)
     {
-        return Parse(source, sourcePath, semanticModel, charsetBomMarked);
+        return Parse(source, sourcePath, semanticModel, charsetBomMarked, typeCache);
     }
 
     private CompilationUnit ParseMultiWithSymbolSets(string source, string sourcePath,
-        SemanticModel? semanticModel, List<HashSet<string>> symbolSets)
+        SemanticModel? semanticModel, List<HashSet<string>> symbolSets,
+        Dictionary<ISymbol, JavaType>? typeCache = null)
     {
         var directiveLines = PreprocessorSourceTransformer.GetDirectivePositions(source);
 
@@ -79,7 +81,7 @@ public class CSharpParser
 
         if (permutations.Count <= 1)
         {
-            return ParseSingle(source, sourcePath, semanticModel);
+            return ParseSingle(source, sourcePath, semanticModel, typeCache);
         }
 
         PreprocessorSourceTransformer.ComputeActiveBranchIndices(directiveLines, permutations);
@@ -100,11 +102,11 @@ public class CSharpParser
                 var compilation = semanticModel.Compilation.ReplaceSyntaxTree(
                     semanticModel.SyntaxTree, syntaxTree);
                 var newSemanticModel = compilation.GetSemanticModel(syntaxTree);
-                cu = ParseSingle(cleanSource, sourcePath, newSemanticModel);
+                cu = ParseSingle(cleanSource, sourcePath, newSemanticModel, typeCache);
             }
             else
             {
-                cu = ParseSingle(cleanSource, sourcePath, null);
+                cu = ParseSingle(cleanSource, sourcePath, null, typeCache);
             }
 
             cu = (CompilationUnit)DirectiveBoundaryInjector.Inject(cu);
@@ -138,12 +140,13 @@ public class CSharpParser
         );
     }
 
-    private CompilationUnit ParseSingle(string source, string sourcePath, SemanticModel? semanticModel)
+    private CompilationUnit ParseSingle(string source, string sourcePath, SemanticModel? semanticModel,
+        Dictionary<ISymbol, JavaType>? typeCache = null)
     {
         if (semanticModel != null)
         {
             var root = semanticModel.SyntaxTree.GetCompilationUnitRoot();
-            var visitor = new CSharpParserVisitor(source, semanticModel, _charsetBomMarked);
+            var visitor = new CSharpParserVisitor(source, semanticModel, _charsetBomMarked, typeCache);
             var cu = visitor.VisitCompilationUnit(root);
             // Override source path since the semantic model's tree has the absolute path
             // from MSBuildWorkspace, but we want the relative path
@@ -161,7 +164,8 @@ public class CSharpParser
     }
 
     private CompilationUnit ParseMulti(string source, string sourcePath,
-        SemanticModel? semanticModel, HashSet<string> symbols)
+        SemanticModel? semanticModel, HashSet<string> symbols,
+        Dictionary<ISymbol, JavaType>? typeCache = null)
     {
         var directiveLines = PreprocessorSourceTransformer.GetDirectivePositions(source);
 
@@ -190,11 +194,11 @@ public class CSharpParser
                 var compilation = semanticModel.Compilation.ReplaceSyntaxTree(
                     semanticModel.SyntaxTree, syntaxTree);
                 var newSemanticModel = compilation.GetSemanticModel(syntaxTree);
-                cu = ParseSingle(cleanSource, sourcePath, newSemanticModel);
+                cu = ParseSingle(cleanSource, sourcePath, newSemanticModel, typeCache);
             }
             else
             {
-                cu = ParseSingle(cleanSource, sourcePath, null);
+                cu = ParseSingle(cleanSource, sourcePath, null, typeCache);
             }
 
             // Convert ghost comments in whitespace to DirectiveBoundaryMarker markers
@@ -254,12 +258,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
     private Space _pendingSemicolonSpace = Space.Empty;
 
     public CSharpParserVisitor(string source, SemanticModel? semanticModel = null,
-        bool charsetBomMarked = false)
+        bool charsetBomMarked = false, Dictionary<ISymbol, JavaType>? sharedTypeCache = null)
     {
         _source = source;
         _cursor = 0;
         _semanticModel = semanticModel;
-        _typeMapping = semanticModel != null ? new CSharpTypeMapping(semanticModel) : null;
+        _typeMapping = semanticModel != null ? new CSharpTypeMapping(semanticModel, sharedTypeCache) : null;
         _charsetBomMarked = charsetBomMarked;
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
@@ -26,11 +26,20 @@ namespace OpenRewrite.CSharp;
 internal class CSharpTypeMapping
 {
     private readonly SemanticModel _model;
-    private readonly Dictionary<ISymbol, JavaType> _typeCache = new(SymbolEqualityComparer.Default);
+    private readonly Dictionary<ISymbol, JavaType> _typeCache;
 
-    public CSharpTypeMapping(SemanticModel model)
+    /// <param name="model">Semantic model for the document being parsed.</param>
+    /// <param name="sharedTypeCache">
+    /// Optional symbol→JavaType cache shared across all documents in the same project
+    /// (Roslyn Compilation). Symbols are interned per Compilation, so sharing this cache
+    /// makes a given type resolve to a single JavaType instance across the whole project,
+    /// letting the RPC layer (asRef) serialize it once instead of once per referencing file.
+    /// When null, a fresh per-document cache is used (single-file parsing, tests).
+    /// </param>
+    public CSharpTypeMapping(SemanticModel model, Dictionary<ISymbol, JavaType>? sharedTypeCache = null)
     {
         _model = model;
+        _typeCache = sharedTypeCache ?? new Dictionary<ISymbol, JavaType>(SymbolEqualityComparer.Default);
     }
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -575,6 +575,12 @@ public class SolutionParser
 
         var dotNetProject = CreateDotNetProjectMarker(projectPath, projectName);
 
+        // One shared symbol→JavaType cache for the whole project. Roslyn interns symbols
+        // per Compilation, so every document in this project resolves a given type to the
+        // same JavaType instance — letting the RPC layer (asRef) serialize each type once
+        // per project instead of re-serializing it for every referencing file.
+        var projectTypeCache = new Dictionary<ISymbol, OpenRewrite.Java.JavaType>(SymbolEqualityComparer.Default);
+
         var results = new List<SourceFile>();
         var fileIndex = 0;
         var projectSw = Stopwatch.StartNew();
@@ -607,11 +613,11 @@ public class SolutionParser
                 if (configSymbolSets.Count > 1)
                 {
                     cu = _parser.ParseWithConfigurations(source, relativePath, semanticModel, configSymbolSets,
-                        charsetBomMarked);
+                        charsetBomMarked, projectTypeCache);
                 }
                 else
                 {
-                    cu = _parser.Parse(source, relativePath, semanticModel, charsetBomMarked);
+                    cu = _parser.Parse(source, relativePath, semanticModel, charsetBomMarked, projectTypeCache);
                 }
 
                 // Attach formatting style marker from .editorconfig


### PR DESCRIPTION
## Motivation

When the C# parser builds an LST for a solution, type attribution maps Roslyn symbols to OpenRewrite `JavaType`. That mapping — and its `ISymbol → JavaType` cache — was created **per document**. Roslyn interns symbols per `Compilation`, so a type referenced from many files in a project (`System.String`, `System.Object`, or any shared project type) resolved to a *distinct* `JavaType` instance in each file.

The RPC layer deduplicates objects with `asRef()`, which is **identity-based**. Per-document `JavaType` instances have different identities, so they cannot be collapsed — each type's full `JavaType` (its methods, and each method's parameter/return types, recursively) is **re-serialized once per referencing file**.

On `bitwarden/server` (4,816 C# files) this inflated the parse-time RPC stream to **~129 million `RpcObjectData` items** (avg ~27k/file, max ~485k for a single file). The .NET-side parse itself is fast (~1 min); the time went into moving and rebuilding those objects across the RPC boundary.

## What changed

- Thread an optional per-project (per-`Compilation`) `ISymbol → JavaType` cache from `SolutionParser.ParseProject` → `CSharpParser` → `CSharpParserVisitor` → `CSharpTypeMapping`.
- A type now resolves to a single `JavaType` instance across all documents in a project, so `asRef()` serializes it **once per project** instead of once per referencing file.
- The shared cache is **optional and backward-compatible**: single-file parsing and tests pass `null` and keep the previous per-document behavior.
- Scope is **per project**. Cross-project dedup is intentionally out of scope here — different `Compilation`s have distinct metadata symbols, so it would need FQN-keying (with care for multi-targeting); left as a follow-up.

## Test plan

- [x] New test `CSharpTypeMappingTests.SharedTypeCache_DedupesTypeInstancesAcrossDocumentsInProject`: two documents in one `Compilation` that reference a shared type resolve to the **same** `JavaType` instance when a shared cache is used, and to **distinct** instances without one. Written test-first (failed before the change, passes after).
- [x] All 12 existing `CSharpTypeMappingTests` pass (no regression).
- [ ] End-to-end `mod build` on `bitwarden/server`: total parse RPC items **before ≈ 129M**; **after = _measuring, will update_**.
