### PR TITLE
C#: Stream RPC with `System.Text.Json` instead of `Newtonsoft`

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/SystemTextJsonRpcTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/SystemTextJsonRpcTest.cs
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Text.Json;
+using OpenRewrite.Core;
+using OpenRewrite.Core.Rpc;
+
+namespace OpenRewrite.Tests.Rpc;
+
+/// <summary>
+/// Verifies the JSON-RPC wire format under the streaming System.Text.Json path:
+/// the receive side reconstructs inline payloads from <see cref="JsonElement"/>
+/// (as produced by SystemTextJsonFormatter) rather than Newtonsoft JObject, and
+/// the wire shape stays compatible with the Java peer (camelCase, string enums,
+/// omitted nulls).
+/// </summary>
+public class SystemTextJsonRpcTest
+{
+    [Fact]
+    public void DeserializeInline_UnknownMarker_FromJsonElement_PreservesId()
+    {
+        var id = Guid.NewGuid();
+        // SystemTextJsonFormatter deserializes object-typed payloads to JsonElement.
+        object value = JsonSerializer.SerializeToElement(new { id = id.ToString() }, RpcJson.Options);
+
+        // An unmapped marker type name resolves to the Marker interface -> UnknownMarker path.
+        var result = RpcReceiveQueue.DeserializeInline<Marker>(
+            "org.openrewrite.marker.SomeUnknownMarker", value);
+
+        var unknown = Assert.IsType<UnknownMarker>(result);
+        Assert.Equal(id, unknown.Id);
+    }
+
+    [Fact]
+    public void Serialize_RpcObjectData_IsJavaCompatible()
+    {
+        var data = new RpcObjectData
+        {
+            State = RpcObjectData.ObjectState.ADD,
+            ValueType = "java.lang.String",
+            Value = "hi",
+        };
+
+        var json = JsonSerializer.Serialize(data, RpcJson.Options);
+
+        Assert.Contains("\"state\":\"ADD\"", json);   // camelCase key + enum as string
+        Assert.Contains("\"valueType\":\"java.lang.String\"", json);
+        Assert.Contains("\"value\":\"hi\"", json);
+        Assert.DoesNotContain("\"ref\"", json);        // null omitted
+        Assert.DoesNotContain("\"trace\"", json);      // null omitted
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -17,10 +17,8 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Loader;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using OpenRewrite.Core;
 using OpenRewrite.Core.Rpc;
 using OpenRewrite.Java;
@@ -214,11 +212,15 @@ public class RewriteRpcServer
         var requirePrintEqualsInput = true;
         if (request.Options?.TryGetValue("org.openrewrite.requirePrintEqualsInput", out var val) == true)
         {
-            // StreamJsonRpc with Newtonsoft.Json may deliver values as JToken wrappers
-            if (val is JToken jt)
-                requirePrintEqualsInput = jt.Value<bool>();
-            else
-                requirePrintEqualsInput = Convert.ToBoolean(val);
+            // SystemTextJsonFormatter delivers object-typed option values as JsonElement.
+            requirePrintEqualsInput = val switch
+            {
+                JsonElement { ValueKind: JsonValueKind.True } => true,
+                JsonElement { ValueKind: JsonValueKind.False } => false,
+                JsonElement { ValueKind: JsonValueKind.String } je => bool.Parse(je.GetString()!),
+                JsonElement je => Convert.ToBoolean(je.ToString()),
+                _ => Convert.ToBoolean(val),
+            };
         }
 
         var solution = await solutionParser.LoadAsync(path, CancellationToken.None);
@@ -541,20 +543,32 @@ public class RewriteRpcServer
         var beforeCount = _marketplace.AllRecipes().Count;
         string? version = null;
 
-        if (request.Recipes is string path)
+        // SystemTextJsonFormatter deserializes the object-typed Recipes payload to a JsonElement:
+        // a JSON string is a local assembly path; a JSON object describes a NuGet package.
+        var recipesString = request.Recipes switch
+        {
+            string s => s,
+            JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
+            _ => null,
+        };
+        var recipesObject = request.Recipes is JsonElement { ValueKind: JsonValueKind.Object } obj
+            ? (JsonElement?)obj
+            : null;
+
+        if (recipesString != null)
         {
             // Local assembly path
-            var absolutePath = Path.GetFullPath(path);
+            var absolutePath = Path.GetFullPath(recipesString);
             var context = new PluginLoadContext(absolutePath);
             var assembly = context.LoadFromAssemblyPath(absolutePath);
             CheckVersionCompatibility(assembly);
             ActivateAssembly(assembly);
         }
-        else if (request.Recipes is JObject packageObj)
+        else if (recipesObject is { } packageObj)
         {
-            var packageName = packageObj["packageName"]?.ToString()
+            var packageName = (packageObj.TryGetProperty("packageName", out var pn) ? pn.GetString() : null)
                               ?? throw new ArgumentException("Missing packageName in recipes object");
-            version = packageObj["version"]?.ToString();
+            version = packageObj.TryGetProperty("version", out var v) ? v.GetString() : null;
 
             if (File.Exists(packageName))
             {
@@ -1235,13 +1249,15 @@ public class RewriteRpcServer
         using var inputStream = Console.OpenStandardInput();
         using var outputStream = Console.OpenStandardOutput();
 
-        // Configure JSON serialization to match Java expectations:
-        // - camelCase property names
-        // - string enum values (not integers)
-        var formatter = new JsonMessageFormatter();
-        formatter.JsonSerializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
-        formatter.JsonSerializer.Converters.Add(new StringEnumConverter());
-        formatter.JsonSerializer.NullValueHandling = NullValueHandling.Ignore;
+        // Stream the JSON-RPC envelope with System.Text.Json (Utf8JsonWriter/Utf8JsonReader)
+        // instead of Newtonsoft's JToken-DOM formatter. The wire format stays JSON and matches
+        // Java's expectations (camelCase property names, string enum values, omitted nulls) via
+        // the shared RpcJson.Options. See RpcJson for why this is far cheaper on the .NET side
+        // (no per-message DOM, no per-value converter scan under lock, far less GC pressure).
+        var formatter = new SystemTextJsonFormatter
+        {
+            JsonSerializerOptions = RpcJson.Options,
+        };
 
         var handler = new HeaderDelimitedMessageHandler(outputStream, inputStream, formatter);
         using var jsonRpc = new StringErrorDataJsonRpc(handler);
@@ -1630,7 +1646,7 @@ public class Precondition
 public class GenerateRequest
 {
     public string Id { get; set; } = "";
-    [JsonProperty("p")]
+    [JsonPropertyName("p")]
     public string? P { get; set; }
 }
 
@@ -1642,13 +1658,13 @@ public class GenerateResponse
 
 public class VisitRequest
 {
-    [JsonProperty("visitor")]
+    [JsonPropertyName("visitor")]
     public string VisitorName { get; set; } = "";
     public string? SourceFileType { get; set; }
     public string TreeId { get; set; } = "";
-    [JsonProperty("p")]
+    [JsonPropertyName("p")]
     public string? PId { get; set; }
-    [JsonProperty("cursor")]
+    [JsonPropertyName("cursor")]
     public List<string>? CursorIds { get; set; }
 }
 
@@ -1661,9 +1677,9 @@ public class BatchVisitRequest
 {
     public string SourceFileType { get; set; } = "";
     public string TreeId { get; set; } = "";
-    [JsonProperty("p")]
+    [JsonPropertyName("p")]
     public string? PId { get; set; }
-    [JsonProperty("cursor")]
+    [JsonPropertyName("cursor")]
     public List<string>? CursorIds { get; set; }
     public List<BatchVisitItem> Visitors { get; set; } = new();
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcJson.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcJson.cs
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenRewrite.Core.Rpc;
+
+/// <summary>
+/// Shared <see cref="JsonSerializerOptions"/> for the JSON-RPC wire format.
+/// <para>
+/// Used both by the StreamJsonRpc <c>SystemTextJsonFormatter</c> (which streams
+/// the RPC envelope straight to/from the pipe via <c>Utf8JsonWriter</c>/<c>Utf8JsonReader</c>,
+/// with no intermediate DOM) and by <see cref="RpcReceiveQueue"/> when deserializing
+/// inline object payloads. Keeping a single options instance guarantees the
+/// serialize and deserialize sides agree on naming, enum handling, and escaping.
+/// </para>
+/// <para>
+/// The shape matches what the Java peer expects: camelCase property names, enum
+/// values as strings, and omitted nulls.
+/// </para>
+/// </summary>
+public static class RpcJson
+{
+    /// <summary>
+    /// The shared, pre-configured options. Configured once and never mutated after
+    /// first use (System.Text.Json freezes options on first (de)serialization).
+    /// </summary>
+    public static JsonSerializerOptions Options { get; } = Create();
+
+    private static JsonSerializerOptions Create()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            // Match Newtonsoft's relaxed escaping so the Java/Jackson peer parses
+            // byte-identical content. STJ otherwise escapes '+', '<', '>', '&', and
+            // other characters for HTML safety, which is unnecessary over a private
+            // RPC pipe and would alter (and inflate) the payload.
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        };
+        options.Converters.Add(new JsonStringEnumConverter());
+        return options;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
@@ -16,7 +16,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
-using Newtonsoft.Json.Linq;
 using OpenRewrite.CSharp;
 using OpenRewrite.Java;
 using static OpenRewrite.Core.Rpc.RpcObjectData.ObjectState;
@@ -392,9 +391,9 @@ public class RpcReceiveQueue
 
     /// <summary>
     /// Deserializes a non-codec object that was sent inline in the ADD message.
-    /// The value is typically a JObject from Newtonsoft.Json deserialization.
+    /// The value is typically a JsonElement from System.Text.Json deserialization.
     /// </summary>
-    private static T DeserializeInline<T>(string javaTypeName, object value)
+    internal static T DeserializeInline<T>(string javaTypeName, object value)
     {
         var type = FromJavaTypeName(javaTypeName) ?? typeof(T);
 
@@ -410,17 +409,18 @@ public class RpcReceiveQueue
         // LstProvenance, BuildTool, etc. added by the mod CLI).
         if ((type.IsInterface || type.IsAbstract) && typeof(Marker).IsAssignableFrom(type))
         {
-            if (value is JObject jobj)
+            if (value is JsonElement je && je.ValueKind == JsonValueKind.Object)
             {
-                var idToken = jobj["id"];
-                var id = idToken != null ? Guid.Parse(idToken.ToString()) : Guid.NewGuid();
+                var id = je.TryGetProperty("id", out var idProp) && idProp.ValueKind == JsonValueKind.String
+                    ? Guid.Parse(idProp.GetString()!)
+                    : Guid.NewGuid();
                 return (T)(object)new UnknownMarker(id);
             }
             return (T)(object)new UnknownMarker(Guid.NewGuid());
         }
 
-        if (value is JObject jobjNormal)
-            return (T)jobjNormal.ToObject(type)!;
+        if (value is JsonElement jeNormal)
+            return (T)jeNormal.Deserialize(type, RpcJson.Options)!;
 
         if (value is T t)
             return t;


### PR DESCRIPTION
## Motivation

The C# parser serializes its LST to the Java side over JSON-RPC. The RPC server used StreamJsonRpc's Newtonsoft-based `JsonMessageFormatter`, which builds a full `JToken` DOM for every message before writing it and — because request dispatch is concurrent (`SynchronizationContext = null`) — runs Newtonsoft's per-value converter scan against a single shared serializer under a contended lock.

Profiling a parse of `bitwarden/server` (4,816 C# files, ~129M `RpcObjectData` items over the wire) with `dotnet-trace` showed the .NET process spending the large majority of its CPU on serialization *infrastructure* rather than useful work:

- ~33% in `Monitor.Enter_Slowpath` — lock contention from the per-value converter `CanConvert` scan under concurrent dispatch
- ~39% in GC finalizers (incl. dynamic-accessor `DestroyScout` cleanup) and ~13% in GC-suspension polling, driven by the `JToken`/boxing allocation rate
- only ~10% in the actual JSON encoding

Serialization was the rate-limiter: the .NET process pinned ~1.3 cores while the Java side mostly sat blocked on the pipe.

## What changed

Switch the formatter to the streaming `SystemTextJsonFormatter`, which writes JSON straight to the pipe via `Utf8JsonWriter` with no intermediate DOM and no per-value converter scan. The wire format stays JSON; a shared `RpcJson.Options` reproduces the shape the Java peer expects (camelCase property names, string enum values, omitted nulls, and relaxed escaping so the bytes match what Jackson reads).

- Add `RpcJson` holding the shared `JsonSerializerOptions`, used by both the formatter and `RpcReceiveQueue`.
- `RewriteRpcServer`: use `SystemTextJsonFormatter`; port the inline value handling that read Newtonsoft `JToken`/`JObject` to `JsonElement`; replace `[JsonProperty]` with `[JsonPropertyName]` on the RPC request DTOs.
- `RpcReceiveQueue.DeserializeInline`: reconstruct inline payloads from per-value `JsonElement` fragments (`JsonElement.Deserialize`) instead of a Newtonsoft `JObject` DOM. (The primitive/array/string receive paths were already `JsonElement`-based.)

The send side (`RpcSendQueue`) needed no changes — System.Text.Json serializes the `object?`-typed payload fields by runtime type.

## Performance

Parsing `bitwarden/server` (4,816 files) over the RPC bridge with the formatter as the only changed variable:

| | Newtonsoft `JsonMessageFormatter` | streaming `SystemTextJsonFormatter` |
|---|---|---|
| parse + RPC transfer | ~17 min | ~6.4 min |

The .NET side is no longer the bottleneck: the streaming-phase CPU balance flips from roughly ".NET ~105% / Java ~25%" to ".NET ~67% / Java ~78%".

## Test plan

- [x] New `SystemTextJsonRpcTest`: `DeserializeInline` reconstructs an `UnknownMarker` from a `JsonElement` (written test-first, verified red→green), and `RpcObjectData` serializes to the Java-compatible wire shape (camelCase keys, string enum, omitted nulls).
- [x] Full C# test suite green (1961 tests), including the cross-process RPC tests that round-trip against the real Java (Jackson) peer — confirming wire compatibility across the bridge.
