### PR TITLE
Make MavenPomDownloaderTest hermetic with MockWebServer

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -39,8 +39,6 @@ import org.openrewrite.maven.MavenSettings;
 import org.openrewrite.maven.http.OkHttpSender;
 import org.openrewrite.maven.tree.*;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.text.PlainText;
-import org.openrewrite.text.PlainTextVisitor;
 import org.openrewrite.xml.tree.Xml;
 
 import javax.net.ssl.SSLSocketFactory;
@@ -63,7 +61,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.maven.tree.MavenRepository.MAVEN_CENTRAL;
-import static org.openrewrite.test.SourceSpecs.text;
 
 @SuppressWarnings({"HttpUrlsUsage"})
 class MavenPomDownloaderTest implements RewriteTest {
@@ -1663,33 +1660,96 @@ class MavenPomDownloaderTest implements RewriteTest {
           .anyMatch(c -> !"".equals(c));
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/pull/7685")
     @Test
-    void doesNotThrowONMissingModuleWhenNot404() {
-        rewriteRun(
-          spec -> spec.recipe(RewriteTest.toRecipe(() -> new PlainTextVisitor<>() {
-              @Override
-              public PlainText visitText(PlainText text, ExecutionContext ctx) {
-                  List<MavenRepository> repositories = singletonList(new MavenRepository("cache-3", "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/", null, null, null, null, null));
-                  GroupArtifact unexisting = new GroupArtifact("org.springframework.integration", "fail");
-                  GroupArtifact existing = new GroupArtifact("org.springframework.integration", "spring-integration-bom");
-                  MavenPomDownloader downloader = new MavenPomDownloader(ctx);
+    void doesNotThrowONMissingModuleWhenNot404() throws Exception {
+        // Mimics an Artifactory virtual repository accessed anonymously: it answers 401 (not 404)
+        // for artifacts it will not serve, and 200 for the ones it does. A local mock server keeps
+        // the test hermetic instead of depending on a live repository's (drifting) contents.
+        try (MockWebServer mockRepo = new MockWebServer()) {
+            mockRepo.setDispatcher(new Dispatcher() {
+                @Override
+                public MockResponse dispatch(RecordedRequest request) {
+                    String path = request.getPath() == null ? "" : request.getPath();
+                    // Existing group:artifact metadata
+                    if (path.endsWith("/org/springframework/integration/spring-integration-bom/maven-metadata.xml")) {
+                        return new MockResponse().setResponseCode(200).setBody(
+                          //language=xml
+                          """
+                            <metadata>
+                                <groupId>org.springframework.integration</groupId>
+                                <artifactId>spring-integration-bom</artifactId>
+                                <versioning>
+                                    <latest>5.5.0</latest>
+                                    <release>5.5.0</release>
+                                    <versions>
+                                        <version>5.5.0</version>
+                                    </versions>
+                                </versioning>
+                            </metadata>
+                            """);
+                    }
+                    // Existing snapshot-version metadata
+                    if (path.endsWith("/com/fasterxml/jackson/jackson-base/2.19.3-SNAPSHOT/maven-metadata.xml")) {
+                        return new MockResponse().setResponseCode(200).setBody(
+                          //language=xml
+                          """
+                            <metadata modelVersion="1.1.0">
+                                <groupId>com.fasterxml.jackson</groupId>
+                                <artifactId>jackson-base</artifactId>
+                                <version>2.19.3-SNAPSHOT</version>
+                                <versioning>
+                                    <snapshot>
+                                        <timestamp>20240101.000000</timestamp>
+                                        <buildNumber>1</buildNumber>
+                                    </snapshot>
+                                    <lastUpdated>20240101000000</lastUpdated>
+                                </versioning>
+                            </metadata>
+                            """);
+                    }
+                    // Existing release POM, declaring Gradle module metadata so the downloader fetches the `.module` side-car
+                    if (path.endsWith("/org/springframework/integration/spring-integration-bom/5.5.0/spring-integration-bom-5.5.0.pom")) {
+                        return new MockResponse().setResponseCode(200).setBody(
+                          //language=xml
+                          """
+                            <project>
+                                <!-- do_not_remove: published-with-gradle-metadata -->
+                                <modelVersion>4.0.0</modelVersion>
+                                <groupId>org.springframework.integration</groupId>
+                                <artifactId>spring-integration-bom</artifactId>
+                                <version>5.5.0</version>
+                                <packaging>pom</packaging>
+                            </project>
+                            """);
+                    }
+                    // Everything else - missing artifacts and the Gradle `.module` side-car - answers 401, never 404.
+                    return new MockResponse().setResponseCode(401);
+                }
+            });
+            mockRepo.start();
 
-                  //Artifactory virtual anonymous repo returns 401 on unexisting and 404 for authenticated unexisting
-                  assertThrows(MavenDownloadingException.class, () -> downloader.downloadMetadata(unexisting, null, repositories));
-                  assertDoesNotThrow(() -> downloader.downloadMetadata(existing, null, repositories));
-                  //Artifactory virtual anonymous repo returns 401 on unexisting and 404 for authenticated unexisting
-                  assertThrows(MavenDownloadingException.class, () -> downloader.downloadMetadata(new GroupArtifactVersion("com.fasterxml.jackson", "jackson-base", "2.19.3"), null, repositories));
-                  //Artifactory virtual returns 200 anonymous and authenticated existing
-                  assertDoesNotThrow(() -> downloader.downloadMetadata(new GroupArtifactVersion("com.fasterxml.jackson", "jackson-base", "2.19.3-SNAPSHOT"), null, repositories));
-                  //Artifactory virtual anonymous repo returns 401 on unexisting and 404 for authenticated unexisting
-                  assertThrows(MavenDownloadingException.class, () -> downloader.download(new GroupArtifactVersion(existing.getGroupId(), existing.getArtifactId(), "5.5.-1"), null, null, repositories));
-                  //Artifactory virtual returns 200 anonymous and authenticated existing
-                  assertDoesNotThrow(() -> downloader.download(new GroupArtifactVersion(existing.getGroupId(), existing.getArtifactId(), "5.5.0"), null, null, repositories));
+            MavenPomDownloader downloader = new MavenPomDownloader(new InMemoryExecutionContext());
+            List<MavenRepository> repositories = singletonList(MavenRepository.builder()
+              .id("cache-3")
+              .uri(mockRepo.url("/").toString())
+              .knownToExist(true)
+              .build());
+            GroupArtifact unexisting = new GroupArtifact("org.springframework.integration", "fail");
+            GroupArtifact existing = new GroupArtifact("org.springframework.integration", "spring-integration-bom");
 
-                  return super.visitText(text, ctx);
-              }
-          })),
-          text("")
-        );
+            // Missing module: the repo answers 401 (not 404), but no metadata is retrievable -> still throws
+            assertThrows(MavenDownloadingException.class, () -> downloader.downloadMetadata(unexisting, null, repositories));
+            // Existing group:artifact metadata (200) -> does not throw
+            assertDoesNotThrow(() -> downloader.downloadMetadata(existing, null, repositories));
+            // Missing release-version metadata (401) -> throws
+            assertThrows(MavenDownloadingException.class, () -> downloader.downloadMetadata(new GroupArtifactVersion("com.fasterxml.jackson", "jackson-base", "2.19.3"), null, repositories));
+            // Existing snapshot-version metadata (200) -> does not throw
+            assertDoesNotThrow(() -> downloader.downloadMetadata(new GroupArtifactVersion("com.fasterxml.jackson", "jackson-base", "2.19.3-SNAPSHOT"), null, repositories));
+            // Missing POM version (401) -> throws
+            assertThrows(MavenDownloadingException.class, () -> downloader.download(new GroupArtifactVersion(existing.getGroupId(), existing.getArtifactId(), "5.5.-1"), null, null, repositories));
+            // Existing POM whose Gradle `.module` side-car returns 401 (not 404) -> does not throw (PR #7685)
+            assertDoesNotThrow(() -> downloader.download(new GroupArtifactVersion(existing.getGroupId(), existing.getArtifactId(), "5.5.0"), null, null, repositories));
+        }
     }
 }


### PR DESCRIPTION
## Motivation

`MavenPomDownloaderTest.doesNotThrowONMissingModuleWhenNot404` made live HTTP calls to the Artifactory virtual repo `artifactory.moderne.ninja/.../moderne-cache-3/` and asserted specific 401/404/200 outcomes for hard-coded coordinates. That repo was reconfigured and now returns **401** (instead of the previously-served **200**) for `com.fasterxml.jackson:jackson-base:2.19.3-SNAPSHOT` metadata, so the `assertDoesNotThrow` for that snapshot started failing on `main` (nightly run 26966736996 onward) and on subsequent PR builds.

The production behavior is correct — `downloadMetadata` throws when no repository yields parseable metadata, and a `401` yields nothing. The test was simply coupled to live external state that drifted.

## Summary

- Rewrote the test to use a local `MockWebServer` (the `Dispatcher` pattern already used throughout this file) that mimics an anonymous Artifactory virtual repo: **401 (never 404)** for unserved artifacts, **200** for served ones — covering all six original scenarios deterministically and offline.
- Made the PR #7685 guarantee explicit: a 200 POM carrying the `published-with-gradle-metadata` marker whose `.module` side-car returns 401 must not cause `download` to throw (the old code threw on `!= 404`). Previously this only held by coincidence of the live POM's shape.
- Built the mock repo with `knownToExist(true)` and a plain `InMemoryExecutionContext` (Maven Central/local not added) so the test is fully hermetic.
- Removed three now-unused imports (`PlainText`, `PlainTextVisitor`, `SourceSpecs.text`).

Note: the original test depended on a live Artifactory virtual repo; this change removes that coupling so the assertions can no longer drift with the repository's contents.

## Test plan

- [x] `./gradlew :rewrite-maven:test --tests "org.openrewrite.maven.internal.MavenPomDownloaderTest"` — 62 tests, 0 failures, 0 errors (1 pre-existing skip).
- [x] Reproduced the original failure first (live 401 on the jackson snapshot metadata) before applying the fix.