### PR TITLE
Let callers opt out of the GitProvenance committer-history walk

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -195,6 +195,26 @@ public class GitProvenance extends Reference implements Marker {
     public static @Nullable GitProvenance fromProjectDirectory(Path projectDir,
                                                                @Nullable BuildEnvironment environment,
                                                                GitRemote.@Nullable Parser gitRemoteParser) {
+        return fromProjectDirectory(projectDir, environment, gitRemoteParser, true);
+    }
+
+    /**
+     * @param projectDir       The project directory.
+     * @param environment      In detached head scenarios, the branch is best
+     *                         determined from a {@link BuildEnvironment} marker if possible.
+     * @param gitRemoteParser  Parses the remote url into a {@link GitRemote}. Custom remotes can be registered to it,
+     *                         or a default with known git hosting services can be used.
+     * @param includeCommitters When {@code false}, skips the unbounded walk over the entire commit history that
+     *                          {@link #getCommitters()} otherwise requires, yielding an empty committers list. Callers
+     *                          that only consume origin/branch/change can opt out to avoid that cost. Everything else
+     *                          (origin, branch, change, autocrlf, eol, remote) is unaffected, so the resulting marker
+     *                          is otherwise identical to the committer-including path.
+     * @return A marker containing git provenance information.
+     */
+    public static @Nullable GitProvenance fromProjectDirectory(Path projectDir,
+                                                               @Nullable BuildEnvironment environment,
+                                                               GitRemote.@Nullable Parser gitRemoteParser,
+                                                               boolean includeCommitters) {
         if (gitRemoteParser == null) {
             gitRemoteParser = new GitRemote.Parser();
         }
@@ -205,7 +225,7 @@ public class GitProvenance extends Reference implements Marker {
                     String branch = jenkinsBuildEnvironment.getLocalBranch() != null ?
                             jenkinsBuildEnvironment.getLocalBranch() :
                             localBranchName(repository, jenkinsBuildEnvironment.getBranch());
-                    return fromGitConfig(repository, branch, getChangeset(repository), gitRemoteParser);
+                    return fromGitConfig(repository, branch, getChangeset(repository), gitRemoteParser, includeCommitters);
                 } catch (IllegalArgumentException | GitAPIException e) {
                     // Silently ignore if the project directory is not a git repository
                     printRequireGitDirOrWorkTreeException(e);
@@ -217,18 +237,18 @@ public class GitProvenance extends Reference implements Marker {
                 File gitDir = new RepositoryBuilder().findGitDir(projectDir.toFile()).getGitDir();
                 if (gitDir != null && gitDir.exists()) {
                     //it has been cloned with --depth > 0
-                    return fromGitConfig(projectDir, gitRemoteParser);
+                    return fromGitConfig(projectDir, gitRemoteParser, includeCommitters);
                 } else {
                     //there is not .git config
                     try {
                         return environment.buildGitProvenance();
                     } catch (IncompleteGitConfigException e) {
-                        return fromGitConfig(projectDir, gitRemoteParser);
+                        return fromGitConfig(projectDir, gitRemoteParser, includeCommitters);
                     }
                 }
             }
         } else {
-            return fromGitConfig(projectDir, gitRemoteParser);
+            return fromGitConfig(projectDir, gitRemoteParser, includeCommitters);
         }
     }
 
@@ -238,14 +258,14 @@ public class GitProvenance extends Reference implements Marker {
         }
     }
 
-    private static @Nullable GitProvenance fromGitConfig(Path projectDir, GitRemote.Parser gitRemoteParser) {
+    private static @Nullable GitProvenance fromGitConfig(Path projectDir, GitRemote.Parser gitRemoteParser, boolean includeCommitters) {
         String branch = null;
         try (Repository repository = new RepositoryBuilder().findGitDir(projectDir.toFile()).build()) {
             String changeset = getChangeset(repository);
             if (!repository.getBranch().equals(changeset)) {
                 branch = repository.getBranch();
             }
-            return fromGitConfig(repository, branch, changeset, gitRemoteParser);
+            return fromGitConfig(repository, branch, changeset, gitRemoteParser, includeCommitters);
         } catch (IllegalArgumentException e) {
             printRequireGitDirOrWorkTreeException(e);
             return null;
@@ -254,7 +274,7 @@ public class GitProvenance extends Reference implements Marker {
         }
     }
 
-    private static @Nullable GitProvenance fromGitConfig(Repository repository, @Nullable String branch, @Nullable String changeset, GitRemote.Parser gitRemoteParser) {
+    private static @Nullable GitProvenance fromGitConfig(Repository repository, @Nullable String branch, @Nullable String changeset, GitRemote.Parser gitRemoteParser, boolean includeCommitters) {
         if (repository.isBare()) {
             return null;
         }
@@ -270,7 +290,7 @@ public class GitProvenance extends Reference implements Marker {
         }
         return new GitProvenance(randomId(), remoteOriginUrl, branch, changeset,
                 getAutocrlf(repository), getEOF(repository),
-                getCommitters(repository), remote);
+                includeCommitters ? getCommitters(repository) : emptyList(), remote);
     }
 
     static @Nullable String resolveBranchFromGitConfig(Repository repository) {

--- a/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
@@ -141,6 +141,27 @@ class GitProvenanceTest {
     }
 
     @Test
+    void excludeCommittersMatchesIncludingPath(@TempDir Path projectDir) throws Exception {
+        try (Git ignored = initGitWithOneCommit(projectDir)) {
+            GitProvenance withCommitters = GitProvenance.fromProjectDirectory(projectDir, null, null, true);
+            GitProvenance withoutCommitters = GitProvenance.fromProjectDirectory(projectDir, null, null, false);
+
+            assertThat(withCommitters).isNotNull();
+            assertThat(withoutCommitters).isNotNull();
+
+            // origin/branch/change are identical whether or not committers are walked
+            assertThat(withoutCommitters.getOrigin()).isEqualTo(withCommitters.getOrigin());
+            assertThat(withoutCommitters.getBranch()).isEqualTo(withCommitters.getBranch());
+            assertThat(withoutCommitters.getChange()).isEqualTo(withCommitters.getChange());
+
+            // the including path actually walks history and finds the commit author
+            assertThat(withCommitters.getCommitters()).isNotEmpty();
+            // the opt-out path skips the walk and returns an empty list
+            assertThat(withoutCommitters.getCommitters()).isEmpty();
+        }
+    }
+
+    @Test
     void detachedHead(@TempDir Path projectDir) throws Exception {
         try (Git git = initGitWithOneCommit(projectDir)) {
             git.checkout().setName(git.getRepository().resolve(Constants.HEAD).getName()).call();


### PR DESCRIPTION
## Motivation

`GitProvenance.fromProjectDirectory(...)` unconditionally calls `getCommitters(repository)`, which does an **unbounded** `git.log()` walk over the entire commit history. There is no flag, env gate, or bound on it.

Many callers consume only `getOrigin()`/`getRepositoryOrigin()`/`getRepositoryPath()`/`getBranch()`/`getChange()` and never read committers — for them the walk is pure waste. CPU profiling of `CommonStaticAnalysis` over a ~40k-commit repository (spring-boot) attributed **~11% of the whole run** to `GitProvenance.getCommitters` → JGit `PackIndex` binary search. This PR lets such callers opt out of the walk.

## Examples

```java
// Existing behavior — walks full history to populate committers (unchanged):
GitProvenance withCommitters =
    GitProvenance.fromProjectDirectory(projectDir, environment, gitRemoteParser);

// New overload — skip the committer walk; getCommitters() returns an empty list.
// origin/branch/change/autocrlf/eol/remote are identical to the call above.
GitProvenance fast =
    GitProvenance.fromProjectDirectory(projectDir, environment, gitRemoteParser, /* includeCommitters */ false);
```

## Summary

- Added a public overload `fromProjectDirectory(Path, BuildEnvironment, GitRemote.Parser, boolean includeCommitters)`.
- The existing three-arg overload delegates to it with `includeCommitters = true`, so all existing overloads keep current behavior.
- Threaded `includeCommitters` through both private `fromGitConfig` methods (including the Jenkins branch). When `false`, the committer field is populated with `emptyList()` instead of `getCommitters(repository)`, skipping the history walk.
- Everything else (origin, branch, change, autocrlf, eol, remote) is unchanged, so `GitProvenance.equals`, `RepositoryId` derivation, and serialized markers stay byte-identical for committer-consuming callers.

### Out of scope / follow-ups

- Even the committer-including path is unbounded. The only first-party consumer (`FindCommitters`) bounds to 90 days; adding a `since`/limit parameter could be a follow-up.
- A downstream consumer can now drop its hand-rolled reimplementation of the cheap git-config read path in favor of this overload.

## Test plan

- [x] New `GitProvenanceTest.excludeCommittersMatchesIncludingPath`: on a normal branch checkout, asserts the opt-out overload produces a `GitProvenance` whose `origin`/`branch`/`change` match the committer-including path, with a non-empty committers list on the including path (proving the walk ran) and an empty list on the opt-out path (proving it was skipped).
- [x] Existing `GitProvenanceTest` stays green: 59 tests, 2 `@Disabled` skipped, 0 failures, 0 errors.
