### PR TITLE
ImportLayoutStyle: cache classpath conflict data per JavaSourceSet

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -180,7 +180,7 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
             List<JavaType.FullyQualified> classpath = sourceSet.map(JavaSourceSet::getClasspath).orElse(emptyList());
             boolean classpathDirty = p instanceof ExecutionContext && JavaSourceSet.isDirty((ExecutionContext) p, cu);
 
-            List<JRightPadded<J.Import>> newImports = layoutStyle.addImport(cu.getPadding().getImports(), importToAdd, cu.getPackageDeclaration(), classpath, classpathDirty);
+            List<JRightPadded<J.Import>> newImports = layoutStyle.addImport(cu.getPadding().getImports(), importToAdd, cu.getPackageDeclaration(), classpath, classpathDirty, sourceSet.orElse(null));
 
             if (member != null && typeReference.isPresent()) {
                 cu = (JavaSourceFile) new ShortenFullyQualifiedMemberReferences(typeReference.get()).visit(cu, p);

--- a/rewrite-java/src/main/java/org/openrewrite/java/OrderImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/OrderImports.java
@@ -98,7 +98,7 @@ public class OrderImports extends Recipe {
                 boolean classpathDirty = JavaSourceSet.isDirty(ctx, cu);
 
                 ImportLayoutStyle importLayoutStyle = importLayoutStyle(cu, namedStyles);
-                List<JRightPadded<J.Import>> orderedImports = importLayoutStyle.orderImports(cu.getPadding().getImports(), classpath, classpathDirty);
+                List<JRightPadded<J.Import>> orderedImports = importLayoutStyle.orderImports(cu.getPadding().getImports(), classpath, classpathDirty, sourceSet.orElse(null));
 
                 boolean changed = false;
                 if (orderedImports.size() != cu.getImports().size()) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
@@ -125,7 +125,10 @@ public class JavaSourceSet implements SourceSet {
 
     private Map<String, List<JavaType.FullyQualified>> buildTypesByPackage() {
         Map<String, List<JavaType.FullyQualified>> index = new HashMap<>();
-        for (JavaType.FullyQualified fqn : classpath) {
+        // Read through getClasspath(), not the `classpath` field: subclasses (e.g. a lazily
+        // hydrating proxy) leave the field empty and serve the real classpath only via the
+        // overridden getter. The lazy getter runs after construction, so the override is in place.
+        for (JavaType.FullyQualified fqn : getClasspath()) {
             index.computeIfAbsent(fqn.getPackageName(), k -> new ArrayList<>()).add(fqn);
         }
         return index;

--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
@@ -22,6 +22,7 @@ import io.github.classgraph.ScanResult;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.Value;
@@ -45,6 +46,7 @@ import java.util.function.Function;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.internal.StringUtils.matchesGlob;
@@ -81,6 +83,19 @@ public class JavaSourceSet implements SourceSet {
     @ToString.Exclude
     transient @Nullable JavaTypeFactory typeFactory;
 
+    /**
+     * Classpath types grouped by package name, built lazily from a single walk of
+     * {@link #classpath} the first time {@link #typesInPackage(String)} is called and cached for
+     * the lifetime of this instance. As a Lombok lazy getter it is thread-safe and excluded from
+     * serialization, {@code equals}/{@code hashCode}, {@code toString}, and the {@code with*}
+     * methods, so a source set produced by {@link #withClasspath} rebuilds the index for its new
+     * classpath rather than reusing a stale one.
+     */
+    @JsonIgnore
+    @ToString.Exclude
+    @Getter(value = AccessLevel.PRIVATE, lazy = true)
+    private final Map<String, List<JavaType.FullyQualified>> typesByPackage = buildTypesByPackage();
+
     public JavaSourceSet(UUID id, String name,
                          List<JavaType.FullyQualified> classpath,
                          Map<String, List<JavaType.FullyQualified>> gavToTypes) {
@@ -97,6 +112,23 @@ public class JavaSourceSet implements SourceSet {
         this.classpath = classpath;
         this.gavToTypes = gavToTypes;
         this.typeFactory = typeFactory;
+    }
+
+    /**
+     * @param packageName a package name (e.g. {@code "java.util"})
+     * @return the classpath types declared directly in {@code packageName}, or an empty list when
+     * none. Implemented as a single classpath walk grouped by package.
+     */
+    public List<JavaType.FullyQualified> typesInPackage(String packageName) {
+        return getTypesByPackage().getOrDefault(packageName, emptyList());
+    }
+
+    private Map<String, List<JavaType.FullyQualified>> buildTypesByPackage() {
+        Map<String, List<JavaType.FullyQualified>> index = new HashMap<>();
+        for (JavaType.FullyQualified fqn : classpath) {
+            index.computeIfAbsent(fqn.getPackageName(), k -> new ArrayList<>()).add(fqn);
+        }
+        return index;
     }
 
     /**

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -37,6 +37,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.JavaPrinter;
 import org.openrewrite.java.JavaStyle;
+import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.style.Style;
@@ -144,6 +145,19 @@ public class ImportLayoutStyle implements JavaStyle {
                                                   J.Import toAdd, J.@Nullable Package pkg,
                                                   Collection<JavaType.FullyQualified> classpath,
                                                   boolean classpathDirty) {
+        return addImport(originalImports, toAdd, pkg, classpath, classpathDirty, null);
+    }
+
+    /**
+     * @param sourceSet when non-null, classpath-derived conflict data is resolved through the
+     *                  source set's per-instance {@link JavaSourceSet#typesInPackage(String)} cache,
+     *                  so the classpath is walked once per source set rather than once per file.
+     */
+    public List<JRightPadded<J.Import>> addImport(List<JRightPadded<J.Import>> originalImports,
+                                                  J.Import toAdd, J.@Nullable Package pkg,
+                                                  Collection<JavaType.FullyQualified> classpath,
+                                                  boolean classpathDirty,
+                                                  @Nullable JavaSourceSet sourceSet) {
         JRightPadded<J.Import> paddedToAdd = new JRightPadded<>(toAdd, Space.EMPTY, Markers.EMPTY);
 
         if (originalImports.isEmpty()) {
@@ -237,7 +251,7 @@ public class ImportLayoutStyle implements JavaStyle {
 
         List<JRightPadded<J.Import>> checkConflicts = new ArrayList<>(originalImports);
         checkConflicts.add(paddedToAdd);
-        boolean isFoldable = new ImportLayoutConflictDetection(classpath, checkConflicts, classpathDirty)
+        boolean isFoldable = new ImportLayoutConflictDetection(classpath, checkConflicts, classpathDirty, sourceSet)
                 .isPackageFoldable(packageOrOuterClassName(paddedToAdd));
 
         // Walk both directions from the insertion point, looking for imports that are in the same block and have the
@@ -349,8 +363,17 @@ public class ImportLayoutStyle implements JavaStyle {
     }
 
     public List<JRightPadded<J.Import>> orderImports(List<JRightPadded<J.Import>> originalImports, Collection<JavaType.FullyQualified> classpath, boolean classpathDirty) {
+        return orderImports(originalImports, classpath, classpathDirty, null);
+    }
+
+    /**
+     * @param sourceSet when non-null, classpath-derived conflict data is resolved through the
+     *                  source set's per-instance {@link JavaSourceSet#typesInPackage(String)} cache,
+     *                  so the classpath is walked once per source set rather than once per file.
+     */
+    public List<JRightPadded<J.Import>> orderImports(List<JRightPadded<J.Import>> originalImports, Collection<JavaType.FullyQualified> classpath, boolean classpathDirty, @Nullable JavaSourceSet sourceSet) {
         LayoutState layoutState = new LayoutState();
-        ImportLayoutConflictDetection importLayoutConflictDetection = new ImportLayoutConflictDetection(classpath, originalImports, classpathDirty);
+        ImportLayoutConflictDetection importLayoutConflictDetection = new ImportLayoutConflictDetection(classpath, originalImports, classpathDirty, sourceSet);
         List<JRightPadded<J.Import>> orderedImports = new ArrayList<>();
 
         List<Block> effectiveLayout = getLayout();
@@ -558,6 +581,14 @@ public class ImportLayoutStyle implements JavaStyle {
         private final Collection<JavaType.FullyQualified> classpath;
         private final List<JRightPadded<J.Import>> originalImports;
         private final boolean classpathDirty;
+
+        /**
+         * When non-null, classpath-derived conflict data is resolved through this source set's
+         * per-instance {@link JavaSourceSet#typesInPackage(String)} cache instead of walking the
+         * full classpath for every file. The {@link #classpath} is still retained for the cheap
+         * {@code isEmpty()} guard.
+         */
+        private final @Nullable JavaSourceSet sourceSet;
         private final Set<String> jvmClasspathNames = new HashSet<>();
         private @Nullable Set<String> containsClassNameConflict = null;
 
@@ -566,9 +597,14 @@ public class ImportLayoutStyle implements JavaStyle {
         }
 
         ImportLayoutConflictDetection(Collection<JavaType.FullyQualified> classpath, List<JRightPadded<J.Import>> originalImports, boolean classpathDirty) {
+            this(classpath, originalImports, classpathDirty, null);
+        }
+
+        ImportLayoutConflictDetection(Collection<JavaType.FullyQualified> classpath, List<JRightPadded<J.Import>> originalImports, boolean classpathDirty, @Nullable JavaSourceSet sourceSet) {
             this.classpath = classpath;
             this.originalImports = originalImports;
             this.classpathDirty = classpathDirty;
+            this.sourceSet = sourceSet;
         }
 
         /**
@@ -598,6 +634,12 @@ public class ImportLayoutStyle implements JavaStyle {
         }
 
         private void setJVMClassNames() {
+            if (sourceSet != null) {
+                for (JavaType.FullyQualified fqn : sourceSet.typesInPackage("java.lang")) {
+                    jvmClasspathNames.add(fqn.getClassName());
+                }
+                return;
+            }
             for (JavaType.FullyQualified fqn : classpath) {
                 // first check `getFullyQualifiedName()` to avoid unnecessary allocations
                 if (fqn.getFullyQualifiedName().startsWith("java.lang.") && "java.lang".equals(fqn.getPackageName())) {
@@ -616,27 +658,65 @@ public class ImportLayoutStyle implements JavaStyle {
                                 .add(anImport.getElement().getPackageName());
             }
 
+            if (sourceSet != null) {
+                // Resolve only the packages actually imported through the per-source-set index,
+                // rather than walking the whole classpath for every file.
+                for (String pkgOrFqn : checkPackageForClasses) {
+                    for (JavaType.FullyQualified t : sourceSet.typesInPackage(pkgOrFqn)) {
+                        nameToPackages.computeIfAbsent(t.getClassName(), p -> new HashSet<>(3)).add(pkgOrFqn);
+                    }
+                    JavaType.FullyQualified outer = findClasspathType(sourceSet, pkgOrFqn);
+                    if (outer != null) {
+                        addStaticMembers(outer, pkgOrFqn, nameToPackages);
+                    }
+                }
+                return nameToPackages;
+            }
+
             for (JavaType.FullyQualified classGraphFqn : classpath) {
                 String packageName = classGraphFqn.getPackageName();
                 if (checkPackageForClasses.contains(packageName)) {
                     String className = classGraphFqn.getClassName();
                     nameToPackages.computeIfAbsent(className, p -> new HashSet<>(3)).add(packageName);
                 } else if (checkPackageForClasses.contains(classGraphFqn.getFullyQualifiedName())) {
-                    packageName = classGraphFqn.getFullyQualifiedName();
-                    for (JavaType.Variable member : classGraphFqn.getMembers()) {
-                        if (member.hasFlags(Flag.Static)) {
-                            nameToPackages.computeIfAbsent(member.getName(), p -> new HashSet<>(3)).add(packageName);
-                        }
-                    }
-
-                    for (JavaType.Method method : classGraphFqn.getMethods()) {
-                        if (method.hasFlags(Flag.Static)) {
-                            nameToPackages.computeIfAbsent(method.getName(), p -> new HashSet<>(3)).add(packageName);
-                        }
-                    }
+                    addStaticMembers(classGraphFqn, classGraphFqn.getFullyQualifiedName(), nameToPackages);
                 }
             }
             return nameToPackages;
+        }
+
+        /**
+         * Record the static members and methods of {@code type} under {@code packageKey} in
+         * {@code nameToPackages}, so a member's simple name maps to every package/outer class that
+         * provides it.
+         */
+        private static void addStaticMembers(JavaType.FullyQualified type, String packageKey, Map<String, Set<String>> nameToPackages) {
+            for (JavaType.Variable member : type.getMembers()) {
+                if (member.hasFlags(Flag.Static)) {
+                    nameToPackages.computeIfAbsent(member.getName(), p -> new HashSet<>(3)).add(packageKey);
+                }
+            }
+            for (JavaType.Method method : type.getMethods()) {
+                if (method.hasFlags(Flag.Static)) {
+                    nameToPackages.computeIfAbsent(method.getName(), p -> new HashSet<>(3)).add(packageKey);
+                }
+            }
+        }
+
+        /**
+         * Locate the classpath type whose fully qualified name is {@code fullyQualifiedName} via the
+         * source set's package index. The package is derived the same way {@link JavaType.FullyQualified#getPackageName()}
+         * would, so a default-package (dot-less) name maps to the {@code ""} bucket.
+         */
+        private static JavaType.@Nullable FullyQualified findClasspathType(JavaSourceSet sourceSet, String fullyQualifiedName) {
+            int lastDot = fullyQualifiedName.lastIndexOf('.');
+            String packageName = lastDot < 0 ? "" : fullyQualifiedName.substring(0, lastDot);
+            for (JavaType.FullyQualified t : sourceSet.typesInPackage(packageName)) {
+                if (t.getFullyQualifiedName().equals(fullyQualifiedName)) {
+                    return t;
+                }
+            }
+            return null;
         }
     }
 

--- a/rewrite-java/src/test/java/org/openrewrite/java/marker/JavaSourceSetTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/marker/JavaSourceSetTest.java
@@ -15,23 +15,95 @@
  */
 package org.openrewrite.java.marker;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.Tree;
 import org.openrewrite.java.tree.JavaType;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JavaSourceSetTest {
 
     @TempDir
     Path tempDir;
+
+    @Test
+    void typesInPackageReturnsTypesInThatPackage() {
+        JavaType.FullyQualified list = JavaType.ShallowClass.build("java.util.List");
+        JavaType.FullyQualified map = JavaType.ShallowClass.build("java.util.Map");
+        JavaType.FullyQualified pattern = JavaType.ShallowClass.build("java.util.regex.Pattern");
+        JavaSourceSet sourceSet = new JavaSourceSet(Tree.randomId(), "main",
+          List.of(list, map, pattern), emptyMap());
+
+        assertThat(sourceSet.typesInPackage("java.util")).containsExactlyInAnyOrder(list, map);
+        assertThat(sourceSet.typesInPackage("java.util.regex")).containsExactly(pattern);
+        assertThat(sourceSet.typesInPackage("does.not.exist")).isEmpty();
+    }
+
+    @Test
+    void typesInPackageWalksClasspathOnce() {
+        List<JavaType.FullyQualified> backing = List.of(
+          JavaType.ShallowClass.build("java.util.List"),
+          JavaType.ShallowClass.build("java.util.regex.Pattern"));
+        AtomicInteger iterations = new AtomicInteger();
+        JavaSourceSet sourceSet = new JavaSourceSet(Tree.randomId(), "main",
+          new CountingList<>(backing, iterations), emptyMap());
+
+        sourceSet.typesInPackage("java.util");
+        sourceSet.typesInPackage("java.util.regex");
+        sourceSet.typesInPackage("java.util");
+
+        assertThat(iterations).hasValue(1);
+    }
+
+    @Test
+    void lazyPackageIndexIsNotSerialized() throws Exception {
+        ObjectMapper mapper = new ObjectMapper()
+          .registerModule(new ParameterNamesModule())
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        JavaSourceSet sourceSet = new JavaSourceSet(Tree.randomId(), "main", List.of(), emptyMap());
+        sourceSet.typesInPackage("java.util"); // force the lazy index to be built
+
+        String json = mapper.writeValueAsString(sourceSet);
+        assertThat(json).doesNotContain("typesByPackage");
+
+        JavaSourceSet roundTripped = mapper.readValue(json, JavaSourceSet.class);
+        assertThat(roundTripped.getId()).isEqualTo(sourceSet.getId());
+    }
+
+    /**
+     * A {@link List} that counts how many times it is iterated, to prove the package index is
+     * built from a single classpath walk and then cached.
+     */
+    private static class CountingList<E> extends ArrayList<E> {
+        private final transient AtomicInteger iterations;
+
+        CountingList(Collection<E> backing, AtomicInteger iterations) {
+            super(backing);
+            this.iterations = iterations;
+        }
+
+        @Override
+        public Iterator<E> iterator() {
+            iterations.incrementAndGet();
+            return super.iterator();
+        }
+    }
 
     @Test
     void skipsMetaInfEntriesInJar() throws Exception {

--- a/rewrite-java/src/test/java/org/openrewrite/java/style/ImportLayoutStyleTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/style/ImportLayoutStyleTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.Issue;
 import org.openrewrite.Tree;
 import org.openrewrite.config.DeclarativeNamedStyles;
 import org.openrewrite.java.OrderImports;
+import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.style.NamedStyles;
@@ -30,8 +31,10 @@ import org.openrewrite.test.RewriteTest;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,6 +91,63 @@ class ImportLayoutStyleTest implements RewriteTest {
         );
 
         mapper.readValue(mapper.writeValueAsBytes(style), DeclarativeNamedStyles.class);
+    }
+
+    @Test
+    void orderImportsWithSourceSetSuppressesFoldOnJavaLangCollision() {
+        // kotlin.String collides with java.lang.String on the classpath, so kotlin.* must not fold.
+        List<JRightPadded<J.Import>> imports = List.of(
+          imp("kotlin.DeepRecursiveFunction"), imp("kotlin.Function"),
+          imp("kotlin.Lazy"), imp("kotlin.Pair"), imp("kotlin.String"));
+        List<JavaType.FullyQualified> classpath = List.of(
+          JavaType.ShallowClass.build("java.lang.String"),
+          JavaType.ShallowClass.build("kotlin.DeepRecursiveFunction"),
+          JavaType.ShallowClass.build("kotlin.Function"),
+          JavaType.ShallowClass.build("kotlin.Lazy"),
+          JavaType.ShallowClass.build("kotlin.Pair"),
+          JavaType.ShallowClass.build("kotlin.String"));
+        JavaSourceSet sourceSet = new JavaSourceSet(randomId(), "main", classpath, emptyMap());
+        ImportLayoutStyle style = org.openrewrite.java.style.IntelliJ.importLayout();
+
+        List<String> fullWalk = printed(style.orderImports(imports, classpath, false));
+        List<String> cached = printed(style.orderImports(imports, classpath, false, sourceSet));
+
+        assertThat(cached).isEqualTo(fullWalk).noneMatch(s -> s.endsWith(".*"));
+    }
+
+    @Test
+    void orderImportsWithSourceSetFoldsWhenNoConflict() {
+        List<JRightPadded<J.Import>> imports = List.of(
+          imp("java.util.ArrayList"), imp("java.util.List"), imp("java.util.Map"),
+          imp("java.util.Set"), imp("java.util.Collection"), imp("java.util.Objects"));
+        List<JavaType.FullyQualified> classpath = List.of(
+          JavaType.ShallowClass.build("java.util.ArrayList"),
+          JavaType.ShallowClass.build("java.util.List"),
+          JavaType.ShallowClass.build("java.util.Map"),
+          JavaType.ShallowClass.build("java.util.Set"),
+          JavaType.ShallowClass.build("java.util.Collection"),
+          JavaType.ShallowClass.build("java.util.Objects"));
+        JavaSourceSet sourceSet = new JavaSourceSet(randomId(), "main", classpath, emptyMap());
+        ImportLayoutStyle style = org.openrewrite.java.style.IntelliJ.importLayout();
+
+        List<String> fullWalk = printed(style.orderImports(imports, classpath, false));
+        List<String> cached = printed(style.orderImports(imports, classpath, false, sourceSet));
+
+        assertThat(cached).isEqualTo(fullWalk).anyMatch(s -> s.endsWith("java.util.*"));
+    }
+
+    private static JRightPadded<J.Import> imp(String fullyQualifiedName) {
+        return new JRightPadded<>(
+          new J.Import(randomId(), Space.EMPTY, Markers.EMPTY,
+            new JLeftPadded<>(Space.EMPTY, false, Markers.EMPTY),
+            TypeTree.build(fullyQualifiedName).withPrefix(Space.SINGLE_SPACE), null),
+          Space.EMPTY, Markers.EMPTY);
+    }
+
+    private static List<String> printed(List<JRightPadded<J.Import>> imports) {
+        return imports.stream()
+          .map(i -> i.getElement().getQualid().printTrimmed())
+          .collect(Collectors.toList());
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/4196")


### PR DESCRIPTION
## Motivation

`ImportLayoutStyle.ImportLayoutConflictDetection` walks the **entire classpath for every file** in `setJVMClassNames()` and `mapNamesInPackageToPackages()` — a fresh detector is created per file by `OrderImports`/`AddImport`, so the cost is **O(files × classpath)** of `getPackageName()`/`getFullyQualifiedName()` string work plus `HashMap` churn. CPU profiling of a static-analysis run over a large multi-module project showed `ImportLayoutStyle` at ~15% of the whole run. With a lazily-resolved classpath it is worse, because the full per-file walk forces materializing the entire lazy classpath on every file.

- A fast path along these lines was added in #7528 (a `JavaSourceSet.ClasspathIndex` SPI) and later reverted in #7845 as an unused SPI surface. This restores the optimization **without any SPI** — a concrete, lazily-cached method on `JavaSourceSet` with a live consumer — so it can't be dropped again as "unused".

## What changed

`JavaSourceSet` gains a lazily-built, per-instance index of classpath types grouped by package, exposed as a single generic accessor (import-conflict *policy* stays in `ImportLayoutStyle`):

```java
public List<JavaType.FullyQualified> typesInPackage(String packageName);
```

It is a Lombok `@Getter(lazy = true)` field: thread-safe lazy init, and excluded from serialization, `equals`/`hashCode`, `toString`, and the `with*` constructor threading — so a source set produced by `withClasspath` (e.g. `addTypesForGav`/`removeTypesForGav`) rebuilds the index for its new classpath rather than reusing a stale one.

`ImportLayoutConflictDetection` resolves only the *imported* packages through that index when a source set is available, instead of walking the whole classpath:

```java
// new overloads; the existing ones delegate with sourceSet = null (unchanged full-walk behavior)
style.orderImports(imports, classpath, classpathDirty, sourceSet);
style.addImport(imports, toAdd, pkg, classpath, classpathDirty, sourceSet);
```

`OrderImports`/`AddImport` pass the CU's `JavaSourceSet`. The `classpathDirty` safe path and the cheap `classpath.isEmpty()` guard are unchanged, and the cached path is byte-for-byte equivalent to the full walk (mirrors the per-type semantics of the original loop, including the static-member/FQN branch).

## Summary

- Add `JavaSourceSet.typesInPackage(String)` backed by a lazily-built `Map<packageName, List<FullyQualified>>` (single classpath walk per instance, `@Getter(lazy = true)`).
- `ImportLayoutConflictDetection` uses the per-source-set index when present; falls back to the existing full walk when no source set is supplied.
- New `orderImports`/`addImport` overloads carrying the `JavaSourceSet`; old overloads retained and delegate with `null`.
- `OrderImports` and `AddImport` thread the source set through.

## Scope note

The cache is keyed to a `JavaSourceSet` **instance**, so it benefits every file that shares that instance (the in-memory parse/recipe path). On serialized pipelines where each file is re-hydrated into its own marker instance, the transient index is cold per file (same as the existing transient `typeFactory`); a follow-up can add an `ExecutionContext`-id-keyed backstop if profiling shows that path still hot. Memoizing `JavaType.FullyQualified.getPackageName()` is a complementary, independently valuable follow-up.

## Test plan

- [x] `JavaSourceSetTest`: `typesInPackage` returns the types in a package; the classpath is walked exactly once across repeated calls (counting collection); the lazy index is excluded from the Jackson payload and the marker round-trips.
- [x] `ImportLayoutStyleTest`: the new `orderImports(..., sourceSet)` overload is byte-for-byte equal to the full-walk path, both when a `java.lang` collision must suppress folding and when folding must proceed.
- [x] Regression green: `OrderImportsTest`, `AddImportTest` (incl. `doNotFoldPackageWithJavaLangClassNames`, now exercising the cached path), full `:rewrite-java`, `DirtyJavaSourceSetsProducerTest`, `ChangeTypeTest`/`ChangePackageTest`/`RemoveImportTest`/`RemoveUnusedImportsTest`.