### PR TITLE
Scala: fix spacing before underscore parameter

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -698,13 +698,24 @@ class ScalaTreeVisitor(
         val spaceBeforeUnderscore = if (postfixOp.od.span.exists && postfixOp.op.span.exists) {
           val odEnd = postfixOp.od.span.end - offsetAdjustment
           val opStart = postfixOp.op.span.start - offsetAdjustment
-          if (odEnd < opStart && odEnd >= 0 && opStart <= source.length) {
-            Space.format(source, odEnd, opStart)
+          if (odEnd >= 0 && opStart <= source.length) {
+            val underscoreStart = indexOfNextNonWhitespace(opStart)
+            val operandEnd =
+              if (odEnd < underscoreStart) {
+                odEnd
+              } else {
+                source.lastIndexWhere(c => !Character.isWhitespace(c), underscoreStart - 1) + 1
+              }
+            if (operandEnd <= underscoreStart && underscoreStart < source.length && source.charAt(underscoreStart) == '_') {
+              Space.format(source, operandEnd, underscoreStart)
+            } else {
+              Space.EMPTY
+            }
           } else {
-            Space.SINGLE_SPACE
+            Space.EMPTY
           }
         } else {
-          Space.SINGLE_SPACE
+          Space.EMPTY
         }
         
         // Create a member reference

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MemberReferenceTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MemberReferenceTest.java
@@ -50,6 +50,19 @@ class MemberReferenceTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void memberReferenceAfterMethodInvocationWithoutWhitespaceBeforeUnderscore() {
+        rewriteRun(
+            scala(
+                """
+                class Test {
+                  def events = find()_
+                }
+                """
+            )
+        );
+    }
     
     @Test
     void staticMemberReference() {


### PR DESCRIPTION
## What's changed?

Fix Scala parser handling of non-standard whitespace before the `_` as a parameter, e.g.
```
find()_
```

## What's your motivation?

It suffers from idempotency issues.