### PR TITLE
Scala: handle case guards with complex (block) conditions

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7245,6 +7245,7 @@ class ScalaTreeVisitor(
         val guardResult = visitTree(caseDef.guard)
         guardResult match {
           case expr: Expression => guard = expr
+          case j: J => guard = new S.StatementExpression(Tree.randomId(), j)
           case _ =>
         }
         val arrowPos = positionOfNext("=>", cursor)

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
@@ -231,6 +231,24 @@ class MatchTest implements RewriteTest {
     }
 
     @Test
+    void matchWithBlockGuard() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              def handle(x: Any): String = x match {
+                case s: String if {
+                      s.nonEmpty
+                    } => s
+                case _ => "empty"
+              }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void matchWithGuardComment() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

It turns out Scala can have a whole block of code in the case guard, e.g.
```
                case s: String if {
                      s.nonEmpty
                    } => s
```
Thus providing support for such syntax.

## What's your motivation?

Otherwise it fails to parse properly with the guard being swallowed.