### PR TITLE
Go: make sure go.mod is emitted as GoMod source

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -2077,7 +2077,39 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		})
 	}
 
-	s.logger.Printf("ParseProject: parsed %d files across %d module(s)", len(items), len(mods))
+	// Emit each go.mod as a lossless GoMod LST so recipes operate on the
+	// module file directly instead of plain text. Mirrors the single-file
+	// Parse path; the GoResolutionResult — already parsed above for module
+	// context — is attached as a marker when available.
+	for _, modPath := range disc.goMods {
+		data, err := os.ReadFile(modPath)
+		if err != nil {
+			continue
+		}
+		gm, err := goparser.ParseGoModFile(modPath, string(data))
+		if err != nil {
+			s.logger.Printf("ParseProject: skip go.mod LST %s: %v", modPath, err)
+			continue
+		}
+		if m, ok := mods[filepath.Dir(modPath)]; ok && m.mrr != nil {
+			gm.Markers.Entries = append(gm.Markers.Entries, *m.mrr)
+		}
+		sourcePath := modPath
+		if req.RelativeTo != nil && *req.RelativeTo != "" {
+			if rel, err := filepath.Rel(*req.RelativeTo, modPath); err == nil {
+				sourcePath = rel
+			}
+		}
+		id := gm.Ident.String()
+		s.localObjects[id] = gm
+		items = append(items, parseProjectResponseItem{
+			ID:             id,
+			SourceFileType: "org.openrewrite.golang.tree.GoMod",
+			SourcePath:     sourcePath,
+		})
+	}
+
+	s.logger.Printf("ParseProject: parsed %d sources across %d module(s)", len(items), len(mods))
 	return items, nil
 }
 

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/ParseProjectModuleContextTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/ParseProjectModuleContextTest.java
@@ -24,6 +24,8 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.golang.marker.GoResolutionResult;
 import org.openrewrite.golang.tree.Go;
+import org.openrewrite.golang.tree.GoMod;
+import org.openrewrite.text.PlainText;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -108,6 +110,43 @@ class ParseProjectModuleContextTest {
                     .extracting(GoResolutionResult.Require::getModulePath)
                     .contains("github.com/google/uuid");
         }
+    }
+
+    @Test
+    void goModParsedAsGoModNotPlainText() throws Exception {
+        // The project's go.mod must be emitted as a rich GoMod LST, not
+        // plain text, carrying the module's GoResolutionResult marker.
+        write(projectDir.resolve("go.mod"), """
+                module example.com/foo
+
+                go 1.22
+
+                require github.com/google/uuid v1.6.0
+                """);
+        write(projectDir.resolve("main.go"), """
+                package main
+
+                func main() {}
+                """);
+
+        GoRewriteRpc rpc = GoRewriteRpc.getOrStart();
+        List<SourceFile> sources = rpc.parseProject(projectDir, new InMemoryExecutionContext()).collect(Collectors.toList());
+
+        List<GoMod> goMods = sources.stream()
+                .filter(s -> s instanceof GoMod)
+                .map(s -> (GoMod) s)
+                .collect(Collectors.toList());
+        assertThat(goMods).as("expected the go.mod to be parsed as a GoMod").hasSize(1);
+        assertThat(sources).noneMatch(s -> s instanceof PlainText);
+
+        GoMod goMod = goMods.get(0);
+        assertThat(goMod.getSourcePath().toString().replace('\\', '/')).endsWith("go.mod");
+        GoResolutionResult mrr = goMod.getMarkers().findFirst(GoResolutionResult.class).orElseThrow(
+                () -> new AssertionError("missing GoResolutionResult on go.mod"));
+        assertThat(mrr.getModulePath()).isEqualTo("example.com/foo");
+        assertThat(mrr.getRequires())
+                .extracting(GoResolutionResult.Require::getModulePath)
+                .contains("github.com/google/uuid");
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

- A follow-up to #7862.
Making sure that the RPC request to parse a Go project returns the `go.mod` file parsed as `org.openrewrite.golang.tree.GoMod`.

## What's your motivation?

Otherwise it ends up as PlainText and it's not being fed to recipes.