### PR TITLE
Scala: fix too optimistic matching of `???`

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -4663,11 +4663,7 @@ class ScalaTreeVisitor(
         case ta: Trees.TypeApply[?] => hasTripleQ(ta.fun)
         case _ => false
       }
-      hasTripleQ(block.expr) || {
-        // Catch-all: check any tree containing ???
-        val exprStr = try { block.expr.show } catch { case _: Exception => try { block.expr.toString } catch { case _: Exception => "" } }
-        exprStr.contains("???")
-      } || (block.expr.span.exists && {
+      hasTripleQ(block.expr) || (block.expr.span.exists && {
         val s = block.expr.span.start - offsetAdjustment
         s < 0 || s >= source.length
       })
@@ -4684,16 +4680,14 @@ class ScalaTreeVisitor(
       }
     }
     if (!block.expr.isEmpty && !isSyntheticExpr) {
-      // Visit the expression and check if it's a synthetic ???
+      // Visit the expression and check if it's a synthetic ??? that slipped through.
+      // Detect structurally (a `Predef.???`-style field access), never by string-matching
+      // the printed output — user code such as the string literal `"???"` is not synthetic.
       val exprResult = visitTree(block.expr)
-      val resultText = try {
-        if (exprResult != null) exprResult.print(new org.openrewrite.Cursor(null, exprResult)) else ""
-      } catch { case _: Exception => "" }
-      val isSyntheticResult = resultText.contains("???") || resultText.contains("Predef") || resultText.contains("$qmark") ||
-        (exprResult.isInstanceOf[J.FieldAccess] && {
-          val fa = exprResult.asInstanceOf[J.FieldAccess]
-          fa.getSimpleName == "???" || fa.getSimpleName == "$qmark$qmark$qmark"
-        })
+      val isSyntheticResult = exprResult.isInstanceOf[J.FieldAccess] && {
+        val fa = exprResult.asInstanceOf[J.FieldAccess]
+        fa.getSimpleName == "???" || fa.getSimpleName == "$qmark$qmark$qmark"
+      }
       if (isSyntheticResult) {
         // Synthetic ??? slipped through — skip it
       } else exprResult match {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LiteralTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LiteralTest.java
@@ -99,6 +99,21 @@ class LiteralTest implements RewriteTest {
     }
 
     @Test
+    void stringLiteralContainingTripleQuestionMark() {
+        // The `???` content must not be mistaken for the compiler-synthetic Predef.???
+        // placeholder and dropped from the block's trailing expression.
+        rewriteRun(
+          scala(
+            """
+            val code = {
+              "???"
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void multilineStringLiteral() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

`???` is a special construct in Scala.
But these three signs appearing in a String literal shouldn't be matched. Fixing this.

## What's your motivation?

Otherwise the parsing goes wrong.