### PR TITLE
rewrite-csharp: add LOCAL_NUGET_FEED env var and skip repo nuget.config on tool install

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -36,6 +36,7 @@ import org.openrewrite.table.SourcesFileErrors;
 import org.openrewrite.table.SourcesFileResults;
 
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.rpc.DynamicDispatchRpcCodec;
 import org.openrewrite.rpc.RewriteRpc;
 import org.openrewrite.rpc.RpcRecipe;
 import org.openrewrite.rpc.request.BatchVisit;
@@ -332,7 +333,14 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                     // otherwise the BatchVisit RPC fails on the remote side and the resulting
                     // exception gets attached to the source as a Markup$Error, falsely marking
                     // the file as modified.
-                    if (currentRpc.getLanguages().contains(src.getClass().getName())) {
+                    // Use the canonical (codec-registered) source file type rather than the raw
+                    // runtime class name: under lazy-deserialization LSTs the runtime class is a
+                    // generated proxy (e.g. GeneratedTreeProxies$Lazy_xml_tree_xml_document) that
+                    // is absent from the remote's declared languages, which would otherwise skip
+                    // every batched edit on that file. canonicalSourceFileType walks the proxy's
+                    // supertype chain to the registered type (e.g. Xml$Document).
+                    if (currentRpc.getLanguages().contains(
+                            DynamicDispatchRpcCodec.canonicalSourceFileType(src.getClass()))) {
                         RpcRecipe rpcRecipe = (RpcRecipe) recipe;
                         // Evaluate the precondition locally before batching. The non-batch
                         // path runs the precondition via getVisitor()'s Preconditions.check

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -670,20 +670,36 @@ public class RewriteRpcServer
             </Project>
             """);
 
-        // Add local NuGet feed as a package source if it exists, so that
-        // locally-published SDK snapshots are discovered alongside nuget.org
-        var localFeed = Path.Combine(
+        // Add local directory-based NuGet feeds so locally-published SDK/recipe
+        // snapshots are discovered. We only *add* sources here and deliberately do
+        // NOT declare nuget.org: dotnet merges this project-level nuget.config with
+        // the user- and machine-level configuration, so the environment's already
+        // configured default feed (which may be an internal mirror rather than
+        // nuget.org in networks that block it) is preserved and combined with these
+        // local feeds. Hardcoding nuget.org here would break such environments.
+        var localFeeds = new List<(string Key, string Path)>();
+
+        var defaultLocalFeed = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             ".nuget", "local-feed");
-        if (Directory.Exists(localFeed))
+        if (Directory.Exists(defaultLocalFeed))
+            localFeeds.Add(("local-feed", defaultLocalFeed));
+
+        // Allow an arbitrary additional feed directory to be supplied out-of-band.
+        var envFeed = Environment.GetEnvironmentVariable("LOCAL_NUGET_FEED");
+        if (!string.IsNullOrWhiteSpace(envFeed) && Directory.Exists(envFeed))
+            localFeeds.Add(("local-feed-env", Path.GetFullPath(envFeed)));
+
+        if (localFeeds.Count > 0)
         {
+            var sources = string.Join(Environment.NewLine,
+                localFeeds.Select(f => $"    <add key=\"{f.Key}\" value=\"{f.Path}\" />"));
             var nugetConfig = Path.Combine(_recipesProjectDir, "nuget.config");
             File.WriteAllText(nugetConfig, $"""
                 <?xml version="1.0" encoding="utf-8"?>
                 <configuration>
                   <packageSources>
-                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-                    <add key="local-feed" value="{localFeed}" />
+                {sources}
                   </packageSources>
                 </configuration>
                 """);

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -454,6 +454,7 @@ public class CSharpRewriteRpc extends RewriteRpc {
         }
 
         private void installTool(Path dotnetPath, String version, Path toolPath) {
+            Path installCwd = null;
             try {
                 Files.createDirectories(toolPath);
 
@@ -466,18 +467,40 @@ public class CSharpRewriteRpc extends RewriteRpc {
                         "--ignore-failed-sources"
                 ));
 
-                // When the tool package exists in the NuGet global cache (e.g. from publishToMavenLocal),
-                // add it as a source so the install can resolve it without remote feeds
-                Path globalCachePath = Paths.get(System.getProperty("user.home"),
-                        ".nuget", "packages", NUGET_PACKAGE_ID.toLowerCase(), version);
-                if (Files.isDirectory(globalCachePath)) {
-                    installCmd.addAll(Arrays.asList("--add-source", globalCachePath.toString()));
+                // Resolve the feed that provides the tool package itself. LOCAL_NUGET_FEED, when
+                // set, takes precedence; otherwise default to the NuGet global packages cache,
+                // where publishToMavenLocal lands the tool package.
+                String localFeedOverride = environment.get("LOCAL_NUGET_FEED");
+                if (localFeedOverride == null) {
+                    localFeedOverride = System.getenv("LOCAL_NUGET_FEED");
+                }
+                Path localFeed;
+                boolean addLocalFeed;
+                if (localFeedOverride != null && !localFeedOverride.isEmpty()) {
+                    localFeed = Paths.get(localFeedOverride);
+                    addLocalFeed = true;
+                } else {
+                    localFeed = Paths.get(System.getProperty("user.home"),
+                            ".nuget", "packages", NUGET_PACKAGE_ID.toLowerCase(), version);
+                    addLocalFeed = Files.isDirectory(localFeed);
+                }
+                if (addLocalFeed) {
+                    installCmd.addAll(Arrays.asList("--add-source",
+                            localFeed.toAbsolutePath().normalize().toString()));
                 }
 
                 ProcessBuilder pb = new ProcessBuilder(installCmd);
-                if (workingDirectory != null) {
-                    pb.directory(workingDirectory.toFile());
-                }
+                // Run from a fresh, empty directory whose ancestors hold no nuget.config. This
+                // lets NuGet's own config discovery pick up the user/machine-level global
+                // configuration (which applies regardless of working directory, and may span
+                // multiple files) while skipping any repo-level nuget.config that would otherwise
+                // be discovered up the working-directory hierarchy — such a config could <clear/>
+                // global sources or enable <packageSourceMapping> that rejects --add-source with
+                // "The --add-source option cannot be combined with package source mapping". We
+                // delegate to NuGet's discovery rather than locating the global config ourselves,
+                // since its path is convention, not a stable contract.
+                installCwd = Files.createTempDirectory("rewrite-csharp-tool-install");
+                pb.directory(installCwd.toFile());
                 pb.environment().putAll(environment);
                 pb.redirectErrorStream(true);
                 Process process = pb.start();
@@ -494,6 +517,14 @@ public class CSharpRewriteRpc extends RewriteRpc {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException("Interrupted while installing " + NUGET_PACKAGE_ID + "@" + version, e);
+            } finally {
+                if (installCwd != null) {
+                    try {
+                        Files.deleteIfExists(installCwd);
+                    } catch (IOException ignored) {
+                        // Best effort: the temp directory is empty and harmless if it lingers.
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Installs the C# tool from a fresh working directory with no `nuget.config` on any ancestor path, so NuGet's own config discovery applies the user/machine-level global configuration (preserving nuget.org / private-proxy feeds for transitive dependencies) while skipping repo-level overrides that could `<clear/>` sources or enable package source mapping. The tool package's feed now comes from `LOCAL_NUGET_FEED` when set, otherwise the NuGet global packages cache (`~/.nuget/packages/...`) as before. This also fixes RPC edit batching to resolve the canonical (codec-registered) source file type rather than the raw runtime class name, since under lazy-deserialization LSTs the runtime class is a generated proxy absent from the remote's declared languages, which would otherwise skip every batched edit on that file.