### PR TITLE
rewrite-csharp: stream RPC peer data tables to the orchestrator's datatables directory

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/CsvDataTableStore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/CsvDataTableStore.java
@@ -166,6 +166,35 @@ public class CsvDataTableStore implements DataTableStore, AutoCloseable {
         }
     }
 
+    /**
+     * The directory CSV files are written into. Exposed so the RPC layer can tell a remote
+     * peer where to write its own data tables.
+     */
+    public Path getOutputDir() {
+        return outputDir;
+    }
+
+    /**
+     * The file extension (including dot) written files use, e.g. {@code .csv} or {@code .csv.gz}.
+     */
+    public String getFileExtension() {
+        return fileExtension;
+    }
+
+    /**
+     * Static columns prepended to every row (e.g. repository metadata), in insertion order.
+     */
+    public Map<String, String> getPrefixColumns() {
+        return prefixColumns;
+    }
+
+    /**
+     * Static columns appended to every row (e.g. organization), in insertion order.
+     */
+    public Map<String, String> getSuffixColumns() {
+        return suffixColumns;
+    }
+
     private static OutputStream defaultOutputStream(Path path) {
         try {
             return Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.APPEND);

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -42,6 +42,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -92,6 +93,12 @@ public class RewriteRpc {
     final IdentityHashMap<Object, Integer> localRefs = new IdentityHashMap<>();
 
     private @Nullable List<String> remoteLanguages;
+
+    /**
+     * ExecutionContext ids for which a {@link ConfigureDataTables} message has already been
+     * sent to this peer, so the (constant per run) data table output config is sent at most once.
+     */
+    private final Set<String> configuredDataTablePIds = ConcurrentHashMap.newKeySet();
 
     /**
      * Creates a new RPC interface that can be used to communicate with a remote.
@@ -282,6 +289,43 @@ public class RewriteRpc {
         remoteLanguages = null;
     }
 
+    /**
+     * Whether this peer can be told (via {@link ConfigureDataTables}) to write the data tables
+     * its recipes produce into the orchestrator's {@code datatables/} directory. Overridden to
+     * {@code true} by peers that implement the {@code ConfigureDataTables} RPC method; the default
+     * is {@code false} so that peers without it never receive an unsupported call.
+     */
+    protected boolean supportsDataTableConfig() {
+        return false;
+    }
+
+    /**
+     * Send the (constant per run) data table output configuration to the remote peer the first
+     * time we visit with a given {@link ExecutionContext}, so that data tables the peer's recipes
+     * produce are written alongside ours. No-op unless the peer {@linkplain #supportsDataTableConfig()
+     * supports it} and the context is backed by a {@link CsvDataTableStore}.
+     */
+    private <P> void ensureDataTablesConfigured(String pId, P p) {
+        if (!supportsDataTableConfig() || !(p instanceof ExecutionContext) ||
+            !configuredDataTablePIds.add(pId)) {
+            return;
+        }
+        DataTableStore store = DataTableExecutionContextView.view((ExecutionContext) p).getDataTableStore();
+        if (!(store instanceof CsvDataTableStore)) {
+            return;
+        }
+        CsvDataTableStore csv = (CsvDataTableStore) store;
+        send("ConfigureDataTables", new ConfigureDataTables(
+                pId,
+                csv.getOutputDir().toAbsolutePath().toString(),
+                csv.getFileExtension(),
+                new ArrayList<>(csv.getPrefixColumns().keySet()),
+                new ArrayList<>(csv.getPrefixColumns().values()),
+                new ArrayList<>(csv.getSuffixColumns().keySet()),
+                new ArrayList<>(csv.getSuffixColumns().values())
+        ), ConfigureDataTablesResponse.class);
+    }
+
     public <P> @Nullable Tree visit(SourceFile sourceFile, String visitorName, P p) {
         return visit(sourceFile, visitorName, p, null);
     }
@@ -291,6 +335,7 @@ public class RewriteRpc {
         localObjects.put(tree.getId().toString(), tree);
 
         String pId = maybeUnwrapExecutionContext(p);
+        ensureDataTablesConfigured(pId, p);
         List<String> cursorIds = getCursorIds(cursor);
 
         String sourceFileType = DynamicDispatchRpcCodec.canonicalSourceFileType(
@@ -311,6 +356,7 @@ public class RewriteRpc {
         localObjects.put(treeId, tree);
 
         String pId = maybeUnwrapExecutionContext(p);
+        ensureDataTablesConfigured(pId, p);
         List<String> cursorIds = getCursorIds(cursor);
 
         String sourceFileType = DynamicDispatchRpcCodec.canonicalSourceFileType(

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/ConfigureDataTables.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/ConfigureDataTables.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc.request;
+
+import lombok.Value;
+
+import java.util.List;
+
+/**
+ * Tells a remote RPC peer where (and in what format) to write the data table rows that
+ * recipes it executes produce, so the peer's data tables land alongside the orchestrator's
+ * in the same {@code datatables/} directory. Sent once per {@link org.openrewrite.ExecutionContext}
+ * (identified by {@link #pId}) before any visit, and only to peers that
+ * {@linkplain org.openrewrite.rpc.RewriteRpc#supportsDataTableConfig() advertise support}.
+ * <p>
+ * Columns are passed as parallel name/value lists to preserve their order across
+ * language-specific JSON deserializers.
+ */
+@Value
+public class ConfigureDataTables implements RpcRequest {
+    String pId;
+
+    /**
+     * Absolute path of the directory the peer should write its CSV files into.
+     */
+    String outputDir;
+
+    /**
+     * File extension including the leading dot, e.g. {@code .csv} or {@code .csv.gz}.
+     * A {@code .gz} suffix instructs the peer to GZIP its output.
+     */
+    String fileExtension;
+
+    List<String> prefixColumnNames;
+    List<String> prefixColumnValues;
+    List<String> suffixColumnNames;
+    List<String> suffixColumnValues;
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/ConfigureDataTablesResponse.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/ConfigureDataTablesResponse.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Value;
+
+@Value
+public class ConfigureDataTablesResponse {
+    boolean configured;
+
+    @JsonCreator
+    public ConfigureDataTablesResponse(@JsonProperty("configured") boolean configured) {
+        this.configured = configured;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -50,6 +50,13 @@ public class RewriteRpcServer
     private readonly ConcurrentDictionary<string, Recipe> _preparedRecipes = new();
     private readonly ConcurrentDictionary<string, object?> _recipeAccumulators = new();
     private readonly ConcurrentDictionary<string, ExecutionContext> _executionContexts = new();
+
+    /// <summary>
+    /// Per-ExecutionContext data table output configuration sent by the orchestrator via
+    /// <c>ConfigureDataTables</c>, so rows produced by recipes are written to the orchestrator's
+    /// <c>datatables/</c> directory instead of an unread in-memory store.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, ConfigureDataTablesRequest> _dataTableConfigs = new();
     private string? _recipesProjectDir;
     private JsonRpc? _jsonRpc;
     private DotNetBuildContext? _buildContext;
@@ -1052,6 +1059,19 @@ public class RewriteRpcServer
         return Convert.ChangeType(value, conversionType);
     }
 
+    [JsonRpcMethod("ConfigureDataTables", UseSingleObjectParameterDeserialization = true)]
+    public ConfigureDataTablesResponse ConfigureDataTables(ConfigureDataTablesRequest request)
+    {
+        if (request.PId == null)
+            return new ConfigureDataTablesResponse { Configured = false };
+
+        _dataTableConfigs[request.PId] = request;
+        // If the context already exists (e.g. config arrived after a prior visit), install now.
+        if (_executionContexts.TryGetValue(request.PId, out var existing))
+            InstallDataTableStore(existing, request);
+        return new ConfigureDataTablesResponse { Configured = true };
+    }
+
     [JsonRpcMethod("Visit", UseSingleObjectParameterDeserialization = true)]
     public async Task<VisitResponse> Visit(VisitRequest request)
     {
@@ -1433,12 +1453,37 @@ public class RewriteRpcServer
         // reattestation (MSBuildProjectHelper) can materialize build files
         _buildContext?.StoreIn(ctx);
 
+        // If the orchestrator told us where to write data tables for this context, install a
+        // CsvDataTableStore so recipe InsertRow calls stream to the shared datatables directory.
+        if (pId != null && _dataTableConfigs.TryGetValue(pId, out var config))
+            InstallDataTableStore(ctx, config);
+
         if (pId != null)
         {
             _executionContexts[pId] = ctx;
             _localObjects[pId] = ctx;
         }
         return ctx;
+    }
+
+    private static void InstallDataTableStore(ExecutionContext ctx, ConfigureDataTablesRequest config)
+    {
+        var prefix = ZipColumns(config.PrefixColumnNames, config.PrefixColumnValues);
+        var suffix = ZipColumns(config.SuffixColumnNames, config.SuffixColumnValues);
+        var store = new CsvDataTableStore(config.OutputDir, config.FileExtension ?? ".csv", prefix, suffix);
+        ctx.PutMessage(DataTable<object>.DataTableStoreKey, store);
+    }
+
+    private static IReadOnlyList<KeyValuePair<string, string>> ZipColumns(
+        IReadOnlyList<string>? names, IReadOnlyList<string>? values)
+    {
+        if (names == null || values == null)
+            return [];
+        var count = Math.Min(names.Count, values.Count);
+        var result = new List<KeyValuePair<string, string>>(count);
+        for (var i = 0; i < count; i++)
+            result.Add(new KeyValuePair<string, string>(names[i], values[i]));
+        return result;
     }
 
     /// <summary>
@@ -1738,6 +1783,23 @@ public class VisitRequest
 public class VisitResponse
 {
     public bool Modified { get; set; }
+}
+
+public class ConfigureDataTablesRequest
+{
+    [JsonPropertyName("pId")]
+    public string? PId { get; set; }
+    public string OutputDir { get; set; } = "";
+    public string? FileExtension { get; set; }
+    public List<string>? PrefixColumnNames { get; set; }
+    public List<string>? PrefixColumnValues { get; set; }
+    public List<string>? SuffixColumnNames { get; set; }
+    public List<string>? SuffixColumnValues { get; set; }
+}
+
+public class ConfigureDataTablesResponse
+{
+    public bool Configured { get; set; }
 }
 
 public class BatchVisitRequest

--- a/rewrite-csharp/csharp/OpenRewrite/Core/CsvDataTableStore.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/CsvDataTableStore.cs
@@ -13,50 +13,107 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System.IO.Compression;
 using System.Reflection;
 using System.Text;
 
 namespace OpenRewrite.Core;
 
 /// <summary>
-/// Writes data table rows directly to CSV files (RFC 4180 format).
-/// Each data table bucket is written to a separate CSV file using the
-/// data table's file-safe key as the filename.
+/// Writes data table rows directly to CSV files (RFC 4180 format), one file per data-table
+/// bucket keyed by the data table's file-safe key.
+/// <para/>
+/// Mirrors the Java <c>org.openrewrite.CsvDataTableStore</c> so that data tables produced by
+/// C#-authored recipes (running as an RPC peer) land in the same <c>datatables/</c> directory,
+/// in the same format, as the orchestrator's own tables. Supports optional GZIP compression
+/// (when the file extension ends in <c>.gz</c>) and static prefix/suffix columns (e.g. repository
+/// and organization metadata). Each row is appended as an independent stream member; for GZIP
+/// this produces a multi-member archive, which <c>GZIPInputStream</c> reads transparently — so no
+/// end-of-run flush/close handshake is required across the RPC boundary.
 /// </summary>
 public class CsvDataTableStore : IDataTableStore
 {
     private readonly string _outputDir;
+    private readonly string _fileExtension;
+    private readonly IReadOnlyList<KeyValuePair<string, string>> _prefixColumns;
+    private readonly IReadOnlyList<KeyValuePair<string, string>> _suffixColumns;
+    private readonly bool _gzip;
     private readonly HashSet<string> _initializedTables = [];
     private readonly Dictionary<string, int> _rowCounts = new();
     private readonly Dictionary<string, object> _dataTables = new();
     private readonly Dictionary<Type, PropertyInfo[]> _propertyCache = new();
+    private readonly object _lock = new();
 
+    /// <summary>
+    /// Create a store that writes plain (uncompressed) CSV files with no prefix/suffix columns.
+    /// </summary>
     public CsvDataTableStore(string outputDir)
+        : this(outputDir, ".csv", [], [])
+    {
+    }
+
+    /// <summary>
+    /// Create a store matching an orchestrator-configured layout: GZIP when
+    /// <paramref name="fileExtension"/> ends in <c>.gz</c>, with static columns prepended and
+    /// appended to every row (and to the header).
+    /// </summary>
+    public CsvDataTableStore(
+        string outputDir,
+        string fileExtension,
+        IReadOnlyList<KeyValuePair<string, string>> prefixColumns,
+        IReadOnlyList<KeyValuePair<string, string>> suffixColumns)
     {
         _outputDir = outputDir;
+        _fileExtension = fileExtension;
+        _prefixColumns = prefixColumns;
+        _suffixColumns = suffixColumns;
+        _gzip = fileExtension.EndsWith(".gz", StringComparison.OrdinalIgnoreCase);
         Directory.CreateDirectory(outputDir);
     }
 
     public void InsertRow<TRow>(DataTable<TRow> dataTable, ExecutionContext ctx, TRow row) where TRow : notnull
     {
         var fileKey = FileKey(dataTable);
-        var csvPath = Path.Combine(_outputDir, fileKey + ".csv");
+        var csvPath = Path.Combine(_outputDir, fileKey + _fileExtension);
 
-        if (!_initializedTables.Contains(fileKey))
+        lock (_lock)
         {
-            _initializedTables.Add(fileKey);
-            _rowCounts[fileKey] = 0;
-            _dataTables[fileKey] = dataTable;
+            if (_initializedTables.Add(fileKey))
+            {
+                _rowCounts[fileKey] = 0;
+                _dataTables[fileKey] = dataTable;
 
-            var headers = dataTable.Descriptor.Columns.Select(c => EscapeCsv(c.DisplayName));
-            var comments = $"# @name {dataTable.Name}\n# @instanceName {dataTable.InstanceName}\n# @group {dataTable.Group ?? ""}\n";
-            File.WriteAllText(csvPath, comments + string.Join(",", headers) + "\n");
+                var headers = _prefixColumns.Select(c => c.Key)
+                    .Concat(dataTable.Descriptor.Columns.Select(c => c.DisplayName))
+                    .Concat(_suffixColumns.Select(c => c.Key))
+                    .Select(EscapeCsv);
+                var comments = $"# @name {dataTable.Name}\n# @instanceName {dataTable.InstanceName}\n# @group {dataTable.Group ?? ""}\n";
+                AppendMember(csvPath, comments + string.Join(",", headers) + "\n");
+            }
+
+            var properties = GetCachedProperties(typeof(TRow), dataTable.Descriptor);
+            var values = _prefixColumns.Select(c => (object?)c.Value)
+                .Concat(properties.Select(p => p.GetValue(row)))
+                .Concat(_suffixColumns.Select(c => (object?)c.Value))
+                .Select(EscapeCsv);
+            AppendMember(csvPath, string.Join(",", values) + "\n");
+            _rowCounts[fileKey]++;
         }
+    }
 
-        var properties = GetCachedProperties(typeof(TRow), dataTable.Descriptor);
-        var values = properties.Select(p => EscapeCsv(p.GetValue(row)));
-        File.AppendAllText(csvPath, string.Join(",", values) + "\n");
-        _rowCounts[fileKey]++;
+    private void AppendMember(string path, string text)
+    {
+        var bytes = Encoding.UTF8.GetBytes(text);
+        using var fs = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read);
+        if (_gzip)
+        {
+            using var gz = new GZipStream(fs, CompressionMode.Compress);
+            gz.Write(bytes, 0, bytes.Length);
+        }
+        else
+        {
+            fs.Write(bytes, 0, bytes.Length);
+        }
     }
 
     public IEnumerable<object> GetRows(string dataTableName, string? group)
@@ -67,7 +124,10 @@ public class CsvDataTableStore : IDataTableStore
 
     public IReadOnlyList<object> GetDataTables()
     {
-        return _dataTables.Values.ToList();
+        lock (_lock)
+        {
+            return _dataTables.Values.ToList();
+        }
     }
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
@@ -160,13 +160,19 @@ public abstract class RewriteTest
             var prevThrow = WhitespaceReconciler.ThrowOnMismatchDefault;
             WhitespaceReconciler.ThrowOnMismatchDefault = validations.FormattingReconciliation;
             List<Result> results;
+            var runCtx = new ExecutionContext();
             try
             {
-                results = RecipeScheduler.Run(recipeSpec.Recipe, sources, new ExecutionContext());
+                results = RecipeScheduler.Run(recipeSpec.Recipe, sources, runCtx);
             }
             finally
             {
                 WhitespaceReconciler.ThrowOnMismatchDefault = prevThrow;
+            }
+
+            foreach (var afterRecipe in recipeSpec.AfterRecipe)
+            {
+                afterRecipe(runCtx);
             }
 
             foreach (var (spec, source) in parsed)
@@ -300,9 +306,35 @@ public class RecipeSpec
     public ReferenceAssemblies? ReferenceAssemblies { get; private set; } = Assemblies.Net90;
     public Validations Validations { get; private set; } = Validations.All;
 
+    private readonly List<Action<OpenRewrite.Core.ExecutionContext>> _afterRecipe = [];
+
+    /// <summary>
+    /// Assertions run against the execution context after the recipe completes (e.g. to verify
+    /// data table rows).
+    /// </summary>
+    public IReadOnlyList<Action<OpenRewrite.Core.ExecutionContext>> AfterRecipe => _afterRecipe;
+
     public RecipeSpec SetRecipe(Recipe recipe)
     {
         Recipe = recipe;
+        return this;
+    }
+
+    /// <summary>
+    /// Assert the rows a recipe wrote to a data table. <paramref name="group"/> is the data
+    /// table's bucket key — its <c>Group</c> if set, otherwise its <c>InstanceName</c> (which
+    /// defaults to the display name).
+    /// </summary>
+    public RecipeSpec ExpectDataTable<TRow>(string name, string group, Action<IReadOnlyList<TRow>> assertion)
+        where TRow : notnull
+    {
+        _afterRecipe.Add(ctx =>
+        {
+            var store = ctx.GetMessage<OpenRewrite.Core.IDataTableStore>(
+                OpenRewrite.Core.DataTable<TRow>.DataTableStoreKey);
+            var rows = (store?.GetRows(name, group) ?? []).Cast<TRow>().ToList();
+            assertion(rows);
+        });
         return this;
     }
 
@@ -326,6 +358,14 @@ public static class Assemblies
 {
     public static ReferenceAssemblies Net90 => Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90;
     public static ReferenceAssemblies Net100 => Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net100;
+
+    /// <summary>
+    /// .NET Framework 4.8 reference assemblies (via the
+    /// <c>Microsoft.NETFramework.ReferenceAssemblies.net48</c> package). Use for tests that
+    /// need to attest legacy framework types such as <c>System.Web.UI.Page</c>,
+    /// <c>System.ServiceModel.*</c>, or <c>System.Data.Entity.*</c>.
+    /// </summary>
+    public static ReferenceAssemblies Net48 => Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net48.Default;
 
     public static ReferenceAssemblies AspNet90 =>
         Net90.AddPackage("Microsoft.AspNetCore.App.Ref");

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -65,6 +65,16 @@ public class CSharpRewriteRpc extends RewriteRpc {
         this.process = process;
     }
 
+    /**
+     * The C# RPC server implements the {@code ConfigureDataTables} method, so data tables
+     * produced by C#-authored recipes are written into the orchestrator's {@code datatables/}
+     * directory rather than being lost in the peer's in-memory store.
+     */
+    @Override
+    protected boolean supportsDataTableConfig() {
+        return true;
+    }
+
     public static @Nullable CSharpRewriteRpc get() {
         return MANAGER.get();
     }


### PR DESCRIPTION
Adds a `ConfigureDataTables` RPC message so the orchestrator can tell a supporting peer where and in what format to write the data table rows its recipes produce, sent once per `ExecutionContext` before the first visit and only to peers that advertise support. The C# RPC server implements the method and installs a `CsvDataTableStore` so recipe `InsertRow` calls stream into the orchestrator's shared `datatables/` directory (with optional GZIP and prefix/suffix columns) instead of being lost in an unread in-memory store. The C# `CsvDataTableStore` is brought in line with the Java implementation (configurable extension, static columns, thread-safe append-as-member writes). Also adds an `ExpectDataTable` assertion plus `Net48` reference assemblies to the C# `RewriteTest` harness.