### PR TITLE
GitProvenance: replace the `includeCommitters` boolean with a `CommitHistory` options type

### DIFF
--- a/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/core/GitProvenanceBenchmark.java
+++ b/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/core/GitProvenanceBenchmark.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.core;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.jgit.lib.RepositoryBuilder;
+import org.openrewrite.marker.GitProvenance;
+import org.openrewrite.marker.GitProvenance.CommitHistory;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures the cost of {@link GitProvenance#fromProjectDirectory} as the commit-history walk is bounded
+ * by {@link CommitHistory}. Runs against this repository's own git working tree, which has a deep history
+ * and many committers, so the cost curve from {@code none()} (no walk) to {@code full()} (the entire
+ * history) is realistic.
+ * <p>
+ * Run with: {@code ./gradlew :rewrite-benchmarks:jmh -Pjmh.includes=GitProvenance}
+ * <p>
+ * The repository is auto-detected by walking up from {@code user.dir}; override with
+ * {@code -Drewrite.repoRoot=/path/to/a/deep/clone} (e.g. a full clone of openrewrite/rewrite).
+ */
+@Fork(1)
+@Warmup(iterations = 3, time = 5)
+@Measurement(iterations = 5, time = 5)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class GitProvenanceBenchmark {
+
+    Path projectDir;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        String override = System.getProperty("rewrite.repoRoot");
+        File start = override != null && !override.isEmpty() ?
+                new File(override) :
+                new File(System.getProperty("user.dir"));
+        File gitDir = new RepositoryBuilder().findGitDir(start).getGitDir();
+        if (gitDir == null || !gitDir.exists()) {
+            throw new IllegalStateException("No .git found from " + start.getAbsolutePath() +
+                    "; set -Drewrite.repoRoot to a git working tree with deep history.");
+        }
+        // fromProjectDirectory re-resolves the git dir from this starting directory.
+        projectDir = start.toPath();
+
+        // Fail loud rather than silently measuring nothing: a shallow clone has no deep history to walk,
+        // and the whole point of this benchmark is a deep history. (Linked git worktrees are supported.)
+        GitProvenance full = GitProvenance.fromProjectDirectory(projectDir, null, null, CommitHistory.full());
+        if (full == null || full.getCommitters() == null || full.getCommitters().isEmpty()) {
+            throw new IllegalStateException("GitProvenance produced no committers for " + start.getAbsolutePath() +
+                    " (a shallow clone has no history to walk). Set -Drewrite.repoRoot to a clone with full " +
+                    "history, e.g. a clone of openrewrite/rewrite.");
+        }
+    }
+
+    @Benchmark
+    public void none(Blackhole bh) {
+        bh.consume(GitProvenance.fromProjectDirectory(projectDir, null, null, CommitHistory.none()));
+    }
+
+    @Benchmark
+    public void full(Blackhole bh) {
+        bh.consume(GitProvenance.fromProjectDirectory(projectDir, null, null, CommitHistory.full()));
+    }
+
+    @Benchmark
+    public void lastCommits100(Blackhole bh) {
+        bh.consume(GitProvenance.fromProjectDirectory(projectDir, null, null, CommitHistory.lastCommits(100)));
+    }
+
+    @Benchmark
+    public void lastCommits1000(Blackhole bh) {
+        bh.consume(GitProvenance.fromProjectDirectory(projectDir, null, null, CommitHistory.lastCommits(1000)));
+    }
+
+    @Benchmark
+    public void sinceDaysAgo90(Blackhole bh) {
+        bh.consume(GitProvenance.fromProjectDirectory(projectDir, null, null, CommitHistory.sinceDaysAgo(90)));
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(GitProvenanceBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -24,9 +24,11 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.GitRemote;
 import org.openrewrite.Incubating;
 import org.openrewrite.jgit.api.Git;
+import org.openrewrite.jgit.api.LogCommand;
 import org.openrewrite.jgit.api.errors.GitAPIException;
 import org.openrewrite.jgit.lib.*;
 import org.openrewrite.jgit.revwalk.RevCommit;
+import org.openrewrite.jgit.revwalk.filter.CommitTimeRevFilter;
 import org.openrewrite.jgit.transport.RemoteConfig;
 import org.openrewrite.jgit.treewalk.WorkingTreeOptions;
 import org.openrewrite.marker.ci.BuildEnvironment;
@@ -38,11 +40,15 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.*;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyNavigableMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.openrewrite.Tree.randomId;
@@ -195,37 +201,49 @@ public class GitProvenance extends Reference implements Marker {
     public static @Nullable GitProvenance fromProjectDirectory(Path projectDir,
                                                                @Nullable BuildEnvironment environment,
                                                                GitRemote.@Nullable Parser gitRemoteParser) {
-        return fromProjectDirectory(projectDir, environment, gitRemoteParser, true);
+        return fromProjectDirectory(projectDir, environment, gitRemoteParser, CommitHistory.full());
     }
 
     /**
-     * @param projectDir       The project directory.
-     * @param environment      In detached head scenarios, the branch is best
-     *                         determined from a {@link BuildEnvironment} marker if possible.
-     * @param gitRemoteParser  Parses the remote url into a {@link GitRemote}. Custom remotes can be registered to it,
-     *                         or a default with known git hosting services can be used.
-     * @param includeCommitters When {@code false}, skips the unbounded walk over the entire commit history that
-     *                          {@link #getCommitters()} otherwise requires, yielding an empty committers list. Callers
-     *                          that only consume origin/branch/change can opt out to avoid that cost. Everything else
-     *                          (origin, branch, change, autocrlf, eol, remote) is unaffected, so the resulting marker
-     *                          is otherwise identical to the committer-including path.
+     * The cheap provenance fields (origin, branch, change, autocrlf, eol, remote) are always computed.
+     * Only the optional, expensive commit-history walk that populates {@link #getCommitters()} is
+     * configurable, via {@link CommitHistory}.
+     *
+     * @param projectDir      The project directory.
+     * @param environment     In detached head scenarios, the branch is best
+     *                        determined from a {@link BuildEnvironment} marker if possible.
+     * @param gitRemoteParser Parses the remote url into a {@link GitRemote}. Custom remotes can be registered to it,
+     *                        or a default with known git hosting services can be used.
+     * @param commitHistory   Controls how much of the commit history to walk and how much per-committer
+     *                        detail to retain. Use {@link CommitHistory#none()} to skip the walk entirely
+     *                        (in which case {@link #getCommitters()} is {@code null}), {@link CommitHistory#full()}
+     *                        for the entire history, or a bounded preset such as {@link CommitHistory#since(LocalDate)}
+     *                        or {@link CommitHistory#lastCommits(int)}.
      * @return A marker containing git provenance information.
      */
     public static @Nullable GitProvenance fromProjectDirectory(Path projectDir,
                                                                @Nullable BuildEnvironment environment,
                                                                GitRemote.@Nullable Parser gitRemoteParser,
-                                                               boolean includeCommitters) {
+                                                               CommitHistory commitHistory) {
         if (gitRemoteParser == null) {
             gitRemoteParser = new GitRemote.Parser();
         }
         if (environment != null) {
             if (environment instanceof JenkinsBuildEnvironment) {
                 JenkinsBuildEnvironment jenkinsBuildEnvironment = (JenkinsBuildEnvironment) environment;
-                try (Repository repository = new RepositoryBuilder().findGitDir(projectDir.toFile()).build()) {
-                    String branch = jenkinsBuildEnvironment.getLocalBranch() != null ?
-                            jenkinsBuildEnvironment.getLocalBranch() :
-                            localBranchName(repository, jenkinsBuildEnvironment.getBranch());
-                    return fromGitConfig(repository, branch, getChangeset(repository), gitRemoteParser, includeCommitters);
+                try {
+                    RepositoryContext ctx = openRepository(projectDir.toFile());
+                    if (ctx == null) {
+                        return null;
+                    }
+                    try (Repository repository = ctx.repository) {
+                        String branch = jenkinsBuildEnvironment.getLocalBranch() != null ?
+                                jenkinsBuildEnvironment.getLocalBranch() :
+                                ctx.branch != null ? ctx.branch :
+                                        localBranchName(repository, jenkinsBuildEnvironment.getBranch());
+                        String changeset = ctx.changeset != null ? ctx.changeset : getChangeset(repository);
+                        return fromGitConfig(repository, branch, changeset, gitRemoteParser, commitHistory, ctx.committerStart, ctx.linkedWorktree);
+                    }
                 } catch (IllegalArgumentException | GitAPIException e) {
                     // Silently ignore if the project directory is not a git repository
                     printRequireGitDirOrWorkTreeException(e);
@@ -237,18 +255,18 @@ public class GitProvenance extends Reference implements Marker {
                 File gitDir = new RepositoryBuilder().findGitDir(projectDir.toFile()).getGitDir();
                 if (gitDir != null && gitDir.exists()) {
                     //it has been cloned with --depth > 0
-                    return fromGitConfig(projectDir, gitRemoteParser, includeCommitters);
+                    return fromGitConfig(projectDir, gitRemoteParser, commitHistory);
                 } else {
                     //there is not .git config
                     try {
                         return environment.buildGitProvenance();
                     } catch (IncompleteGitConfigException e) {
-                        return fromGitConfig(projectDir, gitRemoteParser, includeCommitters);
+                        return fromGitConfig(projectDir, gitRemoteParser, commitHistory);
                     }
                 }
             }
         } else {
-            return fromGitConfig(projectDir, gitRemoteParser, includeCommitters);
+            return fromGitConfig(projectDir, gitRemoteParser, commitHistory);
         }
     }
 
@@ -258,14 +276,20 @@ public class GitProvenance extends Reference implements Marker {
         }
     }
 
-    private static @Nullable GitProvenance fromGitConfig(Path projectDir, GitRemote.Parser gitRemoteParser, boolean includeCommitters) {
-        String branch = null;
-        try (Repository repository = new RepositoryBuilder().findGitDir(projectDir.toFile()).build()) {
-            String changeset = getChangeset(repository);
-            if (!repository.getBranch().equals(changeset)) {
-                branch = repository.getBranch();
+    private static @Nullable GitProvenance fromGitConfig(Path projectDir, GitRemote.Parser gitRemoteParser, CommitHistory commitHistory) {
+        try {
+            RepositoryContext ctx = openRepository(projectDir.toFile());
+            if (ctx == null) {
+                return null;
             }
-            return fromGitConfig(repository, branch, changeset, gitRemoteParser, includeCommitters);
+            try (Repository repository = ctx.repository) {
+                String branch = ctx.branch;
+                String changeset = ctx.changeset != null ? ctx.changeset : getChangeset(repository);
+                if (branch == null && !ctx.linkedWorktree && !repository.getBranch().equals(changeset)) {
+                    branch = repository.getBranch();
+                }
+                return fromGitConfig(repository, branch, changeset, gitRemoteParser, commitHistory, ctx.committerStart, ctx.linkedWorktree);
+            }
         } catch (IllegalArgumentException e) {
             printRequireGitDirOrWorkTreeException(e);
             return null;
@@ -274,11 +298,111 @@ public class GitProvenance extends Reference implements Marker {
         }
     }
 
-    private static @Nullable GitProvenance fromGitConfig(Repository repository, @Nullable String branch, @Nullable String changeset, GitRemote.Parser gitRemoteParser, boolean includeCommitters) {
+    /**
+     * Opens the git repository for {@code projectDir}, transparently handling linked git worktrees. The
+     * shaded JGit predates {@code commondir} support and so cannot open a worktree's private gitdir
+     * (it would report the repository as bare with no refs or objects). For a worktree we instead open
+     * the shared common repository, which owns the objects, refs, and config, and recover this
+     * worktree's branch and HEAD from its own gitdir.
+     */
+    private static @Nullable RepositoryContext openRepository(File projectDir) throws IOException {
+        File gitDir = new RepositoryBuilder().findGitDir(projectDir).getGitDir();
+        File commonDir = gitDir == null ? null : commonDir(gitDir);
+        if (commonDir == null) {
+            // A normal repository (or a shallow clone). Build exactly as before; a missing git dir
+            // throws IllegalArgumentException, which callers translate to a null provenance.
+            return new RepositoryContext(new RepositoryBuilder().findGitDir(projectDir).build(), null, null, null, false);
+        }
+        // A linked worktree: open the shared common repository and derive HEAD from the worktree gitdir.
+        Repository repository = new RepositoryBuilder().setGitDir(commonDir).build();
+        try {
+            String[] head = readWorktreeHead(gitDir);
+            ObjectId headId = head[1] == null ? null : repository.resolve(head[1]);
+            String changeset = headId == null ? null : headId.getName();
+            return new RepositoryContext(repository, head[0], changeset, headId, true);
+        } catch (IOException | RuntimeException e) {
+            // Don't leak the open repository if reading the worktree's HEAD fails (e.g. a corrupt worktree).
+            repository.close();
+            throw e;
+        }
+    }
+
+    /**
+     * @return the shared common git directory if {@code gitDir} is a linked worktree's private gitdir
+     * (i.e. it contains a {@code commondir} file), or {@code null} for a normal repository.
+     */
+    private static @Nullable File commonDir(File gitDir) {
+        File commonDirFile = new File(gitDir, "commondir");
+        if (!commonDirFile.isFile()) {
+            return null;
+        }
+        try {
+            String content = new String(Files.readAllBytes(commonDirFile.toPath()), StandardCharsets.UTF_8).trim();
+            File common = new File(content);
+            if (!common.isAbsolute()) {
+                common = new File(gitDir, content);
+            }
+            return common.getCanonicalFile();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Reads a worktree's own {@code HEAD}.
+     *
+     * @return a two element array of {@code [branchName, refOrSha]}; {@code branchName} is {@code null}
+     * for a detached HEAD, and {@code refOrSha} is the symbolic ref (e.g. {@code refs/heads/main}) or the
+     * commit sha to resolve against the shared common repository.
+     */
+    private static String[] readWorktreeHead(File gitDir) throws IOException {
+        String head = new String(Files.readAllBytes(new File(gitDir, "HEAD").toPath()), StandardCharsets.UTF_8).trim();
+        if (head.startsWith("ref:")) {
+            String ref = head.substring(4).trim();
+            String branch = ref.startsWith("refs/heads/") ? ref.substring("refs/heads/".length()) : null;
+            return new String[]{branch, ref};
+        }
+        return new String[]{null, head.isEmpty() ? null : head};
+    }
+
+    /**
+     * The opened repository together with the branch, changeset, and committer-walk start that a linked
+     * worktree's own HEAD implies. For a normal repository the latter three are {@code null}, so callers
+     * fall back to reading them from the repository's HEAD as before.
+     */
+    private static class RepositoryContext {
+        final Repository repository;
+
+        @Nullable
+        final String branch;
+
+        @Nullable
+        final String changeset;
+
+        @Nullable
+        final ObjectId committerStart;
+
+        /** Whether {@link #repository} is the shared common repository of a linked worktree, in which
+         * case its own HEAD belongs to a different checkout and must not be consulted for branch/changeset. */
+        final boolean linkedWorktree;
+
+        RepositoryContext(Repository repository, @Nullable String branch, @Nullable String changeset,
+                          @Nullable ObjectId committerStart, boolean linkedWorktree) {
+            this.repository = repository;
+            this.branch = branch;
+            this.changeset = changeset;
+            this.committerStart = committerStart;
+            this.linkedWorktree = linkedWorktree;
+        }
+    }
+
+    private static @Nullable GitProvenance fromGitConfig(Repository repository, @Nullable String branch, @Nullable String changeset, GitRemote.Parser gitRemoteParser, CommitHistory commitHistory, @Nullable ObjectId committerStart, boolean linkedWorktree) {
         if (repository.isBare()) {
             return null;
         }
-        if (branch == null) {
+        if (branch == null && !linkedWorktree) {
+            // A linked worktree's branch is authoritative from its own HEAD (null means genuinely
+            // detached); resolving from the shared repository's HEAD would report a different checkout's branch.
             branch = resolveBranchFromGitConfig(repository);
         }
         String remoteOriginUrl = getRemoteOriginUrl(repository);
@@ -288,9 +412,14 @@ public class GitProvenance extends Reference implements Marker {
         } else {
             remote = gitRemoteParser.parse(remoteOriginUrl);
         }
+        // null (not emptyList) when the walk is skipped, so consumers can distinguish
+        // "committers were not computed" from "walked the history and found nobody". For a linked
+        // worktree whose own HEAD couldn't be resolved, leave committers null rather than walking from
+        // the shared repository's HEAD, which belongs to a different checkout.
+        List<Committer> committers = commitHistory.isEnabled() && !(linkedWorktree && committerStart == null) ?
+                getCommitters(repository, committerStart, commitHistory) : null;
         return new GitProvenance(randomId(), remoteOriginUrl, branch, changeset,
-                getAutocrlf(repository), getEOF(repository),
-                includeCommitters ? getCommitters(repository) : emptyList(), remote);
+                getAutocrlf(repository), getEOF(repository), committers, remote);
     }
 
     static @Nullable String resolveBranchFromGitConfig(Repository repository) {
@@ -390,9 +519,14 @@ public class GitProvenance extends Reference implements Marker {
         }
     }
 
-    private static List<Committer> getCommitters(Repository repository) {
+    private static List<Committer> getCommitters(Repository repository, @Nullable ObjectId from, CommitHistory commitHistory) {
         try (Git git = Git.open(repository.getDirectory())) {
-            ObjectId head = repository.readOrigHead();
+            // A linked worktree supplies its own HEAD (the repository is the shared common one, whose
+            // HEAD/ORIG_HEAD belong to a different checkout). Otherwise prefer ORIG_HEAD, then HEAD.
+            ObjectId head = from;
+            if (head == null) {
+                head = repository.readOrigHead();
+            }
             if (head == null) {
                 Ref headRef = repository.getRefDatabase().findRef("HEAD");
                 if (headRef == null || headRef.getObjectId() == null) {
@@ -401,22 +535,43 @@ public class GitProvenance extends Reference implements Marker {
                 head = headRef.getObjectId();
             }
 
+            LogCommand log = git.log().add(head);
+            CommitHistory.Scope scope = commitHistory.getScope();
+            switch (scope.getKind()) {
+                case SINCE:
+                    // CommitTimeRevFilter.after throws StopWalkException on the first commit older than the
+                    // cutoff, which prunes the walk (real CPU savings). Because git timestamps are
+                    // non-monotonic, this is an approximation, exactly like `git log --since`.
+                    log.setRevFilter(CommitTimeRevFilter.after(
+                            Date.from(requireNonNull(scope.getSince()).atStartOfDay(ZoneId.systemDefault()).toInstant())));
+                    break;
+                case LAST_COMMITS:
+                    log.setMaxCount(scope.getMaxCommits());
+                    break;
+                case NONE:
+                case FULL:
+                default:
+                    break;
+            }
+
+            boolean perDay = commitHistory.getDetail() == CommitHistory.Detail.COMMITS_BY_DAY;
             Map<String, String> committerName = new HashMap<>();
             Map<String, NavigableMap<LocalDate, Integer>> commitMap = new HashMap<>();
-            for (RevCommit commit : git.log().add(head).call()) {
+            for (RevCommit commit : log.call()) {
                 PersonIdent who = commit.getAuthorIdent();
                 committerName.putIfAbsent(who.getEmailAddress(), who.getName());
-                commitMap.computeIfAbsent(who.getEmailAddress(),
-                        email -> new TreeMap<>()).compute(who.getWhen().toInstant().atZone(who.getTimeZone().toZoneId())
-                                .toLocalDate(),
-                        (day, count) -> count == null ? 1 : count + 1);
+                if (perDay) {
+                    commitMap.computeIfAbsent(who.getEmailAddress(),
+                            email -> new TreeMap<>()).compute(who.getWhen().toInstant().atZone(who.getTimeZone().toZoneId())
+                                    .toLocalDate(),
+                            (day, count) -> count == null ? 1 : count + 1);
+                }
             }
             return committerName.entrySet().stream()
-                    .map(c -> new Committer(
-                            c.getValue(),
-                            c.getKey(),
-                            commitMap.get(c.getKey()))
-                    ).collect(toList());
+                    .map(c -> {
+                        NavigableMap<LocalDate, Integer> byDay = perDay ? commitMap.get(c.getKey()) : emptyNavigableMap();
+                        return new Committer(c.getValue(), c.getKey(), byDay);
+                    }).collect(toList());
         } catch (IOException | GitAPIException e) {
             return emptyList();
         }
@@ -452,6 +607,130 @@ public class GitProvenance extends Reference implements Marker {
         CRLF,
         LF,
         Native
+    }
+
+    /**
+     * Controls the optional, expensive commit-history walk that {@link GitProvenance} performs to
+     * populate {@link GitProvenance#getCommitters()}. The cheap provenance fields (origin, branch,
+     * change, autocrlf, eol, remote) are always computed and are not affected by this type.
+     * <p>
+     * Two axes are bounded here, but only through named presets, so the combination space stays small
+     * and every reachable state is meaningful:
+     * <ul>
+     *   <li><b>Scope</b> &mdash; how far back the walk goes: {@link #none()} (don't walk),
+     *       {@link #full()} (entire history), {@link #since(LocalDate)} / {@link #sinceDaysAgo(int)}
+     *       (pruned at a date), or {@link #lastCommits(int)} (a hard commit cap).</li>
+     *   <li><b>Detail</b> &mdash; how much per-committer information is retained, and only applies when we
+     *       walk: {@link Detail#COMMITTERS} (identities only) or {@link Detail#COMMITS_BY_DAY} (the full
+     *       per-day breakdown). Override it with {@link #withDetail(Detail)}.</li>
+     * </ul>
+     * The off-switch lives on the scope axis, so {@code since(date).withDetail(...)} can never collapse
+     * to "walk nothing." This is a factory <em>input</em> only; it is never stored on the marker and
+     * never serialized.
+     */
+    @Value
+    @Incubating(since = "8.85.0")
+    public static class CommitHistory {
+        Scope scope;
+        Detail detail;
+
+        private CommitHistory(Scope scope, Detail detail) {
+            this.scope = scope;
+            this.detail = detail;
+        }
+
+        /** Skip the walk entirely. {@link GitProvenance#getCommitters()} will be {@code null}. */
+        public static CommitHistory none() {
+            return new CommitHistory(Scope.none(), Detail.COMMITS_BY_DAY);
+        }
+
+        /** Walk the entire reachable history, retaining the full per-day commit breakdown. */
+        public static CommitHistory full() {
+            return new CommitHistory(Scope.full(), Detail.COMMITS_BY_DAY);
+        }
+
+        /**
+         * Walk commits committed on or after {@code since}, retaining the full per-day breakdown. The walk
+         * is pruned at the cutoff by commit time (like {@code git log --since}); because git timestamps are
+         * non-monotonic this is an approximation. Note the per-day breakdown is keyed by author date, which
+         * for rebased or cherry-picked commits can differ from the commit date the cutoff is applied to.
+         */
+        public static CommitHistory since(LocalDate since) {
+            return new CommitHistory(Scope.since(since), Detail.COMMITS_BY_DAY);
+        }
+
+        /** Walk commits committed within the last {@code days} days, retaining the full per-day breakdown. */
+        public static CommitHistory sinceDaysAgo(int days) {
+            return since(LocalDate.now().minusDays(days));
+        }
+
+        /** Walk at most {@code maxCommits} commits (an exact cap), retaining the full per-day breakdown. */
+        public static CommitHistory lastCommits(int maxCommits) {
+            if (maxCommits < 0) {
+                throw new IllegalArgumentException("maxCommits must be non-negative, but was " + maxCommits);
+            }
+            return new CommitHistory(Scope.lastCommits(maxCommits), Detail.COMMITS_BY_DAY);
+        }
+
+        /**
+         * Walk the entire reachable history but retain only the distinct committer identities (name and
+         * email), discarding the per-day breakdown. Cheaper to hold and serialize; the resulting
+         * {@link Committer}s have an empty {@link Committer#getCommitsByDay()}.
+         */
+        public static CommitHistory identities() {
+            return new CommitHistory(Scope.full(), Detail.COMMITTERS);
+        }
+
+        /**
+         * Override the detail axis on any scope, e.g. {@code CommitHistory.since(date).withDetail(COMMITTERS)}.
+         * Has no observable effect when the scope is {@link #none()} (the walk is skipped regardless).
+         */
+        public CommitHistory withDetail(Detail detail) {
+            return new CommitHistory(scope, detail);
+        }
+
+        boolean isEnabled() {
+            return scope.getKind() != Scope.Kind.NONE;
+        }
+
+        /** How far back the commit walk extends. Constructed only through {@link CommitHistory}'s presets. */
+        @Value
+        static class Scope {
+            enum Kind {
+                NONE, FULL, SINCE, LAST_COMMITS
+            }
+
+            Kind kind;
+
+            @Nullable
+            LocalDate since;
+
+            int maxCommits;
+
+            static Scope none() {
+                return new Scope(Kind.NONE, null, -1);
+            }
+
+            static Scope full() {
+                return new Scope(Kind.FULL, null, -1);
+            }
+
+            static Scope since(LocalDate since) {
+                return new Scope(Kind.SINCE, since, -1);
+            }
+
+            static Scope lastCommits(int maxCommits) {
+                return new Scope(Kind.LAST_COMMITS, null, maxCommits);
+            }
+        }
+
+        /** How much per-committer detail to retain. Applies only when the history is walked. */
+        public enum Detail {
+            /** Distinct committer identities only (name + email); {@code commitsByDay} is empty. */
+            COMMITTERS,
+            /** The full per-day commit breakdown (the historical default). */
+            COMMITS_BY_DAY
+        }
     }
 
     @Value

--- a/rewrite-core/src/main/java/org/openrewrite/search/FindCommitters.java
+++ b/rewrite-core/src/main/java/org/openrewrite/search/FindCommitters.java
@@ -28,6 +28,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.NavigableMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyList;
@@ -86,13 +87,16 @@ public class FindCommitters extends ScanningRecipe<AtomicReference<GitProvenance
             LocalDate from = StringUtils.isBlank(fromDate) ? null : LocalDate.parse(fromDate);
             Collection<GitProvenance.Committer> committerList = findCommitters(gitProvenance, from);
             for (GitProvenance.Committer committer : committerList) {
+                // commitsByDay is empty when only committer identities were collected
+                // (GitProvenance.CommitHistory.Detail.COMMITTERS), so guard the per-day reporting.
+                NavigableMap<LocalDate, Integer> byDay = committer.getCommitsByDay();
                 committers.insertRow(ctx, new DistinctCommitters.Row(
                         committer.getName(),
                         committer.getEmail(),
-                        committer.getCommitsByDay().lastKey(),
-                        committer.getCommitsByDay().values().stream().mapToInt(Integer::intValue).sum()
+                        byDay.isEmpty() ? null : byDay.lastKey(),
+                        byDay.values().stream().mapToInt(Integer::intValue).sum()
                 ));
-                committer.getCommitsByDay().forEach((day, commits) -> commitsByDay.insertRow(ctx, new CommitsByDay.Row(
+                byDay.forEach((day, commits) -> commitsByDay.insertRow(ctx, new CommitsByDay.Row(
                         committer.getName(),
                         committer.getEmail(),
                         day,
@@ -107,7 +111,10 @@ public class FindCommitters extends ScanningRecipe<AtomicReference<GitProvenance
         LocalDate cutOff = from == null ? null : from.minusDays(1);
         List<GitProvenance.Committer> committerList = new ArrayList<>();
         for (GitProvenance.Committer committer : requireNonNull(gitProvenance.getCommitters())) {
-            if (cutOff == null || committer.getCommitsByDay().keySet().stream().anyMatch(day -> day.isAfter(cutOff))) {
+            NavigableMap<LocalDate, Integer> byDay = committer.getCommitsByDay();
+            // An identities-only committer (Detail.COMMITTERS) carries no per-day dates; surface it rather
+            // than silently dropping it, matching generate(), which reports it with a null last commit.
+            if (cutOff == null || byDay.isEmpty() || byDay.keySet().stream().anyMatch(day -> day.isAfter(cutOff))) {
                 committerList.add(committer);
             }
         }

--- a/rewrite-core/src/main/java/org/openrewrite/table/DistinctCommitters.java
+++ b/rewrite-core/src/main/java/org/openrewrite/table/DistinctCommitters.java
@@ -16,6 +16,7 @@
 package org.openrewrite.table;
 
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.Column;
 import org.openrewrite.DataTable;
 import org.openrewrite.Recipe;
@@ -39,7 +40,9 @@ public class DistinctCommitters extends DataTable<DistinctCommitters.Row> {
         String email;
 
         @Column(displayName = "Last commit",
-                description = "The date of this committer's last commit.")
+                description = "The date of this committer's last commit. " +
+                              "Null when only committer identities were collected, without per-day commit detail.")
+        @Nullable
         LocalDate lastCommit;
 
         @Column(displayName = "Number of commits",

--- a/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openrewrite.GitRemote;
+import org.openrewrite.marker.GitProvenance.CommitHistory;
 import org.openrewrite.jgit.api.Git;
 import org.openrewrite.jgit.api.errors.GitAPIException;
 import org.openrewrite.jgit.lib.Constants;
@@ -41,6 +42,7 @@ import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -141,10 +143,10 @@ class GitProvenanceTest {
     }
 
     @Test
-    void excludeCommittersMatchesIncludingPath(@TempDir Path projectDir) throws Exception {
+    void noneSkipsWalkButMatchesCheapFields(@TempDir Path projectDir) throws Exception {
         try (Git ignored = initGitWithOneCommit(projectDir)) {
-            GitProvenance withCommitters = GitProvenance.fromProjectDirectory(projectDir, null, null, true);
-            GitProvenance withoutCommitters = GitProvenance.fromProjectDirectory(projectDir, null, null, false);
+            GitProvenance withCommitters = GitProvenance.fromProjectDirectory(projectDir, null, null, CommitHistory.full());
+            GitProvenance withoutCommitters = GitProvenance.fromProjectDirectory(projectDir, null, null, CommitHistory.none());
 
             assertThat(withCommitters).isNotNull();
             assertThat(withoutCommitters).isNotNull();
@@ -154,11 +156,105 @@ class GitProvenanceTest {
             assertThat(withoutCommitters.getBranch()).isEqualTo(withCommitters.getBranch());
             assertThat(withoutCommitters.getChange()).isEqualTo(withCommitters.getChange());
 
-            // the including path actually walks history and finds the commit author
+            // the full path actually walks history and finds the commit author
             assertThat(withCommitters.getCommitters()).isNotEmpty();
-            // the opt-out path skips the walk and returns an empty list
-            assertThat(withoutCommitters.getCommitters()).isEmpty();
+            // none() skips the walk; committers is null ("not computed"), not an empty list
+            assertThat(withoutCommitters.getCommitters()).isNull();
         }
+    }
+
+    @Test
+    void commitHistoryBoundsScopeAndDetail(@TempDir Path projectDir) throws Exception {
+        try (Git ignored = initGitWithOneCommit(projectDir)) {
+            // lastCommits keeps the walk bounded but still yields the committer with per-day detail
+            GitProvenance lastCommit = GitProvenance.fromProjectDirectory(projectDir, null, null, CommitHistory.lastCommits(1));
+            assertThat(lastCommit.getCommitters()).isNotEmpty();
+            assertThat(lastCommit.getCommitters().get(0).getCommitsByDay()).isNotEmpty();
+
+            // identities() walks but retains only name/email, with no per-day breakdown
+            GitProvenance identities = GitProvenance.fromProjectDirectory(projectDir, null, null, CommitHistory.identities());
+            assertThat(identities.getCommitters()).isNotEmpty();
+            assertThat(identities.getCommitters().get(0).getCommitsByDay()).isEmpty();
+
+            // since() prunes the walk at the cutoff: a future cutoff yields a walked-but-empty list (not null)
+            GitProvenance sinceFuture = GitProvenance.fromProjectDirectory(projectDir, null, null,
+              CommitHistory.since(LocalDate.now().plusDays(1)));
+            assertThat(sinceFuture.getCommitters()).isEmpty();
+
+            // a past cutoff still includes the commit
+            GitProvenance sincePast = GitProvenance.fromProjectDirectory(projectDir, null, null,
+              CommitHistory.since(LocalDate.now().minusDays(1)));
+            assertThat(sincePast.getCommitters()).isNotEmpty();
+        }
+    }
+
+    @Test
+    void linkedWorktree(@TempDir Path projectDir) throws Exception {
+        // The shaded JGit cannot open a linked worktree's private gitdir, so GitProvenance opens the
+        // shared common repository and recovers the worktree's branch/HEAD from its own gitdir.
+        Path mainDir = projectDir.resolve("main");
+        Files.createDirectories(mainDir);
+        String commit;
+        try (Git git = Git.init().setDirectory(mainDir.toFile()).setInitialBranch("main").call()) {
+            Files.writeString(mainDir.resolve("test.txt"), "hi");
+            git.add().addFilepattern("*").call();
+            commit = git.commit().setMessage("init").setSign(false).call().getName();
+            git.branchCreate().setName("feature").call();
+            git.remoteAdd().setName("origin").setUri(new URIish("git@github.com:openrewrite/doesnotexist.git")).call();
+        }
+
+        // Hand-build the linked-worktree layout that `git worktree add` would create.
+        Path wtPrivate = mainDir.resolve(".git").resolve("worktrees").resolve("wt");
+        Files.createDirectories(wtPrivate);
+        Path worktreeDir = projectDir.resolve("wt");
+        Files.createDirectories(worktreeDir);
+        Files.writeString(worktreeDir.resolve(".git"), "gitdir: " + wtPrivate.toAbsolutePath() + "\n");
+        Files.writeString(wtPrivate.resolve("HEAD"), "ref: refs/heads/feature\n");
+        Files.writeString(wtPrivate.resolve("commondir"), "../..\n");
+        Files.writeString(wtPrivate.resolve("gitdir"), worktreeDir.resolve(".git").toAbsolutePath() + "\n");
+
+        GitProvenance withCommitters = GitProvenance.fromProjectDirectory(worktreeDir, null, null, CommitHistory.full());
+        assertThat(withCommitters).isNotNull();
+        // the worktree's own branch and HEAD, not the main checkout's
+        assertThat(withCommitters.getBranch()).isEqualTo("feature");
+        assertThat(withCommitters.getChange()).isEqualTo(commit);
+        // origin comes from the shared config, and the walk reaches the shared objects
+        assertThat(withCommitters.getOrigin()).isEqualTo("git@github.com:openrewrite/doesnotexist.git");
+        assertThat(withCommitters.getCommitters()).isNotEmpty();
+
+        // none() still resolves the cheap fields on a worktree, skipping only the walk
+        GitProvenance none = GitProvenance.fromProjectDirectory(worktreeDir, null, null, CommitHistory.none());
+        assertThat(none.getBranch()).isEqualTo("feature");
+        assertThat(none.getChange()).isEqualTo(commit);
+        assertThat(none.getCommitters()).isNull();
+    }
+
+    @Test
+    void detachedHeadLinkedWorktree(@TempDir Path projectDir) throws Exception {
+        Path mainDir = projectDir.resolve("main");
+        Files.createDirectories(mainDir);
+        String commit;
+        try (Git git = Git.init().setDirectory(mainDir.toFile()).setInitialBranch("main").call()) {
+            Files.writeString(mainDir.resolve("test.txt"), "hi");
+            git.add().addFilepattern("*").call();
+            commit = git.commit().setMessage("init").setSign(false).call().getName();
+        }
+
+        Path wtPrivate = mainDir.resolve(".git").resolve("worktrees").resolve("wt");
+        Files.createDirectories(wtPrivate);
+        Path worktreeDir = projectDir.resolve("wt");
+        Files.createDirectories(worktreeDir);
+        Files.writeString(worktreeDir.resolve(".git"), "gitdir: " + wtPrivate.toAbsolutePath() + "\n");
+        Files.writeString(wtPrivate.resolve("HEAD"), commit + "\n"); // detached: a raw sha, not a ref
+        Files.writeString(wtPrivate.resolve("commondir"), "../..\n");
+        Files.writeString(wtPrivate.resolve("gitdir"), worktreeDir.resolve(".git").toAbsolutePath() + "\n");
+
+        GitProvenance gp = GitProvenance.fromProjectDirectory(worktreeDir, null, null, CommitHistory.full());
+        assertThat(gp).isNotNull();
+        // detached HEAD has no branch, and crucially must NOT report the common checkout's "main"
+        assertThat(gp.getBranch()).isNull();
+        assertThat(gp.getChange()).isEqualTo(commit);
+        assertThat(gp.getCommitters()).isNotEmpty();
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/search/FindCommittersTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/search/FindCommittersTest.java
@@ -118,4 +118,53 @@ class FindCommittersTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void identitiesOnlyCommittersHaveNoPerDayDetail() {
+        // GitProvenance.CommitHistory.identities() yields committers with an empty commitsByDay.
+        // FindCommitters must not throw on the empty per-day map and should report a null last commit.
+        var git = new GitProvenance(
+          randomId(), "https://github.com/org/repo.git", "main", "123", null, null,
+          List.of(new GitProvenance.Committer("Jon", "jkschneider@gmail.com", new TreeMap<>()))
+        );
+
+        rewriteRun(
+          spec -> spec.dataTable(DistinctCommitters.Row.class, rows -> {
+              assertThat(rows).satisfiesExactly(
+                r -> {
+                    assertThat(r.getEmail()).isEqualTo("jkschneider@gmail.com");
+                    assertThat(r.getLastCommit()).isNull();
+                    assertThat(r.getCommits()).isZero();
+                }
+              );
+          }),
+          text(
+            "hi",
+            spec -> spec.mapBeforeRecipe(pt -> pt.withMarkers(pt.getMarkers().add(git)))
+          )
+        );
+    }
+
+    @Test
+    void identitiesOnlyCommittersSurviveDateFilter() {
+        // identities-only committers carry no dates, so a fromDate filter can't evaluate them; they are
+        // surfaced rather than silently dropped (consistent with the no-date path).
+        var git = new GitProvenance(
+          randomId(), "https://github.com/org/repo.git", "main", "123", null, null,
+          List.of(new GitProvenance.Committer("Jon", "jkschneider@gmail.com", new TreeMap<>()))
+        );
+
+        rewriteRun(
+          spec -> spec.recipe(new FindCommitters("2023-01-01"))
+            .dataTable(DistinctCommitters.Row.class, rows -> {
+                assertThat(rows).satisfiesExactly(
+                  r -> assertThat(r.getEmail()).isEqualTo("jkschneider@gmail.com")
+                );
+            }),
+          text(
+            "hi",
+            spec -> spec.mapBeforeRecipe(pt -> pt.withMarkers(pt.getMarkers().add(git)))
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Motivation

- PR #7910 added a `boolean includeCommitters` overload to `GitProvenance.fromProjectDirectory(...)` so callers could skip the unbounded `git.log()` walk that populates `getCommitters()` (~11% of a `CommonStaticAnalysis` run on a 40k-commit repo). A boolean only offers all-or-nothing, and masks the real question: *how much* history, and at *what detail*? Since that overload is unreleased, this replaces it outright rather than leaving a one-shot flag behind.

## What changed

`GitProvenance.CommitHistory` — a factory-input value type (never stored on the marker, never serialized) with named presets on two axes:

- **Scope** (how far the walk goes): `none()`, `full()`, `since(LocalDate)` / `sinceDaysAgo(int)`, `lastCommits(int)`.
- **Detail** (how much per-committer data is retained, only when walking): `COMMITTERS` (identities) or `COMMITS_BY_DAY` (the full per-day breakdown), overridable via `withDetail(...)`.

```java
// only origin/branch/change — skip the walk entirely
GitProvenance.fromProjectDirectory(dir, env, parser, CommitHistory.none());
- // entire history with per-day detail (the pre-#7910 default; the 3-arg overload still maps here)
GitProvenance.fromProjectDirectory(dir, env, parser, CommitHistory.full());
// bounded — both genuinely prune the JGit walk (CPU savings, not just output filters)
GitProvenance.fromProjectDirectory(dir, env, parser, CommitHistory.sinceDaysAgo(90));
GitProvenance.fromProjectDirectory(dir, env, parser, CommitHistory.lastCommits(1000));
```

`since(date)` prunes via `CommitTimeRevFilter.after` (StopWalkException) and `lastCommits(n)` via `setMaxCount` — both stop the walk, so they are real cost reductions. The off-switch lives on the *scope* axis, so a nonsense state like `since(date).withDetail(NONE)` is not expressible.

The cheap fields (origin, branch, change, autocrlf, eol, remote) are always computed. `none()` now yields `committers == null` ("not computed"), distinct from `emptyList()` ("walked, found nobody"), which keeps `FindCommitters`'s non-null latch semantics correct.

### Linked git worktree support

`fromProjectDirectory` previously returned `null` for *any* git worktree checkout. Root cause: the shaded JGit (5.13) predates `commondir` support, so pointed at a worktree's private gitdir it reports `isBare=true` with no refs or objects. The fix detects the worktree, opens the shared **common** repository (which owns objects/refs/config), and recovers this worktree's branch/HEAD from its own `HEAD` file. The normal-repo path is unchanged.

### Benchmark

`GitProvenanceBenchmark` (rewrite-benchmarks) measures the cost curve against a deep-history repo (auto-detects the working tree; override with `-Drewrite.repoRoot`). Against openrewrite/rewrite's own history (305 committers):

| `none()` | `lastCommits(100)` | `sinceDaysAgo(90)` | `lastCommits(1000)` | `full()` |
|---|---|---|---|---|
| ~0.7 ms | ~10 ms | ~20 ms | ~21 ms | ~80 ms |

Run: `./gradlew :rewrite-benchmarks:jmh -Pjmh.includes=GitProvenance`

## Compatibility

- The `boolean` overload from #7910 is **removed** (unreleased).
- The deprecated 1-arg/2-arg and the 3-arg `fromProjectDirectory` overloads keep full-history behavior.
- `DistinctCommitters.Row.lastCommit` is now `@Nullable` (null only for identities-only committers, which are opt-in).

## Test plan

- [x] `GitProvenanceTest`: scope/detail presets, plus attached and detached-HEAD linked-worktree resolution.
- [x] `FindCommittersTest`: identities-only committers tolerated (no per-day map), including under a date filter.
- [x] `FindGitProvenanceTest` and existing `GitProvenanceTest` green.