### PR TITLE
Python: insert imports in sorted order in `maybe_add_import`

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/add_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/add_import.py
@@ -208,21 +208,13 @@ class AddImport(PythonVisitor):
             if from_name != self.module:
                 continue
 
-            # Found an existing import from the same module - add our name
+            # Found an existing import from the same module - add our name in
+            # case-insensitive alphabetical position (mirrors rewrite-javascript's
+            # AddImport). Existing members are not reordered; only the new member
+            # is positioned.
             new_import = self._create_import_element(self.name, self.alias)
-            # Give the new import a space prefix (space after comma)
-            new_import = new_import.replace(prefix=Space.SINGLE_SPACE)
-
-            # Preserve existing padded elements; append new one with proper padding
-            existing_padded = list(stmt.padding.names.padding.elements)
-            # Move last element's .after (typically '\n') to the new element
-            if existing_padded:
-                last = existing_padded[-1]
-                existing_padded[-1] = last.replace(_after=Space.EMPTY)
-                new_padded_import = JRightPadded(new_import, last.after, Markers.EMPTY)
-            else:
-                new_padded_import = JRightPadded(new_import, Space.EMPTY, Markers.EMPTY)
-            existing_padded.append(new_padded_import)
+            existing_padded = self._insert_member(
+                list(stmt.padding.names.padding.elements), new_import)
 
             # Recreate the MultiImport with the new names
             new_multi = MultiImport(
@@ -245,6 +237,63 @@ class AddImport(PythonVisitor):
             return cu.padding.replace(_statements=padded_stmts)
 
         return cu
+
+    def _insert_member(self, elements: list, new_import: Import) -> list:
+        """Insert ``new_import`` into a list of ``JRightPadded[Import]`` at its
+        case-insensitive alphabetical position.
+
+        The space after the ``import`` keyword lives in the surrounding
+        ``JContainer.before``, so the element at index 0 carries an empty prefix
+        while every later element carries a single-space prefix (the space after
+        the separating comma). Trailing whitespace (e.g. before a ``)`` in a
+        parenthesized import) lives in the last element's ``.after`` and must
+        travel with whichever element ends up last.
+        """
+        insert_idx = self._sorted_insert_index(elements, new_import)
+        end = len(elements)
+
+        if insert_idx == 0:
+            prefix = Space.EMPTY
+            if elements:
+                # The displaced first element now follows a comma.
+                first = elements[0]
+                elements[0] = first.replace(
+                    _element=first.element.replace(prefix=Space.SINGLE_SPACE))
+        else:
+            prefix = Space.SINGLE_SPACE
+        new_import = new_import.replace(prefix=prefix)
+
+        if insert_idx == end and elements:
+            # Appending at the end: the new element becomes the last, so any
+            # trailing whitespace moves from the old last element onto it.
+            last = elements[-1]
+            elements[-1] = last.replace(_after=Space.EMPTY)
+            after = last.after
+        else:
+            after = Space.EMPTY
+
+        elements.insert(insert_idx, JRightPadded(new_import, after, Markers.EMPTY))
+        return elements
+
+    def _sorted_insert_index(self, elements: list, new_import: Import) -> int:
+        """Return the index at which the new member keeps the list in
+        case-insensitive alphabetical order: the first existing member whose
+        bound name sorts after the new member's, or the end if none does.
+
+        Members are sorted by their bound name (alias if present, else the
+        imported name), matching rewrite-javascript's comparator.
+        """
+        new_key = self._sort_key(new_import)
+        for i, padded in enumerate(elements):
+            if new_key < self._sort_key(padded.element):
+                return i
+        return len(elements)
+
+    @staticmethod
+    def _sort_key(imp: Import) -> str:
+        """Case-insensitive sort key for an imported member: its alias if it has
+        one, otherwise the imported name."""
+        return (get_alias_name(imp) or get_qualid_name(imp.qualid)).lower()
 
     def _add_import(self, cu: CompilationUnit) -> CompilationUnit:
         """Add a new import statement to the compilation unit."""

--- a/rewrite-python/rewrite/tests/python/test_add_import.py
+++ b/rewrite-python/rewrite/tests/python/test_add_import.py
@@ -22,6 +22,21 @@ from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python, from_visitor
 
 
+def _add_import_visitor(module, name=None, alias=None):
+    """Build a visitor that registers a single maybe_add_import (always added)."""
+    class _V(PythonVisitor[ExecutionContext]):
+        def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
+            maybe_add_import(self, AddImportOptions(
+                module=module,
+                name=name,
+                alias=alias,
+                only_if_referenced=False,
+            ))
+            return super().visit_compilation_unit(cu, p)
+
+    return _V()
+
+
 class TestMaybeAddImport:
     """Tests for maybe_add_import scheduling via _after_visit."""
 
@@ -113,17 +128,12 @@ class TestMaybeAddImport:
         )
 
     def test_merge_into_existing_from_import(self):
-        """Merge a new name into an existing 'from X import ...' statement."""
-        class AddExistsVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_add_import(self, AddImportOptions(
-                    module='os.path',
-                    name='exists',
-                    only_if_referenced=False
-                ))
-                return super().visit_compilation_unit(cu, p)
+        """Merge a new name into an existing 'from X import ...' statement.
 
-        spec = RecipeSpec(recipe=from_visitor(AddExistsVisitor()))
+        The new member is inserted in case-insensitive alphabetical position
+        ('exists' < 'join'), not appended.
+        """
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('os.path', 'exists')))
         spec.rewrite_run(
             python(
                 """
@@ -131,8 +141,125 @@ class TestMaybeAddImport:
                 x = 1
                 """,
                 """
-                from os.path import join, exists
+                from os.path import exists, join
                 x = 1
+                """,
+            )
+        )
+
+    def test_merge_inserts_member_in_sorted_position(self):
+        """Insert before an existing member when it sorts earlier (the reported bug)."""
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('typing', 'ClassVar')))
+        spec.rewrite_run(
+            python(
+                """
+                from typing import Final
+                x = 1
+                """,
+                """
+                from typing import ClassVar, Final
+                x = 1
+                """,
+            )
+        )
+
+    def test_merge_inserts_member_in_middle(self):
+        """Insert a member between two existing, already-sorted members."""
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('typing', 'ClassVar')))
+        spec.rewrite_run(
+            python(
+                """
+                from typing import Any, Final
+                x = 1
+                """,
+                """
+                from typing import Any, ClassVar, Final
+                x = 1
+                """,
+            )
+        )
+
+    def test_merge_appends_when_alphabetically_last(self):
+        """Append a member when it sorts after all existing members."""
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('typing', 'Final')))
+        spec.rewrite_run(
+            python(
+                """
+                from typing import Any, ClassVar
+                x = 1
+                """,
+                """
+                from typing import Any, ClassVar, Final
+                x = 1
+                """,
+            )
+        )
+
+    def test_merge_is_case_insensitive(self):
+        """Ordering is case-insensitive: 'cast' sorts before 'Optional'."""
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('typing', 'cast')))
+        spec.rewrite_run(
+            python(
+                """
+                from typing import Optional
+                x = 1
+                """,
+                """
+                from typing import cast, Optional
+                x = 1
+                """,
+            )
+        )
+
+    def test_merge_into_unsorted_list_still_inserts_sorted(self):
+        """When existing members are unsorted, the new member is still placed at
+        its first sorted position; existing members are not reordered."""
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('os.path', 'exists')))
+        spec.rewrite_run(
+            python(
+                """
+                from os.path import join, abspath
+                x = 1
+                """,
+                """
+                from os.path import exists, join, abspath
+                x = 1
+                """,
+            )
+        )
+
+    def test_merge_aliased_member_sorted_by_alias(self):
+        """An aliased member is sorted by its alias (the bound name)."""
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('typing', 'Final', alias='abc')))
+        spec.rewrite_run(
+            python(
+                """
+                from typing import Optional
+                x = 1
+                """,
+                """
+                from typing import Final as abc, Optional
+                x = 1
+                """,
+            )
+        )
+
+    def test_new_from_import_added_after_existing_imports(self):
+        """A brand-new 'from' import is placed after existing imports; import
+        statements are not reordered among themselves."""
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('mmm', 'w')))
+        spec.rewrite_run(
+            python(
+                """
+                from aaa import x
+                from zzz import y
+                z = 1
+                """,
+                """
+                from aaa import x
+                from zzz import y
+                from mmm import w
+                z = 1
                 """,
             )
         )


### PR DESCRIPTION
## Motivation

The Python SDK's `maybe_add_import` appended new members to an existing `from X import ...` statement instead of inserting them in sorted position. Adding `ClassVar` to `from typing import Final` produced `from typing import Final, ClassVar` rather than the isort/PEP 8-conventional `from typing import ClassVar, Final`.

This also brings the Python SDK in line with rewrite-javascript's `AddImport`, which already inserts members in case-insensitive alphabetical position.

## Examples

Before:

```python
from typing import Final, ClassVar   # appended
```

After:

```python
from typing import ClassVar, Final   # sorted
```

## Summary

- `_try_merge_into_existing` now inserts the new member at its case-insensitive alphabetical position instead of appending, via new `_insert_member` / `_sorted_insert_index` / `_sort_key` helpers.
- Sort key is the member's bound name (alias if present, else the imported name), lowercased — matching rewrite-javascript's comparator.
- Insertion is unconditional (always sorted), mirroring rewrite-javascript. Existing members are not reordered, and new import *statements* are still appended after existing imports (statement ordering is left to an `OrderImports`-style recipe).
- Padding is preserved: the index-0 element keeps an empty prefix (the space after `import` lives in `JContainer.before`), later elements get a single-space prefix, and trailing `.after` whitespace travels with whichever element ends up last.

## Test plan

- [x] Updated `test_merge_into_existing_from_import` (previously asserted the appended order)
- [x] Added tests: insert-at-front (the reported bug), middle insert, append-when-last, case-insensitivity, unsorted-list-still-sorts, alias-sorted-by-alias, and new-statement placement
- [x] `pytest tests/python/test_add_import.py` — 12 passed
- [x] Full non-RPC suite (`tests/python`, `tests/recipes`) — 1480 passed, 6 skipped