### PR TITLE
Python: handle ty-types 0.0.44 `typeForm` descriptor

### DIFF
--- a/rewrite-python/rewrite/pyproject.toml
+++ b/rewrite-python/rewrite/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "more_itertools>=10.0.0",
-    "ty-types>=0.0.39",  # Type inference CLI for Python type attribution
+    "ty-types>=0.0.44",  # Type inference CLI for Python type attribution
     "parso>=0.7.1,<0.8",  # Python 2/3 parser with CST support (0.8+ dropped Python 2.7 grammar)
 ]
 

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -532,6 +532,17 @@ class PythonTypeMapping:
                     return result
             return _UNKNOWN
 
+        elif kind == 'typeForm':
+            # PEP 747 TypeForm[T] (ty-types >= 0.0.44): a type expression used
+            # as a runtime value. Resolve through to the wrapped type argument,
+            # mirroring how `subclassOf` resolves to its base.
+            type_arg_id = descriptor.get('typeArgument')
+            if type_arg_id is not None:
+                result = self._resolve_type(type_arg_id)
+                if result is not None:
+                    return result
+            return _UNKNOWN
+
         elif kind == 'newType':
             name = descriptor.get('name', '')
             if name:
@@ -1069,6 +1080,12 @@ class PythonTypeMapping:
             base_id = descriptor.get('base')
             if base_id is not None:
                 return self._resolve_declaring_type(base_id)
+            return None
+
+        elif kind == 'typeForm':
+            type_arg_id = descriptor.get('typeArgument')
+            if type_arg_id is not None:
+                return self._resolve_declaring_type(type_arg_id)
             return None
 
         elif kind == 'newType':

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -2292,3 +2292,90 @@ class TestMethodDeclarationResultType:
             assert t is md.method_type.return_type
         finally:
             _cleanup_parse(tmpdir, client)
+
+
+class TestTypeFormDescriptor:
+    """Unit tests for the ty-types 0.0.44 `typeForm` descriptor kind.
+
+    PEP 747 `TypeForm[T]` values (a type expression used as a runtime value,
+    e.g. ``x: TypeForm[str] = str``) are surfaced by ty-types >= 0.0.44 as a
+    first-class ``typeForm`` descriptor carrying a ``typeArgument`` reference,
+    rather than the older ``other`` fallback. Like ``subclassOf`` (``type[X]``),
+    the descriptor resolves through to its wrapped argument.
+
+    Use mock descriptors so the logic is exercised without the ty-types CLI.
+    End-to-end tests against real source live in TestTypeFormIntegration below.
+    """
+
+    def test_type_form_resolves_to_primitive_type_argument(self):
+        """`TypeForm[str]` resolves through to its `typeArgument` (str)."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[3] = {'kind': 'instance', 'className': 'str'}
+        mapping._type_registry[10] = {
+            'kind': 'typeForm', 'display': 'TypeForm[str]', 'typeArgument': 3,
+        }
+        result = mapping._resolve_type(10)
+        assert result is JavaType.Primitive.String
+
+    def test_type_form_resolves_to_class_type_argument(self):
+        """`TypeForm[MyClass]` resolves through to the wrapped class type."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[5] = {
+            'kind': 'classLiteral', 'className': 'MyClass', 'moduleName': 'mymod',
+        }
+        mapping._type_registry[11] = {
+            'kind': 'typeForm', 'display': 'TypeForm[MyClass]', 'typeArgument': 5,
+        }
+        result = mapping._resolve_type(11)
+        assert isinstance(result, JavaType.FullyQualified)
+        assert result.fully_qualified_name == 'mymod.MyClass'
+
+    def test_type_form_declaring_type_resolves_to_type_argument(self):
+        """Declaring-type resolution unwraps `typeForm` to its argument too,
+        mirroring `subclassOf`."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[5] = {
+            'kind': 'instance', 'className': 'MyClass', 'moduleName': 'mymod',
+        }
+        mapping._type_registry[11] = {
+            'kind': 'typeForm', 'display': 'TypeForm[MyClass]', 'typeArgument': 5,
+        }
+        result = mapping._resolve_declaring_type(11)
+        assert result is not None
+        assert result.fully_qualified_name == 'mymod.MyClass'
+
+    def test_type_form_without_type_argument_is_unknown(self):
+        """A `typeForm` descriptor lacking `typeArgument` degrades to Unknown
+        rather than raising."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[12] = {'kind': 'typeForm', 'display': 'TypeForm[?]'}
+        result = mapping._resolve_type(12)
+        assert isinstance(result, JavaType.Unknown)
+
+
+@requires_ty_types_cli
+class TestTypeFormIntegration:
+    """End-to-end tests exercising ty-types 0.0.44 TypeForm output.
+
+    Requires ty-types >= 0.0.44, which surfaces PEP 747 `TypeForm[T]` as a
+    first-class `typeForm` descriptor whose `typeArgument` is the wrapped type
+    (for `TypeForm[str]`, an `instance` of `str`). Without the `typeForm`
+    handling in type_mapping this regresses to Unknown on 0.0.44; with it, the
+    reference resolves to `str`. CLIs predating the TypeForm variant infer the
+    reference as the `str` *class* instead, so this assertion is version-gated
+    (same contract as the ParamSpec/Concatenate integration tests).
+    """
+
+    def test_type_form_value_resolves_to_type_argument(self):
+        """Reading a `TypeForm[str]` value resolves to its wrapped `str`."""
+        source = '''from typing_extensions import TypeForm
+string_form: TypeForm[str] = str
+ref = string_form
+'''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            ref = tree.body[2].value  # `string_form` on the RHS of `ref = string_form`
+            result = mapping.type(ref)
+            assert result is JavaType.Primitive.String
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)


### PR DESCRIPTION
## Motivation

- [ty-types 0.0.44](https://github.com/openrewrite/ty-types/releases/tag/v0.0.44) surfaces [PEP 747](https://peps.python.org/pep-0747/) `TypeForm[T]` values — a type expression used as a runtime value, e.g. `x: TypeForm[str] = str` — as a first-class `typeForm` descriptor (openrewrite/ty-types#17), rather than the prior `other`/`classLiteral` fallback.

The consumer side did not know this descriptor kind, so after the upgrade these references would fall through `PythonTypeMapping`'s dispatch to the `else` branch and **regress from a resolved type to `JavaType.Unknown`**. This change adds handling so the wrapped type argument is preserved.

## Examples

For ty-types 0.0.44, reading `string_form` below yields a `typeForm` descriptor whose `typeArgument` references the `str` type:

```python
from typing_extensions import TypeForm

string_form: TypeForm[str] = str
ref = string_form   # type attribution now resolves `str`, not Unknown
```

```json
{ "kind": "typeForm", "display": "TypeForm[str]", "typeArgument": 3 }
```

`PythonTypeMapping` now unwraps the descriptor to its `typeArgument`, mirroring how `subclassOf` resolves to its `base`.

## Summary

- Bump the `ty-types` dependency pin to `>=0.0.44` (`rewrite-python/rewrite/pyproject.toml`).
- Handle the `typeForm` descriptor kind in `PythonTypeMapping`, resolving through to its `typeArgument` in both `_descriptor_to_java_type` (expression type) and `_declaring_type_from_descriptor` (declaring type). A descriptor lacking `typeArgument` degrades to `Unknown`/`None` rather than raising.
- Add unit tests (mock descriptors, no CLI required) covering primitive, class, and declaring-type arguments plus the missing-argument case, and a live `@requires_ty_types_cli` integration test exercising real ty-types output.

## Test plan

- [x] New `TestTypeFormDescriptor` unit tests pass without the CLI.
- [x] `TestTypeFormIntegration` verified end-to-end against a real `ty-types==0.0.44` binary (the `typeForm` descriptor's `typeArgument` is an `instance` of `str`, resolving to `Primitive.String`).
- [x] Full `tests/python/test_type_attribution.py` green against `ty-types==0.0.44` (120 passed).
