### PR TITLE
Python: add TypeUtils-style type comparison helpers

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/__init__.py
@@ -90,6 +90,17 @@ from rewrite.python.add_import import AddImport, AddImportOptions, maybe_add_imp
 from rewrite.python.remove_import import RemoveImport, RemoveImportOptions, maybe_remove_import
 from rewrite.python.method_matcher import MethodMatcher
 
+# Type-comparison helpers
+from rewrite.python.type_utils import (
+    is_assignable_to,
+    is_of_type,
+    is_of_class_type,
+    is_string,
+    is_object,
+    as_fully_qualified,
+    fully_qualified_names_are_equal,
+)
+
 # Precondition helpers (delegate to Java via RPC)
 from rewrite.python.preconditions import (
     has_source_path,
@@ -183,6 +194,14 @@ __all__ = [
     "maybe_remove_import",
     # Method matching
     "MethodMatcher",
+    # Type-comparison helpers
+    "is_assignable_to",
+    "is_of_type",
+    "is_of_class_type",
+    "is_string",
+    "is_object",
+    "as_fully_qualified",
+    "fully_qualified_names_are_equal",
     # Precondition helpers
     "has_source_path",
     "uses_method",

--- a/rewrite-python/rewrite/src/rewrite/python/type_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_utils.py
@@ -1,0 +1,252 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Type-comparison helpers for the shared ``JavaType`` model.
+
+A small, Python-flavoured counterpart to rewrite-java's
+``org.openrewrite.java.tree.TypeUtils``. Provides the pieces recipes most
+commonly need:
+
+* :func:`is_assignable_to` — is a value of ``from_`` assignable to ``to``
+  (a fully-qualified name *or* a :class:`JavaType`), walking the supertype and
+  interface hierarchy.
+* :func:`is_of_type` — exact structural type equality.
+* :func:`is_of_class_type` — does a type match a given fully-qualified name.
+
+Generic variance and full type inference are intentionally out of scope for
+now; assignability of parameterized types is reduced to their raw fully
+qualified name.
+"""
+
+
+from rewrite.java.support_types import JavaType
+
+__all__ = [
+    "is_assignable_to",
+    "is_of_type",
+    "is_of_class_type",
+    "is_string",
+    "is_object",
+    "as_fully_qualified",
+    "fully_qualified_names_are_equal",
+]
+
+# Fully-qualified names that denote the universal supertype. Python's root is
+# ``object``; ``java.lang.Object`` is accepted too since the model is shared.
+_OBJECT_NAMES = frozenset({"object", "builtins.object", "java.lang.Object"})
+
+# Mirrors the primitive <-> name mapping used by ``python.type_mapping``. Kept
+# local so this module stays free of the (heavyweight) type-mapping imports.
+_PRIMITIVE_KEYWORDS = {
+    JavaType.Primitive.String: "str",
+    JavaType.Primitive.Int: "int",
+    JavaType.Primitive.Double: "float",
+    JavaType.Primitive.Boolean: "bool",
+    JavaType.Primitive.None_: "None",
+}
+_KEYWORD_TO_PRIMITIVE = {name: prim for prim, name in _PRIMITIVE_KEYWORDS.items()}
+
+# Permitted primitive widenings (``to`` accepts these ``from_`` primitives). In
+# Python ``bool`` is a subclass of ``int`` and ``int`` widens to ``float``.
+_PRIMITIVE_WIDENING = {
+    JavaType.Primitive.Int: frozenset({JavaType.Primitive.Boolean}),
+    JavaType.Primitive.Double: frozenset({JavaType.Primitive.Boolean, JavaType.Primitive.Int}),
+}
+
+
+def fully_qualified_names_are_equal(fqn1: str | None, fqn2: str | None) -> bool:
+    """Compare two fully-qualified names, treating ``$`` and ``.`` as equivalent."""
+    if fqn1 is not None and fqn2 is not None:
+        if fqn1 == fqn2:
+            return True
+        if len(fqn1) != len(fqn2):
+            return False
+        for c1, c2 in zip(fqn1, fqn2):
+            if c1 != c2 and not ((c1 == "$" and c2 == ".") or (c1 == "." and c2 == "$")):
+                return False
+        return True
+    return fqn1 is None and fqn2 is None
+
+
+def as_fully_qualified(type_: JavaType | None) -> JavaType.FullyQualified | None:
+    """Return ``type_`` as a :class:`JavaType.FullyQualified`, or ``None``.
+
+    ``JavaType.Unknown`` is treated as *not* fully qualified.
+    """
+    if isinstance(type_, JavaType.FullyQualified) and not isinstance(type_, JavaType.Unknown):
+        return type_
+    return None
+
+
+def _fqn(type_: JavaType | None) -> str | None:
+    """Best-effort fully-qualified name for a type, or ``None``."""
+    fq = as_fully_qualified(type_)
+    return getattr(fq, "fully_qualified_name", None) if fq is not None else None
+
+
+def is_string(type_: JavaType | None) -> bool:
+    """True for the ``str`` primitive or a ``str`` class."""
+    if type_ is JavaType.Primitive.String:
+        return True
+    return _fqn(type_) in ("str", "java.lang.String")
+
+
+def is_object(type_: JavaType | None) -> bool:
+    """True for the universal supertype (``object``)."""
+    return _fqn(type_) in _OBJECT_NAMES
+
+
+def is_of_class_type(type_: JavaType | None, fqn: str) -> bool:
+    """True if ``type_`` (or what it wraps) matches the fully-qualified name ``fqn``.
+
+    This is an *exact* match; it does not walk the supertype hierarchy. Use
+    :func:`is_assignable_to` for that.
+    """
+    if isinstance(type_, JavaType.FullyQualified):
+        return fully_qualified_names_are_equal(_fqn(type_), fqn)
+    if isinstance(type_, JavaType.Variable):
+        return is_of_class_type(type_.type, fqn)
+    if isinstance(type_, JavaType.Method):
+        return is_of_class_type(type_.return_type, fqn)
+    if isinstance(type_, JavaType.Array):
+        return is_of_class_type(type_.elem_type, fqn)
+    if isinstance(type_, JavaType.Primitive):
+        return _PRIMITIVE_KEYWORDS.get(type_) == fqn
+    return False
+
+
+def is_of_type(type1: JavaType | None, type2: JavaType | None) -> bool:
+    """True if the two types are exactly the same type.
+
+    Parameterized types are compared by their raw name *and* type parameters.
+    Generic variance is not considered.
+    """
+    if type1 is None or type2 is None:
+        return False
+    if type1 is type2 and not isinstance(type1, JavaType.Unknown):
+        return True
+    # ``str`` is special: it can show up as either a primitive or a class.
+    if is_string(type1) and is_string(type2):
+        return True
+    if isinstance(type1, JavaType.Primitive) or isinstance(type2, JavaType.Primitive):
+        return type1 is type2
+    if isinstance(type1, JavaType.Array) and isinstance(type2, JavaType.Array):
+        return is_of_type(type1.elem_type, type2.elem_type)
+
+    fqn1 = _fqn(type1)
+    fqn2 = _fqn(type2)
+    if fqn1 is not None and fqn2 is not None:
+        if not fully_qualified_names_are_equal(fqn1, fqn2):
+            return False
+        is_p1 = isinstance(type1, JavaType.Parameterized)
+        is_p2 = isinstance(type2, JavaType.Parameterized)
+        if is_p1 != is_p2:
+            return False
+        if is_p1 and is_p2:
+            tp1 = type1.type_parameters or []
+            tp2 = type2.type_parameters or []
+            if len(tp1) != len(tp2):
+                return False
+            return all(is_of_type(a, b) for a, b in zip(tp1, tp2))
+        return True
+    return False
+
+
+def is_assignable_to(to: str | JavaType, from_: JavaType | None) -> bool:
+    """True if a value of type ``from_`` can be assigned to ``to``.
+
+    ``to`` may be a fully-qualified name (the common case for recipes that don't
+    hold a :class:`JavaType` handle) or a :class:`JavaType`. The ``from_``
+    hierarchy is walked through its supertype and interfaces.
+    """
+    try:
+        if isinstance(to, str):
+            return _is_assignable_to_fqn(to, from_)
+        return _is_assignable_to_type(to, from_)
+    except Exception:
+        return False
+
+
+def _is_assignable_to_fqn(to: str, from_: JavaType | None) -> bool:
+    if isinstance(from_, JavaType.FullyQualified) and not isinstance(from_, JavaType.Unknown):
+        if fully_qualified_names_are_equal(to, _fqn(from_)):
+            return True
+        if _is_assignable_to_fqn(to, getattr(from_, "_supertype", None)):
+            return True
+        for i in getattr(from_, "_interfaces", None) or []:
+            if _is_assignable_to_fqn(to, i):
+                return True
+        return False
+    elif isinstance(from_, JavaType.GenericTypeVariable):
+        for bound in from_.bounds:
+            if _is_assignable_to_fqn(to, bound):
+                return True
+    elif isinstance(from_, JavaType.Primitive):
+        to_primitive = _KEYWORD_TO_PRIMITIVE.get(to)
+        if to_primitive is not None and _is_assignable_to_primitive(to_primitive, from_):
+            return True
+    elif isinstance(from_, JavaType.Variable):
+        return _is_assignable_to_fqn(to, from_.type)
+    elif isinstance(from_, JavaType.Method):
+        return _is_assignable_to_fqn(to, from_.return_type)
+    elif isinstance(from_, (JavaType.Intersection, JavaType.Union)):
+        for bound in from_.bounds:
+            if _is_assignable_to_fqn(to, bound):
+                return True
+    # Everything is ultimately an ``object``.
+    return to in _OBJECT_NAMES
+
+
+def _is_assignable_to_type(to: JavaType | None, from_: JavaType | None) -> bool:
+    if to is from_ and not isinstance(to, JavaType.Unknown):
+        return True
+    if to is None or from_ is None:
+        return False
+    if is_string(to) and is_string(from_):
+        return True
+
+    # Unwrap variables and methods to the type they carry.
+    if isinstance(to, JavaType.Variable):
+        return _is_assignable_to_type(to.type, from_)
+    if isinstance(to, JavaType.Method):
+        return _is_assignable_to_type(to.return_type, from_)
+    if isinstance(from_, JavaType.Variable):
+        return _is_assignable_to_type(to, from_.type)
+    if isinstance(from_, JavaType.Method):
+        return _is_assignable_to_type(to, from_.return_type)
+
+    if isinstance(to, JavaType.Primitive):
+        return _is_assignable_to_primitive(to, from_)
+    if isinstance(to, JavaType.Array):
+        return isinstance(from_, JavaType.Array) and is_of_type(to.elem_type, from_.elem_type)
+    if isinstance(to, JavaType.GenericTypeVariable):
+        bounds = to.bounds
+        if not bounds:
+            return True
+        return all(_is_assignable_to_type(bound, from_) for bound in bounds)
+
+    # Reduce a fully-qualified ``to`` (including parameterized) to its raw name
+    # and walk the ``from_`` hierarchy.
+    to_fqn = _fqn(to)
+    if to_fqn is not None:
+        return _is_assignable_to_fqn(to_fqn, from_)
+    return False
+
+
+def _is_assignable_to_primitive(to: JavaType.Primitive, from_: JavaType | None) -> bool:
+    if not isinstance(from_, JavaType.Primitive):
+        return False
+    if to is from_:
+        return True
+    return from_ in _PRIMITIVE_WIDENING.get(to, frozenset())

--- a/rewrite-python/rewrite/tests/python/test_type_utils.py
+++ b/rewrite-python/rewrite/tests/python/test_type_utils.py
@@ -1,0 +1,375 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``rewrite.python.type_utils``.
+
+Pure-Python tests that construct ``JavaType`` instances directly (no parsing or
+RPC) and exercise the type-comparison helpers.
+"""
+
+
+from rewrite.java import JavaType
+from rewrite.python.type_utils import (
+    as_fully_qualified,
+    fully_qualified_names_are_equal,
+    is_assignable_to,
+    is_object,
+    is_of_class_type,
+    is_of_type,
+    is_string,
+)
+
+# ---------------------------------------------------------------------------
+# Construction helpers
+# ---------------------------------------------------------------------------
+
+def _cls(
+    fqn: str,
+    supertype: JavaType.FullyQualified | None = None,
+    interfaces: list[JavaType.FullyQualified] | None = None,
+    kind: JavaType.FullyQualified.Kind | None = None,
+) -> JavaType.Class:
+    """Build a ``JavaType.Class`` the way the type mapping does (set fields directly).
+
+    Deliberately leaves ``_supertype``/``_interfaces`` *unset* when not provided,
+    to exercise the missing-attribute path that real instances often hit.
+    """
+    c = JavaType.Class()
+    c._flags_bit_map = 0
+    c._fully_qualified_name = fqn
+    c._kind = kind if kind is not None else JavaType.FullyQualified.Kind.Class
+    if supertype is not None:
+        c._supertype = supertype
+    if interfaces is not None:
+        c._interfaces = interfaces
+    return c
+
+
+def _param(base: JavaType.FullyQualified, params: list[JavaType]) -> JavaType.Parameterized:
+    p = JavaType.Parameterized()
+    p._type = base
+    p._type_parameters = params
+    return p
+
+
+def _var(name: str, type_: JavaType, owner: JavaType | None = None) -> JavaType.Variable:
+    v = JavaType.Variable()
+    v._flags_bit_map = 0
+    v._name = name
+    v._type = type_
+    v._owner = owner
+    v._annotations = None
+    return v
+
+
+def _method(name: str, declaring: JavaType.FullyQualified, return_type: JavaType) -> JavaType.Method:
+    m = JavaType.Method()
+    m._flags_bit_map = 0
+    m._declaring_type = declaring
+    m._name = name
+    m._return_type = return_type
+    m._parameter_names = None
+    m._parameter_types = None
+    m._thrown_exceptions = None
+    m._annotations = None
+    m._default_value = None
+    m._declared_formal_type_names = None
+    return m
+
+
+def _generic(name: str, bounds: list[JavaType] | None = None) -> JavaType.GenericTypeVariable:
+    return JavaType.GenericTypeVariable(
+        _name=name,
+        _variance=JavaType.GenericTypeVariable.Variance.Invariant,
+        _bounds=bounds,
+    )
+
+
+# A small inheritance fixture:
+#   object
+#     ^
+#   Animal
+#     ^
+#   Dog  (also implements Comparable)
+OBJECT = _cls("object")
+ANIMAL = _cls("zoo.Animal", supertype=OBJECT)
+COMPARABLE = _cls("typing.Comparable", kind=JavaType.FullyQualified.Kind.Interface)
+DOG = _cls("zoo.Dog", supertype=ANIMAL, interfaces=[COMPARABLE])
+
+
+# ---------------------------------------------------------------------------
+# fully_qualified_names_are_equal
+# ---------------------------------------------------------------------------
+
+class TestFqnEquality:
+    def test_equal(self):
+        assert fully_qualified_names_are_equal("a.B", "a.B")
+
+    def test_not_equal(self):
+        assert not fully_qualified_names_are_equal("a.B", "a.C")
+
+    def test_both_none(self):
+        assert fully_qualified_names_are_equal(None, None)
+
+    def test_one_none(self):
+        assert not fully_qualified_names_are_equal("a.B", None)
+        assert not fully_qualified_names_are_equal(None, "a.B")
+
+
+# ---------------------------------------------------------------------------
+# as_fully_qualified
+# ---------------------------------------------------------------------------
+
+class TestAsFullyQualified:
+    def test_class(self):
+        assert as_fully_qualified(DOG) is DOG
+
+    def test_parameterized(self):
+        p = _param(_cls("list"), [JavaType.Primitive.String])
+        assert as_fully_qualified(p) is p
+
+    def test_unknown_is_none(self):
+        assert as_fully_qualified(JavaType.Unknown()) is None
+
+    def test_primitive_is_none(self):
+        assert as_fully_qualified(JavaType.Primitive.Int) is None
+
+    def test_none_is_none(self):
+        assert as_fully_qualified(None) is None
+
+
+# ---------------------------------------------------------------------------
+# is_string / is_object
+# ---------------------------------------------------------------------------
+
+class TestIsString:
+    def test_primitive_string(self):
+        assert is_string(JavaType.Primitive.String)
+
+    def test_str_class(self):
+        assert is_string(_cls("str"))
+
+    def test_not_string(self):
+        assert not is_string(JavaType.Primitive.Int)
+        assert not is_string(_cls("zoo.Dog"))
+        assert not is_string(None)
+
+
+class TestIsObject:
+    def test_object_class(self):
+        assert is_object(_cls("object"))
+        assert is_object(_cls("builtins.object"))
+
+    def test_not_object(self):
+        assert not is_object(_cls("zoo.Dog"))
+        assert not is_object(JavaType.Primitive.Int)
+        assert not is_object(None)
+
+
+# ---------------------------------------------------------------------------
+# is_of_class_type
+# ---------------------------------------------------------------------------
+
+class TestIsOfClassType:
+    def test_direct_match(self):
+        assert is_of_class_type(DOG, "zoo.Dog")
+
+    def test_no_supertype_match(self):
+        # is_of_class_type is an *exact* match; it does not walk the hierarchy
+        assert not is_of_class_type(DOG, "zoo.Animal")
+
+    def test_parameterized_matches_raw_fqn(self):
+        assert is_of_class_type(_param(_cls("list"), [JavaType.Primitive.String]), "list")
+
+    def test_variable_unwrapped(self):
+        assert is_of_class_type(_var("d", DOG), "zoo.Dog")
+
+    def test_method_uses_return_type(self):
+        assert is_of_class_type(_method("get", DOG, DOG), "zoo.Dog")
+
+    def test_array_uses_elem_type(self):
+        arr = JavaType.Array(_elem_type=DOG, _annotations=None)
+        assert is_of_class_type(arr, "zoo.Dog")
+
+    def test_primitive_keyword(self):
+        assert is_of_class_type(JavaType.Primitive.String, "str")
+        assert is_of_class_type(JavaType.Primitive.Int, "int")
+        assert not is_of_class_type(JavaType.Primitive.Int, "str")
+
+    def test_unknown(self):
+        assert not is_of_class_type(JavaType.Unknown(), "object")
+
+    def test_none(self):
+        assert not is_of_class_type(None, "zoo.Dog")
+
+
+# ---------------------------------------------------------------------------
+# is_of_type
+# ---------------------------------------------------------------------------
+
+class TestIsOfType:
+    def test_identity(self):
+        assert is_of_type(DOG, DOG)
+
+    def test_same_fqn(self):
+        assert is_of_type(_cls("zoo.Dog"), _cls("zoo.Dog"))
+
+    def test_different_fqn(self):
+        assert not is_of_type(_cls("zoo.Dog"), _cls("zoo.Animal"))
+
+    def test_does_not_walk_hierarchy(self):
+        # exact type, not assignability
+        assert not is_of_type(DOG, ANIMAL)
+
+    def test_primitive(self):
+        assert is_of_type(JavaType.Primitive.Int, JavaType.Primitive.Int)
+        assert not is_of_type(JavaType.Primitive.Int, JavaType.Primitive.Double)
+
+    def test_string_primitive_and_class(self):
+        # str is special: primitive String and a `str` class are the same type
+        assert is_of_type(JavaType.Primitive.String, _cls("str"))
+
+    def test_parameterized_same_params(self):
+        a = _param(_cls("list"), [JavaType.Primitive.String])
+        b = _param(_cls("list"), [JavaType.Primitive.String])
+        assert is_of_type(a, b)
+
+    def test_parameterized_different_params(self):
+        a = _param(_cls("list"), [JavaType.Primitive.String])
+        b = _param(_cls("list"), [JavaType.Primitive.Int])
+        assert not is_of_type(a, b)
+
+    def test_parameterized_vs_raw(self):
+        a = _param(_cls("list"), [JavaType.Primitive.String])
+        assert not is_of_type(a, _cls("list"))
+
+    def test_array(self):
+        a = JavaType.Array(_elem_type=DOG, _annotations=None)
+        b = JavaType.Array(_elem_type=_cls("zoo.Dog"), _annotations=None)
+        assert is_of_type(a, b)
+        assert not is_of_type(a, JavaType.Array(_elem_type=ANIMAL, _annotations=None))
+
+    def test_none(self):
+        assert not is_of_type(None, DOG)
+        assert not is_of_type(DOG, None)
+        assert not is_of_type(None, None)
+
+    def test_unknown_not_equal_to_itself(self):
+        u = JavaType.Unknown()
+        assert not is_of_type(u, u)
+
+
+# ---------------------------------------------------------------------------
+# is_assignable_to — string (FQN) form
+# ---------------------------------------------------------------------------
+
+class TestIsAssignableToFqn:
+    def test_direct(self):
+        assert is_assignable_to("zoo.Dog", DOG)
+
+    def test_supertype(self):
+        assert is_assignable_to("zoo.Animal", DOG)
+
+    def test_transitive_supertype(self):
+        assert is_assignable_to("object", DOG)
+
+    def test_interface(self):
+        assert is_assignable_to("typing.Comparable", DOG)
+
+    def test_not_assignable(self):
+        assert not is_assignable_to("zoo.Cat", DOG)
+
+    def test_object_fallback_when_no_supertype(self):
+        # A class with no _supertype attribute is still assignable to object
+        assert is_assignable_to("object", _cls("loose.Thing"))
+
+    def test_not_object_when_no_supertype(self):
+        assert not is_assignable_to("other.Thing", _cls("loose.Thing"))
+
+    def test_variable_unwrapped(self):
+        assert is_assignable_to("zoo.Animal", _var("d", DOG))
+
+    def test_method_return_type(self):
+        assert is_assignable_to("zoo.Animal", _method("get", DOG, DOG))
+
+    def test_generic_bound(self):
+        t = _generic("T", bounds=[DOG])
+        assert is_assignable_to("zoo.Animal", t)
+        assert not is_assignable_to("zoo.Cat", t)
+
+    def test_str_primitive(self):
+        assert is_assignable_to("str", JavaType.Primitive.String)
+
+    def test_primitive_widening_bool_to_int(self):
+        assert is_assignable_to("int", JavaType.Primitive.Boolean)
+
+    def test_primitive_widening_int_to_float(self):
+        assert is_assignable_to("float", JavaType.Primitive.Int)
+
+    def test_primitive_no_narrowing(self):
+        assert not is_assignable_to("int", JavaType.Primitive.Double)
+
+    def test_primitive_is_object(self):
+        assert is_assignable_to("object", JavaType.Primitive.Int)
+
+    def test_none_from(self):
+        assert not is_assignable_to("zoo.Dog", None)
+
+    def test_unknown_from_only_object(self):
+        assert is_assignable_to("object", JavaType.Unknown())
+        assert not is_assignable_to("zoo.Dog", JavaType.Unknown())
+
+
+# ---------------------------------------------------------------------------
+# is_assignable_to — JavaType form
+# ---------------------------------------------------------------------------
+
+class TestIsAssignableToType:
+    def test_direct(self):
+        assert is_assignable_to(_cls("zoo.Dog"), DOG)
+
+    def test_supertype(self):
+        assert is_assignable_to(ANIMAL, DOG)
+
+    def test_interface(self):
+        assert is_assignable_to(COMPARABLE, DOG)
+
+    def test_not_assignable(self):
+        assert not is_assignable_to(_cls("zoo.Cat"), DOG)
+
+    def test_parameterized_to_reduced_to_raw(self):
+        # `to` parameterized list; from a `list` subtype — reduced to raw fqn walk
+        list_param = _param(_cls("list"), [JavaType.Primitive.String])
+        my_list = _cls("mymod.MyList", supertype=_cls("list"))
+        assert is_assignable_to(list_param, my_list)
+
+    def test_primitive_identity(self):
+        assert is_assignable_to(JavaType.Primitive.Int, JavaType.Primitive.Int)
+
+    def test_primitive_widening(self):
+        assert is_assignable_to(JavaType.Primitive.Double, JavaType.Primitive.Int)
+
+    def test_string_primitive_and_class(self):
+        assert is_assignable_to(JavaType.Primitive.String, _cls("str"))
+        assert is_assignable_to(_cls("str"), JavaType.Primitive.String)
+
+    def test_object_to_accepts_anything(self):
+        assert is_assignable_to(OBJECT, DOG)
+        assert is_assignable_to(_cls("object"), JavaType.Primitive.Int)
+
+    def test_variable_to_unwrapped(self):
+        assert is_assignable_to(_var("a", ANIMAL), DOG)
+
+    def test_none(self):
+        assert not is_assignable_to(DOG, None)


### PR DESCRIPTION
## Motivation

rewrite-java has `org.openrewrite.java.tree.TypeUtils`, which recipes rely on for the most common type questions — "is this type assignable to `X`?", "is this exactly type `Y`?", "does this match FQN `Z`?". The Python implementation (which reuses the shared `JavaType` model) had no equivalent: recipe authors had to reach into `JavaType` internals and walk `_supertype`/`_interfaces` by hand. rewrite-javascript has no general assignability utility either, so there was no prior art to port — this establishes the pattern on the Python side.

This is a deliberately modest first cut: assignability with supertype/interface walking, exact type comparison, and FQN matching. Generic variance and full type inference are out of scope.

## Examples

```python
from rewrite.python import is_assignable_to, is_of_type, is_of_class_type

# `to` may be a fully-qualified name (handy when the recipe has no type handle)...
is_assignable_to("collections.abc.Sequence", some_expr.type)

# ...or a JavaType
is_assignable_to(target_type, some_expr.type)

# Exact match (does not walk the hierarchy)
is_of_type(a.type, b.type)

# FQN match with Variable/Method/Array/Primitive unwrapping
is_of_class_type(method_invocation.method_type, "builtins.list")
```

## Summary

- New module `rewrite/python/type_utils.py`, exported from `rewrite.python`:
  - `is_assignable_to(to, from_)` — `to` is either an FQN string or a `JavaType`; walks the source type's `_supertype` and `_interfaces`, unwraps `Variable`/`Method`/`GenericTypeVariable` bounds, handles the `str`/`Primitive.String` duality and primitive widening (`bool`→`int`, `int`→`float`), and treats everything as ultimately assignable to `object`. A `JavaType` target is reduced to its raw fully-qualified name for the walk.
  - `is_of_type(t1, t2)` — exact type equality (FQN plus recursive type-parameter comparison for `Parameterized`).
  - `is_of_class_type(type, fqn)` — exact FQN match, unwrapping `Variable`/`Method`/`Array`/`Primitive`.
  - Helpers: `is_string`, `is_object`, `as_fully_qualified`, `fully_qualified_names_are_equal`.
- Robustness: `JavaType.Class` instances are commonly built field-by-field without `_supertype`/`_interfaces`, so the hierarchy walk uses `getattr(..., None)` rather than bare attribute access.
- Deliberate, reasoned divergences from the Java semantics: the root supertype is Python's `object`; primitive widening follows Python's numeric model; and `is_of_type(None, None)` returns `False` (two missing types should not be reported as the same type).

## Test plan

- [x] New `tests/python/test_type_utils.py` — 63 pure-Python unit tests (no parsing/RPC) constructing `JavaType` instances directly: direct/supertype/interface/transitive assignability, `object` fallback, missing `_supertype`/`_interfaces`, `str`/`Primitive.String` duality, primitive widening, parameterized comparison, and negative cases. All pass.
- [x] Existing `tests/recipes` suite still passes; `rewrite.python` package imports cleanly.
- [x] `ruff check` clean on the new files.
