### PR TITLE
Fix Windows portability in Go/Python recipe install (+ PEP 440 specifiers)

### DIFF
--- a/rewrite-go/pkg/recipe/installer/installer.go
+++ b/rewrite-go/pkg/recipe/installer/installer.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"text/template"
 
@@ -189,6 +190,10 @@ func (inst *Installer) loadRecipes(modulePath, activatePkg string, registry *rec
 	}
 
 	helperBin := filepath.Join(helperDir, "helper")
+	if runtime.GOOS == "windows" {
+		// `go build -o` appends .exe on Windows; match it so exec.Command finds the binary.
+		helperBin += ".exe"
+	}
 	cmd := exec.Command("go", "build", "-o", helperBin, ".")
 	cmd.Dir = helperDir
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")

--- a/rewrite-go/pkg/recipe/installer/installer.go
+++ b/rewrite-go/pkg/recipe/installer/installer.go
@@ -189,11 +189,7 @@ func (inst *Installer) loadRecipes(modulePath, activatePkg string, registry *rec
 		}
 	}
 
-	helperBin := filepath.Join(helperDir, "helper")
-	if runtime.GOOS == "windows" {
-		// `go build -o` appends .exe on Windows; match it so exec.Command finds the binary.
-		helperBin += ".exe"
-	}
+	helperBin := helperBinaryPath(helperDir, runtime.GOOS)
 	cmd := exec.Command("go", "build", "-o", helperBin, ".")
 	cmd.Dir = helperDir
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
@@ -256,6 +252,16 @@ type RecipeDescriptorJSON struct {
 type CategoryDescriptorJSON struct {
 	DisplayName string `json:"displayName"`
 	Description string `json:"description"`
+}
+
+// helperBinaryPath returns the helper binary path, adding the Windows .exe that
+// `go build -o` appends so exec.Command can find it.
+func helperBinaryPath(helperDir, goos string) string {
+	bin := filepath.Join(helperDir, "helper")
+	if goos == "windows" {
+		bin += ".exe"
+	}
+	return bin
 }
 
 // helperTemplate is the Go source template for the recipe discovery helper program.

--- a/rewrite-go/pkg/recipe/installer/installer_test.go
+++ b/rewrite-go/pkg/recipe/installer/installer_test.go
@@ -31,6 +31,18 @@ func writeGoMod(t *testing.T, contents string) string {
 	return dir
 }
 
+func TestHelperBinaryPath(t *testing.T) {
+	for _, tc := range []struct{ goos, want string }{
+		{"windows", filepath.Join("ws", "helper") + ".exe"},
+		{"linux", filepath.Join("ws", "helper")},
+		{"darwin", filepath.Join("ws", "helper")},
+	} {
+		if got := helperBinaryPath("ws", tc.goos); got != tc.want {
+			t.Errorf("helperBinaryPath(ws, %q) = %q, want %q", tc.goos, got, tc.want)
+		}
+	}
+}
+
 func TestReadResolvedVersion_DirectRequireInBlock(t *testing.T) {
 	// given
 	goMod := `module example.com/workspace

--- a/rewrite-python/rewrite/src/rewrite/python/template/dependency_workspace.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/dependency_workspace.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import logging
 import os
@@ -37,7 +38,9 @@ if sys.platform == "win32":
             try:
                 msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
                 return
-            except OSError:
+            except OSError as exc:
+                if exc.errno not in (errno.EACCES, errno.EDEADLK):
+                    raise
                 continue
 else:
     import fcntl

--- a/rewrite-python/rewrite/src/rewrite/python/template/dependency_workspace.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/dependency_workspace.py
@@ -16,14 +16,34 @@
 
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import logging
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from typing import Dict, Tuple
+
+# Cross-platform exclusive file lock. POSIX has fcntl.flock; Windows has neither
+# fcntl nor flock, so fall back to msvcrt byte-range locking there.
+if sys.platform == "win32":
+    import msvcrt
+
+    def _lock_exclusive(lock_file) -> None:
+        # msvcrt.LK_LOCK retries internally for ~10s before raising; loop so we
+        # block as long as needed (a uv sync can exceed that window).
+        while True:
+            try:
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+                return
+            except OSError:
+                continue
+else:
+    import fcntl
+
+    def _lock_exclusive(lock_file) -> None:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +196,7 @@ class DependencyWorkspace:
         # across uv sync is intentional — only one process should build the same
         # workspace at a time.
         with open(lock_path, "w") as lock_file:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            _lock_exclusive(lock_file)
 
             # Another holder may have built it while we waited for the lock.
             if cls._is_valid(final_dir):

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -723,7 +723,12 @@ def _pip_install_recipe_package(package_name: str, version: Optional[str], targe
     import subprocess
 
     target_dir.mkdir(parents=True, exist_ok=True)
-    spec = f"{package_name}=={version}" if version else package_name
+    # Accept a full PEP 440 specifier (">=1.0", "~=1.4", "==1.0", …). A bare
+    # version (no comparator) defaults to an exact "==" match.
+    if version:
+        spec = f"{package_name}{version}" if version[0] in "=<>!~" else f"{package_name}=={version}"
+    else:
+        spec = package_name
     cmd = [sys.executable, "-m", "pip", "install", "--target", str(target_dir), spec]
     logger.info(f"pip install: {' '.join(cmd)}")
     result = subprocess.run(cmd, capture_output=True, text=True)

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -78,6 +78,40 @@ def test_pip_install_recipe_package_shape(tmp_path, monkeypatch):
     assert str(install_dir.resolve()) in __import__("sys").path
 
 
+def test_pip_install_recipe_package_comparator_spec(tmp_path, monkeypatch):
+    import rewrite.rpc.server as server
+    import subprocess
+
+    install_dir = tmp_path / "recipes"
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    for version, expected_spec in [
+        (">=1.0", "openrewrite-recipes-python>=1.0"),
+        ("~=1.4", "openrewrite-recipes-python~=1.4"),
+    ]:
+        captured = {}
+
+        def fake_run(cmd, capture_output=False, text=False):
+            captured["cmd"] = cmd
+            return FakeCompletedProcess()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        server._pip_install_recipe_package(
+            "openrewrite-recipes-python", version, install_dir
+        )
+
+        assert captured["cmd"][1:] == [
+            "-m", "pip", "install",
+            "--target", str(install_dir),
+            expected_spec,
+        ], f"version {version!r}: expected spec {expected_spec!r}"
+
+
 def test_recipe_descriptor_to_dict_emits_all_collection_keys():
     from rewrite.recipe import RecipeDescriptor
     from rewrite.rpc.server import _recipe_descriptor_to_dict


### PR DESCRIPTION
Three small fixes that make **Go and Python recipe install work on Windows** — each was a hard blocker (recipe install failed entirely on Windows). Found while testing moderne-cli's recipe-artifact feed support end-to-end on Windows.

### rewrite-go: `.exe` for the recipe-install helper on Windows
`installer.go` builds a short-lived `helper` binary via `go build -o <name>` (which appends `.exe` on Windows) and then exec's it — but exec'd the name without `.exe`, so install failed with `exec: "...\helper\helper": executable file not found in %PATH%`. Now appends `.exe` on Windows so the build output and exec agree.

### rewrite-python: cross-platform dependency-workspace lock
`dependency_workspace.py` did a top-level `import fcntl` (POSIX-only), so the module failed to import on Windows (`No module named 'fcntl'`), breaking pip recipe install. Now uses `fcntl.flock` on POSIX and `msvcrt` byte-range locking on Windows.

### rewrite-python: honor full PEP 440 specifiers in pip install
`server.py` hardcoded the pip spec as `name==version`, limiting installs to exact/latest. Now accepts any PEP 440 comparator (`>=`, `~=`, `<`, …); a bare version still defaults to `==`. (Pairs with a moderne-cli change that parses the specifier; the moderne-cli PR will link here.)

**Verified on Windows:** go build OK; `dependency_workspace` imports (msvcrt branch active, fcntl absent); pip recipe install resolves `>=` floating, `==` exact, and latest.
