### PR TITLE
Use canonical source file type in the RPC edit-batch gate

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -37,6 +37,7 @@ import org.openrewrite.table.SourcesFileResults;
 
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.rpc.RewriteRpc;
+import org.openrewrite.rpc.DynamicDispatchRpcCodec;
 import org.openrewrite.rpc.RpcRecipe;
 import org.openrewrite.rpc.request.BatchVisit;
 import org.openrewrite.rpc.request.BatchVisitResponse;
@@ -332,7 +333,14 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                     // otherwise the BatchVisit RPC fails on the remote side and the resulting
                     // exception gets attached to the source as a Markup$Error, falsely marking
                     // the file as modified.
-                    if (currentRpc.getLanguages().contains(src.getClass().getName())) {
+                    //
+                    // Compare against the canonical source file type, not the raw class name:
+                    // lazily-loaded LSTs (e.g. the Moderne CLI's V3 format) hand the scheduler
+                    // generated subclasses of the real tree type, whose getClass().getName() is
+                    // the subclass name. getLanguages() reports canonical type names (the same
+                    // ones used as the RPC sourceFileType), so a raw name comparison never
+                    // matches for those, silently dropping every batched recipe but the last.
+                    if (currentRpc.getLanguages().contains(DynamicDispatchRpcCodec.canonicalSourceFileType(src.getClass()))) {
                         RpcRecipe rpcRecipe = (RpcRecipe) recipe;
                         // Evaluate the precondition locally before batching. The non-batch
                         // path runs the precondition via getVisitor()'s Preconditions.check
@@ -479,7 +487,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         SourceFile fetched;
         if (anyModified) {
             // Fetch final tree state from remote
-            fetched = rpc.getObject(originalBefore.getId().toString(), originalBefore.getClass().getName());
+            fetched = rpc.getObject(originalBefore.getId().toString(), DynamicDispatchRpcCodec.canonicalSourceFileType(originalBefore.getClass()));
         } else {
             fetched = source;
         }

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/rpc/CompositeBatchVisitSubclassTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/rpc/CompositeBatchVisitSubclassTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.xml.rpc;
+
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import io.moderne.jsonrpc.JsonRpc;
+import io.moderne.jsonrpc.formatter.JsonMessageFormatter;
+import io.moderne.jsonrpc.handler.HeaderDelimitedMessageHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.RecipeRun;
+import org.openrewrite.RecipeScheduler;
+import org.openrewrite.SourceFile;
+import org.openrewrite.config.CompositeRecipe;
+import org.openrewrite.config.Environment;
+import org.openrewrite.internal.InMemoryLargeSourceSet;
+import org.openrewrite.rpc.RewriteRpc;
+import org.openrewrite.xml.XmlParser;
+import org.openrewrite.xml.tree.Xml;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.marketplace.RecipeBundle.runtimeClasspath;
+
+/**
+ * Regression test for the RPC edit-phase {@code BatchVisit} batching: when a composite
+ * runs several same-RPC recipes against a source file whose runtime class is a
+ * <em>subclass</em> of the canonical tree type (as produced by lazily-loaded LSTs such as
+ * the Moderne CLI's V3 format), every batched recipe but the last was silently skipped.
+ * <p>
+ * The cause was {@code RecipeRunCycle} keying off the raw {@code src.getClass().getName()}
+ * (the subclass name) instead of {@link org.openrewrite.rpc.DynamicDispatchRpcCodec#canonicalSourceFileType}.
+ * {@code getLanguages()} advertises canonical type names, so the batch language gate never
+ * matched for subclasses and the batch was abandoned; only the trailing recipe (which falls
+ * through to the non-batch path) ran.
+ */
+class CompositeBatchVisitSubclassTest {
+
+    RewriteRpc server;
+    RewriteRpc client;
+
+    /**
+     * A non-final {@link SourceFile} subtype whose runtime class name is not the canonical
+     * type registered with the codec — mirrors a lazily-deserialized LST proxy.
+     */
+    static class LazyXmlDocument extends Xml.Document {
+        LazyXmlDocument(Xml.Document d) {
+            super(d.getId(), d.getSourcePath(), "", d.getMarkers(), null, d.isCharsetBomMarked(),
+                    d.getChecksum(), d.getFileAttributes(), d.getProlog(), d.getRoot(), d.getEof());
+        }
+    }
+
+    @BeforeEach
+    void before() throws IOException {
+        var serverOut = new PipedOutputStream();
+        var clientOut = new PipedOutputStream();
+        var serverIn = new PipedInputStream(clientOut);
+        var clientIn = new PipedInputStream(serverOut);
+
+        Environment env = Environment.builder().build();
+
+        var serverFormatter = new JsonMessageFormatter(new ParameterNamesModule());
+        var clientFormatter = new JsonMessageFormatter(new ParameterNamesModule());
+
+        client = new RewriteRpc(new JsonRpc(new HeaderDelimitedMessageHandler(clientFormatter, clientIn, clientOut)), env.toMarketplace(runtimeClasspath()))
+          .batchSize(1);
+        server = new RewriteRpc(new JsonRpc(new HeaderDelimitedMessageHandler(serverFormatter, serverIn, serverOut)), env.toMarketplace(runtimeClasspath()))
+          .batchSize(1);
+    }
+
+    @AfterEach
+    void after() {
+        client.shutdown();
+        server.shutdown();
+    }
+
+    @Test
+    void allBatchedRecipesRunWhenSourceIsCanonicalTypeSubclass() {
+        Xml.Document parsed = (Xml.Document) XmlParser.builder().build()
+          .parse("<root attr=\"oldA\">\n    <child>oldV</child>\n</root>\n")
+          .findFirst()
+          .orElseThrow();
+        // Hand the scheduler a subclass instance, so getClass().getName() != canonical type.
+        Xml.Document subclass = new LazyXmlDocument(parsed);
+
+        // Two consecutive same-RPC recipes that edit different parts of the document.
+        Recipe changeChild = client.prepareRecipe("org.openrewrite.xml.ChangeTagValue",
+          Map.of("elementName", "/root/child", "oldValue", "oldV", "newValue", "newV"));
+        Recipe changeAttr = client.prepareRecipe("org.openrewrite.xml.ChangeTagAttribute",
+          Map.of("elementName", "root", "attributeName", "attr", "oldValue", "oldA", "newValue", "newA"));
+
+        var ctx = new InMemoryExecutionContext(t -> {
+            throw new IllegalStateException(t);
+        });
+        RecipeRun run = new RecipeScheduler().scheduleRun(
+          new CompositeRecipe(List.of(changeChild, changeAttr)),
+          new InMemoryLargeSourceSet(List.of(subclass)), ctx, 2, 1);
+
+        SourceFile after = run.getChangeset().getAllResults().get(0).getAfter();
+        String printed = after.printAll();
+
+        // The trailing recipe always ran (even with the bug).
+        assertThat(printed).as("trailing batched recipe").contains("attr=\"newA\"");
+        // The non-trailing recipe must also run — this is what the bug skipped.
+        assertThat(printed).as("non-trailing batched recipe").contains("<child>newV</child>");
+    }
+}


### PR DESCRIPTION
## What's changed

`RecipeRunCycle`'s edit-phase `BatchVisit` optimization keyed off the raw `src.getClass().getName()` in two places:

1. the language gate that decides whether a source file can be batched — `currentRpc.getLanguages().contains(src.getClass().getName())`; and
2. `flushBatch`'s `rpc.getObject(id, originalBefore.getClass().getName())` that fetches the batched result.

Both now use `DynamicDispatchRpcCodec.canonicalSourceFileType(...)` instead.

## Why

`getLanguages()` advertises **canonical**, codec-registered type names (e.g. `org.openrewrite.xml.tree.Xml$Document`), and every other RPC `sourceFileType` is derived via `DynamicDispatchRpcCodec.canonicalSourceFileType(...)`.

- the batch language gate failed for every such source, and
- because a recipe that is "in a batch" but fails the gate returns without falling through to the non-batch path, **every batched recipe but the last was silently skipped** (the trailing recipe has no next recipe, so it isn't batched and runs via the non-batch path).

The net effect: a multi-recipe composite of same-RPC recipes (e.g. a language migration) applied only its last sub-recipe when run against a lazily-loaded LST. Recipes ran correctly standalone and in-process (`InMemoryLargeSourceSet`, where sources are the real type), which masked the issue.

`DynamicDispatchRpcCodec.canonicalSourceFileType` already walks a subclass up to its registered supertype (see `SubclassCodecDispatchTest`), so using it here makes the gate and the result fetch agree with the rest of the RPC pipeline.

## Test plan

- New `CompositeBatchVisitSubclassTest` (rewrite-xml) runs a two-recipe composite (`ChangeTagValue` + `ChangeTagAttribute`) over an RPC peer against a `LazyXmlDocument` (a subclass of `Xml.Document`, mirroring a lazy LST proxy), and asserts **both** recipes applied.
- Verified the test **fails without** this change (only the trailing recipe runs — the child tag keeps its old value) and **passes with** it.
- `./gradlew :rewrite-xml:test --tests "org.openrewrite.xml.rpc.CompositeBatchVisitSubclassTest"` green.
