### PR TITLE
Python: accept a caller-provisioned dependency path for `ty` type attribution

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/ty_client.py
+++ b/rewrite-python/rewrite/src/rewrite/python/ty_client.py
@@ -47,11 +47,25 @@ class TyTypesClient:
             result = client.get_types("/path/to/file.py")
     """
 
-    def __init__(self):
+    def __init__(self, virtual_env: Optional[str] = None):
+        """Create a client and start the ``ty-types --serve`` subprocess.
+
+        Args:
+            virtual_env: Optional path to a virtual environment whose
+                ``site-packages`` ty-types should use to resolve the project's
+                third-party dependencies. When provided it is exported as
+                ``VIRTUAL_ENV`` to the subprocess and takes precedence over the
+                running interpreter's ``sys.prefix`` fallback. The normal parse
+                path uses this to point ty-types at a dependency workspace built
+                from the project's ``pyproject.toml`` so that supertypes reaching
+                into installed dependencies (e.g. ``class User(BaseModel)``)
+                resolve.
+        """
         self._process: Optional[subprocess.Popen] = None
         self._request_id: int = 0
         self._initialized = False
         self._project_root: Optional[str] = None
+        self._virtual_env: Optional[str] = str(virtual_env) if virtual_env else None
 
         self._start_process()
 
@@ -76,7 +90,7 @@ class TyTypesClient:
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                env=self._subprocess_env(),
+                env=self._subprocess_env(virtual_env=self._virtual_env),
             )
         except FileNotFoundError:
             self._process = None
@@ -87,32 +101,51 @@ class TyTypesClient:
     @staticmethod
     def _subprocess_env(base_env: Optional[Dict[str, str]] = None,
                         prefix: Optional[str] = None,
-                        base_prefix: Optional[str] = None) -> Dict[str, str]:
+                        base_prefix: Optional[str] = None,
+                        virtual_env: Optional[str] = None) -> Dict[str, str]:
         """Build the environment for the ty-types subprocess.
 
         ty-types resolves a project's third-party packages by discovering the
-        active Python environment, primarily via ``VIRTUAL_ENV``. When the
-        interpreter running the parse is itself a virtual environment but
-        ``VIRTUAL_ENV`` is not exported — e.g. tests launched through an
-        absolute interpreter path rather than an activated venv — ty would fall
-        back to a bare environment and resolve imports like ``pydantic`` to
-        ``Unknown``. Point ty at the running interpreter's environment so those
-        imports (and the supertypes reachable through them) resolve.
+        active Python environment, primarily via ``VIRTUAL_ENV``.
 
-        An explicitly set ``VIRTUAL_ENV`` is always respected and never
-        overridden. The interpreter checks (``prefix``/``base_prefix``) are
-        injectable to keep this unit-testable.
+        Precedence:
+
+        1. An explicit ``virtual_env`` (a dependency workspace built from the
+           project's ``pyproject.toml``) is exported as ``VIRTUAL_ENV`` and wins
+           over everything else. This is the normal parse path: the interpreter
+           running the parse (e.g. the CLI's RPC server) does not have the
+           project's dependencies installed, so ty must be pointed at a venv that
+           does, otherwise imports like ``pydantic`` — and the supertypes
+           reachable through them — resolve to ``Unknown``.
+        2. Otherwise, an inherited ``VIRTUAL_ENV`` is respected.
+        3. Otherwise, when the interpreter running the parse is itself a virtual
+           environment (``prefix`` differs from ``base_prefix``) — e.g. tests
+           launched through an absolute interpreter path rather than an activated
+           venv — fall back to that interpreter's environment.
+
+        The interpreter checks (``prefix``/``base_prefix``) and ``virtual_env``
+        are injectable to keep this unit-testable.
         """
         env = dict(os.environ if base_env is None else base_env)
+
+        def _point_at(venv: str) -> None:
+            env['VIRTUAL_ENV'] = venv
+            bin_dir = os.path.join(venv, 'Scripts' if os.name == 'nt' else 'bin')
+            env['PATH'] = bin_dir + os.pathsep + env.get('PATH', '')
+
+        # 1. Explicit dependency workspace venv takes precedence, overriding any
+        #    inherited VIRTUAL_ENV (which would point at the parser's own env).
+        if virtual_env:
+            _point_at(virtual_env)
+            return env
+
         prefix = sys.prefix if prefix is None else prefix
         base_prefix = sys.base_prefix if base_prefix is None else base_prefix
 
-        # Only when we are inside a virtual environment (prefix differs from the
-        # base interpreter) and the caller hasn't already pinned an environment.
+        # 2./3. Only when the caller hasn't already pinned an environment and we
+        #       are inside a virtual environment.
         if 'VIRTUAL_ENV' not in env and prefix != base_prefix:
-            env['VIRTUAL_ENV'] = prefix
-            bin_dir = os.path.join(prefix, 'Scripts' if os.name == 'nt' else 'bin')
-            env['PATH'] = bin_dir + os.pathsep + env.get('PATH', '')
+            _point_at(prefix)
         return env
 
     @staticmethod

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -425,6 +425,12 @@ def handle_parse(params: dict) -> List[str]:
     # Absent for older clients; absent or unknown keys are silently ignored.
     options = params.get('options') or {}
     language_level = options.get('languageLevel')
+    # Path to a virtual environment with the project's dependencies installed,
+    # provisioned and forwarded by the caller (the CLI build step in production;
+    # a test/template helper in-repo). Points ty-types at the deps so supertypes
+    # reaching into third-party packages resolve (e.g. a first-party class
+    # extending pydantic.BaseModel). The handler never provisions deps itself.
+    dependency_path = params.get('dependencyPath')
     results = []
 
     # If no relativeTo provided, try to infer from absolute input paths
@@ -442,7 +448,9 @@ def handle_parse(params: dict) -> List[str]:
     tmpdir = None
     try:
         from rewrite.python.ty_client import TyTypesClient
-        ty_client = TyTypesClient()
+        # Point ty-types at the caller-provisioned dependency environment (if any)
+        # so supertypes reaching into third-party packages resolve.
+        ty_client = TyTypesClient(virtual_env=dependency_path)
         if relative_to:
             ty_client.initialize(relative_to)
         else:
@@ -505,6 +513,8 @@ def handle_parse_project(params: dict) -> List[dict]:
     # Per-request explicit override (mirror of the Parse RPC options carrier).
     options = params.get('options') or {}
     language_level = options.get('languageLevel')
+    # Caller-provisioned dependency environment for ty-types (see handle_parse).
+    dependency_path = params.get('dependencyPath')
 
     # Resolve project-level language version once for the whole walk; each
     # file may still override it via in-source signals inside parse_python_source.
@@ -516,7 +526,9 @@ def handle_parse_project(params: dict) -> List[dict]:
     ty_client = None
     try:
         from rewrite.python.ty_client import TyTypesClient
-        ty_client = TyTypesClient()
+        # Point ty-types at the caller-provisioned dependency environment (if any)
+        # so supertypes reaching into third-party packages resolve.
+        ty_client = TyTypesClient(virtual_env=dependency_path)
         ty_client.initialize(project_path)
     except (ImportError, RuntimeError):
         pass

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -2379,3 +2379,256 @@ ref = string_form
             assert result is JavaType.Primitive.String
         finally:
             _cleanup_mapping(mapping, tmpdir, client)
+
+
+def _uv_available() -> bool:
+    import shutil
+    return shutil.which('uv') is not None
+
+
+requires_uv = pytest.mark.skipif(
+    not _uv_available(),
+    reason="uv is not installed (needed to build a dependency workspace)"
+)
+
+
+class TestSubprocessEnvVirtualEnv:
+    """Unit tests for TyTypesClient._subprocess_env explicit virtual_env handling.
+
+    The normal CLI parse path resolves a project's third-party dependencies into
+    a cached workspace venv and points ty-types at it via ``virtual_env``. An
+    explicit ``virtual_env`` must win over both the running interpreter's
+    ``sys.prefix`` fallback and any inherited ``VIRTUAL_ENV``.
+    """
+
+    def test_explicit_virtual_env_is_set_and_on_path(self):
+        env = TyTypesClient._subprocess_env(
+            base_env={'PATH': '/usr/bin'},
+            virtual_env='/tmp/ws/.venv',
+        )
+        assert env['VIRTUAL_ENV'] == '/tmp/ws/.venv'
+        bin_dir = os.path.join('/tmp/ws/.venv', 'Scripts' if os.name == 'nt' else 'bin')
+        assert env['PATH'].split(os.pathsep)[0] == bin_dir
+
+    def test_explicit_virtual_env_overrides_inherited(self):
+        env = TyTypesClient._subprocess_env(
+            base_env={'PATH': '/usr/bin', 'VIRTUAL_ENV': '/inherited/.venv'},
+            virtual_env='/tmp/ws/.venv',
+        )
+        assert env['VIRTUAL_ENV'] == '/tmp/ws/.venv'
+
+    def test_explicit_virtual_env_overrides_sys_prefix_fallback(self):
+        # Even when the running interpreter looks like a venv (prefix != base),
+        # an explicit virtual_env takes precedence over the sys.prefix fallback.
+        env = TyTypesClient._subprocess_env(
+            base_env={'PATH': '/usr/bin'},
+            prefix='/some/dev/.venv',
+            base_prefix='/usr',
+            virtual_env='/tmp/ws/.venv',
+        )
+        assert env['VIRTUAL_ENV'] == '/tmp/ws/.venv'
+
+    def test_no_virtual_env_keeps_existing_sys_prefix_behavior(self):
+        env = TyTypesClient._subprocess_env(
+            base_env={'PATH': '/usr/bin'},
+            prefix='/dev/.venv',
+            base_prefix='/usr',
+        )
+        assert env['VIRTUAL_ENV'] == '/dev/.venv'
+
+
+class TestDependencyPathForwarding:
+    """The parse RPC handlers forward the caller-supplied dependency path to
+    ty-types via ``TyTypesClient(virtual_env=...)`` and do NOT provision a
+    dependency environment themselves.
+
+    Provisioning is the caller's responsibility — the CLI build step for a
+    ``mod build``, or the test/template helper in-repo — and the path is handed
+    to the handler explicitly as the ``dependencyPath`` request option. This
+    keeps the handler a pure consumer with a single injection seam, and lets
+    unit tests point ty-types at a workspace they built themselves (overriding
+    the build convention) instead of relying on an in-handler auto-build.
+    """
+
+    _captured: list = []
+
+    class _StubTyClient:
+        def __init__(self, virtual_env=None):
+            TestDependencyPathForwarding._captured.append(virtual_env)
+
+        def initialize(self, project_root):
+            return True
+
+        @property
+        def is_available(self):
+            # False so PythonTypeMapping skips real type lookups: we only care
+            # which virtual_env the handler constructed the client with.
+            return False
+
+        def get_types(self, *args, **kwargs):
+            return None
+
+        def shutdown(self):
+            pass
+
+    @pytest.fixture(autouse=True)
+    def _patch_client(self, monkeypatch):
+        import rewrite.python.ty_client as ty_mod
+        TestDependencyPathForwarding._captured = []
+        monkeypatch.setattr(ty_mod, 'TyTypesClient',
+                            TestDependencyPathForwarding._StubTyClient)
+        yield
+
+    def test_handle_parse_forwards_dependency_path(self, tmp_path):
+        from rewrite.rpc import server
+        (tmp_path / "m.py").write_text("x = 1\n")
+        server.handle_parse({
+            "inputs": [str(tmp_path / "m.py")],
+            "relativeTo": str(tmp_path),
+            "dependencyPath": "/deps/proj/.venv",
+        })
+        assert self._captured == ["/deps/proj/.venv"]
+
+    def test_handle_parse_project_forwards_dependency_path(self, tmp_path):
+        from rewrite.rpc import server
+        (tmp_path / "m.py").write_text("x = 1\n")
+        server.handle_parse_project({
+            "projectPath": str(tmp_path),
+            "dependencyPath": "/deps/proj/.venv",
+        })
+        assert self._captured == ["/deps/proj/.venv"]
+
+    def test_handle_parse_without_dependency_path_does_not_auto_provision(self, tmp_path, monkeypatch):
+        # A pyproject.toml with dependencies present must NOT trigger an
+        # in-handler dependency build when no dependencyPath is forwarded.
+        # Stub the workspace builder so that, if the handler ever reached for it,
+        # we'd capture a non-None venv (failing the assert) — without running uv.
+        import importlib
+        from rewrite.rpc import server
+        autows = tmp_path / "autows"
+        (autows / ".venv").mkdir(parents=True)
+        dw_mod = importlib.import_module("rewrite.python.template.dependency_workspace")
+        monkeypatch.setattr(
+            dw_mod.DependencyWorkspace,
+            "get_or_create_from_pyproject",
+            staticmethod(lambda content: str(autows)),
+        )
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "x"\nversion = "0"\ndependencies = ["pydantic"]\n')
+        (tmp_path / "m.py").write_text("x = 1\n")
+        server.handle_parse({
+            "inputs": [str(tmp_path / "m.py")],
+            "relativeTo": str(tmp_path),
+        })
+        assert self._captured == [None]
+
+
+@requires_ty_types_cli
+@requires_uv
+class TestExternalSupertypeResolutionInParsePath:
+    """The normal parse path must resolve first-party classes' supertypes that
+    come from installed third-party dependencies (e.g. ``class User(BaseModel)``
+    where ``BaseModel`` is ``pydantic``), even when the interpreter running the
+    parse does NOT have those dependencies installed.
+
+    This is the CLI ``mod build`` scenario: the RPC server runs on an
+    interpreter that has only ``openrewrite`` + ``ty-types`` installed (not the
+    project's deps), and the project directory has no ``.venv``. The parse path
+    must build a dependency workspace from the project's ``pyproject.toml`` so
+    ty-types can resolve ``pydantic`` and surface ``User``'s supertype.
+
+    NOTE: this test is only meaningful when ``pydantic`` is NOT importable in
+    the test interpreter; otherwise ty-types would resolve it ambiently.
+    """
+
+    _SOURCE = (
+        "from pydantic import BaseModel\n"
+        "\n"
+        "\n"
+        "class User(BaseModel):\n"
+        "    name: str\n"
+        "\n"
+        "    def field_names(self):\n"
+        "        return list(self.model_fields.keys())\n"
+    )
+    _PYPROJECT = (
+        "[project]\n"
+        'name = "tyrepro"\n'
+        'version = "0.0.0"\n'
+        'requires-python = ">=3.10"\n'
+        'dependencies = ["pydantic>=2.11"]\n'
+    )
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_pydantic_ambient(self):
+        try:
+            import pydantic  # noqa: F401
+            pytest.skip("pydantic is importable in the test interpreter; "
+                        "ty-types would resolve it ambiently, masking the fix")
+        except ImportError:
+            pass
+
+    def _dependency_venv(self):
+        # The caller (here, the test; in production, the CLI build step) builds
+        # the dependency environment and forwards its path. The handler itself
+        # never provisions.
+        from rewrite.python.template.dependency_workspace import DependencyWorkspace
+        workspace = DependencyWorkspace.get_or_create_from_pyproject(self._PYPROJECT)
+        return os.path.join(workspace, ".venv")
+
+    def _parse_project(self, tmp_path, dependency_path):
+        from rewrite.rpc import server
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "pyproject.toml").write_text(self._PYPROJECT)
+        (proj / "models.py").write_text(self._SOURCE)
+        params = {
+            "inputs": [str(proj / "models.py")],
+            "relativeTo": str(proj),
+        }
+        if dependency_path is not None:
+            params["dependencyPath"] = dependency_path
+        ids = server.handle_parse(params)
+        assert ids, "handle_parse returned no results"
+        return server.local_objects[ids[0]]
+
+    def _collect_self_types(self, cu):
+        from rewrite.java.tree import Identifier
+        collected = []
+
+        class _Collector(PythonVisitor):
+            def visit_identifier(self, ident: Identifier, p):
+                if ident.simple_name == 'self':
+                    collected.append(ident.type)
+                return super().visit_identifier(ident, p)
+
+        _Collector().visit(cu, None)
+        return collected
+
+    def test_self_receiver_is_assignable_to_basemodel(self, tmp_path):
+        from rewrite.python.type_utils import is_assignable_to
+        cu = self._parse_project(tmp_path, self._dependency_venv())
+        self_types = self._collect_self_types(cu)
+        assert self_types, "no `self` identifiers found in parsed LST"
+        assert any(
+            is_assignable_to("pydantic.main.BaseModel", t) for t in self_types
+        ), (
+            "the `self` receiver's type does not resolve as a subclass of "
+            "pydantic.main.BaseModel; the first-party class supertype was not "
+            "populated from the forwarded dependency environment"
+        )
+
+    def test_without_dependency_path_supertype_is_not_resolved(self, tmp_path):
+        # No dependency path forwarded → the handler must not provision pydantic
+        # itself, so ty-types cannot resolve the external base class and the
+        # `self` receiver does not resolve as a BaseModel subclass.
+        from rewrite.python.type_utils import is_assignable_to
+        cu = self._parse_project(tmp_path, None)
+        self_types = self._collect_self_types(cu)
+        assert self_types, "no `self` identifiers found in parsed LST"
+        assert not any(
+            is_assignable_to("pydantic.main.BaseModel", t) for t in self_types
+        ), (
+            "without a forwarded dependency path the parser must not auto-provision "
+            "pydantic, so the supertype must not resolve to BaseModel"
+        )

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProject.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProject.java
@@ -47,4 +47,16 @@ class ParseProject implements RpcRequest {
      */
     @Nullable
     Path relativeTo;
+
+    /**
+     * Optional path to a virtual environment with the project's dependencies installed.
+     * <p>
+     * The caller (e.g. a CLI build step) provisions this environment and forwards its
+     * path so the parser can point ty-types at it, allowing supertypes that reach into
+     * third-party packages to resolve (e.g. a first-party class extending
+     * {@code pydantic.BaseModel}). The parser never provisions dependencies itself.
+     * When {@code null}, parsing proceeds without dependency-backed type resolution.
+     */
+    @Nullable
+    Path dependencyPath;
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProjectOptions.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProjectOptions.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.rpc;
+
+import lombok.Builder;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Optional inputs to {@link PythonRewriteRpc#parseProject(Path, ParseProjectOptions, org.openrewrite.ExecutionContext)}.
+ * <p>
+ * Bundles the optional, independent parsing inputs into one value so the API doesn't grow a long
+ * tail of positional parameters (and adjacent same-typed arguments that are easy to transpose). Build
+ * with {@link #builder()}; every field is optional and defaults to {@code null}.
+ */
+@Value
+@Builder
+public class ParseProjectOptions {
+
+    /**
+     * Glob patterns to exclude from parsing. When {@code null}, the parser's default exclusions
+     * ({@code __pycache__}, {@code .venv}, etc.) are used.
+     */
+    @Nullable
+    List<String> exclusions;
+
+    /**
+     * Path to make source file paths relative to. When {@code null}, paths are relative to the project
+     * path. Use this when parsing a subdirectory but wanting paths relative to the repository root.
+     */
+    @Nullable
+    Path relativeTo;
+
+    /**
+     * Path to a virtual environment with the project's dependencies installed.
+     * <p>
+     * The caller (e.g. a CLI build step) provisions this environment and forwards its path so the
+     * parser can point ty-types at it, allowing supertypes that reach into third-party packages to
+     * resolve (e.g. a first-party class extending {@code pydantic.BaseModel}). The parser never
+     * provisions dependencies itself; when {@code null}, parsing proceeds without dependency-backed
+     * type resolution.
+     */
+    @Nullable
+    Path dependencyPath;
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -144,7 +144,7 @@ public class PythonRewriteRpc extends RewriteRpc {
      * @return Stream of parsed source files
      */
     public Stream<SourceFile> parseProject(Path projectPath, ExecutionContext ctx) {
-        return parseProject(projectPath, null, null, ctx);
+        return parseProject(projectPath, ParseProjectOptions.builder().build(), ctx);
     }
 
     /**
@@ -155,9 +155,13 @@ public class PythonRewriteRpc extends RewriteRpc {
      * @param exclusions  Optional glob patterns to exclude from parsing
      * @param ctx         Execution context for parsing
      * @return Stream of parsed source files
+     * @deprecated Use {@link #parseProject(Path, ParseProjectOptions, ExecutionContext)} instead.
      */
+    @Deprecated
     public Stream<SourceFile> parseProject(Path projectPath, @Nullable List<String> exclusions, ExecutionContext ctx) {
-        return parseProject(projectPath, exclusions, null, ctx);
+        return parseProject(projectPath, ParseProjectOptions.builder()
+                .exclusions(exclusions)
+                .build(), ctx);
     }
 
     /**
@@ -169,8 +173,31 @@ public class PythonRewriteRpc extends RewriteRpc {
      * @param relativeTo  Optional path to make source file paths relative to
      * @param ctx         Execution context for parsing
      * @return Stream of parsed source files
+     * @deprecated Use {@link #parseProject(Path, ParseProjectOptions, ExecutionContext)} instead.
      */
+    @Deprecated
     public Stream<SourceFile> parseProject(Path projectPath, @Nullable List<String> exclusions, @Nullable Path relativeTo, ExecutionContext ctx) {
+        return parseProject(projectPath, ParseProjectOptions.builder()
+                .exclusions(exclusions)
+                .relativeTo(relativeTo)
+                .build(), ctx);
+    }
+
+    /**
+     * Parses an entire Python project directory.
+     * Discovers and parses all relevant source files.
+     *
+     * @param projectPath Path to the project directory to parse
+     * @param options     Optional parsing inputs — exclusions, relativeTo, and the caller-provisioned
+     *                    dependency environment; see {@link ParseProjectOptions}. This is the only
+     *                    overload that accepts a {@code dependencyPath}.
+     * @param ctx         Execution context for parsing
+     * @return Stream of parsed source files
+     */
+    public Stream<SourceFile> parseProject(Path projectPath, ParseProjectOptions options, ExecutionContext ctx) {
+        @Nullable List<String> exclusions = options.getExclusions();
+        @Nullable Path relativeTo = options.getRelativeTo();
+        @Nullable Path dependencyPath = options.getDependencyPath();
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
 
         Stream<SourceFile> rpcStream = StreamSupport.stream(new Spliterator<SourceFile>() {
@@ -181,7 +208,7 @@ public class PythonRewriteRpc extends RewriteRpc {
             public boolean tryAdvance(Consumer<? super SourceFile> action) {
                 if (response == null) {
                     parsingListener.intermediateMessage("Starting project parsing: " + projectPath);
-                    response = send("ParseProject", new ParseProject(projectPath, exclusions, relativeTo), ParseProjectResponse.class);
+                    response = send("ParseProject", new ParseProject(projectPath, exclusions, relativeTo, dependencyPath), ParseProjectResponse.class);
                     parsingListener.intermediateMessage(String.format("Discovered %,d files to parse", response.size()));
                 }
 


### PR DESCRIPTION
## Motivation

ty resolves a first-party class's third-party supertypes — e.g. `class User(BaseModel)` where `BaseModel` comes from pydantic — only when the project's dependencies are discoverable. During a parse the interpreter running the RPC server has just `openrewrite` + `ty-types` installed, not the project's deps, so ty emits the base as `dynamic`, the supertype maps to `JavaType.Unknown`, the class's `_supertype` stays `None`, and receiver-type checks such as `is_assignable_to("pydantic.main.BaseModel", self.type)` never fire.

Rather than have the parser provision dependencies itself, this gives it a way to be **pointed at** an already-provisioned environment. The parser becomes a pure consumer; provisioning is the caller's responsibility — whatever orchestrates the parse and has already resolved the project's dependencies, or a test/template helper. This mirrors how the JavaScript parser resolves against an already-installed `node_modules`.

This PR is the parser-side mechanism only. No caller forwards a path yet, so behavior is unchanged on `main`; forwarding a per-project dependency environment from the parse orchestration is follow-up work.

## Example

```java
// The caller provisions a venv with the project's dependencies, then forwards it:
Path depsVenv = /* provisioned by the caller */;
rpc.parseProject(
        projectDir,
        ParseProjectOptions.builder()
                .relativeTo(repoRoot)
                .dependencyPath(depsVenv)
                .build(),
        ctx);
```

The new optional inputs are bundled into a `@Builder` value object instead of growing `parseProject` another positional parameter (two adjacent nullable `Path`s — `relativeTo`, `dependencyPath` — are easy to transpose), following the spirit of the recent `GitProvenance.CommitHistory` addition.

## Summary

- Add `ParseProjectOptions` (`exclusions`, `relativeTo`, `dependencyPath`) and `parseProject(Path, ParseProjectOptions, ExecutionContext)` — the only overload that accepts a `dependencyPath`.
- Deprecate the positional overloads that pass optional config (`exclusions` / `relativeTo`); they delegate to the new method. The no-config `parseProject(Path, ExecutionContext)` convenience is kept.
- `ParseProject` RPC request carries `dependencyPath`.
- `server.py` `handle_parse` / `handle_parse_project` read the forwarded `dependencyPath` and pass it to `TyTypesClient(virtual_env=...)`. The in-handler auto-provisioning helper (`_resolve_dependency_venv`) is removed — the handler no longer builds environments. With it gone, the dependency-workspace builder is now used only by templates and tests (a test builds the venv it forwards).

## Test plan

- [x] New `TestDependencyPathForwarding` (fast, deterministic): both handlers forward the path to `TyTypesClient`; with no `dependencyPath` no auto-provisioning occurs.
- [x] Reworked `TestExternalSupertypeResolutionInParsePath` (real ty + uv): a forwarded venv resolves the `self` receiver as a `pydantic.main.BaseModel` subclass; with no path the supertype does **not** resolve.
- [x] `tests/python`: 1532 passed, 6 skipped.
- [x] `:rewrite-python:compileJava` + `:rewrite-python:compileTestJava` clean (no internal deprecated-usage warnings).
- [x] `:rewrite-python:integTest --tests ParseProjectIntegTest` passes (refactored `parseProject` path is behavior-preserving).
- [x] One RPC bridge test (`AssignTest`) passes (serialization of the new `ParseProject` shape is intact).
