### PR TITLE
JavaScript: Add optional `files` subset to RPC `parseProject`

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/project-parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/project-parser.ts
@@ -195,6 +195,10 @@ export class ProjectParser {
      * Builds an Autodetect marker from the given source files.
      * Samples all files to detect common formatting styles.
      * Uses dynamic import to avoid circular dependencies.
+     *
+     * When {@code sourceFiles} is empty (e.g. a subset parse that doesn't include any
+     * JS/TS files to sample) the detector yields its built-in defaults rather than
+     * throwing — a less-rich marker, but a safe one.
      */
     async buildAutodetectMarker(sourceFiles: SourceFile[]): Promise<Marker> {
         // Dynamic import to break circular dependency at module load time:

--- a/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
@@ -54,7 +54,19 @@ export class ParseProject {
          * If not specified, paths are relative to projectPath.
          * Use this when parsing a subdirectory but wanting paths relative to the repository root.
          */
-        private readonly relativeTo?: string
+        private readonly relativeTo?: string,
+        /**
+         * Optional subset of files to serialize and return, identified by their source path relative to
+         * `relativeTo` (or `projectPath` when not set), normalized to forward slashes. When omitted the
+         * whole project is returned. When present the whole project is still discovered and type-checked,
+         * but only these files are serialized and returned.
+         */
+        private readonly files?: string[],
+        /**
+         * Forward-compatibility carrier for additional, as-yet-undefined parsing options. Reserved for a
+         * future optimization (e.g. true incremental re-parsing); currently ignored by the server.
+         */
+        private readonly options?: Record<string, unknown>
     ) {}
 
     static handle(
@@ -82,6 +94,31 @@ export class ParseProject {
                     const projectParser = new ProjectParser(projectPath, {exclusions});
                     const discovered = await projectParser.discoverFiles();
                     const prettierLoader = await projectParser.createPrettierLoader();
+
+                    // Optional subset of files to serialize and return. When provided, the whole project is
+                    // still discovered and (for JS/TS) type-checked so types resolve exactly as in a full
+                    // parse, but only the files in this set are returned. Entries and response sourcePaths
+                    // share the same base (relativeTo, else projectPath) and are normalized to "/". A subset
+                    // entry that discovery wouldn't have parsed simply matches nothing.
+                    const toForwardSlashes = (p: string) => p.split(/[\\/]/).join("/");
+                    const subset = request.files != null
+                        ? new Set(request.files.map(toForwardSlashes))
+                        : undefined;
+                    const inSubset = (absolutePath: string): boolean =>
+                        !subset || subset.has(toForwardSlashes(path.relative(relativeTo, absolutePath)));
+
+                    // For everything except JS/TS there is no cross-file type context, so we can restrict
+                    // discovery to the subset up front. JS/TS files are intentionally left whole here and
+                    // filtered at serialization time below (see the jsFiles block) to preserve type context.
+                    if (subset) {
+                        discovered.packageJsonFiles = discovered.packageJsonFiles.filter(inSubset);
+                        discovered.lockFiles.json = discovered.lockFiles.json.filter(inSubset);
+                        discovered.lockFiles.yaml = discovered.lockFiles.yaml.filter(inSubset);
+                        discovered.lockFiles.text = discovered.lockFiles.text.filter(inSubset);
+                        discovered.jsonFiles = discovered.jsonFiles.filter(inSubset);
+                        discovered.yamlFiles = discovered.yamlFiles.filter(inSubset);
+                        discovered.textFiles = discovered.textFiles.filter(inSubset);
+                    }
 
                     const resultItems: ParseProjectResponseItem[] = [];
                     const ctx = new ExecutionContext();
@@ -166,7 +203,54 @@ export class ParseProject {
                     }
 
                     // Parse JavaScript/TypeScript source files
-                    if (discovered.jsFiles.length > 0) {
+                    if (discovered.jsFiles.length > 0 && subset) {
+                        // Subset mode: parse the WHOLE project for type context (a single TypeScript program
+                        // over every JS/TS file), but serialize and return only the files in the subset.
+                        //
+                        // We eagerly drain the parser into an array keyed by file path so we can pick the
+                        // subset out by path. The full-project branch below relies on the parse generator
+                        // being consumed in lockstep with resultItems, which no longer holds once non-subset
+                        // files are skipped — hence the separate, eager handling here.
+                        const parser = Parsers.createParser("javascript", {ctx, relativeTo});
+                        const detection = await prettierLoader.detectPrettier();
+
+                        const parsedFiles: { sourceFile: SourceFile, filePath: string }[] = [];
+                        let fileIndex = 0;
+                        for await (const sourceFile of parser.parse(...discovered.jsFiles)) {
+                            parsedFiles.push({sourceFile, filePath: discovered.jsFiles[fileIndex++]});
+                        }
+
+                        // Without Prettier we sample parsed files to build an Autodetect marker. We've parsed
+                        // the whole project here, so the sample is still project-wide; buildAutodetectMarker
+                        // falls back to defaults if the sample is empty rather than crashing.
+                        const autodetectMarker = detection.available
+                            ? undefined
+                            : await projectParser.buildAutodetectMarker(parsedFiles.map(p => p.sourceFile));
+
+                        for (const {sourceFile, filePath} of parsedFiles) {
+                            if (!inSubset(filePath)) {
+                                continue;
+                            }
+                            const id = randomId();
+                            localObjects.set(id, async (newId: string) => {
+                                let markers = sourceFile.markers;
+                                if (detection.available) {
+                                    const prettierMarker = await prettierLoader.getConfigMarker(filePath);
+                                    if (prettierMarker) {
+                                        markers = replaceMarkerByKind(markers, prettierMarker);
+                                    }
+                                } else {
+                                    markers = replaceMarkerByKind(markers, autodetectMarker!);
+                                }
+                                return {...sourceFile, id: newId, markers};
+                            });
+                            resultItems.push({
+                                id,
+                                sourceFileType: "org.openrewrite.javascript.tree.JS$CompilationUnit", // break cycle
+                                sourcePath: path.relative(relativeTo, filePath)
+                            });
+                        }
+                    } else if (discovered.jsFiles.length > 0) {
                         const parser = Parsers.createParser("javascript", {
                             ctx,
                             relativeTo

--- a/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
@@ -56,15 +56,17 @@ export class ParseProject {
          */
         private readonly relativeTo?: string,
         /**
-         * Optional subset of files to serialize and return, identified by their source path relative to
-         * `relativeTo` (or `projectPath` when not set), normalized to forward slashes. When omitted the
-         * whole project is returned. When present the whole project is still discovered and type-checked,
-         * but only these files are serialized and returned.
+         * The incremental "changed files" channel: the subset of source files to serialize and return,
+         * relative to `relativeTo` (or `projectPath` when not set), normalized to forward slashes.
+         * Omitted/`undefined` = a full parse of the whole project. When present, the whole project is still
+         * discovered and type-checked (so types resolve as in a full parse) but only these files are
+         * returned. The caller decides full vs. incremental and escalates to a full parse when a
+         * configuration input changes; the server never auto-upgrades an incremental request to a full one.
          */
         private readonly files?: string[],
         /**
-         * Forward-compatibility carrier for additional, as-yet-undefined parsing options. Reserved for a
-         * future optimization (e.g. true incremental re-parsing); currently ignored by the server.
+         * Forward-compatibility carrier for additional, as-yet-undefined parsing options — reserved for a
+         * future stateful-session / true-incremental optimization; currently ignored by the server.
          */
         private readonly options?: Record<string, unknown>
     ) {}

--- a/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
@@ -228,7 +228,10 @@ export class ParseProject {
                             : await projectParser.buildAutodetectMarker(parsedFiles.map(p => p.sourceFile));
 
                         for (const {sourceFile, filePath} of parsedFiles) {
-                            if (!inSubset(filePath)) {
+                            // Compute the relative path once; it's both the subset-match key and the
+                            // response sourcePath. (`subset` is defined here — see the guard above.)
+                            const relativePath = path.relative(relativeTo, filePath);
+                            if (!subset.has(toForwardSlashes(relativePath))) {
                                 continue;
                             }
                             const id = randomId();
@@ -247,7 +250,7 @@ export class ParseProject {
                             resultItems.push({
                                 id,
                                 sourceFileType: "org.openrewrite.javascript.tree.JS$CompilationUnit", // break cycle
-                                sourcePath: path.relative(relativeTo, filePath)
+                                sourcePath: relativePath
                             });
                         }
                     } else if (discovered.jsFiles.length > 0) {

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
@@ -30,6 +30,7 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.javascript.JavaScriptIsoVisitor;
 import org.openrewrite.javascript.JavaScriptParser;
 import org.openrewrite.javascript.style.Autodetect;
+import org.openrewrite.javascript.tree.JS;
 import org.openrewrite.marker.Markup;
 import org.openrewrite.marketplace.RecipeBundle;
 import org.openrewrite.rpc.request.Print;
@@ -432,6 +433,83 @@ class JavaScriptRewriteRpcTest implements RewriteTest {
         assertThat(paths)
           .containsExactlyInAnyOrder("package.json", "index.js")
           .noneMatch(p -> p.contains("vendor"));
+    }
+
+    @Test
+    void parseProjectSubset(@TempDir Path projectDir) throws Exception {
+        Files.writeString(projectDir.resolve("package.json"), """
+          {"name": "test-project", "version": "1.0.0"}
+          """);
+        Files.writeString(projectDir.resolve("math.ts"), """
+          export function add(a: number, b: number): number {
+              return a + b;
+          }
+          """);
+        Files.writeString(projectDir.resolve("app.ts"), """
+          import {add} from "./math";
+          const result = add(1, 2);
+          """);
+
+        // Full parse establishes the baseline: which path app.ts gets and how add(...) resolves.
+        List<SourceFile> full = client()
+          .parseProject(projectDir, new InMemoryExecutionContext())
+          .toList();
+
+        SourceFile fullApp = full.stream()
+          .filter(sf -> sf.getSourcePath().toString().equals("app.ts"))
+          .findFirst().orElseThrow();
+        JavaType.Method fullAddType = findAddInvocationType(fullApp);
+        assertThat(fullAddType).as("add(...) should resolve to a method type in a full parse").isNotNull();
+
+        // Subset parse: ask for only app.ts. The whole project is still loaded for typing.
+        List<SourceFile> subset = client()
+          .parseProject(projectDir, ParseProjectOptions.builder()
+            .files(List.of("app.ts"))
+            .build(), new InMemoryExecutionContext())
+          .toList();
+
+        // (a) Only app.ts is returned — not package.json, not the unchanged math.ts.
+        assertThat(subset).hasSize(1);
+        SourceFile subsetApp = subset.get(0);
+        assertThat(subsetApp).isInstanceOf(JS.CompilationUnit.class);
+
+        // (b) Its sourcePath matches the full-parse path exactly.
+        assertThat(subsetApp.getSourcePath()).isEqualTo(fullApp.getSourcePath());
+
+        // (c) Types that resolve in a full parse still resolve in the subset parse — proving the whole
+        // project (math.ts) was loaded for type context even though it was not returned.
+        JavaType.Method subsetAddType = findAddInvocationType(subsetApp);
+        assertThat(subsetAddType).as("add(...) should still resolve in a subset parse").isNotNull();
+        assertThat(subsetAddType.toString()).isEqualTo(fullAddType.toString());
+    }
+
+    @Test
+    void parseProjectSubsetWithUnknownFileYieldsNothing(@TempDir Path projectDir) throws Exception {
+        Files.writeString(projectDir.resolve("index.ts"), "const x = 1;");
+
+        // A subset entry that discovery wouldn't have parsed (missing/excluded/not a source file)
+        // simply matches nothing rather than erroring.
+        List<SourceFile> subset = client()
+          .parseProject(projectDir, ParseProjectOptions.builder()
+            .files(List.of("does-not-exist.ts"))
+            .build(), new InMemoryExecutionContext())
+          .toList();
+
+        assertThat(subset).isEmpty();
+    }
+
+    private static JavaType.Method findAddInvocationType(SourceFile sf) {
+        JavaType.Method[] found = new JavaType.Method[1];
+        new JavaScriptIsoVisitor<Integer>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer p) {
+                if ("add".equals(method.getSimpleName())) {
+                    found[0] = method.getMethodType();
+                }
+                return super.visitMethodInvocation(method, p);
+            }
+        }.visit(sf, 0);
+        return found[0];
     }
 
     @Test

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -157,6 +157,27 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
      * @return Stream of parsed source files
      */
     public Stream<SourceFile> parseProject(Path projectPath, @Nullable List<String> exclusions, @Nullable Path relativeTo, ExecutionContext ctx) {
+        return parseProject(projectPath, ParseProjectOptions.builder()
+                .exclusions(exclusions)
+                .relativeTo(relativeTo)
+                .build(), ctx);
+    }
+
+    /**
+     * Parses an entire JavaScript/TypeScript project directory.
+     * Discovers and parses all relevant source files, package.json files, and lock files.
+     *
+     * @param projectPath Path to the project directory to parse
+     * @param options     Optional parsing inputs — exclusions, relativeTo, and the optional {@code files}
+     *                    subset; see {@link ParseProjectOptions}. This is the only overload that accepts a
+     *                    {@code files} subset.
+     * @param ctx         Execution context for parsing
+     * @return Stream of parsed source files
+     */
+    public Stream<SourceFile> parseProject(Path projectPath, ParseProjectOptions options, ExecutionContext ctx) {
+        @Nullable List<String> exclusions = options.getExclusions();
+        @Nullable Path relativeTo = options.getRelativeTo();
+        @Nullable List<String> files = options.getFiles();
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
         JavaScriptValidator<Integer> validator = new JavaScriptValidator<>();
 
@@ -168,7 +189,7 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
             public boolean tryAdvance(Consumer<? super SourceFile> action) {
                 if (response == null) {
                     parsingListener.intermediateMessage("Starting project parsing: " + projectPath);
-                    response = send("ParseProject", new ParseProject(projectPath, exclusions, relativeTo), ParseProjectResponse.class);
+                    response = send("ParseProject", new ParseProject(projectPath, exclusions, relativeTo, files), ParseProjectResponse.class);
                     parsingListener.intermediateMessage(String.format("Discovered %,d files to parse", response.size()));
                 }
 

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/ParseProject.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/ParseProject.java
@@ -21,6 +21,7 @@ import org.openrewrite.rpc.request.RpcRequest;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 /**
  * RPC request to parse an entire JavaScript/TypeScript project.
@@ -48,17 +49,47 @@ class ParseProject implements RpcRequest {
     @Nullable
     Path relativeTo;
 
+    /**
+     * Optional subset of files to serialize and return, identified by their source path relative to
+     * {@link #relativeTo} (or {@link #projectPath} when {@code relativeTo} is {@code null}), normalized
+     * to forward slashes.
+     * <p>
+     * When {@code null} the whole project is returned (the default, original behavior). When non-{@code null}
+     * the server still loads and type-checks the entire project for full type context, but only returns the
+     * files in this set.
+     */
+    @Nullable
+    List<String> files;
+
+    /**
+     * Forward-compatibility carrier for additional, as-yet-undefined parsing options. Frozen into the
+     * wire shape now — but unused — so that a future optimization (e.g. true incremental re-parsing) can
+     * be threaded through without a second breaking change to the request type. Always {@code null} today.
+     */
+    @Nullable
+    Map<String, Object> options;
+
     ParseProject(Path projectPath) {
-        this(projectPath, null, null);
+        this(projectPath, null, null, null, null);
     }
 
     ParseProject(Path projectPath, @Nullable List<String> exclusions) {
-        this(projectPath, exclusions, null);
+        this(projectPath, exclusions, null, null, null);
     }
 
     ParseProject(Path projectPath, @Nullable List<String> exclusions, @Nullable Path relativeTo) {
+        this(projectPath, exclusions, relativeTo, null, null);
+    }
+
+    ParseProject(Path projectPath, @Nullable List<String> exclusions, @Nullable Path relativeTo, @Nullable List<String> files) {
+        this(projectPath, exclusions, relativeTo, files, null);
+    }
+
+    ParseProject(Path projectPath, @Nullable List<String> exclusions, @Nullable Path relativeTo, @Nullable List<String> files, @Nullable Map<String, Object> options) {
         this.projectPath = projectPath;
         this.exclusions = exclusions;
         this.relativeTo = relativeTo;
+        this.files = files;
+        this.options = options;
     }
 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/ParseProject.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/ParseProject.java
@@ -50,21 +50,23 @@ class ParseProject implements RpcRequest {
     Path relativeTo;
 
     /**
-     * Optional subset of files to serialize and return, identified by their source path relative to
-     * {@link #relativeTo} (or {@link #projectPath} when {@code relativeTo} is {@code null}), normalized
-     * to forward slashes.
+     * The incremental "changed files" channel (see {@code ParseProjectOptions#files}): the subset of source
+     * files to serialize and return, relative to {@link #relativeTo} (or {@link #projectPath} when
+     * {@code relativeTo} is {@code null}), normalized to forward slashes.
      * <p>
-     * When {@code null} the whole project is returned (the default, original behavior). When non-{@code null}
-     * the server still loads and type-checks the entire project for full type context, but only returns the
-     * files in this set.
+     * {@code null} = a full parse of the whole project (the default, original behavior). Non-{@code null} =
+     * the server still loads and type-checks the entire project for full type context, but returns only this
+     * set. The caller decides full vs. incremental and escalates to a full parse on configuration-input
+     * changes; the server never auto-upgrades.
      */
     @Nullable
     List<String> files;
 
     /**
-     * Forward-compatibility carrier for additional, as-yet-undefined parsing options. Frozen into the
-     * wire shape now — but unused — so that a future optimization (e.g. true incremental re-parsing) can
-     * be threaded through without a second breaking change to the request type. Always {@code null} today.
+     * Forward-compatibility carrier for additional, as-yet-undefined parsing options — reserved, today
+     * always {@code null} and ignored by the server. Frozen into the wire shape now so a future addition
+     * (e.g. stateful-session control or true-incremental re-parsing hints) needs no second breaking change
+     * to the request type.
      */
     @Nullable
     Map<String, Object> options;

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/ParseProjectOptions.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/ParseProjectOptions.java
@@ -28,6 +28,14 @@ import java.util.List;
  * Bundles the optional, independent parsing inputs into one value so the API doesn't grow a long
  * tail of positional parameters (and adjacent same-typed arguments that are easy to transpose). Build
  * with {@link #builder()}; every field is optional and defaults to {@code null}.
+ * <p>
+ * Beyond a one-shot full parse, this is the entry point for <em>incremental re-parsing</em>: a caller
+ * (e.g. a build or IDE integration refreshing edited files) passes the changed files in {@link #files}
+ * while the project path identifies the project. Today the server re-parses the whole project
+ * statelessly and returns only the requested subset; the request shape is deliberately compatible with a
+ * future stateful session — a warm parser keyed by project path that reuses TypeScript's incremental
+ * program — so that evolution is additive and will not change this API. See {@link #files} for the
+ * full-vs-incremental and configuration-change contract.
  */
 @Value
 @Builder
@@ -48,17 +56,24 @@ public class ParseProjectOptions {
     Path relativeTo;
 
     /**
-     * Subset of files to return, identified by their source path relative to {@link #relativeTo} (or the
-     * project path when {@code relativeTo} is {@code null}), normalized to forward slashes.
+     * The incremental "changed files" channel: the subset of source files to re-parse and return,
+     * identified by their source path relative to {@link #relativeTo} (or the project path when
+     * {@code relativeTo} is {@code null}), normalized to forward slashes.
      * <p>
-     * When {@code null} the whole project is parsed and returned (the default). When non-{@code null} the
-     * parser still loads and type-checks the entire project — so types in the returned files resolve
-     * exactly as in a full parse — but only serializes and returns the files in this set. This lets a
-     * caller (e.g. a CLI doing in-session incremental re-parsing) refresh just the files that changed
-     * while still getting full type context, without paying to serialize every unchanged file.
+     * When {@code null} the whole project is parsed and returned — a <em>full</em> parse (the default, and
+     * what a caller issues on the first build or whenever a configuration input changes). When
+     * non-{@code null} the parser still loads and type-checks the entire project — so types in the returned
+     * files resolve exactly as in a full parse — but only serializes and returns the files in this set,
+     * letting a caller refresh just the files that changed without paying to serialize every unchanged file.
+     * <p>
+     * Change detection is the caller's responsibility, not the server's: on a source-file change the caller
+     * passes the changed paths here; when a <em>configuration</em> input changes (package.json, tsconfig,
+     * lock file, prettier config, …) the caller escalates to a full parse by passing {@code null}. The
+     * server never silently upgrades an incremental request to a full one.
      * <p>
      * A path that discovery wouldn't have parsed (excluded, not a source file, or missing) simply yields
-     * nothing rather than an error.
+     * nothing rather than an error. Deletions need not be listed — a deleted file is absent from discovery
+     * and so is naturally not returned.
      */
     @Nullable
     List<String> files;

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/ParseProjectOptions.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/ParseProjectOptions.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript.rpc;
+
+import lombok.Builder;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Optional inputs to {@link JavaScriptRewriteRpc#parseProject(Path, ParseProjectOptions, org.openrewrite.ExecutionContext)}.
+ * <p>
+ * Bundles the optional, independent parsing inputs into one value so the API doesn't grow a long
+ * tail of positional parameters (and adjacent same-typed arguments that are easy to transpose). Build
+ * with {@link #builder()}; every field is optional and defaults to {@code null}.
+ */
+@Value
+@Builder
+public class ParseProjectOptions {
+
+    /**
+     * Glob patterns to exclude from parsing. When {@code null}, the parser's default exclusions
+     * ({@code node_modules}, {@code dist}, etc.) are used.
+     */
+    @Nullable
+    List<String> exclusions;
+
+    /**
+     * Path to make source file paths relative to. When {@code null}, paths are relative to the project
+     * path. Use this when parsing a subdirectory but wanting paths relative to the repository root.
+     */
+    @Nullable
+    Path relativeTo;
+
+    /**
+     * Subset of files to return, identified by their source path relative to {@link #relativeTo} (or the
+     * project path when {@code relativeTo} is {@code null}), normalized to forward slashes.
+     * <p>
+     * When {@code null} the whole project is parsed and returned (the default). When non-{@code null} the
+     * parser still loads and type-checks the entire project — so types in the returned files resolve
+     * exactly as in a full parse — but only serializes and returns the files in this set. This lets a
+     * caller (e.g. a CLI doing in-session incremental re-parsing) refresh just the files that changed
+     * while still getting full type context, without paying to serialize every unchanged file.
+     * <p>
+     * A path that discovery wouldn't have parsed (excluded, not a source file, or missing) simply yields
+     * nothing rather than an error.
+     */
+    @Nullable
+    List<String> files;
+}


### PR DESCRIPTION
## Motivation

Tools that do in-session incremental re-parsing of edited source files have no good way to refresh a single changed `.ts`/`.js` file today: a changed file can only be refreshed by re-parsing the entire JS project (slow) or by falling back to a Quark placeholder (no AST at all).

This adds an optional `files` subset parameter to the JavaScript RPC `parseProject` API so a caller can re-parse only a specific set of changed files within an already-established project context. The strategy is **"load the whole project for typing, return only the subset"**: the parser still discovers and type-checks the entire project (so types in the returned subset resolve exactly as in a full parse — including ambient/global declarations that a subset-rooted program would miss), but only serializes and returns the requested files, avoiding the cost of shipping every unchanged file across the RPC boundary.

The change is fully additive and backward-compatible: when `files == null`, behavior is identical to today. The same shape will later be applied to Python/Go/C#.

## Examples

```java
// Full project parse (unchanged):
client.parseProject(projectPath, ctx);

// Re-parse only the files that changed, with full project type context:
client.parseProject(projectPath, ParseProjectOptions.builder()
        .files(List.of("src/app.ts"))
        .build(), ctx);
```

`ParseProjectOptions` follows the builder pattern introduced for `rewrite-python`'s `parseProject`; the new `files` input is builder-only (mirroring how `dependencyPath` is builder-only there). Existing positional overloads are unchanged and delegate through the builder.

## Summary

- **`ParseProjectOptions`** (new): `@Value @Builder` bundling the optional parsing inputs (`exclusions`, `relativeTo`, `files`), mirroring the rewrite-python class.
- **`ParseProject`** (wire request): added `@Nullable List<String> files` and a frozen-but-unused `@Nullable Map<String, Object> options` forward-compat carrier (so a future "true incremental" optimization needs no second wire break), plus backward-compatible constructors.
- **`JavaScriptRewriteRpc`**: new canonical `parseProject(Path, ParseProjectOptions, ExecutionContext)` overload; the existing positional overloads delegate to it.
- **`parse-project.ts`** (server): when `files` is provided, non-JS categories are restricted to the subset up front; JS/TS files are still all parsed (one TypeScript program over the whole project) and filtered only at serialization time. Subset matching compares `path.relative(relativeTo, absolutePath)` normalized to `/` against the `files` set. A `files` entry that discovery wouldn't have parsed simply yields nothing. The `options` field is ignored for now.
- **`project-parser.ts`**: documented that `buildAutodetectMarker` yields detector defaults (rather than throwing) on an empty sample.

### Path contract

`files` entries and response `sourcePath`s share the same base — relative to `relativeTo` when set, else `projectPath` — normalized to `/`.

## Test plan

- [x] New `parseProjectSubset` integration test: full parse vs `parseProject(..., files=["app.ts"], ...)` — asserts (a) only `app.ts` is returned, (b) its `sourcePath` matches the full-parse path exactly, and (c) a type that resolves in a full parse (a cross-file `add(...)` call into an unreturned `math.ts`) still resolves in the subset parse, proving the whole project was loaded for typing.
- [x] New `parseProjectSubsetWithUnknownFileYieldsNothing` test: a subset entry discovery wouldn't have parsed yields an empty result, not an error.
- [x] Existing `parseProject`, `parseProjectWithExclusions`, `parseProjectWithVariousYamlStructures`, and `javaTypeAcrossRpcBoundary` integration tests still pass (full mode, `files == null`, unregressed).
- [x] `npm run typecheck` passes; existing `test/rpc/parse-project.test.ts` Node tests pass.