### PR TITLE
Python: share the ty-types type registry across a project parse

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/ty_client.py
+++ b/rewrite-python/rewrite/src/rewrite/python/ty_client.py
@@ -67,6 +67,26 @@ class TyTypesClient:
         self._project_root: Optional[str] = None
         self._virtual_env: Optional[str] = str(virtual_env) if virtual_env else None
 
+        # Cumulative type table for the lifetime of this ``--serve`` session.
+        #
+        # ty's ``--serve`` session deduplicates type descriptors: each type is
+        # emitted in full exactly once, in the first ``getTypes`` response that
+        # references it, and later responses reference it by id only. When a
+        # whole project is parsed through one shared session (see
+        # ``handle_parse_project``), a type first seen in an earlier file (e.g.
+        # ``pydantic.BaseModel``) is therefore absent from later files'
+        # responses. Because each file builds its own per-file registry, those
+        # later files could not resolve such cross-file references — supertypes
+        # of first-party classes silently degraded to ``Unknown``.
+        #
+        # Accumulating every descriptor here, keyed by ty's session-stable type
+        # ids, lets per-file mappings fall back to the cumulative table for any
+        # id missing from their own response, restoring resolution while keeping
+        # ty's dedup performance benefit. It is reset whenever a new session
+        # starts (a fresh client, or ``initialize`` with a different root) so no
+        # state leaks across unrelated parses.
+        self.session_types: Dict[int, Dict[str, Any]] = {}
+
         self._start_process()
 
     def __enter__(self) -> TyTypesClient:
@@ -224,6 +244,9 @@ class TyTypesClient:
 
         if self._initialized:
             self.shutdown()
+            # A different project root means a brand-new ty session whose type
+            # ids start over; drop the accumulated table so ids don't collide.
+            self.session_types.clear()
             self._start_process()
 
         result = self._send_request("initialize", {"projectRoot": project_root})
@@ -246,11 +269,21 @@ class TyTypesClient:
         """
         if not self._initialized:
             return None
-        return self._send_request(
+        result = self._send_request(
             "getTypes",
             {"file": file_path, "includeDisplay": include_display},
             timeout=timeout,
         )
+        if result:
+            # Fold this response's type table into the cumulative session table.
+            # Keys are stringified ids in the JSON payload; ty keeps ids stable
+            # across the session, and each descriptor is emitted in full only on
+            # first sight, so ``setdefault`` preserves that full descriptor.
+            types = result.get('types')
+            if types:
+                for type_id_str, descriptor in types.items():
+                    self.session_types.setdefault(int(type_id_str), descriptor)
+        return result
 
     @property
     def is_available(self) -> bool:

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -159,6 +159,16 @@ class PythonTypeMapping:
         self._declaring_cycle_placeholders: Dict[int, JavaType.Class] = {}
         self._class_literal_index: Dict[str, int] = {}  # className -> classLiteral type_id
 
+        # Cumulative, session-wide type table shared by every file parsed through
+        # the same ty ``--serve`` session. ty deduplicates descriptors across a
+        # session, so a type first seen in an earlier file is omitted from later
+        # files' responses; this table restores those descriptors as a fallback
+        # (see TyTypesClient.session_types and _build_index back-fill).
+        self._session_types: Dict[int, Dict[str, Any]] = (
+            ty_client.session_types if ty_client is not None
+            and hasattr(ty_client, 'session_types') else {}
+        )
+
         # Fetch all types in one batch call
         if ty_client is not None:
             try:
@@ -261,6 +271,19 @@ class PythonTypeMapping:
                 cn = descriptor.get('className', '')
                 if cn:
                     self._class_literal_index[cn] = tid
+
+        # Back-fill descriptors that this file's response omitted because ty's
+        # shared --serve session already emitted them for an earlier file. The
+        # session table is keyed by ty's session-stable ids, so a referenced id
+        # absent from this file's registry resolves through the cumulative table.
+        # File-local descriptors take precedence (setdefault) — they are the
+        # authoritative, full descriptors for types this file is the first to see.
+        for tid, descriptor in self._session_types.items():
+            if self._type_registry.setdefault(tid, descriptor) is descriptor and \
+                    descriptor.get('kind') == 'classLiteral':
+                cn = descriptor.get('className', '')
+                if cn:
+                    self._class_literal_index.setdefault(cn, tid)
 
     def _lookup_type_id(self, node: ast.AST) -> Optional[int]:
         """Look up a node's type ID by converting AST position to byte offset.

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -2632,3 +2632,117 @@ class TestExternalSupertypeResolutionInParsePath:
             "without a forwarded dependency path the parser must not auto-provision "
             "pydantic, so the supertype must not resolve to BaseModel"
         )
+
+
+@requires_ty_types_cli
+@requires_uv
+class TestProjectParseSupertypeAcrossFiles:
+    """Multi-file project parse path, exactly as the CLI's ``mod build`` uses it.
+
+    ``mod build`` calls ``rpc.parseProject`` -> ``handle_parse_project``, which
+    parses every ``.py`` file in the project through a SINGLE shared ty-types
+    session. ty's ``--serve`` session emits each type descriptor only once per
+    session, so a type first seen in an earlier file (e.g. ``pydantic.BaseModel``)
+    is not re-sent in a later file's ``getTypes`` response. Because the parser
+    builds a fresh per-file type registry, a first-party class in any file but the
+    first loses its third-party supertype, and ``self`` stops resolving as a
+    ``BaseModel`` subclass.
+
+    Two peer model files make the failure order-independent: whichever file ty
+    processes second drops its base, so requiring BOTH to resolve fails regardless
+    of the directory walk order. This is the gap that single-file ``handle_parse``
+    tests (see ``TestExternalSupertypeResolutionInParsePath``) cannot catch,
+    because a fresh session per parse never triggers the dedup.
+    """
+
+    _PYPROJECT = (
+        "[project]\n"
+        'name = "tyrepro"\n'
+        'version = "0.0.0"\n'
+        'requires-python = ">=3.10"\n'
+        'dependencies = ["pydantic>=2.11"]\n'
+    )
+    _A = (
+        "from pydantic import BaseModel\n"
+        "\n"
+        "\n"
+        "class A(BaseModel):\n"
+        "    x: int\n"
+        "\n"
+        "    def fa(self):\n"
+        "        return self.model_fields\n"
+    )
+    _B = (
+        "from pydantic import BaseModel\n"
+        "\n"
+        "\n"
+        "class B(BaseModel):\n"
+        "    y: int\n"
+        "\n"
+        "    def fb(self):\n"
+        "        return self.model_fields\n"
+    )
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_pydantic_ambient(self):
+        try:
+            import pydantic  # noqa: F401
+            pytest.skip("pydantic is importable in the test interpreter; "
+                        "ty-types would resolve it ambiently, masking the bug")
+        except ImportError:
+            pass
+
+    def _dependency_venv(self):
+        from rewrite.python.template.dependency_workspace import DependencyWorkspace
+        workspace = DependencyWorkspace.get_or_create_from_pyproject(self._PYPROJECT)
+        return os.path.join(workspace, ".venv")
+
+    def _self_types(self, cu):
+        from rewrite.java.tree import Identifier
+        collected = []
+
+        class _Collector(PythonVisitor):
+            def visit_identifier(self, ident: Identifier, p):
+                if ident.simple_name == 'self':
+                    collected.append(ident.type)
+                return super().visit_identifier(ident, p)
+
+        _Collector().visit(cu, None)
+        return collected
+
+    def test_supertype_resolves_in_every_file_of_a_project(self, tmp_path):
+        from rewrite.rpc import server
+        from rewrite.python.type_utils import is_assignable_to
+
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "pyproject.toml").write_text(self._PYPROJECT)
+        (proj / "a.py").write_text(self._A)
+        (proj / "b.py").write_text(self._B)
+
+        items = server.handle_parse_project({
+            "projectPath": str(proj),
+            "relativeTo": str(proj),
+            "dependencyPath": self._dependency_venv(),
+        })
+        assert items, "handle_parse_project returned no results"
+
+        by_name = {}
+        for it in items:
+            obj = server.local_objects[it["id"]]
+            sp = getattr(obj, "source_path", None)
+            if sp:
+                by_name[os.path.basename(str(sp))] = obj
+
+        for fname in ("a.py", "b.py"):
+            cu = by_name.get(fname)
+            assert cu is not None, f"{fname} missing from parse results"
+            self_types = self._self_types(cu)
+            assert self_types, f"no `self` identifiers found in {fname}"
+            assert all(
+                is_assignable_to("pydantic.main.BaseModel", t) for t in self_types
+            ), (
+                f"`self` in {fname} did not resolve as a pydantic.main.BaseModel "
+                "subclass; the shared ty-types session dropped the supertype "
+                "descriptor for a file parsed after the first"
+            )


### PR DESCRIPTION
## Motivation

`rewrite-python`'s whole-project parse path (`handle_parse_project`, used by the CLI's `mod build` via `rpc.parseProject`) parses every `.py` file in a project through a **single shared ty-types `--serve` session**. ty's session **deduplicates type descriptors**: each type is emitted in full exactly once — in the first `getTypes` response that references it — and later responses reference it by id only.

But the parser builds a **fresh per-file type registry**, populated solely from that file's `getTypes` response. So any type first seen in an earlier file (e.g. `pydantic.BaseModel`) is **absent** from later files' registries, and supertypes pointing into it can't resolve. The net effect on a real multi-file repo: first-party classes in every file but the first lose their supertypes, `self` no longer resolves as a `BaseModel` subclass, and a type-aware recipe like `ReplaceModelFieldsInstanceAccess` silently does nothing across most of the project.

- This is a pre-existing latent bug, newly exposed by #7930 (the dependency-path work that made third-party supertypes resolvable in the first place). Single-file `handle_parse` does not hit it, because it creates a fresh ty session per parse, so every file is "first".

ty type ids are **stable within a session** (e.g. id 1 == `BaseModel` across all files), which is what makes a session-scoped registry sound.

## Summary

- `TyTypesClient` now accumulates every descriptor returned across all `getTypes` calls into a cumulative, session-scoped `session_types` table, keyed by ty's session-stable type ids. The table is reset when a new session starts (a fresh client, or `initialize` with a different project root) so no state leaks across unrelated parses.
- `PythonTypeMapping` references that table and, in `_build_index`, **back-fills** any descriptor missing from the current file's own response (and seeds `_class_literal_index` from the cumulative class literals). File-local descriptors take precedence, preserving the existing FQN-based dedup of `Class` objects.
- This keeps ty's dedup performance benefit (descriptors are still emitted only once per session) while restoring correct supertype resolution in every file of a project.

Alternatives considered: (a) a fresh ty session per file in `handle_parse_project` — correct but re-initializes ty per file and loses the shared-session speedup; (b) a ty `--serve` "no-dedup" mode — least control and would regress payload size. The session-scoped registry retains the performance benefit and is fully under our control.

## Test plan

- Added `TestProjectParseSupertypeAcrossFiles` to `tests/python/test_type_attribution.py`, exercising `handle_parse_project` exactly as `mod build` does. It uses two peer model files so the failure is **order-independent** (whichever file ty parses second loses its base), asserting that `self` resolves as a `pydantic.main.BaseModel` subclass in **both** files. Fails before this change (the second file drops the supertype), passes after.
- The single-file `TestExternalSupertypeResolutionInParsePath` positive/negative tests still pass.
- Full `tests/python/test_type_attribution.py` green (130 passed).
- Broader `tests/python` + `tests/recipes` suites green (1565 passed, 6 skipped).

(The new test relies on `ty-types` and `uv` being available and `pydantic` **not** being importable in the test interpreter; it skips otherwise by design.)