### PR TITLE
Go: use typeParameters in method invocations

### DIFF
--- a/rewrite-go/pkg/parser/generic_call_test.go
+++ b/rewrite-go/pkg/parser/generic_call_test.go
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// firstAssignRHS parses src and returns the RHS expression of the first
+// short variable declaration (`:=`) found in the first function body.
+func firstAssignRHS(t *testing.T, src string) java.Expression {
+	t.Helper()
+	cu, err := parser.NewGoParser().Parse("g.go", src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, rp := range cu.Statements {
+		md, ok := rp.Element.(*java.MethodDeclaration)
+		if !ok || md.Body == nil {
+			continue
+		}
+		for _, st := range md.Body.Statements {
+			if a, ok := st.Element.(*java.Assignment); ok {
+				return a.Value.Element
+			}
+		}
+	}
+	t.Fatalf("no `:=` assignment found")
+	return nil
+}
+
+// A call to a generic function with an explicit type argument — `Map[int](42)`
+// — must be modeled as a J.MethodInvocation whose callee Name is "Map", whose
+// type argument `int` is captured in TypeParameters, and whose MethodType is
+// attributed. It must NOT be modeled as a J.ArrayAccess in the Select slot with
+// an empty Name (the pre-fix behavior).
+func TestGenericFuncCallSingleTypeArg(t *testing.T) {
+	// given
+	src := "package main\n\nfunc Map[T any](x T) T {\n\treturn x\n}\n\nfunc main() {\n\tv := Map[int](42)\n\t_ = v\n}\n"
+
+	// when
+	rhs := firstAssignRHS(t, src)
+
+	// then
+	mi, ok := rhs.(*java.MethodInvocation)
+	if !ok {
+		t.Fatalf("expected RHS to be *java.MethodInvocation, got %T", rhs)
+	}
+	if mi.Select != nil {
+		t.Errorf("expected Select to be nil for a free generic function call, got %T", mi.Select.Element)
+	}
+	if mi.Name == nil || mi.Name.Name != "Map" {
+		t.Errorf("expected Name == %q, got %q", "Map", nameOrEmpty(mi.Name))
+	}
+	if mi.TypeParameters == nil {
+		t.Fatalf("expected TypeParameters to be non-nil")
+	}
+	if len(mi.TypeParameters.Elements) != 1 {
+		t.Fatalf("expected 1 type argument, got %d", len(mi.TypeParameters.Elements))
+	}
+	if id, ok := mi.TypeParameters.Elements[0].Element.(*java.Identifier); !ok || id.Name != "int" {
+		t.Errorf("expected type argument Identifier(int), got %T", mi.TypeParameters.Elements[0].Element)
+	}
+	if len(mi.Arguments.Elements) != 1 {
+		t.Errorf("expected 1 call argument, got %d", len(mi.Arguments.Elements))
+	}
+	if mi.MethodType == nil {
+		t.Errorf("expected MethodType to be attributed")
+	}
+
+	assertRoundTrip(t, src)
+}
+
+// `Pair[int, string](1, "x")` — a generic call with multiple explicit type
+// arguments — must capture both type arguments in TypeParameters.
+func TestGenericFuncCallMultipleTypeArgs(t *testing.T) {
+	// given
+	callSrc := "package main\n\nfunc Pair[A any, B any](a A, b B) {\n}\n\nfunc main() {\n\tPair[int, string](1, \"x\")\n}\n"
+
+	// when
+	ccu, err := parser.NewGoParser().Parse("g.go", callSrc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	// then
+	var mi *java.MethodInvocation
+	for _, rp := range ccu.Statements {
+		md, ok := rp.Element.(*java.MethodDeclaration)
+		if !ok || md.Body == nil || md.Name == nil || md.Name.Name != "main" {
+			continue
+		}
+		for _, st := range md.Body.Statements {
+			if m, ok := st.Element.(*java.MethodInvocation); ok {
+				mi = m
+			}
+		}
+	}
+	if mi == nil {
+		t.Fatalf("no MethodInvocation found")
+	}
+	if mi.Name == nil || mi.Name.Name != "Pair" {
+		t.Errorf("expected Name == %q, got %q", "Pair", nameOrEmpty(mi.Name))
+	}
+	if mi.TypeParameters == nil || len(mi.TypeParameters.Elements) != 2 {
+		t.Fatalf("expected 2 type arguments, got %v", mi.TypeParameters)
+	}
+	assertRoundTrip(t, callSrc)
+}
+
+// Calling a function value stored in a slice — `funcs[0]()` — is ordinary
+// indexing, NOT a generic instantiation. The Select must remain a J.ArrayAccess
+// and TypeParameters must stay nil.
+func TestFuncValueIndexCallIsNotGeneric(t *testing.T) {
+	// given
+	src := "package main\n\nfunc main() {\n\tfuncs := []func() int{}\n\tfuncs[0]()\n}\n"
+
+	// when
+	cu, err := parser.NewGoParser().Parse("g.go", src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	// then
+	var mi *java.MethodInvocation
+	for _, rp := range cu.Statements {
+		md, ok := rp.Element.(*java.MethodDeclaration)
+		if !ok || md.Body == nil {
+			continue
+		}
+		for _, st := range md.Body.Statements {
+			if m, ok := st.Element.(*java.MethodInvocation); ok {
+				mi = m
+			}
+		}
+	}
+	if mi == nil {
+		t.Fatalf("no MethodInvocation found")
+	}
+	if mi.TypeParameters != nil {
+		t.Errorf("expected TypeParameters to be nil for func-value index call")
+	}
+	if mi.Select == nil {
+		t.Fatalf("expected Select to be present")
+	}
+	if _, ok := mi.Select.Element.(*java.ArrayAccess); !ok {
+		t.Errorf("expected Select to be *java.ArrayAccess, got %T", mi.Select.Element)
+	}
+	assertRoundTrip(t, src)
+}
+
+func nameOrEmpty(id *java.Identifier) string {
+	if id == nil {
+		return ""
+	}
+	return id.Name
+}

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -128,6 +128,10 @@ func (gp *GoParser) ParsePackage(files []FileInput) ([]*golang.CompilationUnit, 
 		Defs:       make(map[*ast.Ident]types.Object),
 		Uses:       make(map[*ast.Ident]types.Object),
 		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		// Instances records identifiers denoting generic functions/types that are
+		// instantiated with explicit type arguments, e.g. the `Map` in `Map[int]`.
+		// Used to distinguish generic instantiation from ordinary indexing.
+		Instances: make(map[*ast.Ident]types.Instance),
 	}
 	conf := types.Config{
 		Importer: gp.Importer,
@@ -1847,7 +1851,33 @@ func (ctx *parseContext) mapBinaryExpr(expr *ast.BinaryExpr) java.Expression {
 
 // mapCallExpr maps a function/method call.
 func (ctx *parseContext) mapCallExpr(expr *ast.CallExpr) java.Expression {
-	fun := ctx.mapExpr(expr.Fun)
+	// `Map[int](42)` / `Pair[K, V](...)`: the callee is a generic function (or
+	// type) instantiated with explicit type arguments. Go reuses *ast.IndexExpr
+	// for both this and ordinary indexing (`funcs[0]()`), so disambiguate via the
+	// type checker's Instances set before treating `[...]` as type arguments.
+	// The callee X is mapped first, then the bracketed type args, matching the
+	// positional cursor's left-to-right order.
+	calleeAst := expr.Fun
+	var typeParams *java.Container[java.Expression]
+	var fun java.Expression
+	switch f := expr.Fun.(type) {
+	case *ast.IndexExpr:
+		if ctx.isGenericInstantiation(f.X) {
+			calleeAst = f.X
+			fun = ctx.mapExpr(f.X)
+			typeParams = ctx.mapTypeArgsSingle(f)
+		} else {
+			fun = ctx.mapExpr(expr.Fun)
+		}
+	case *ast.IndexListExpr:
+		// Multiple bracketed args are only ever a generic instantiation; `a[i, j]`
+		// is not valid Go indexing.
+		calleeAst = f.X
+		fun = ctx.mapExpr(f.X)
+		typeParams = ctx.mapTypeArgsMulti(f)
+	default:
+		fun = ctx.mapExpr(expr.Fun)
+	}
 
 	var sel *java.RightPadded[java.Expression]
 	var name *java.Identifier
@@ -1930,16 +1960,18 @@ func (ctx *parseContext) mapCallExpr(expr *ast.CallExpr) java.Expression {
 	}
 
 	mi := &java.MethodInvocation{
-		ID:        uuid.New(),
-		Prefix:    java.EmptySpace,
-		Markers:   markers,
-		Select:    sel,
-		Name:      name,
-		Arguments: java.Container[java.Expression]{Before: argsBefore, Elements: argElements},
+		ID:             uuid.New(),
+		Prefix:         java.EmptySpace,
+		Markers:        markers,
+		Select:         sel,
+		TypeParameters: typeParams,
+		Name:           name,
+		Arguments:      java.Container[java.Expression]{Before: argsBefore, Elements: argElements},
 	}
 
-	// Type attribution for method invocation
-	if selExpr, ok := expr.Fun.(*ast.SelectorExpr); ok {
+	// Type attribution for method invocation. For a generic call `Map[int](...)`
+	// calleeAst is the underlying callee (`Map`), not the IndexExpr.
+	if selExpr, ok := calleeAst.(*ast.SelectorExpr); ok {
 		if selection, ok := ctx.typeInfo.Selections[selExpr]; ok {
 			mi.MethodType = ctx.mapper.mapSelectionToMethod(selection)
 		} else if obj, ok := ctx.typeInfo.Uses[selExpr.Sel]; ok {
@@ -1948,7 +1980,7 @@ func (ctx *parseContext) mapCallExpr(expr *ast.CallExpr) java.Expression {
 				mi.MethodType = ctx.mapper.mapMethodObject(fn)
 			}
 		}
-	} else if ident, ok := expr.Fun.(*ast.Ident); ok {
+	} else if ident, ok := calleeAst.(*ast.Ident); ok {
 		if obj, ok := ctx.typeInfo.Uses[ident]; ok {
 			if fn, ok := obj.(*types.Func); ok {
 				mi.MethodType = ctx.mapper.mapMethodObject(fn)
@@ -1957,6 +1989,35 @@ func (ctx *parseContext) mapCallExpr(expr *ast.CallExpr) java.Expression {
 	}
 
 	return mi
+}
+
+// isGenericInstantiation reports whether x — the operand of an *ast.IndexExpr
+// used as a call target — denotes a generic function or type being instantiated
+// with explicit type arguments (e.g. `Map` in `Map[int](42)`), as opposed to a
+// value being indexed (e.g. `funcs` in `funcs[0]()`). It relies on the type
+// checker's Instances set, which records exactly those generic-instantiation
+// identifiers.
+func (ctx *parseContext) isGenericInstantiation(x ast.Expr) bool {
+	id := instanceIdent(x)
+	if id == nil {
+		return false
+	}
+	_, ok := ctx.typeInfo.Instances[id]
+	return ok
+}
+
+// instanceIdent returns the identifier that types.Info.Instances would key on
+// for a generic-instantiation operand: the identifier itself for a bare name
+// (`Map`), or the selector's field for a qualified name (`pkg.Map`).
+func instanceIdent(x ast.Expr) *ast.Ident {
+	switch e := x.(type) {
+	case *ast.Ident:
+		return e
+	case *ast.SelectorExpr:
+		return e.Sel
+	default:
+		return nil
+	}
 }
 
 // mapSelectorExpr maps a selector expression (e.g., pkg.Name).
@@ -2250,19 +2311,25 @@ func (ctx *parseContext) mapArrayType(expr *ast.ArrayType) java.Expression {
 // e.g. `JSONArray[string]`, producing a J.ParameterizedType.
 func (ctx *parseContext) mapParameterizedType(expr *ast.IndexExpr) java.Expression {
 	target := ctx.mapExpr(expr.X)
+	return &java.ParameterizedType{
+		ID:             uuid.New(),
+		Clazz:          target,
+		TypeParameters: ctx.mapTypeArgsSingle(expr),
+	}
+}
+
+// mapTypeArgsSingle consumes the `[T]` of a single-type-arg generic
+// instantiation and returns the type-argument container. The caller must have
+// already consumed everything up to (but not including) the `[`.
+func (ctx *parseContext) mapTypeArgsSingle(expr *ast.IndexExpr) *java.Container[java.Expression] {
 	lbrackPrefix := ctx.prefix(expr.Lbrack)
 	ctx.skip(1) // "["
 	typeArg := ctx.mapTypeExpr(expr.Index)
 	rbrackPrefix := ctx.prefix(expr.Rbrack)
 	ctx.skip(1) // "]"
-
-	return &java.ParameterizedType{
-		ID:    uuid.New(),
-		Clazz: target,
-		TypeParameters: &java.Container[java.Expression]{
-			Before:   lbrackPrefix,
-			Elements: []java.RightPadded[java.Expression]{{Element: typeArg, After: rbrackPrefix}},
-		},
+	return &java.Container[java.Expression]{
+		Before:   lbrackPrefix,
+		Elements: []java.RightPadded[java.Expression]{{Element: typeArg, After: rbrackPrefix}},
 	}
 }
 
@@ -2270,6 +2337,17 @@ func (ctx *parseContext) mapParameterizedType(expr *ast.IndexExpr) java.Expressi
 // e.g. `Store[string, any]`, producing a J.ParameterizedType.
 func (ctx *parseContext) mapParameterizedTypeMulti(expr *ast.IndexListExpr) java.Expression {
 	target := ctx.mapExpr(expr.X)
+	return &java.ParameterizedType{
+		ID:             uuid.New(),
+		Clazz:          target,
+		TypeParameters: ctx.mapTypeArgsMulti(expr),
+	}
+}
+
+// mapTypeArgsMulti consumes the `[T, U, ...]` of a multi-type-arg generic
+// instantiation and returns the type-argument container. The caller must have
+// already consumed everything up to (but not including) the `[`.
+func (ctx *parseContext) mapTypeArgsMulti(expr *ast.IndexListExpr) *java.Container[java.Expression] {
 	lbrackPrefix := ctx.prefix(expr.Lbrack)
 	ctx.skip(1) // "["
 
@@ -2290,13 +2368,9 @@ func (ctx *parseContext) mapParameterizedTypeMulti(expr *ast.IndexListExpr) java
 	}
 	ctx.skip(1) // "]"
 
-	return &java.ParameterizedType{
-		ID:    uuid.New(),
-		Clazz: target,
-		TypeParameters: &java.Container[java.Expression]{
-			Before:   lbrackPrefix,
-			Elements: elements,
-		},
+	return &java.Container[java.Expression]{
+		Before:   lbrackPrefix,
+		Elements: elements,
 	}
 }
 

--- a/rewrite-go/pkg/printer/go_printer.go
+++ b/rewrite-go/pkg/printer/go_printer.go
@@ -335,6 +335,18 @@ func (p *GoPrinter) VisitMethodInvocation(mi *java.MethodInvocation, param any) 
 	if mi.Name.Name != "" {
 		p.Visit(mi.Name, out)
 	}
+	if mi.TypeParameters != nil {
+		p.visitSpace(mi.TypeParameters.Before, out)
+		out.Append("[")
+		for i, rp := range mi.TypeParameters.Elements {
+			p.Visit(rp.Element, out)
+			p.visitSpace(rp.After, out)
+			if i < len(mi.TypeParameters.Elements)-1 {
+				out.Append(",")
+			}
+		}
+		out.Append("]")
+	}
 	p.visitSpace(mi.Arguments.Before, out)
 	out.Append("(")
 	tc := java.FindMarker[golang.TrailingComma](mi.Markers)

--- a/rewrite-go/pkg/rpc/java_receiver.go
+++ b/rewrite-go/pkg/rpc/java_receiver.go
@@ -219,8 +219,8 @@ func (r *JavaReceiver) VisitMethodInvocation(mi *java.MethodInvocation, p any) j
 	} else {
 		mi.Select = nil
 	}
-	// typeParameters (nil for Go)
-	q.Receive(nil, nil)
+	// typeParameters (explicit call-site type args; nullable container)
+	mi.TypeParameters = receivePointerContainer[java.Expression](r, q, mi.TypeParameters)
 	// name
 	mi.Name = receiveValue(q, mi.Name, func(e *java.Identifier) any { return r.Visit(e, q) })
 	// arguments

--- a/rewrite-go/pkg/rpc/java_sender.go
+++ b/rewrite-go/pkg/rpc/java_sender.go
@@ -538,8 +538,15 @@ func (s *JavaSender) VisitMethodInvocation(mi *java.MethodInvocation, p any) jav
 		}
 		return *sel
 	}, func(v any) { sendRightPadded(s, v, q) })
-	// typeParameters (nil for Go)
-	q.GetAndSend(mi, func(_ any) any { return nil }, nil)
+	// typeParameters (explicit call-site type args, e.g. `[int]` in `Map[int](42)`;
+	// nullable container — dereference so sendContainer sees a value Container)
+	q.GetAndSend(mi, func(v any) any {
+		tp := v.(*java.MethodInvocation).TypeParameters
+		if tp == nil {
+			return nil
+		}
+		return *tp
+	}, func(v any) { sendContainer(s, v, q) })
 	// name
 	q.GetAndSend(mi, func(v any) any { return v.(*java.MethodInvocation).Name },
 		func(v any) { s.Visit(v.(java.Tree), q) })

--- a/rewrite-go/pkg/tree/java/j.go
+++ b/rewrite-go/pkg/tree/java/j.go
@@ -1177,13 +1177,14 @@ func (n *FieldAccess) WithTarget(target Expression) *FieldAccess {
 
 // MethodInvocation represents a function or method call like `f(args)`.
 type MethodInvocation struct {
-	ID         uuid.UUID
-	Prefix     Space
-	Markers    Markers
-	Select     *RightPadded[Expression] // nil for free functions
-	Name       *Identifier
-	Arguments  Container[Expression]
-	MethodType *JavaTypeMethod // the method type being invoked (nullable)
+	ID             uuid.UUID
+	Prefix         Space
+	Markers        Markers
+	Select         *RightPadded[Expression] // nil for free functions
+	TypeParameters *Container[Expression]   // explicit call-site type arguments, e.g. `[int]` in `Map[int](42)`; nil otherwise
+	Name           *Identifier
+	Arguments      Container[Expression]
+	MethodType     *JavaTypeMethod // the method type being invoked (nullable)
 }
 
 func (*MethodInvocation) IsTree()       {}
@@ -1206,6 +1207,12 @@ func (n *MethodInvocation) WithMarkers(markers Markers) *MethodInvocation {
 func (n *MethodInvocation) WithName(name *Identifier) *MethodInvocation {
 	c := *n
 	c.Name = name
+	return &c
+}
+
+func (n *MethodInvocation) WithTypeParameters(typeParameters *Container[Expression]) *MethodInvocation {
+	c := *n
+	c.TypeParameters = typeParameters
 	return &c
 }
 

--- a/rewrite-go/pkg/visitor/go_visitor.go
+++ b/rewrite-go/pkg/visitor/go_visitor.go
@@ -586,6 +586,12 @@ func (v *GoVisitor) VisitMethodInvocation(mi *java.MethodInvocation, p any) java
 		mi.Select = &sel
 	}
 	mi = mi.WithName(visitAndCast[*java.Identifier](v, mi.Name, p))
+	if mi.TypeParameters != nil {
+		tp := *mi.TypeParameters
+		tp.Before = v.self().VisitSpace(tp.Before, p)
+		tp.Elements = visitRightPaddedList(v, tp.Elements, p)
+		mi.TypeParameters = &tp
+	}
 	mi.Arguments.Before = v.self().VisitSpace(mi.Arguments.Before, p)
 	mi.Arguments.Elements = visitRightPaddedList(v, mi.Arguments.Elements, p)
 	return mi

--- a/rewrite-go/test/generics_rpc_test.go
+++ b/rewrite-go/test/generics_rpc_test.go
@@ -74,6 +74,61 @@ func TestGenericFuncTypeParametersSurviveRpc(t *testing.T) {
 	}
 }
 
+// Explicit call-site type arguments — the `[int]` in `Map[int](42)` — are
+// carried on MethodInvocation.TypeParameters and must survive the RPC round-trip.
+func TestGenericCallTypeArgumentsSurviveRpc(t *testing.T) {
+	for _, tc := range []struct {
+		src   string
+		count int
+	}{
+		{"package main\n\nfunc Id[T any](x T) T {\n\treturn x\n}\n\nfunc main() {\n\t_ = Id[int](42)\n}\n", 1},
+		{"package main\n\nfunc Pair[A any, B any](a A, b B) {\n}\n\nfunc main() {\n\tPair[int, string](1, \"x\")\n}\n", 2},
+	} {
+		// given
+		cu, err := parser.NewGoParser().Parse("x.go", tc.src)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+
+		// when
+		got := rpcRoundTrip(t, cu)
+
+		// then
+		mi := findFirstCallInMain(t, got)
+		if mi.TypeParameters == nil {
+			t.Fatalf("call-site type arguments lost over RPC for %q", tc.src)
+		}
+		if len(mi.TypeParameters.Elements) != tc.count {
+			t.Errorf("expected %d type arguments, got %d for %q", tc.count, len(mi.TypeParameters.Elements), tc.src)
+		}
+		if printed := printer.Print(got); printed != tc.src {
+			t.Errorf("RPC round-trip mismatch\nexpected:\n%s\nactual:\n%s", tc.src, printed)
+		}
+	}
+}
+
+func findFirstCallInMain(t *testing.T, cu *golang.CompilationUnit) *java.MethodInvocation {
+	t.Helper()
+	for _, rp := range cu.Statements {
+		md, ok := rp.Element.(*java.MethodDeclaration)
+		if !ok || md.Body == nil || md.Name == nil || md.Name.Name != "main" {
+			continue
+		}
+		for _, st := range md.Body.Statements {
+			switch e := st.Element.(type) {
+			case *java.MethodInvocation:
+				return e
+			case *java.Assignment:
+				if mi, ok := e.Value.Element.(*java.MethodInvocation); ok {
+					return mi
+				}
+			}
+		}
+	}
+	t.Fatalf("no MethodInvocation found in main()")
+	return nil
+}
+
 func TestGenericTypeDeclTypeParametersSurviveRpc(t *testing.T) {
 	for _, src := range []string{
 		"package main\n\ntype Pair[T any] struct {\n\tFirst  T\n\tSecond T\n}\n",


### PR DESCRIPTION
## What's changed?

Changing how method invocations with type parameters in Go are parsed.
Fit them into `J.MethodDeclaration.typeParameters` like we do for other languages.

## What's your motivation?

Before they would land as awkward `ArrayAccess`, which was print-idempotent only by accident. But it didn't make sense.