### PR TITLE
Go: introduce Go.DeclarationBlock to hold blocked variable declarations

### DIFF
--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -443,19 +443,18 @@ func (ctx *parseContext) mapVarConstDecl(decl *ast.GenDecl) java.Statement {
 		})
 	}
 
-	var markerEntries []java.Marker
-	if keyword == "var" {
-		markerEntries = append(markerEntries, golang.VarKeyword{Ident: uuid.New()})
-	} else if keyword == "const" {
-		markerEntries = append(markerEntries, golang.ConstDecl{Ident: uuid.New()})
+	kind := golang.DeclVar
+	if keyword == "const" {
+		kind = golang.DeclConst
 	}
 
 	specs := &java.Container[java.Statement]{Before: lparenPrefix, Elements: elements}
-	return &java.VariableDeclarations{
+	return &golang.DeclarationBlock{
 		ID:                 uuid.New(),
 		Prefix:             prefix,
-		Markers:            java.Markers{ID: uuid.New(), Entries: markerEntries},
+		Markers:            java.Markers{ID: uuid.New()},
 		LeadingAnnotations: leadingAnns,
+		Kind:               kind,
 		Specs:              specs,
 	}
 }

--- a/rewrite-go/pkg/printer/go_printer.go
+++ b/rewrite-go/pkg/printer/go_printer.go
@@ -379,19 +379,6 @@ func (p *GoPrinter) VisitVariableDeclarations(vd *java.VariableDeclarations, par
 		}
 	}
 
-	if vd.Specs != nil {
-		// Grouped: var ( ... ) or const ( ... )
-		p.visitSpace(vd.Specs.Before, out)
-		out.Append("(")
-		for _, rp := range vd.Specs.Elements {
-			p.Visit(rp.Element, out)
-			p.visitSpace(rp.After, out)
-		}
-		out.Append(")")
-		p.afterSyntax(vd.Markers, out)
-		return vd
-	}
-
 	// Go order: keyword name[, name]... type [= value]
 	// Print variable names first (without initializers)
 	for i, v := range vd.Variables {
@@ -446,6 +433,33 @@ func (p *GoPrinter) VisitVariableDeclarations(vd *java.VariableDeclarations, par
 	}
 	p.afterSyntax(vd.Markers, out)
 	return vd
+}
+
+func (p *GoPrinter) VisitDeclarationBlock(db *golang.DeclarationBlock, param any) java.J {
+	out := param.(*PrintOutputCapture)
+	// Leading `//go:` directives, emitted before the var/const keyword.
+	for _, ann := range db.LeadingAnnotations {
+		p.visitSpace(ann.Prefix, out)
+		out.Append("//")
+		p.printDirectiveBody(ann, out)
+	}
+	p.beforeSyntax(db.Prefix, db.Markers, out)
+	if db.Kind == golang.DeclConst {
+		out.Append("const")
+	} else {
+		out.Append("var")
+	}
+	if db.Specs != nil {
+		p.visitSpace(db.Specs.Before, out)
+		out.Append("(")
+		for _, rp := range db.Specs.Elements {
+			p.Visit(rp.Element, out)
+			p.visitSpace(rp.After, out)
+		}
+		out.Append(")")
+	}
+	p.afterSyntax(db.Markers, out)
+	return db
 }
 
 func (p *GoPrinter) VisitVariableDeclarator(vd *java.VariableDeclarator, param any) java.J {

--- a/rewrite-go/pkg/rpc/go_receiver.go
+++ b/rewrite-go/pkg/rpc/go_receiver.go
@@ -398,6 +398,36 @@ func (r *GoReceiver) VisitTypeDecl(td *golang.TypeDecl, p any) java.J {
 	return td
 }
 
+func (r *GoReceiver) VisitDeclarationBlock(db *golang.DeclarationBlock, p any) java.J {
+	q := p.(*ReceiveQueue)
+	c := *db // shallow copy to avoid mutating remoteObjects baseline
+	db = &c
+	// leadingAnnotations
+	beforeAnns := make([]any, len(db.LeadingAnnotations))
+	for i, a := range db.LeadingAnnotations {
+		beforeAnns[i] = a
+	}
+	afterAnns := q.ReceiveList(beforeAnns, func(v any) any { return r.Visit(v.(java.Tree), q) })
+	if afterAnns != nil {
+		db.LeadingAnnotations = make([]*java.Annotation, 0, len(afterAnns))
+		for _, a := range afterAnns {
+			if a != nil {
+				db.LeadingAnnotations = append(db.LeadingAnnotations, a.(*java.Annotation))
+			}
+		}
+	}
+	// kind
+	kindStr := receiveScalar[string](q, "")
+	switch kindStr {
+	case "CONST":
+		db.Kind = golang.DeclConst
+	case "VAR":
+		db.Kind = golang.DeclVar
+	}
+	db.Specs = receivePointerContainer[java.Statement](r, q, db.Specs)
+	return db
+}
+
 func (r *GoReceiver) VisitMultiAssignment(ma *golang.MultiAssignment, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *ma // shallow copy to avoid mutating remoteObjects baseline

--- a/rewrite-go/pkg/rpc/go_sender.go
+++ b/rewrite-go/pkg/rpc/go_sender.go
@@ -366,6 +366,38 @@ func (s *GoSender) VisitTypeDecl(td *golang.TypeDecl, p any) java.J {
 	return td
 }
 
+func (s *GoSender) VisitDeclarationBlock(db *golang.DeclarationBlock, p any) java.J {
+	q := p.(*SendQueue)
+	// leadingAnnotations (`//go:` directives modeled as J.Annotation)
+	q.GetAndSendList(db,
+		func(v any) []any {
+			anns := v.(*golang.DeclarationBlock).LeadingAnnotations
+			result := make([]any, len(anns))
+			for i, a := range anns {
+				result[i] = a
+			}
+			return result
+		},
+		func(v any) any { return extractID(v) },
+		func(v any) { s.Visit(v.(java.Tree), q) })
+	// kind (enum name)
+	q.GetAndSend(db, func(v any) any {
+		if v.(*golang.DeclarationBlock).Kind == golang.DeclConst {
+			return "CONST"
+		}
+		return "VAR"
+	}, nil)
+	// Specs — dereference pointer so sendContainer gets a value type
+	q.GetAndSend(db, func(v any) any {
+		sp := v.(*golang.DeclarationBlock).Specs
+		if sp == nil {
+			return nil
+		}
+		return *sp
+	}, func(v any) { sendContainer(s, v, q) })
+	return db
+}
+
 func (s *GoSender) VisitMultiAssignment(ma *golang.MultiAssignment, p any) java.J {
 	q := p.(*SendQueue)
 	q.GetAndSendList(ma,

--- a/rewrite-go/pkg/rpc/value_types.go
+++ b/rewrite-go/pkg/rpc/value_types.go
@@ -50,6 +50,7 @@ func init() {
 	RegisterValueType(reflect.TypeOf((*golang.Union)(nil)), "org.openrewrite.golang.tree.Go$Union")
 	RegisterValueType(reflect.TypeOf((*golang.UnderlyingType)(nil)), "org.openrewrite.golang.tree.Go$UnderlyingType")
 	RegisterValueType(reflect.TypeOf((*golang.TypeDecl)(nil)), "org.openrewrite.golang.tree.Go$TypeDecl")
+	RegisterValueType(reflect.TypeOf((*golang.DeclarationBlock)(nil)), "org.openrewrite.golang.tree.Go$DeclarationBlock")
 	RegisterValueType(reflect.TypeOf((*golang.MultiAssignment)(nil)), "org.openrewrite.golang.tree.Go$MultiAssignment")
 	RegisterValueType(reflect.TypeOf((*golang.Return)(nil)), "org.openrewrite.golang.tree.Go$Return")
 	RegisterValueType(reflect.TypeOf((*golang.CommClause)(nil)), "org.openrewrite.golang.tree.Go$CommClause")

--- a/rewrite-go/pkg/tree/golang/go.go
+++ b/rewrite-go/pkg/tree/golang/go.go
@@ -558,6 +558,53 @@ func (n *TypeDecl) WithTypeParameters(tps *java.TypeParameters) *TypeDecl {
 	return &c
 }
 
+// DeclKind is the keyword introducing a grouped declaration block.
+type DeclKind int
+
+const (
+	DeclVar   DeclKind = iota // var ( ... )
+	DeclConst                 // const ( ... )
+)
+
+// DeclarationBlock represents a grouped (parenthesized) declaration:
+//
+//	var   ( ... )
+//	const ( ... )
+//
+// The block owns the keyword (Kind); each element of Specs is a single
+// java.VariableDeclarations carrying its own variables/type/initializer.
+// There is no Java J equivalent — grouping is Go-specific.
+type DeclarationBlock struct {
+	ID                 uuid.UUID
+	Prefix             java.Space
+	Markers            java.Markers
+	LeadingAnnotations []*java.Annotation              // `//go:` directives preceding the block
+	Kind               DeclKind                        // var or const
+	Specs              *java.Container[java.Statement] // the grouped declarations; Before = space before `(`
+}
+
+func (*DeclarationBlock) IsTree()      {}
+func (*DeclarationBlock) IsJ()         {}
+func (*DeclarationBlock) IsStatement() {}
+
+func (n *DeclarationBlock) WithPrefix(prefix java.Space) *DeclarationBlock {
+	c := *n
+	c.Prefix = prefix
+	return &c
+}
+
+func (n *DeclarationBlock) WithMarkers(markers java.Markers) *DeclarationBlock {
+	c := *n
+	c.Markers = markers
+	return &c
+}
+
+func (n *DeclarationBlock) WithLeadingAnnotations(anns []*java.Annotation) *DeclarationBlock {
+	c := *n
+	c.LeadingAnnotations = anns
+	return &c
+}
+
 // ShortVarDecl is a marker on Assignment indicating `:=` instead of `=`.
 type ShortVarDecl struct {
 	Ident uuid.UUID

--- a/rewrite-go/pkg/tree/golang/go_methods.go
+++ b/rewrite-go/pkg/tree/golang/go_methods.go
@@ -322,6 +322,18 @@ func (n *TypeDecl) WithID(id uuid.UUID) java.J {
 func (n *TypeDecl) GetPrefix() java.Space    { return n.Prefix }
 func (n *TypeDecl) GetMarkers() java.Markers { return n.Markers }
 
+func (n *DeclarationBlock) GetID() uuid.UUID { return n.ID }
+func (n *DeclarationBlock) WithID(id uuid.UUID) java.J {
+	if n.ID == id {
+		return n
+	}
+	c := *n
+	c.ID = id
+	return &c
+}
+func (n *DeclarationBlock) GetPrefix() java.Space    { return n.Prefix }
+func (n *DeclarationBlock) GetMarkers() java.Markers { return n.Markers }
+
 func (n *TypeList) GetID() uuid.UUID { return n.ID }
 func (n *TypeList) WithID(id uuid.UUID) java.J {
 	if n.ID == id {

--- a/rewrite-go/pkg/tree/java/j.go
+++ b/rewrite-go/pkg/tree/java/j.go
@@ -1210,8 +1210,8 @@ func (n *MethodInvocation) WithName(name *Identifier) *MethodInvocation {
 }
 
 // VariableDeclarations represents one or more variable declarations.
-// For grouped declarations `var ( ... )` or `const ( ... )`, Specs is non-nil and
-// Variables/TypeExpr are unused.
+// Grouped declarations `var ( ... )` / `const ( ... )` are modeled by
+// golang.DeclarationBlock, whose elements are single VariableDeclarations.
 type VariableDeclarations struct {
 	ID                 uuid.UUID
 	Prefix             Space
@@ -1220,7 +1220,6 @@ type VariableDeclarations struct {
 	TypeExpr           Expression                         // the declared type (nil if inferred)
 	Varargs            *Space                             // non-nil for variadic params (`...T`); holds prefix of `...`
 	Variables          []RightPadded[*VariableDeclarator] // the declared variables
-	Specs              *Container[Statement]              // non-nil for grouped `var ( ... )`; Before = space before `(`
 }
 
 func (*VariableDeclarations) IsTree()      {}

--- a/rewrite-go/pkg/visitor/go_visitor.go
+++ b/rewrite-go/pkg/visitor/go_visitor.go
@@ -153,6 +153,8 @@ func (v *GoVisitor) Visit(t java.Tree, p any) java.Tree {
 		return v.self().VisitMethodInvocation(n, p)
 	case *java.VariableDeclarations:
 		return v.self().VisitVariableDeclarations(n, p)
+	case *golang.DeclarationBlock:
+		return v.self().VisitDeclarationBlock(n, p)
 	case *java.VariableDeclarator:
 		return v.self().VisitVariableDeclarator(n, p)
 	case *java.Import:
@@ -292,6 +294,7 @@ type VisitorI interface {
 	VisitFieldAccess(fa *java.FieldAccess, p any) java.J
 	VisitMethodInvocation(mi *java.MethodInvocation, p any) java.J
 	VisitVariableDeclarations(vd *java.VariableDeclarations, p any) java.J
+	VisitDeclarationBlock(db *golang.DeclarationBlock, p any) java.J
 	VisitVariableDeclarator(vd *java.VariableDeclarator, p any) java.J
 	VisitImport(imp *java.Import, p any) java.J
 	VisitUnary(unary *java.Unary, p any) java.J
@@ -609,13 +612,30 @@ func (v *GoVisitor) VisitVariableDeclarations(vd *java.VariableDeclarations, p a
 		vd.TypeExpr = visitExpression(v, vd.TypeExpr, p)
 	}
 	vd.Variables = visitRightPaddedList(v, vd.Variables, p)
-	if vd.Specs != nil {
-		specs := *vd.Specs
+	return vd
+}
+
+func (v *GoVisitor) VisitDeclarationBlock(db *golang.DeclarationBlock, p any) java.J {
+	db = db.WithPrefix(v.self().VisitSpace(db.Prefix, p))
+	db = db.WithMarkers(v.visitMarkers(db.Markers, p))
+	if len(db.LeadingAnnotations) > 0 {
+		anns := make([]*java.Annotation, 0, len(db.LeadingAnnotations))
+		for _, a := range db.LeadingAnnotations {
+			visited := v.self().Visit(a, p)
+			if visited == nil {
+				continue
+			}
+			anns = append(anns, visited.(*java.Annotation))
+		}
+		db = db.WithLeadingAnnotations(anns)
+	}
+	if db.Specs != nil {
+		specs := *db.Specs
 		specs.Before = v.self().VisitSpace(specs.Before, p)
 		specs.Elements = visitRightPaddedList(v, specs.Elements, p)
-		vd.Specs = &specs
+		db.Specs = &specs
 	}
-	return vd
+	return db
 }
 
 func (v *GoVisitor) VisitVariableDeclarator(vd *java.VariableDeclarator, p any) java.J {

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangRecipeIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangRecipeIntegTest.java
@@ -114,6 +114,71 @@ class GolangRecipeIntegTest implements RewriteTest {
     }
 
     /**
+     * Renames an identifier declared inside a grouped {@code const ( ... )}
+     * block. This only works if the grouped declarations (modeled as
+     * Go.DeclarationBlock) round-trip their inner specs to the Java side —
+     * before DeclarationBlock existed the group's contents were not
+     * serialized, so a Java recipe could not see or rename {@code x}.
+     */
+    @Test
+    void renameVarInsideGroupedBlock() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new org.openrewrite.java.JavaIsoVisitor<>() {
+              @Override
+              public J.Identifier visitIdentifier(J.Identifier ident, org.openrewrite.ExecutionContext ctx) {
+                  if ("x".equals(ident.getSimpleName())) {
+                      return ident.withSimpleName("flag");
+                  }
+                  return ident;
+              }
+          })).expectedCyclesThatMakeChanges(1).cycles(1),
+          go(
+            """
+              package main
+
+              const (
+              \tx = 1
+              \ty = 2
+              )
+              """,
+            """
+              package main
+
+              const (
+              \tflag = 1
+              \ty = 2
+              )
+              """
+          )
+        );
+    }
+
+    /**
+     * Grouped {@code var ( ... )} / {@code const ( ... )} blocks survive a
+     * full Java RPC round-trip with no changes (idempotent print).
+     */
+    @Test
+    void groupedDeclarationBlockRoundTrip() {
+        rewriteRun(
+          go(
+            """
+              package main
+
+              var (
+              \ta int
+              \tb = 2
+              )
+
+              const (
+              \tc = 3
+              \td = 4
+              )
+              """
+          )
+        );
+    }
+
+    /**
      * Tests Go-native recipe execution via the full RPC Visit path.
      * The RenameXToFlag recipe has a real Go Editor() that visits identifiers.
      * This exercises: PrepareRecipe → Visit → getObjectFromJava → Go visitor →

--- a/rewrite-go/src/main/java/org/openrewrite/golang/GolangVisitor.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/GolangVisitor.java
@@ -254,6 +254,15 @@ public class GolangVisitor<P> extends JavaVisitor<P> {
         return t;
     }
 
+    public J visitDeclarationBlock(Go.DeclarationBlock declarationBlock, P p) {
+        Go.DeclarationBlock d = declarationBlock;
+        d = d.withPrefix(visitSpace(d.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        d = d.withMarkers(visitMarkers(d.getMarkers(), p));
+        d = d.withLeadingAnnotations(ListUtils.map(d.getLeadingAnnotations(), a -> visitAndCast(a, p)));
+        d = d.getPadding().withSpecs(visitContainer(d.getPadding().getSpecs(), JContainer.Location.LANGUAGE_EXTENSION, p));
+        return d;
+    }
+
     public J visitMultiAssignment(Go.MultiAssignment multiAssignment, P p) {
         Go.MultiAssignment m = multiAssignment;
         m = m.withPrefix(visitSpace(m.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangReceiver.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangReceiver.java
@@ -194,6 +194,14 @@ public class GolangReceiver extends GolangVisitor<RpcReceiveQueue> {
     }
 
     @Override
+    public J visitDeclarationBlock(Go.DeclarationBlock declarationBlock, RpcReceiveQueue q) {
+        return declarationBlock
+                .withLeadingAnnotations(q.receiveList(declarationBlock.getLeadingAnnotations(), a -> (J.Annotation) visitNonNull(a, q)))
+                .withKind(q.receiveAndGet(declarationBlock.getKind(), v -> Go.DeclKind.valueOf((String) v)))
+                .getPadding().withSpecs(q.receive(declarationBlock.getPadding().getSpecs(), el -> visitContainer(el, q)));
+    }
+
+    @Override
     public J visitMultiAssignment(Go.MultiAssignment multiAssignment, RpcReceiveQueue q) {
         return multiAssignment
                 .getPadding().withVariables(q.receiveList(multiAssignment.getPadding().getVariables(), v -> visitRightPadded(v, q)))

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangSender.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangSender.java
@@ -189,6 +189,14 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
     }
 
     @Override
+    public J visitDeclarationBlock(Go.DeclarationBlock declarationBlock, RpcSendQueue q) {
+        q.getAndSendList(declarationBlock, Go.DeclarationBlock::getLeadingAnnotations, Tree::getId, a -> visit(a, q));
+        q.getAndSend(declarationBlock, d -> d.getKind().name());
+        q.getAndSend(declarationBlock, d -> d.getPadding().getSpecs(), el -> visitContainer(el, q));
+        return declarationBlock;
+    }
+
+    @Override
     public J visitMultiAssignment(Go.MultiAssignment multiAssignment, RpcSendQueue q) {
         q.getAndSendList(multiAssignment, m -> m.getPadding().getVariables(), v -> v.getElement().getId(), v -> visitRightPadded(v, q));
         q.getAndSend(multiAssignment, m -> m.getPadding().getOperator(), el -> visitLeftPadded(el, q));

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
@@ -960,6 +960,11 @@ public interface Go extends J {
         RECV_ONLY   // <-chan T
     }
 
+    enum DeclKind {
+        VAR,    // var ( ... )
+        CONST   // const ( ... )
+    }
+
     // ---------------------------------------------------------------
     // PointerType (*T)
     // ---------------------------------------------------------------
@@ -1620,6 +1625,86 @@ public interface Go extends J {
 
             public Go.TypeDecl withSpecs(@Nullable JContainer<Statement> specs) {
                 return t.specs == specs ? t : new Go.TypeDecl(t.padding, t.id, t.prefix, t.markers, t.leadingAnnotations, t.name, t.typeParameters, t.assign, t.definition, specs);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // DeclarationBlock (var ( ... ) / const ( ... ))
+    // ---------------------------------------------------------------
+
+    @ToString
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class DeclarationBlock implements Go, Statement {
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @EqualsAndHashCode.Include
+        @With
+        @Getter
+        UUID id;
+
+        @With
+        @Getter
+        Space prefix;
+
+        @With
+        @Getter
+        Markers markers;
+
+        @With
+        @Getter
+        List<J.Annotation> leadingAnnotations;
+
+        @With
+        @Getter
+        DeclKind kind;
+
+        JContainer<Statement> specs;
+
+        public List<Statement> getSpecs() {
+            return specs.getElements();
+        }
+
+        @Override
+        public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {
+            return v.visitDeclarationBlock(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Statement getCoordinates() {
+            return new CoordinateBuilder.Statement(this);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final Go.DeclarationBlock t;
+
+            public JContainer<Statement> getSpecs() {
+                return t.specs;
+            }
+
+            public Go.DeclarationBlock withSpecs(JContainer<Statement> specs) {
+                return t.specs == specs ? t : new Go.DeclarationBlock(t.padding, t.id, t.prefix, t.markers, t.leadingAnnotations, t.kind, specs);
             }
         }
     }


### PR DESCRIPTION
## What's changed?

Add `Go.DeclarationBlock` LST element to hold a block of variable declarations.

## What's your motivation?

Before they would land into `Specs` field in `java.VariableDeclarations` which doesn't exist on Java side.