### PR TITLE
Go: clean up Go's copy of `ForEachControl` to mimic the Java one

### DIFF
--- a/rewrite-go/pkg/parser/for_range_test.go
+++ b/rewrite-go/pkg/parser/for_range_test.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// nthStatementInBody parses src and returns the n-th (0-based) statement of the
+// first top-level function's body.
+func nthStatementInBody(t *testing.T, src string, n int) java.Statement {
+	t.Helper()
+	cu, err := parser.NewGoParser().Parse("body.go", src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	fn, ok := cu.Statements[0].Element.(*java.MethodDeclaration)
+	if !ok {
+		t.Fatalf("expected first statement to be *java.MethodDeclaration, got %T", cu.Statements[0].Element)
+	}
+	if fn.Body == nil || len(fn.Body.Statements) <= n {
+		t.Fatalf("function body has fewer than %d statements", n+1)
+	}
+	return fn.Body.Statements[n].Element
+}
+
+// forEachControlOf parses src and returns the ForEachControl of the first
+// for-range loop in the first function body.
+func forEachControlOf(t *testing.T, src string) *java.ForEachControl {
+	t.Helper()
+	stmt := firstStatementInBody(t, src)
+	loop, ok := stmt.(*java.ForEachLoop)
+	if !ok {
+		t.Fatalf("expected first statement to be *java.ForEachLoop, got %T", stmt)
+	}
+	return &loop.Control
+}
+
+// A keyless `for range expr {}` has no loop target; the Variable slot holds a
+// J.Empty so the round trip stays keyless (mirroring J.ForEachLoop.Control).
+func TestForRangeKeylessUsesEmpty(t *testing.T) {
+	// given
+	src := "package main\n\nfunc f(items []int) {\n\tfor range items {\n\t}\n}\n"
+
+	// when
+	control := forEachControlOf(t, src)
+
+	// then
+	if _, ok := control.Variable.Element.(*java.Empty); !ok {
+		t.Fatalf("keyless range Variable must be *java.Empty, got %T", control.Variable.Element)
+	}
+}
+
+// `for k, v := range expr {}` carries both targets and the `:=` operator in a
+// golang.MultiAssignment, with a ShortVarDecl marker for the `:=` spelling.
+func TestForRangeTwoVarsDefineUsesMultiAssignment(t *testing.T) {
+	// given
+	src := "package main\n\nfunc f(items []int) {\n\tfor k, v := range items {\n\t\t_ = k\n\t\t_ = v\n\t}\n}\n"
+
+	// when
+	control := forEachControlOf(t, src)
+
+	// then
+	ma, ok := control.Variable.Element.(*golang.MultiAssignment)
+	if !ok {
+		t.Fatalf("range head Variable must be *golang.MultiAssignment, got %T", control.Variable.Element)
+	}
+	if len(ma.Variables) != 2 {
+		t.Fatalf("expected 2 loop targets, got %d", len(ma.Variables))
+	}
+	if java.FindMarker[golang.ShortVarDecl](ma.Markers) == nil {
+		t.Fatalf("`:=` range must carry a ShortVarDecl marker")
+	}
+}
+
+// `for k, v = range expr {}` uses `=`, so the MultiAssignment must NOT carry a
+// ShortVarDecl marker — this is the distinction the old single-variable mapping
+// dropped (it always re-emitted `:=`).
+func TestForRangeAssignHasNoShortVarDeclMarker(t *testing.T) {
+	// given
+	src := "package main\n\nfunc f(items []int) {\n\tvar k, v int\n\tfor k, v = range items {\n\t}\n\t_ = k\n\t_ = v\n}\n"
+
+	// when
+	stmt := nthStatementInBody(t, src, 1) // the for-range, after `var k, v int`
+	loop, ok := stmt.(*java.ForEachLoop)
+	if !ok {
+		t.Fatalf("expected *java.ForEachLoop, got %T", stmt)
+	}
+	ma, ok := loop.Control.Variable.Element.(*golang.MultiAssignment)
+	if !ok {
+		t.Fatalf("range head Variable must be *golang.MultiAssignment, got %T", loop.Control.Variable.Element)
+	}
+
+	// then
+	if java.FindMarker[golang.ShortVarDecl](ma.Markers) != nil {
+		t.Fatalf("`=` range must NOT carry a ShortVarDecl marker")
+	}
+}
+
+// Every for-range variant must round-trip parse → print byte-for-byte.
+func TestForRangeVariantsRoundTrip(t *testing.T) {
+	cases := []string{
+		"package main\n\nfunc f(items []int) {\n\tfor range items {\n\t}\n}\n",
+		"package main\n\nfunc f(items []int) {\n\tfor k := range items {\n\t\t_ = k\n\t}\n}\n",
+		"package main\n\nfunc f(items []int) {\n\tfor k, v := range items {\n\t\t_ = k\n\t\t_ = v\n\t}\n}\n",
+		"package main\n\nfunc f(items []int) {\n\tfor _, v := range items {\n\t\t_ = v\n\t}\n}\n",
+		"package main\n\nfunc f(items []int) {\n\tvar k, v int\n\tfor k, v = range items {\n\t}\n\t_ = k\n\t_ = v\n}\n",
+		"package main\n\nfunc f(items []int, m map[int]int) {\n\tvar v int\n\tfor m[0], v = range items {\n\t}\n\t_ = v\n}\n",
+	}
+	for _, src := range cases {
+		src := src
+		t.Run(src, func(t *testing.T) {
+			assertRoundTrip(t, src)
+		})
+	}
+}

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -1621,53 +1621,61 @@ func (ctx *parseContext) mapRangeStmt(stmt *ast.RangeStmt) *java.ForEachLoop {
 	control := java.ForEachControl{ID: uuid.New()}
 
 	if stmt.Key != nil {
-		// Has key variable
-		key := ctx.mapExpr(stmt.Key)
+		// `for [k [, v]] :=|= range expr {}` — the target list and the `:=`/`=`
+		// operator are carried by a golang.MultiAssignment (mirroring how Go's
+		// general multi-assignment is modeled), so this ForEachControl stays a
+		// faithful mirror of Java's J.ForEachLoop.Control.
+		var targets []java.RightPadded[java.Expression]
+		key := ctx.mapExpr(stmt.Key) // prefix = space after "for"
 
 		if stmt.Value != nil {
-			// for k, v := range expr {}
-			// Key.After captures comma space
+			// for k, v ...: key.After captures the space before the comma
 			commaOffset := ctx.findNext(',')
 			var keyAfter java.Space
 			if commaOffset >= 0 {
 				keyAfter = ctx.prefix(ctx.file.Pos(commaOffset))
 				ctx.skip(1) // ","
 			}
-			keyRP := java.RightPadded[java.Expression]{Element: key, After: keyAfter}
-			control.Key = &keyRP
-
-			value := ctx.mapExpr(stmt.Value)
-			// Value.After captures space before operator
-			opPrefix := ctx.prefix(stmt.TokPos)
-			valueRP := java.RightPadded[java.Expression]{Element: value, After: opPrefix}
-			control.Value = &valueRP
+			targets = append(targets, java.RightPadded[java.Expression]{Element: key, After: keyAfter})
+			value := ctx.mapExpr(stmt.Value) // prefix = space after comma
+			targets = append(targets, java.RightPadded[java.Expression]{Element: value})
 		} else {
-			// for k := range expr {} — no value
-			opPrefix := ctx.prefix(stmt.TokPos)
-			keyRP := java.RightPadded[java.Expression]{Element: key, After: opPrefix}
-			control.Key = &keyRP
+			targets = append(targets, java.RightPadded[java.Expression]{Element: key})
 		}
 
-		// Parse operator (:= or =)
-		var op java.AssignOp
-		if stmt.Tok == token.DEFINE {
-			op = java.AssignOpDefine
-		} else {
-			op = java.AssignOpEquals
-		}
+		// Operator: space before `:=`/`=`; the := vs = distinction is the
+		// ShortVarDecl marker, exactly as for general Go assignments.
+		opPrefix := ctx.prefix(stmt.TokPos)
 		ctx.skip(len(stmt.Tok.String()))
+		var markers java.Markers
+		if stmt.Tok == token.DEFINE {
+			markers = java.Markers{
+				ID:      uuid.New(),
+				Entries: []java.Marker{golang.ShortVarDecl{Ident: uuid.New()}},
+			}
+		}
 
-		// Space between operator and "range"
+		assign := &golang.MultiAssignment{
+			ID:        uuid.New(),
+			Markers:   markers,
+			Variables: targets,
+			Operator:  java.LeftPadded[java.Space]{Before: opPrefix},
+		}
+
+		// Space between operator and "range" lives on Variable.After.
 		rangePrefix := ctx.prefix(stmt.Range)
-		control.Operator = java.LeftPadded[java.AssignOp]{Before: rangePrefix, Element: op}
+		control.Variable = java.RightPadded[java.Statement]{Element: assign, After: rangePrefix}
 	} else {
-		// for range expr {} — no variable
-		control.Prefix = ctx.prefix(stmt.Range)
+		// `for range expr {}` — no loop target; J.Empty fills the Variable slot.
+		// Variable.After holds the space between "for" and "range".
+		rangePrefix := ctx.prefix(stmt.Range)
+		empty := &java.Empty{ID: uuid.New()}
+		control.Variable = java.RightPadded[java.Statement]{Element: empty, After: rangePrefix}
 	}
 	ctx.skip(len("range"))
 
-	iterable := ctx.mapExpr(stmt.X)
-	control.Iterable = iterable
+	iterable := ctx.mapExpr(stmt.X) // prefix = space after "range"
+	control.Iterable = java.RightPadded[java.Expression]{Element: iterable}
 
 	body := ctx.mapBlockStmt(stmt.Body)
 

--- a/rewrite-go/pkg/printer/go_printer.go
+++ b/rewrite-go/pkg/printer/go_printer.go
@@ -680,23 +680,13 @@ func (p *GoPrinter) VisitForEachLoop(forEach *java.ForEachLoop, param any) java.
 func (p *GoPrinter) VisitForEachControl(control *java.ForEachControl, param any) java.J {
 	out := param.(*PrintOutputCapture)
 	p.beforeSyntax(control.Prefix, control.Markers, out)
-	if control.Key != nil {
-		p.Visit(control.Key.Element, out)
-		p.visitSpace(control.Key.After, out)
-		if control.Value != nil {
-			out.Append(",")
-			p.Visit(control.Value.Element, out)
-			p.visitSpace(control.Value.After, out)
-		}
-		if control.Operator.Element == java.AssignOpDefine {
-			out.Append(":=")
-		} else {
-			out.Append("=")
-		}
-		p.visitSpace(control.Operator.Before, out)
-	}
+	// Variable prints the target list and `:=`/`=` operator (or nothing for a
+	// J.Empty keyless range); the MultiAssignment owns the operator spelling.
+	p.Visit(control.Variable.Element, out)
+	p.visitSpace(control.Variable.After, out)
 	out.Append("range")
-	p.Visit(control.Iterable, out)
+	p.Visit(control.Iterable.Element, out)
+	p.visitSpace(control.Iterable.After, out)
 	p.afterSyntax(control.Markers, out)
 	return control
 }

--- a/rewrite-go/pkg/rpc/java_receiver.go
+++ b/rewrite-go/pkg/rpc/java_receiver.go
@@ -540,32 +540,14 @@ func (r *JavaReceiver) VisitForEachControl(fc *java.ForEachControl, p any) java.
 	q := p.(*ReceiveQueue)
 	c := *fc // shallow copy to avoid mutating remoteObjects baseline
 	fc = &c
-	// key (right-padded, nullable)
-	var beforeKey any
-	if fc.Key != nil {
-		beforeKey = *fc.Key
+	// variable (right-padded Statement)
+	if result := q.Receive(fc.Variable, func(v any) any { return receiveRightPadded(r, q, v) }); result != nil {
+		fc.Variable = coerceToStatementRP(result)
 	}
-	if result := q.Receive(beforeKey, func(v any) any { return receiveRightPadded(r, q, v) }); result != nil {
-		rp := coerceToExpressionRP(result)
-		fc.Key = &rp
-	} else {
-		fc.Key = nil
+	// iterable (right-padded Expression)
+	if result := q.Receive(fc.Iterable, func(v any) any { return receiveRightPadded(r, q, v) }); result != nil {
+		fc.Iterable = coerceToExpressionRP(result)
 	}
-	// value (right-padded, nullable)
-	var beforeValue any
-	if fc.Value != nil {
-		beforeValue = *fc.Value
-	}
-	if result := q.Receive(beforeValue, func(v any) any { return receiveRightPadded(r, q, v) }); result != nil {
-		rp := coerceToExpressionRP(result)
-		fc.Value = &rp
-	} else {
-		fc.Value = nil
-	}
-	// operator (left-padded AssignOp enum)
-	fc.Operator = receiveLeftPaddedEnum(r, q, fc.Operator, parseAssignOpDefaulting)
-	// iterable
-	fc.Iterable = receiveValue(q, fc.Iterable, func(e java.Expression) any { return r.Visit(e, q) })
 	return fc
 }
 

--- a/rewrite-go/pkg/rpc/java_sender.go
+++ b/rewrite-go/pkg/rpc/java_sender.go
@@ -384,28 +384,11 @@ func (s *JavaSender) VisitForEachLoop(f *java.ForEachLoop, p any) java.J {
 
 func (s *JavaSender) VisitForEachControl(fc *java.ForEachControl, p any) java.J {
 	q := p.(*SendQueue)
-	// Go sends: key (right-padded), value (right-padded), operator (left-padded string), iterable
-	// Java GolangReceiver override reads this format
-	q.GetAndSend(fc, func(v any) any {
-		k := v.(*java.ForEachControl).Key
-		if k == nil {
-			return nil
-		}
-		return *k
-	}, func(v any) { sendRightPadded(s, v, q) })
-	q.GetAndSend(fc, func(v any) any {
-		val := v.(*java.ForEachControl).Value
-		if val == nil {
-			return nil
-		}
-		return *val
-	}, func(v any) { sendRightPadded(s, v, q) })
-	q.GetAndSend(fc, func(v any) any {
-		op := v.(*java.ForEachControl).Operator
-		return java.LeftPadded[string]{Before: op.Before, Element: op.Element.String(), Markers: op.Markers}
-	}, func(v any) { sendLeftPadded(s, v, q) })
+	// Mirrors J.ForEachLoop.Control: variable (right-padded), iterable (right-padded).
+	q.GetAndSend(fc, func(v any) any { return v.(*java.ForEachControl).Variable },
+		func(v any) { sendRightPadded(s, v, q) })
 	q.GetAndSend(fc, func(v any) any { return v.(*java.ForEachControl).Iterable },
-		func(v any) { s.Visit(v.(java.Tree), q) })
+		func(v any) { sendRightPadded(s, v, q) })
 	return fc
 }
 

--- a/rewrite-go/pkg/rpc/padding_rpc.go
+++ b/rewrite-go/pkg/rpc/padding_rpc.go
@@ -350,16 +350,6 @@ func coerceLeftPaddedIdent(lp any) java.LeftPadded[*java.Identifier] {
 	return java.LeftPadded[*java.Identifier]{Before: before, Markers: m}
 }
 
-// parseAssignOpDefaulting parses a Go assignment operator, defaulting to "=" rather
-// than crashing the recipe on an unrecognized spelling. Used as the receiveLeftPaddedEnum
-// parser for AssignOp slots.
-func parseAssignOpDefaulting(s string) java.AssignOp {
-	if op := java.ParseAssignOp(s); op != 0 {
-		return op
-	}
-	return java.AssignOpEquals
-}
-
 func leftPaddedBefore(lp any) any {
 	switch v := lp.(type) {
 	case java.LeftPadded[java.J]:
@@ -375,8 +365,6 @@ func leftPaddedBefore(lp any) any {
 	case java.LeftPadded[java.UnaryOperator]:
 		return v.Before
 	case java.LeftPadded[java.Space]:
-		return v.Before
-	case java.LeftPadded[java.AssignOp]:
 		return v.Before
 	case java.LeftPadded[string]:
 		return v.Before
@@ -403,8 +391,6 @@ func leftPaddedElement(lp any) any {
 		return v.Element
 	case java.LeftPadded[java.Space]:
 		return v.Element
-	case java.LeftPadded[java.AssignOp]:
-		return v.Element
 	case java.LeftPadded[string]:
 		return v.Element
 	case java.LeftPadded[bool]:
@@ -430,8 +416,6 @@ func leftPaddedMarkers(lp any) any {
 		return v.Markers
 	case java.LeftPadded[java.Space]:
 		return v.Markers
-	case java.LeftPadded[java.AssignOp]:
-		return v.Markers
 	case java.LeftPadded[string]:
 		return v.Markers
 	case java.LeftPadded[bool]:
@@ -444,7 +428,7 @@ func leftPaddedMarkers(lp any) any {
 // leftPaddedFromElement creates a LeftPadded with the correct generic type
 // based on the element's concrete type.
 // leftPaddedFromElement infers a LeftPadded's generic type from the element's concrete
-// type. Enum-valued slots (operators, AssignOp) do NOT come through here — they use
+// type. Enum-valued slots (operators) do NOT come through here — they use
 // receiveLeftPaddedEnum, which resolves the ambiguous wire name via a caller-supplied
 // parser — so this only handles unambiguous element kinds.
 func leftPaddedFromElement(before java.Space, elem any, markers java.Markers) any {

--- a/rewrite-go/pkg/rpc/padding_rpc_test.go
+++ b/rewrite-go/pkg/rpc/padding_rpc_test.go
@@ -128,56 +128,6 @@ func TestRawCastPanics_LeftPaddedIdentFromExpression(t *testing.T) {
 	})
 }
 
-// ----- Group 3a: ParseAssignOp recognizes Java's source-symbol spellings -----
-
-func TestParseAssignOp(t *testing.T) {
-	cases := []struct {
-		in   string
-		want java.AssignOp
-	}{
-		// Go enum names (what AssignOp.String emits)
-		{"Equals", java.AssignOpEquals},
-		{"Define", java.AssignOpDefine},
-		// Java source-symbol forms (what JavaSender ships)
-		{"=", java.AssignOpEquals},
-		{":=", java.AssignOpDefine},
-		// Unknown spelling: 0 lets the caller fall back deliberately.
-		{"<-", 0},
-		{"", 0},
-	}
-	for _, c := range cases {
-		if got := java.ParseAssignOp(c.in); got != c.want {
-			t.Errorf("ParseAssignOp(%q): want %v, got %v", c.in, c.want, got)
-		}
-	}
-}
-
-// ----- Group 3b: AssignOp slots receive via coerceLeftPaddedEnum + parseAssignOpDefaulting -----
-
-func TestCoerceLeftPaddedEnum_AssignOpFromString(t *testing.T) {
-	// The wire ships the AssignOp as a string; the parser resolves it to the enum.
-	if got := coerceLeftPaddedEnum(java.EmptySpace, ":=", java.Markers{}, parseAssignOpDefaulting); got.Element != java.AssignOpDefine {
-		t.Errorf(":= want AssignOpDefine, got %v", got.Element)
-	}
-	if got := coerceLeftPaddedEnum(java.EmptySpace, "=", java.Markers{}, parseAssignOpDefaulting); got.Element != java.AssignOpEquals {
-		t.Errorf("= want AssignOpEquals, got %v", got.Element)
-	}
-}
-
-func TestCoerceLeftPaddedEnum_AssignOpPreTypedPassThrough(t *testing.T) {
-	// already-typed enum (NO_CHANGE) passes through unchanged.
-	if got := coerceLeftPaddedEnum(java.EmptySpace, java.AssignOpDefine, java.Markers{}, parseAssignOpDefaulting); got.Element != java.AssignOpDefine {
-		t.Errorf("pass-through broke: got %v", got.Element)
-	}
-}
-
-func TestParseAssignOpDefaulting_UnknownSpellingFallsBack(t *testing.T) {
-	// Defense-in-depth: we'd rather emit a possibly-wrong = than crash the recipe.
-	if got := parseAssignOpDefaulting("<-"); got != java.AssignOpEquals {
-		t.Errorf("want fallback to AssignOpEquals, got %v", got)
-	}
-}
-
 // ----- Group 4: coerceRightPaddedTyped[T] element coercion -----
 //
 // receiveContainerTyped[T] builds Container[T] by running each received element

--- a/rewrite-go/pkg/template/comparator.go
+++ b/rewrite-go/pkg/template/comparator.go
@@ -237,13 +237,8 @@ func (c *patternComparator) matchProperties(pattern, candidate java.J) bool {
 			c.matchNode(p.Body, cand.Body)
 	case *java.ForEachControl:
 		cand := candidate.(*java.ForEachControl)
-		if !c.matchOptionalRightPaddedExpr2(p.Key, cand.Key) {
-			return false
-		}
-		if !c.matchOptionalRightPaddedExpr2(p.Value, cand.Value) {
-			return false
-		}
-		return c.matchNode(p.Iterable, cand.Iterable)
+		return c.matchNode(p.Variable.Element, cand.Variable.Element) &&
+			c.matchNode(p.Iterable.Element, cand.Iterable.Element)
 	case *java.Switch:
 		cand := candidate.(*java.Switch)
 		if !c.matchOptionalRightPaddedExpr(p.Tag, cand.Tag) {
@@ -445,10 +440,6 @@ func (c *patternComparator) matchOptionalRightPaddedExpr(pattern, candidate *jav
 		return false
 	}
 	return c.matchNode(pattern.Element, candidate.Element)
-}
-
-func (c *patternComparator) matchOptionalRightPaddedExpr2(pattern, candidate *java.RightPadded[java.Expression]) bool {
-	return c.matchOptionalRightPaddedExpr(pattern, candidate)
 }
 
 func (c *patternComparator) matchOptionalRightPaddedJ(pattern, candidate *java.RightPadded[java.J]) bool {

--- a/rewrite-go/pkg/tree/java/j.go
+++ b/rewrite-go/pkg/tree/java/j.go
@@ -751,54 +751,22 @@ func (n *ForEachLoop) WithBody(body *Block) *ForEachLoop {
 	return &c
 }
 
-// ForEachControl holds the variable and iterable of a for-range loop.
-// The "range" keyword is implicit (always present).
+// ForEachControl is a faithful mirror of Java's J.ForEachLoop.Control: it has
+// exactly the same two slots, Variable and Iterable. The "range" keyword (the
+// Go analog of Java's `:` separator) is implicit and always present.
 //
-// Structure: `for` [key] [`,` value] [`:=`|`=`] `range` iterable
-//   - Key and Value may be nil (e.g., `for range expr {}`)
-//   - When Key is non-nil, Operator contains `:=` or `=`
+// Structure: `for` [variable] `range` iterable
+//   - Variable holds the loop target(s). Keyless `for range expr {}` uses a
+//     J.Empty here. One or more targets — together with the `:=`/`=` operator —
+//     are carried by a golang.MultiAssignment (its ShortVarDecl marker encodes
+//     `:=` vs `=`); this keeps all Go-specific structure out of this mirror.
+//   - Variable.After = space before "range".
 type ForEachControl struct {
 	ID       uuid.UUID
 	Prefix   Space
 	Markers  Markers
-	Key      *RightPadded[Expression] // nil for `for range expr`; After = space after key (including comma)
-	Value    *RightPadded[Expression] // nil when no value; After = space before operator
-	Operator LeftPadded[AssignOp]     // `:=` or `=`; Before = space before operator. Unused when Key is nil
-	Iterable Expression               // expression after "range" keyword
-}
-
-// AssignOp distinguishes := from = in assignment contexts.
-type AssignOp int
-
-const (
-	AssignOpEquals AssignOp = iota + 1 // =
-	AssignOpDefine                     // :=
-)
-
-// String returns a string representation of AssignOp for RPC serialization.
-func (op AssignOp) String() string {
-	switch op {
-	case AssignOpEquals:
-		return "Equals"
-	case AssignOpDefine:
-		return "Define"
-	default:
-		return "Equals"
-	}
-}
-
-// ParseAssignOp converts a string to an AssignOp.
-// Accepts both the Go enum names emitted by AssignOp.String() ("Equals", "Define")
-// and the Java-side source-symbol spellings ("=", ":=").
-func ParseAssignOp(s string) AssignOp {
-	switch s {
-	case "Equals", "=":
-		return AssignOpEquals
-	case "Define", ":=":
-		return AssignOpDefine
-	default:
-		return 0 // Unknown
-	}
+	Variable RightPadded[Statement]  // loop target(s); J.Empty when keyless
+	Iterable RightPadded[Expression] // expression after "range" keyword
 }
 
 func (*ForEachControl) IsTree() {}

--- a/rewrite-go/pkg/visitor/go_visitor.go
+++ b/rewrite-go/pkg/visitor/go_visitor.go
@@ -760,20 +760,10 @@ func (v *GoVisitor) VisitForEachLoop(forEach *java.ForEachLoop, p any) java.J {
 func (v *GoVisitor) VisitForEachControl(control *java.ForEachControl, p any) java.J {
 	control = control.WithPrefix(v.self().VisitSpace(control.Prefix, p))
 	control = control.WithMarkers(v.visitMarkers(control.Markers, p))
-	if control.Key != nil {
-		key := *control.Key
-		key.Element = visitExpression(v, key.Element, p)
-		key.After = v.self().VisitSpace(key.After, p)
-		control.Key = &key
-	}
-	if control.Value != nil {
-		value := *control.Value
-		value.Element = visitExpression(v, value.Element, p)
-		value.After = v.self().VisitSpace(value.After, p)
-		control.Value = &value
-	}
-	control.Operator.Before = v.self().VisitSpace(control.Operator.Before, p)
-	control.Iterable = visitExpression(v, control.Iterable, p)
+	control.Variable.Element = visitAndCast[java.Statement](v, control.Variable.Element, p)
+	control.Variable.After = v.self().VisitSpace(control.Variable.After, p)
+	control.Iterable.Element = visitExpression(v, control.Iterable.Element, p)
+	control.Iterable.After = v.self().VisitSpace(control.Iterable.After, p)
 	return control
 }
 

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoRpcPrintRoundTripIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoRpcPrintRoundTripIntegTest.java
@@ -329,4 +329,85 @@ class GoRpcPrintRoundTripIntegTest {
                 "\treturn &T{Name: dst[0]}\n" +
                 "}\n");
     }
+
+    /**
+     * for-range headers carry up to two loop targets plus a {@code :=}/{@code =}
+     * operator. These live in the {@code Variable} slot of J.ForEachLoop.Control
+     * as a Go MultiAssignment (the {@code :=} vs {@code =} is a ShortVarDecl
+     * marker), so the full head must survive the wire. Before that mapping the
+     * Java side could hold only a single loop variable and always re-emitted
+     * {@code :=}, so {@code for k, v = range} came back as {@code for k := range}.
+     */
+    @Test
+    void forRangeKeylessSurvivesReset() {
+        assertPrintsUnchangedAfterReset(
+                """
+                package main
+
+                func f(items []int) {
+                \tfor range items {
+                \t}
+                }
+                """);
+    }
+
+    @Test
+    void forRangeTwoVarsDefineSurvivesReset() {
+        assertPrintsUnchangedAfterReset(
+                """
+                package main
+
+                func f(items []int) {
+                \tfor k, v := range items {
+                \t\t_ = k
+                \t\t_ = v
+                \t}
+                }
+                """);
+    }
+
+    @Test
+    void forRangeBlankKeySurvivesReset() {
+        assertPrintsUnchangedAfterReset(
+                """
+                package main
+
+                func f(items []int) {
+                \tfor _, v := range items {
+                \t\t_ = v
+                \t}
+                }
+                """);
+    }
+
+    @Test
+    void forRangeTwoVarsAssignSurvivesReset() {
+        assertPrintsUnchangedAfterReset(
+                """
+                package main
+
+                func f(items []int) {
+                \tvar k, v int
+                \tfor k, v = range items {
+                \t}
+                \t_ = k
+                \t_ = v
+                }
+                """);
+    }
+
+    @Test
+    void forRangeArbitraryLhsAssignSurvivesReset() {
+        assertPrintsUnchangedAfterReset(
+                """
+                package main
+
+                func f(items []int, m map[int]int) {
+                \tvar v int
+                \tfor m[0], v = range items {
+                \t}
+                \t_ = v
+                }
+                """);
+    }
 }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangReceiver.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangReceiver.java
@@ -324,63 +324,6 @@ public class GolangReceiver extends GolangVisitor<RpcReceiveQueue> {
         }
 
         @Override
-        public J visitForEachControl(J.ForEachLoop.Control control, RpcReceiveQueue q) {
-            // Go sends: key (right-padded), value (right-padded), operator (left-padded string), iterable
-            // Read these and construct a valid ForEachLoop.Control
-
-            // key (right-padded Expression, nullable)
-            @SuppressWarnings({"unchecked", "rawtypes"})
-            JRightPadded<Expression> key = (JRightPadded<Expression>) ((RpcReceiveQueue) q).receive(
-                    null, (java.util.function.UnaryOperator) el -> visitRightPadded((JRightPadded<?>) el, q));
-            // value (right-padded Expression, nullable)
-            @SuppressWarnings({"unchecked", "rawtypes"})
-            JRightPadded<Expression> value = (JRightPadded<Expression>) ((RpcReceiveQueue) q).receive(
-                    null, (java.util.function.UnaryOperator) el -> visitRightPadded((JRightPadded<?>) el, q));
-            // operator (left-padded string - AssignOp, skip it)
-            q.receive(null);
-            // iterable (Expression)
-            Expression iterable = q.receive(null, el -> (Expression) visitNonNull(el, q));
-            if (iterable == null) {
-                iterable = new J.Empty(Tree.randomId(), Space.EMPTY, Markers.EMPTY);
-            }
-
-            JRightPadded<Statement> varPadded;
-            if (key == null) {
-                // Keyless `for range expr` — no loop variable. Represent the
-                // absent variable with J.Empty so the round trip stays keyless
-                // instead of synthesizing a `_ :=`. GolangSender sends key=null
-                // for any non-VariableDeclarations variable.
-                @SuppressWarnings("unchecked")
-                JRightPadded<Statement> empty = (JRightPadded<Statement>) (JRightPadded<?>)
-                        JRightPadded.build(new J.Empty(Tree.randomId(), Space.EMPTY, Markers.EMPTY));
-                varPadded = empty;
-            } else {
-                // Build a synthetic VariableDeclarations to represent the key.
-                J.Identifier varName = key.getElement() instanceof J.Identifier ?
-                        (J.Identifier) key.getElement() :
-                        new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-                                Collections.emptyList(), "_", null, null);
-
-                J.VariableDeclarations.NamedVariable namedVar = new J.VariableDeclarations.NamedVariable(
-                        Tree.randomId(), varName.getPrefix(), varName.getMarkers(),
-                        varName.withPrefix(Space.EMPTY), Collections.emptyList(), null, null);
-
-                J.VariableDeclarations varDecls = new J.VariableDeclarations(
-                        Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-                        Collections.emptyList(), Collections.emptyList(), null,
-                        null, Collections.emptyList(),
-                        Collections.singletonList(JRightPadded.build(namedVar)));
-
-                @SuppressWarnings("unchecked")
-                JRightPadded<Statement> built = (JRightPadded<Statement>) (JRightPadded<?>) JRightPadded.build(varDecls).withAfter(key.getAfter());
-                varPadded = built;
-            }
-            return control
-                    .getPadding().withVariable(varPadded)
-                    .getPadding().withIterable(JRightPadded.build(iterable));
-        }
-
-        @Override
         public J visitImport(J.Import importStmt, RpcReceiveQueue q) {
             importStmt = importStmt.getPadding().withStatic(
                     q.receive(importStmt.getPadding().getStatic(), s -> visitLeftPadded(s, q)));

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangSender.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangSender.java
@@ -315,31 +315,6 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
         }
 
         @Override
-        public J visitForEachControl(J.ForEachLoop.Control control, RpcSendQueue q) {
-            // Send in Go's format: key (right-padded), value (right-padded), operator (left-padded string), iterable
-            // Extract key identifier from variable declarations
-            Statement varStmt = control.getVariable();
-            JRightPadded<Expression> key = null;
-            if (varStmt instanceof J.VariableDeclarations) {
-                J.VariableDeclarations varDecls = (J.VariableDeclarations) varStmt;
-                if (!varDecls.getVariables().isEmpty()) {
-                    J.VariableDeclarations.NamedVariable nv = varDecls.getVariables().get(0);
-                    key = JRightPadded.<Expression>build(nv.getName()).withAfter(control.getPadding().getVariable().getAfter());
-                }
-            }
-            final JRightPadded<Expression> finalKey = key;
-            // key
-            q.getAndSend(control, c -> finalKey, el -> visitRightPadded(el, q));
-            // value (null for Go's single-variable range)
-            q.getAndSend(control, c -> (JRightPadded<Expression>) null, el -> visitRightPadded(el, q));
-            // operator (left-padded string - ":=")
-            q.getAndSend(control, c -> JLeftPadded.build(":=").withBefore(Space.EMPTY));
-            // iterable
-            q.getAndSend(control, c -> c.getIterable(), el -> visit(el, q));
-            return control;
-        }
-
-        @Override
         public J visitImport(J.Import importStmt, RpcSendQueue q) {
             q.getAndSend(importStmt, i -> i.getPadding().getStatic(), s -> visitLeftPadded(s, q));
             // Convert FieldAccess qualid to Literal for Go


### PR DESCRIPTION
## What's changed?

A clean-up of `java.ForEachControl` in rewrite-go.
It introduced extra fields which we didn't have in Java.
Also removing `AssignOp` as it turned out not to be needed anymore.

## What's your motivation?

The assymetry in LST trees makes the parsing store the constructs in accidental LST structure and it doesn't work well. As evidenced over RPC recipe calls.