### PR TITLE
Go: remove excessive type fields in LST

### DIFF
--- a/rewrite-go/pkg/matcher/matcher_test.go
+++ b/rewrite-go/pkg/matcher/matcher_test.go
@@ -320,3 +320,34 @@ func (v *methodMatcherVisitor) VisitMethodInvocation(mi *java.MethodInvocation, 
 	}
 	return mi
 }
+
+// TypeOfExpression for Parentheses and TypeCast must DERIVE the type from the
+// inner expression (mirroring Java's J.Parentheses.getType / J.TypeCast.getType),
+// since neither struct stores a Type field.
+func TestTypeOfExpressionDerivesThroughWrappers(t *testing.T) {
+	// given
+	strType := &java.JavaTypeClass{FullyQualifiedName: "string"}
+	inner := &java.Identifier{Name: "s", Type: strType}
+
+	parens := &java.Parentheses{
+		Tree: java.RightPadded[java.Expression]{Element: inner},
+	}
+	cast := &java.TypeCast{
+		Clazz: &java.ControlParentheses{
+			Tree: java.RightPadded[java.Expression]{Element: inner},
+		},
+		Expr: &java.Identifier{Name: "x"},
+	}
+
+	// when
+	parensType := TypeOfExpression(parens)
+	castType := TypeOfExpression(cast)
+
+	// then
+	if parensType != strType {
+		t.Errorf("Parentheses: got %v, want derived inner type %v", parensType, strType)
+	}
+	if castType != strType {
+		t.Errorf("TypeCast: got %v, want derived Clazz type %v", castType, strType)
+	}
+}

--- a/rewrite-go/pkg/matcher/type_utils.go
+++ b/rewrite-go/pkg/matcher/type_utils.go
@@ -200,11 +200,15 @@ func TypeOfExpression(expr java.Expression) java.JavaType {
 	case *java.FieldAccess:
 		return n.Type
 	case *java.TypeCast:
-		return n.Type
+		if n.Clazz != nil {
+			return TypeOfExpression(n.Clazz.Tree.Element)
+		}
 	case *java.ArrayAccess:
 		return n.Type
 	case *java.Parentheses:
-		return n.Type
+		return TypeOfExpression(n.Tree.Element)
+	case *java.ControlParentheses:
+		return TypeOfExpression(n.Tree.Element)
 	case *java.MethodInvocation:
 		if n.MethodType != nil {
 			return n.MethodType.ReturnType

--- a/rewrite-go/pkg/tree/java/j.go
+++ b/rewrite-go/pkg/tree/java/j.go
@@ -1283,7 +1283,6 @@ type Parentheses struct {
 	Prefix  Space
 	Markers Markers
 	Tree    RightPadded[Expression] // Element = inner expr, After = space before `)`
-	Type    JavaType                // the result type (nullable)
 }
 
 func (*Parentheses) IsTree()       {}
@@ -1309,7 +1308,6 @@ type TypeCast struct {
 	Markers Markers
 	Clazz   *ControlParentheses // the type in parentheses
 	Expr    Expression          // the expression being cast/asserted
-	Type    JavaType            // the result type (nullable)
 }
 
 func (*TypeCast) IsTree()       {}


### PR DESCRIPTION
## What's changed?

Removing excessive `type` fields from LST elements of:
- `java.Parentheses`
- `java.TypeCast`

## What's your motivation?

They are not present in corresponding Java counterparts. They are not used. Always `nil`.