### PR TITLE
Scala: fix parsing of multiple anonymous using parameters

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -6748,7 +6748,7 @@ class ScalaTreeVisitor(
         } else true
       } else paramSource.contains(rawParamName)
     }
-    val anonymousParam: Boolean = isUsing && !nameInSource
+    val anonymousParam: Boolean = isUsing && (rawParamName.matches("x\\$\\d+") || !nameInSource)
     val (namePrefix, displayParamName, paramNameEnd) =
       if (vd.nameSpan.exists && !anonymousParam) {
         val rawNameStart = Math.max(0, vd.nameSpan.start - offsetAdjustment)

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -538,6 +538,18 @@ class MethodDeclarationTest implements RewriteTest {
                 )
             );
         }
+
+        @Test
+        void multipleAnonymousParameters() {
+            rewriteRun(
+                scala(
+                    """
+                    object Test:
+                      def foo(using Me, Perf): Int = 1
+                    """
+                )
+            );
+        }
     }
 
     @Nested


### PR DESCRIPTION
## What's changed?

We already have support for parsing anonymous `using` parameters.
Now extending it to the case of multiple such parameters coming one after another (separated by comma).

## What's your motivation?

They are not parsed properly.