### PR TITLE
Go: Make sure `go.mod` files when parsed have relative path, not absolute

### DIFF
--- a/rewrite-go/cmd/rpc/gomod_sourcepath_test.go
+++ b/rewrite-go/cmd/rpc/gomod_sourcepath_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+)
+
+// TestParseProjectRelativizesGoModSourcePath pins down that a GoMod LST
+// produced by ParseProject carries a project-root-relative SourcePath, just
+// like compilation units do. The Java side reads SourcePath off the
+// serialized object (not the response item), so the object's own field must
+// be relativized — not just the response item's.
+func TestParseProjectRelativizesGoModSourcePath(t *testing.T) {
+	// given
+	s, _ := newTestServer(t)
+	projectDir := t.TempDir()
+	writeFile(t, filepath.Join(projectDir, "go.mod"), "module example.com/foo\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(projectDir, "main.go"), "package main\n\nfunc main() {}\n")
+
+	relativeTo := projectDir
+	params, err := json.Marshal(parseProjectRequest{
+		ProjectPath: projectDir,
+		RelativeTo:  &relativeTo,
+	})
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+
+	// when
+	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
+		t.Fatalf("handleParseProject: %v", rpcErr.Message)
+	}
+
+	// then
+	var gm *golang.GoMod
+	for _, obj := range s.localObjects {
+		if g, ok := obj.(*golang.GoMod); ok {
+			gm = g
+			break
+		}
+	}
+	if gm == nil {
+		t.Fatal("expected a GoMod object to be produced")
+	}
+	if gm.SourcePath != "go.mod" {
+		t.Fatalf("expected GoMod SourcePath relativized to %q, got %q", "go.mod", gm.SourcePath)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -2086,19 +2086,22 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		if err != nil {
 			continue
 		}
-		gm, err := goparser.ParseGoModFile(modPath, string(data))
+		// Relativize before building the LST so the GoMod's own SourcePath
+		// matches the response item (and the compilation units) — the Java
+		// side reads SourcePath off the serialized object, not the item.
+		sourcePath := modPath
+		if req.RelativeTo != nil && *req.RelativeTo != "" {
+			if rel, err := filepath.Rel(*req.RelativeTo, modPath); err == nil {
+				sourcePath = rel
+			}
+		}
+		gm, err := goparser.ParseGoModFile(sourcePath, string(data))
 		if err != nil {
 			s.logger.Printf("ParseProject: skip go.mod LST %s: %v", modPath, err)
 			continue
 		}
 		if m, ok := mods[filepath.Dir(modPath)]; ok && m.mrr != nil {
 			gm.Markers.Entries = append(gm.Markers.Entries, *m.mrr)
-		}
-		sourcePath := modPath
-		if req.RelativeTo != nil && *req.RelativeTo != "" {
-			if rel, err := filepath.Rel(*req.RelativeTo, modPath); err == nil {
-				sourcePath = rel
-			}
 		}
 		id := gm.Ident.String()
 		s.localObjects[id] = gm


### PR DESCRIPTION
## What's changed?

Changing how source path is populated for `go.mod` files after parsing.
The path is now relative to the project.

## What's your motivation?

This is actually the OpenRewrite expectation.
I think it's a bug if the path is absolute. It's not portable. And actually doesn't work well as observed in Moderne CLI.