### PR TITLE
rewrite-kotlin: stop mapped-type fallback shadowing real stdlib extensions

### DIFF
--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeFirMappedTypeFallbackExtension.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeFirMappedTypeFallbackExtension.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.fir.extensions.DeclarationGenerationContext
 import org.jetbrains.kotlin.fir.extensions.ExperimentalTopLevelDeclarationsGenerationApi
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationGenerationExtension
 import org.jetbrains.kotlin.fir.plugin.createTopLevelFunction
+import org.jetbrains.kotlin.fir.resolve.providers.dependenciesSymbolProvider
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.fir.types.ConeKotlinTypeProjectionOut
@@ -182,6 +183,18 @@ internal class RecipeFirMappedTypeFallbackExtension(session: FirSession) :
                 // member of the same arity to avoid `equals/hashCode/toString`
                 // double-declaration in the generated facade.
                 if (method.name in MASKED_INHERITED_NAMES) continue
+                // Only fill genuine gaps. If the method name already resolves on
+                // the Kotlin side as a real stdlib extension (e.g. `toUpperCase`,
+                // `trim`, `substring`, `isEmpty` all live in `kotlin.text`),
+                // generating a stand-in here would SHADOW that real declaration.
+                // Two failures result: ordinary parsing mis-attributes the call's
+                // declaringType, and (more visibly) the recipe DSL's MethodMatcher
+                // spec computation records the synthetic `__GENERATED__CALLABLES__Kt`
+                // facade instead of the canonical owner (e.g. `kotlin.text.StringsKt`),
+                // so authored recipes never match at runtime. We want ONLY the
+                // methods Kotlin's mapped-type customizer hides with no Kotlin
+                // equivalent — e.g. `String.stripIndent`/`formatted`/`translateEscapes`.
+                if (resolvesAsKotlinExtension(Name.identifier(method.name))) continue
                 // Deduplicate at the *erased* JVM-bytecode level. The generated
                 // top-level extensions all sit in the same facade class
                 // `__GENERATED__CALLABLES__Kt`; two extensions on the same
@@ -228,6 +241,32 @@ internal class RecipeFirMappedTypeFallbackExtension(session: FirSession) :
         else -> "Ljava/lang/Object;"
     }
 
+    /**
+     * True when [name] already resolves on the Kotlin side as a real stdlib
+     * extension function — i.e. some top-level function with that name and an
+     * extension receiver exists in one of the [STDLIB_EXTENSION_PACKAGES]. The
+     * mapped types' stdlib extensions all live in these facades
+     * (`kotlin.text` for `String`/`CharSequence`, `kotlin.collections` for the
+     * collection types, etc.), so a name match there means Kotlin already has a
+     * genuine declaration we must not shadow.
+     *
+     * A name-based check (rather than full receiver-type resolution) is
+     * sufficient and safe here: the only methods we intend to keep generating
+     * are JDK additions the mapped-type customizer hides with NO Kotlin
+     * equivalent (`stripIndent`, `formatted`, `transform`, `translateEscapes`,
+     * …), and none of those names collide with a stdlib extension. Results are
+     * memoized because the same name recurs across many mapped Java classes.
+     */
+    private val resolvableExtensionNames = HashMap<Name, Boolean>()
+
+    private fun resolvesAsKotlinExtension(name: Name): Boolean =
+        resolvableExtensionNames.getOrPut(name) {
+            STDLIB_EXTENSION_PACKAGES.any { pkg ->
+                session.dependenciesSymbolProvider.getTopLevelFunctionSymbols(pkg, name)
+                    .any { it.receiverParameterSymbol != null }
+            }
+        }
+
     private companion object {
         /**
          * Names whose Java instance versions are already members of every
@@ -238,6 +277,21 @@ internal class RecipeFirMappedTypeFallbackExtension(session: FirSession) :
          * them through the receiver's member scope).
          */
         val MASKED_INHERITED_NAMES = setOf("equals", "hashCode", "toString", "getClass", "notify", "notifyAll", "wait")
+
+        /**
+         * Kotlin stdlib facade packages that hold the top-level extension
+         * functions for the mapped types. Used by [resolvesAsKotlinExtension] to
+         * detect (and skip) Java method names that already have a real Kotlin
+         * extension, so the generated fallbacks never shadow them.
+         */
+        val STDLIB_EXTENSION_PACKAGES = listOf(
+            FqName("kotlin"),
+            FqName("kotlin.text"),
+            FqName("kotlin.collections"),
+            FqName("kotlin.sequences"),
+            FqName("kotlin.ranges"),
+            FqName("kotlin.comparisons"),
+        )
     }
 
     override fun getTopLevelCallableIds(): Set<CallableId> {

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/RecipeFirMappedTypeFallbackParsingTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/RecipeFirMappedTypeFallbackParsingTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Invariant guard: ordinary {@link KotlinParser} parsing must attribute calls to
+ * Java&#8596;Kotlin mapped-class stdlib extensions (e.g. {@code String.toUpperCase},
+ * {@code trim}, {@code substring}, {@code isEmpty}) to the canonical
+ * {@code kotlin.text.StringsKt} owner — never the recipe-DSL plugin's synthetic
+ * facade {@code __GENERATED__CALLABLES__Kt}.
+ *
+ * <p>The recipe-DSL compiler plugin ({@code RecipeFirMappedTypeFallbackExtension})
+ * is NOT active during {@code KotlinParser} parsing, so parsing already resolves
+ * the real {@code StringsKt} regardless of classpath — this test documents and
+ * locks in that invariant for both an empty classpath and a real one
+ * ({@link JavaParser#runtimeClasspath()}). The user-visible regression caused by
+ * the plugin's over-broad stand-in generation manifested at recipe-DSL <em>authoring</em>
+ * time (the generated {@code MethodMatcher} recorded the synthetic facade); that
+ * path is covered decisively by
+ * {@code org.openrewrite.kotlin.recipe.MappedTypeFallbackShadowingTest}.
+ */
+class RecipeFirMappedTypeFallbackParsingTest {
+
+    private static String declaringType(List<Path> classpath, String source, String methodName) {
+        ExecutionContext ctx = new InMemoryExecutionContext();
+        SourceFile cu = KotlinParser.builder()
+          .classpath(classpath)
+          .build()
+          .parse(ctx, source)
+          .findFirst()
+          .orElseThrow();
+
+        AtomicReference<JavaType.Method> found = new AtomicReference<>();
+        new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext p) {
+                if (methodName.equals(method.getSimpleName()) && method.getMethodType() != null) {
+                    found.compareAndSet(null, method.getMethodType());
+                }
+                return super.visitMethodInvocation(method, p);
+            }
+        }.visit(cu, ctx);
+
+        JavaType.Method methodType = found.get();
+        assertThat(methodType)
+          .as("method invocation '%s' should have a resolved method type", methodName)
+          .isNotNull();
+        return methodType.getDeclaringType().toString();
+    }
+
+    private static void assertStringsKt(String source, String methodName) {
+        assertThat(declaringType(emptyList(), source, methodName))
+          .as("empty classpath: %s", methodName)
+          .isEqualTo("kotlin.text.StringsKt");
+        assertThat(declaringType(JavaParser.runtimeClasspath(), source, methodName))
+          .as("runtime classpath: %s", methodName)
+          .isEqualTo("kotlin.text.StringsKt");
+    }
+
+    @Test
+    void toUpperCase() {
+        assertStringsKt("val s: String = \"hello\".toUpperCase()", "toUpperCase");
+    }
+
+    @Test
+    void trim() {
+        assertStringsKt("fun f(s: String): String = s.trim()", "trim");
+    }
+
+    @Test
+    void isEmpty() {
+        assertStringsKt("fun f(s: String): Boolean = s.trim().isEmpty()", "isEmpty");
+    }
+
+    @Test
+    void substring() {
+        assertStringsKt("fun f(s: String, n: Int): String = s.substring(0, n)", "substring");
+    }
+}

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/MappedTypeFallbackShadowingTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/MappedTypeFallbackShadowingTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi::class)
+package org.openrewrite.kotlin.recipe
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.openrewrite.Preconditions
+import org.openrewrite.Recipe
+import org.openrewrite.java.search.UsesMethod
+
+/**
+ * Regression test for the mapped-type fallback extension shadowing real Kotlin
+ * stdlib extensions.
+ *
+ * [org.openrewrite.kotlin.recipe.internal.RecipeFirMappedTypeFallbackExtension]
+ * re-exposes JDK instance methods that Kotlin's mapped-type customizer hides.
+ * It must only fill genuine gaps: for a method that ALSO exists as a real
+ * Kotlin stdlib extension (e.g. `String.toUpperCase`/`trim`/`substring` in
+ * `kotlin.text`), generating a synthetic stand-in shadows the real declaration.
+ * The recipe DSL's IR matcher-spec computation then records the synthetic facade
+ * `__GENERATED__CALLABLES__Kt` instead of the canonical `kotlin.text.StringsKt`,
+ * so the authored recipe matches nothing at runtime (parsing — which has no
+ * plugin active — resolves the real `StringsKt`). This regressed 9 downstream
+ * `moderneinc/recipes-kotlin` tests.
+ *
+ * Each test below compiles a `rewrite { } to { }` recipe whose before-pattern
+ * calls a mapped-class method that DOES have a Kotlin stdlib extension and
+ * asserts the generated `MethodMatcher` names the canonical `kotlin.text.StringsKt`
+ * owner — not the synthetic facade.
+ */
+class MappedTypeFallbackShadowingTest {
+
+    private fun matcherFor(beforeBody: String): String {
+        val recipe = loadRecipe(
+            // Suppress deprecation just as the real recipes-kotlin recipe does:
+            // after the fix, `toUpperCase()`/`toLowerCase()` resolve to the REAL
+            // (deprecated) `kotlin.text.StringsKt` extension rather than the
+            // non-deprecated synthetic stand-in — which is exactly the point.
+            """
+            @file:Suppress("DEPRECATION", "DEPRECATION_ERROR")
+            import org.openrewrite.recipe
+            val R = recipe("d", "desc") {
+                edit {
+                    $beforeBody
+                }
+            }
+            """.trimIndent(),
+            "R",
+        )
+        val visitor = recipe.visitor
+        val check = (visitor as Preconditions.Check).check
+        return (check as UsesMethod<*>).methodMatcher.toString()
+    }
+
+    private fun loadRecipe(source: String, propertyName: String): Recipe {
+        val result = RecipePluginCompileFixture.compile(source)
+        check(result.exitOk()) { "compile failed:\n${result.messages}" }
+        val cls = result.classLoader.loadClass("RecipesKt")
+        val getter = cls.getDeclaredMethod("get" + propertyName.replaceFirstChar { it.uppercase() })
+        getter.isAccessible = true
+        return getter.invoke(null) as Recipe
+    }
+
+    @Test
+    fun `toUpperCase matcher targets kotlin_text_StringsKt`() {
+        assertThat(matcherFor("rewrite { s: String -> s.toUpperCase() } to { s -> s.uppercase() }"))
+            .isEqualTo("kotlin.text.StringsKt toUpperCase(*)")
+    }
+
+    @Test
+    fun `toLowerCase matcher targets kotlin_text_StringsKt`() {
+        assertThat(matcherFor("rewrite { s: String -> s.toLowerCase() } to { s -> s.lowercase() }"))
+            .isEqualTo("kotlin.text.StringsKt toLowerCase(*)")
+    }
+
+    @Test
+    fun `trim matcher targets kotlin_text_StringsKt`() {
+        assertThat(matcherFor("rewrite { s: String -> s.trim() } to { s -> s.trim() }"))
+            .isEqualTo("kotlin.text.StringsKt trim(*)")
+    }
+
+    @Test
+    fun `substring matcher targets kotlin_text_StringsKt`() {
+        // The DSL emits arg-count-precise patterns; the receiver plus two args
+        // produce three wildcards. The owner is what matters: not the synthetic facade.
+        assertThat(matcherFor("rewrite { s: String, n: Int -> s.substring(0, n) } to { s, n -> s.substring(0, n) }"))
+            .isEqualTo("kotlin.text.StringsKt substring(*, *, *)")
+    }
+}


### PR DESCRIPTION
`RecipeFirMappedTypeFallbackExtension` generated a synthetic top-level extension for every public instance method of each Java↔Kotlin mapped class, including names that already have a real Kotlin stdlib extension (`toUpperCase`, `trim`, `substring`, `isEmpty`, …), which shadowed the real `kotlin.text.StringsKt` extensions. As a result the recipe DSL's `MethodMatcher` spec recorded the synthetic `__GENERATED__CALLABLES__Kt` facade while parsing (where the plugin is inactive) resolves the canonical owner, so authored recipes matched nothing at runtime — regressing 9 `moderneinc/recipes-kotlin` tests. The fix only fills genuine gaps: it skips generating a stand-in whenever the method name already resolves as a real stdlib extension (queried via the non-generated `dependenciesSymbolProvider` to avoid recursion), while JDK additions the mapped-type customizer hides with no Kotlin equivalent (`stripIndent`, `formatted`, `translateEscapes`, …) are still generated so recipe authoring is unaffected. Adds `MappedTypeFallbackShadowingTest` (asserts the generated matcher targets `kotlin.text.StringsKt`, not the synthetic facade) and `RecipeFirMappedTypeFallbackParsingTest` (parser-side invariant). Verified: full `:rewrite-kotlin:test` green, and against a locally-published patched snapshot the previously-failing `recipes-kotlin` tests go from 9 failures to 0 with no test changes.