### PR TITLE
Go: fix GoMod LST to descend from Tree

### DIFF
--- a/rewrite-go/src/main/java/org/openrewrite/golang/GoModVisitor.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/GoModVisitor.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.SourceFile;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.golang.tree.GoMod;
+import org.openrewrite.golang.tree.GoModTree;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+
+/**
+ * Java-side visitor for the {@code go.mod} LST, analogous to {@link GolangVisitor}
+ * for {@code .go} sources and {@code HclVisitor} for HCL. It traverses the bespoke
+ * {@link GoMod} node set (directives, blocks, values) so recipes can inspect and
+ * rewrite go.mod entirely in Java; printing still goes through the Go RPC server.
+ */
+@SuppressWarnings("unused")
+public class GoModVisitor<P> extends TreeVisitor<GoModTree, P> {
+
+    @Override
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
+        return sourceFile instanceof GoMod;
+    }
+
+    @Override
+    public String getLanguage() {
+        return "gomod";
+    }
+
+    public GoModTree visitGoMod(GoMod goMod, P p) {
+        GoMod g = goMod;
+        g = g.withPrefix(visitSpace(g.getPrefix(), p));
+        g = g.withMarkers(visitMarkers(g.getMarkers(), p));
+        g = g.withStatements(ListUtils.map(g.getStatements(), s -> visitRightPadded(s, p)));
+        g = g.withEof(visitSpace(g.getEof(), p));
+        return g;
+    }
+
+    public GoModTree visitDirective(GoMod.Directive directive, P p) {
+        GoMod.Directive d = directive;
+        d = d.withPrefix(visitSpace(d.getPrefix(), p));
+        d = d.withMarkers(visitMarkers(d.getMarkers(), p));
+        d = d.withValues(ListUtils.map(d.getValues(), v -> (GoMod.Value) visit(v, p)));
+        return d;
+    }
+
+    public GoModTree visitBlock(GoMod.Block block, P p) {
+        GoMod.Block b = block;
+        b = b.withPrefix(visitSpace(b.getPrefix(), p));
+        b = b.withMarkers(visitMarkers(b.getMarkers(), p));
+        b = b.withBeforeLParen(visitSpace(b.getBeforeLParen(), p));
+        b = b.withEntries(ListUtils.map(b.getEntries(), e -> visitRightPadded(e, p)));
+        b = b.withBeforeRParen(visitSpace(b.getBeforeRParen(), p));
+        return b;
+    }
+
+    public GoModTree visitValue(GoMod.Value value, P p) {
+        GoMod.Value v = value;
+        v = v.withPrefix(visitSpace(v.getPrefix(), p));
+        v = v.withMarkers(visitMarkers(v.getMarkers(), p));
+        return v;
+    }
+
+    /**
+     * go.mod {@link Space} carries no location taxonomy (unlike {@code J}/HCL), so
+     * this is a plain identity hook for subclasses to override.
+     */
+    public Space visitSpace(Space space, P p) {
+        return space;
+    }
+
+    public <T extends GoModTree> @Nullable JRightPadded<T> visitRightPadded(@Nullable JRightPadded<T> right, P p) {
+        if (right == null) {
+            return null;
+        }
+        setCursor(new Cursor(getCursor(), right));
+        T t = visitAndCast(right.getElement(), p);
+        setCursor(getCursor().getParent());
+        if (t == null) {
+            return null;
+        }
+        Space after = visitSpace(right.getAfter(), p);
+        Markers markers = visitMarkers(right.getMarkers(), p);
+        return after == right.getAfter() && t == right.getElement() && markers == right.getMarkers() ?
+                right : new JRightPadded<>(t, after, markers);
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/GoMod.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/GoMod.java
@@ -25,6 +25,7 @@ import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.golang.GoModVisitor;
 import org.openrewrite.golang.rpc.GoRewriteRpc;
 import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
@@ -53,7 +54,7 @@ import java.util.UUID;
  */
 @lombok.Value
 @With
-public class GoMod implements SourceFile {
+public class GoMod implements SourceFile, GoModTree {
 
     UUID id;
 
@@ -95,14 +96,8 @@ public class GoMod implements SourceFile {
     }
 
     @Override
-    public <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
-        return true;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <R extends Tree, P> R accept(TreeVisitor<R, P> v, P p) {
-        return (R) this;
+    public <P> GoModTree acceptGoMod(GoModVisitor<P> v, P p) {
+        return v.visitGoMod(this, p);
     }
 
     @Override
@@ -121,8 +116,7 @@ public class GoMod implements SourceFile {
     /**
      * A top-level go.mod statement or a single entry line inside a {@link Block}.
      */
-    public interface GoModStatement {
-        UUID getId();
+    public interface GoModStatement extends GoModTree {
     }
 
     /**
@@ -150,6 +144,11 @@ public class GoMod implements SourceFile {
          * individual values.
          */
         List<Value> values;
+
+        @Override
+        public <P> GoModTree acceptGoMod(GoModVisitor<P> v, P p) {
+            return v.visitDirective(this, p);
+        }
     }
 
     /**
@@ -171,6 +170,11 @@ public class GoMod implements SourceFile {
         Space beforeLParen;
         List<JRightPadded<GoModStatement>> entries;
         Space beforeRParen;
+
+        @Override
+        public <P> GoModTree acceptGoMod(GoModVisitor<P> v, P p) {
+            return v.visitBlock(this, p);
+        }
     }
 
     /**
@@ -179,10 +183,15 @@ public class GoMod implements SourceFile {
      */
     @lombok.Value
     @With
-    public static class Value {
+    public static class Value implements GoModTree {
         UUID id;
         Space prefix;
         Markers markers;
         String text;
+
+        @Override
+        public <P> GoModTree acceptGoMod(GoModVisitor<P> v, P p) {
+            return v.visitValue(this, p);
+        }
     }
 }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/GoModTree.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/GoModTree.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.tree;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.golang.GoModVisitor;
+
+/**
+ * Node family for the {@code go.mod} LST: {@link GoMod} and its statements/values.
+ * <p>
+ * Mirrors {@code org.openrewrite.hcl.tree.Hcl} (a standalone, non-{@code J} LST):
+ * extending {@link Tree} gives every node {@code Tree}'s {@code @c} polymorphic type
+ * id so the elements survive {@code .lst} (de)serialization, and the {@code accept}
+ * dispatch routes traversal to a {@link GoModVisitor} just as {@code Hcl} routes to
+ * {@code HclVisitor}. Printing remains delegated to the Go RPC server.
+ */
+public interface GoModTree extends Tree {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    default <R extends Tree, P> @Nullable R accept(TreeVisitor<R, P> v, P p) {
+        return (R) acceptGoMod(v.adapt(GoModVisitor.class), p);
+    }
+
+    default <P> @Nullable GoModTree acceptGoMod(GoModVisitor<P> v, P p) {
+        return v.defaultValue(this, p);
+    }
+
+    @Override
+    default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
+        return v.isAdaptableTo(GoModVisitor.class);
+    }
+}

--- a/rewrite-go/src/test/java/org/openrewrite/golang/GoModSerializationTest.java
+++ b/rewrite-go/src/test/java/org/openrewrite/golang/GoModSerializationTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Tree;
+import org.openrewrite.golang.tree.GoMod;
+import org.openrewrite.golang.tree.GoMod.GoModStatement;
+import org.openrewrite.internal.ObjectMappers;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces the production go.mod RPC panic at its true source: the LST
+ * serialize/deserialize step the Moderne CLI runs between {@code mod build}
+ * and {@code mod run}.
+ * <p>
+ * The CLI persists the parsed {@link GoMod} to a {@code .lst} and reads it back
+ * before the recipe runs. Polymorphic LST nodes rely on the {@code @c} type id
+ * declared by {@link Tree} ({@code @JsonTypeInfo(use = Id.CLASS, property = "@c")}).
+ * {@link GoModStatement} must carry the same type id, otherwise the
+ * {@link JRightPadded#getElement() element} of each statement deserializes to
+ * {@code null} — which later NPEs in {@code GoModRpcCodec.rpcSend} when the tree
+ * is shipped to the Go visitor.
+ */
+class GoModSerializationTest {
+
+    private static final ObjectMapper MAPPER = ObjectMappers.propertyBasedMapper(null);
+
+    @Test
+    void statementElementsSurviveLstRoundTrip() throws Exception {
+        // given: a parsed-shape GoMod with two directive statements (module, go)
+        GoMod before = goModWithModuleAndGo();
+        assertThat(before.getStatements()).allSatisfy(rp ->
+                assertThat(rp.getElement()).as("element non-null before serialization").isNotNull());
+
+        // when: round-tripped through the LST serializer (mirrors mod build -> mod run)
+        byte[] bytes = MAPPER.writeValueAsBytes(before);
+        GoMod after = MAPPER.readValue(bytes, GoMod.class);
+
+        // then: every statement still has its concrete element (no null JRightPadded element)
+        assertThat(after.getStatements()).hasSize(before.getStatements().size());
+        assertThat(after.getStatements()).allSatisfy(rp ->
+                assertThat(rp.getElement())
+                        .as("statement element must survive the .lst round-trip")
+                        .isNotNull());
+    }
+
+    private static GoMod goModWithModuleAndGo() {
+        List<JRightPadded<GoModStatement>> stmts = new ArrayList<>();
+        stmts.add(directive("module", "example.com/two"));
+        stmts.add(directive("go", "1.21"));
+        return new GoMod(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                Paths.get("go.mod"),
+                "UTF-8",
+                false,
+                null,
+                null,
+                stmts,
+                Space.EMPTY);
+    }
+
+    private static JRightPadded<GoModStatement> directive(String keyword, String value) {
+        GoMod.Value v = new GoMod.Value(Tree.randomId(), Space.format(" "), Markers.EMPTY, value);
+        GoMod.Directive d = new GoMod.Directive(Tree.randomId(), Space.EMPTY, Markers.EMPTY, keyword, List.of(v));
+        return new JRightPadded<>(d, Space.format("\n"), Markers.EMPTY);
+    }
+}

--- a/rewrite-go/src/test/java/org/openrewrite/golang/GoModVisitorTest.java
+++ b/rewrite-go/src/test/java/org/openrewrite/golang/GoModVisitorTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Tree;
+import org.openrewrite.golang.tree.GoMod;
+import org.openrewrite.golang.tree.GoMod.GoModStatement;
+import org.openrewrite.golang.tree.GoModTree;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Java-side traversal of the {@code go.mod} LST via {@link GoModVisitor} — the
+ * visitor reaches every node (directives, block entries, values) and can rewrite
+ * them, mirroring how {@code GolangVisitor} works for {@code .go} sources.
+ */
+class GoModVisitorTest {
+
+    @Test
+    void visitsEveryNodeAndCanRewriteValues() {
+        // given: module + go directives and a require block with one entry
+        GoMod before = sampleGoMod();
+
+        // when: a visitor counts values and bumps the go version
+        AtomicInteger valuesSeen = new AtomicInteger();
+        GoModVisitor<Integer> v = new GoModVisitor<Integer>() {
+            @Override
+            public GoModTree visitValue(GoMod.Value value, Integer p) {
+                valuesSeen.incrementAndGet();
+                GoMod.Value visited = (GoMod.Value) super.visitValue(value, p);
+                return "1.21".equals(visited.getText()) ? visited.withText("1.22") : visited;
+            }
+        };
+        GoMod after = (GoMod) v.visitGoMod(before, 0);
+
+        // then: every value node was reached and the go version was rewritten
+        assertThat(valuesSeen.get()).isEqualTo(4); // example.com/two, 1.21, github.com/a/b, v1.0.0
+        assertThat(goVersion(after)).isEqualTo("1.22");
+        assertThat(after.getStatements()).allSatisfy(rp -> assertThat(rp.getElement()).isNotNull());
+    }
+
+    private static String goVersion(GoMod gm) {
+        for (JRightPadded<GoModStatement> rp : gm.getStatements()) {
+            if (rp.getElement() instanceof GoMod.Directive) {
+                GoMod.Directive d = (GoMod.Directive) rp.getElement();
+                if ("go".equals(d.getKeyword())) {
+                    return d.getValues().get(0).getText();
+                }
+            }
+        }
+        throw new IllegalStateException("no go directive");
+    }
+
+    private static GoMod sampleGoMod() {
+        List<JRightPadded<GoModStatement>> stmts = new ArrayList<>();
+        stmts.add(rightPad(directive("module", "example.com/two")));
+        stmts.add(rightPad(directive("go", "1.21")));
+
+        GoMod.Directive entry = new GoMod.Directive(Tree.randomId(), Space.format("\n\t"), Markers.EMPTY, "",
+                List.of(value("github.com/a/b"), value("v1.0.0")));
+        GoMod.Block block = new GoMod.Block(Tree.randomId(), Space.format("\n\n"), Markers.EMPTY, "require",
+                Space.format(" "), List.of(rightPad(entry)), Space.format("\n"));
+        stmts.add(rightPad(block));
+
+        return new GoMod(Tree.randomId(), Space.EMPTY, Markers.EMPTY, Paths.get("go.mod"),
+                "UTF-8", false, null, null, stmts, Space.EMPTY);
+    }
+
+    private static GoMod.Directive directive(String keyword, String value) {
+        return new GoMod.Directive(Tree.randomId(), Space.EMPTY, Markers.EMPTY, keyword, List.of(value(value)));
+    }
+
+    private static GoMod.Value value(String text) {
+        return new GoMod.Value(Tree.randomId(), Space.format(" "), Markers.EMPTY, text);
+    }
+
+    private static JRightPadded<GoModStatement> rightPad(GoModStatement s) {
+        return new JRightPadded<>(s, Space.format("\n"), Markers.EMPTY);
+    }
+}


### PR DESCRIPTION
## What's changed?

Fix the LST tree for `GoMod` source files.
Make sure it descends from the `Tree` interface.

## What's your motivation?

Otherwise the LSTs are mis-serialized and fail when recipes are executed against them. Symptoms I have observed included:
```
java.lang.NullPointerException: Cannot invoke
  "org.openrewrite.golang.tree.GoMod$GoModStatement.getId()"                                                 because the return value of "org.openrewrite.java.tree.JRightPadded.getElement()" is null
  at o.o.golang.internal.rpc.GoModRpcCodec.lambda$rpcSend$3(GoModRpcCodec.java:72)
  at o.o.rpc.RpcSendQueue.putListPositions(RpcSendQueue.java:169)
```