### PR TITLE
Scala: fix for space between curried parameter lists in method declar…

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -549,6 +549,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
      * Print a J.Lambda.Parameters as a curried parameter list: (param1, param2)
      */
     private void printLambdaParamsAsCurried(J.Lambda.Parameters lambdaParams, PrintOutputCapture<P> p) {
+        visitSpace(lambdaParams.getPrefix(), Space.Location.LAMBDA_PARAMETERS_PREFIX, p);
         if (lambdaParams.isParenthesized()) {
             p.append('(');
         }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -6227,6 +6227,7 @@ class ScalaTreeVisitor(
       val searchEnd = Math.min(cursor + 50, source.length)
       val searchText = source.substring(cursor, searchEnd)
       val parenIdx = positionOfNextIn(searchText, "(", 0)
+      val parenSpace = if (parenIdx > 0) Space.format(searchText.substring(0, parenIdx)) else Space.EMPTY
       if (parenIdx >= 0) cursor = cursor + parenIdx + 1
 
       val jParams = new util.ArrayList[JRightPadded[J]]()
@@ -6270,7 +6271,7 @@ class ScalaTreeVisitor(
         if (closeParen >= 0) cursor = cursor + closeParen + 1
       }
 
-      new J.Lambda.Parameters(Tree.randomId(), Space.EMPTY, Markers.EMPTY, true, jParams)
+      new J.Lambda.Parameters(Tree.randomId(), parenSpace, Markers.EMPTY, true, jParams)
     }
 
     // Handle value parameters — first list goes in J.MethodDeclaration.parameters,

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -800,4 +800,16 @@ class MethodDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void curriedParameterListsOnSeparateLines() {
+        rewriteRun(
+          scala(
+            """
+            def f(a: Int)
+                (b: Int): Int = a + b
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
…ations

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Fix Scala parser wrt non-standard (i.e. non-empty) space between curried lists of arguments in a method declaration, e.g.
```
            def f(a: Int)
                (b: Int): Int = a + b
```

## What's your motivation?

They suffer from idempotency issues (the whitespace is swallowed).