### PR TITLE
Scala: fix prefix handling in partial function applications

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -9296,11 +9296,14 @@ class ScalaTreeVisitor(
 
         partialApplication match {
           case Some(app) =>
-            // Partially applied function - return the method invocation
+            // Partially applied function - return the underlying call with the lambda's
+            // leading whitespace re-attached. Covers method invocations (`add(5, _)`) as
+            // well as constructor applications (`new Foo(_)`), which yield a J.NewClass
+            // whose own prefix is empty because `extractPrefix` already consumed it.
             val prefix = extractPrefix(func.span)
             val result = visitApply(app)
             result match {
-              case mi: J.MethodInvocation => return mi.withPrefix(prefix)
+              case e: Expression => return e.withPrefix(prefix).asInstanceOf[Expression]
               case _ => return result
             }
           case None =>

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LambdaTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LambdaTest.java
@@ -362,4 +362,17 @@ class LambdaTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void underscorePlaceholderInNewInsideBraceBlock() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  val r = Option(1).map { new Foo(_) }
+                }
+                """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Scala: fix prefix handling (i.e. non-standard whitespace) in some partial function applications, e.g.
```
.map { new Foo(_) }
```

## What's your motivation?

They suffer from idempotency issues.
