### PR TITLE
Scala: fix parsing of alternate matching pattern in case binding

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -6926,7 +6926,11 @@ class ScalaTreeVisitor(
             case typed: Trees.Typed[?] =>
               val tpeName = typed.tpt match { case id: Trees.Ident[?] => id.name.toString; case sel: Trees.Select[?] => extractSource(sel.span); case _ => null }
               (bind.name.toString, if (tpeName != null) ident(tpeName, Space.format(" ")) else null)
-            case _ => (bind.name.toString, null)
+            case _ =>
+              // e.g. `e @ (_: A | _: B)` — bind over an Alternative (or other pattern);
+              // preserve the full source so the `@ (...)` part isn't lost on print.
+              val patSource = if (caseDef.pat.span.exists) extractSource(caseDef.pat.span) else ""
+              (if (patSource.nonEmpty) patSource else bind.name.toString, null)
           }
           case typed: Trees.Typed[?] =>
             val name = typed.expr match { case id: Trees.Ident[?] => id.name.toString; case _ => "_" }
@@ -7083,7 +7087,11 @@ class ScalaTreeVisitor(
             case typed: Trees.Typed[?] =>
               val tpeName = typed.tpt match { case id: Trees.Ident[?] => id.name.toString; case sel: Trees.Select[?] => extractSource(sel.span); case _ => null }
               (bind.name.toString, if (tpeName != null) ident(tpeName, Space.format(" ")) else null)
-            case _ => (bind.name.toString, null)
+            case _ =>
+              // e.g. `e @ (_: A | _: B)` — bind over an Alternative (or other pattern);
+              // preserve the full source so the `@ (...)` part isn't lost on print.
+              val patSource = if (caseDef.pat.span.exists) extractSource(caseDef.pat.span) else ""
+              (if (patSource.nonEmpty) patSource else bind.name.toString, null)
           }
           case typed: Trees.Typed[?] =>
             val name = typed.expr match { case id: Trees.Ident[?] => id.name.toString; case _ => "_" }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/AlternativePatternTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/AlternativePatternTest.java
@@ -56,6 +56,25 @@ class AlternativePatternTest implements RewriteTest {
     }
 
     @Test
+    void boundTypedAlternatives() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                def run(): Unit = {
+                  try {
+                    ()
+                  } catch {
+                    case e @ (_: ClassNotFoundException | _: NoSuchMethodException) =>
+                  }
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void typedAlternatives() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

Fix Scala parser for handling alternative matching patterns in case bindings. Typically used to catch various exception types, e.g.
```
 case e @ (_: ClassNotFoundException | _: NoSuchMethodException)
```

## What's your motivation?

They wouldn't be parsed at all and the LST missed the part of the tree.