### PR TITLE
Go: add Go.DeclarationBlock to the type registry

### DIFF
--- a/rewrite-go/pkg/rpc/value_types.go
+++ b/rewrite-go/pkg/rpc/value_types.go
@@ -175,6 +175,7 @@ func init() {
 	RegisterFactory("org.openrewrite.golang.tree.Go$Union", func() any { return &golang.Union{ID: uuid.New()} })
 	RegisterFactory("org.openrewrite.golang.tree.Go$UnderlyingType", func() any { return &golang.UnderlyingType{ID: uuid.New()} })
 	RegisterFactory("org.openrewrite.golang.tree.Go$TypeDecl", func() any { return &golang.TypeDecl{ID: uuid.New()} })
+	RegisterFactory("org.openrewrite.golang.tree.Go$DeclarationBlock", func() any { return &golang.DeclarationBlock{ID: uuid.New()} })
 	RegisterFactory("org.openrewrite.golang.tree.Go$MultiAssignment", func() any { return &golang.MultiAssignment{ID: uuid.New()} })
 	RegisterFactory("org.openrewrite.golang.tree.Go$Return", func() any { return &golang.Return{ID: uuid.New()} })
 	RegisterFactory("org.openrewrite.golang.tree.Go$MethodDeclaration", func() any { return &golang.MethodDeclaration{ID: uuid.New()} })

--- a/rewrite-go/pkg/rpc/value_types_registration_test.go
+++ b/rewrite-go/pkg/rpc/value_types_registration_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"reflect"
+	"testing"
+)
+
+// value_types.go holds two parallel registries that MUST stay in sync:
+//
+//   - valueTypeMap (send side): Go type -> Java class name. The sender writes
+//     this class name onto the wire for every object it emits.
+//   - factories    (receive side): Java class name -> constructor. newObj uses
+//     it to instantiate an incoming node when Java sends an ADD for that type.
+//
+// Anything the Go side can SEND, Java can send BACK (e.g. when a recipe edits
+// the tree). So every value type needs a matching factory, or the receive path
+// panics with "no factory registered for type: ...". This is exactly how the
+// Go$DeclarationBlock node regressed: registered as a value type, but the
+// factory was forgotten, so production parsing of grouped var/const blocks
+// panicked the moment Java round-tripped the node.
+//
+// This test enforces the invariant generically — adding any new value type
+// without its factory (or with a mismatched factory) fails here, with no
+// per-type test needed.
+func TestEveryValueTypeHasMatchingFactory(t *testing.T) {
+	for goType, javaClassName := range valueTypeMap {
+		// given: a registered send-side value type
+		factory, ok := factories[javaClassName]
+		if !ok {
+			// then: a receivable factory must exist for the same class name
+			t.Errorf("value type %s (registered as %q) has no RegisterFactory entry; "+
+				"newObj will panic when Java sends this node back over the wire",
+				goType, javaClassName)
+			continue
+		}
+
+		// then: the factory must build the very type the sender announced,
+		// otherwise the receiver populates the wrong struct
+		built := reflect.TypeOf(factory())
+		if built != goType {
+			t.Errorf("factory for %q builds %s, but it is registered as value type %s",
+				javaClassName, built, goType)
+		}
+	}
+}


### PR DESCRIPTION
## What's changed?

- An amendment to #7938. Adding the `DeclarationBlock` to type registry.

Also adding a test enforcing the completeness of the registry to prevent the same kind of mistakes in the future.

## What's your motivation?

It was missed and panics like this are observed:
```
2026/06/10 10:14:43 PANIC in Visit: no factory registered for type: org.openrewrite.golang.tree.Go$DeclarationBlock
goroutine 1 [running]:
main.(*server).safeHandleRequest.func1()
        rewrite-recipe-workspace/cmd/rpc/main.go:405 +0x84
panic({0x101026b80?, 0x1400097ea20?})
        runtime/panic.go:783 +0x120
main.(*server).getObjectFromJava.func2.1()
        rewrite-recipe-workspace/cmd/rpc/main.go:905 +0x78
panic({0x101026b80?, 0x1400097ea20?})
        runtime/panic.go:783 +0x120
github.com/openrewrite/rewrite/rewrite-go/pkg/rpc.newObj({0x140003f7bc0, 0x2f})
        github.com/openrewrite/rewrite/rewrite-go@v0.0.14/pkg/rpc/receive_queue.go:289 +0x128
github.com/openrewrite/rewrite/rewrite-go/pkg/rpc.(*ReceiveQueue).Receive(0x140006fb290, {0x0, 0x0}, 0x140009a3118)
```