### PR TITLE
Scala: fix for double-dollar, i.e. dollar escaping in String interpol…

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7433,9 +7433,38 @@ class ScalaTreeVisitor(
 
     val parts = new util.ArrayList[Expression]()
 
+    // Dotty reports each literal segment's span end as `start + decodedLength`, so every `$$`
+    // escape (which is two source chars but one decoded char) makes the span end one char too
+    // short. Re-derive the true source end by replaying the decoded value over the source,
+    // collapsing `$$` -> `$`. Returns -1 when some other escape (e.g. `\n` in a non-raw string)
+    // prevents a clean 1:1 replay, in which case the caller keeps dotty's span end.
+    def sourceEndForValue(ls: Int, value: String): Int = {
+      var pos = ls
+      var i = 0
+      while (i < value.length) {
+        if (pos >= source.length) return -1
+        val sc = source.charAt(pos)
+        val vc = value.charAt(i)
+        if (sc == '$' && vc == '$' && pos + 1 < source.length && source.charAt(pos + 1) == '$') {
+          pos += 2
+        } else if (sc == vc) {
+          pos += 1
+        } else {
+          return -1
+        }
+        i += 1
+      }
+      pos
+    }
+
     def addLiteral(litTree: Trees.Literal[?]): Unit = {
       val ls = Math.max(0, litTree.span.start - offsetAdjustment)
-      val le = Math.max(0, litTree.span.end - offsetAdjustment)
+      val le = litTree.const.value match {
+        case s: String =>
+          val reconstructed = sourceEndForValue(ls, s)
+          if (reconstructed >= 0) reconstructed else Math.max(0, litTree.span.end - offsetAdjustment)
+        case _ => Math.max(0, litTree.span.end - offsetAdjustment)
+      }
       if (le > ls && le <= source.length) {
         val text = source.substring(ls, le)
         if (text.nonEmpty) {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InterpolatedStringTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/InterpolatedStringTest.java
@@ -85,6 +85,19 @@ class InterpolatedStringTest implements RewriteTest {
     }
 
     /**
+     * Dotty reports each literal segment's span end as {@code start + decodedLength}, so a {@code $$}
+     * escape (two source chars, one decoded char) leaves the span one char short. That dropped the
+     * character before the next interpolation and shifted the {@code $} into the interpolation's
+     * prefix, corrupting round-trips of strings that mix {@code $$} escapes with interpolations.
+     */
+    @Test
+    void dollarEscapeFollowedByInterpolation() {
+        rewriteRun(
+          scala("val x = s\"\"\"$$('#x-$id')\"\"\"")
+        );
+    }
+
+    /**
      * The embedded expressions must be first-class LST nodes, not text stuffed into a J.Identifier.
      * This is the assertion that fails against the old behavior (the whole {@code s"..."} was a
      * single J.Identifier whose simpleName held the raw source).


### PR DESCRIPTION
…ations

## What's changed?

Fix Scala parser to handle escaping of some special characters in String interpolation, e.g. `$$` for escaping a dollar sign.

## What's your motivation?

They suffer from idempotency issues.