### PR TITLE
Go: Add GetSourcePath() and use it in preconditions

### DIFF
--- a/rewrite-go/pkg/preconditions/preconditions.go
+++ b/rewrite-go/pkg/preconditions/preconditions.go
@@ -95,11 +95,10 @@ type CheckVisitor struct {
 // matches. RecipeRef operands are treated as "always matches" in-process
 // (they're wire-only placeholders).
 func (c *CheckVisitor) Visit(t java.Tree, p any) java.Tree {
-	sf, IsSourceFile := t.(java.SourceFile)
-	if !IsSourceFile {
+	if !isSourceFile(t) {
 		return c.V.Visit(t, p)
 	}
-	if c.matches(sf, p) {
+	if c.matches(t, p) {
 		return c.V.Visit(t, p)
 	}
 	return t

--- a/rewrite-go/pkg/preconditions/preconditions_test.go
+++ b/rewrite-go/pkg/preconditions/preconditions_test.go
@@ -188,6 +188,104 @@ func TestHelpersPopulateLocalVisitor(t *testing.T) {
 	}
 }
 
+func TestHasSourcePathMatchesCompilationUnit(t *testing.T) {
+	// given a real source file with a path
+	editor := &recordingVisitor{}
+	cu := &golang.CompilationUnit{SourcePath: "pkg/foo/bar.go"}
+
+	// when the glob matches the path
+	Check(HasSourcePath("**/*.go"), editor).Visit(cu, nil)
+
+	// then the editor runs
+	if editor.calls != 1 {
+		t.Errorf("editor calls (matching path) = %d, want 1", editor.calls)
+	}
+
+	// and when the glob does not match
+	editor2 := &recordingVisitor{}
+	Check(HasSourcePath("**/*.java"), editor2).Visit(cu, nil)
+	if editor2.calls != 0 {
+		t.Errorf("editor calls (non-matching path) = %d, want 0", editor2.calls)
+	}
+}
+
+func TestHasSourcePathMatchesGoMod(t *testing.T) {
+	// given a go.mod root (a non-J SourceFile)
+	editor := &recordingVisitor{}
+	mod := &golang.GoMod{SourcePath: "go.mod"}
+
+	// when the glob matches
+	Check(HasSourcePath("**/go.mod"), editor).Visit(mod, nil)
+
+	// then the editor runs even though GoMod is not a java.SourceFile
+	if editor.calls != 1 {
+		t.Errorf("editor calls (go.mod) = %d, want 1", editor.calls)
+	}
+
+	// and a non-matching glob must actually filter the GoMod out, rather
+	// than the gate being bypassed because GoMod is not a java.SourceFile.
+	editor2 := &recordingVisitor{}
+	Check(HasSourcePath("**/*.go"), editor2).Visit(mod, nil)
+	if editor2.calls != 0 {
+		t.Errorf("editor calls (go.mod, non-matching) = %d, want 0", editor2.calls)
+	}
+}
+
+func TestUsesMethodMatchesInvocationInTree(t *testing.T) {
+	// given a compilation unit containing fmt.Println(...)
+	mi := &java.MethodInvocation{
+		Select: &java.RightPadded[java.Expression]{Element: &java.Identifier{Name: "fmt"}},
+		Name:   &java.Identifier{Name: "Println"},
+	}
+	cu := &golang.CompilationUnit{
+		Statements: []java.RightPadded[java.Statement]{{Element: mi}},
+	}
+
+	// when gating on the matching method pattern
+	editor := &recordingVisitor{}
+	Check(UsesMethod("fmt Println(..)"), editor).Visit(cu, nil)
+
+	// then the editor runs
+	if editor.calls != 1 {
+		t.Errorf("editor calls (matching method) = %d, want 1", editor.calls)
+	}
+
+	// and a non-matching pattern skips the editor
+	editor2 := &recordingVisitor{}
+	Check(UsesMethod("fmt Printf(..)"), editor2).Visit(cu, nil)
+	if editor2.calls != 0 {
+		t.Errorf("editor calls (non-matching method) = %d, want 0", editor2.calls)
+	}
+}
+
+func TestUsesTypeMatchesAttributionInTree(t *testing.T) {
+	// given a node carrying type attribution for "tarfile"
+	typed := &java.Identifier{
+		Name: "tr",
+		Type: &java.JavaTypeClass{FullyQualifiedName: "tarfile"},
+	}
+	mi := &java.MethodInvocation{Name: typed}
+	cu := &golang.CompilationUnit{
+		Statements: []java.RightPadded[java.Statement]{{Element: mi}},
+	}
+
+	// when gating on the matching type
+	editor := &recordingVisitor{}
+	Check(UsesType("tarfile"), editor).Visit(cu, nil)
+
+	// then the editor runs
+	if editor.calls != 1 {
+		t.Errorf("editor calls (matching type) = %d, want 1", editor.calls)
+	}
+
+	// and an unrelated type skips the editor
+	editor2 := &recordingVisitor{}
+	Check(UsesType("zipfile"), editor2).Visit(cu, nil)
+	if editor2.calls != 0 {
+		t.Errorf("editor calls (non-matching type) = %d, want 0", editor2.calls)
+	}
+}
+
 func TestOrRequiresAtLeastTwoOperands(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {

--- a/rewrite-go/pkg/preconditions/search.go
+++ b/rewrite-go/pkg/preconditions/search.go
@@ -17,13 +17,23 @@
 package preconditions
 
 import (
-	"path"
+	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/matcher"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
+
+// isSourceFile reports whether t is a source-file root for gating purposes.
+// It duck-types IsSourceFile() rather than asserting java.SourceFile so that
+// non-J roots (e.g. golang.GoMod, which models go.mod and is intentionally
+// not a J node) are still recognized as source files.
+func isSourceFile(t java.Tree) bool {
+	_, ok := t.(interface{ IsSourceFile() })
+	return ok
+}
 
 // IsSourceFileVisitor matches SourceFile trees by path glob.
 //
@@ -39,11 +49,10 @@ func NewIsSourceFile(filePattern string) *IsSourceFileVisitor {
 }
 
 func (v *IsSourceFileVisitor) Visit(t java.Tree, _ any) java.Tree {
-	sf, ok := t.(java.SourceFile)
-	if !ok {
+	if !isSourceFile(t) {
 		return t
 	}
-	src := sourceFilePath(sf)
+	src := sourceFilePath(t)
 	if src == "" {
 		return t
 	}
@@ -77,24 +86,45 @@ func (v *UsesTypeVisitor) Visit(t java.Tree, _ any) java.Tree {
 
 func (v *UsesTypeVisitor) treeUsesType(t java.Tree) bool {
 	found := false
-	walkTree(t, func(node java.Tree) bool {
-		if found {
-			return false
+	java.WalkTree(t, func(node java.Tree) bool {
+		jt := nodeType(node)
+		if jt == nil {
+			return true
 		}
-		if typed, ok := node.(interface{ GetType() java.JavaType }); ok {
-			if jt := typed.GetType(); jt != nil {
-				if fq, ok := jt.(java.FullyQualified); ok {
-					fqn := fq.GetFullyQualifiedName()
-					if fqn != "" && matchTypeGlob(v.pattern, fqn) {
-						found = true
-						return false
-					}
-				}
+		if fq, ok := jt.(java.FullyQualified); ok {
+			fqn := fq.GetFullyQualifiedName()
+			if fqn != "" && matchTypeGlob(v.pattern, fqn) {
+				found = true
+				return false
 			}
 		}
 		return true
 	})
 	return found
+}
+
+// nodeType extracts the JavaType attribution from a node via its exported
+// "Type" field. LST nodes expose type attribution as a `Type JavaType`
+// field rather than through a common accessor method (mirroring
+// matcher.TypeOfExpression), so we read it reflectively and uniformly
+// across every node shape that carries one.
+func nodeType(node java.Tree) java.JavaType {
+	v := reflect.ValueOf(node)
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+	f := v.FieldByName("Type")
+	if !f.IsValid() || !f.CanInterface() {
+		return nil
+	}
+	jt, _ := f.Interface().(java.JavaType)
+	return jt
 }
 
 // UsesMethodVisitor matches files using a specific method, by walking
@@ -121,10 +151,7 @@ func (v *UsesMethodVisitor) Visit(t java.Tree, _ any) java.Tree {
 
 func (v *UsesMethodVisitor) treeUsesMethod(t java.Tree) bool {
 	found := false
-	walkTree(t, func(node java.Tree) bool {
-		if found {
-			return false
-		}
+	java.WalkTree(t, func(node java.Tree) bool {
 		if mi, ok := node.(*java.MethodInvocation); ok {
 			if v.matcher.Matches(mi) {
 				found = true
@@ -138,100 +165,53 @@ func (v *UsesMethodVisitor) treeUsesMethod(t java.Tree) bool {
 
 // markFound returns a sentinel "different tree" so the wrapping
 // CheckVisitor sees a non-identity result and runs the wrapped editor.
-// We use a wrapper struct rather than mutating the original tree to
-// avoid coupling search visitors to the concrete tree type.
-type matchedSourceFile struct {
-	java.SourceFile
+// We wrap rather than mutate the original tree to avoid coupling search
+// visitors to the concrete tree type; any java.Tree (including non-J
+// roots like golang.GoMod) can be wrapped.
+type matchedTree struct {
+	java.Tree
 }
 
 func markFound(t java.Tree) java.Tree {
-	if sf, ok := t.(java.SourceFile); ok {
-		return &matchedSourceFile{SourceFile: sf}
-	}
-	return t
+	return &matchedTree{Tree: t}
 }
 
-// walkTree does a best-effort iterative DFS over a tree. Returns “false“
-// from “visit“ to stop walking. Implementation uses pkg/tree's existing
-// SearchWalker if available; otherwise falls back to walking the
-// java.J interface via reflection-free iteration of known shapes.
+// matchPathGlob matches a path against an Ant-style glob pattern. It mirrors
+// the matching semantics of org.openrewrite.FindSourceFiles:
+//   - "**" matches any number of path segments (crossing "/")
+//   - "*"  matches any run of characters within a single segment
+//   - "?"  matches a single non-separator character
 //
-// For simplicity we delegate to a shared helper that knows how to descend
-// into common LST nodes — see WalkSubtree below.
-func walkTree(root java.Tree, visit func(java.Tree) bool) {
-	walker := newSearchWalker(visit)
-	walker.walk(root)
-}
-
-// searchWalker is a minimal iterative walker that knows just enough
-// about the LST to descend into compilation units and statement trees.
-// It intentionally does not duplicate tree/search_walker.go's full
-// machinery — only enough to find type-bearing nodes and method
-// invocations for HasType/HasMethod.
-type searchWalker struct {
-	visit func(java.Tree) bool
-	stop  bool
-}
-
-func newSearchWalker(visit func(java.Tree) bool) *searchWalker {
-	return &searchWalker{visit: visit}
-}
-
-func (w *searchWalker) walk(node java.Tree) {
-	if w.stop || node == nil {
-		return
-	}
-	if !w.visit(node) {
-		w.stop = true
-		return
-	}
-	for _, child := range childrenOf(node) {
-		w.walk(child)
-		if w.stop {
-			return
-		}
-	}
-}
-
-// childrenOf returns immediate child Tree nodes of the given node.
-// Best-effort: uses the SearchWalker shape from pkg/tree where available
-// and falls back to no children for unknown shapes (which means the
-// search visitor returns false negatives for those, but never false
-// positives — safe for a precondition gate).
-func childrenOf(node java.Tree) []java.Tree {
-	if hc, ok := node.(interface{ Children() []java.Tree }); ok {
-		return hc.Children()
-	}
-	return nil
-}
-
-// matchPathGlob matches a path against a glob pattern using Go's
-// path.Match plus a "**" extension for recursive matching.
+// The pattern is translated to an anchored regexp once per call.
 func matchPathGlob(pattern, p string) bool {
-	if strings.Contains(pattern, "**") {
-		// "**/*.go" → match any .go anywhere
-		// We simplify to: split on "**", require all parts to appear in order.
-		parts := strings.Split(pattern, "**")
-		idx := 0
-		for i, part := range parts {
-			if part == "" {
-				continue
+	var b strings.Builder
+	b.WriteByte('^')
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		switch c {
+		case '*':
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				b.WriteString(".*")
+				i++
+				// Swallow a trailing "/" so "**/x" also matches a bare "x".
+				if i+1 < len(pattern) && pattern[i+1] == '/' {
+					i++
+				}
+			} else {
+				b.WriteString("[^/]*")
 			}
-			// First part must match prefix; intermediate parts can match
-			// anywhere; last part must match suffix.
-			j := strings.Index(p[idx:], strings.Trim(part, "/"))
-			if j < 0 {
-				return false
-			}
-			if i == 0 && j != 0 {
-				return false
-			}
-			idx += j + len(strings.Trim(part, "/"))
+		case '?':
+			b.WriteString("[^/]")
+		case '.', '+', '(', ')', '|', '[', ']', '{', '}', '^', '$', '\\':
+			b.WriteByte('\\')
+			b.WriteByte(c)
+		default:
+			b.WriteByte(c)
 		}
-		return true
 	}
-	matched, err := path.Match(pattern, p)
-	return err == nil && matched
+	b.WriteByte('$')
+	re, err := regexp.Compile(b.String())
+	return err == nil && re.MatchString(p)
 }
 
 // matchTypeGlob matches a fully-qualified type name against a pattern.
@@ -261,13 +241,15 @@ func matchTypeGlob(pattern, fqn string) bool {
 	return true
 }
 
-// sourceFilePath extracts a string path from a SourceFile, falling back
-// to the empty string when none is available.
-func sourceFilePath(sf java.SourceFile) string {
-	if hp, ok := sf.(interface{ GetSourcePath() string }); ok {
+// sourceFilePath extracts a string path from a source-file root, falling
+// back to the empty string when none is available. It duck-types the
+// path accessor so it works for both J source files (CompilationUnit)
+// and non-J roots (GoMod).
+func sourceFilePath(t java.Tree) string {
+	if hp, ok := t.(interface{ GetSourcePath() string }); ok {
 		return hp.GetSourcePath()
 	}
-	if hp, ok := sf.(interface{ SourcePath() string }); ok {
+	if hp, ok := t.(interface{ SourcePath() string }); ok {
 		return hp.SourcePath()
 	}
 	return ""

--- a/rewrite-go/pkg/tree/golang/go.go
+++ b/rewrite-go/pkg/tree/golang/go.go
@@ -38,6 +38,8 @@ func (*CompilationUnit) IsTree()       {}
 func (*CompilationUnit) IsJ()          {}
 func (*CompilationUnit) IsSourceFile() {}
 
+func (n *CompilationUnit) GetSourcePath() string { return n.SourcePath }
+
 func (n *CompilationUnit) WithPrefix(prefix java.Space) *CompilationUnit {
 	c := *n
 	c.Prefix = prefix

--- a/rewrite-go/pkg/tree/golang/gomod.go
+++ b/rewrite-go/pkg/tree/golang/gomod.go
@@ -51,6 +51,8 @@ type GoMod struct {
 func (*GoMod) IsTree()       {}
 func (*GoMod) IsSourceFile() {}
 
+func (n *GoMod) GetSourcePath() string { return n.SourcePath }
+
 func (n *GoMod) WithPrefix(prefix java.Space) *GoMod {
 	c := *n
 	c.Prefix = prefix

--- a/rewrite-go/pkg/tree/java/search_walker.go
+++ b/rewrite-go/pkg/tree/java/search_walker.go
@@ -43,6 +43,69 @@ type searchWalker struct {
 	seen map[uuid.UUID]struct{}
 }
 
+// WalkTree performs a reflection-based pre-order DFS over the LST rooted at
+// t, invoking visit on every Tree node encountered (t included). Returning
+// false from visit stops the walk early. Descent transparently crosses
+// pointers, interfaces, slices/arrays, and the RightPadded / LeftPadded /
+// Container wrappers, so callers need not enumerate concrete node shapes.
+//
+// Prefix and Markers fields and uuid.UUID values are skipped — they never
+// hold child trees. This is the shared "real tree walker" used by search
+// preconditions (HasType / HasMethod) that need to inspect every node.
+func WalkTree(t Tree, visit func(Tree) bool) {
+	(&treeWalker{visit: visit}).walk(reflect.ValueOf(t))
+}
+
+type treeWalker struct {
+	visit func(Tree) bool
+	stop  bool
+}
+
+func (w *treeWalker) walk(v reflect.Value) {
+	if w.stop || !v.IsValid() {
+		return
+	}
+	switch v.Kind() {
+	case reflect.Interface:
+		if !v.IsNil() {
+			w.walk(v.Elem())
+		}
+	case reflect.Ptr:
+		if v.IsNil() {
+			return
+		}
+		// LST node types implement Tree on pointer receivers, so a Tree is
+		// always reached as a non-nil pointer. Visiting only here (never in
+		// the Interface case, which unwraps to this same pointer) avoids
+		// double-visiting interface-held nodes.
+		if t, ok := v.Interface().(Tree); ok {
+			if !w.visit(t) {
+				w.stop = true
+				return
+			}
+		}
+		w.walk(v.Elem())
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			sf := v.Type().Field(i)
+			if !sf.IsExported() || sf.Name == "Prefix" || sf.Name == "Markers" || sf.Type == uuidType {
+				continue
+			}
+			w.walk(v.Field(i))
+			if w.stop {
+				return
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			w.walk(v.Index(i))
+			if w.stop {
+				return
+			}
+		}
+	}
+}
+
 var (
 	treeIface   = reflect.TypeOf((*Tree)(nil)).Elem()
 	markersType = reflect.TypeOf(Markers{})


### PR DESCRIPTION
## What's changed?

Adding the `GetSourcePath()` method to Go LST source file elements.
And using it in the preconditions.

## What's your motivation?

Otherwise it's cumbersome to write some of the real-life recipe preconditions.