### PR TITLE
Scala: handle dotted match syntax

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -33,6 +33,7 @@ import org.openrewrite.java.tree.TypeTree;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.scala.marker.AsInstanceOfPrefix;
 import org.openrewrite.scala.marker.BlockArgument;
+import org.openrewrite.scala.marker.DottedMatch;
 import org.openrewrite.scala.marker.IndentedSyntax;
 import org.openrewrite.scala.marker.PackageBraces;
 import org.openrewrite.scala.marker.SObject;
@@ -304,6 +305,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         JRightPadded<Expression> selector = switch_.getSelector().getPadding().getTree();
         visit(selector.getElement(), p);
         visitSpace(selector.getAfter(), Space.Location.CONTROL_PARENTHESES_PREFIX, p);
+        if (switch_.getMarkers().findFirst(DottedMatch.class).isPresent()) {
+            p.append(".");
+        }
         p.append("match");
         boolean indented = switch_.getMarkers().findFirst(IndentedSyntax.class).isPresent();
         if (!indented) {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/DottedMatch.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/DottedMatch.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Marks a {@link org.openrewrite.java.tree.J.Switch} that uses Scala 3's selector-style
+ * match, where the {@code match} keyword is invoked with a dot on the selector:
+ * {@code selector.match { ... }} rather than {@code selector match { ... }}.
+ * <p>
+ * The printer emits a {@code .} between the selector and the {@code match} keyword when
+ * this marker is present.
+ */
+@Value
+@With
+public class DottedMatch implements Marker {
+    UUID id;
+
+    public static DottedMatch create() {
+        return new DottedMatch(Tree.randomId());
+    }
+}

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -25,6 +25,7 @@ import org.openrewrite.java.tree.*
 import org.openrewrite.java.marker.ImplicitReturn
 import org.openrewrite.java.marker.OmitParentheses
 import org.openrewrite.marker.Markers
+import org.openrewrite.scala.marker.DottedMatch
 import org.openrewrite.scala.marker.Implicit
 import org.openrewrite.scala.marker.LambdaParameter
 import org.openrewrite.scala.marker.IndentedSyntax
@@ -1780,6 +1781,10 @@ class ScalaTreeVisitor(
       case block: J.Block =>
         // Block arguments in infix calls: `"test" should { ... }`
         new S.StatementExpression(Tree.randomId(), block.withPrefix(rhsSpace))
+      case j: J =>
+        // A compound statement as the right operand, e.g. `x := y.match\n  case _ => ...`
+        // where the dotted `.match` binds to `y`, making the J.Switch the infix argument.
+        new S.StatementExpression(Tree.randomId(), j)
       case _ => cursor = savedCursorArg; return visitUnknown(infixOp)
     }
 
@@ -7233,7 +7238,15 @@ class ScalaTreeVisitor(
 
     val ms = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 30, source.length)) else ""
     val mi = positionOfNextIn(ms, "match", 0)
-    val matchKeywordSpace = if (mi > 0) Space.format(ms.substring(0, mi)) else Space.EMPTY
+    // Scala 3 selector-style match `selector.match { ... }`: the `match` keyword is preceded
+    // by a `.`. Record it via a marker so the dot isn't stored as (non-whitespace) Space.
+    val beforeMatch = if (mi > 0) ms.substring(0, mi) else ""
+    val dotIdx = beforeMatch.indexOf('.')
+    val isDottedMatch = dotIdx >= 0
+    val matchKeywordSpace =
+      if (isDottedMatch) Space.format(beforeMatch.substring(0, dotIdx))
+      else if (mi > 0) Space.format(beforeMatch)
+      else Space.EMPTY
     if (mi >= 0) cursor = cursor + mi + 5
     // Scala 3 `x match\n  case ...` has no `{` before the cases — detect that form.
     val bs = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 200, source.length)) else ""
@@ -7246,9 +7259,10 @@ class ScalaTreeVisitor(
     val casesBlock = buildCasesBlock(matchTree, isBraceForm).withPrefix(matchBraceSpace)
     updateCursor(matchTree.span.end)
     val selectorParens = new J.ControlParentheses[Expression](Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(selector).withAfter(matchKeywordSpace))
-    val markers = if (isBraceForm) Markers.EMPTY
-      else Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId())))
-    new J.Switch(Tree.randomId(), prefix, markers, selectorParens, casesBlock)
+    val markersList = new util.ArrayList[org.openrewrite.marker.Marker]()
+    if (!isBraceForm) markersList.add(new IndentedSyntax(Tree.randomId()))
+    if (isDottedMatch) markersList.add(DottedMatch.create())
+    new J.Switch(Tree.randomId(), prefix, Markers.build(markersList), selectorParens, casesBlock)
   }
 
   private def buildCasesBlock(matchTree: Trees.Match[?], hasClosingBrace: Boolean = true): J.Block = {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
@@ -569,6 +569,18 @@ class MatchTest implements RewriteTest {
     }
 
     @Test
+    void dottedMatchOnRightSideOfInfixOperator() {
+        rewriteRun(
+          scala(
+            """
+            val x = a := b.match
+              case _ => 1
+            """
+          )
+        );
+    }
+
+    @Test
     void significantCharactersInComments() {
         // buildCasesBlock — `=>` arrow in case line comment
         rewriteRun(


### PR DESCRIPTION
## What's changed?

Fix Scala parser for dotted match syntax in Scala 3, e.g.
```
         b.match
              case _ => 1
```

## What's your motivation?

It suffers from idempotency issues.
