### PR TITLE
Scala: fix parsing of trailing comments in parameter lists

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -6262,13 +6262,13 @@ class ScalaTreeVisitor(
         jParams.add(new JRightPadded(param.asInstanceOf[J], afterParam, Markers.EMPTY))
       }
 
-      // Find closing paren
+      // Find closing paren — search the full remaining source (comment-aware) so a
+      // long trailing line comment before `)` doesn't push it outside a fixed window.
       val lastParamEnd = if (params.nonEmpty) Math.max(0, params.last.span.end - offsetAdjustment) else cursor
       cursor = Math.max(cursor, lastParamEnd)
       if (cursor < source.length) {
-        val remaining = source.substring(cursor, Math.min(cursor + 50, source.length))
-        val closeParen = positionOfNextIn(remaining, ")", 0)
-        if (closeParen >= 0) cursor = cursor + closeParen + 1
+        val closeParen = positionOfNextIn(source, ")", cursor)
+        if (closeParen >= 0) cursor = closeParen + 1
       }
 
       new J.Lambda.Parameters(Tree.randomId(), parenSpace, Markers.EMPTY, true, jParams)
@@ -6321,9 +6321,8 @@ class ScalaTreeVisitor(
         val lastParamEnd = if (firstList.nonEmpty) Math.max(0, firstList.last.span.end - offsetAdjustment) else cursor
         cursor = Math.max(cursor, lastParamEnd)
         if (cursor < source.length) {
-          val remaining = source.substring(cursor, Math.min(cursor + 50, source.length))
-          val closeParen = positionOfNextIn(remaining, ")", 0)
-          if (closeParen >= 0) cursor = cursor + closeParen + 1
+          val closeParen = positionOfNextIn(source, ")", cursor)
+          if (closeParen >= 0) cursor = closeParen + 1
         }
 
         // Build additional param lists as J.Lambda.Parameters for later wrapping

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -6272,6 +6272,27 @@ class ScalaTreeVisitor(
       new J.Lambda.Parameters(Tree.randomId(), parenSpace, Markers.EMPTY, true, jParams)
     }
 
+    // Build an empty parameter list `()`, advancing the cursor past `)`. Any interior
+    // whitespace/comments (e.g. `( // note\n)`) are preserved as a J.Empty element so
+    // the list round-trips; a truly empty `()` keeps a zero-element container.
+    def buildEmptyParamList(): JContainer[Statement] = {
+      val parenIdx = positionOfNextIn(source, "(", cursor)
+      val parenSpace = if (parenIdx > cursor) Space.format(source.substring(cursor, parenIdx)) else Space.EMPTY
+      val elements = new util.ArrayList[JRightPadded[Statement]]()
+      if (parenIdx >= 0) {
+        cursor = parenIdx + 1
+        val closeParen = positionOfNextIn(source, ")", cursor)
+        if (closeParen >= 0) {
+          if (closeParen > cursor) {
+            val interior = new J.Empty(Tree.randomId(), Space.format(source.substring(cursor, closeParen)), Markers.EMPTY)
+            elements.add(new JRightPadded(interior.asInstanceOf[Statement], Space.EMPTY, Markers.EMPTY))
+          }
+          cursor = closeParen + 1
+        }
+      }
+      JContainer.build(parenSpace, elements, Markers.EMPTY)
+    }
+
     // Handle value parameters — first list goes in J.MethodDeclaration.parameters,
     // additional curried lists become nested J.Lambda nodes (built after the body is parsed)
     val curriedParamLists = new util.ArrayList[J.Lambda.Parameters]()
@@ -6331,30 +6352,14 @@ class ScalaTreeVisitor(
 
         JContainer.build(parenSpace, jParams, Markers.EMPTY)
       } else if (hasParensInSource) {
-        // Empty parameter list ()
-        val parenIdx = positionOfNextIn(source, "(", cursor)
-        val parenSpace = if (parenIdx > cursor) Space.format(source.substring(cursor, parenIdx)) else Space.EMPTY
-        if (parenIdx >= 0) {
-          cursor = parenIdx + 1
-          val closeParen = positionOfNextIn(source, ")", cursor)
-          if (closeParen >= 0) cursor = closeParen + 1
-        }
-        JContainer.build(parenSpace, new util.ArrayList[JRightPadded[Statement]](), Markers.EMPTY)
+        buildEmptyParamList()
       } else {
         // Parameterless method — mark so printer omits ()
         JContainer.build(Space.EMPTY, new util.ArrayList[JRightPadded[Statement]](),
           Markers.build(Collections.singletonList(new org.openrewrite.scala.marker.OmitBraces(Tree.randomId()))))
       }
     } else if (hasParensInSource) {
-      // Empty parameter list ()
-      val parenIdx = positionOfNextIn(source, "(", cursor)
-      val parenSpace = if (parenIdx > cursor) Space.format(source.substring(cursor, parenIdx)) else Space.EMPTY
-      if (parenIdx >= 0) {
-        cursor = parenIdx + 1
-        val closeParen = positionOfNextIn(source, ")", cursor)
-        if (closeParen >= 0) cursor = closeParen + 1
-      }
-      JContainer.build(parenSpace, new util.ArrayList[JRightPadded[Statement]](), Markers.EMPTY)
+      buildEmptyParamList()
     } else {
       // Parameterless method — mark so printer omits ()
       JContainer.build(Space.EMPTY, new util.ArrayList[JRightPadded[Statement]](),

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -6224,11 +6224,9 @@ class ScalaTreeVisitor(
 
     // Visit a parameter list from source, returning J.Lambda.Parameters and advancing cursor past `)`
     def visitParamListAsLambdaParams(params: List[Trees.ValDef[?]]): J.Lambda.Parameters = {
-      val searchEnd = Math.min(cursor + 50, source.length)
-      val searchText = source.substring(cursor, searchEnd)
-      val parenIdx = positionOfNextIn(searchText, "(", 0)
-      val parenSpace = if (parenIdx > 0) Space.format(searchText.substring(0, parenIdx)) else Space.EMPTY
-      if (parenIdx >= 0) cursor = cursor + parenIdx + 1
+      val parenIdx = positionOfNextIn(source, "(", cursor)
+      val parenSpace = if (parenIdx > cursor) Space.format(source.substring(cursor, parenIdx)) else Space.EMPTY
+      if (parenIdx >= 0) cursor = parenIdx + 1
 
       val jParams = new util.ArrayList[JRightPadded[J]]()
       params.zipWithIndex.foreach { case (vd, idx) =>
@@ -6281,11 +6279,9 @@ class ScalaTreeVisitor(
       val firstList = valueParamLists.head.collect { case vd: Trees.ValDef[?] => vd }
       if (firstList.nonEmpty) {
         // Build first list as JContainer for J.MethodDeclaration
-        val searchEnd = Math.min(cursor + 50, source.length)
-        val searchText = source.substring(cursor, searchEnd)
-        val parenIdx = positionOfNextIn(searchText, "(", 0)
-        val parenSpace = if (parenIdx > 0) Space.format(searchText.substring(0, parenIdx)) else Space.EMPTY
-        if (parenIdx >= 0) cursor = cursor + parenIdx + 1
+        val parenIdx = positionOfNextIn(source, "(", cursor)
+        val parenSpace = if (parenIdx > cursor) Space.format(source.substring(cursor, parenIdx)) else Space.EMPTY
+        if (parenIdx >= 0) cursor = parenIdx + 1
 
         val jParams = new util.ArrayList[JRightPadded[Statement]]()
         firstList.zipWithIndex.foreach { case (vd, idx) =>
@@ -6336,15 +6332,12 @@ class ScalaTreeVisitor(
         JContainer.build(parenSpace, jParams, Markers.EMPTY)
       } else if (hasParensInSource) {
         // Empty parameter list ()
-        val searchEnd = Math.min(cursor + 50, source.length)
-        val searchText = source.substring(cursor, searchEnd)
-        val parenIdx = positionOfNextIn(searchText, "(", 0)
-        val parenSpace = if (parenIdx > 0) Space.format(searchText.substring(0, parenIdx)) else Space.EMPTY
+        val parenIdx = positionOfNextIn(source, "(", cursor)
+        val parenSpace = if (parenIdx > cursor) Space.format(source.substring(cursor, parenIdx)) else Space.EMPTY
         if (parenIdx >= 0) {
-          cursor = cursor + parenIdx + 1
-          val afterSearch = source.substring(cursor, Math.min(cursor + 50, source.length))
-          val closeParen = positionOfNextIn(afterSearch, ")", 0)
-          if (closeParen >= 0) cursor = cursor + closeParen + 1
+          cursor = parenIdx + 1
+          val closeParen = positionOfNextIn(source, ")", cursor)
+          if (closeParen >= 0) cursor = closeParen + 1
         }
         JContainer.build(parenSpace, new util.ArrayList[JRightPadded[Statement]](), Markers.EMPTY)
       } else {
@@ -6354,15 +6347,12 @@ class ScalaTreeVisitor(
       }
     } else if (hasParensInSource) {
       // Empty parameter list ()
-      val searchEnd = Math.min(cursor + 50, source.length)
-      val searchText = source.substring(cursor, searchEnd)
-      val parenIdx = positionOfNextIn(searchText, "(", 0)
-      val parenSpace = if (parenIdx > 0) Space.format(searchText.substring(0, parenIdx)) else Space.EMPTY
+      val parenIdx = positionOfNextIn(source, "(", cursor)
+      val parenSpace = if (parenIdx > cursor) Space.format(source.substring(cursor, parenIdx)) else Space.EMPTY
       if (parenIdx >= 0) {
-        cursor = cursor + parenIdx + 1
-        val afterSearch = source.substring(cursor, Math.min(cursor + 50, source.length))
-        val closeParen = positionOfNextIn(afterSearch, ")", 0)
-        if (closeParen >= 0) cursor = cursor + closeParen + 1
+        cursor = parenIdx + 1
+        val closeParen = positionOfNextIn(source, ")", cursor)
+        if (closeParen >= 0) cursor = closeParen + 1
       }
       JContainer.build(parenSpace, new util.ArrayList[JRightPadded[Statement]](), Markers.EMPTY)
     } else {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -812,4 +812,17 @@ class MethodDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void multilineParameterListWithTrailingLineComment() {
+        rewriteRun(
+          scala(
+            """
+            def resize(
+                size: Int // either the width or the height! the other one will be preserved
+            ): Url = 1
+            """
+          )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -825,4 +825,29 @@ class MethodDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void curriedParameterListWithTrailingLineComment() {
+        rewriteRun(
+          scala(
+            """
+            def f(a: Int)(
+                b: Int // either the width or the height! the other one will be preserved
+            ): Int = a + b
+            """
+          )
+        );
+    }
+
+    @Test
+    void longLineCommentBeforeParameterList() {
+        rewriteRun(
+          scala(
+            """
+            def resize // either the width or the height! the other one will be preserved
+            (size: Int): Int = 1
+            """
+          )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -850,4 +850,27 @@ class MethodDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void emptyParameterListWithInteriorLineComment() {
+        rewriteRun(
+          scala(
+            """
+            def resize( // either the width or the height! the other one will be preserved
+            ): Int = 1
+            """
+          )
+        );
+    }
+
+    @Test
+    void emptyParameterListWithInteriorBlockComment() {
+        rewriteRun(
+          scala(
+            """
+            def resize(/* nothing here */): Int = 1
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fixing Scala parser for several cases of comments appearing at the last position in the parameter list, e.g.
```
def resize(/* nothing here */): Int = 1
```

## What's your motivation?

They suffer from idempotency issues.
