### PR TITLE
Docker: fix stale alpine suggestion in FindEndOfLifeImagesTest

### DIFF
--- a/rewrite-docker/src/test/java/org/openrewrite/docker/search/FindEndOfLifeImagesTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/search/FindEndOfLifeImagesTest.java
@@ -134,7 +134,7 @@ class FindEndOfLifeImagesTest implements RewriteTest {
               RUN apk update
               """,
             """
-              ~~(EOL: alpine:3.14 (ended 2023-05-01, suggest 3.23 or 3.22))~~>FROM alpine:3.14
+              ~~(EOL: alpine:3.14 (ended 2023-05-01, suggest 3.24 or 3.23))~~>FROM alpine:3.14
               RUN apk update
               """
           )


### PR DESCRIPTION
The `eol-images.yaml` data was auto-updated to suggest `3.24 or 3.23` for alpine, but `FindEndOfLifeImagesTest.detectAlpine3_14()` still expected `3.23 or 3.22`, causing the test to fail.

This updates the test expectation to match the current EOL data.