### PR TITLE
JavaScript: share active RewriteRpc connection across module copies (#7968)

### DIFF
--- a/rewrite-javascript/rewrite/src/marketplace.ts
+++ b/rewrite-javascript/rewrite/src/marketplace.ts
@@ -87,7 +87,14 @@ export namespace RecipeMarketplace {
                         const recipeInst = new recipe({});
                         this.recipes.set(await recipeInst.descriptor(), recipe);
                     } catch (e) {
-                        const err = new Error(`Failed to install recipe '${recipe.name}'. Ensure the constructor can be called without any arguments.`);
+                        // Surface the underlying cause inline: it is dropped at the
+                        // JSON-RPC serialization boundary (only `message` survives), so
+                        // folding it into the message is the only way it reaches the
+                        // caller's logs. Without this, a failure deeper in the recipe
+                        // (e.g. a sub-recipe needing an RPC connection) is hidden behind
+                        // the generic "constructor" hint. See gh-7968.
+                        const cause = e instanceof Error ? e.message : String(e);
+                        const err = new Error(`Failed to install recipe '${recipe.name}'. Ensure the constructor can be called without any arguments. Cause: ${cause}`);
                         (err as any).cause = e;
                         throw err;
                     }

--- a/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
+++ b/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
@@ -46,7 +46,21 @@ import {ReferenceMap} from "../reference";
 import {GetLanguages} from "./request/get-languages";
 
 export class RewriteRpc {
-    private static _global?: RewriteRpc;
+    /**
+     * Key for the active {@link RewriteRpc} connection on {@link globalThis}.
+     *
+     * It deliberately lives on `globalThis` rather than as a `static` field:
+     * a recipe package that bundles `@openrewrite/rewrite` (or resolves it from
+     * its own `node_modules`) loads a *separate copy* of this module, with its
+     * own class object and therefore its own statics. A `static` field set by
+     * the host would be invisible to such a copy, so `RewriteRpc.get()` (e.g.
+     * via `prepareJavaRecipe`) would return `undefined` and throw "no active
+     * RewriteRpc connection" — surfacing during `InstallRecipes` as the
+     * misleading "Ensure the constructor can be called without any arguments".
+     * {@link Symbol.for} resolves to the same symbol across every module copy,
+     * so all copies share the one active connection. See gh-7968.
+     */
+    private static readonly GLOBAL_KEY: symbol = Symbol.for("org.openrewrite.rpc.RewriteRpc.global");
 
     private readonly snowflake = SnowflakeId();
 
@@ -154,11 +168,11 @@ export class RewriteRpc {
     }
 
     static set(value: RewriteRpc) {
-        this._global = value;
+        (globalThis as any)[RewriteRpc.GLOBAL_KEY] = value;
     }
 
     static get(): RewriteRpc | undefined {
-        return this._global;
+        return (globalThis as any)[RewriteRpc.GLOBAL_KEY];
     }
 
     end(): RewriteRpc {

--- a/rewrite-javascript/rewrite/test/recipe.test.ts
+++ b/rewrite-javascript/rewrite/test/recipe.test.ts
@@ -13,11 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {RecipeMarketplace} from "../src";
+import {JavaScript, Recipe, RecipeMarketplace} from "../src";
 import {activate} from "../fixtures/example-recipe";
 import {ChangeText} from "../fixtures/change-text";
 
 describe("recipes", () => {
+
+    // gh-7968: a failure while computing a recipe's descriptor (e.g. a sub-recipe
+    // in recipeList() that needs an RPC connection) is dropped at the JSON-RPC
+    // boundary, leaving only the generic "constructor" hint. The marketplace must
+    // fold the underlying cause into the message so it survives to the caller.
+    test("install surfaces the underlying cause when descriptor computation fails", async () => {
+        class FailingRecipe extends Recipe {
+            name = "org.openrewrite.example.failing";
+            displayName = "Failing recipe";
+            description = "Throws while resolving its recipe list.";
+
+            async recipeList(): Promise<Recipe[]> {
+                throw new Error("no active RewriteRpc connection");
+            }
+        }
+
+        const marketplace = new RecipeMarketplace();
+        await expect(marketplace.install(FailingRecipe, JavaScript)).rejects.toThrow(
+            /Cause: no active RewriteRpc connection/
+        );
+    });
 
     test("register a recipe with options", async () => {
         const marketplace = new RecipeMarketplace();

--- a/rewrite-javascript/rewrite/test/rpc/global-connection.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/global-connection.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {RewriteRpc} from "../../src/rpc/rewrite-rpc";
+
+/**
+ * Regression tests for gh-7968: the active {@link RewriteRpc} connection must be
+ * shared across *every copy* of the `@openrewrite/rewrite` module, not just the
+ * host's. A recipe package that bundles the library (or resolves it from its own
+ * `node_modules`) loads a separate copy of this class, so a `static` field would
+ * be invisible to it — `prepareJavaRecipe` would then fail with "no active
+ * RewriteRpc connection", which `InstallRecipes` masks as the misleading
+ * "Ensure the constructor can be called without any arguments".
+ *
+ * Storing the connection on `globalThis` under a `Symbol.for` key — which
+ * resolves to the same symbol in any module copy — keeps it visible everywhere.
+ */
+describe("RewriteRpc active connection", () => {
+    // The key every module copy resolves to via Symbol.for.
+    const GLOBAL_KEY = Symbol.for("org.openrewrite.rpc.RewriteRpc.global");
+
+    const saved = (globalThis as any)[GLOBAL_KEY];
+    afterEach(() => {
+        (globalThis as any)[GLOBAL_KEY] = saved;
+    });
+
+    test("set() stores the connection on globalThis under the shared Symbol.for key", () => {
+        const fake = {iAm: "connection"} as unknown as RewriteRpc;
+        RewriteRpc.set(fake);
+        // A separately-loaded module copy reads this exact slot through its own
+        // (distinct) RewriteRpc class object — Symbol.for guarantees the same key.
+        expect((globalThis as any)[GLOBAL_KEY]).toBe(fake);
+    });
+
+    test("get() sees a connection set by another module copy", () => {
+        const fake = {iAm: "connection-from-other-copy"} as unknown as RewriteRpc;
+        // Simulate the host copy publishing the active connection.
+        (globalThis as any)[GLOBAL_KEY] = fake;
+        expect(RewriteRpc.get()).toBe(fake);
+    });
+});


### PR DESCRIPTION
## What's changed?

- Fixes #7968. A TypeScript recipe whose `recipeList()` composes Java recipes via `prepareJavaRecipe` (e.g. `addDependency` / `removeDependency`) failed to install through the Moderne CLI with the misleading wrapper error:

```
Failed to install recipe 'ReplaceNodeSassWithSass'. Ensure the constructor can be called without any arguments.
```

- This is the same symptom #7892 set out to fix, but on the `InstallRecipes` → `RecipeMarketplace.descriptor()` path rather than the `PrepareRecipe` path.

## Root cause

The active `RewriteRpc` connection was held in a `static` field on the class. A recipe package that **bundles** `@openrewrite/rewrite` (or resolves it from its own `node_modules`) loads a *separate copy* of the module, with its own class object and therefore its own statics. The host sets `_global` on its copy; the recipe package's copy never sees it, so:

- `recipeList()` → `prepareJavaRecipe()` → `RewriteRpc.get()` returns `undefined`
- `prepareJavaRecipe` throws `"no active RewriteRpc connection"`
- during `InstallRecipes`, that real cause is dropped at the JSON-RPC boundary (only `message` crosses) and the marketplace re-wraps it as the generic "constructor" hint.

Verified the static is per-copy: loading two physical copies of the compiled module and calling `set()` on one leaves `get()` on the other returning `undefined`. Moving the slot to `globalThis` makes both copies agree.

## The fix

- **`rewrite-rpc.ts`** — store the active connection on `globalThis` under a `Symbol.for("org.openrewrite.rpc.RewriteRpc.global")` key. `Symbol.for` resolves to the same symbol in every module copy, so all copies (host, bundled recipe package, separately-installed `node_modules`) share one connection.
- **`marketplace.ts`** — fold the underlying cause into the install error message (`… Cause: <message>`) so it survives the JSON-RPC boundary and reaches the caller's logs instead of being hidden behind the constructor hint.

## Tests

- `test/rpc/global-connection.test.ts` — the active connection is shared via the `globalThis` `Symbol.for` slot (the cross-copy contract).
- `test/recipe.test.ts` — `marketplace.install` surfaces the underlying cause when descriptor computation fails.

All `test/rpc/` and `test/recipe.test.ts` suites pass (Java RPC integration tests included); `npm run typecheck` is clean.