### PR TITLE
Use JavaSourceFile, not J.CompilationUnit, when a Java recipe only needs file-level data

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
@@ -23,6 +23,7 @@ import org.openrewrite.java.search.DeclaresMethod;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Javadoc;
 
@@ -110,7 +111,7 @@ public class UseStaticImport extends Recipe {
     }
 
     private static boolean hasConflictingImport(String typeName, String methodName, Cursor cursor) {
-        J.CompilationUnit cu = cursor.firstEnclosing(J.CompilationUnit.class);
+        JavaSourceFile cu = cursor.firstEnclosing(JavaSourceFile.class);
         if (cu != null) {
             for (J.Import imp : cu.getImports()) {
                 if (imp.isStatic() &&

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindCompileErrors.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindCompileErrors.java
@@ -22,6 +22,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.table.CompileErrors;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.marker.SearchResult;
 
 public class FindCompileErrors extends Recipe {
@@ -39,7 +40,7 @@ public class FindCompileErrors extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.Erroneous visitErroneous(J.Erroneous erroneous, ExecutionContext ctx) {
-                J.CompilationUnit cu = getCursor().firstEnclosing(J.CompilationUnit.class);
+                JavaSourceFile cu = getCursor().firstEnclosing(JavaSourceFile.class);
                 String sourceFile = cu != null ? cu.getSourcePath().toString() : "Unknown source file";
                 String code = erroneous.print(getCursor());
                 report.insertRow(ctx, new CompileErrors.Row(

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindFieldsOfType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindFieldsOfType.java
@@ -23,6 +23,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.TypeMatcher;
 import org.openrewrite.java.table.FieldsOfTypeUses;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.marker.SearchResult;
 
@@ -79,7 +80,7 @@ public class FindFieldsOfType extends Recipe {
                             varType = variable.getInitializer().getType().toString();
                         }
                         fieldsOfTypeUses.insertRow(ctx, new FieldsOfTypeUses.Row(
-                            getCursor().firstEnclosingOrThrow(J.CompilationUnit.class).getSourcePath().toString(),
+                            getCursor().firstEnclosingOrThrow(JavaSourceFile.class).getSourcePath().toString(),
                             variable.getSimpleName(),
                             multiVariable.getTypeExpression().getType().toString(),
                             varType,

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/FindFieldsOfTypeTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/FindFieldsOfTypeTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.search.FindFieldsOfType;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class FindFieldsOfTypeTest implements RewriteTest {
+
+    @DocumentExample
+    @Test
+    void findsKotlinFieldWithoutThrowing() {
+        rewriteRun(
+          spec -> spec.recipe(new FindFieldsOfType("java.util.ArrayList", false)),
+          kotlin(
+            """
+              import java.io.File
+
+              class Checksum {
+                  val files: ArrayList<File> = arrayListOf()
+              }
+              """,
+            """
+              import java.io.File
+
+              class Checksum {
+                  /*~~>*/val files: ArrayList<File> = arrayListOf()
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's wrong

Java recipes built on `JavaIsoVisitor` also traverse Kotlin and Groovy sources, because `K.CompilationUnit` / `G.CompilationUnit` implement `JavaSourceFile`. A recipe that asserts its enclosing tree is a `J.CompilationUnit` therefore breaks on those sources.

`FindFieldsOfType` calls `firstEnclosingOrThrow(J.CompilationUnit.class).getSourcePath()` to populate its `FieldsOfTypeUses` data table. When it matches a field in a Kotlin source, the enclosing CU is a `K.CompilationUnit` (not a `J.CompilationUnit`), so it throws `IllegalStateException: Expected to find enclosing CompilationUnit`. `RecipeRunCycle` records that as a `Markup.Error` on the node — and any consumer that prints the result back out gets a corrupted tree.

Two siblings have the same root assumption via the non-throwing `firstEnclosing(J.CompilationUnit.class)` and silently misbehave on Kotlin/Groovy:
- `FindCompileErrors` — reports `"Unknown source file"` instead of the real path.
- `UseStaticImport` — `cu` comes back `null`, so the conflicting-import safety check is skipped (it can then create a static import that collides with an existing one).

## Fix

Switch all three to `firstEnclosing[OrThrow](JavaSourceFile.class)`. `JavaSourceFile` declares both `getSourcePath()` and `getImports()`, and every language's CompilationUnit implements it, so the code keeps working on Java and starts working on Kotlin/Groovy. This is already the prevailing idiom in the codebase (13 existing uses of `firstEnclosingOrThrow(JavaSourceFile.class)`).

**Deliberately left as `J.CompilationUnit`:** `FindMissingTypes` and the rewrite-kotlin `Assertions` helper read `getPackageDeclaration()`, which is not on `JavaSourceFile` — they are genuinely Java-specific, and their existing null-guards correctly skip the package cross-check on non-Java sources.

## Test

`rewrite-kotlin/.../FindFieldsOfTypeTest` runs `FindFieldsOfType("java.util.ArrayList", false)` against a Kotlin class with an `ArrayList<File>` field. Verified that it **fails without this change** (the `IllegalStateException` above) and passes with it. Existing `UseStaticImportTest` (15) and `FindFieldsOfTypeTest` (10, rewrite-java-test) stay green.