### PR TITLE
JS RPC: accept all engines shapes that npm accepts

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/node-resolution-result.ts
+++ b/rewrite-javascript/rewrite/src/javascript/node-resolution-result.ts
@@ -243,26 +243,40 @@ export function createNodeResolutionResultMarker(
     const dependencyCache = new Map<string, Dependency>();
 
     /**
-     * Normalizes the engines field from package-lock.json.
-     * Some older packages have engines as an array like ["node >=0.6.0"] instead of
-     * the standard object format {"node": ">=0.6.0"}.
+     * Coerces the engines field to the Map<String,String> shape Java's
+     * NodeResolutionResult.ResolvedDependency expects. The npm registry
+     * accepts and serves several shapes that don't fit that type; sending
+     * any of them across RPC throws ClassCastException, which (because
+     * pendingData survives mid-stream failures) cascades the receive queue
+     * out of sync for every subsequent file in the build.
+     *
+     * Shapes seen in the wild and what we do with them:
+     *  - object: pass through.
+     *  - ["node >=0.6.0"]: split on the first space → {node: ">=0.6.0"}.
+     *  - ["node", "rhino"]: bare names with no version. Preserve the
+     *      engine list as {node: "*", rhino: "*"}.
+     *  - ">=0.10.40": bare semver with no engine name (qs@5.2.1 ships this
+     *      verbatim from its published package.json). npm itself drops it —
+     *      npm-install-checks reads eng.node/eng.npm off the string, both
+     *      undefined, so the constraint is silently ignored. Match that.
      */
-    function normalizeEngines(engines?: Record<string, string> | string[]): Record<string, string> | undefined {
+    function normalizeEngines(engines?: unknown): Record<string, string> | undefined {
         if (!engines) return undefined;
         if (Array.isArray(engines)) {
-            // Convert array format to object format
-            // e.g., ["node >=0.6.0"] -> {"node": ">=0.6.0"}
             const result: Record<string, string> = {};
             for (const entry of engines) {
+                if (typeof entry !== 'string') continue;
                 const spaceIdx = entry.indexOf(' ');
                 if (spaceIdx > 0) {
-                    const key = entry.substring(0, spaceIdx);
-                    result[key] = entry.substring(spaceIdx + 1);
+                    result[entry.substring(0, spaceIdx)] = entry.substring(spaceIdx + 1);
+                } else {
+                    result[entry] = "*";
                 }
             }
             return Object.keys(result).length > 0 ? result : undefined;
         }
-        return engines;
+        if (typeof engines !== 'object') return undefined;
+        return engines as Record<string, string>;
     }
 
     /**
@@ -271,7 +285,7 @@ export function createNodeResolutionResultMarker(
      * - Array: ["MIT", "Apache2"] -> "(MIT OR Apache2)"
      * - Object: { type: "MIT", url: "..." } -> "MIT"
      */
-    function normalizeLicense(license?: string | string[] | { type?: string; url?: string }): string | undefined {
+    function normalizeLicense(license?: unknown): string | undefined {
         if (!license) return undefined;
         if (Array.isArray(license)) {
             // Convert array format to SPDX OR expression
@@ -281,9 +295,10 @@ export function createNodeResolutionResultMarker(
         if (typeof license === 'object') {
             // Extract type from object format
             // e.g., { type: "MIT", url: "..." } -> "MIT"
-            return license.type || undefined;
+            const type = (license as { type?: unknown }).type;
+            return typeof type === 'string' ? type : undefined;
         }
-        return license;
+        return typeof license === 'string' ? license : undefined;
     }
 
     /**
@@ -588,7 +603,7 @@ export function createNodeResolutionResultMarker(
         bundledDependencies,
         resolvedDependencies,
         packageManager,
-        engines: packageJsonContent.engines,
+        engines: normalizeEngines(packageJsonContent.engines),
         npmrcConfigs,
     } as NodeResolutionResult;
 }

--- a/rewrite-javascript/rewrite/test/javascript/node-resolution-result.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/node-resolution-result.test.ts
@@ -865,6 +865,64 @@ describe("NodeResolutionResult marker", () => {
         });
     });
 
+    test("should drop engines when the value is a bare semver string (engine name absent)", () => {
+        // qs@5.2.1 publishes `engines: ">=0.10.40"` verbatim — a bare semver
+        // with no engine name. Java's NodeResolutionResult.ResolvedDependency
+        // expects Map<String,String> and a String over the RPC wire throws
+        // ClassCastException mid-stream, cascading the receive queue out of
+        // sync for every subsequent file in the build (silently dropping JS
+        // LSTs while reporting BUILD SUCCESS).
+        //
+        // npm itself drops this — npm-install-checks reads eng.node/eng.npm
+        // off the string, both undefined, so the constraint is ignored. We
+        // match that behavior rather than guess at an implicit engine name.
+        const marker = createNodeResolutionResultMarker(
+            "package.json",
+            {name: "test-project", version: "1.0.0", dependencies: {qs: "*"}},
+            {
+                name: "test-project",
+                version: "1.0.0",
+                lockfileVersion: 3,
+                packages: {
+                    "": {version: "1.0.0", dependencies: {qs: "*"}},
+                    "node_modules/qs": {
+                        version: "5.2.1",
+                        engines: ">=0.10.40" as any
+                    }
+                }
+            }
+        );
+
+        const qsDep = marker.dependencies.find(d => d.name === "qs");
+        expect(qsDep?.resolved?.engines).toBeUndefined();
+    });
+
+    test("should preserve engines list from legacy array of bare names", () => {
+        // e.g., lodash's package-lock entry has `engines: ["node", "rhino"]` —
+        // engine names with no version constraint. Preserve the list as
+        // {node: "*", rhino: "*"} so downstream recipes can still ask which
+        // engines a package declares support for.
+        const marker = createNodeResolutionResultMarker(
+            "package.json",
+            {name: "test-project", version: "1.0.0", dependencies: {lodash: "*"}},
+            {
+                name: "test-project",
+                version: "1.0.0",
+                lockfileVersion: 3,
+                packages: {
+                    "": {version: "1.0.0", dependencies: {lodash: "*"}},
+                    "node_modules/lodash": {
+                        version: "1.0.0",
+                        engines: ["node", "rhino"]
+                    }
+                }
+            }
+        );
+
+        const lodashDep = marker.dependencies.find(d => d.name === "lodash");
+        expect(lodashDep?.resolved?.engines).toEqual({node: "*", rhino: "*"});
+    });
+
     test("should resolve pnpm-style paths with version suffix", () => {
         // pnpm stores packages with version in the path: node_modules/package@version
         // This is different from npm's node_modules/package


### PR DESCRIPTION
## Summary
- `NodeResolutionResult.ResolvedDependency` expects `engines` as `Map<String,String>` on the Java side. The npm registry accepts and serves several `engines` shapes that don't fit that type, and sending any of them over RPC throws `ClassCastException` in `ResolvedDependency.rpcReceive`. That failure happens mid-stream while Java is decoding a single file's LST; pending data on the JS side still holds the remaining batches, including refs already registered in `localRefs` but never flushed. Every subsequent file's reference-only message points at those orphaned refs and throws `IllegalStateException: Received a reference to an object that was not previously sent` — one bad lock entry cascades into hundreds of silent `ParseError` fallbacks while the build reports SUCCESS.
- `normalizeEngines` now coerces every shape that round-trips through npm:
  - `{node: ">=14"}` — pass through (standard).
  - `["node >=0.6.0"]` — split on first space → `{node: ">=0.6.0"}` (existing behavior).
  - `["node", "rhino"]` — bare names, no constraint → preserve as `{node: "*", rhino: "*"}` (was dropped).
  - `">=0.10.40"` — bare semver, no engine name. `qs@5.2.1` ships this verbatim from its published `package.json`. npm itself silently ignores it (`npm-install-checks` reads `eng.node`/`eng.npm` off the string, both `undefined`), so we do the same.
- `normalizeLicense` tightened to drop non-string types instead of leaking them through.
- `normalizeEngines` now also runs at the outer `NodeResolutionResult.engines` pass-through so a top-level package.json with a non-standard engines field doesn't hit the same cascade.

## Repro
A jhipster customer repo with `karma-phantomjs-launcher/node_modules/qs` in its `package-lock.json` (engines: `">=0.10.40"`):

| | Before | After |
|---|---:|---:|
| `IllegalStateException` | 442 | **0** |
| `ClassCastException` | 1 | **0** |
| `JS.CompilationUnit` in manifest | 0 (all `.js` silently fell to `PlainText`) | **84** |

## Test plan
- [x] `npm test` — 1773 + 2 new passing, 0 failing
- [x] Customer repro: zero exceptions, 84 JS LSTs produced
- [x] New regression tests cover the qs-bare-string and lodash-bare-names cases