### PR TITLE
Guard against null requested managed dependency in isManagedDependencyTag

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -198,8 +198,8 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
         for (ResolvedManagedDependency dm : getResolutionResult().getPom().getDependencyManagement()) {
             if (matchesGlob(dm.getGroupId(), groupId) && matchesGlob(dm.getArtifactId(), artifactId)) {
                 ManagedDependency req = dm.getRequested();
-                String reqGroup = req.getGroupId();
-                if (reqGroup.equals(tag.getChildValue("groupId").orElse(null)) &&
+                if (req != null &&
+                        req.getGroupId().equals(tag.getChildValue("groupId").orElse(null)) &&
                         req.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
                         dm.getScope() == tag.getChildValue("scope").map(Scope::fromName).orElse(null)) {
                     return true;
@@ -208,8 +208,8 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
             if (dm.getBomGav() != null) {
                 if (matchesGlob(dm.getBomGav().getGroupId(), groupId) && matchesGlob(dm.getBomGav().getArtifactId(), artifactId)) {
                     ManagedDependency requestedBom = dm.getRequestedBom();
-                    //noinspection ConstantConditions
-                    if (requestedBom.getGroupId().equals(tag.getChildValue("groupId").orElse(null)) &&
+                    if (requestedBom != null &&
+                            requestedBom.getGroupId().equals(tag.getChildValue("groupId").orElse(null)) &&
                             requestedBom.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null))) {
                         return true;
                     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -3139,4 +3139,36 @@ class UpgradeDependencyVersionTest implements RewriteTest {
         }
     }
 
+    @Test
+    void doesNotThrowWhenManagedDependencyHasNullRequested() {
+        // Older serialized LSTs can carry BOM-imported managed dependencies whose `requested` is null.
+        // `MavenVisitor.isManagedDependencyTag` must not dereference it unconditionally, otherwise recipes
+        // such as DependencyVulnerabilityCheck blow up with an NPE on otherwise valid poms.
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.flywaydb", "flyway-core", "10.15.0", "", true, null)),
+          pomXml(
+            """
+              <project>
+                  <groupId>com.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.springframework.boot</groupId>
+                              <artifactId>spring-boot-dependencies</artifactId>
+                              <version>3.3.0</version>
+                              <type>pom</type>
+                              <scope>import</scope>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """,
+            spec -> spec.beforeRecipe(doc -> doc.getMarkers().findFirst(MavenResolutionResult.class)
+              .ifPresent(mrr -> mrr.getPom().getDependencyManagement().replaceAll(dm -> dm.withRequested(null))))
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?

`MavenVisitor.isManagedDependencyTag(String, String)` dereferenced `dm.getRequested()` (and `dm.getRequestedBom()`) without a null check:

```java
ManagedDependency req = dm.getRequested();
String reqGroup = req.getGroupId(); // NPE when req is null
```

Older serialized LSTs can contain BOM-imported managed dependencies whose `requested` is null (the `requestedBom` branch already carried a `//noinspection ConstantConditions` acknowledging the same possibility). When such an entry's group/artifact matched the queried coordinates, the unconditional dereference threw:

```
java.lang.NullPointerException: Cannot invoke "org.openrewrite.maven.tree.ManagedDependency.getGroupId()" because "req" is null
    at org.openrewrite.maven.MavenVisitor.isManagedDependencyTag(MavenVisitor.java:201)
    at org.openrewrite.maven.UpgradeDependencyVersion$3.visitTag(UpgradeDependencyVersion.java:257)
```

OpenRewrite catches this per-tag and attaches a `Markup.Error` marker, which renders as an **empty diff** (only document-boundary noise) — so downstream tooling reports a "change" on a pom the recipe could not actually touch. This was hit in the wild by `org.openrewrite.java.dependencies.DependencyVulnerabilityCheck` (which runs `UpgradeDependencyVersion`) on poms importing a BOM.

## Fix

Null-guard both `requested` and `requestedBom` before dereferencing, returning no match instead of throwing.

## Anything in particular you'd like a reviewer to focus on?

The added test reproduces the exact production stack trace by simulating the older-LST condition (a managed dependency with `requested == null`); it fails with the NPE before the fix and passes after.