### PR TITLE
Data tables over RPC: share store configuration via the ExecutionContext codec

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/CsvDataTableStore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/CsvDataTableStore.java
@@ -388,6 +388,10 @@ public class CsvDataTableStore implements DataTableStore, AutoCloseable {
             }
 
             csvWriter.writeRow((Object[]) values);
+            // Rows must be durable without an explicit close: a store on an RPC peer
+            // has no end-of-run hook, so readers (e.g. the orchestrating process)
+            // would otherwise only ever see empty files.
+            csvWriter.flush();
         }
 
         void close() {

--- a/rewrite-core/src/main/java/org/openrewrite/DataTableExecutionContextView.java
+++ b/rewrite-core/src/main/java/org/openrewrite/DataTableExecutionContextView.java
@@ -15,8 +15,38 @@
  */
 package org.openrewrite;
 
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import static java.util.Collections.emptyMap;
+
 public class DataTableExecutionContextView extends DelegatingExecutionContext {
     public static final String DATA_TABLE_STORE = "org.openrewrite.dataTables.store";
+
+    /**
+     * Configuration for constructing a {@link CsvDataTableStore} locally. These keys
+     * use {@link ExecutionContext#RPC_SHARED_MESSAGE_PREFIX} so that the configuration
+     * travels to remote RPC peers along with the context, allowing each peer to write
+     * data table rows to its own files in the shared output directory. Values are
+     * restricted to strings and lists of strings so every peer language can read them.
+     */
+    public static final String DATA_TABLE_STORE_OUTPUT_DIR = ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "dataTableOutputDir";
+    public static final String DATA_TABLE_STORE_FILE_EXTENSION = ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "dataTableFileExtension";
+    public static final String DATA_TABLE_STORE_PREFIX_COLUMNS = ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "dataTablePrefixColumns";
+    public static final String DATA_TABLE_STORE_SUFFIX_COLUMNS = ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "dataTableSuffixColumns";
 
     private DataTableExecutionContextView(ExecutionContext delegate) {
         super(delegate);
@@ -34,12 +64,101 @@ public class DataTableExecutionContextView extends DelegatingExecutionContext {
         return this;
     }
 
+    /**
+     * Configure how data table rows are persisted to CSV files. The configuration is
+     * stored as RPC-shared messages, so when this context is transferred to a remote
+     * RPC peer, the peer installs its own local {@link CsvDataTableStore} from it and
+     * streams rows to disk in the same output directory. Every store created from this
+     * configuration (local or remote) writes files with a unique name suffix, so
+     * concurrently open (possibly compressed) streams never collide.
+     *
+     * @param outputDir     directory to write files into
+     * @param fileExtension file extension including dot, {@code .csv} or {@code .csv.gz}
+     *                      ({@code .gz} implies GZIP compression)
+     * @param prefixColumns static columns prepended to each row, in iteration order
+     * @param suffixColumns static columns appended to each row, in iteration order
+     */
+    public DataTableExecutionContextView setDataTableStoreConfig(Path outputDir, String fileExtension,
+                                                                 Map<String, String> prefixColumns,
+                                                                 Map<String, String> suffixColumns) {
+        putMessage(DATA_TABLE_STORE_OUTPUT_DIR, outputDir.toString());
+        putMessage(DATA_TABLE_STORE_FILE_EXTENSION, fileExtension);
+        putMessage(DATA_TABLE_STORE_PREFIX_COLUMNS, flattenColumns(prefixColumns));
+        putMessage(DATA_TABLE_STORE_SUFFIX_COLUMNS, flattenColumns(suffixColumns));
+        return this;
+    }
+
     public DataTableStore getDataTableStore() {
         DataTableStore store = getMessage(DATA_TABLE_STORE);
         if (store == null) {
-            store = new InMemoryDataTableStore();
+            String outputDir = getMessage(DATA_TABLE_STORE_OUTPUT_DIR);
+            store = outputDir == null ? new InMemoryDataTableStore() : csvDataTableStore(Paths.get(outputDir));
             putMessage(DATA_TABLE_STORE, store);
         }
         return store;
+    }
+
+    private CsvDataTableStore csvDataTableStore(Path outputDir) {
+        String fileExtension = getMessage(DATA_TABLE_STORE_FILE_EXTENSION, ".csv");
+        // A unique per-store suffix keeps this store's files separate from those of
+        // other processes (or other contexts) writing to the same directory.
+        String uniqueExtension = "-" + UUID.randomUUID().toString().substring(0, 8) + fileExtension;
+        Map<String, String> prefixColumns = unflattenColumns(getMessage(DATA_TABLE_STORE_PREFIX_COLUMNS));
+        Map<String, String> suffixColumns = unflattenColumns(getMessage(DATA_TABLE_STORE_SUFFIX_COLUMNS));
+        if (fileExtension.endsWith(".gz")) {
+            return new CsvDataTableStore(outputDir,
+                    path -> {
+                        try {
+                            return new GZIPOutputStream(Files.newOutputStream(path,
+                                    StandardOpenOption.CREATE, StandardOpenOption.APPEND));
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    },
+                    path -> {
+                        try {
+                            return new GZIPInputStream(Files.newInputStream(path));
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    },
+                    uniqueExtension, prefixColumns, suffixColumns);
+        }
+        return new CsvDataTableStore(outputDir,
+                path -> {
+                    try {
+                        return Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                },
+                path -> {
+                    try {
+                        return Files.newInputStream(path);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                },
+                uniqueExtension, prefixColumns, suffixColumns);
+    }
+
+    private static List<String> flattenColumns(Map<String, String> columns) {
+        List<String> flattened = new ArrayList<>(columns.size() * 2);
+        for (Map.Entry<String, String> column : columns.entrySet()) {
+            flattened.add(column.getKey());
+            flattened.add(column.getValue());
+        }
+        return flattened;
+    }
+
+    private static Map<String, String> unflattenColumns(@Nullable List<String> flattened) {
+        if (flattened == null || flattened.isEmpty()) {
+            return emptyMap();
+        }
+        Map<String, String> columns = new LinkedHashMap<>();
+        for (int i = 0; i + 1 < flattened.size(); i += 2) {
+            columns.put(flattened.get(i), flattened.get(i + 1));
+        }
+        return columns;
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
@@ -40,6 +40,17 @@ public interface ExecutionContext extends RpcCodec<ExecutionContext> {
     String REQUIRE_PRINT_EQUALS_INPUT = "org.openrewrite.requirePrintEqualsInput";
     String SCANNING_MUTATION_VALIDATION = "org.openrewrite.test.scanningMutationValidation";
 
+    /**
+     * Messages whose keys start with this prefix are shared with remote RPC peers
+     * when this context is transferred via {@link #rpcSend} / {@link #rpcReceive}.
+     * All other messages are process-local (they may hold non-serializable state
+     * like caches, callbacks or open resources) and never cross the wire.
+     * <p>
+     * Values of shared messages must be limited to strings and lists of strings so
+     * that every peer language can consume them without dedicated codecs.
+     */
+    String RPC_SHARED_MESSAGE_PREFIX = "org.openrewrite.rpc.shared.";
+
     @Incubating(since = "7.20.0")
     default ExecutionContext addObserver(TreeObserver.Subscription observer) {
         putMessageInCollection("org.openrewrite.internal.treeObservers", observer,
@@ -119,15 +130,54 @@ public interface ExecutionContext extends RpcCodec<ExecutionContext> {
     }
 
     /**
-     * The after state will change if any messages have changed by a call to clone in the
-     * {@link Visit.Handler} implementation.
+     * Sends the messages under {@link #RPC_SHARED_MESSAGE_PREFIX} as a single value:
+     * a list of {@code [key, value]} pairs sorted by key, or nothing (NO_CHANGE) when
+     * there are none. Because a plain list carries no value type, peers receive it as
+     * raw JSON without needing a dedicated codec for it.
+     * <p>
+     * Note that contexts are mutated in place rather than copied, so on a re-send the
+     * before and after state are the same instance and the shared messages are simply
+     * sent again whenever any exist.
      */
     @Override
     default void rpcSend(ExecutionContext ctx, RpcSendQueue q) {
+        q.getAndSend(ctx, ExecutionContext::rpcSharedMessages);
     }
 
     @Override
     default ExecutionContext rpcReceive(ExecutionContext ctx, RpcReceiveQueue q) {
+        List<List<Object>> after = q.receive(rpcSharedMessages(ctx));
+        Set<String> retained = new HashSet<>();
+        if (after != null) {
+            for (List<Object> entry : after) {
+                String key = (String) entry.get(0);
+                ctx.putMessage(key, entry.get(1));
+                retained.add(key);
+            }
+        }
+        ctx.getMessages().keySet().removeIf(key ->
+                key.startsWith(RPC_SHARED_MESSAGE_PREFIX) && !retained.contains(key));
         return ctx;
+    }
+
+    /**
+     * @return The messages under {@link #RPC_SHARED_MESSAGE_PREFIX} as a list of
+     * {@code [key, value]} pairs sorted by key, or null when there are none.
+     */
+    static @Nullable List<List<Object>> rpcSharedMessages(ExecutionContext ctx) {
+        Map<String, Object> shared = new TreeMap<>();
+        for (Map.Entry<String, @Nullable Object> message : ctx.getMessages().entrySet()) {
+            if (message.getKey().startsWith(RPC_SHARED_MESSAGE_PREFIX) && message.getValue() != null) {
+                shared.put(message.getKey(), message.getValue());
+            }
+        }
+        if (shared.isEmpty()) {
+            return null;
+        }
+        List<List<Object>> entries = new ArrayList<>(shared.size());
+        for (Map.Entry<String, Object> entry : shared.entrySet()) {
+            entries.add(Arrays.asList(entry.getKey(), entry.getValue()));
+        }
+        return entries;
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcRecipe.java
@@ -137,14 +137,11 @@ public class RpcRecipe extends ScanningRecipe<Integer> {
 
     @Override
     public void onComplete(ExecutionContext ctx) {
-        // This will merge data tables from the remote into the local context.
-        //
-        // When multiple recipes ran on the same RPC peer, they will all have been
-        // adding to the same ExecutionContext instance on that peer, and so really
-        // a CHANGE will only be returned for the first of any recipes on that peer.
-        //
-        // It doesn't matter which one added data table entries, because they all share
-        // the same view of the data tables.
+        // Synchronize the final state of the remote's ExecutionContext. Data table
+        // rows do not flow back over RPC: when a data table store is configured
+        // (see DataTableExecutionContextView#setDataTableStoreConfig), the peer
+        // streams its rows to its own files in the shared output directory as they
+        // are inserted.
         String id = ctx.getMessage("org.openrewrite.rpc.id");
         if (id != null) {
             rpc.getObject(id, null);

--- a/rewrite-core/src/test/java/org/openrewrite/DataTableStoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/DataTableStoreTest.java
@@ -209,6 +209,95 @@ class DataTableStoreTest {
     }
 
     // =========================================================================
+    // DataTableExecutionContextView: store configuration shared over RPC
+    // =========================================================================
+
+    @Test
+    void storeConfigIsWhitelistedForRpcSharing(@TempDir Path tempDir) {
+        ExecutionContext ctx = ctx();
+        Map<String, String> prefix = new LinkedHashMap<>();
+        prefix.put("repositoryOrigin", "github.com/acme/demo");
+        Map<String, String> suffix = new LinkedHashMap<>();
+        suffix.put("runId", "run-1");
+        DataTableExecutionContextView.view(ctx)
+                .setDataTableStoreConfig(tempDir, ".csv", prefix, suffix);
+
+        assertThat(ctx.getMessages().entrySet())
+                .filteredOn(message -> message.getKey().startsWith(ExecutionContext.RPC_SHARED_MESSAGE_PREFIX))
+                .hasSize(4)
+                .allSatisfy(message -> assertThat(message.getValue())
+                        .satisfiesAnyOf(
+                                v -> assertThat(v).isInstanceOf(String.class),
+                                v -> assertThat(v).isInstanceOf(List.class)));
+    }
+
+    @Test
+    void materializesCsvStoreFromConfig(@TempDir Path tempDir) throws Exception {
+        ExecutionContext ctx = ctx();
+        Map<String, String> prefix = new LinkedHashMap<>();
+        prefix.put("repositoryOrigin", "github.com/acme/demo");
+        Map<String, String> suffix = new LinkedHashMap<>();
+        suffix.put("runId", "run-1");
+        DataTableExecutionContextView.view(ctx)
+                .setDataTableStoreConfig(tempDir, ".csv", prefix, suffix);
+
+        DataTableStore store = DataTableExecutionContextView.view(ctx).getDataTableStore();
+        assertThat(store).isInstanceOf(CsvDataTableStore.class);
+        store.insertRow(new TestTable(Recipe.noop()), ctx, new TestTable.Row("alice"));
+        ((AutoCloseable) store).close();
+
+        var files = tempDir.toFile().listFiles((dir, name) -> name.endsWith(".csv"));
+        assertThat(files).hasSize(1);
+        assertThat(files[0].getName()).startsWith(TestTable.class.getName() + "-");
+        List<String> lines = Files.readAllLines(files[0].toPath());
+        assertThat(lines).contains(
+                "repositoryOrigin,name,runId",
+                "github.com/acme/demo,alice,run-1");
+    }
+
+    @Test
+    void materializesGzipCsvStoreFromConfig(@TempDir Path tempDir) throws Exception {
+        ExecutionContext ctx = ctx();
+        DataTableExecutionContextView.view(ctx)
+                .setDataTableStoreConfig(tempDir, ".csv.gz", Map.of(), Map.of());
+
+        DataTableStore store = DataTableExecutionContextView.view(ctx).getDataTableStore();
+        store.insertRow(new TestTable(Recipe.noop()), ctx, new TestTable.Row("alice"));
+        ((AutoCloseable) store).close();
+
+        var files = tempDir.toFile().listFiles((dir, name) -> name.endsWith(".csv.gz"));
+        assertThat(files).hasSize(1);
+        try (var in = new java.util.zip.GZIPInputStream(new FileInputStream(files[0]))) {
+            String content = new String(in.readAllBytes());
+            assertThat(content).contains("alice");
+        }
+    }
+
+    @Test
+    void materializedStoresWriteDistinctFiles(@TempDir Path tempDir) throws Exception {
+        // Each store gets a unique filename suffix so that processes sharing an
+        // output directory (orchestrator + RPC peers) never append to each
+        // other's open (possibly gzip) streams.
+        for (int i = 0; i < 2; i++) {
+            ExecutionContext ctx = ctx();
+            DataTableExecutionContextView.view(ctx)
+                    .setDataTableStoreConfig(tempDir, ".csv", Map.of(), Map.of());
+            DataTableStore store = DataTableExecutionContextView.view(ctx).getDataTableStore();
+            store.insertRow(new TestTable(Recipe.noop()), ctx, new TestTable.Row("row-" + i));
+            ((AutoCloseable) store).close();
+        }
+
+        assertThat(tempDir.toFile().listFiles((dir, name) -> name.endsWith(".csv"))).hasSize(2);
+    }
+
+    @Test
+    void noStoreConfigFallsBackToInMemory() {
+        ExecutionContext ctx = ctx();
+        assertThat(DataTableExecutionContextView.view(ctx).getDataTableStore())
+                .isInstanceOf(InMemoryDataTableStore.class);
+    }
+
+    // =========================================================================
     // CsvDataTableStore
     // =========================================================================
 

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/ExecutionContextRpcCodecTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/ExecutionContextRpcCodecTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.rpc.RpcObjectData.State.END_OF_OBJECT;
+
+/**
+ * Round-trip tests for the {@link ExecutionContext} RPC codec, which transfers
+ * only messages under {@link ExecutionContext#RPC_SHARED_MESSAGE_PREFIX} between
+ * RPC peers.
+ */
+class ExecutionContextRpcCodecTest {
+
+    private final Deque<RpcObjectData> wire = new ArrayDeque<>();
+    private final RpcSendQueue sendQueue = new RpcSendQueue(10, wire::addAll, new IdentityHashMap<>(), null, false);
+    private final RpcReceiveQueue receiveQueue = new RpcReceiveQueue(new HashMap<>(), () -> {
+        List<RpcObjectData> batch = new ArrayList<>(wire);
+        wire.clear();
+        return batch;
+    }, null, null);
+
+    /**
+     * Mirrors how {@link org.openrewrite.rpc.request.GetObject.Handler} sends and
+     * {@link RewriteRpc#getObject} receives a single object, including the
+     * END_OF_OBJECT framing that detects send/receive message count mismatches.
+     */
+    private ExecutionContext roundTrip(ExecutionContext after, @org.jspecify.annotations.Nullable ExecutionContext senderBefore,
+                                       @org.jspecify.annotations.Nullable ExecutionContext remoteBefore) {
+        sendQueue.send(after, senderBefore, null);
+        sendQueue.put(new RpcObjectData(END_OF_OBJECT, null, null, null, false));
+        sendQueue.flush();
+
+        ExecutionContext received = receiveQueue.receive(remoteBefore, null);
+        assertThat(receiveQueue.take().getState())
+          .as("codec must consume exactly the messages that were sent")
+          .isEqualTo(END_OF_OBJECT);
+        return received;
+    }
+
+    @Test
+    void sharedMessagesTransfer() {
+        InMemoryExecutionContext ctx = new InMemoryExecutionContext();
+        ctx.putMessage(ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "outputDir", "/tmp/data-tables");
+        ctx.putMessage(ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "columns", List.of("a", "b"));
+        ctx.putMessage("org.openrewrite.processLocal", "should-not-transfer");
+
+        ExecutionContext received = roundTrip(ctx, null, null);
+
+        assertThat(received).isNotSameAs(ctx);
+        assertThat(received.<String>getMessage(ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "outputDir"))
+          .isEqualTo("/tmp/data-tables");
+        assertThat(received.<List<String>>getMessage(ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "columns"))
+          .containsExactly("a", "b");
+        assertThat(received.<String>getMessage("org.openrewrite.processLocal")).isNull();
+        assertThat(received.<Object>getMessage(ExecutionContext.RUN_TIMEOUT)).isNull();
+    }
+
+    @Test
+    void noSharedMessages() {
+        InMemoryExecutionContext ctx = new InMemoryExecutionContext();
+        ctx.putMessage("org.openrewrite.processLocal", "should-not-transfer");
+
+        ExecutionContext received = roundTrip(ctx, null, null);
+
+        assertThat(received.getMessages()).isEmpty();
+    }
+
+    @Test
+    void resendUpdatesAndRemovesSharedMessages() {
+        InMemoryExecutionContext ctx = new InMemoryExecutionContext();
+        ctx.putMessage(ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "outputDir", "/tmp/v1");
+        ctx.putMessage(ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "removed", "gone-on-resend");
+
+        ExecutionContext received = roundTrip(ctx, null, null);
+        assertThat(received.<String>getMessage(ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "outputDir"))
+          .isEqualTo("/tmp/v1");
+
+        // Snapshot the state the remote knows, then mutate and re-send as a diff.
+        InMemoryExecutionContext snapshot = ctx.clone();
+        ctx.putMessage(ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "outputDir", "/tmp/v2");
+        ctx.putMessage(ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "removed", null);
+
+        ExecutionContext receivedAgain = roundTrip(ctx, snapshot, received);
+        assertThat(receivedAgain).isSameAs(received);
+        assertThat(receivedAgain.<String>getMessage(ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "outputDir"))
+          .isEqualTo("/tmp/v2");
+        assertThat(receivedAgain.<String>getMessage(ExecutionContext.RPC_SHARED_MESSAGE_PREFIX + "removed"))
+          .isNull();
+    }
+}

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.*;
 import org.openrewrite.internal.InMemoryLargeSourceSet;
 import org.openrewrite.marker.Markup;
@@ -40,9 +41,11 @@ import org.openrewrite.marker.RecipesThatMadeChanges;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -265,6 +268,40 @@ class RewriteRpcTest implements RewriteTest {
         );
 
         assertThat(latch.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    void dataTablesWrittenToCsvOnRemotePeer(@TempDir Path tempDir) throws IOException {
+        InMemoryExecutionContext ctx = new InMemoryExecutionContext();
+        DataTableExecutionContextView.view(ctx).setDataTableStoreConfig(
+          tempDir, ".csv",
+          Map.of("repository", "acme/demo"),
+          Map.of("runId", "run-1"));
+
+        rewriteRun(
+          spec -> spec
+            .recipe(client.prepareRecipe("org.openrewrite.text.Find",
+              Map.of("find", "hello")))
+            .executionContext(ctx)
+            .validateRecipeSerialization(false),
+          text(
+            "Hello Jon!",
+            "~~>Hello Jon!",
+            spec -> spec.path("hello.txt")
+          )
+        );
+
+        // The remote peer wrote the recipe's TextMatches rows; the local scheduler
+        // wrote run-level tables (SourcesFileResults etc.) through the same
+        // configuration, each store using its own unique file name suffix.
+        File[] files = tempDir.toFile().listFiles((dir, name) ->
+          name.startsWith(TextMatches.class.getName() + "-") && name.endsWith(".csv"));
+        assertThat(files).isNotNull().hasSize(1);
+        assertThat(Files.readAllLines(files[0].toPath()))
+          .anySatisfy(line -> assertThat(line)
+            .contains("acme/demo")
+            .contains("hello.txt")
+            .contains("run-1"));
     }
 
     @Test

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -362,13 +362,15 @@ public class RewriteRpcServer
             });
         }
 
-        // ExecutionContext is sent as a typed shell with no data,
-        // matching the JavaScript pattern (empty codec).
+        // ExecutionContext is sent as a typed shell. The Java codec consumes one
+        // body message (the RPC-shared messages, see ExecutionContext.rpcReceive
+        // in Java); this peer shares none, so it sends NO_CHANGE for that value.
         if (after is ExecutionContext)
         {
             return Task.FromResult(new List<RpcObjectData>
             {
                 new() { State = ADD, ValueType = "org.openrewrite.InMemoryExecutionContext" },
+                new() { State = NO_CHANGE },
                 new() { State = END_OF_OBJECT }
             });
         }

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -905,9 +905,14 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 		}()
 
 		obj = q.Receive(before, func(v any) any {
-			// ExecutionContext uses an empty-body codec (matches JS execution.ts):
-			// the type tag arrives via the queue envelope; no field messages follow.
+			// The ExecutionContext codec carries a single value: the RPC-shared
+			// messages as a list of [key, value] pairs (see ExecutionContext.rpcSend
+			// in Java). This peer consumes and ignores them for now; data table
+			// output is configured via --data-tables-csv-dir instead. Receive()
+			// pushes back an END_OF_OBJECT, so this also tolerates senders that
+			// ship the context with an empty body.
 			if ctx, ok := v.(*recipe.ExecutionContext); ok {
+				q.Receive(nil, nil)
 				return ctx
 			}
 			if t, ok := v.(java.Tree); ok {

--- a/rewrite-javascript/rewrite/src/data-table.ts
+++ b/rewrite-javascript/rewrite/src/data-table.ts
@@ -16,11 +16,25 @@
 import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
-import {ExecutionContext} from "./execution";
+import * as zlib from 'zlib';
+import {ExecutionContext, RPC_SHARED_MESSAGE_PREFIX} from "./execution";
 import {OptionDescriptor} from "./recipe";
 
 export const DATA_TABLE_STORE = Symbol.for("org.openrewrite.dataTables.store");
 const COLUMNS_KEY = Symbol.for("org.openrewrite.dataTables.columns");
+
+/**
+ * RPC-shared messages carrying the configuration for a {@link CsvDataTableStore}.
+ * An orchestrating process (typically the JVM) sets these on its ExecutionContext;
+ * they travel to this peer with the context, and {@link DataTable#insertRow}
+ * materializes a local store from them on first use.
+ *
+ * Must stay in sync with `DataTableExecutionContextView` in Java.
+ */
+export const DATA_TABLE_STORE_OUTPUT_DIR = RPC_SHARED_MESSAGE_PREFIX + "dataTableOutputDir";
+export const DATA_TABLE_STORE_FILE_EXTENSION = RPC_SHARED_MESSAGE_PREFIX + "dataTableFileExtension";
+export const DATA_TABLE_STORE_PREFIX_COLUMNS = RPC_SHARED_MESSAGE_PREFIX + "dataTablePrefixColumns";
+export const DATA_TABLE_STORE_SUFFIX_COLUMNS = RPC_SHARED_MESSAGE_PREFIX + "dataTableSuffixColumns";
 
 export function Column(descriptor: ColumnDescriptor) {
     return function (target: any, propertyKey: string) {
@@ -144,11 +158,45 @@ export class DataTable<Row> {
 
     insertRow(ctx: ExecutionContext, row: Row): void {
         if (!ctx.messages[DATA_TABLE_STORE]) {
-            ctx.messages[DATA_TABLE_STORE] = new InMemoryDataTableStore();
+            ctx.messages[DATA_TABLE_STORE] = csvDataTableStoreFromConfig(ctx) ?? new InMemoryDataTableStore();
         }
         const dataTableStore: DataTableStore = ctx.messages[DATA_TABLE_STORE];
         dataTableStore.insertRow(this, ctx, row);
     }
+}
+
+/**
+ * Materialize a {@link CsvDataTableStore} from the RPC-shared configuration
+ * messages in the context, or undefined when no output directory is configured.
+ * The store's files get a unique name suffix so that other processes writing
+ * to the same directory (the orchestrator, other peers) never collide with it.
+ */
+function csvDataTableStoreFromConfig(ctx: ExecutionContext): CsvDataTableStore | undefined {
+    const outputDir = ctx.messages[DATA_TABLE_STORE_OUTPUT_DIR];
+    if (typeof outputDir !== 'string') {
+        return undefined;
+    }
+    const fileExtension = ctx.messages[DATA_TABLE_STORE_FILE_EXTENSION] ?? '.csv';
+    return new CsvDataTableStore(outputDir, {
+        fileExtension: `-${crypto.randomBytes(4).toString('hex')}${fileExtension}`,
+        prefixColumns: unflattenColumns(ctx.messages[DATA_TABLE_STORE_PREFIX_COLUMNS]),
+        suffixColumns: unflattenColumns(ctx.messages[DATA_TABLE_STORE_SUFFIX_COLUMNS]),
+    });
+}
+
+/**
+ * Static columns travel over RPC as a flat list alternating name and value,
+ * preserving column order while staying within the string/list-of-strings
+ * restriction on shared message values.
+ */
+function unflattenColumns(flattened?: string[]): Record<string, string> {
+    const columns: Record<string, string> = {};
+    if (Array.isArray(flattened)) {
+        for (let i = 0; i + 1 < flattened.length; i += 2) {
+            columns[flattened[i]] = flattened[i + 1];
+        }
+    }
+    return columns;
 }
 
 export interface DataTableDescriptor {
@@ -178,6 +226,22 @@ function escapeCsv(value: unknown): string {
 }
 
 /**
+ * Options for {@link CsvDataTableStore}.
+ */
+export interface CsvDataTableStoreOptions {
+    /**
+     * File extension including dot (default ".csv"). An extension ending in
+     * ".gz" GZIP-compresses the output; each write appends a complete GZIP
+     * member, producing a valid multi-member archive at all times.
+     */
+    fileExtension?: string;
+    /** Static columns prepended to each row, in insertion order. */
+    prefixColumns?: Record<string, string>;
+    /** Static columns appended to each row, in insertion order. */
+    suffixColumns?: Record<string, string>;
+}
+
+/**
  * A DataTableStore that writes rows directly to CSV files as they are inserted.
  * Uses the data table's file-safe key for filenames.
  */
@@ -185,14 +249,29 @@ export class CsvDataTableStore implements DataTableStore {
     private readonly _initializedTables = new Set<string>();
     private readonly _rowCounts: { [key: string]: number } = {};
     private readonly _dataTables = new Map<string, DataTable<any>>();
+    private readonly _fileExtension: string;
+    private readonly _prefixColumns: Record<string, string>;
+    private readonly _suffixColumns: Record<string, string>;
 
-    constructor(private readonly outputDir: string) {
+    constructor(private readonly outputDir: string, options?: CsvDataTableStoreOptions) {
+        this._fileExtension = options?.fileExtension ?? '.csv';
+        this._prefixColumns = options?.prefixColumns ?? {};
+        this._suffixColumns = options?.suffixColumns ?? {};
         fs.mkdirSync(outputDir, {recursive: true});
+    }
+
+    private write(csvPath: string, text: string, append: boolean): void {
+        const data = this._fileExtension.endsWith('.gz') ? zlib.gzipSync(Buffer.from(text, 'utf8')) : text;
+        if (append) {
+            fs.appendFileSync(csvPath, data);
+        } else {
+            fs.writeFileSync(csvPath, data);
+        }
     }
 
     insertRow<Row>(dataTable: DataTable<Row>, _ctx: ExecutionContext, row: Row): void {
         const fileKey = CsvDataTableStore.fileKey(dataTable);
-        const csvPath = path.join(this.outputDir, fileKey + '.csv');
+        const csvPath = path.join(this.outputDir, fileKey + this._fileExtension);
 
         if (!this._initializedTables.has(fileKey)) {
             this._initializedTables.add(fileKey);
@@ -200,22 +279,27 @@ export class CsvDataTableStore implements DataTableStore {
             this._dataTables.set(fileKey, dataTable);
 
             const columns = dataTable.descriptor.columns;
-            const headerRow = columns.map(col => escapeCsv(col.displayName)).join(',');
+            const headerRow = [
+                ...Object.keys(this._prefixColumns),
+                ...columns.map(col => col.displayName),
+                ...Object.keys(this._suffixColumns)
+            ].map(escapeCsv).join(',');
             // Write metadata comments + header
             const comments = [
                 `# @name ${dataTable.descriptor.name}`,
                 `# @instanceName ${dataTable.instanceName}`,
                 `# @group ${dataTable.group ?? ''}`,
             ].join('\n');
-            fs.writeFileSync(csvPath, comments + '\n' + headerRow + '\n');
+            this.write(csvPath, comments + '\n' + headerRow + '\n', false);
         }
 
         const columns = dataTable.descriptor.columns;
-        const rowValues = columns.map(col => {
-            const value = (row as any)[col.name];
-            return escapeCsv(value);
-        });
-        fs.appendFileSync(csvPath, rowValues.join(',') + '\n');
+        const rowValues = [
+            ...Object.values(this._prefixColumns),
+            ...columns.map(col => (row as any)[col.name]),
+            ...Object.values(this._suffixColumns)
+        ].map(escapeCsv);
+        this.write(csvPath, rowValues.join(',') + '\n', true);
         this._rowCounts[fileKey]++;
     }
 

--- a/rewrite-javascript/rewrite/src/execution.ts
+++ b/rewrite-javascript/rewrite/src/execution.ts
@@ -22,16 +22,53 @@ export class ExecutionContext {
     }
 }
 
+/**
+ * Messages whose keys start with this prefix are shared with remote RPC peers
+ * when an {@link ExecutionContext} is transferred. All other messages are
+ * process-local and never cross the wire. Values of shared messages must be
+ * limited to strings and lists of strings so that every peer language can
+ * consume them without dedicated codecs.
+ *
+ * Must stay in sync with `ExecutionContext.RPC_SHARED_MESSAGE_PREFIX` in Java.
+ */
+export const RPC_SHARED_MESSAGE_PREFIX = "org.openrewrite.rpc.shared.";
+
+/**
+ * The messages under {@link RPC_SHARED_MESSAGE_PREFIX} as a list of
+ * `[key, value]` pairs sorted by key, or undefined when there are none.
+ */
+function rpcSharedMessages(ctx: ExecutionContext): [string, any][] | undefined {
+    const entries = Object.keys(ctx.messages)
+        .filter(key => key.startsWith(RPC_SHARED_MESSAGE_PREFIX) && ctx.messages[key] !== undefined)
+        .sort()
+        .map(key => [key, ctx.messages[key]] as [string, any]);
+    return entries.length === 0 ? undefined : entries;
+}
+
 const executionContextCodec: RpcCodec<ExecutionContext> = {
     rpcNew(): ExecutionContext {
         return new ExecutionContext();
     },
 
-    async rpcSend(_after: ExecutionContext, _q: RpcSendQueue): Promise<void> {
+    async rpcSend(after: ExecutionContext, q: RpcSendQueue): Promise<void> {
+        await q.getAndSend(after, rpcSharedMessages);
     },
 
-    async rpcReceive(_before: ExecutionContext, _q: RpcReceiveQueue): Promise<ExecutionContext> {
-        return new ExecutionContext();
+    async rpcReceive(before: ExecutionContext, q: RpcReceiveQueue): Promise<ExecutionContext> {
+        const after: [string, any][] | undefined = await q.receive(rpcSharedMessages(before));
+        const retained = new Set<string>();
+        if (after) {
+            for (const [key, value] of after) {
+                before.messages[key] = value;
+                retained.add(key);
+            }
+        }
+        for (const key of Object.keys(before.messages)) {
+            if (key.startsWith(RPC_SHARED_MESSAGE_PREFIX) && !retained.has(key)) {
+                delete before.messages[key];
+            }
+        }
+        return before;
     }
 }
 

--- a/rewrite-javascript/rewrite/src/rpc/recipe.ts
+++ b/rewrite-javascript/rewrite/src/rpc/recipe.ts
@@ -68,13 +68,10 @@ export class RpcRecipe extends ScanningRecipe<number> {
     }
 
     async onComplete(ctx: ExecutionContext): Promise<void> {
-        // This will merge data tables from the remote into the local context.
-        //
-        // When multiple recipes ran on the same RPC peer, they will all have been
-        // adding to the same ExecutionContext instance on that peer, and so really
-        // a CHANGE will only be returned for the first of any recipes on that peer.
-        // It doesn't matter which one added data table entries, because they all share
-        // the same view of the data tables.
+        // Synchronize the final state of the remote's ExecutionContext. Data table
+        // rows do not flow back over RPC: when a data table store is configured
+        // (see DATA_TABLE_STORE_OUTPUT_DIR in data-table.ts), the peer streams its
+        // rows to its own files in the shared output directory as they are inserted.
         if ("org.openrewrite.rpc.id" in ctx) {
             const updated = await this.rpc.getObject(ctx.messages["org.openrewrite.rpc.id"]);
             Object.assign(ctx, updated);

--- a/rewrite-javascript/rewrite/test/data-table.test.ts
+++ b/rewrite-javascript/rewrite/test/data-table.test.ts
@@ -18,7 +18,16 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import {ReplacedText} from "../fixtures/replaced-text";
-import {CsvDataTableStore, DATA_TABLE_STORE, ExecutionContext} from "../src";
+import {
+    CsvDataTableStore,
+    DATA_TABLE_STORE,
+    DATA_TABLE_STORE_FILE_EXTENSION,
+    DATA_TABLE_STORE_OUTPUT_DIR,
+    DATA_TABLE_STORE_PREFIX_COLUMNS,
+    DATA_TABLE_STORE_SUFFIX_COLUMNS,
+    ExecutionContext,
+    InMemoryDataTableStore
+} from "../src";
 
 describe("data tables", () => {
 
@@ -145,5 +154,74 @@ describe("data tables", () => {
 
         const store = new CsvDataTableStore(nestedDir);
         expect(fs.existsSync(nestedDir)).toBe(true);
+    });
+
+    test("writes static prefix and suffix columns", () => {
+        const store = new CsvDataTableStore(tmpDir, {
+            prefixColumns: {repositoryOrigin: "github.com/acme/demo"},
+            suffixColumns: {runId: "run-1"}
+        });
+        const ctx = new ExecutionContext();
+        ctx.messages[DATA_TABLE_STORE] = store;
+
+        ReplacedText.dataTable.insertRow(ctx, new ReplacedText("src/foo.ts", "old text"));
+
+        const fileKey = CsvDataTableStore.fileKey(ReplacedText.dataTable);
+        const lines = fs.readFileSync(path.join(tmpDir, fileKey + ".csv"), 'utf8').split('\n');
+        expect(lines[3]).toBe('repositoryOrigin,Source Path,Text,runId');
+        expect(lines[4]).toBe('github.com/acme/demo,src/foo.ts,old text,run-1');
+    });
+
+    test("gzip file extension writes readable multi-member gzip", () => {
+        const store = new CsvDataTableStore(tmpDir, {fileExtension: ".csv.gz"});
+        const ctx = new ExecutionContext();
+        ctx.messages[DATA_TABLE_STORE] = store;
+
+        ReplacedText.dataTable.insertRow(ctx, new ReplacedText("src/foo.ts", "first"));
+        ReplacedText.dataTable.insertRow(ctx, new ReplacedText("src/bar.ts", "second"));
+
+        const fileKey = CsvDataTableStore.fileKey(ReplacedText.dataTable);
+        const gzPath = path.join(tmpDir, fileKey + ".csv.gz");
+        expect(fs.existsSync(gzPath)).toBe(true);
+
+        const zlib = require('zlib');
+        const content = zlib.gunzipSync(fs.readFileSync(gzPath)).toString('utf8');
+        expect(content).toContain('Source Path,Text');
+        expect(content).toContain('src/foo.ts,first');
+        expect(content).toContain('src/bar.ts,second');
+    });
+
+    test("insertRow materializes a CSV store from RPC-shared config messages", () => {
+        const writtenFiles: string[] = [];
+        for (let i = 0; i < 2; i++) {
+            const ctx = new ExecutionContext();
+            ctx.messages[DATA_TABLE_STORE_OUTPUT_DIR] = tmpDir;
+            ctx.messages[DATA_TABLE_STORE_FILE_EXTENSION] = ".csv";
+            ctx.messages[DATA_TABLE_STORE_PREFIX_COLUMNS] = ["repositoryOrigin", "github.com/acme/demo"];
+            ctx.messages[DATA_TABLE_STORE_SUFFIX_COLUMNS] = ["runId", "run-1"];
+
+            ReplacedText.dataTable.insertRow(ctx, new ReplacedText("src/foo.ts", "row-" + i));
+
+            expect(ctx.messages[DATA_TABLE_STORE]).toBeInstanceOf(CsvDataTableStore);
+            writtenFiles.push(...fs.readdirSync(tmpDir).filter(f => !writtenFiles.includes(f)));
+        }
+
+        const fileKey = CsvDataTableStore.fileKey(ReplacedText.dataTable);
+        // Each context materialized its own store writing its own uniquely
+        // suffixed file, so concurrent writers never collide.
+        expect(writtenFiles).toHaveLength(2);
+        for (const file of writtenFiles) {
+            expect(file).toMatch(new RegExp(`^${fileKey.replace(/[.$]/g, '\\$&')}-.+\\.csv$`));
+        }
+        const content = fs.readFileSync(path.join(tmpDir, writtenFiles[0]), 'utf8');
+        expect(content).toContain('repositoryOrigin,Source Path,Text,runId');
+        expect(content).toContain('github.com/acme/demo,src/foo.ts,row-0,run-1');
+    });
+
+    test("insertRow without store or config defaults to in-memory", () => {
+        const ctx = new ExecutionContext();
+        ReplacedText.dataTable.insertRow(ctx, new ReplacedText("src/foo.ts", "in-memory"));
+        expect(ctx.messages[DATA_TABLE_STORE]).toBeInstanceOf(InMemoryDataTableStore);
+        expect(fs.readdirSync(tmpDir)).toHaveLength(0);
     });
 });

--- a/rewrite-javascript/rewrite/test/rpc/execution-context-codec.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/execution-context-codec.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {ExecutionContext, RPC_SHARED_MESSAGE_PREFIX} from "../../src/execution";
+import {DATA_TABLE_STORE} from "../../src/data-table";
+import {ReferenceMap, RpcObjectState, RpcReceiveQueue, RpcSendQueue} from "../../src/rpc";
+
+describe("ExecutionContext RPC codec", () => {
+
+    async function roundTrip(after: ExecutionContext,
+                             senderBefore?: ExecutionContext,
+                             remoteBefore?: ExecutionContext): Promise<ExecutionContext> {
+        const sq = new RpcSendQueue(new ReferenceMap(), undefined, false);
+        const batch = await sq.generate(after, senderBefore);
+
+        const rq = new RpcReceiveQueue(new Map(), undefined, async () => batch, undefined, false);
+        const received = await rq.receive<ExecutionContext>(remoteBefore);
+        // The codec must consume exactly the messages that were sent.
+        expect((await rq.take()).state).toBe(RpcObjectState.END_OF_OBJECT);
+        return received;
+    }
+
+    test("shared messages transfer, process-local ones do not", async () => {
+        const ctx = new ExecutionContext();
+        ctx.messages[RPC_SHARED_MESSAGE_PREFIX + "outputDir"] = "/tmp/data-tables";
+        ctx.messages[RPC_SHARED_MESSAGE_PREFIX + "columns"] = ["a", "b"];
+        ctx.messages["org.openrewrite.processLocal"] = "should-not-transfer";
+
+        const received = await roundTrip(ctx);
+
+        expect(received).not.toBe(ctx);
+        expect(received.messages[RPC_SHARED_MESSAGE_PREFIX + "outputDir"]).toBe("/tmp/data-tables");
+        expect(received.messages[RPC_SHARED_MESSAGE_PREFIX + "columns"]).toEqual(["a", "b"]);
+        expect(received.messages["org.openrewrite.processLocal"]).toBeUndefined();
+    });
+
+    test("context without shared messages round-trips", async () => {
+        const ctx = new ExecutionContext();
+        ctx.messages["org.openrewrite.processLocal"] = "should-not-transfer";
+
+        const received = await roundTrip(ctx);
+
+        expect(Object.keys(received.messages)).toHaveLength(0);
+    });
+
+    test("re-receive preserves identity and process-local state", async () => {
+        const ctx = new ExecutionContext();
+        ctx.messages[RPC_SHARED_MESSAGE_PREFIX + "outputDir"] = "/tmp/v1";
+
+        const received = await roundTrip(ctx);
+        // Simulate process-local state installed on the receiving side, e.g. a
+        // materialized data table store under a symbol key.
+        received.messages[DATA_TABLE_STORE] = {marker: "local-store"};
+        received.messages["receiverLocal"] = "kept";
+
+        // A re-fetch sends a diff against a snapshot of what the remote knows.
+        const snapshot = new ExecutionContext({...ctx.messages});
+        ctx.messages[RPC_SHARED_MESSAGE_PREFIX + "outputDir"] = "/tmp/v2";
+
+        const receivedAgain = await roundTrip(ctx, snapshot, received);
+
+        expect(receivedAgain).toBe(received);
+        expect(receivedAgain.messages[RPC_SHARED_MESSAGE_PREFIX + "outputDir"]).toBe("/tmp/v2");
+        expect(receivedAgain.messages[DATA_TABLE_STORE]).toEqual({marker: "local-store"});
+        expect(receivedAgain.messages["receiverLocal"]).toBe("kept");
+    });
+});

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
@@ -110,6 +110,43 @@ class JavaScriptRewriteRpcTest implements RewriteTest {
     }
 
     @Test
+    void dataTablesWrittenToCsvByJavaScriptPeer() throws IOException {
+        installRecipes();
+        Path dataTableDir = tempDir.resolve("data-tables");
+        InMemoryExecutionContext ctx = new InMemoryExecutionContext();
+        DataTableExecutionContextView.view(ctx).setDataTableStoreConfig(
+          dataTableDir, ".csv",
+          Map.of("repositoryOrigin", "github.com/acme/demo"),
+          Map.of("runId", "run-1"));
+
+        rewriteRun(
+          spec -> spec
+            .recipe(client().prepareRecipe("org.openrewrite.example.text.change-text",
+              Map.of("text", "Hello World!")))
+            .executionContext(ctx),
+          text(
+            "Hello Jon!",
+            "Hello World!",
+            spec -> spec.path("hello.txt")
+          )
+        );
+
+        // The JavaScript peer installed its own CsvDataTableStore from the
+        // configuration carried by the ExecutionContext and wrote the recipe's
+        // data table rows to a uniquely suffixed file in the shared directory.
+        File[] files = dataTableDir.toFile().listFiles((dir, name) ->
+          name.startsWith("org.openrewrite.text.replaced-text-") && name.endsWith(".csv"));
+        assertThat(files).isNotNull().hasSize(1);
+        assertThat(Files.readAllLines(files[0].toPath()))
+          .contains("repositoryOrigin,Source Path,Text,runId")
+          .anySatisfy(line -> assertThat(line)
+            .contains("github.com/acme/demo")
+            .contains("hello.txt")
+            .contains("Hello Jon!")
+            .contains("run-1"));
+    }
+
+    @Test
     void printSubtree() {
         rewriteRun(
           typescript(


### PR DESCRIPTION
## Motivation

When a recipe runs on a remote RPC peer (JavaScript, Python, C#, Go), any data table rows it inserts are silently lost: the peer's `ExecutionContext` never gets a `DataTableStore`, and the `ExecutionContext` RPC codec was a no-op on both sides. `RpcRecipe.onComplete()` even claimed to "merge data tables from the remote" — it didn't, because the codec sent nothing.

- This prototype follows the direction from #7920's review (storage stays behind the `DataTableStore` abstraction in each process, no new protocol message): the existing `ExecutionContext` object transfer carries only the store *configuration*, and each peer writes rows directly to disk. Nothing row-related crosses the wire. Because `Visit`/`BatchVisit` already transfer the context by object-cache id, this naturally has per-`ExecutionContext` granularity — a fresh context per repository run delivers fresh config, and prepared-recipe reuse across runs (the flaw in #6990's `PrepareRecipe`-based approach) is harmless.

## Approach

- **Codec**: `ExecutionContext.rpcSend`/`rpcReceive` now transfer messages under the reserved prefix `org.openrewrite.rpc.shared.` as a single value — a list of `[key, value]` pairs sorted by key (or `NO_CHANGE` when empty). A plain list carries no `valueType`, so every peer receives it as raw JSON without dedicated codecs. Values are restricted to strings and lists of strings. The codec stays a generic facility; data-table knowledge lives in `DataTableExecutionContextView`.
- **Configuration**: `DataTableExecutionContextView.setDataTableStoreConfig(outputDir, fileExtension, prefixColumns, suffixColumns)` stores the whitelisted shared messages. `.csv.gz` implies GZIP. Prefix/suffix columns are static columns (e.g. repository metadata) added around each row.
- **Materialization**: on first use, `getDataTableStore()` (Java) / `DataTable.insertRow` (TS) lazily construct a local `CsvDataTableStore` from the config. Every materialized store writes files with a unique name suffix (`<table>-<hex>.csv`), so peers never append to files the orchestrator (or another peer) holds open — a directory scan merges them at read time.
- **Durability**: `CsvDataTableStore` (Java) now flushes after each row, since a store on an RPC peer has no end-of-run close hook.

## Example

```java
InMemoryExecutionContext ctx = new InMemoryExecutionContext();
DataTableExecutionContextView.view(ctx).setDataTableStoreConfig(
    outputDir, ".csv",
    Map.of("repositoryOrigin", "github.com/acme/demo"),  // prefix columns
    Map.of("runId", "run-1"));                            // suffix columns

// Run any recipe — local or on a remote RPC peer — with this context.
// Each process streams its data table rows to its own CSV files in outputDir:
//   org.openrewrite.table.TextMatches-3f9c12ab.csv   (JVM orchestrator)
//   org.openrewrite.text.replaced-text-9e01d27c.csv  (JS peer)
```

## Per-peer compatibility

Changing the Java sender/receiver changes the wire contract for every peer. Findings and changes:

| Peer | Receives ctx from Java | Sends ctx to Java (`onComplete`) | Change |
|------|------------------------|----------------------------------|--------|
| JavaScript | yes (every `Visit`) | typed shell with codec | full implementation: codec + `CsvDataTableStore` options (gzip, prefix/suffix) + store materialization |
| C# | no (creates locally) | typed shell, **no body** | shell now includes one `NO_CHANGE` body message so Java's consuming receive stays in sync |
| Go | yes (once per prepared ctx) | bare `ADD`, no valueType | receive callback consumes (and for now ignores) the one config value; Go keeps its `--data-tables-csv-dir` flag |
| Python | no (creates locally) | bare `ADD`, no valueType | **no change needed** — Java's receive only invokes the codec when a typed shell was sent |

## Test plan

- [x] `ExecutionContextRpcCodecTest` (new): codec round-trip incl. END_OF_OBJECT framing, exclusion of process-local messages, diff re-send with update/removal
- [x] `DataTableStoreTest` additions: config whitelisting, store materialization (plain + gzip), unique file suffixes, in-memory fallback
- [x] `RewriteRpcTest.dataTablesWrittenToCsvOnRemotePeer` (new): Java↔Java end-to-end — `text.Find` over RPC writes `TextMatches` CSV with prefix/suffix columns
- [x] `JavaScriptRewriteRpcTest.dataTablesWrittenToCsvByJavaScriptPeer` (new): end-to-end against the real JS peer — JS recipe's data table rows land as CSV in the configured directory with prefix/suffix columns
- [x] TS unit tests (new): codec round-trip, gzip multi-member output, prefix/suffix columns, materialization with unique suffixes, in-memory fallback
- [x] No-regression: full `:rewrite-core:test`; all `javascript.rpc` integ tests + `ParallelPrintTest`; TS `test/rpc/*` incl. JS-orchestrated Java recipes; `:rewrite-csharp:integTest` `CSharpRecipeTest` (10/10); `:rewrite-go:integTest` `GolangRecipeIntegTest` (12/13, the one failure is a marker-placement diff that reproduces at baseline); `:rewrite-python:integTest` `FindMethodsIntegTest`/`RemovePassIntegTest` fail identically at baseline (known pre-existing int-id issue)
- [x] `JavaToJavaScriptRpcTest` TCK suite fails identically with and without this change in my environment (332/383 at baseline and on this branch)

## Known limitations (prototype)

- `GetObject` uses the same mutable context instance as both diff baseline and payload, so in-place message changes between fetches short-circuit to `NO_CHANGE`. The codec itself is diff-capable (covered by tests); set-once configuration is unaffected.
- A Java peer's gzip files only get their trailer on `getRows()`/`close()`; the JS peer writes complete gzip members per append and is always readable.
- Merging the per-process CSV files at read time (directory scan) is left to the consumer.
