### PR TITLE
Scala: fix parsing of union type literals

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -8282,12 +8282,28 @@ class ScalaTreeVisitor(
       visitRepeatedType(po)
     case tuple: untpd.Tuple => visitTupleType(tuple)
     case parens: untpd.Parens => visitParenthesizedType(parens)
+    case infix: untpd.InfixOp if infix.op != null &&
+        (infix.op.name.toString == "|" || infix.op.name.toString == "&") =>
+      visitTypeOperatorInfix(infix)
     case _ =>
       visitTree(tpt) match {
         case tt: TypeTree => tt
         case id: J.Identifier => id
         case _ => null
       }
+  }
+
+  /**
+   * Union (`A | B`) and intersection (`A & B`) types are parsed as an `untpd.InfixOp`.
+   * Neither has a dedicated J/S type yet, so — like the `with`-less `&` already handled
+   * elsewhere — preserve the whole expression as a source-text identifier rather than
+   * letting it fall through to a `J.Binary` (which isn't a `TypeTree`) and get dropped.
+   * Returning a non-null `TypeTree` here fixes every type position at once (params,
+   * return types, type ascriptions, bounds, tuple/function components, ...).
+   */
+  private def visitTypeOperatorInfix(infix: untpd.InfixOp): TypeTree = {
+    val prefix = extractPrefix(infix.span)
+    ident(extractSource(infix.span), prefix)
   }
 
   /**
@@ -9111,7 +9127,7 @@ class ScalaTreeVisitor(
           val loPrefix = if (loOpIdx > cursor) ScalaSpace.format(source, cursor, loOpIdx) else Space.EMPTY
           if (loOpIdx >= 0) cursor = loOpIdx + 2
           val savedCursorLo = cursor
-          val loType = visitTree(tb.lo) match {
+          val loType = visitTypeTree(tb.lo) match {
             case tt: TypeTree => tt
             case _ => cursor = savedCursorLo; visitUnknown(tb.lo).asInstanceOf[TypeTree]
           }
@@ -9126,7 +9142,7 @@ class ScalaTreeVisitor(
           val hiPrefix = if (hiOpIdx > cursor) ScalaSpace.format(source, cursor, hiOpIdx) else Space.EMPTY
           if (hiOpIdx >= 0) cursor = hiOpIdx + 2
           val savedCursorHi = cursor
-          val hiType = visitTree(tb.hi) match {
+          val hiType = visitTypeTree(tb.hi) match {
             case tt: TypeTree => tt
             case _ => cursor = savedCursorHi; visitUnknown(tb.hi).asInstanceOf[TypeTree]
           }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/UnionTypeTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/UnionTypeTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.scala.Assertions.scala;
+
+/**
+ * Union (`A | B`) and operator-form intersection (`A & B`) types are parsed as an
+ * {@code untpd.InfixOp}. These must round-trip in every type position rather than being
+ * silently dropped (the original report: a union literal type on a method parameter).
+ */
+class UnionTypeTest implements RewriteTest {
+
+    @Test
+    void methodParameterUnionLiteralType() {
+        rewriteRun(
+          scala("def display(operation: \"resize\" | \"thumbnail\") = 1\n")
+        );
+    }
+
+    @Test
+    void methodReturnType() {
+        rewriteRun(
+          scala("def f: Int | String = ???\n")
+        );
+    }
+
+    @Test
+    void valType() {
+        rewriteRun(
+          scala("val x: Int | String = ???\n")
+        );
+    }
+
+    @Test
+    void constructorParameter() {
+        rewriteRun(
+          scala("class C(x: Int | String)\n")
+        );
+    }
+
+    @Test
+    void caseClassParameter() {
+        rewriteRun(
+          scala("case class C(x: Int | String)\n")
+        );
+    }
+
+    @Test
+    void typeAlias() {
+        rewriteRun(
+          scala("type T = Int | String\n")
+        );
+    }
+
+    @Test
+    void typeAscription() {
+        rewriteRun(
+          scala("val y = (1: Int | String)\n")
+        );
+    }
+
+    @Test
+    void typeParameterBound() {
+        rewriteRun(
+          scala("def f[T <: Int | String](x: T) = x\n")
+        );
+    }
+
+    @Test
+    void lambdaParameter() {
+        rewriteRun(
+          scala("val f = (x: Int | String) => x\n")
+        );
+    }
+
+    @Test
+    void functionTypeComponent() {
+        rewriteRun(
+          scala("val f: (Int | String) => Int = ???\n")
+        );
+    }
+
+    @Test
+    void tupleTypeElement() {
+        rewriteRun(
+          scala("val t: (Int | String, Long) = ???\n")
+        );
+    }
+
+    @Test
+    void genericTypeArgument() {
+        rewriteRun(
+          scala("val l: List[Int | String] = ???\n")
+        );
+    }
+
+    @Test
+    void multiWayUnion() {
+        rewriteRun(
+          scala("def f(x: Int | String | Long) = 1\n")
+        );
+    }
+
+    @Test
+    void intersectionOperatorParameter() {
+        rewriteRun(
+          scala("def f(x: Int & String) = 1\n")
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?

In Scala fix parsing of union type literals, e.g.
```
val x: Int | String
```

## What's your motivation?

They suffer from idempotency issues.
