### PR TITLE
Scala: don't drop the final modifier for objects

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -34,6 +34,7 @@ import org.openrewrite.marker.Marker;
 import org.openrewrite.scala.marker.AsInstanceOfPrefix;
 import org.openrewrite.scala.marker.BlockArgument;
 import org.openrewrite.scala.marker.DottedMatch;
+import org.openrewrite.scala.marker.Implicit;
 import org.openrewrite.scala.marker.IndentedSyntax;
 import org.openrewrite.scala.marker.PackageBraces;
 import org.openrewrite.scala.marker.SObject;
@@ -826,9 +827,12 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             beforeSyntax(classDecl, Space.Location.CLASS_DECLARATION_PREFIX, p);
             visit(classDecl.getLeadingAnnotations(), p);
             
-            // For objects, skip the final modifier (it's implicit)
+            // For objects, skip the final modifier only when it's implicit (synthesized
+            // because objects are implicitly final). An explicitly written `final` carries
+            // no Implicit marker and must be printed to round-trip faithfully.
             for (J.Modifier m : classDecl.getModifiers()) {
-                if (!(isObject && m.getType() == J.Modifier.Type.Final)) {
+                if (!(isObject && m.getType() == J.Modifier.Type.Final &&
+                      m.getMarkers().findFirst(Implicit.class).isPresent())) {
                     visit(m, p);
                 }
             }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -3697,15 +3697,21 @@ class ScalaTreeVisitor(
       }
     }
     
-    // Objects are implicitly final
-    modifiers.add(new J.Modifier(
-      Tree.randomId(),
-      Space.EMPTY,
-      Markers.EMPTY,
-      null, // No keyword for implicit final
-      J.Modifier.Type.Final,
-      Collections.emptyList()
-    ).withMarkers(Markers.build(Collections.singletonList(new Implicit(Tree.randomId())))))
+    // Objects are implicitly final. Only synthesize the implicit modifier when the
+    // source didn't already spell out `final` (e.g. `final object Foo`); otherwise the
+    // explicit modifier extracted above is kept and printed verbatim.
+    var hasExplicitFinal = false
+    modifiers.forEach(m => if (m.getType == J.Modifier.Type.Final) hasExplicitFinal = true)
+    if (!hasExplicitFinal) {
+      modifiers.add(new J.Modifier(
+        Tree.randomId(),
+        Space.EMPTY,
+        Markers.EMPTY,
+        null, // No keyword for implicit final
+        J.Modifier.Type.Final,
+        Collections.emptyList()
+      ).withMarkers(Markers.build(Collections.singletonList(new Implicit(Tree.randomId())))))
+    }
     
     // Find where "object"/"case" keyword ends
     val keywordLen = if (isEnumCase) "case".length else "object".length

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ObjectDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ObjectDeclarationTest.java
@@ -81,6 +81,19 @@ class ObjectDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void finalObject() {
+        rewriteRun(
+            scala(
+                """
+                final object Foo {
+                  val x = 1
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void companionObject() {
         rewriteRun(
             scala(


### PR DESCRIPTION
## What's changed?

The `final` modifier on objects in Scala is optional. The objects are implicitly final anyway.
But the syntax allows for optional placement of `final`.
Fixing the Scala parser to handle this.

## What's your motivation?

Otherwise the modifier is swallowed.
