### PR TITLE
Scala: fix braceless extension methods

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7898,11 +7898,15 @@ class ScalaTreeVisitor(
     }
     val parameters = JContainer.build(beforeParen, rpParams, Markers.EMPTY)
 
-    // Visit method declarations as a block. Find the opening brace within the
-    // extension's span. Scala 3 extension can also use indented (braceless) form,
-    // in which case there is no `{` between `)` and the span end.
+    // Visit method declarations as a block. Find the opening brace that begins
+    // the extension body. Scala 3 extension can also use indented (braceless) form,
+    // in which case there is no `{` between `)` and the first method. Only search up
+    // to the first method's start — otherwise a `{` inside a method body (e.g.
+    // `def f = { ... }`) would be mistaken for the extension's opening brace.
     val extEnd = Math.max(0, ext.span.end - offsetAdjustment)
-    val remainingBeforeBody = if (cursor < extEnd && extEnd <= source.length) source.substring(cursor, extEnd) else ""
+    val firstMethodStart = if (ext.methods.nonEmpty) Math.max(0, ext.methods.head.span.start - offsetAdjustment) else extEnd
+    val braceSearchEnd = Math.min(extEnd, firstMethodStart)
+    val remainingBeforeBody = if (cursor < braceSearchEnd && braceSearchEnd <= source.length) source.substring(cursor, braceSearchEnd) else ""
     val localBraceIdx = positionOfNextIn(remainingBeforeBody, "{", 0)
     val isExtBraceless = localBraceIdx < 0
 

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -631,6 +631,24 @@ class MethodDeclarationTest implements RewriteTest {
                 )
             );
         }
+
+        @Test
+        void bracelessExtensionWithBraceBlockMethodBody() {
+            // A `{` inside a method body must not be mistaken for the extension's
+            // opening brace, which would make the parser treat this braceless
+            // (indented) extension as brace-delimited.
+            rewriteRun(
+                scala(
+                    """
+                    extension (g: Int)
+                      def rankable =
+                        {
+                          2
+                        }
+                    """
+                )
+            );
+        }
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

In Scala fix parsing of extension methods which use indentation (braceless) syntax, e.g.
```scala
                    extension (g: Int)
                      def rankable =
                        {
                          2
                        }
```

## What's your motivation?

They suffer from idempotency issues.