### PR TITLE
Scala: never throw from `parseInputs` and self-heal compiler core libraries

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaParser.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaParser.java
@@ -95,8 +95,18 @@ public class ScalaParser implements Parser {
             inputList.add(input);
         }
 
-        // Batch compile all sources with type checking
-        Map<String, ScalaCompilerContext.ParseResult> compiledResults = compilerContext.compileAll(inputList);
+        // Batch compile all sources with type checking. If the batch fails as a
+        // whole, degrade to per-file parsing below so a single bad input (or a
+        // transient failure) yields a ParseError for that input only instead of
+        // failing the entire parse stream.
+        Map<String, ScalaCompilerContext.ParseResult> compiledResults;
+        try {
+            compiledResults = compilerContext.compileAll(inputList);
+        } catch (Throwable t) {
+            ctx.getOnError().accept(t);
+            compiledResults = Collections.emptyMap();
+        }
+        Map<String, ScalaCompilerContext.ParseResult> finalCompiledResults = compiledResults;
 
         // Map results back to SourceFiles
         return inputList.stream()
@@ -105,7 +115,7 @@ public class ScalaParser implements Parser {
                     pctx.getParsingListener().startedParsing(input);
 
                     try {
-                        ScalaCompilerContext.ParseResult parseResult = compiledResults.get(input.getPath().toString());
+                        ScalaCompilerContext.ParseResult parseResult = finalCompiledResults.get(input.getPath().toString());
 
                         // Fall back to single-file parse if batch didn't include this file
                         if (parseResult == null) {

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala
@@ -45,6 +45,32 @@ class ScalaCompilerBridge {
   }
 
   /**
+   * Creates a fully configured compiler context on a new `ContextBase`:
+   * Scala 2 compat source version, `postfixOps`, the given reporter, and
+   * (when non-empty) output directory and classpath.
+   */
+  private def configuredContext(reporter: StoreReporter, classpath: String, outputDir: String = null): Context = {
+    val fresh = new ParsingDriver().getInitialContext.fresh
+    // Accept both Scala 2 and Scala 3 syntax (including indentation-based).
+    fresh.setSetting(fresh.settings.source, "3.6-migration")
+    // Enable `postfixOps` so the parser emits `PostfixOp` AST nodes for trailing
+    // postfix calls (e.g., `xs filter p list`). Without this, Dotty's parser
+    // silently drops the trailing token rather than emitting an AST node.
+    fresh.setSetting(fresh.settings.language, List(
+      new dotty.tools.dotc.config.Settings.Setting.ChoiceWithHelp[String]("postfixOps", "")
+    ))
+    fresh.setReporter(reporter)
+    // Send compiler output to a designated dir so .class files don't pollute cwd.
+    if (outputDir != null) {
+      fresh.setSetting(fresh.settings.outputDir, dotty.tools.io.AbstractFile.getDirectory(outputDir))
+    }
+    if (classpath.nonEmpty) {
+      fresh.setSetting(fresh.settings.classpath, classpath)
+    }
+    fresh
+  }
+
+  /**
    * Batch-compile multiple Scala source files through the typer phase.
    * Returns a map from path to ScalaParseResult, each containing both the
    * untyped tree (for formatting fidelity) and the typed tree (for type info).
@@ -54,53 +80,45 @@ class ScalaCompilerBridge {
   def compileAll(sources: JList[SourceEntry], classpath: JList[String], outputDir: String = null): JMap[String, ScalaParseResult] = {
     val results = new HashMap[String, ScalaParseResult]()
 
-    val driver = new ParsingDriver()
-    val baseCtx: Context = driver.getInitialContext
-
     // Buffer diagnostics in-memory so they don't leak to stderr via Dotty's default ConsoleReporter.
     val storeReporter = new StoreReporter(null)
 
-    // Configure source version, output directory, and classpath.
-    val configuredCtx: Context = {
-      val fresh = baseCtx.fresh
-      // Accept both Scala 2 and Scala 3 syntax (including indentation-based).
-      fresh.setSetting(fresh.settings.source, "3.6-migration")
-      // Enable `postfixOps` so the parser emits `PostfixOp` AST nodes for trailing
-      // postfix calls (e.g., `xs filter p list`). Without this, Dotty's parser
-      // silently drops the trailing token rather than emitting an AST node.
-      fresh.setSetting(fresh.settings.language, List(
-        new dotty.tools.dotc.config.Settings.Setting.ChoiceWithHelp[String]("postfixOps", "")
-      ))
-      fresh.setReporter(storeReporter)
-      // Send compiler output to a designated dir so .class files don't pollute cwd.
-      if (outputDir != null) {
-        fresh.setSetting(fresh.settings.outputDir, dotty.tools.io.AbstractFile.getDirectory(outputDir))
-      }
-      val cpString = ScalaCompilerBridge.buildClasspath(classpath)
-      if (cpString.nonEmpty) {
-        fresh.setSetting(fresh.settings.classpath, cpString)
-      }
-      fresh
-    }
+    val cpString = ScalaCompilerBridge.buildClasspath(classpath)
+    val configuredCtx: Context = configuredContext(storeReporter, cpString, outputDir)
 
     // Create the Run up front. Run construction initializes Definitions and
     // ContextBase state (e.g., `ctx.base.TypeBoundsEmpty`) that the parser
     // requires when it sees `A with B` types — those go through
-    // `untpd.makeAndType` → `Definitions.andType`, which would NPE on an
-    // uninitialized base. Parsing under `run.runContext` keeps that path safe.
+    // `untpd.makeAndType` → `Definitions.andType`, which would throw
+    // MissingCoreLibraryException on an uninitialized base. Parsing under
+    // `run.runContext` keeps that path safe.
     //
-    // Run construction requires the Scala stdlib on the classpath (to resolve
-    // `scala.Any`, etc.). Some callers (e.g. ScalaTemplate-style usage that
-    // intentionally narrows the classpath) supply none, so fall back to the
-    // configured base context if Run init fails. Code paths that don't hit
-    // `with` types continue to parse fine; `with` types will fail loudly.
-    val compiler = new Compiler()
+    // Run construction requires the Scala stdlib on dotty's classpath (to
+    // resolve `scala.Any`, etc.). When the caller's classpath lacks it — or
+    // overrides dotty's default lookup, as in a fat-jar environment — retry
+    // with the compiler's own core library jars (located via ProtectionDomain)
+    // appended, but use the resulting Run for *parsing only*: callers that
+    // narrow the classpath (e.g. ScalaTemplate) do so to avoid type
+    // resolution, so type attribution stays off for them; they only need the
+    // initialized ContextBase so `with` types parse. The retry needs an
+    // entirely new context: the failed attempt has already initialized (and
+    // cached) the ContextBase's platform classpath, so updating the setting
+    // on a `fresh` of the same base would have no effect. Only if the retry
+    // also fails do we fall back to a bare context, where `with` types fail
+    // per-file.
     val (runOpt, parseContext): (Option[Run], Context) =
       try {
-        val r = compiler.newRun(using configuredCtx)
+        val r = (new Compiler()).newRun(using configuredCtx)
         (Some(r), r.runContext)
       } catch {
-        case _: Throwable => (None, configuredCtx)
+        case _: Throwable =>
+          try {
+            val healedCp = ScalaCompilerBridge.appendStdlib(cpString)
+            val r = (new Compiler()).newRun(using configuredContext(storeReporter, healedCp, outputDir))
+            (None, r.runContext)
+          } catch {
+            case _: Throwable => (None, configuredCtx)
+          }
       }
     given ctx: Context = parseContext
 
@@ -111,15 +129,22 @@ class ScalaCompilerBridge {
     val srcIter = sources.iterator()
     while (srcIter.hasNext) {
       val entry = srcIter.next()
-      val parsed = parseOne(entry.path, entry.content)
+      try {
+        val parsed = parseOne(entry.path, entry.content)
 
-      results.put(entry.path, buildResult(parsed, new ArrayList[ScalaWarning]()))
+        results.put(entry.path, buildResult(parsed, new ArrayList[ScalaWarning]()))
 
-      // Track unit for batch type-checking. The *raw* parsed tree (pre-unwrap)
-      // is what the typer needs — it's the form the parser actually produced.
-      parsed.unit.untpdTree = parsed.rawTree
-      units.add(parsed.unit)
-      sourceEntries.add(entry)
+        // Track unit for batch type-checking. The *raw* parsed tree (pre-unwrap)
+        // is what the typer needs — it's the form the parser actually produced.
+        parsed.unit.untpdTree = parsed.rawTree
+        units.add(parsed.unit)
+        sourceEntries.add(entry)
+      } catch {
+        case _: Throwable =>
+          // Leave this entry out of the results so the caller falls back to a
+          // single-file parse, surfacing the failure as a ParseError for this
+          // file only instead of aborting the whole batch.
+      }
     }
 
     // Phase 2: Attempt batch type-checking (only if we managed to create a Run).
@@ -200,27 +225,23 @@ class ScalaCompilerBridge {
     // Buffer diagnostics in-memory so they don't leak to stderr via Dotty's default ConsoleReporter.
     val storeReporter = new StoreReporter(null)
 
-    // Create our custom driver and get a proper context with Scala 2 compat.
+    val configuredCtx: Context = configuredContext(storeReporter, "")
+
     // Best-effort Run init so `ctx.base` is wired up for `A with B` parsing
-    // (which goes through `Definitions.andType` and NPEs on a bare context);
-    // fall back to the raw context if no Scala stdlib is on the classpath.
-    val driver = new ParsingDriver()
-    val configuredCtx: Context = {
-      val fresh = driver.getInitialContext.fresh
-      fresh.setSetting(fresh.settings.source, "3.6-migration")
-      // Enable `postfixOps` so the parser emits `PostfixOp` AST nodes for trailing
-      // postfix calls (e.g., `xs filter p list`). Without this, Dotty's parser
-      // silently drops the trailing token rather than emitting an AST node.
-      fresh.setSetting(fresh.settings.language, List(
-        new dotty.tools.dotc.config.Settings.Setting.ChoiceWithHelp[String]("postfixOps", "")
-      ))
-      fresh.setReporter(storeReporter)
-      fresh
-    }
+    // (which goes through `Definitions.andType` and throws on a bare context).
+    // Same self-heal as compileAll: when dotty's default classpath lookup
+    // can't find the stdlib (fat-jar environments), retry Run construction on
+    // a new context with the compiler's own core library jars; only then
+    // degrade to the bare context, where `A with B` types fail to parse.
     given Context = try {
       (new Compiler()).newRun(using configuredCtx).runContext
     } catch {
-      case _: Throwable => configuredCtx
+      case _: Throwable =>
+        try {
+          (new Compiler()).newRun(using configuredContext(storeReporter, ScalaCompilerBridge.appendStdlib(""))).runContext
+        } catch {
+          case _: Throwable => configuredCtx
+        }
     }
 
     val parsed = parseOne(path, content)
@@ -359,17 +380,37 @@ object ScalaCompilerBridge {
       }
     }
     if (hasScalaArtifact) {
-      for (cls <- StdlibProbeClasses) {
-        locateJar(cls).foreach { jar =>
-          if (!present.contains(fileName(jar))) {
-            if (sb.nonEmpty) sb.append(File.pathSeparator)
-            sb.append(jar)
-            present.add(fileName(jar))
-          }
+      appendStdlibTo(sb, present)
+    }
+    sb.toString()
+  }
+
+  /**
+   * Append the compiler's own core library jars (located via `ProtectionDomain`)
+   * to an existing classpath string, skipping entries already present. Used to
+   * retry `Run` construction when the configured classpath lacks the Scala
+   * stdlib that dotty's `Definitions` needs to initialize.
+   */
+  private[internal] def appendStdlib(cpString: String): String = {
+    val sb = new StringBuilder(cpString)
+    val present = new LinkedHashSet[String]()
+    if (cpString.nonEmpty) {
+      cpString.split(File.pathSeparator).foreach(e => if (e.nonEmpty) present.add(fileName(e)))
+    }
+    appendStdlibTo(sb, present)
+    sb.toString()
+  }
+
+  private def appendStdlibTo(sb: StringBuilder, present: LinkedHashSet[String]): Unit = {
+    for (cls <- StdlibProbeClasses) {
+      locateJar(cls).foreach { jar =>
+        if (!present.contains(fileName(jar))) {
+          if (sb.nonEmpty) sb.append(File.pathSeparator)
+          sb.append(jar)
+          present.add(fileName(jar))
         }
       }
     }
-    sb.toString()
   }
 
   private def isScalaArtifact(fileName: String): Boolean = {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaParserErrorHandlingTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaParserErrorHandlingTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.scala.tree.S;
+import org.openrewrite.tree.ParseError;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link ScalaParser#parseInputs(Iterable, java.nio.file.Path, org.openrewrite.ExecutionContext)}
+ * must never throw: a failure to parse one input yields a {@link ParseError} for that input
+ * only, and a failure of the batch as a whole degrades to per-file parsing.
+ */
+class ScalaParserErrorHandlingTest {
+
+    private static final String GOOD_SOURCE = "object Good { val x = 1 }";
+
+    @Test
+    void unparseableInputProducesParseErrorAndOtherInputsStillParse() {
+        // Expression nesting deep enough to overflow the stack of dotty's
+        // recursive descent parser, making this single input "throw" to parse.
+        StringBuilder bad = new StringBuilder("object Bad { val x = ");
+        int depth = 20_000;
+        for (int i = 0; i < depth; i++) {
+            bad.append('(');
+        }
+        bad.append('1');
+        for (int i = 0; i < depth; i++) {
+            bad.append(')');
+        }
+        bad.append(" }");
+
+        ScalaParser parser = ScalaParser.builder().build();
+        List<SourceFile> parsed = parser.parse(GOOD_SOURCE, bad.toString()).collect(Collectors.toList());
+
+        assertThat(parsed).hasSize(2);
+        assertThat(parsed.get(0)).isInstanceOf(S.CompilationUnit.class);
+        assertThat(parsed.get(1)).isInstanceOf(ParseError.class);
+    }
+
+    @Test
+    void batchFailureDegradesToPerFileParsing() {
+        // A source whose first read fails (e.g. a transient I/O error) makes batch
+        // compilation fail as a whole; parseInputs must degrade to per-file parsing
+        // instead of throwing.
+        Supplier<InputStream> flakySource = new Supplier<InputStream>() {
+            private boolean first = true;
+
+            @Override
+            public InputStream get() {
+                if (first) {
+                    first = false;
+                    throw new IllegalStateException("simulated transient read failure");
+                }
+                return new ByteArrayInputStream("object Flaky { val x = 2 }".getBytes(StandardCharsets.UTF_8));
+            }
+        };
+
+        List<Parser.Input> inputs = Arrays.asList(
+          Parser.Input.fromString(Paths.get("Good.scala"), GOOD_SOURCE),
+          new Parser.Input(Paths.get("Flaky.scala"), flakySource)
+        );
+
+        ScalaParser parser = ScalaParser.builder().build();
+        List<SourceFile> parsed = parser.parseInputs(inputs, null, new InMemoryExecutionContext())
+          .collect(Collectors.toList());
+
+        assertThat(parsed).hasSize(2);
+        assertThat(parsed.get(0)).isInstanceOf(S.CompilationUnit.class);
+        assertThat(parsed.get(1)).isInstanceOf(S.CompilationUnit.class);
+    }
+
+    @Test
+    void withSelfTypeParsesWhenClasspathLacksScalaStdlib() {
+        // A non-empty classpath without the Scala stdlib overrides dotty's default
+        // classpath lookup, so `Run` construction cannot resolve the `scala` package
+        // (the situation a fat-jar application is in even with an empty classpath).
+        // Parsing an `A with B` type must still produce a real tree, not throw
+        // MissingCoreLibraryException.
+        ScalaParser parser = ScalaParser.builder()
+          .classpath(JavaParser.dependenciesFromClasspath("assertj-core"))
+          .build();
+
+        List<SourceFile> parsed = parser.parse("class Service { self: Logging with Config => }")
+          .collect(Collectors.toList());
+
+        assertThat(parsed).hasSize(1);
+        assertThat(parsed.get(0)).isInstanceOf(S.CompilationUnit.class);
+    }
+
+    @Test
+    void withSelfTypeParsesWithRuntimeClasspath() {
+        // Precondition for withSelfTypeParsesWhenClasspathLacksScalaStdlib: the
+        // self-type syntax itself is supported when the stdlib is resolvable.
+        ScalaParser parser = ScalaParser.builder().classpath(JavaParser.runtimeClasspath()).build();
+
+        List<SourceFile> parsed = parser.parse("class Service { self: Logging with Config => }")
+          .collect(Collectors.toList());
+
+        assertThat(parsed).hasSize(1);
+        assertThat(parsed.get(0)).isInstanceOf(S.CompilationUnit.class);
+    }
+}


### PR DESCRIPTION
## Motivation

`ScalaParser.parseInputs()` could throw instead of producing per-file `ParseError` source files, which kills entire builds in downstream tools (observed on apache/flink, where a resource build step died mid-build). Two related problems:

1. **`parseInputs()` could throw.** Batch compilation (`compilerContext.compileAll(...)`) ran *outside* the per-input try/catch, so any exception from it propagated to the caller and failed the whole parse stream. Inside the bridge, the phase-1 parse loop also had no per-entry handling, so one file that failed to parse aborted the entire batch. Other parsers (e.g. `JavaParser`, `KotlinParser`) yield a `ParseError` for the failing file and keep going.

2. **Parsing `A with B` types threw `MissingCoreLibraryException` without the Scala stdlib on the classpath.** Parsing a self-type like `class Service { self: Logging with Config => }` with an empty classpath inside a fat-jar application threw `dotty.tools.dotc.MissingCoreLibraryException: Could not find package scala from compiler core libraries` (`withTypeRest` → `untpd.makeAndType` → `Definitions.andType` → `Denotations.staticRef`). Dotty's `Run` construction needs the Scala stdlib to initialize `Definitions`; when the caller's classpath lacks it — or overrides dotty's default lookup, as a fat jar does — the bridge fell back to a bare context where `with` types "fail loudly". This didn't reproduce in the test JVM because dotty finds the stdlib via the JVM classpath there.

## Summary

* `ScalaParser.parseInputs()` wraps batch compilation in a catch-all; on failure it reports via `ctx.getOnError()` and degrades to the existing per-file fallback, where each input independently yields a real tree or a `ParseError`.
* `ScalaCompilerBridge.compileAll` catches per-entry parse failures in its phase-1 loop and omits the entry, so the caller's single-file fallback surfaces a `ParseError` for that file only.
* When `Run` construction fails, the bridge retries it with the compiler's own core library jars appended (located via `ProtectionDomain`, which works inside a fat jar). The retry needs an entirely new compiler context: the failed attempt has already cached the `ContextBase`'s platform classpath, so updating the setting on a `fresh` of the same base has no effect.
* The healed `Run` is used for *parsing only* — no type attribution. Narrow-classpath callers like `ScalaTemplate` intentionally avoid type resolution of user types; they only need the initialized `ContextBase` so `with` types parse.
* Extracted `configuredContext(...)` in the bridge to share compiler context setup between `compileAll` and `parse`.

## Test plan

- [x] New test: one unparseable input (stack-overflowing nesting) among good inputs → good inputs parse, bad one comes back as `ParseError` (previously the error killed the whole stream)
- [x] New test: a batch failure (source whose first read throws) degrades to per-file parsing instead of throwing out of `parseInputs`
- [x] New test: `with` self-type parses to a real `S.CompilationUnit` with a classpath containing only a non-Scala jar, which overrides dotty's default stdlib lookup to simulate the fat-jar environment (previously `MissingCoreLibraryException`)
- [x] New test: precondition check that the same self-type parses with the full runtime classpath
- [x] `./gradlew :rewrite-scala:check` passes (full module test suite, license check)