### PR TITLE
Scala: fix parsing of `summon[Type]`

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5604,10 +5604,16 @@ class ScalaTreeVisitor(
         // marked OmitParentheses (since the source has no `(...)`).
         return visitMethodInvocationFromTypeApply(ta, sel, savedCursor)
 
-      case id: Trees.Ident[?] if id.name.toString == "classOf" && ta.args.size == 1 =>
-        // classOf[String] is a type application with no value argument list.
+      case id: Trees.Ident[?] if ta.args.nonEmpty =>
+        // A type application whose function is a bare identifier and which has no
+        // value-argument list is a generic method/function reference with the parens
+        // omitted, e.g. `classOf[String]`, `summon[Foo]`, `implicitly[Foo]`,
+        // `identity[Int]`. (When a value-argument list is present, dotty wraps this
+        // node in an Apply that visitApply handles.) Map it to a J.MethodInvocation
+        // with typeParameters populated and arguments marked OmitParentheses.
+        val name = id.name.toString
         val prefix = extractPrefix(ta.span)
-        val nameEnd = if (id.span.exists) Math.max(0, id.span.end - offsetAdjustment) else cursor + "classOf".length
+        val nameEnd = if (id.span.exists) Math.max(0, id.span.end - offsetAdjustment) else cursor + name.length
         if (nameEnd > cursor && nameEnd <= source.length) {
           cursor = nameEnd
         }
@@ -5621,7 +5627,7 @@ class ScalaTreeVisitor(
           Markers.EMPTY,
           null,
           typeParams,
-          ident("classOf"),
+          ident(name),
           args,
           methodTypeOfTree(ta)
         )

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TypeApplyTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TypeApplyTest.java
@@ -200,6 +200,38 @@ class TypeApplyTest implements RewriteTest {
     }
 
     @Test
+    void summonTypeApplyIsMethodInvocation() {
+        rewriteRun(
+          scala(
+            """
+              val x = summon[Foo]
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                AtomicReference<J.MethodInvocation> summon = new AtomicReference<>();
+                new ScalaIsoVisitor<Integer>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer p) {
+                        if ("summon".equals(method.getSimpleName())) {
+                            summon.set(method);
+                        }
+                        return super.visitMethodInvocation(method, p);
+                    }
+                }.visit(cu, 0);
+
+                assertThat(summon.get())
+                  .as("summon[Foo] should be a method invocation, not crammed into an identifier")
+                  .isNotNull();
+                assertThat(summon.get().getArguments()).isEmpty();
+                assertThat(summon.get().getPadding().getArguments().getMarkers().findFirst(OmitParentheses.class)).isPresent();
+                assertThat(summon.get().getTypeParameters()).singleElement().satisfies(typeParameter ->
+                  assertThat(typeParameter).isInstanceOf(J.Identifier.class)
+                    .extracting(t -> ((J.Identifier) t).getSimpleName()).isEqualTo("Foo"));
+            })
+          )
+        );
+    }
+
+    @Test
     void significantCharactersInComments() {
         // visitTypeApply — `)` in line comment closing the value-arg list of a type-applied call
         rewriteRun(


### PR DESCRIPTION
## What's changed?

In Scala, fix parsing of `summon` with type parameter to be a method invocation.

## What's your motivation?

Otherwise, wrong LST is produced, the type information lands into the identifier.