### PR TITLE
Scala: fix parsing of procedure-syntax setter

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5949,10 +5949,15 @@ class ScalaTreeVisitor(
     // reached before any method-body `=`. The scan skips parameter clauses and
     // type parameter lists so a default value (`x: Int = 0`) or a function-type
     // parameter (`g: () => Unit`) isn't mistaken for the method-body `=`.
+    // Start scanning after the method name so a setter name's trailing `=`
+    // (`def engine_=(...) { ... }`) isn't mistaken for the method-body `=`.
     // Note: nested braces (def foo = { { ... } }) are flattened by the compiler;
     // the AST has one block, so the inner braces are lost in the round-trip.
-    if (adjustedStart < adjustedEnd && adjustedEnd <= source.length) {
-      isProcedureSyntax = bodyOpensWithBrace(adjustedStart, adjustedEnd)
+    val procScanStart =
+      if (dd.nameSpan.exists) Math.max(adjustedStart, Math.max(0, dd.nameSpan.end - offsetAdjustment))
+      else adjustedStart
+    if (procScanStart < adjustedEnd && adjustedEnd <= source.length) {
+      isProcedureSyntax = bodyOpensWithBrace(procScanStart, adjustedEnd)
     }
 
     // Detect parameterless methods (def name: Type = ...) — no parens in source.

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -873,4 +873,19 @@ class MethodDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void procedureSyntaxSetter() {
+        rewriteRun(
+          scala(
+            """
+            trait T {
+              def engine_=(x: Int) {
+                println(x)
+              }
+            }
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

In Scala fix parsing of a procedure-syntax setter with no `=` equal sign before the braces, e.g.
```
def engine_=(x: Int) {
```

## What's your motivation?

The `=` from the setter is currently confused for the one to start method body.