### PR TITLE
Python: fix RPC placeholder construction broken by id coercion

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/markers.py
+++ b/rewrite-python/rewrite/src/rewrite/markers.py
@@ -24,9 +24,11 @@ class Marker(ABC):
 
     # `_id` is on the public positional constructor surface, so callers may pass
     # a `uuid.UUID`; the dataclass `__init__` of every concrete marker calls this
-    # inherited hook to normalise it to the internal int form.
+    # inherited hook to normalise it to the internal int form. A None id passes
+    # through untouched: the RPC receiver constructs all-None placeholders (see
+    # `make_dataclass_factory`) and fills the id in later.
     def __post_init__(self):
-        if type(self._id) is not int:  # ty: ignore[unresolved-attribute]  # _id on concrete subclasses
+        if self._id is not None and type(self._id) is not int:  # ty: ignore[unresolved-attribute]  # _id on concrete subclasses
             object.__setattr__(self, '_id', id_to_int(self._id))  # ty: ignore[unresolved-attribute]
 
     def replace(self, **kwargs) -> 'Marker':
@@ -58,7 +60,8 @@ class Markers:
 
     def __post_init__(self):
         # Normalise `uuid.UUID` ids from external callers to the internal int form.
-        if type(self._id) is not int:
+        # None passes through: the RPC receiver constructs all-None placeholders.
+        if self._id is not None and type(self._id) is not int:
             object.__setattr__(self, '_id', id_to_int(self._id))
 
     _markers: List[Marker]

--- a/rewrite-python/rewrite/src/rewrite/tree.py
+++ b/rewrite-python/rewrite/src/rewrite/tree.py
@@ -38,8 +38,10 @@ class Tree(ABC):
     # pass a `uuid.UUID` (e.g. `uuid4()` or another node's `.id`). The dataclass
     # `__init__` of every concrete subclass calls this inherited hook; normalise
     # to the internal int form here so `.id`, equality and hashing stay correct.
+    # A None id passes through untouched: the RPC receiver constructs all-None
+    # placeholders (see `make_dataclass_factory`) and fills the id in later.
     def __post_init__(self):
-        if type(self._id) is not int:  # ty: ignore[unresolved-attribute]  # _id on concrete subclasses
+        if self._id is not None and type(self._id) is not int:  # ty: ignore[unresolved-attribute]  # _id on concrete subclasses
             object.__setattr__(self, '_id', id_to_int(self._id))  # ty: ignore[unresolved-attribute]
 
     @property

--- a/rewrite-python/rewrite/tests/test_id_normalization.py
+++ b/rewrite-python/rewrite/tests/test_id_normalization.py
@@ -76,3 +76,26 @@ class TestMarkerIdNormalization:
         found = SearchResult.found(ident, "match")
         assert found.markers.id == ident.markers.id
         assert found.markers.find_first(SearchResult) is not None
+
+
+class TestRpcPlaceholderConstruction:
+    """The RPC receiver constructs placeholder instances with every field None
+    (see ``make_dataclass_factory``) and fills them in field by field. The id
+    normalization hooks must let a None id pass through untouched."""
+
+    def test_tree_factory_accepts_none_id(self):
+        from rewrite.rpc.receive_queue import make_dataclass_factory
+        placeholder = make_dataclass_factory(Identifier)()
+        assert placeholder._id is None
+        uid = uuid4()
+        assert placeholder.replace(_id=uid.int).id == uid
+
+    def test_marker_factory_accepts_none_id(self):
+        from rewrite.rpc.receive_queue import make_dataclass_factory
+        placeholder = make_dataclass_factory(SearchResult)()
+        assert placeholder._id is None
+
+    def test_markers_factory_accepts_none_id(self):
+        from rewrite.rpc.receive_queue import make_dataclass_factory
+        placeholder = make_dataclass_factory(Markers)()
+        assert placeholder._id is None


### PR DESCRIPTION
## Motivation

- The coercing `__post_init__` hooks added in #7972 normalize UUID ids to the internal int form by calling `id_to_int(self._id)` for any non-int id. However, the RPC receiver's `make_dataclass_factory` constructs placeholder instances with **every field set to `None`** and fills them in field by field during deserialization. Every `_new_obj` on the receive path therefore crashed with `'NoneType' object has no attribute 'replace'`.

This broke `PythonParserTest.parseAndPrint` and both `AutoFormatTest` tests on `main` — all annotated `@DisabledIfEnvironmentVariable(named = "CI", ...)`, so CI never surfaced the failures (they only reproduce locally, where the Python RPC server is available).

## Summary

- Let a `None` id pass through the `__post_init__` hooks on `Tree`, `Marker`, and `Markers` untouched. The placeholder receives its real id later via `replace()`, which already normalizes (explicitly in `replace_if_changed`, and again via `__post_init__` on reconstruction).
- Added regression tests for the placeholder construction path in `tests/test_id_normalization.py`.

## Test plan

- [x] New `TestRpcPlaceholderConstruction` tests fail before the fix, pass after
- [x] `./gradlew :rewrite-python:test --tests org.openrewrite.python.PythonParserTest --tests org.openrewrite.python.format.AutoFormatTest` passes (previously 3 failing tests)
- [x] Full Python suite: `pytest tests/` — 1691 passed, 11 skipped
- [x] Full `./gradlew :rewrite-python:test` — only remaining failure is `RequirementsTxtParserTest.markerContainsDependenciesFromFreeze`, which fails identically on a clean `main` checkout (pre-existing, `uv`-environment-dependent, unrelated to this change)