### PR TITLE
Python: remove stale workspace directories blocking rebuilds

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/DependencyWorkspace.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/DependencyWorkspace.java
@@ -19,7 +19,6 @@ import lombok.experimental.UtilityClass;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.python.internal.PackageManagerExecutor;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -96,7 +95,6 @@ public class DependencyWorkspace {
                 return cached;
             }
             cache.remove(hash);
-            ensureTempDirIsAbsent(cached);
         }
 
         // Check disk cache
@@ -105,6 +103,10 @@ public class DependencyWorkspace {
             cache.put(hash, workspaceDir);
             return workspaceDir;
         }
+        // An invalid leftover at the target path (e.g. gutted by macOS periodic tmp
+        // cleanup, which deletes old files but keeps the directory skeleton) would
+        // block the final Files.move into place; remove it before rebuilding.
+        cleanupDirectory(workspaceDir);
 
         // Create new workspace
         try {
@@ -196,7 +198,6 @@ public class DependencyWorkspace {
                 return cached;
             }
             cache.remove(hash);
-            ensureTempDirIsAbsent(cached);
         }
 
         // Check disk cache
@@ -205,6 +206,10 @@ public class DependencyWorkspace {
             cache.put(hash, workspaceDir);
             return workspaceDir;
         }
+        // An invalid leftover at the target path (e.g. gutted by macOS periodic tmp
+        // cleanup, which deletes old files but keeps the directory skeleton) would
+        // block the final Files.move into place; remove it before rebuilding.
+        cleanupDirectory(workspaceDir);
 
         // Create new workspace
         try {
@@ -307,7 +312,6 @@ public class DependencyWorkspace {
                 return cached;
             }
             cache.remove(hash);
-            ensureTempDirIsAbsent(cached);
         }
 
         // Check disk cache
@@ -316,6 +320,10 @@ public class DependencyWorkspace {
             cache.put(hash, workspaceDir);
             return workspaceDir;
         }
+        // An invalid leftover at the target path (e.g. gutted by macOS periodic tmp
+        // cleanup, which deletes old files but keeps the directory skeleton) would
+        // block the final Files.move into place; remove it before rebuilding.
+        cleanupDirectory(workspaceDir);
 
         if (projectDir == null || !Files.isDirectory(projectDir)) {
             return null;
@@ -496,17 +504,6 @@ public class DependencyWorkspace {
                     });
         } catch (IOException e) {
             // Ignore - cache will be populated as needed
-        }
-    }
-
-    private static void ensureTempDirIsAbsent(Path cached) {
-        File file = cached.toFile();
-        if (file.exists()) {
-            try {
-                file.delete();
-            } catch (Exception e) {
-                //Just a safety to make sure we can write to the directory later on.
-            }
         }
     }
 }

--- a/rewrite-python/src/test/java/org/openrewrite/python/DependencyWorkspaceTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/DependencyWorkspaceTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.python.internal.PackageManagerExecutor;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class DependencyWorkspaceTest {
+
+    @Test
+    void rebuildsWorkspaceWhenStaleDirectoryOccupiesTarget() throws IOException {
+        assumeTrue(PackageManagerExecutor.UV.find() != null, "uv is not installed");
+
+        String requirements = "six==1.17.0\n";
+        Path workspace = DependencyWorkspace.getOrCreateRequirementsWorkspace(requirements, null);
+        assumeTrue(workspace != null, "could not create workspace (uv install failed?)");
+
+        // Simulate macOS periodic tmp cleanup, which deletes files older than three
+        // days from $TMPDIR but leaves the directory skeleton (including .venv) in
+        // place. The leftover directory occupies the path the rebuild moves into.
+        Files.deleteIfExists(workspace.resolve("freeze.txt"));
+        Files.deleteIfExists(workspace.resolve("version.txt"));
+        // A fresh JVM would not have the (now invalid) workspace in the in-memory cache.
+        DependencyWorkspace.clearCache();
+
+        Path rebuilt = DependencyWorkspace.getOrCreateRequirementsWorkspace(requirements, null);
+        assertThat(rebuilt).isNotNull();
+        assertThat(rebuilt.resolve("freeze.txt")).exists();
+        assertThat(rebuilt.resolve("version.txt")).exists();
+    }
+}


### PR DESCRIPTION
## Motivation

`RequirementsTxtParserTest.markerContainsDependenciesFromFreeze` fails persistently on macOS dev machines (it is `assumeTrue(uv)`-guarded, so CI never sees it). The root cause: `DependencyWorkspace` caches uv workspaces under `$TMPDIR/openrewrite-python-workspaces/<content-hash>`, and macOS's daily periodic maintenance (03:35) deletes tmp files not accessed for three days while keeping the directory skeleton. The gutted workspace (only a `.venv` shell, no `freeze.txt`/`version.txt`) fails validation and is rebuilt in a temp directory — but the final `Files.move` into place throws `FileAlreadyExistsException` because the stale directory still occupies the target path. The exception is silently swallowed (`return null`), the parser attaches a `ParseExceptionResult` instead of the `PythonResolutionResult` marker, and since nothing ever removes the leftover, resolution fails permanently for that requirements content.

There was an attempt to handle this (`ensureTempDirIsAbsent`), but it used `File.delete()`, which cannot remove non-empty directories, and it only ran when the entry was still in the in-memory cache — never on a fresh JVM.

## Summary

- Recursively delete an invalid leftover workspace directory (`cleanupDirectory`) after the disk-cache validity check fails, before rebuilding — applied to all three workspace creators (pyproject, requirements.txt, setuptools), which share the `Files.move` pattern
- Removed the ineffective `ensureTempDirIsAbsent`
- Added `DependencyWorkspaceTest` reproducing the gutted-by-tmp-cleanup scenario

## Test plan

- [x] New `DependencyWorkspaceTest.rebuildsWorkspaceWhenStaleDirectoryOccupiesTarget` fails before the fix with exactly the production symptom (rebuild returns null), passes after
- [x] Recreated the real-world gutted state (`.venv`-only skeleton at the cached path for `requests>=2.28.0`) and verified `markerContainsDependenciesFromFreeze` passes in a fresh JVM
- [x] Full `./gradlew :rewrite-python:test` is green