### PR TITLE
Python: upgrade to ty/ty-types 0.0.49 and drop stale suppressions

### DIFF
--- a/rewrite-python/rewrite/pyproject.toml
+++ b/rewrite-python/rewrite/pyproject.toml
@@ -87,7 +87,11 @@ include = ["src"]
 #   visitor and padding methods (e.g. visit_and_cast's `Type[T]` parameter,
 #   accept_*() narrowing `Self` to the concrete subclass). The `Self` case is
 #   tracked upstream as https://github.com/astral-sh/ty/issues/2255
-# - unresolved-reference: ~430 errors from TYPE_CHECKING forward references
+# - unresolved-reference: ~340 forward-reference annotations (mostly in the
+#   generated .pyi stubs) naming types not imported into that file/stub. These
+#   are quoted and never evaluated at runtime, so they are harmless; in most
+#   cases ty is correct rather than limited, so there is no single upstream issue
+#   to track. Fixable piecemeal by adding the missing TYPE_CHECKING imports.
 invalid-argument-type = "ignore"
 unresolved-reference = "ignore"
 

--- a/rewrite-python/rewrite/pyproject.toml
+++ b/rewrite-python/rewrite/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "more_itertools>=10.0.0",
-    "ty-types>=0.0.44",  # Type inference CLI for Python type attribution
+    "ty-types>=0.0.49",  # Type inference CLI for Python type attribution
     "parso>=0.7.1,<0.8",  # Python 2/3 parser with CST support (0.8+ dropped Python 2.7 grammar)
 ]
 
@@ -81,10 +81,13 @@ root = ["src"]
 include = ["src"]
 
 [tool.ty.rules]
-# Ignored rules (ty limitations with visitor pattern architecture):
-# - invalid-argument-type: ~200 errors from Self type vs concrete type in accept_*() methods
-#   (tracked as ty bug: https://github.com/astral-sh/ty/issues/2255)
-# - unresolved-reference: TYPE_CHECKING forward references
+# Ignored rules (ty limitations with the visitor-pattern architecture).
+# Counts are approximate and reflect ty 0.0.49.
+# - invalid-argument-type: ~770 errors from generic TypeVar / `Self` variance in
+#   visitor and padding methods (e.g. visit_and_cast's `Type[T]` parameter,
+#   accept_*() narrowing `Self` to the concrete subclass). The `Self` case is
+#   tracked upstream as https://github.com/astral-sh/ty/issues/2255
+# - unresolved-reference: ~430 errors from TYPE_CHECKING forward references
 invalid-argument-type = "ignore"
 unresolved-reference = "ignore"
 

--- a/rewrite-python/rewrite/src/rewrite/python/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/__init__.py
@@ -67,7 +67,7 @@ from rewrite.python.tree import (
     VariableScope,
     YieldFrom,
 )
-from rewrite.python.support_types import PyComment  # ty: ignore[unresolved-import]
+from rewrite.python.support_types import PyComment
 from rewrite.python.visitor import PythonVisitor
 from rewrite.python.style import (
     SpacesStyle,

--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -2283,7 +2283,7 @@ class ParserVisitor(ast.NodeVisitor):
             name = name.replace(prefix=extra_parens[-1][1])  # ty: ignore[unresolved-attribute]  # recursive call returns unknown
 
             # Wrap in extra parentheses (innermost to outermost)
-            wrapped: Expression = name  # ty: ignore[invalid-assignment]
+            wrapped: Expression = name
             for i in range(len(extra_parens) - 1, -1, -1):
                 paren_prefix, _ = extra_parens[i]
                 suffix = self.__whitespace()

--- a/rewrite-python/rewrite/src/rewrite/python/format/blank_lines.py
+++ b/rewrite-python/rewrite/src/rewrite/python/format/blank_lines.py
@@ -36,7 +36,7 @@ class BlankLinesVisitor(PythonVisitor):
                 parent_cursor.put_message('prev_import', False)
 
         if top_level:
-            if stmt == cast(CompilationUnit, parent_cursor.value).statements[0]:
+            if stmt == parent_cursor.value.statements[0]:
                 stmt = stmt.replace(prefix=stmt.prefix.replace(whitespace=''))
             else:
                 min_lines = max(self._style.minimum.around_top_level_classes_functions if isinstance(stmt, (ClassDeclaration, MethodDeclaration)) else 0,

--- a/rewrite-python/rewrite/src/rewrite/python/format/minimum_viable_spacing.py
+++ b/rewrite-python/rewrite/src/rewrite/python/format/minimum_viable_spacing.py
@@ -24,9 +24,9 @@ class MinimumViableSpacingVisitor(PythonVisitor):
             if not previous_statement or not previous_statement.markers.find_first(Semicolon):
                 new_prefix = tree.prefix.replace(whitespace='\n' + tree.prefix.whitespace)
                 if isinstance(tree, ExpressionStatement):
-                    tree = tree.replace(expression=tree.expression.replace(prefix=new_prefix))  # ty: ignore[invalid-assignment]
+                    tree = tree.replace(expression=tree.expression.replace(prefix=new_prefix))
                 else:
-                    tree = tree.replace(prefix=new_prefix)  # ty: ignore[invalid-assignment]
+                    tree = tree.replace(prefix=new_prefix)
 
         return tree
 

--- a/rewrite-python/rewrite/src/rewrite/python/template/comparator.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/comparator.py
@@ -97,7 +97,7 @@ class PythonComparatorVisitor:
         # Special cases
         if isinstance(pattern, j.Literal):
             return self._compare_literal(
-                cast(j.Literal, pattern), cast(j.Literal, target)
+                pattern, cast(j.Literal, target)
             )
         if isinstance(pattern, j.Empty):
             return True

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -542,6 +542,13 @@ class PythonTypeMapping:
             return class_type
 
         elif kind == 'typedDict':
+            # Map a TypedDict to a nominal class type by name. We intentionally
+            # drop the descriptor's `fields` and (ty-types >= 0.0.49) the PEP 728
+            # `closed` / `extraItems` openness fields: a field *use* `m["name"]`
+            # is a subscript whose value type ty already attributes on the access
+            # node, so the common case is covered without modeling the shape.
+            # Populating the class's members and linking subscript uses back to
+            # field declarations (a J.ArrayAccess LST change) is deferred.
             name = descriptor.get('name', '')
             if name:
                 return self._create_class_type(name)

--- a/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
@@ -1761,7 +1761,7 @@ def _register_core_marker_codecs():
 
 def _register_markup_marker_codecs():
     """Register codecs for Markup marker types (Warn, Error, Info, Debug)."""
-    from rewrite.markers import MarkupWarn, MarkupError, MarkupInfo, MarkupDebug  # ty: ignore[unresolved-import]
+    from rewrite.markers import MarkupWarn, MarkupError, MarkupInfo, MarkupDebug
     from rewrite.rpc.receive_queue import register_codec_with_both_names
 
     for java_suffix, py_cls in [

--- a/rewrite-python/rewrite/src/rewrite/rpc/python_sender.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_sender.py
@@ -4,7 +4,7 @@ Python RPC Sender that mirrors Java's PythonSender structure.
 This uses the visitor pattern with pre_visit handling common fields (id, prefix, markers)
 and type-specific visit methods handling only additional fields.
 """
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from rewrite import Markers
 from rewrite.utils import id_to_str
@@ -19,6 +19,9 @@ from rewrite.python.tree import (
     TypeAlias, YieldFrom, UnionType, VariableScope, Del, SpecialParameter,
     Star, NamedArgument, TypeHintedExpression, ErrorFrom, MatchCase, Slice
 )
+
+if TYPE_CHECKING:
+    from rewrite.rpc.send_queue import RpcSendQueue
 
 
 class PythonRpcSender:

--- a/rewrite-python/rewrite/src/rewrite/tree.py
+++ b/rewrite-python/rewrite/src/rewrite/tree.py
@@ -241,13 +241,13 @@ class _VerboseMarkerPrinter(PrintOutputCapture.MarkerPrinter):
 class _FencedMarkerPrinter(PrintOutputCapture.MarkerPrinter):
     """Prints SearchResult and Markup markers with fenced {{uuid}} format."""
     def before_syntax(self, marker: 'Marker', cursor: 'Cursor', comment_wrapper: Callable[[str], str]) -> str:
-        from .markers import SearchResult, Markup  # ty: ignore[unresolved-import]
+        from .markers import SearchResult, Markup
         if isinstance(marker, (SearchResult, Markup)):
             return "{{" + str(marker.id) + "}}"
         return ""
 
     def after_syntax(self, marker: 'Marker', cursor: 'Cursor', comment_wrapper: Callable[[str], str]) -> str:
-        from .markers import SearchResult, Markup  # ty: ignore[unresolved-import]
+        from .markers import SearchResult, Markup
         if isinstance(marker, (SearchResult, Markup)):
             return "{{" + str(marker.id) + "}}"
         return ""

--- a/rewrite-python/rewrite/src/rewrite/utils.py
+++ b/rewrite-python/rewrite/src/rewrite/utils.py
@@ -96,7 +96,7 @@ def replace_if_changed(obj: T, **kwargs) -> T:
         name: mapped_kwargs[name] if name in mapped_kwargs else getattr(obj, name)
         for name in init_fields
     }
-    return cast(T, cls(**new_kwargs))
+    return cls(**new_kwargs)
 
 
 def random_id() -> int:


### PR DESCRIPTION
## Motivation

`rewrite-python` uses `ty-types` for type attribution during parsing and `ty` as its type checker. Both were behind (ty-types floor `>=0.0.44`, ty checked at 0.0.18). The 0.0.49 ty-types release ([openrewrite/ty-types#18](https://github.com/openrewrite/ty-types/pull/18)) surfaces PEP 728 TypedDict openness (`closed` / `extra_items`) on the `typedDict` descriptor. This bumps both to 0.0.49, confirms our consumer is unaffected, and cleans up type-checker noise that 0.0.49 lets us address.

## Summary

- Bump `ty-types` floor to `>=0.0.49` in `pyproject.toml`.
- The new `typedDict` descriptor fields (`closed`, `extraItems`) are additive. Our `type_mapping.py` maps a TypedDict to a nominal class type by name and already ignores the descriptor's `fields`, so the new fields are harmlessly dropped — documented inline at the handler. (Populating TypedDict members and linking subscript field uses back to declarations is intentionally out of scope here.)
- Remove 7 `# ty: ignore[...]` directives that 0.0.49 reports as unused.
- Remove 3 redundant `cast(...)` calls (value already has the cast-to type under 0.0.49).
- Add a missing `TYPE_CHECKING` import for `RpcSendQueue` in `python_sender.py`. ~94 method signatures annotated parameters with the quoted forward reference `'RpcSendQueue'` without ever importing the type; ty correctly flagged these (they only worked at runtime because the annotations are strings that are never evaluated). The import is `TYPE_CHECKING`-only — zero runtime cost, no circular-import risk.
- Refresh the `[tool.ty.rules]` comment so the ignored-rule rationale and approximate counts match ty 0.0.49.

## Test plan

- [x] `ty check` (0.0.49): `unused-ignore-comment` and `redundant-cast` go to zero; `unresolved-reference` drops 430 → 336 (the 94 `RpcSendQueue` hits); no new diagnostics introduced.
- [x] `pytest tests/python/all tests/python/format tests/python/template tests/recipes` — 901 passed.
- [x] `pytest tests/python/test_type_attribution.py` — 137 passed (type attribution against ty-types 0.0.49).
- [x] `python -c "import rewrite.rpc.python_sender"` — clean import (TYPE_CHECKING-only change is inert at runtime).
- [x] `ruff check --select F401,F811` on edited files — clean.