### PR TITLE
Preserve Flag.Varargs in bytecode/reflection type mappers

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTypeMapping.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTypeMapping.java
@@ -208,7 +208,7 @@ class GroovyTypeMapping implements JavaTypeMapping<ASTNode> {
         String[] finalParamNames = paramNames;
         return typeFactory.methodFor(signature,
                 () -> new JavaType.Method(
-                    null, node.getModifiers(), null,
+                    null, Flag.mapBytecodeAccessFlagsToBitMap(node.getModifiers()), null,
                     node instanceof ConstructorNode ? "<constructor>" : node.getName(),
                     null, finalParamNames, null, null, null, null, null),
                 method -> {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyVarargsTypeMappingTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyVarargsTypeMappingTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.Flag;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.groovy.Assertions.groovy;
+
+class GroovyVarargsTypeMappingTest implements RewriteTest {
+
+    @Test
+    void varargsMethodHasVarargsFlag() {
+        // Groovy resolves library methods from byte code, where varargs is encoded as
+        // ACC_VARARGS (0x80) in MethodNode.getModifiers(). That bit collides with
+        // Flag.Transient, so without remapping the call would be flagged Transient and
+        // lose Varargs -- the upstream cause of UseDiamondOperator's AIOOBE.
+        rewriteRun(
+          groovy(
+            """
+              java.util.Arrays.asList("a", "b", "c")
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                AtomicReference<JavaType.Method> ref = new AtomicReference<>();
+                new GroovyIsoVisitor<Integer>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer p) {
+                        if (method.getMethodType() != null && "asList".equals(method.getMethodType().getName())) {
+                            ref.set(method.getMethodType());
+                        }
+                        return super.visitMethodInvocation(method, p);
+                    }
+                }.visit(cu, 0);
+
+                assertThat(ref.get()).as("asList method type resolved").isNotNull();
+                assertThat(ref.get().getFlags())
+                  .contains(Flag.Varargs)
+                  .doesNotContain(Flag.Transient);
+            })
+          )
+        );
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.internal;
 
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.java.JavaTypeMapping;
+import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.JavaType;
 
 import java.lang.annotation.Annotation;
@@ -305,7 +306,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
         String[] finalParamNames = paramNames;
         return typeFactory.methodFor(signature,
                 () -> new JavaType.Method(
-                        null, method.getModifiers(), null, "<constructor>",
+                        null, Flag.mapBytecodeAccessFlagsToBitMap(method.getModifiers()), null, "<constructor>",
                         null, finalParamNames, null, null, null, null, null),
                 mappedMethod -> {
             List<JavaType> thrownExceptions = null;
@@ -413,7 +414,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
         String[] finalFormalTypeNames = declaredFormalTypeNames == null ? null : declaredFormalTypeNames.toArray(new String[0]);
         return typeFactory.methodFor(signature,
                 () -> new JavaType.Method(
-                        null, method.getModifiers(), null, method.getName(),
+                        null, Flag.mapBytecodeAccessFlagsToBitMap(method.getModifiers()), null, method.getName(),
                         null, finalParamNames, null, null, null, finalDefaultValues, finalFormalTypeNames),
                 mappedMethod -> {
             List<JavaType> thrownExceptions = null;

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/Flag.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/Flag.java
@@ -92,6 +92,40 @@ public enum Flag {
     }
 
     /**
+     * The JVM/bytecode {@code ACC_VARARGS} access flag, which is also the bit
+     * {@code java.lang.reflect.Member#getModifiers()} and ASM report for varargs methods.
+     * It occupies bit {@code 0x0080} — the very same bit this enum assigns to {@link #Transient}.
+     * Varargs, by contrast, is modeled by {@link #Varargs} ({@code 1L << 34}, matching javac's
+     * {@code com.sun.tools.javac.code.Flags.VARARGS}).
+     */
+    private static final long ACC_VARARGS = 0x0080;
+
+    /**
+     * Translate a bytecode-level access-flags bitmap of a <em>method or constructor</em> — as
+     * produced by ASM or {@code java.lang.reflect.Member#getModifiers()}, where
+     * {@code ACC_VARARGS == 0x0080} — into the canonical bitmap consumed by
+     * {@link #bitMapToFlags(long)} and stored on {@link org.openrewrite.java.tree.JavaType.Method}.
+     * <p>
+     * The {@code ACC_VARARGS} bit collides with {@link #Transient}. Because {@code transient} is
+     * meaningless on an executable, the bit is rewritten to {@link #Varargs} so that varargs methods
+     * carry the correct flag rather than a spurious {@code Transient}. Flags that originate from
+     * javac already use {@link #Varargs}'s bit and never set {@code 0x0080} on an executable, so they
+     * pass through unchanged.
+     * <p>
+     * Do not apply this to field access flags: for fields {@code 0x0080} legitimately means
+     * {@code transient}.
+     *
+     * @param accessFlags bytecode access flags for a method or constructor
+     * @return the access flags with {@code ACC_VARARGS} remapped to {@link #Varargs}
+     */
+    public static long mapBytecodeAccessFlagsToBitMap(long accessFlags) {
+        if ((accessFlags & ACC_VARARGS) != 0) {
+            return (accessFlags & ~ACC_VARARGS) | Varargs.bitMask;
+        }
+        return accessFlags;
+    }
+
+    /**
      * Converts a set of flag enumerations into the Java Language Specification's access_flags bitmap
      *
      * @param flags A set of Flag enumerations

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/JavaReflectionTypeMappingTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/JavaReflectionTypeMappingTest.java
@@ -19,8 +19,11 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.JavaTypeGoat;
 import org.openrewrite.java.JavaTypeMappingTest;
+import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -91,6 +94,17 @@ class JavaReflectionTypeMappingTest implements JavaTypeMappingTest {
         // synthetic slots and a different length than the types list.
         assertThat(constructor.getParameterNames()).doesNotContainNull();
         assertThat(constructor.getParameterNames()).hasSameSizeAs(constructor.getParameterTypes());
+    }
+
+    @Test
+    void varargsMethodHasVarargsFlag() throws Exception {
+        // Reflection exposes varargs as ACC_VARARGS (0x80) in getModifiers(), which collides
+        // with Flag.Transient. The mapping must translate it to Flag.Varargs rather than
+        // leaving a spurious Transient.
+        JavaType.Method asList = typeMapping.method(Arrays.class.getMethod("asList", Object[].class));
+        assertThat(asList.getFlags())
+          .contains(Flag.Varargs)
+          .doesNotContain(Flag.Transient);
     }
 
 }

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTest.java
@@ -527,6 +527,67 @@ class TypeTableTest implements RewriteTest {
         }
 
         @Test
+        void varargsFlagPreservedThroughTypeTableRoundtrip() throws Exception {
+            //language=java
+            String libraryClass = """
+              package test.library;
+
+              public class VarargsLibrary {
+                  public static String join(String separator, Object... args) {
+                      return null;
+                  }
+              }
+              """;
+
+            Path[] classFiles = compileToClassFiles(
+              libraryClass, "test.library.VarargsLibrary"
+            );
+            Path testJar = createJarFromClasses("varargs-library.jar", classFiles);
+
+            // Write through TypeTable
+            try (TypeTable.Writer writer = TypeTable.newWriter(Files.newOutputStream(tsv))) {
+                writer.jar("test.group", "varargs-library", "1.0").write(testJar);
+            }
+
+            // Load back via TypeTable
+            var table = new TypeTable(ctx, tsv.toUri().toURL(), List.of("varargs-library"));
+            Path classesDir = table.load("varargs-library");
+            assertThat(classesDir).isNotNull();
+
+            rewriteRun(
+              spec -> spec.parser((Parser.Builder) JavaParser.fromJavaVersion()
+                .classpath(List.of(classesDir)).logCompilationWarningsAndErrors(true)),
+              java(
+                """
+                  import test.library.VarargsLibrary;
+
+                  class TestClient {
+                      void use() {
+                          VarargsLibrary.join(",", "a", "b");
+                      }
+                  }
+                  """,
+                spec -> spec.afterRecipe(cu -> {
+                    J.MethodInvocation invocation = new org.openrewrite.java.JavaIsoVisitor<List<J.MethodInvocation>>() {
+                        @Override
+                        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, List<J.MethodInvocation> found) {
+                            found.add(method);
+                            return super.visitMethodInvocation(method, found);
+                        }
+                    }.reduce(cu, new java.util.ArrayList<J.MethodInvocation>()).getFirst();
+
+                    JavaType.Method methodType = invocation.getMethodType();
+                    assertThat(methodType).isNotNull();
+                    assertThat(methodType.getName()).isEqualTo("join");
+                    assertThat(methodType.getFlags())
+                      .as("Varargs flag must survive the TypeTable round-trip")
+                      .contains(org.openrewrite.java.tree.Flag.Varargs);
+                })
+              )
+            );
+        }
+
+        @Test
         void annotationAttributeValuesPreservedThroughTypeTableRoundtrip() throws Exception {
             // Create annotation with various default values to test escaping and preservation
             //language=java

--- a/rewrite-java/src/test/java/org/openrewrite/java/tree/FlagTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/tree/FlagTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.tree;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FlagTest {
+
+    // ACC_PUBLIC | ACC_STATIC | ACC_VARARGS, e.g. java.util.Arrays.asList
+    private static final long PUBLIC_STATIC_VARARGS = 0x0001 | 0x0008 | 0x0080;
+
+    @Test
+    void mapsAccVarargsToVarargsFlag() {
+        long bitMap = Flag.mapBytecodeAccessFlagsToBitMap(PUBLIC_STATIC_VARARGS);
+        assertThat(Flag.bitMapToFlags(bitMap))
+          .contains(Flag.Public, Flag.Static, Flag.Varargs)
+          .doesNotContain(Flag.Transient);
+    }
+
+    @Test
+    void leavesNonVarargsFlagsUntouched() {
+        long publicStatic = 0x0001 | 0x0008;
+        assertThat(Flag.mapBytecodeAccessFlagsToBitMap(publicStatic)).isEqualTo(publicStatic);
+    }
+}


### PR DESCRIPTION
## Motivation

`Flag.Varargs` was silently dropped from `JavaType.Method` for varargs methods attributed through some (non-javac) paths, because of a bit collision:

- The JVM/bytecode `ACC_VARARGS` access flag — also the bit returned by `java.lang.reflect.Member#getModifiers()` and ASM — occupies bit `0x0080`.
- `Flag` assigns that same bit (`1L << 7`) to `Transient`. `Flag.Varargs` is instead `1L << 34`, matching javac's `com.sun.tools.javac.code.Flags.VARARGS`.

Any type mapper that fed **raw** JVM/reflection access flags into `JavaType.Method`'s flags bitmap therefore produced a spurious `Transient` and lost `Varargs`. `GroovyTypeMapping` (`MethodNode.getModifiers()`) and `JavaReflectionTypeMapping` (`Member.getModifiers()`) both did this. `KotlinTypeMapping` already compensated for the same collision (`KotlinTypeMapping.kt`, search for the `1L shl 7` / `1L shl 34` remap), confirming the convention.

This is a broad-impact attribution gap: anything that branches on `Flag.Varargs` or reasons about varargs (overload resolution, method matching, templating, etc.) can misbehave on these method types. It was the upstream cause of an `ArrayIndexOutOfBoundsException` in `UseDiamondOperator.getMethodParamType` (`rewrite-static-analysis`) seen in a flagship recipe run — that recipe maps invocation arguments by index and is only reachable when a call has more arguments than the method's reported parameter types, which in valid Java only happens for a varargs method whose `Flag.Varargs` was missing. (A defensive guard for the recipe itself is handled separately in `rewrite-static-analysis`.)

### Scope / where the flag is and isn't dropped

I exercised each attribution path:

| Path | `Flag.Varargs` preserved before this PR? |
|---|---|
| OpenRewrite Java parser (javac) | ✅ (javac uses `1L << 34` natively) |
| `TypeTable` jar round-trip (`writeJar` → javac) | ✅ (added a regression test) |
| `KotlinTypeMapping` | ✅ (already remapped) |
| `GroovyTypeMapping` | ❌ fixed here |
| `JavaReflectionTypeMapping` | ❌ fixed here |

Note: the in-memory `TypeTableSink` consumer that builds `JavaType` directly from bytecode (used for fast classpath type loading) lives outside this repo and receives the same raw ASM `access` int; it needs the equivalent remap and is tracked separately.

## Summary

- Add `Flag.mapBytecodeAccessFlagsToBitMap(long)` — remaps `ACC_VARARGS` (`0x0080`) to `Flag.Varargs` for method/constructor access flags; leaves everything else (and field flags, where `0x0080` legitimately means `transient`) untouched.
- Route `GroovyTypeMapping#methodType` and `JavaReflectionTypeMapping`'s method and constructor mapping through the helper.

## Test plan

- `FlagTest` — unit-tests the helper (remaps varargs, leaves non-varargs flags identical).
- `JavaReflectionTypeMappingTest#varargsMethodHasVarargsFlag` — maps `Arrays.asList(Object...)` reflectively; asserts `Varargs` present and `Transient` absent.
- `GroovyVarargsTypeMappingTest#varargsMethodHasVarargsFlag` — parses Groovy calling `Arrays.asList`; asserts the resolved method type has `Varargs` and not `Transient`.
- `TypeTableTest#varargsFlagPreservedThroughTypeTableRoundtrip` — positive regression guard proving the `TypeTable` jar path already preserves the flag.
- `./gradlew :rewrite-java:test :rewrite-groovy:test` — full suites pass.