### PR TITLE
Scala: S.ConstructorInvocation type tree

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaIsoVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaIsoVisitor.java
@@ -373,4 +373,9 @@ public class ScalaIsoVisitor<P> extends ScalaVisitor<P> {
     public J.Yield visitYield(J.Yield yield, P p) {
         return (J.Yield) super.visitYield(yield, p);
     }
+
+    @Override
+    public S.ConstructorInvocation visitConstructorInvocation(S.ConstructorInvocation constructorInvocation, P p) {
+        return (S.ConstructorInvocation) super.visitConstructorInvocation(constructorInvocation, p);
+    }
 }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -633,6 +633,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return visitAnonymousGiven((S.AnonymousGiven) tree, p);
         } else if (tree instanceof S.FunctionCall) {
             return visitFunctionCall((S.FunctionCall) tree, p);
+        } else if (tree instanceof S.ConstructorInvocation) {
+            return visitConstructorInvocation((S.ConstructorInvocation) tree, p);
         } else if (tree instanceof S.SingletonType) {
             return visitSingletonType((S.SingletonType) tree, p);
         } else if (tree instanceof S.RepeatedType) {
@@ -1112,6 +1114,14 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         }
         afterSyntax(fc, p);
         return fc;
+    }
+
+    public J visitConstructorInvocation(S.ConstructorInvocation ci, PrintOutputCapture<P> p) {
+        beforeSyntax(ci, Space.Location.LANGUAGE_EXTENSION, p);
+        visit(ci.getTypeTree(), p);
+        visitContainer("(", ci.getPadding().getArguments(), JContainer.Location.METHOD_INVOCATION_ARGUMENTS, ",", ")", p);
+        afterSyntax(ci, p);
+        return ci;
     }
 
     @Override

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -237,6 +237,15 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         return f;
     }
 
+    public J visitConstructorInvocation(S.ConstructorInvocation constructorInvocation, P p) {
+        S.ConstructorInvocation c = constructorInvocation;
+        c = c.withPrefix(visitSpace(c.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        c = c.withMarkers(visitMarkers(c.getMarkers(), p));
+        c = c.withTypeTree(visitAndCast(c.getTypeTree(), p));
+        c = c.getPadding().withArguments(visitContainer(c.getPadding().getArguments(), JContainer.Location.METHOD_INVOCATION_ARGUMENTS, p));
+        return c;
+    }
+
     public J visitSingletonType(S.SingletonType singletonType, P p) {
         S.SingletonType s = singletonType;
         s = s.withPrefix(visitSpace(s.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -1504,6 +1504,103 @@ public interface S extends J {
     }
 
     /**
+     * Represents a parent constructor invocation in an {@code extends}/{@code with} clause,
+     * e.g. {@code class E(msg: String) extends Exception(msg)}. Models the supertype together
+     * with its constructor arguments.
+     * <p>
+     * Implements {@link TypeTree} so it can occupy the {@code extends}/{@code implements} slots
+     * of {@link J.ClassDeclaration} (which hold {@code TypeTree}, not {@code Expression}), mirroring
+     * {@code K.ConstructorInvocation} in rewrite-kotlin. The leading {@code extends}/{@code with}
+     * keyword space is held by the surrounding {@link J.ClassDeclaration} padding, so this node's
+     * {@code prefix} is the space between that keyword and the supertype.
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class ConstructorInvocation implements S, TypeTree {
+
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @With
+        @Getter
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        @With
+        @Getter
+        Space prefix;
+
+        @With
+        @Getter
+        Markers markers;
+
+        @With
+        @Getter
+        TypeTree typeTree;
+
+        JContainer<Expression> arguments;
+
+        public List<Expression> getArguments() {
+            return arguments.getElements();
+        }
+
+        public S.ConstructorInvocation withArguments(List<Expression> arguments) {
+            return getPadding().withArguments(JContainer.withElements(this.arguments, arguments));
+        }
+
+        public static ConstructorInvocation build(UUID id, Space prefix, Markers markers,
+                                                  TypeTree typeTree, JContainer<Expression> arguments) {
+            return new ConstructorInvocation(null, id, prefix, markers, typeTree, arguments);
+        }
+
+        @Override
+        public @Nullable JavaType getType() {
+            return typeTree.getType();
+        }
+
+        @Override
+        public S.ConstructorInvocation withType(@Nullable JavaType type) {
+            return withTypeTree(typeTree.withType(type));
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitConstructorInvocation(this, p);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final S.ConstructorInvocation t;
+
+            public JContainer<Expression> getArguments() {
+                return t.arguments;
+            }
+
+            public S.ConstructorInvocation withArguments(JContainer<Expression> arguments) {
+                return t.arguments == arguments ? t : new S.ConstructorInvocation(null, t.id, t.prefix, t.markers, t.typeTree, arguments);
+            }
+        }
+    }
+
+    /**
      * Represents a Scala singleton type: {@code foo.type}.
      * The qualifier is any expression, typically an object/module reference.
      */

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -3809,12 +3809,12 @@ class ScalaTreeVisitor(
         // Now visit the parent with cursor positioned correctly
         val firstParent = tmpl.parents.head
         val savedCursorExtends = cursor
-        val extendsType = visitTree(firstParent) match {
-          case typeTree: TypeTree => typeTree
-          case id: J.Identifier => id.asInstanceOf[TypeTree]
-          case other =>
+        val visitedFirstParent = visitTree(firstParent)
+        val extendsType: TypeTree = parentTypeTree(visitedFirstParent) match {
+          case tt: TypeTree => tt
+          case _ =>
             updateCursor(firstParent.span.end)
-            ident(extractSource(firstParent.span), other.getPrefix).asInstanceOf[TypeTree]
+            ident(extractSource(firstParent.span), visitedFirstParent.getPrefix).asInstanceOf[TypeTree]
         }
 
         extendings = new JLeftPadded(extendsSpace, extendsType, Markers.EMPTY)
@@ -3839,12 +3839,12 @@ class ScalaTreeVisitor(
           
           for (i <- 1 until tmpl.parents.size) {
             val parent = tmpl.parents(i)
-            val implType = visitTree(parent) match {
-              case typeTree: TypeTree => typeTree
-              case id: J.Identifier => id.asInstanceOf[TypeTree]
-              case other =>
+            val visitedParent = visitTree(parent)
+            val implType: TypeTree = parentTypeTree(visitedParent) match {
+              case tt: TypeTree => tt
+              case _ =>
                 updateCursor(parent.span.end)
-                ident(extractSource(parent.span), other.getPrefix).asInstanceOf[TypeTree]
+                ident(extractSource(parent.span), visitedParent.getPrefix).asInstanceOf[TypeTree]
             }
             
             // For subsequent traits, extract space between them
@@ -5136,13 +5136,13 @@ class ScalaTreeVisitor(
         // First parent is the extends clause
         val firstParent = sourceParents.head
         val savedCursorExtends = cursor
-        val extendsType: TypeTree = visitTree(firstParent) match {
+        val visitedFirstParent = visitTree(firstParent)
+        val extendsType: TypeTree = parentTypeTree(visitedFirstParent) match {
           case tt: TypeTree => tt
-          case id: J.Identifier => id.asInstanceOf[TypeTree]
-          case other =>
-            // Constructor call, intersection type, or other complex parent — preserve source
+          case _ =>
+            // Intersection type or other complex parent — preserve source
             updateCursor(firstParent.span.end)
-            ident(extractSource(firstParent.span), other.getPrefix).asInstanceOf[TypeTree]
+            ident(extractSource(firstParent.span), visitedFirstParent.getPrefix).asInstanceOf[TypeTree]
         }
         
         extendings = new JLeftPadded(extendsSpace, extendsType, Markers.EMPTY)
@@ -5173,9 +5173,8 @@ class ScalaTreeVisitor(
             val parent = sourceParents(i)
             val savedCursorWith = cursor
 
-            val implType: TypeTree = visitTree(parent) match {
+            val implType: TypeTree = parentTypeTree(visitTree(parent)) match {
               case tt: TypeTree => tt
-              case id: J.Identifier => id.asInstanceOf[TypeTree]
               case _ =>
                 cursor = savedCursorWith
                 visitUnknown(parent)
@@ -8682,6 +8681,38 @@ class ScalaTreeVisitor(
    * it consumes `sourceBefore(endDelim)` (e.g. `")"` or `"]"`), so the trailing
    * whitespace before the closing delimiter is captured on the last element.
    */
+  /**
+   * Map a visited class/object parent into a `TypeTree` for the `extends`/`with`
+   * slots of `J.ClassDeclaration` (which hold `TypeTree`, not `Expression`).
+   *
+   * A bare supertype maps directly. A parent constructor call like
+   * `extends Exception(msg)` is parsed as a `J.NewClass` (dotty wraps it in a
+   * `New`/`<init>` apply) or, for some forms, a `J.MethodInvocation` whose `select`
+   * is the supertype. Either way we lift it into an `S.ConstructorInvocation` so the
+   * arguments stay first-class LST nodes instead of being crammed into a
+   * `J.Identifier` name. Returns null when no rich mapping fits, so callers can fall back.
+   */
+  private def parentTypeTree(visited: J): TypeTree = visited match {
+    case tt: TypeTree => tt
+    case nc: J.NewClass if nc.getClazz != null && nc.getPadding.getArguments != null =>
+      S.ConstructorInvocation.build(
+        Tree.randomId(),
+        nc.getPrefix,
+        Markers.EMPTY,
+        nc.getClazz,
+        nc.getPadding.getArguments
+      )
+    case mi: J.MethodInvocation if mi.getSelect != null && mi.getSelect.isInstanceOf[TypeTree] =>
+      S.ConstructorInvocation.build(
+        Tree.randomId(),
+        mi.getPrefix,
+        Markers.EMPTY,
+        mi.getSelect.asInstanceOf[TypeTree],
+        mi.getPadding.getArguments
+      )
+    case _ => null
+  }
+
   private def buildArgumentContainer[A, T <: J](
     items: Seq[A],
     convert: A => T,

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
@@ -16,8 +16,14 @@
 package org.openrewrite.scala.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.scala.ScalaIsoVisitor;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.scala.Assertions.scala;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
@@ -473,6 +479,44 @@ class ClassDeclarationTest implements RewriteTest {
                 class B5(x: Int) extends Exception(s"${x}") with T
                 case class B6(json: String, err: String)
                     extends A(s"[x] $json --- ${err.length}")
+                """
+            )
+        );
+    }
+
+    @Test
+    void parentConstructorCallIsModeledNotCrammedIntoIdentifier() {
+        // A parent constructor call must become an S.ConstructorInvocation (supertype + args),
+        // not a J.Identifier whose simpleName is the raw source "Exception(msg)".
+        rewriteRun(
+            spec -> spec.beforeRecipe(sources -> {
+                List<S.ConstructorInvocation> invocations = new ArrayList<>();
+                List<String> identifierNames = new ArrayList<>();
+                ScalaIsoVisitor<Integer> visitor = new ScalaIsoVisitor<Integer>() {
+                    @Override
+                    public S.ConstructorInvocation visitConstructorInvocation(S.ConstructorInvocation ci, Integer i) {
+                        invocations.add(ci);
+                        return super.visitConstructorInvocation(ci, i);
+                    }
+
+                    @Override
+                    public J.Identifier visitIdentifier(J.Identifier ident, Integer i) {
+                        identifierNames.add(ident.getSimpleName());
+                        return super.visitIdentifier(ident, i);
+                    }
+                };
+                sources.forEach(source -> visitor.visit(source, 0));
+
+                assertThat(identifierNames).noneMatch(name -> name.contains("("));
+                assertThat(invocations).hasSize(1);
+                S.ConstructorInvocation ci = invocations.get(0);
+                assertThat(ci.getTypeTree()).isInstanceOf(J.Identifier.class);
+                assertThat(((J.Identifier) ci.getTypeTree()).getSimpleName()).isEqualTo("Exception");
+                assertThat(ci.getArguments()).hasSize(1);
+            }),
+            scala(
+                """
+                class E(msg: String) extends Exception(msg)
                 """
             )
         );


### PR DESCRIPTION
## What's changed?

Adding `S.ConstructorInvocation` LST element to model type reference in `extends` like this:
```scala
class E(msg: String) extends Exception(msg)
```

## What's your motivation?

Otherwise it's not parsed properly and the information is lost.