### PR TITLE
Scala: fix parsing @throws[Exception] annotations

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -597,6 +597,16 @@ class ScalaTreeVisitor(
           case nt: NameTree => nt
           case _ => return visitUnknown(app)
         }
+      case at: Trees.AppliedTypeTree[?] =>
+        // Parameterized annotation type like @throws[Exception]; skip the leading '@'
+        // so the parameterized type's own prefix stays empty, then map it to a
+        // J.ParameterizedType (a NameTree via TypeTree) instead of leaking source text.
+        val atStart = Math.max(0, at.span.start - offsetAdjustment)
+        if (atStart > cursor) cursor = atStart
+        visitTree(at) match {
+          case nt: NameTree => nt
+          case _ => return visitUnknown(app)
+        }
       case _ => return visitUnknown(app)
     }
     

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/AnnotationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/AnnotationTest.java
@@ -16,8 +16,14 @@
 package org.openrewrite.scala.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.scala.Assertions.scala;
 
 class AnnotationTest implements RewriteTest {
@@ -301,6 +307,47 @@ class AnnotationTest implements RewriteTest {
                 @scala.annotation.implicitNotFound("msg")
                 trait Foo[T]
                 """
+            )
+        );
+    }
+
+    @Test
+    void throwsAnnotationTypeArgNotInIdentifier() {
+        assertNoTypeArgInIdentifier(
+            """
+            @throws[Exception]
+            def riskyMethod(): Unit = {}
+            """
+        );
+    }
+
+    @Test
+    void throwsAnnotationWithTypeArgAndValueArgNotInIdentifier() {
+        assertNoTypeArgInIdentifier(
+            """
+            @throws[IllegalArgumentException]("Invalid argument")
+            def validate(x: Int): Unit = {}
+            """
+        );
+    }
+
+    private void assertNoTypeArgInIdentifier(String source) {
+        rewriteRun(
+            scala(
+                source,
+                spec -> spec.afterRecipe(cu -> {
+                    List<String> identifierNames = new ArrayList<>();
+                    new JavaIsoVisitor<Integer>() {
+                        @Override
+                        public J.Identifier visitIdentifier(J.Identifier identifier, Integer p) {
+                            identifierNames.add(identifier.getSimpleName());
+                            return super.visitIdentifier(identifier, p);
+                        }
+                    }.visit(cu, 0);
+                    assertThat(identifierNames)
+                      .as("type-arg source text should not be crammed into an identifier name")
+                      .allSatisfy(name -> assertThat(name).doesNotContain("[", "@"));
+                })
             )
         );
     }


### PR DESCRIPTION
## What's changed?

In Scala fixing parsing of annotations with type parameters, e.g. `@throws[Exception]`.

## What's your motivation?

They are currently not parsed right. And the type parameter might not be carried over.