### PR TITLE
Fix `ChangeMethodInvocationReturnType` changing variable type for nested matches

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodInvocationReturnType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodInvocationReturnType.java
@@ -17,6 +17,7 @@ package org.openrewrite.java;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.tree.Expression;
@@ -81,11 +82,8 @@ public class ChangeMethodInvocationReturnType extends Recipe {
                 // Only change the declared type when a variable's initializer is itself the matched
                 // method invocation. A match nested deeper (e.g. as an argument to another call, such
                 // as `Cell c = row.createCell(i, other.getCellType())`) must not change the variable type.
-                boolean initializedByMatch = mv.getVariables().stream().anyMatch(v -> {
-                    Expression initializer = v.getInitializer();
-                    return initializer instanceof J.MethodInvocation &&
-                            methodMatcher.matches((J.MethodInvocation) initializer);
-                });
+                boolean initializedByMatch = mv.getVariables().stream()
+                        .anyMatch(v -> isInitializedByMatch(v.getInitializer()));
 
                 if (methodUpdated && initializedByMatch) {
                     JavaType newType = JavaType.buildType(newReturnType);
@@ -116,6 +114,27 @@ public class ChangeMethodInvocationReturnType extends Recipe {
                 }
 
                 return mv;
+            }
+
+            /**
+             * Returns true when the matched invocation is the direct initializer, is inside
+             * wrapping parentheses (stripped before checking), or is a branch of a ternary —
+             * in all of those positions the invocation determines the variable's type.
+             */
+            private boolean isInitializedByMatch(@Nullable Expression expression) {
+                if (expression == null) {
+                    return false;
+                }
+                Expression unwrapped = expression.unwrap();
+                if (unwrapped instanceof J.MethodInvocation) {
+                    return methodMatcher.matches((J.MethodInvocation) unwrapped);
+                }
+                if (unwrapped instanceof J.Ternary) {
+                    J.Ternary ternary = (J.Ternary) unwrapped;
+                    return isInitializedByMatch(ternary.getTruePart()) ||
+                            isInitializedByMatch(ternary.getFalsePart());
+                }
+                return false;
             }
         };
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodInvocationReturnType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodInvocationReturnType.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
@@ -77,7 +78,16 @@ public class ChangeMethodInvocationReturnType extends Recipe {
                 JavaType.FullyQualified originalType = multiVariable.getTypeAsFullyQualified();
                 J.VariableDeclarations mv = super.visitVariableDeclarations(multiVariable, ctx);
 
-                if (methodUpdated) {
+                // Only change the declared type when a variable's initializer is itself the matched
+                // method invocation. A match nested deeper (e.g. as an argument to another call, such
+                // as `Cell c = row.createCell(i, other.getCellType())`) must not change the variable type.
+                boolean initializedByMatch = mv.getVariables().stream().anyMatch(v -> {
+                    Expression initializer = v.getInitializer();
+                    return initializer instanceof J.MethodInvocation &&
+                            methodMatcher.matches((J.MethodInvocation) initializer);
+                });
+
+                if (methodUpdated && initializedByMatch) {
                     JavaType newType = JavaType.buildType(newReturnType);
                     JavaType.FullyQualified newFieldType = TypeUtils.asFullyQualified(newType);
 

--- a/rewrite-java/src/test/java/org/openrewrite/java/ChangeMethodInvocationReturnTypeTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/ChangeMethodInvocationReturnTypeTest.java
@@ -108,6 +108,102 @@ class ChangeMethodInvocationReturnTypeTest implements RewriteTest {
     }
 
     @Test
+    void replaceParenthesizedInitializer() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Foo {
+                  void bar() {
+                      int one = (Integer.parseInt("1"));
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      long one = (Integer.parseInt("1"));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceTernaryInitializerWithMatchInBothBranches() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Foo {
+                  void bar(boolean flag) {
+                      int one = flag ? Integer.parseInt("1") : Integer.parseInt("2");
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar(boolean flag) {
+                      long one = flag ? Integer.parseInt("1") : Integer.parseInt("2");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceTernaryInitializerWithMatchInOneBranch() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Foo {
+                  void bar(boolean flag) {
+                      int one = flag ? (Integer.parseInt("1")) : 0;
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar(boolean flag) {
+                      long one = flag ? (Integer.parseInt("1")) : 0;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void shouldNotChangeVariableTypeWhenInitializerIsTypeCast() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Foo {
+                  void bar() {
+                      int direct = Integer.parseInt("1");
+                      // the cast, not the matched invocation, determines the type of `one`
+                      int one = (int) Integer.parseInt("2");
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      long direct = Integer.parseInt("1");
+                      // the cast, not the matched invocation, determines the type of `one`
+                      int one = (int) Integer.parseInt("2");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void replaceVariableAssignmentFullyQualified() {
         rewriteRun(
           spec -> spec.recipe(new ChangeMethodInvocationReturnType("bar.Bar bar()", "java.math.BigInteger"))

--- a/rewrite-java/src/test/java/org/openrewrite/java/ChangeMethodInvocationReturnTypeTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/ChangeMethodInvocationReturnTypeTest.java
@@ -81,6 +81,33 @@ class ChangeMethodInvocationReturnTypeTest implements RewriteTest {
     }
 
     @Test
+    void shouldNotChangeVariableTypeWhenMatchIsNestedInInitializer() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Foo {
+                  void bar() {
+                      int direct = Integer.parseInt("1");
+                      // Integer.parseInt(...) is only an argument here, not the initializer of `s`
+                      String s = String.valueOf(Integer.parseInt("2"));
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      long direct = Integer.parseInt("1");
+                      // Integer.parseInt(...) is only an argument here, not the initializer of `s`
+                      String s = String.valueOf(Integer.parseInt("2"));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void replaceVariableAssignmentFullyQualified() {
         rewriteRun(
           spec -> spec.recipe(new ChangeMethodInvocationReturnType("bar.Bar bar()", "java.math.BigInteger"))


### PR DESCRIPTION
### What's changed?

`ChangeMethodInvocationReturnType` rewrote the declared type of a variable whenever a matching method invocation appeared *anywhere* in the variable declaration subtree — including when the match was nested as an argument to another call, rather than being the initializer itself.

`visitVariableDeclarations` set a `methodUpdated` flag from any descendant match and then unconditionally rewrote the declared type. This change additionally requires that one of the variables' initializer *is* the matched invocation before rewriting the declared type.

### What's your motivation?

- Fixes openrewrite/rewrite-apache#134

The Apache POI 3.17 migration runs:

```yaml
- org.openrewrite.java.ChangeMethodInvocationReturnType:
    methodPattern: org.apache.poi.ss.usermodel.Cell getCellType()
    newReturnType: org.apache.poi.ss.usermodel.CellType
```

Against code like:

```java
Cell xlsxCell = xlsxRow.createCell(xlsCell.getColumnIndex(), xlsCell.getCellType());
```

`getCellType()` is only an argument to `createCell(...)`, but the recipe rewrote the declaration to `CellType xlsxCell = ...`, producing uncompilable code (`Cell` cannot be converted to `CellType`).

### Anything in particular you'd like reviewers to focus on?

The nested method invocation's own return-type attribution is still updated (that is correct); only the enclosing variable's declared type is now left alone when the match isn't the initializer. Added a regression test covering both the legitimate (direct initializer) and the previously-broken (nested argument) cases.

### Checklist

- [x] I've added unit tests to cover my changes