### PR TITLE
C#: pass --no-build to dotnet run so build output can't corrupt the RPC pipe

### DIFF
--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -438,6 +438,14 @@ public class CSharpRewriteRpc extends RewriteRpc {
                     "run",
                     "--project", csproj.toAbsolutePath().normalize().toString(),
                     "--framework", "net10.0",
+                    // Never let `dotnet run` build/restore here: the caller is expected to have
+                    // already built the tool (the Gradle integTest depends on csharpBuild). An
+                    // implicit restore/build streams MSBuild + NuGet audit output (e.g. NU1903
+                    // vulnerability warnings) to stdout, which is the JSON-RPC pipe. That corrupts
+                    // the stream: the Java peer rejects the non-Content-Length text and replies
+                    // with id-less JSON-RPC errors, which crash the C# SystemTextJsonFormatter
+                    // ("Non-default ID required"). --no-build also implies --no-restore.
+                    "--no-build",
                     log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
                     traceRpcMessages ? "--trace-rpc-messages" : null,
                     recipeInstallDir == null ? null : "--recipe-install-dir=" + recipeInstallDir.toAbsolutePath().normalize()


### PR DESCRIPTION
## Problem

`:rewrite-csharp:integTest` fails for **every** test (parse, recipe, and the basic round-trips like `parseSimpleProject`/`xmlDocComment`) with:

```
java.lang.IllegalStateException: RPC process shut down early with exit code 0
```

and, for the first test to run, the underlying cause:

```
io.moderne.jsonrpc.JsonRpcException: JSON-RPC peer closed the stream
```

This reproduces deterministically locally (the C# process exits with SIGABRT / "Non-default ID required"). It was green on `main` only because the heavily-cached `integTest` task was being served `FROM-CACHE`; the moment anything invalidates it, it fails.

## Root cause

The integTest launches the C# server via:

```
dotnet run --project OpenRewrite.Tool.csproj --framework net10.0 ...
```

without `--no-build`. `dotnet run` therefore does an implicit restore + build, and that MSBuild / NuGet-audit output — notably the newly-published **NU1903** advisory for `MessagePack 2.5.187` — is written to **stdout**, which is the JSON-RPC pipe.

- The Java peer (`HeaderDelimitedMessageHandler`) reads that warning text instead of a `Content-Length` header and replies with **id-less** JSON-RPC error responses (`{"error":{"code":-32600,...},"jsonrpc":"2.0"}`). Since #7901 switched the C# side to StreamJsonRpc's `SystemTextJsonFormatter`, those id-less responses route to `OnResponseReceived`, which asserts a non-default `requestId` and throws `System.ArgumentException: Non-default ID required`, killing the process. The previous Newtonsoft formatter tolerated id-less responses, which is why the regression only surfaced once the advisory started appearing in audit output.

Captured wire bytes confirming the corruption:

```
Content-Length: 328
{"id":"hSZm6GbkRc","method":"ParseSolution",...}Content-Length: 477
{"error":{"code":-32600,"message":"Invalid Request: Expected Content-Length header but received '... NU1903: Package 'MessagePack' 2.5.187 has a known high severity vulnerability ...'"},"jsonrpc":"2.0"}...
```

## Fix

Pass `--no-build` (which also implies `--no-restore`) to `dotnet run`, matching what the `csharpTest` Gradle task already does. The integTest depends on `csharpBuild`, so the tool is always built beforehand — there is nothing for `dotnet run` to build, and no MSBuild/NuGet output reaches the pipe.

## Verification

`./gradlew :rewrite-csharp:integTest` — all 17 tests pass (was 16/17 failing).