### PR TITLE
Scala: fix parsing of intersection and union tests with & and |

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -31,6 +31,7 @@ import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeTree;
 import org.openrewrite.marker.Marker;
+import org.openrewrite.scala.marker.AmpersandIntersection;
 import org.openrewrite.scala.marker.AsInstanceOfPrefix;
 import org.openrewrite.scala.marker.BlockArgument;
 import org.openrewrite.scala.marker.DottedMatch;
@@ -659,6 +660,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return visitFunctionType((S.FunctionType) tree, p);
         } else if (tree instanceof S.TupleType) {
             return visitTupleType((S.TupleType) tree, p);
+        } else if (tree instanceof S.UnionType) {
+            return visitUnionType((S.UnionType) tree, p);
         } else if (tree instanceof S.Macro) {
             return visitMacro((S.Macro) tree, p);
         } else if (tree instanceof S.ExtensionMethods) {
@@ -1277,11 +1280,30 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
 
     @Override
     public J visitIntersectionType(J.IntersectionType intersectionType, PrintOutputCapture<P> p) {
-        // In Scala, parents of an anonymous class are joined with `with` (not Java's `&`).
+        // Scala joins intersections with `with` (anonymous-class parents and the `A with B`
+        // form) or with `&` (the Scala 3 operator form, flagged by AmpersandIntersection).
         beforeSyntax(intersectionType, Space.Location.INTERSECTION_TYPE_PREFIX, p);
-        visitContainer("", intersectionType.getPadding().getBounds(), JContainer.Location.TYPE_BOUNDS, "with", "", p);
+        String separator = intersectionType.getMarkers().findFirst(AmpersandIntersection.class).isPresent() ? "&" : "with";
+        visitContainer("", intersectionType.getPadding().getBounds(), JContainer.Location.TYPE_BOUNDS, separator, "", p);
         afterSyntax(intersectionType, p);
         return intersectionType;
+    }
+
+    public J visitUnionType(S.UnionType unionType, PrintOutputCapture<P> p) {
+        beforeSyntax(unionType, Space.Location.LANGUAGE_EXTENSION, p);
+        JContainer<Expression> types = unionType.getPadding().getTypes();
+        visitSpace(types.getBefore(), Space.Location.LANGUAGE_EXTENSION, p);
+        List<JRightPadded<Expression>> padded = types.getPadding().getElements();
+        for (int i = 0; i < padded.size(); i++) {
+            JRightPadded<Expression> element = padded.get(i);
+            visit(element.getElement(), p);
+            visitSpace(element.getAfter(), Space.Location.LANGUAGE_EXTENSION, p);
+            if (i < padded.size() - 1) {
+                p.append('|');
+            }
+        }
+        afterSyntax(unionType, p);
+        return unionType;
     }
 
     @Override

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -353,6 +353,14 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         return t;
     }
 
+    public J visitUnionType(S.UnionType unionType, P p) {
+        S.UnionType u = unionType;
+        u = u.withPrefix(visitSpace(u.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));
+        u = u.withMarkers(visitMarkers(u.getMarkers(), p));
+        u = u.getPadding().withTypes(visitContainer(u.getPadding().getTypes(), JContainer.Location.LANGUAGE_EXTENSION, p));
+        return u;
+    }
+
     public J visitRefinedType(S.RefinedType refinedType, P p) {
         S.RefinedType r = refinedType;
         r = r.withPrefix(visitSpace(r.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/AmpersandIntersection.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/AmpersandIntersection.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Marks a {@link org.openrewrite.java.tree.J.IntersectionType} that uses Scala 3's
+ * operator form ({@code A & B}) rather than the {@code with} form ({@code A with B}).
+ * Both map to {@code J.IntersectionType}; this marker tells the printer to emit
+ * {@code &} as the separator instead of {@code with}.
+ */
+@Value
+@With
+public class AmpersandIntersection implements Marker {
+    UUID id;
+
+    public static AmpersandIntersection create() {
+        return new AmpersandIntersection(Tree.randomId());
+    }
+}

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -578,6 +578,92 @@ public interface S extends J {
     }
 
     /**
+     * Represents a Scala 3 union type: {@code A | B | ...}. For example the return type in
+     * {@code def f: Int | String} or a parameter type {@code def display(op: "resize" | "thumbnail")}.
+     * Operands are held as {@link Expression}s rather than {@link TypeTree}s because singleton
+     * literal types (e.g. {@code "resize"}) are modeled as {@link J.Literal}, which is an
+     * {@code Expression} but not a {@code TypeTree}. Each operand's {@code after} space is the
+     * whitespace before the following {@code |}.
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class UnionType implements S, TypeTree, Expression {
+
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @With @Getter @EqualsAndHashCode.Include
+        UUID id;
+
+        @With @Getter
+        Space prefix;
+
+        @With @Getter
+        Markers markers;
+
+        JContainer<Expression> types;
+
+        @With @Getter
+        @Nullable
+        JavaType type;
+
+        public static UnionType build(UUID id, Space prefix, Markers markers,
+                                      JContainer<Expression> types, @Nullable JavaType type) {
+            return new UnionType(null, id, prefix, markers, types, type);
+        }
+
+        public List<Expression> getTypes() {
+            return types.getElements();
+        }
+
+        public UnionType withTypes(List<Expression> types) {
+            return getPadding().withTypes(JContainer.withElements(this.types, types));
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitUnionType(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final UnionType t;
+
+            public JContainer<Expression> getTypes() {
+                return t.types;
+            }
+
+            public UnionType withTypes(JContainer<Expression> types) {
+                return t.types == types ? t :
+                        new UnionType(null, t.id, t.prefix, t.markers, types, t.type);
+            }
+        }
+    }
+
+    /**
      * Represents a wildcard/underscore placeholder in expressions.
      * Used for partially applied functions (e.g., add(5, _)) and pattern matching.
      * This is NOT for type wildcards (use J.Wildcard) or import wildcards (use * in J.Import).

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -25,6 +25,7 @@ import org.openrewrite.java.tree.*
 import org.openrewrite.java.marker.ImplicitReturn
 import org.openrewrite.java.marker.OmitParentheses
 import org.openrewrite.marker.Markers
+import org.openrewrite.scala.marker.AmpersandIntersection
 import org.openrewrite.scala.marker.DottedMatch
 import org.openrewrite.scala.marker.Implicit
 import org.openrewrite.scala.marker.LambdaParameter
@@ -8382,16 +8383,91 @@ class ScalaTreeVisitor(
   }
 
   /**
-   * Union (`A | B`) and intersection (`A & B`) types are parsed as an `untpd.InfixOp`.
-   * Neither has a dedicated J/S type yet, so — like the `with`-less `&` already handled
-   * elsewhere — preserve the whole expression as a source-text identifier rather than
-   * letting it fall through to a `J.Binary` (which isn't a `TypeTree`) and get dropped.
-   * Returning a non-null `TypeTree` here fixes every type position at once (params,
-   * return types, type ascriptions, bounds, tuple/function components, ...).
+   * Scala 3 operator-form intersection (`A & B`) and union (`A | B`) types are parsed as an
+   * `untpd.InfixOp`. They are modeled structurally — `&` as a `J.IntersectionType` (flagged
+   * with `AmpersandIntersection` so the printer emits `&` rather than `with`) and `|` as an
+   * `S.UnionType` — rather than crammed whole into a single `J.Identifier`. This fixes every
+   * type-annotation position at once (params, return types, ascriptions, bounds, tuple and
+   * function components, ...).
    */
-  private def visitTypeOperatorInfix(infix: untpd.InfixOp): TypeTree = {
+  private def visitTypeOperatorInfix(infix: untpd.InfixOp): TypeTree =
+    if (infix.op.name.toString == "&") visitIntersectionInfixType(infix)
+    else visitUnionInfixType(infix)
+
+  /**
+   * Flatten a (possibly chained) type-level infix `A op B op C` into its leaf operands in
+   * source order, regardless of whether the parser nested it left- or right-associatively.
+   */
+  private def flattenTypeInfix(tree: Trees.Tree[?], opName: String): List[Trees.Tree[?]] = tree match {
+    case nested: untpd.InfixOp if nested.op != null && nested.op.name.toString == opName =>
+      flattenTypeInfix(nested.left, opName) ::: flattenTypeInfix(nested.right, opName)
+    case other => List(other)
+  }
+
+  private def visitIntersectionInfixType(infix: untpd.InfixOp): TypeTree = {
     val prefix = extractPrefix(infix.span)
-    ident(extractSource(infix.span), prefix)
+    val parts = flattenTypeInfix(infix, "&")
+    val elements = new util.ArrayList[JRightPadded[TypeTree]](parts.size)
+    for (i <- parts.indices) {
+      val tt = visitTypeTree(parts(i))
+      if (tt == null) return ident(extractSource(infix.span), prefix)
+      val afterSpace = if (i == parts.size - 1) Space.EMPTY else sourceBefore("&")
+      elements.add(new JRightPadded[TypeTree](tt, afterSpace, Markers.EMPTY))
+    }
+    updateCursor(infix.span.end)
+    new J.IntersectionType(
+      Tree.randomId(),
+      prefix,
+      Markers.EMPTY.add(AmpersandIntersection.create()),
+      JContainer.build(Space.EMPTY, elements, Markers.EMPTY)
+    )
+  }
+
+  private def visitUnionInfixType(infix: untpd.InfixOp): TypeTree = {
+    val prefix = extractPrefix(infix.span)
+    val parts = flattenTypeInfix(infix, "|")
+    val elements = new util.ArrayList[JRightPadded[Expression]](parts.size)
+    for (i <- parts.indices) {
+      val operand = visitUnionOperand(parts(i))
+      if (operand == null) return ident(extractSource(infix.span), prefix)
+      val afterSpace = if (i == parts.size - 1) Space.EMPTY else sourceBefore("|")
+      elements.add(new JRightPadded[Expression](operand, afterSpace, Markers.EMPTY))
+    }
+    updateCursor(infix.span.end)
+    S.UnionType.build(
+      Tree.randomId(),
+      prefix,
+      Markers.EMPTY,
+      JContainer.build(Space.EMPTY, elements, Markers.EMPTY),
+      typeOfTree(infix)
+    )
+  }
+
+  /**
+   * Visit a single union operand as an `Expression`. Most operands are types
+   * (identifiers, parameterized types) that are also `Expression`s. Singleton
+   * literal types like `"resize"` are parsed by Dotty as `SingletonTypeTree(Literal)`;
+   * the literal itself *is* the type (there is no `.type` suffix in source), so we
+   * visit the inner literal directly rather than producing an `S.SingletonType`
+   * (which would print a spurious `.type`). Returns null for an operand that cannot
+   * be represented as an `Expression` (e.g. a nested intersection), signalling the
+   * caller to fall back to source preservation.
+   */
+  private def visitUnionOperand(tree: Trees.Tree[?]): Expression = tree match {
+    case _: Trees.Literal[?] =>
+      asExpression(visitTree(tree))
+    case stt: Trees.SingletonTypeTree[?] if stt.ref.isInstanceOf[Trees.Literal[?]] =>
+      asExpression(visitTree(stt.ref))
+    case _ =>
+      visitTypeTree(tree) match {
+        case e: Expression => e
+        case _ => null
+      }
+  }
+
+  private def asExpression(j: J): Expression = j match {
+    case e: Expression => e
+    case _ => null
   }
 
   /**

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/IntersectionTypeTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/IntersectionTypeTest.java
@@ -112,4 +112,33 @@ class IntersectionTypeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void ampersandOperatorForm() {
+        rewriteRun(
+          scala(
+            """
+              trait A
+              trait B
+              trait C
+              object Test {
+                def f(x: A & B & C): Int = 1
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void ampersandWithParameterizedOperand() {
+        rewriteRun(
+          scala(
+            """
+              object Test {
+                val x: Serializable & Comparable[String] = null
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

- Make sure both intersection and union types are probably parsed for Scala
- Introduce `S.UnionType` for the latter
- Introduce a marker for the former, to distinguish between the `A & B` and `A with B` syntax.

## What's your motivation?

Addressing shortcomings in parsing both of them.