### PR TITLE
Python: Populate JavaType.Class members for classes

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -573,17 +573,42 @@ class PythonTypeMapping:
             return class_type
 
         elif kind == 'typedDict':
-            # Map a TypedDict to a nominal class type by name. We intentionally
-            # drop the descriptor's `fields` and (ty-types >= 0.0.49) the PEP 728
-            # `closed` / `extraItems` openness fields: a field *use* `m["name"]`
-            # is a subscript whose value type ty already attributes on the access
-            # node, so the common case is covered without modeling the shape.
-            # Populating the class's members and linking subscript uses back to
-            # field declarations (a J.ArrayAccess LST change) is deferred.
+            # Map a TypedDict to a nominal class type by name and populate its
+            # members from the descriptor's `fields`. Each field carries its own
+            # `name` and `typeId` (the same shape as a classLiteral member), so
+            # we reuse the variable-building path. The class is keyed by simple
+            # name via `_create_class_type`, so two TypedDicts that share a name
+            # collapse — acceptable until ty emits a qualified name here.
+            #
+            # We still drop the PEP 728 `closed` / `extraItems` openness fields
+            # and the per-field `required` / `readOnly` flags; and linking a
+            # subscript use `m["name"]` back to its field declaration (a
+            # J.ArrayAccess LST change) remains deferred — that value type is
+            # already attributed on the access node.
             name = descriptor.get('name', '')
-            if name:
-                return self._create_class_type(name)
-            return _UNKNOWN
+            if not name:
+                return _UNKNOWN
+            class_type = self._create_class_type(name)
+            fields = descriptor.get('fields', [])
+            if fields and getattr(class_type, '_members', None) is None:
+                variables = []
+                seen_names = set()
+                for field in fields:
+                    if not isinstance(field, dict):
+                        continue
+                    field_name = field.get('name')
+                    field_type_id = field.get('typeId')
+                    if not field_name or field_type_id is None or field_name in seen_names:
+                        continue
+                    field_type = self._resolve_type(field_type_id)
+                    if field_type is None:
+                        continue
+                    seen_names.add(field_name)
+                    variables.append(JavaType.Variable(
+                        _name=field_name, _type=field_type, _owner=class_type))
+                if variables:
+                    class_type._members = variables
+            return class_type
 
         elif kind == 'subclassOf':
             # `subclassOf X` is ty's representation of `type[X]`: a *class

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -539,6 +539,37 @@ class PythonTypeMapping:
                             methods.append(method)
                 class_type._methods = methods if methods else None
 
+            # Populate members (attributes / class & instance variables) from the
+            # non-function members. ty emits a member's *name* on the entry itself
+            # and its *type* via `typeId`; for a field with a default it emits both
+            # the declared type and the default-value literal under the same name,
+            # so de-duplicate by name keeping the first (declared) occurrence. A
+            # member typed as the owning class resolves through the same cycle
+            # guard `_resolve_type` uses for methods, so self-references don't
+            # recurse infinitely.
+            if members and getattr(class_type, '_members', None) is None:
+                variables = []
+                seen_names = set()
+                for member in members:
+                    if not isinstance(member, dict):
+                        continue
+                    member_name = member.get('name')
+                    member_type_id = member.get('typeId')
+                    if not member_name or member_type_id is None or member_name in seen_names:
+                        continue
+                    member_desc = self._type_registry.get(member_type_id)
+                    # Skip function-kinds (handled as methods above) and nested
+                    # classes/modules — only true variables become members.
+                    if member_desc is None or not self._is_variable_descriptor(member_desc):
+                        continue
+                    member_type = self._resolve_type(member_type_id)
+                    if member_type is None:
+                        continue
+                    seen_names.add(member_name)
+                    variables.append(JavaType.Variable(
+                        _name=member_name, _type=member_type, _owner=class_type))
+                class_type._members = variables if variables else None
+
             return class_type
 
         elif kind == 'typedDict':

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -2974,3 +2974,202 @@ class TestProjectParseSupertypeAcrossFiles:
                 "subclass; the shared ty-types session dropped the supertype "
                 "descriptor for a file parsed after the first"
             )
+
+@requires_ty_types_cli
+class TestClassMembers:
+    """``JavaType.Class.members`` must be populated with a class's attributes
+    (annotated class/instance variables), not just its methods.
+
+    Before this, the ``classLiteral`` branch of the type mapping only emitted
+    ``JavaType.Method`` for function-kind members and silently dropped every
+    attribute, so attribute-rich classes (dataclasses, pydantic/ORM models)
+    came back with ``getMembers()`` empty and recipes that reason about fields
+    had nothing to work with.
+
+    The class type is obtained via a method invocation's ``declaring_type``,
+    which the ``classLiteral`` branch builds (and enriches with members).
+    """
+
+    def _class_type(self, source: str):
+        """Parse ``source`` (whose last statement is a method call on an
+        instance) and return the callee's ``declaring_type`` — the populated
+        ``JavaType.Class`` — along with cleanup handles."""
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        call = tree.body[-1].value
+        result = mapping.method_invocation_type(call)
+        assert result is not None and isinstance(result._declaring_type, JavaType.Class)
+        return result._declaring_type, mapping, tmpdir, client
+
+    def test_dataclass_members_populated(self):
+        src = (
+            "from dataclasses import dataclass\n"
+            "\n"
+            "\n"
+            "@dataclass\n"
+            "class Point:\n"
+            "    x: int\n"
+            "    y: int = 0\n"
+            "    label: str = \"p\"\n"
+            "\n"
+            "    def describe(self) -> str:\n"
+            "        return self.label\n"
+            "\n"
+            "Point(1).describe()\n"
+        )
+        cls, mapping, tmpdir, client = self._class_type(src)
+        try:
+            members = cls._members
+            assert members is not None, "dataclass should expose its fields as members"
+            by_name = {v._name: v for v in members}
+
+            assert by_name['x']._type == JavaType.Primitive.Int
+            assert by_name['y']._type == JavaType.Primitive.Int
+            assert by_name['label']._type == JavaType.Primitive.String
+
+            # Each member is a JavaType.Variable owned by the class.
+            for v in members:
+                assert isinstance(v, JavaType.Variable)
+                assert v._owner is cls
+
+            # ty emits both the declared type and the default-value literal for a
+            # field; members must be de-duplicated by name.
+            assert len(members) == len(by_name), \
+                f"members contain duplicate names: {[v._name for v in members]}"
+
+            # Methods must still populate (no regression).
+            assert cls._methods is not None
+            assert 'describe' in [m._name for m in cls._methods]
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_plain_class_members_populated(self):
+        src = (
+            "class Config:\n"
+            "    count: int = 0\n"
+            "    name: str\n"
+            "    ratio: float = 1.5\n"
+            "\n"
+            "    def label(self) -> str:\n"
+            "        return self.name\n"
+            "\n"
+            "Config().label()\n"
+        )
+        cls, mapping, tmpdir, client = self._class_type(src)
+        try:
+            by_name = {v._name: v for v in (cls._members or [])}
+            assert by_name['count']._type == JavaType.Primitive.Int
+            assert by_name['name']._type == JavaType.Primitive.String
+            # ty treats a `float` annotation as accepting `int` too, so the
+            # declared type can come back as a union that includes Double.
+            ratio_type = by_name['ratio']._type
+            ratio_bounds = getattr(ratio_type, '_bounds', [ratio_type])
+            assert JavaType.Primitive.Double in ratio_bounds
+
+            # A function-kind member must not leak into the variables.
+            assert 'label' not in by_name
+            assert cls._methods is not None
+            assert 'label' in [m._name for m in cls._methods]
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_self_typed_member_does_not_hang(self):
+        # A member whose declared type is the owning class must resolve without
+        # infinitely recursing (the cycle guard already covers methods; members
+        # must rely on the same mechanism).
+        src = (
+            "class Node:\n"
+            "    value: int\n"
+            "    next: \"Node\" = None\n"
+            "\n"
+            "    def get(self) -> int:\n"
+            "        return self.value\n"
+            "\n"
+            "Node().get()\n"
+        )
+        cls, mapping, tmpdir, client = self._class_type(src)
+        try:
+            by_name = {v._name: v for v in (cls._members or [])}
+            assert by_name['value']._type == JavaType.Primitive.Int
+
+            next_type = by_name['next']._type
+            assert isinstance(next_type, JavaType.Class)
+            assert next_type.fully_qualified_name.endswith('Node')
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+
+@requires_ty_types_cli
+@requires_uv
+class TestPydanticModelMembers:
+    """A ``pydantic.BaseModel`` subclass must expose its annotated fields as
+    ``JavaType.Class.members``, resolved through a forwarded dependency
+    environment (the CLI ``mod build`` scenario). Mirrors the supertype-
+    resolution setup in ``TestExternalSupertypeResolutionInParsePath``.
+    """
+
+    _SOURCE = (
+        "from pydantic import BaseModel\n"
+        "\n"
+        "\n"
+        "class User(BaseModel):\n"
+        "    name: str\n"
+        "    age: int = 0\n"
+        "\n"
+        "    def greeting(self) -> str:\n"
+        "        return self.name\n"
+    )
+    _PYPROJECT = (
+        "[project]\n"
+        'name = "tyrepro"\n'
+        'version = "0.0.0"\n'
+        'requires-python = ">=3.10"\n'
+        'dependencies = ["pydantic>=2.11"]\n'
+    )
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_pydantic_ambient(self):
+        try:
+            import pydantic  # noqa: F401
+            pytest.skip("pydantic is importable in the test interpreter; "
+                        "ty-types would resolve it ambiently")
+        except ImportError:
+            pass
+
+    def _dependency_venv(self):
+        from rewrite.python.template.dependency_workspace import DependencyWorkspace
+        workspace = DependencyWorkspace.get_or_create_from_pyproject(self._PYPROJECT)
+        return os.path.join(workspace, ".venv")
+
+    def _user_class_type(self, tmp_path):
+        from rewrite.rpc import server
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "pyproject.toml").write_text(self._PYPROJECT)
+        (proj / "models.py").write_text(self._SOURCE)
+        ids = server.handle_parse({
+            "inputs": [str(proj / "models.py")],
+            "relativeTo": str(proj),
+            "dependencyPath": self._dependency_venv(),
+        })
+        assert ids, "handle_parse returned no results"
+        cu = server.local_objects[ids[0]]
+
+        cls = _collect_class_declarations(cu)['User'].type
+        assert isinstance(cls, JavaType.Class), \
+            f"User class type not resolved: {cls!r}"
+        return cls
+
+    def test_pydantic_fields_are_members(self, tmp_path):
+        cls = self._user_class_type(tmp_path)
+        by_name = {v._name: v for v in (cls._members or [])}
+        assert 'name' in by_name, \
+            f"pydantic field `name` missing from members: {sorted(by_name)}"
+        assert by_name['name']._type == JavaType.Primitive.String
+        assert by_name['age']._type == JavaType.Primitive.Int
+        for v in cls._members:
+            assert isinstance(v, JavaType.Variable)
+            assert v._owner is cls
+
+        # Methods still populate.
+        assert cls._methods is not None
+        assert 'greeting' in [m._name for m in cls._methods]

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -3099,6 +3099,82 @@ class TestClassMembers:
 
 
 @requires_ty_types_cli
+class TestTypedDictMembers:
+    """A ``TypedDict`` carries its declared keys in the descriptor's ``fields``;
+    those must surface as ``JavaType.Class.members`` rather than being dropped.
+
+    ty emits a ``typedDict`` descriptor (distinct from the class's
+    ``classLiteral``) as the *type of a value* annotated with the TypedDict, so
+    a recipe reasoning over such a value previously saw an empty shell class.
+    Pydantic-core schemas (``AnySchema``, ``ListSchema``, …) are TypedDicts and
+    were the prime offenders.
+    """
+
+    def _value_type(self, source: str):
+        """Parse ``source`` (whose last statement is an expression whose type is
+        a TypedDict) and return ``mapping.type`` for that expression."""
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        node = tree.body[-1].value
+        result = mapping.type(node)
+        return result, mapping, tmpdir, client
+
+    def test_typed_dict_fields_are_members(self):
+        src = (
+            "from typing import TypedDict\n"
+            "\n"
+            "\n"
+            "class Movie(TypedDict):\n"
+            "    name: str\n"
+            "    year: int\n"
+            "\n"
+            "movie: Movie = {\"name\": \"x\", \"year\": 2020}\n"
+            "movie\n"
+        )
+        cls, mapping, tmpdir, client = self._value_type(src)
+        try:
+            assert isinstance(cls, JavaType.Class)
+            assert cls.fully_qualified_name.endswith('Movie')
+            by_name = {v._name: v for v in (cls._members or [])}
+            assert by_name['name']._type == JavaType.Primitive.String
+            assert by_name['year']._type == JavaType.Primitive.Int
+
+            # Each member is a JavaType.Variable owned by the class.
+            for v in cls._members:
+                assert isinstance(v, JavaType.Variable)
+                assert v._owner is cls
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_self_referential_typed_dict_does_not_hang(self):
+        # ty emits a TypedDict field whose type is the same TypedDict (the
+        # field's typeId points back at the owning descriptor). Resolving the
+        # member must lean on the shared `_resolve_type` cycle guard rather than
+        # recursing forever.
+        src = (
+            "from typing import TypedDict\n"
+            "\n"
+            "\n"
+            "class Tree(TypedDict):\n"
+            "    label: str\n"
+            "    child: \"Tree\"\n"
+            "\n"
+            "t: Tree = {\"label\": \"root\", \"child\": {}}\n"
+            "t\n"
+        )
+        cls, mapping, tmpdir, client = self._value_type(src)
+        try:
+            assert isinstance(cls, JavaType.Class)
+            by_name = {v._name: v for v in (cls._members or [])}
+            assert by_name['label']._type == JavaType.Primitive.String
+
+            child_type = by_name['child']._type
+            assert isinstance(child_type, JavaType.Class)
+            assert child_type.fully_qualified_name.endswith('Tree')
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+
+@requires_ty_types_cli
 @requires_uv
 class TestPydanticModelMembers:
     """A ``pydantic.BaseModel`` subclass must expose its annotated fields as


### PR DESCRIPTION
## Motivation

When building LSTs for Python projects, classes resolved with their methods but **zero members** (attributes / instance & class variables). The `classLiteral` branch of `PythonTypeMapping._descriptor_to_java_type` iterated `descriptor['members']` and only created a `JavaType.Method` for function-kind members — it never set `class_type._members`, so every attribute was silently dropped.

The effect: attribute-rich classes came back with `getMembers()` empty. Concretely, `pydantic.main.BaseModel` resolved with 88 methods but 0 members, and ORM/dataclass model classes (`sqlalchemy...Column`, first-party pydantic/dataclass models) lost their fields entirely. Recipes that reason about fields/attributes (model-field migrations, ORM column analysis) had nothing to work with.

This is purely a `classLiteral` (nominal class) fix. The neighbouring `typedDict` branch's deliberate drop of `fields` is left untouched (TypedDict subscript access is attributed at the use site).

## Summary

- In the `classLiteral` branch, after building `_methods`, also build `_members`: for each non-function member, create a `JavaType.Variable` (name from the member entry, type resolved via `_resolve_type`, `_owner` = the class) and collect them into `class_type._members`.
- Function-kind members (and nested classes/modules) are excluded via the existing `_is_variable_descriptor` helper, so methods keep working unchanged.
- De-duplicate members by name: ty emits both the declared type and the default-value literal for a defaulted field under the same name; the first (declared) occurrence wins.
- Member type resolution reuses the same `_resolve_type` cycle guard as methods, so a self-typed attribute (e.g. `next: "Node"`) resolves to the in-progress class placeholder instead of recursing infinitely.

## Test plan

New `TestClassMembers` and `TestPydanticModelMembers` in `test_type_attribution.py`:

- [x] `@dataclass` with annotated fields (incl. defaults) → members populated with resolved types; owner set; no duplicate names; methods still present.
- [x] Plain class with annotated class variables → members populated; function members do not leak into variables.
- [x] Self-typed attribute (`next: "Node"`) parses without hanging and resolves to the owning class.
- [x] `pydantic.BaseModel` subclass (via a forwarded dependency env, the `mod build` scenario) → annotated fields exposed as members; methods still present.
- [x] Full `rewrite-python` test suite green (type attribution: 144 passed; broader suites: 963 + 587 passed, no regressions).