### PR TITLE
Python: boundary-aware type attribution — map out-of-boundary classes to JavaType.Class shells

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/ty_client.py
+++ b/rewrite-python/rewrite/src/rewrite/python/ty_client.py
@@ -65,6 +65,7 @@ class TyTypesClient:
         self._request_id: int = 0
         self._initialized = False
         self._project_root: Optional[str] = None
+        self._first_party_root: Optional[str] = None
         self._virtual_env: Optional[str] = str(virtual_env) if virtual_env else None
 
         # Cumulative type table for the lifetime of this ``--serve`` session.
@@ -233,13 +234,27 @@ class TyTypesClient:
         except (BrokenPipeError, OSError, json.JSONDecodeError):
             return None
 
-    def initialize(self, project_root: str) -> bool:
+    def initialize(self, project_root: str,
+                   first_party_root: Optional[str] = None) -> bool:
         """Initialize the ty-types session with a project root.
 
-        If already initialized with the same project root, this is a no-op.
-        If initialized with a different root, shuts down and reinitializes.
+        If already initialized with the same project root and boundary, this is
+        a no-op. If initialized with a different root or boundary, shuts down and
+        reinitializes.
+
+        Args:
+            project_root: The project directory ty-types resolves imports against.
+            first_party_root: Optional first-party package root. When set, the
+                session emits classes defined outside this root as ``classRef``
+                descriptors (identity only), which map to body-less class shells
+                — keeping attribution lean and shrinking the RPC payload. When
+                ``None`` (the default) no boundary is sent and types expand
+                fully, exactly as before. The boundary field is only included in
+                the request when explicitly set, preserving backward compat with
+                ty-types builds that predate it.
         """
-        if self._initialized and self._project_root == project_root:
+        if (self._initialized and self._project_root == project_root
+                and self._first_party_root == first_party_root):
             return True
 
         if self._initialized:
@@ -249,10 +264,14 @@ class TyTypesClient:
             self.session_types.clear()
             self._start_process()
 
-        result = self._send_request("initialize", {"projectRoot": project_root})
+        params = {"projectRoot": project_root}
+        if first_party_root is not None:
+            params["firstPartyRoot"] = first_party_root
+        result = self._send_request("initialize", params)
         if result and result.get("ok"):
             self._initialized = True
             self._project_root = project_root
+            self._first_party_root = first_party_root
             return True
         return False
 
@@ -305,3 +324,4 @@ class TyTypesClient:
             self._process = None
             self._initialized = False
             self._project_root = None
+            self._first_party_root = None

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -572,6 +572,26 @@ class PythonTypeMapping:
 
             return class_type
 
+        elif kind == 'classRef':
+            # A class defined outside the session's first-party boundary
+            # (stdlib / third-party). ty-types emits identity only — no members,
+            # methods, supertypes, or type parameters — so map it to a body-less
+            # JavaType.Class shell. This keeps attribution lean and slashes the
+            # JavaType payload that travels over RPC, which otherwise drags a
+            # class's whole member/supertype graph across third-party packages
+            # and stdlib. The FQN scheme matches the classLiteral/instance
+            # branches: builtins stay bare, everything else is module-qualified.
+            # `_create_class_type` returns a Class with only `_fully_qualified_name`
+            # and `_kind` set, leaving members/methods/supertype/interfaces/
+            # type_parameters as None — exactly the shell we want.
+            class_name = descriptor.get('className', '')
+            module_name = descriptor.get('moduleName')
+            if module_name and module_name != 'builtins':
+                fqn = f"{module_name}.{class_name}"
+            else:
+                fqn = class_name
+            return self._create_class_type(fqn)
+
         elif kind == 'typedDict':
             # Map a TypedDict to a nominal class type by name and populate its
             # members from the descriptor's `fields`. Each field carries its own

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -515,6 +515,10 @@ def handle_parse_project(params: dict) -> List[dict]:
     language_level = options.get('languageLevel')
     # Caller-provisioned dependency environment for ty-types (see handle_parse).
     dependency_path = params.get('dependencyPath')
+    # Optional first-party boundary: when set, ty-types emits classes defined
+    # outside this root as `classRef` shells (identity only). Only forwarded
+    # when explicitly provided — absent means full expansion, exactly as before.
+    first_party_root = params.get('firstPartyRoot')
 
     # Resolve project-level language version once for the whole walk; each
     # file may still override it via in-source signals inside parse_python_source.
@@ -529,7 +533,7 @@ def handle_parse_project(params: dict) -> List[dict]:
         # Point ty-types at the caller-provisioned dependency environment (if any)
         # so supertypes reaching into third-party packages resolve.
         ty_client = TyTypesClient(virtual_env=dependency_path)
-        ty_client.initialize(project_path)
+        ty_client.initialize(project_path, first_party_root=first_party_root)
     except (ImportError, RuntimeError):
         pass
 

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -54,6 +54,60 @@ requires_ty_types_cli = pytest.mark.skipif(
 )
 
 
+def _ty_types_supports_boundary() -> bool:
+    """Probe whether the installed ty-types binary honors the first-party
+    boundary, i.e. emits ``classRef`` shells for out-of-boundary classes.
+
+    The boundary is one half of a two-part change; older ty-types binaries
+    silently ignore the ``firstPartyRoot`` init param and fully expand stdlib
+    types. The end-to-end boundary tests are only meaningful against a binary
+    that supports it, so they skip otherwise. Probes by attributing a stdlib
+    reference with the boundary set and checking whether it came back as a
+    body-less shell.
+    """
+    if not _TY_TYPES_CLI_INSTALLED:
+        return False
+    src = "import datetime\nx = datetime.datetime.now()\n"
+    tmpdir = tempfile.mkdtemp()
+    client = None
+    mapping = None
+    try:
+        file_path = os.path.join(tmpdir, 'probe.py')
+        with open(file_path, 'w') as f:
+            f.write(src)
+        client = TyTypesClient()
+        client.initialize(tmpdir, first_party_root=tmpdir)
+        mapping = PythonTypeMapping(src, file_path, ty_client=client)
+        typ = mapping.type(ast.parse(src).body[1].value)
+        if isinstance(typ, JavaType.Parameterized):
+            typ = typ._type
+        if not isinstance(typ, JavaType.Class):
+            return False
+        return (getattr(typ, '_methods', None) is None
+                and getattr(typ, '_members', None) is None
+                and getattr(typ, '_supertype', None) is None)
+    except Exception:
+        return False
+    finally:
+        if mapping is not None:
+            mapping.close()
+        if client is not None:
+            client.shutdown()
+        import shutil
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+_TY_TYPES_BOUNDARY_SUPPORTED = _ty_types_supports_boundary()
+
+
+# Mark for tests that require a ty-types binary with first-party boundary support
+requires_ty_types_boundary = pytest.mark.skipif(
+    not _TY_TYPES_BOUNDARY_SUPPORTED,
+    reason="installed ty-types binary does not support the first-party boundary "
+           "(firstPartyRoot); skipping end-to-end boundary tests"
+)
+
+
 @requires_ty_types_cli
 class TestTyTypesClient:
     """Tests for the TyTypesClient.
@@ -644,6 +698,28 @@ def _cleanup_mapping(mapping, tmpdir, client):
     shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def _make_mapping_with_boundary(source: str, with_boundary: bool) -> tuple:
+    """Helper: like _make_mapping, but optionally sets the first-party boundary
+    to the temp project root.
+
+    When ``with_boundary`` is True the session is initialized with
+    ``first_party_root`` set to the project dir, so ty-types emits classes
+    defined outside it (stdlib / third-party) as ``classRef`` shells. When
+    False, no boundary is sent and attribution fully expands as before.
+
+    Returns (mapping, tree, tmpdir, client).
+    """
+    tree = ast.parse(source)
+    tmpdir = tempfile.mkdtemp()
+    file_path = os.path.join(tmpdir, 'test.py')
+    with open(file_path, 'w') as f:
+        f.write(source)
+    client = TyTypesClient()
+    client.initialize(tmpdir, first_party_root=tmpdir if with_boundary else None)
+    mapping = PythonTypeMapping(source, file_path, ty_client=client)
+    return mapping, tree, tmpdir, client
+
+
 class TestDeclaringTypeFromLiterals:
     """Tests for declaring type inference from literal receivers (no CLI needed)."""
 
@@ -1060,6 +1136,88 @@ class TestParameterizedTypes:
 
 
 @requires_ty_types_cli
+class TestBoundaryAwareAttribution:
+    """End-to-end tests for the first-party boundary on the getTypes session.
+
+    With a boundary set to the project root, classes defined outside it (here,
+    stdlib ``datetime.datetime``) come back as body-less shells, while local
+    (in-boundary) classes stay fully attributed. With no boundary, the external
+    class fully expands exactly as before.
+    """
+
+    # A local class with an explicit local base and a method, plus a reference
+    # to a stdlib class. ``Greeter()`` instantiates the local class (full),
+    # ``datetime.datetime.now()`` yields a stdlib datetime instance (external).
+    _SOURCE = '''import datetime
+
+
+class Base:
+    pass
+
+
+class Greeter(Base):
+    def greet(self) -> str:
+        return "hi"
+
+
+g = Greeter()
+x = datetime.datetime.now()
+'''
+
+    @staticmethod
+    def _base_class_of(typ):
+        """Unwrap an instance/parameterized type to its underlying Class."""
+        if isinstance(typ, JavaType.Parameterized):
+            typ = typ._type
+        return typ if isinstance(typ, JavaType.Class) else None
+
+    def _local_and_external(self, mapping, tree):
+        """Resolve the local-class instance and the external datetime instance
+        from the module body (``g = Greeter()`` then ``x = datetime...now()``)."""
+        greeter_call = tree.body[3].value      # g = Greeter()
+        datetime_call = tree.body[4].value     # x = datetime.datetime.now()
+        local = self._base_class_of(mapping.type(greeter_call))
+        external = self._base_class_of(mapping.type(datetime_call))
+        return local, external
+
+    @requires_ty_types_boundary
+    def test_with_boundary_external_is_shell_local_is_full(self):
+        mapping, tree, tmpdir, client = _make_mapping_with_boundary(
+            self._SOURCE, with_boundary=True)
+        try:
+            local, external = self._local_and_external(mapping, tree)
+
+            assert local is not None and local.fully_qualified_name.endswith('Greeter')
+            assert getattr(local, '_methods', None) is not None and len(local._methods) > 0
+            assert getattr(local, '_supertype', None) is not None
+
+            assert external is not None
+            assert external.fully_qualified_name == 'datetime.datetime'
+            assert getattr(external, '_methods', None) is None
+            assert getattr(external, '_members', None) is None
+            assert getattr(external, '_supertype', None) is None
+            assert getattr(external, '_interfaces', None) is None
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_without_boundary_external_is_fully_expanded(self):
+        mapping, tree, tmpdir, client = _make_mapping_with_boundary(
+            self._SOURCE, with_boundary=False)
+        try:
+            _, external = self._local_and_external(mapping, tree)
+
+            assert external is not None
+            assert external.fully_qualified_name == 'datetime.datetime'
+            # Full expansion: at least one of the structural fields is populated.
+            assert (external._methods is not None
+                    or external._members is not None
+                    or getattr(external, '_supertype', None) is not None), \
+                "datetime.datetime should be fully expanded without a boundary"
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+
+@requires_ty_types_cli
 class TestMethodSignatureDetails:
     """Tests for parameter name and type resolution in method signatures."""
 
@@ -1241,6 +1399,64 @@ class TestCyclicTypeResolution:
 
         result = mapping._resolve_type(50)
         assert result is JavaType.Primitive.Int
+
+
+class TestClassRefShells:
+    """Unit tests for the `classRef` descriptor → body-less `JavaType.Class` shell.
+
+    ty-types emits `classRef` for classes that fall outside the first-party
+    boundary (stdlib / third-party packages). These carry identity only — no
+    members, methods, supertypes, interfaces, or type parameters — so they must
+    map to a body-less Class shell (FQN + kind). Exercised here with mock
+    descriptors so no ty-types CLI is needed; end-to-end boundary behavior lives
+    in TestBoundaryAwareAttribution below.
+    """
+
+    @staticmethod
+    def _assert_shell(result, fqn):
+        # A shell is a body-less JavaType.Class: FQN + kind set, every
+        # structural field absent. `_create_class_type` leaves those slots
+        # unset, which the RPC sender treats as None/empty via getattr — so we
+        # assert absence the same way.
+        assert isinstance(result, JavaType.Class)
+        assert result.fully_qualified_name == fqn
+        assert result._kind == JavaType.FullyQualified.Kind.Class
+        assert getattr(result, '_members', None) is None
+        assert getattr(result, '_methods', None) is None
+        assert getattr(result, '_supertype', None) is None
+        assert getattr(result, '_interfaces', None) is None
+        assert getattr(result, '_type_parameters', None) is None
+
+    def test_class_ref_maps_to_module_qualified_shell(self):
+        """A module-qualified classRef yields `module.Class` with no body."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[100] = {
+            'kind': 'classRef', 'className': 'datetime', 'moduleName': 'datetime'}
+        self._assert_shell(mapping._resolve_type(100), 'datetime.datetime')
+
+    def test_class_ref_builtins_is_bare(self):
+        """A builtins classRef drops the `builtins.` prefix (matches classLiteral)."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[101] = {
+            'kind': 'classRef', 'className': 'int', 'moduleName': 'builtins'}
+        self._assert_shell(mapping._resolve_type(101), 'int')
+
+    def test_class_ref_without_module_is_bare(self):
+        """A classRef with no moduleName uses the bare class name."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[102] = {'kind': 'classRef', 'className': 'Foo'}
+        self._assert_shell(mapping._resolve_type(102), 'Foo')
+
+    def test_instance_with_class_ref_base_is_shell(self):
+        """An `instance` whose `classId` points to a classRef resolves its base
+        class to the shell — the instance branch needs no change."""
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[103] = {
+            'kind': 'classRef', 'className': 'datetime', 'moduleName': 'datetime'}
+        mapping._type_registry[104] = {
+            'kind': 'instance', 'className': 'datetime',
+            'moduleName': 'datetime', 'classId': 103}
+        self._assert_shell(mapping._resolve_type(104), 'datetime.datetime')
 
 
 class TestParamSpecAndConcatenate:
@@ -2679,12 +2895,14 @@ class TestDependencyPathForwarding:
     """
 
     _captured: list = []
+    _captured_boundary: list = []
 
     class _StubTyClient:
         def __init__(self, virtual_env=None):
             TestDependencyPathForwarding._captured.append(virtual_env)
 
-        def initialize(self, project_root):
+        def initialize(self, project_root, first_party_root=None):
+            TestDependencyPathForwarding._captured_boundary.append(first_party_root)
             return True
 
         @property
@@ -2703,6 +2921,7 @@ class TestDependencyPathForwarding:
     def _patch_client(self, monkeypatch):
         import rewrite.python.ty_client as ty_mod
         TestDependencyPathForwarding._captured = []
+        TestDependencyPathForwarding._captured_boundary = []
         monkeypatch.setattr(ty_mod, 'TyTypesClient',
                             TestDependencyPathForwarding._StubTyClient)
         yield
@@ -2725,6 +2944,22 @@ class TestDependencyPathForwarding:
             "dependencyPath": "/deps/proj/.venv",
         })
         assert self._captured == ["/deps/proj/.venv"]
+
+    def test_handle_parse_project_forwards_first_party_root_when_set(self, tmp_path):
+        from rewrite.rpc import server
+        (tmp_path / "m.py").write_text("x = 1\n")
+        server.handle_parse_project({
+            "projectPath": str(tmp_path),
+            "firstPartyRoot": "/repo/src",
+        })
+        assert self._captured_boundary == ["/repo/src"]
+
+    def test_handle_parse_project_no_boundary_when_absent(self, tmp_path):
+        # Backward-compat: absent firstPartyRoot ⇒ None forwarded ⇒ full expansion.
+        from rewrite.rpc import server
+        (tmp_path / "m.py").write_text("x = 1\n")
+        server.handle_parse_project({"projectPath": str(tmp_path)})
+        assert self._captured_boundary == [None]
 
     def test_handle_parse_without_dependency_path_does_not_auto_provision(self, tmp_path, monkeypatch):
         # A pyproject.toml with dependencies present must NOT trigger an

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProject.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProject.java
@@ -59,4 +59,16 @@ class ParseProject implements RpcRequest {
      */
     @Nullable
     Path dependencyPath;
+
+    /**
+     * Optional first-party package root that bounds type attribution.
+     * <p>
+     * When set, ty-types emits classes defined outside this root (stdlib and third-party
+     * packages) as identity-only references, which the parser maps to body-less
+     * {@code JavaType.Class} shells (fully qualified name only). This keeps attribution lean
+     * and shrinks the type payload carried over RPC. When {@code null}, no boundary is applied
+     * and types expand fully, exactly as before.
+     */
+    @Nullable
+    Path firstPartyRoot;
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProjectOptions.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProjectOptions.java
@@ -58,4 +58,17 @@ public class ParseProjectOptions {
      */
     @Nullable
     Path dependencyPath;
+
+    /**
+     * First-party package root that bounds type attribution. When set, classes defined outside
+     * this root (stdlib and third-party packages) are attributed as body-less {@code JavaType.Class}
+     * shells (fully qualified name only) rather than fully expanding their member and supertype
+     * graphs, keeping attribution lean and shrinking the type payload carried over RPC.
+     * <p>
+     * Optional and gated for backward compatibility: when {@code null}, no boundary is applied and
+     * types expand fully, exactly as before. Callers (e.g. a CLI build step) opt in explicitly; the
+     * parser never defaults this to the project path.
+     */
+    @Nullable
+    Path firstPartyRoot;
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -198,6 +198,7 @@ public class PythonRewriteRpc extends RewriteRpc {
         @Nullable List<String> exclusions = options.getExclusions();
         @Nullable Path relativeTo = options.getRelativeTo();
         @Nullable Path dependencyPath = options.getDependencyPath();
+        @Nullable Path firstPartyRoot = options.getFirstPartyRoot();
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
 
         Stream<SourceFile> rpcStream = StreamSupport.stream(new Spliterator<SourceFile>() {
@@ -208,7 +209,7 @@ public class PythonRewriteRpc extends RewriteRpc {
             public boolean tryAdvance(Consumer<? super SourceFile> action) {
                 if (response == null) {
                     parsingListener.intermediateMessage("Starting project parsing: " + projectPath);
-                    response = send("ParseProject", new ParseProject(projectPath, exclusions, relativeTo, dependencyPath), ParseProjectResponse.class);
+                    response = send("ParseProject", new ParseProject(projectPath, exclusions, relativeTo, dependencyPath, firstPartyRoot), ParseProjectResponse.class);
                     parsingListener.intermediateMessage(String.format("Discovered %,d files to parse", response.size()));
                 }
 


### PR DESCRIPTION
## Motivation

Today the rewrite-python parser fully expands every class it attributes, dragging a class's entire member and supertype graph along — across third-party packages and the standard library. That graph dominates the JavaType payload carried over RPC and makes Python parsing expensive.

This PR is the **parser half** of a two-part change that makes attribution *boundary-aware*. The **ty-types half** (separate change) adds a session-wide first-party boundary to the `getTypes` path: when `initialize` is given a first-party root, ty-types emits classes defined outside that boundary as `classRef` descriptors carrying identity only (just like its existing library/stdlib API extraction). This PR (a) plumbs that boundary through, and (b) maps `classRef` to a body-less `JavaType.Class` shell — so out-of-boundary classes attribute as FQN-only shells instead of fully-expanded graphs.

The boundary is **optional and gated for backward compatibility**: when unset, no boundary is sent and types expand fully, exactly as today. The CLI opts in explicitly later; the parser never defaults the boundary to the project path.

## Examples

With a first-party boundary set to the project root, attributing a file that defines a local class and references `datetime.datetime`:

```python
import datetime

class Base: pass

class Greeter(Base):           # in-boundary → fully attributed
    def greet(self) -> str: return "hi"

x = datetime.datetime.now()    # out-of-boundary → body-less shell
```

- `Greeter` → `JavaType.Class` with `_methods` / `_supertype` populated.
- `datetime.datetime` → `JavaType.Class` shell: FQN + kind only; `_members` / `_methods` / `_supertype` / `_interfaces` / `_type_parameters` all absent.

Without a boundary (default), `datetime.datetime` fully expands as before.

## Summary

- **`type_mapping.py`**: new `classRef` case in `_descriptor_to_java_type` that builds a body-less shell via `_create_class_type`, reusing the existing builtins/module FQN scheme (`builtins` bare, else `module.Class`). The `instance` branch needs no change — an instance whose `classId` resolves to a `classRef` already yields the shell as its base class.
- **`ty_client.py`**: `initialize` accepts an optional `first_party_root`, forwarded on the ty-types `initialize` request **only when explicitly set** (and included in the no-op/reinit comparison).
- **`rpc/server.py`**: `handle_parse_project` reads `firstPartyRoot` from the request and forwards it.
- **`ParseProject` / `ParseProjectOptions` / `PythonRewriteRpc`**: carry an optional `firstPartyRoot` over RPC.
- **No RPC codec change**: the sender already serializes a `Class` with absent members/supertype correctly via `getattr(..., None)`, so a shell round-trips as-is.

## Test plan

- [x] Unit tests (no CLI): `classRef` → shell for module-qualified, builtins-bare, and no-module FQNs; an `instance` whose `classId` points to a `classRef` resolves its base class to the shell.
- [x] Forwarding/gating tests for `handle_parse_project`: `firstPartyRoot` forwarded when set; `None` forwarded when absent (backward compat).
- [x] End-to-end (against a ty-types build with boundary support): with a boundary, the external `datetime.datetime` is a shell and the local class is fully attributed; without a boundary, the external class fully expands.
- [x] The end-to-end shell assertion self-skips against ty-types binaries that predate boundary support, so the suite stays green until the ty-types half ships.
- [x] Full `test_type_attribution.py` suite green (154 passed). `ruff check` clean on changed regions. `./gradlew :rewrite-python:compileJava` succeeds.