### PR TITLE
Fix rewrite-csharp integTest: stop `dotnet run` build output corrupting the RPC stream

### DIFF
--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -438,6 +438,12 @@ public class CSharpRewriteRpc extends RewriteRpc {
                     "run",
                     "--project", csproj.toAbsolutePath().normalize().toString(),
                     "--framework", "net10.0",
+                    // --no-build (which implies --no-restore) keeps `dotnet run` from emitting any
+                    // MSBuild/NuGet output on stdout, which is the JSON-RPC channel. A single restore
+                    // audit warning (e.g. NU1903 for a transitively-pulled vulnerable package) printed
+                    // here corrupts the stream and kills the peer. The project is always pre-built by
+                    // the `csharpBuild` Gradle task this command's only caller (tests) depends on.
+                    "--no-build",
                     log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
                     traceRpcMessages ? "--trace-rpc-messages" : null,
                     recipeInstallDir == null ? null : "--recipe-install-dir=" + recipeInstallDir.toAbsolutePath().normalize()


### PR DESCRIPTION
## Motivation

`main` CI has been red since 2026-06-12, with every run failing identically at
`:rewrite-csharp:integTest`:

```
io.moderne.jsonrpc.JsonRpcException: {code=-32603, message='Internal error: JSON-RPC peer closed the stream'}
```

The failures appeared on commits entirely unrelated to C# (e.g. a
`ChangeMethodInvocationReturnType` fix, a Python type-attribution change),
which is the tell that the trigger was external rather than a code regression.

The integTest launches the C# server with `dotnet run --project ... --framework net10.0`.
`dotnet run` performs an **implicit restore + build** and writes MSBuild/NuGet
output to **stdout** — the same stream used for the JSON-RPC bridge. A NuGet
security advisory (NU1903 / GHSA-hv8m-jj95-wg3x) was published around
2026-06-12 for **MessagePack 2.5.187** (pulled transitively). NuGet's restore
audit then started printing a warning to stdout, corrupting the RPC framing and
killing the peer. Reproduced locally, the warning is visible inline in the stream:

```
Invalid Request: Expected Content-Length header but received
'...OpenRewrite.csproj : warning NU1903: Package 'MessagePack' 2.5.187 has a
known high severity vulnerability, https://github.com/advisories/GHSA-hv8m-jj95-wg3x ...'
```

Production launches a pre-built apphost (`buildToolPathCommand`), so only the
test launcher (`buildCsprojCommand`) was affected.

## Summary

- Add `--no-build` to the `dotnet run` command in
  `CSharpRewriteRpc.buildCsprojCommand`. `--no-build` implies `--no-restore`,
  so no restore audit runs and no MSBuild/NuGet output can reach stdout.
- This is safe because the project is always pre-built by the `csharpBuild`
  Gradle task that this command's only caller (`integTest`) depends on. It also
  matches the `--no-build` already used by the `csharpTest` task in the same
  build file.
- `--verbosity quiet` was rejected: it does **not** suppress the NU1903 warning
  on stdout; only skipping restore/build does.

## Test plan

- [x] `./gradlew :rewrite-csharp:integTest` — 17 tests, 0 failures (was 16/17
      failing before the fix).
- [x] Confirmed via direct `dotnet run` invocation that `--no-build` yields a
      clean stdout (no NU1903), while `--verbosity quiet` still leaks it.
