### PR TITLE
Python: only force the [profiling] pip extra when profiling is enabled

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -767,48 +767,18 @@ public class PythonRewriteRpc extends RewriteRpc {
             try {
                 Files.createDirectories(pipPackagesPath);
 
-                // Install with the [profiling] extra so pyroscope-io is available when
-                // PYROSCOPE_SERVER_ADDRESS is set in the rpc subprocess environment. The
-                // SDK init in rewrite.rpc.server is a no-op when the env var is unset, so
-                // adding the extra costs nothing for non-profiled deployments.
-                ProcessBuilder pb = new ProcessBuilder(
-                        pythonPath.toString(),
-                        "-m", "pip", "install",
-                        "--upgrade",
-                        "--target=" + pipPackagesPath.toAbsolutePath().normalize(),
-                        "openrewrite[profiling]==" + version
-                );
-                pb.environment().putAll(environment);
-                pb.redirectErrorStream(true);
-                if (log != null) {
-                    File logFile = log.toAbsolutePath().normalize().toFile();
-                    pb.redirectOutput(ProcessBuilder.Redirect.appendTo(logFile));
-                }
-                Process process = pb.start();
-                String pipOutput = "";
-                if (log == null) {
-                    // Capture stdout+stderr so we can include it in error messages
-                    try (InputStream is = process.getInputStream()) {
-                        pipOutput = StringUtils.readFully(is);
+                // Only request the [profiling] extra (which pulls in pyroscope-io) when
+                // profiling is actually enabled, i.e. PYROSCOPE_SERVER_ADDRESS is set in the
+                // rpc subprocess environment; the SDK init in rewrite.rpc.server is a no-op
+                // otherwise. pyroscope-io ships no wheels for some platforms (e.g. Windows)
+                // and would otherwise force an unbuildable native source build, so even when
+                // profiling is requested we fall back to the plain package if the extra fails.
+                List<String> specs = openrewriteInstallSpecs(version, profilingEnabled());
+                for (int i = 0; i < specs.size(); i++) {
+                    boolean lastAttempt = i == specs.size() - 1;
+                    if (installPackage(pythonPath, pipPackagesPath, specs.get(i), version, lastAttempt)) {
+                        break;
                     }
-                }
-                boolean completed = process.waitFor(2, TimeUnit.MINUTES);
-
-                if (!completed) {
-                    process.destroyForcibly();
-                    throw new RuntimeException("Timed out bootstrapping openrewrite==" + version);
-                }
-
-                int exitCode = process.exitValue();
-                if (exitCode != 0) {
-                    String message = "Failed to install openrewrite==" + version +
-                            " (pip exited with code " + exitCode + ")";
-                    if (!pipOutput.isEmpty()) {
-                        message += ":\n" + pipOutput.trim();
-                    } else if (log != null) {
-                        message += ". See " + log.toAbsolutePath().normalize() + " for details";
-                    }
-                    throw new RuntimeException(message);
                 }
 
                 Files.write(pipPackagesPath.resolve(".openrewrite-version"), version.getBytes(StandardCharsets.UTF_8));
@@ -818,6 +788,83 @@ public class PythonRewriteRpc extends RewriteRpc {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException("Interrupted while bootstrapping openrewrite package", e);
             }
+        }
+
+        /**
+         * Runs {@code pip install} for a single package spec. Returns {@code true} on success.
+         * On failure throws when {@code lastAttempt} is set, otherwise returns {@code false} so
+         * the caller can fall back to another spec.
+         */
+        private boolean installPackage(Path pythonPath, Path pipPackagesPath, String packageSpec,
+                                       String version, boolean lastAttempt) throws IOException, InterruptedException {
+            ProcessBuilder pb = new ProcessBuilder(pipInstallCommand(pythonPath, pipPackagesPath, packageSpec));
+            pb.environment().putAll(environment);
+            pb.redirectErrorStream(true);
+            if (log != null) {
+                File logFile = log.toAbsolutePath().normalize().toFile();
+                pb.redirectOutput(ProcessBuilder.Redirect.appendTo(logFile));
+            }
+            Process process = pb.start();
+            String pipOutput = "";
+            if (log == null) {
+                // Capture stdout+stderr so we can include it in error messages
+                try (InputStream is = process.getInputStream()) {
+                    pipOutput = StringUtils.readFully(is);
+                }
+            }
+            boolean completed = process.waitFor(2, TimeUnit.MINUTES);
+
+            if (!completed) {
+                process.destroyForcibly();
+                throw new RuntimeException("Timed out bootstrapping openrewrite==" + version);
+            }
+
+            int exitCode = process.exitValue();
+            if (exitCode != 0) {
+                if (!lastAttempt) {
+                    return false;
+                }
+                String message = "Failed to install openrewrite==" + version +
+                        " (pip exited with code " + exitCode + ")";
+                if (!pipOutput.isEmpty()) {
+                    message += ":\n" + pipOutput.trim();
+                } else if (log != null) {
+                    message += ". See " + log.toAbsolutePath().normalize() + " for details";
+                }
+                throw new RuntimeException(message);
+            }
+            return true;
+        }
+
+        /**
+         * Whether the profiling SDK will be active in the rpc subprocess, i.e. whether a
+         * non-blank {@code PYROSCOPE_SERVER_ADDRESS} is present in the subprocess environment.
+         */
+        boolean profilingEnabled() {
+            String address = environment.get("PYROSCOPE_SERVER_ADDRESS");
+            return address != null && !address.trim().isEmpty();
+        }
+
+        /**
+         * The openrewrite package specs to attempt installing, in order. When profiling is
+         * enabled the {@code [profiling]} extra is tried first with a plain fallback so a
+         * missing/unbuildable {@code pyroscope-io} can never block the core install.
+         */
+        static List<String> openrewriteInstallSpecs(String version, boolean profiling) {
+            if (profiling) {
+                return Arrays.asList("openrewrite[profiling]==" + version, "openrewrite==" + version);
+            }
+            return Collections.singletonList("openrewrite==" + version);
+        }
+
+        static List<String> pipInstallCommand(Path pythonPath, Path pipPackagesPath, String packageSpec) {
+            return Arrays.asList(
+                    pythonPath.toString(),
+                    "-m", "pip", "install",
+                    "--upgrade",
+                    "--target=" + pipPackagesPath.toAbsolutePath().normalize(),
+                    packageSpec
+            );
         }
     }
 }

--- a/rewrite-python/src/test/java/org/openrewrite/python/rpc/PythonRewriteRpcBuilderTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/rpc/PythonRewriteRpcBuilderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.rpc;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PythonRewriteRpcBuilderTest {
+    private static final String VERSION = "8.84.9";
+    private static final Path PYTHON = Paths.get("python3");
+    private static final Path TARGET = Paths.get("pip-packages");
+
+    @Test
+    void profilingDisabledByDefault() {
+        assertThat(PythonRewriteRpc.builder().profilingEnabled()).isFalse();
+    }
+
+    @Test
+    void profilingDisabledForBlankAddress() {
+        assertThat(PythonRewriteRpc.builder()
+                .environment(singletonMap("PYROSCOPE_SERVER_ADDRESS", "  "))
+                .profilingEnabled()).isFalse();
+    }
+
+    @Test
+    void profilingEnabledWhenAddressSet() {
+        assertThat(PythonRewriteRpc.builder()
+                .environment(singletonMap("PYROSCOPE_SERVER_ADDRESS", "http://localhost:4040"))
+                .profilingEnabled()).isTrue();
+    }
+
+    @Test
+    void plainSpecWhenProfilingDisabled() {
+        List<String> specs = PythonRewriteRpc.Builder.openrewriteInstallSpecs(VERSION, false);
+        assertThat(specs).containsExactly("openrewrite==" + VERSION);
+        assertThat(specs).noneMatch(s -> s.contains("[profiling]"));
+    }
+
+    @Test
+    void profilingSpecTriedFirstWithPlainFallback() {
+        // When profiling is enabled the extra is attempted first, but a plain install is
+        // always available as a fallback so an unbuildable pyroscope-io can't block the core install.
+        List<String> specs = PythonRewriteRpc.Builder.openrewriteInstallSpecs(VERSION, true);
+        assertThat(specs).containsExactly(
+                "openrewrite[profiling]==" + VERSION,
+                "openrewrite==" + VERSION);
+    }
+
+    @Test
+    void pipInstallCommandContainsTargetUpgradeAndSpec() {
+        List<String> command = PythonRewriteRpc.Builder.pipInstallCommand(PYTHON, TARGET, "openrewrite==" + VERSION);
+        assertThat(command)
+                .containsSubsequence("-m", "pip", "install", "--upgrade")
+                .contains("openrewrite==" + VERSION)
+                .doesNotContain("openrewrite[profiling]==" + VERSION);
+        assertThat(command).anyMatch(arg -> arg.startsWith("--target="));
+    }
+}


### PR DESCRIPTION
The Moderne CLI bootstrapped the pinned `openrewrite` package with the `[profiling]` extra unconditionally, which pulls in `pyroscope-io` — a package that ships no wheels for some platforms (e.g. Windows/CPython 3.14) and so forces an unbuildable native (Rust) source build, aborting the whole install. This changes `PythonRewriteRpc$Builder.bootstrapOpenrewrite` to install the plain `openrewrite==<version>` package by default and only request the `[profiling]` extra when profiling is actually active (a non-blank `PYROSCOPE_SERVER_ADDRESS` in the subprocess environment), with a fallback to the plain package if the extra-install fails. The pip-running logic was extracted into small testable helpers (`openrewriteInstallSpecs`, `pipInstallCommand`, `profilingEnabled`, `installPackage`) while preserving all existing behavior (`--upgrade`, `--target`, env passthrough, log redirect, 2-minute timeout, exit-code check, `.openrewrite-version` marker). A new `PythonRewriteRpcBuilderTest` asserts the gating and fallback ordering. The pinned version and public Builder API are unchanged.