### PR TITLE
Fix `TypeNameMatcher` `..*` followed by a suffix matching every name

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/TypeNameMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/TypeNameMatcher.java
@@ -156,9 +156,10 @@ class PatternTypeNameMatcher implements TypeNameMatcher {
 
             if (tIdx >= tLength) {
                 while (pIdx < pLength) {
-                    if (p == '*') {
+                    char pc = pattern.charAt(pIdx);
+                    if (pc == '*') {
                         pIdx++;
-                    } else if (p == '.' && pIdx + 1 < pLength && pattern.charAt(pIdx + 1) == '.') {
+                    } else if (pc == '.' && pIdx + 1 < pLength && pattern.charAt(pIdx + 1) == '.') {
                         pIdx += 2;
                     } else {
                         return false;
@@ -197,7 +198,7 @@ class PatternTypeNameMatcher implements TypeNameMatcher {
                     return true;
                 }
 
-                if (pattern.charAt(pIdx) == '*') {
+                if (pattern.charAt(pIdx) == '*' && pIdx + 1 >= pLength) {
                     return true;
                 }
 

--- a/rewrite-java/src/test/java/org/openrewrite/java/TypeNameMatcherTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/TypeNameMatcherTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TypeNameMatcherTest {
+
+    @Test
+    void doubleDotStarFollowedBySuffixHonorsSuffix() {
+        TypeNameMatcher matcher = TypeNameMatcher.fromPattern("..*.remove");
+        assertThat(matcher.matches("java.util.List.remove")).isTrue();
+        assertThat(matcher.matches("java.util.Map.remove")).isTrue();
+        assertThat(matcher.matches("com.example.Foo.bar")).isFalse();
+        assertThat(matcher.matches("org.springframework.boot.SpringApplication.run")).isFalse();
+    }
+
+    @Test
+    void doubleDotStarFollowedByNestedTypeSuffix() {
+        TypeNameMatcher matcher = TypeNameMatcher.fromPattern("..*.Builder");
+        assertThat(matcher.matches("com.foo.Bar.Builder")).isTrue();
+        assertThat(matcher.matches("com.foo.Bar.Baz")).isFalse();
+    }
+
+    @Test
+    void doubleDotStarAtEndMatchesAnyNonEmptyRemainder() {
+        TypeNameMatcher matcher = TypeNameMatcher.fromPattern("java.util..*");
+        assertThat(matcher.matches("java.util.List")).isTrue();
+        assertThat(matcher.matches("java.util.concurrent.ConcurrentMap")).isTrue();
+    }
+
+    @Test
+    void doubleDotSuffix() {
+        TypeNameMatcher matcher = TypeNameMatcher.fromPattern("..List.remove");
+        assertThat(matcher.matches("java.util.List.remove")).isTrue();
+        assertThat(matcher.matches("java.util.List.add")).isFalse();
+    }
+
+    @Test
+    void leadingFullWildcardSuffix() {
+        TypeNameMatcher matcher = TypeNameMatcher.fromPattern("*..List.remove");
+        assertThat(matcher.matches("java.util.List.remove")).isTrue();
+        assertThat(matcher.matches("java.util.List.add")).isFalse();
+    }
+
+    @Test
+    void singleSegmentWildcardSuffix() {
+        TypeNameMatcher matcher = TypeNameMatcher.fromPattern("java.util.*.remove");
+        assertThat(matcher.matches("java.util.List.remove")).isTrue();
+        assertThat(matcher.matches("java.util.List.add")).isFalse();
+    }
+}


### PR DESCRIPTION
## Motivation

`TypeNameMatcher` is the glob engine behind `FindTypes`, `UsesType`, `TypeMatcher`, `MethodMatcher`, and `AnnotationMatcher`. A `..` token immediately followed by `*` short-circuited to a match *unconditionally*, discarding everything after the `*`. So a pattern like `..*.remove` collapsed to "match anything":

- `..*.remove` matched `com.example.Foo.bar` (does not end in `.remove`)
- `..*.Builder` matched *every* type, not just `*.Builder` nested types

The short-circuit is only correct when `*` is the **final** token — `..*` at the end of a pattern legitimately matches any non-empty remainder. When pattern follows the `*`, the suffix must still be honored.

## Summary

- Guard the `..*` short-circuit in `matchesPattern` so it only fires at end of pattern (`pIdx + 1 >= pLength`); otherwise fall through to the existing position-scan loop, which already matches `*` as exactly one segment and then honors the suffix.
- Fix a latent bug in the text-exhaustion handler that this change exposed: the local `char p` was read once and never refreshed inside the inner `while` loop, so an exhausted text with `*.<literal>` still remaining in the pattern consumed the entire remainder as if every char were a wildcard. The pattern char is now re-read each iteration.
- Add `TypeNameMatcherTest` covering the regression cases and confirming existing forms (`..List.remove`, `*..List.remove`, `java.util.*.remove`, `java.util..*`) still behave correctly.

Existing semantics preserved: `*` = exactly one name segment, `..` = any number of packages, and `*..*` remains a full wildcard.

## Test plan

- [x] `:rewrite-java:test --tests "org.openrewrite.java.TypeNameMatcherTest"` — green
- [x] Consumer suites green: `TypeMatcherTest`, `MethodMatcherTest`, `AnnotationMatcherTest`, `FindTypesTest`, `UsesTypeTest`