### PR TITLE
Build `J.Assignment` directly in `UsePropertyAssignmentSyntax`

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UsePropertyAssignmentSyntax.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UsePropertyAssignmentSyntax.java
@@ -18,9 +18,12 @@ package org.openrewrite.gradle;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
-import org.openrewrite.groovy.GroovyTemplate;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JLeftPadded;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -68,14 +71,33 @@ public class UsePropertyAssignmentSyntax extends Recipe {
                     return m;
                 }
 
+                // The transformation is purely structural (`name arg` -> `name = arg`, or
+                // `select.name arg` -> `select.name = arg`), so synthesize the assignment
+                // directly rather than going through a parser round-trip. This avoids the
+                // template-stub pipeline entirely, preserving the original argument LST (types,
+                // markers, formatting) and sidestepping classpath-sensitive parse failures.
+                Expression rhs = m.getArguments().get(0).withPrefix(Space.SINGLE_SPACE);
+
+                Expression lhs;
                 if (m.getSelect() != null) {
-                    return GroovyTemplate.apply("#{any()}." + propertyName + " = #{any()}",
-                            getCursor(), m.getCoordinates().replace(),
-                            m.getSelect(), m.getArguments().get(0));
+                    lhs = new J.FieldAccess(
+                            Tree.randomId(),
+                            Space.EMPTY,
+                            Markers.EMPTY,
+                            m.getSelect(),
+                            new JLeftPadded<>(Space.EMPTY, m.getName().withPrefix(Space.EMPTY), Markers.EMPTY),
+                            m.getName().getType());
+                } else {
+                    lhs = m.getName().withPrefix(Space.EMPTY);
                 }
-                return GroovyTemplate.apply(propertyName + " = #{any()}",
-                        getCursor(), m.getCoordinates().replace(),
-                        m.getArguments().get(0));
+
+                return new J.Assignment(
+                        Tree.randomId(),
+                        m.getPrefix(),
+                        m.getMarkers(),
+                        lhs,
+                        new JLeftPadded<>(Space.SINGLE_SPACE, rhs, Markers.EMPTY),
+                        rhs.getType());
             }
         });
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UsePropertyAssignmentSyntaxTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UsePropertyAssignmentSyntaxTest.java
@@ -215,6 +215,36 @@ class UsePropertyAssignmentSyntaxTest implements RewriteTest {
     }
 
     @Test
+    void groupOutsidePluginsBlockConverted() {
+        rewriteRun(
+          spec -> spec.recipe(new UsePropertyAssignmentSyntax("group")),
+          buildGradle(
+            """
+              group 'com.example.app'
+              """,
+            """
+              group = 'com.example.app'
+              """
+          )
+        );
+    }
+
+    @Test
+    void groupWithProjectSelectorConverted() {
+        rewriteRun(
+          spec -> spec.recipe(new UsePropertyAssignmentSyntax("group")),
+          buildGradle(
+            """
+              project.group 'com.example.app'
+              """,
+            """
+              project.group = 'com.example.app'
+              """
+          )
+        );
+    }
+
+    @Test
     void methodCallArgConvertedToAssignment() {
         rewriteRun(
           spec -> spec.recipe(new UsePropertyAssignmentSyntax("version")),


### PR DESCRIPTION
## What's wrong

`UsePropertyAssignmentSyntax` converts Gradle property method-call syntax (e.g. `group 'x'`) to assignment syntax (`group = 'x'`) through `GroovyTemplate`, which builds the replacement by re-parsing a stub via `GroovyBlockStatementTemplateGenerator` → `JavaTemplateParser`.

The generator picks its wrapping from the matched `J.MethodInvocation`'s method type:

- **void** return type → instance-initializer block `class Template {{ group = "x" }}` (parses fine)
- **null or non-void** → field initializer `class Template { Object o = group = "x"; }` — the Groovy parser rejects a bare identifier as the LHS of a class-body field initializer

When method types are resolved against a real Gradle classpath, a top-level `group '...'` can take the field-initializer branch and fail with `IllegalArgumentException: Could not parse as Java`. (Unit tests don't catch it because without a resolved classpath the method type is often null and the stub happens to parse for `version`/`description`.)

## The fix

The transformation is purely structural (`name arg` → `name = arg`, or `select.name arg` → `select.name = arg`), so synthesize the `J.Assignment` directly from the matched invocation's name, select, and argument instead of round-tripping through the template parser. This:

- removes the failure mode entirely — no parser, no void-vs-non-void wrap branch, no classpath sensitivity;
- preserves the original argument LST (types, markers, formatting), which matters for non-string arguments such as the existing `version computeVersion()` test case.

## Tests

Adds regression tests for a top-level `group '...'` and a `project.group '...'` selector exercising the `getSelect() != null` branch. `UsePropertyAssignmentSyntaxTest` passes (15/15).