### PR TITLE
C#: REWRITE_DOTNET_RPC_SERVER env-var fallback + symlink-safe project references

### DIFF
--- a/rewrite-csharp/csharp/Directory.Build.targets
+++ b/rewrite-csharp/csharp/Directory.Build.targets
@@ -1,0 +1,30 @@
+<Project>
+  <!--
+    Normalize ProjectReference paths to collapse any '..' segments, evaluated here (not in a
+    <Target>) because NuGet restore's path-walk reads @(ProjectReference) at EVALUATION time,
+    before any target runs. Directory.Build.targets is imported after the project body, so this
+    ItemGroup sees the project's own references and rewrites them in time.
+
+    Why: when this SDK tree is consumed through a symlink (e.g. a recipes repo's
+    external/openrewrite/rewrite -> a local rewrite checkout), a literal '../Sibling.csproj'
+    reference is resolved TWO different ways for the same physical project:
+      - NuGet restore resolves the '..' PHYSICALLY (POSIX), crossing the symlink to the real path;
+      - the build resolves the same '..' LEXICALLY, keeping the symlink path.
+    The project then enters the restore graph as two nodes and races on its shared obj/bin under a
+    parallel build (deps.json / nuget.g.props "file in use" / missing ref-assembly errors).
+
+    Rewriting each ProjectReference to its lexically-normalized %(FullPath) removes the '..' so a
+    single, symlink-stable spelling is seen everywhere. In a non-symlinked checkout %(FullPath)
+    equals the original path, so this is a no-op. The SDK's ProjectReferences carry no custom
+    metadata, so re-projecting on %(FullPath) loses nothing.
+
+    This file also terminates MSBuild's upward search for Directory.Build.targets, mirroring the
+    sibling Directory.Build.props stop-marker, so a consumer's Directory.Build.targets is not
+    inherited by the SDK projects when this tree is symlinked into it.
+  -->
+  <ItemGroup Condition="'@(ProjectReference)' != ''">
+    <_SdkProjectReferenceOriginal Include="@(ProjectReference)" />
+    <ProjectReference Remove="@(ProjectReference)" />
+    <ProjectReference Include="@(_SdkProjectReferenceOriginal->'%(FullPath)')" />
+  </ItemGroup>
+</Project>

--- a/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
@@ -22,10 +22,6 @@
     <!-- CS3021: need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute -->
     <!-- CA2255: ModuleInitializer used in library code is intentional for RPC type-name registration. -->
     <NoWarn>VSTHRD200;VSTHRD002;VSTHRD103;CS0114;CS8602;CS8603;CS8604;CS3021;CA2255</NoWarn>
-
-    <!-- Always emit a ref assembly. Consumers reference us as a ProjectReference (via symlink) -->
-    <!-- and MSBuild's reduced target set during cross-project compile expects obj/.../ref/OpenRewrite.dll. -->
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/EnvServerEntryIntegTest.java
+++ b/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/EnvServerEntryIntegTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.rpc;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.openrewrite.test.RewriteTest;
+
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static org.openrewrite.csharp.Assertions.csharp;
+
+/**
+ * Proves the REWRITE_DOTNET_RPC_SERVER env-var fallback: the factory intentionally does
+ * NOT set csharpServerEntry, so the only way the C# RPC server can launch is via the
+ * env-var path added to {@code CSharpRewriteRpc.Builder.get()}. Runs only when the env
+ * var is set (point it at OpenRewrite.Tool.csproj).
+ */
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+@EnabledIfEnvironmentVariable(named = "REWRITE_DOTNET_RPC_SERVER", matches = ".+")
+class EnvServerEntryIntegTest implements RewriteTest {
+
+    @BeforeAll
+    static void setUpFactory() {
+        // No csharpServerEntry on purpose — exercise the REWRITE_DOTNET_RPC_SERVER fallback.
+        CSharpRewriteRpc.setFactory(
+          CSharpRewriteRpc.builder()
+            .log(Paths.get(System.getProperty("java.io.tmpdir"), "csharp-rpc-envserver.log")));
+    }
+
+    @Test
+    void parseViaEnvServerEntry() {
+        rewriteRun(
+          csharp(
+            """
+              namespace Test
+              {
+                  public class Program
+                  {
+                      public static void Main(string[] args)
+                      {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -319,14 +319,27 @@ public class CSharpRewriteRpc extends RewriteRpc {
 
             Stream<@Nullable String> cmd;
 
-            if (csharpServerEntry != null) {
-                // Explicit override (used by tests)
-                if (csharpServerEntry.toString().endsWith(".csproj")) {
-                    cmd = buildCsprojCommand(dotnetPath, csharpServerEntry);
+            // An explicit builder value wins; otherwise fall back to the
+            // REWRITE_DOTNET_RPC_SERVER environment variable so a source .csproj
+            // or a pre-built dll/exe can be selected without code changes (local
+            // cross-repo development, parallel git worktrees). A .csproj is launched
+            // via `dotnet run --project`; anything else is treated as a server entry
+            // assembly/executable run directly.
+            Path serverEntry = csharpServerEntry;
+            if (serverEntry == null) {
+                String envServerEntry = System.getenv("REWRITE_DOTNET_RPC_SERVER");
+                if (envServerEntry != null && !envServerEntry.isEmpty()) {
+                    serverEntry = Paths.get(envServerEntry);
+                }
+            }
+
+            if (serverEntry != null) {
+                if (serverEntry.toString().endsWith(".csproj")) {
+                    cmd = buildCsprojCommand(dotnetPath, serverEntry);
                 } else {
                     cmd = Stream.of(
                             dotnetPath.toString(),
-                            csharpServerEntry.toAbsolutePath().normalize().toString(),
+                            serverEntry.toAbsolutePath().normalize().toString(),
                             log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
                             traceRpcMessages ? "--trace-rpc-messages" : null,
                             recipeInstallDir == null ? null : "--recipe-install-dir=" + recipeInstallDir.toAbsolutePath().normalize()
@@ -334,9 +347,14 @@ public class CSharpRewriteRpc extends RewriteRpc {
                 }
             } else {
                 // Install and run the tool from a persistent tool-path, bypassing
-                // dotnet tool exec which has auth issues with private feeds (dotnet/sdk#51375)
-                String version = StringUtils.readFully(
-                        CSharpRewriteRpc.class.getResourceAsStream("/META-INF/rewrite-csharp-version.txt")).trim();
+                // dotnet tool exec which has auth issues with private feeds (dotnet/sdk#51375).
+                // REWRITE_DOTNET_RPC_SERVER_VERSION overrides the embedded version so a
+                // specific package version of the tool can be pinned without rebuilding.
+                String version = System.getenv("REWRITE_DOTNET_RPC_SERVER_VERSION");
+                if (version == null || version.isEmpty()) {
+                    version = StringUtils.readFully(
+                            CSharpRewriteRpc.class.getResourceAsStream("/META-INF/rewrite-csharp-version.txt")).trim();
+                }
                 cmd = buildToolPathCommand(dotnetPath, version);
             }
 


### PR DESCRIPTION
Adds a `REWRITE_DOTNET_RPC_SERVER` (and `REWRITE_DOTNET_RPC_SERVER_VERSION`) environment-variable fallback to `CSharpRewriteRpc.Builder` so the C# RPC server—a source `.csproj` or a pre-built dll/exe—can be selected without code changes, supporting local cross-repo development and parallel git worktrees. Adds a `Directory.Build.targets` that lexically normalizes `ProjectReference` paths to remove `..` segments, preventing NuGet restore races when the SDK tree is consumed through a symlink. Removes the now-unneeded `ProduceReferenceAssembly` override from `OpenRewrite.csproj`, and adds `EnvServerEntryIntegTest` which exercises the env-var fallback when `REWRITE_DOTNET_RPC_SERVER` is set.