### PR TITLE
rewrite-csharp: add LOCAL_NUGET_FEED env var and skip repo nuget.config on tool install

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RecipesNuGetConfigTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RecipesNuGetConfigTests.cs
@@ -20,7 +20,8 @@ namespace OpenRewrite.Tests.Rpc;
 /// <summary>
 /// When a local NuGet feed (<c>~/.nuget/local-feed</c>) exists for cross-repo
 /// development, the server makes it additive to the recipe project's
-/// <c>nuget.config</c>: it creates one (public + local feed) when none exists,
+/// <c>nuget.config</c>: it creates one with only the local feed (never nuget.org,
+/// so it merges with the user/machine config's default source) when none exists,
 /// and otherwise only appends the local feed — preserving a caller-written
 /// config (e.g. an exclusive configured feed) untouched.
 /// </summary>
@@ -29,12 +30,12 @@ public class RecipesNuGetConfigTests
     private const string LocalFeed = "/home/dev/.nuget/local-feed";
 
     [Fact]
-    public void CreatesPublicPlusLocalFeedWhenNoConfigExists()
+    public void CreatesLocalFeedOnlyWhenNoConfigExists()
     {
         string xml = RewriteRpcServer.BuildRecipesNuGetConfig(null, LocalFeed);
 
-        Assert.Contains("api.nuget.org", xml);
         Assert.Contains(LocalFeed, xml);
+        Assert.DoesNotContain("api.nuget.org", xml);
     }
 
     [Fact]

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -677,64 +677,45 @@ public class RewriteRpcServer
             </Project>
             """);
 
-        // Add local directory-based NuGet feeds so locally-published SDK/recipe
-        // snapshots are discovered. We only *add* sources here and deliberately do
-        // NOT declare nuget.org: dotnet merges this project-level nuget.config with
-        // the user- and machine-level configuration, so the environment's already
-        // configured default feed (which may be an internal mirror rather than
-        // nuget.org in networks that block it) is preserved and combined with these
-        // local feeds. Hardcoding nuget.org here would break such environments. When a
-        // caller (e.g. the Moderne CLI) has already written its own nuget.config in the
-        // project dir — possibly an exclusive feed with <clear/> — we append rather than
-        // clobber it. No-ops in production, where no local feed is configured.
-        var localFeeds = new List<(string Key, string Path)>();
-
-        var defaultLocalFeed = Path.Combine(
+        // For local cross-repo development, make the local NuGet feed additive to
+        // whatever config already lives in the project dir. A caller (e.g. the Moderne
+        // CLI) may have written its own nuget.config there — possibly an exclusive
+        // configured feed — so we must not clobber it: append only the local feed when
+        // a config is present, and create a standalone dev config that adds only the
+        // local feed (never nuget.org, so it merges with the user/machine config's
+        // default source) when none exists. No-ops in production, where local-feed is absent.
+        var localFeed = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             ".nuget", "local-feed");
-        if (Directory.Exists(defaultLocalFeed))
-            localFeeds.Add(("local-feed", defaultLocalFeed));
-
-        // Additional feed directory supplied out-of-band: the caller-injected
-        // --recipe-install-dir takes precedence, falling back to the LOCAL_NUGET_FEED
-        // environment variable when the argument is absent.
-        var extraFeed = !string.IsNullOrWhiteSpace(_recipeInstallDir)
-            ? _recipeInstallDir
-            : Environment.GetEnvironmentVariable("LOCAL_NUGET_FEED");
-        if (!string.IsNullOrWhiteSpace(extraFeed) && Directory.Exists(extraFeed))
-            localFeeds.Add(("local-feed-env", Path.GetFullPath(extraFeed)));
-
-        if (localFeeds.Count > 0)
+        if (Directory.Exists(localFeed))
         {
             var nugetConfig = Path.Combine(_recipesProjectDir, "nuget.config");
             var existing = File.Exists(nugetConfig) ? File.ReadAllText(nugetConfig) : null;
-            File.WriteAllText(nugetConfig, BuildRecipesNuGetConfig(existing, localFeeds));
+            File.WriteAllText(nugetConfig, BuildRecipesNuGetConfig(existing, localFeed));
         }
 
         return csprojPath;
     }
 
     /// <summary>
-    /// Produces the recipe project's <c>nuget.config</c> with the given local development
-    /// feeds present. When <paramref name="existingConfigXml"/> is null/empty, creates a
-    /// standalone config that adds only those feeds — never nuget.org — so it merges with
-    /// (rather than overrides) the user/machine NuGet configuration that supplies the
+    /// Produces the recipe project's <c>nuget.config</c> with the local development
+    /// feed present. When <paramref name="existingConfigXml"/> is null/empty, creates a
+    /// standalone config that adds only the local feed — never nuget.org — so it merges
+    /// with (rather than overrides) the user/machine NuGet configuration that supplies the
     /// environment's default source. Otherwise the caller already wrote a config (possibly
-    /// an exclusive configured feed): each feed is appended to <c>&lt;packageSources&gt;</c>,
-    /// preserving the caller's sources and any <c>&lt;clear/&gt;</c>, and idempotently.
+    /// an exclusive configured feed): only the local feed is appended to
+    /// <c>&lt;packageSources&gt;</c>, preserving the caller's sources and any
+    /// <c>&lt;clear/&gt;</c>, and idempotently (no duplicate if already present).
     /// </summary>
-    internal static string BuildRecipesNuGetConfig(string? existingConfigXml,
-        IReadOnlyList<(string Key, string Path)> localFeeds)
+    internal static string BuildRecipesNuGetConfig(string? existingConfigXml, string localFeedPath)
     {
         if (string.IsNullOrWhiteSpace(existingConfigXml))
         {
-            var sources = string.Join(Environment.NewLine,
-                localFeeds.Select(f => $"    <add key=\"{f.Key}\" value=\"{f.Path}\" />"));
             return $"""
                 <?xml version="1.0" encoding="utf-8"?>
                 <configuration>
                   <packageSources>
-                {sources}
+                    <add key="local-feed" value="{localFeedPath}" />
                   </packageSources>
                 </configuration>
                 """;
@@ -750,16 +731,13 @@ public class RewriteRpcServer
             configuration.Add(packageSources);
         }
 
-        foreach (var feed in localFeeds)
+        bool alreadyPresent = packageSources.Elements("add").Any(e =>
+            string.Equals((string?)e.Attribute("value"), localFeedPath, StringComparison.OrdinalIgnoreCase));
+        if (!alreadyPresent)
         {
-            bool alreadyPresent = packageSources.Elements("add").Any(e =>
-                string.Equals((string?)e.Attribute("value"), feed.Path, StringComparison.OrdinalIgnoreCase));
-            if (!alreadyPresent)
-            {
-                packageSources.Add(new XElement("add",
-                    new XAttribute("key", feed.Key),
-                    new XAttribute("value", feed.Path)));
-            }
+            packageSources.Add(new XElement("add",
+                new XAttribute("key", "local-feed"),
+                new XAttribute("value", localFeedPath)));
         }
 
         var declaration = doc.Declaration ?? new XDeclaration("1.0", "utf-8", null);

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -677,43 +677,64 @@ public class RewriteRpcServer
             </Project>
             """);
 
-        // For local cross-repo development, make the local NuGet feed additive to
-        // whatever config already lives in the project dir. A caller (e.g. the Moderne
-        // CLI) may have written its own nuget.config there — possibly an exclusive
-        // configured feed — so we must not clobber it: append only the local feed when
-        // a config is present, and create the standalone dev default (public + local
-        // feed) only when none exists. No-ops in production, where local-feed is absent.
-        var localFeed = Path.Combine(
+        // Add local directory-based NuGet feeds so locally-published SDK/recipe
+        // snapshots are discovered. We only *add* sources here and deliberately do
+        // NOT declare nuget.org: dotnet merges this project-level nuget.config with
+        // the user- and machine-level configuration, so the environment's already
+        // configured default feed (which may be an internal mirror rather than
+        // nuget.org in networks that block it) is preserved and combined with these
+        // local feeds. Hardcoding nuget.org here would break such environments. When a
+        // caller (e.g. the Moderne CLI) has already written its own nuget.config in the
+        // project dir — possibly an exclusive feed with <clear/> — we append rather than
+        // clobber it. No-ops in production, where no local feed is configured.
+        var localFeeds = new List<(string Key, string Path)>();
+
+        var defaultLocalFeed = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             ".nuget", "local-feed");
-        if (Directory.Exists(localFeed))
+        if (Directory.Exists(defaultLocalFeed))
+            localFeeds.Add(("local-feed", defaultLocalFeed));
+
+        // Additional feed directory supplied out-of-band: the caller-injected
+        // --recipe-install-dir takes precedence, falling back to the LOCAL_NUGET_FEED
+        // environment variable when the argument is absent.
+        var extraFeed = !string.IsNullOrWhiteSpace(_recipeInstallDir)
+            ? _recipeInstallDir
+            : Environment.GetEnvironmentVariable("LOCAL_NUGET_FEED");
+        if (!string.IsNullOrWhiteSpace(extraFeed) && Directory.Exists(extraFeed))
+            localFeeds.Add(("local-feed-env", Path.GetFullPath(extraFeed)));
+
+        if (localFeeds.Count > 0)
         {
             var nugetConfig = Path.Combine(_recipesProjectDir, "nuget.config");
             var existing = File.Exists(nugetConfig) ? File.ReadAllText(nugetConfig) : null;
-            File.WriteAllText(nugetConfig, BuildRecipesNuGetConfig(existing, localFeed));
+            File.WriteAllText(nugetConfig, BuildRecipesNuGetConfig(existing, localFeeds));
         }
 
         return csprojPath;
     }
 
     /// <summary>
-    /// Produces the recipe project's <c>nuget.config</c> with the local development
-    /// feed present. When <paramref name="existingConfigXml"/> is null/empty, creates a
-    /// standalone config with nuget.org + the local feed. Otherwise the caller already
-    /// wrote a config (possibly an exclusive configured feed): only the local feed is
-    /// appended to <c>&lt;packageSources&gt;</c>, preserving the caller's sources and any
-    /// <c>&lt;clear/&gt;</c>, and idempotently (no duplicate if already present).
+    /// Produces the recipe project's <c>nuget.config</c> with the given local development
+    /// feeds present. When <paramref name="existingConfigXml"/> is null/empty, creates a
+    /// standalone config that adds only those feeds — never nuget.org — so it merges with
+    /// (rather than overrides) the user/machine NuGet configuration that supplies the
+    /// environment's default source. Otherwise the caller already wrote a config (possibly
+    /// an exclusive configured feed): each feed is appended to <c>&lt;packageSources&gt;</c>,
+    /// preserving the caller's sources and any <c>&lt;clear/&gt;</c>, and idempotently.
     /// </summary>
-    internal static string BuildRecipesNuGetConfig(string? existingConfigXml, string localFeedPath)
+    internal static string BuildRecipesNuGetConfig(string? existingConfigXml,
+        IReadOnlyList<(string Key, string Path)> localFeeds)
     {
         if (string.IsNullOrWhiteSpace(existingConfigXml))
         {
+            var sources = string.Join(Environment.NewLine,
+                localFeeds.Select(f => $"    <add key=\"{f.Key}\" value=\"{f.Path}\" />"));
             return $"""
                 <?xml version="1.0" encoding="utf-8"?>
                 <configuration>
                   <packageSources>
-                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-                    <add key="local-feed" value="{localFeedPath}" />
+                {sources}
                   </packageSources>
                 </configuration>
                 """;
@@ -729,13 +750,16 @@ public class RewriteRpcServer
             configuration.Add(packageSources);
         }
 
-        bool alreadyPresent = packageSources.Elements("add").Any(e =>
-            string.Equals((string?)e.Attribute("value"), localFeedPath, StringComparison.OrdinalIgnoreCase));
-        if (!alreadyPresent)
+        foreach (var feed in localFeeds)
         {
-            packageSources.Add(new XElement("add",
-                new XAttribute("key", "local-feed"),
-                new XAttribute("value", localFeedPath)));
+            bool alreadyPresent = packageSources.Elements("add").Any(e =>
+                string.Equals((string?)e.Attribute("value"), feed.Path, StringComparison.OrdinalIgnoreCase));
+            if (!alreadyPresent)
+            {
+                packageSources.Add(new XElement("add",
+                    new XAttribute("key", feed.Key),
+                    new XAttribute("value", feed.Path)));
+            }
         }
 
         var declaration = doc.Declaration ?? new XDeclaration("1.0", "utf-8", null);

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -480,6 +480,7 @@ public class CSharpRewriteRpc extends RewriteRpc {
         }
 
         private void installTool(Path dotnetPath, String version, Path toolPath) {
+            Path installCwd = null;
             try {
                 Files.createDirectories(toolPath);
 
@@ -492,18 +493,40 @@ public class CSharpRewriteRpc extends RewriteRpc {
                         "--ignore-failed-sources"
                 ));
 
-                // When the tool package exists in the NuGet global cache (e.g. from publishToMavenLocal),
-                // add it as a source so the install can resolve it without remote feeds
-                Path globalCachePath = Paths.get(System.getProperty("user.home"),
-                        ".nuget", "packages", NUGET_PACKAGE_ID.toLowerCase(), version);
-                if (Files.isDirectory(globalCachePath)) {
-                    installCmd.addAll(Arrays.asList("--add-source", globalCachePath.toString()));
+                // Resolve the feed that provides the tool package itself. LOCAL_NUGET_FEED, when
+                // set, takes precedence; otherwise default to the NuGet global packages cache,
+                // where publishToMavenLocal lands the tool package.
+                String localFeedOverride = environment.get("LOCAL_NUGET_FEED");
+                if (localFeedOverride == null) {
+                    localFeedOverride = System.getenv("LOCAL_NUGET_FEED");
+                }
+                Path localFeed;
+                boolean addLocalFeed;
+                if (localFeedOverride != null && !localFeedOverride.isEmpty()) {
+                    localFeed = Paths.get(localFeedOverride);
+                    addLocalFeed = true;
+                } else {
+                    localFeed = Paths.get(System.getProperty("user.home"),
+                            ".nuget", "packages", NUGET_PACKAGE_ID.toLowerCase(), version);
+                    addLocalFeed = Files.isDirectory(localFeed);
+                }
+                if (addLocalFeed) {
+                    installCmd.addAll(Arrays.asList("--add-source",
+                            localFeed.toAbsolutePath().normalize().toString()));
                 }
 
                 ProcessBuilder pb = new ProcessBuilder(installCmd);
-                if (workingDirectory != null) {
-                    pb.directory(workingDirectory.toFile());
-                }
+                // Run from a fresh, empty directory whose ancestors hold no nuget.config. This
+                // lets NuGet's own config discovery pick up the user/machine-level global
+                // configuration (which applies regardless of working directory, and may span
+                // multiple files) while skipping any repo-level nuget.config that would otherwise
+                // be discovered up the working-directory hierarchy — such a config could <clear/>
+                // global sources or enable <packageSourceMapping> that rejects --add-source with
+                // "The --add-source option cannot be combined with package source mapping". We
+                // delegate to NuGet's discovery rather than locating the global config ourselves,
+                // since its path is convention, not a stable contract.
+                installCwd = Files.createTempDirectory("rewrite-csharp-tool-install");
+                pb.directory(installCwd.toFile());
                 pb.environment().putAll(environment);
                 pb.redirectErrorStream(true);
                 Process process = pb.start();
@@ -520,6 +543,14 @@ public class CSharpRewriteRpc extends RewriteRpc {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException("Interrupted while installing " + NUGET_PACKAGE_ID + "@" + version, e);
+            } finally {
+                if (installCwd != null) {
+                    try {
+                        Files.deleteIfExists(installCwd);
+                    } catch (IOException ignored) {
+                        // Best effort: the temp directory is empty and harmless if it lingers.
+                    }
+                }
             }
         }
     }

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -493,38 +493,21 @@ public class CSharpRewriteRpc extends RewriteRpc {
                         "--ignore-failed-sources"
                 ));
 
-                // Resolve the feed that provides the tool package itself. LOCAL_NUGET_FEED, when
-                // set, takes precedence; otherwise default to the NuGet global packages cache,
-                // where publishToMavenLocal lands the tool package.
-                String localFeedOverride = environment.get("LOCAL_NUGET_FEED");
-                if (localFeedOverride == null) {
-                    localFeedOverride = System.getenv("LOCAL_NUGET_FEED");
-                }
-                Path localFeed;
-                boolean addLocalFeed;
-                if (localFeedOverride != null && !localFeedOverride.isEmpty()) {
-                    localFeed = Paths.get(localFeedOverride);
-                    addLocalFeed = true;
-                } else {
-                    localFeed = Paths.get(System.getProperty("user.home"),
-                            ".nuget", "packages", NUGET_PACKAGE_ID.toLowerCase(), version);
-                    addLocalFeed = Files.isDirectory(localFeed);
-                }
-                if (addLocalFeed) {
-                    installCmd.addAll(Arrays.asList("--add-source",
-                            localFeed.toAbsolutePath().normalize().toString()));
+                // When the tool package exists in the NuGet global cache (e.g. from publishToMavenLocal),
+                // add it as a source so the install can resolve it without remote feeds
+                Path globalCachePath = Paths.get(System.getProperty("user.home"),
+                        ".nuget", "packages", NUGET_PACKAGE_ID.toLowerCase(), version);
+                if (Files.isDirectory(globalCachePath)) {
+                    installCmd.addAll(Arrays.asList("--add-source", globalCachePath.toString()));
                 }
 
                 ProcessBuilder pb = new ProcessBuilder(installCmd);
-                // Run from a fresh, empty directory whose ancestors hold no nuget.config. This
-                // lets NuGet's own config discovery pick up the user/machine-level global
-                // configuration (which applies regardless of working directory, and may span
-                // multiple files) while skipping any repo-level nuget.config that would otherwise
-                // be discovered up the working-directory hierarchy — such a config could <clear/>
-                // global sources or enable <packageSourceMapping> that rejects --add-source with
-                // "The --add-source option cannot be combined with package source mapping". We
-                // delegate to NuGet's discovery rather than locating the global config ourselves,
-                // since its path is convention, not a stable contract.
+                // Run from a fresh, empty temp directory so NuGet's working-directory config
+                // walk finds no repo-level nuget.config up the hierarchy. Such a config could
+                // <clear/> global sources or enable <packageSourceMapping> that rejects
+                // --add-source with "The --add-source option cannot be combined with package
+                // source mapping". User- and machine-level config still apply, since they are
+                // discovered independently of the working directory.
                 installCwd = Files.createTempDirectory("rewrite-csharp-tool-install");
                 pb.directory(installCwd.toFile());
                 pb.environment().putAll(environment);


### PR DESCRIPTION
Installs the C# tool from a fresh working directory with no `nuget.config` on any ancestor path, so NuGet's own config discovery applies the user/machine-level global configuration (preserving nuget.org / private-proxy feeds for transitive dependencies) while skipping repo-level overrides that could `<clear/>` sources or enable package source mapping. The tool package's feed now comes from `LOCAL_NUGET_FEED` when set, otherwise the NuGet global packages cache (`~/.nuget/packages/...`) as before. This also fixes RPC edit batching to resolve the canonical (codec-registered) source file type rather than the raw runtime class name, since under lazy-deserialization LSTs the runtime class is a generated proxy absent from the remote's declared languages, which would otherwise skip every batched edit on that file.