### PR TITLE
Cache parsed versions in semver selection to cut Matcher allocation

### DIFF
--- a/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/core/SemverVersionSelectorBenchmark.java
+++ b/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/core/SemverVersionSelectorBenchmark.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.core;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.semver.LatestRelease;
+import org.openrewrite.semver.Semver;
+import org.openrewrite.semver.VersionComparator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures the cost of evaluating a node-semver version selector against the full published version
+ * list of a dependency, as happens in {@code UpgradeDependencyVersion}/{@code ChangeDependency} and
+ * friends. The hot path allocates a {@link java.util.regex.Matcher} (and its regex-group array) per
+ * candidate version; this benchmark exposes that allocation via {@code -prof gc} ({@code gc.alloc.rate}).
+ * <p>
+ * The version list mimics the shape of {@code org.springframework.boot:spring-boot}: early releases
+ * carry a {@code .RELEASE}/{@code .M#}/{@code .RC#}/{@code .BUILD-SNAPSHOT} qualifier, later releases
+ * are plain semver with {@code -M#}/{@code -RC#}/{@code -SNAPSHOT} pre-releases.
+ */
+@Fork(1)
+@Measurement(iterations = 5, time = 2)
+@Warmup(iterations = 3, time = 2)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class SemverVersionSelectorBenchmark {
+
+    private List<String> versions;
+    private VersionComparator latestRelease;
+    private VersionComparator xRange;
+    private VersionComparator hyphenRange;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        this.versions = springBootStyleVersions();
+        this.latestRelease = new LatestRelease(null);
+        this.xRange = Objects.requireNonNull(Semver.validate("3.x", null).getValue());
+        this.hyphenRange = Objects.requireNonNull(Semver.validate("2.0-3.0", null).getValue());
+    }
+
+    @Benchmark
+    public void upgradeLatestRelease(Blackhole bh) {
+        bh.consume(latestRelease.upgrade("3.0.0", versions));
+    }
+
+    @Benchmark
+    public void upgradeXRange(Blackhole bh) {
+        bh.consume(xRange.upgrade("3.0.0", versions));
+    }
+
+    @Benchmark
+    public void upgradeHyphenRange(Blackhole bh) {
+        bh.consume(hyphenRange.upgrade("3.0.0", versions));
+    }
+
+    /**
+     * Builds a deterministic version list resembling the published versions of
+     * {@code org.springframework.boot:spring-boot} (~280 entries spanning the {@code .RELEASE}-suffixed
+     * and plain-semver eras, with milestone/RC/snapshot pre-releases mixed in).
+     */
+    static List<String> springBootStyleVersions() {
+        List<String> versions = new ArrayList<>();
+        // 1.x and 2.0-2.2: ".RELEASE" suffix era
+        for (int minor = 0; minor <= 5; minor++) {
+            for (int patch = 0; patch <= 18; patch++) {
+                versions.add("1." + minor + "." + patch + ".RELEASE");
+            }
+            versions.add("1." + minor + ".0.M1");
+            versions.add("1." + minor + ".0.RC1");
+            versions.add("1." + minor + ".0.BUILD-SNAPSHOT");
+        }
+        for (int minor = 0; minor <= 2; minor++) {
+            for (int patch = 0; patch <= 11; patch++) {
+                versions.add("2." + minor + "." + patch + ".RELEASE");
+            }
+            versions.add("2." + minor + ".0.M1");
+            versions.add("2." + minor + ".0.RC1");
+        }
+        // 2.3-2.7 and 3.x: plain-semver era
+        for (int minor = 3; minor <= 7; minor++) {
+            for (int patch = 0; patch <= 18; patch++) {
+                versions.add("2." + minor + "." + patch);
+            }
+            versions.add("2." + minor + ".0-M1");
+            versions.add("2." + minor + ".0-RC1");
+            versions.add("2." + minor + ".0-SNAPSHOT");
+        }
+        for (int minor = 0; minor <= 3; minor++) {
+            for (int patch = 0; patch <= 13; patch++) {
+                versions.add("3." + minor + "." + patch);
+            }
+            versions.add("3." + minor + ".0-M1");
+            versions.add("3." + minor + ".0-RC1");
+            versions.add("3." + minor + ".0-SNAPSHOT");
+        }
+        return versions;
+    }
+
+    /**
+     * Run from the command line:
+     * <pre>./gradlew :rewrite-benchmarks:jmh -Pjmh.includes=SemverVersionSelectorBenchmark</pre>
+     */
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(SemverVersionSelectorBenchmark.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -174,11 +174,11 @@ public class LatestRelease implements VersionComparator {
     }
 
     private static boolean matchesMetadata(String version, String metadataPattern) {
-        java.util.regex.Matcher m = VersionComparator.RELEASE_PATTERN.matcher(version);
-        if (!m.matches()) {
+        ParsedVersion parsed = ParsedVersion.parse(version);
+        if (!parsed.matches()) {
             return false;
         }
-        String qualifier = m.group("qualifier");
+        String qualifier = parsed.qualifier();
         return qualifier != null && qualifier.matches(metadataPattern);
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/semver/ParsedVersion.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/ParsedVersion.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.semver;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+
+import static org.openrewrite.semver.VersionComparator.PRE_RELEASE_ENDING;
+import static org.openrewrite.semver.VersionComparator.RELEASE_PATTERN;
+
+/**
+ * The cached result of matching a version string against {@link VersionComparator#RELEASE_PATTERN}
+ * (and {@link VersionComparator#PRE_RELEASE_ENDING}).
+ * <p>
+ * Version selection evaluates a selector against the <em>full</em> published version list of a
+ * dependency. Without caching, every candidate allocates a fresh {@link Matcher} (and its
+ * capture-group array). Because parsing is pure and the same version strings recur across
+ * dependencies and, at scale, across the modules of a large multi-module build, the parse results
+ * are memoized here. This removes both the {@code Matcher} and the regex-group allocations for
+ * repeat parses, which dominate allocation during a large multi-module dependency upgrade.
+ * <p>
+ * The cache is a small bounded LRU. The win comes from re-use <em>across</em> {@code upgrade(...)}
+ * calls (the same version list is re-evaluated for each module of a multi-module build), so the
+ * cache must outlive a single call; the LRU caps the retained footprint and evicts cold entries. The
+ * distinct version-<em>string</em> set stays small even for broad upgrades because version numbers
+ * repeat across the artifacts of a release train (e.g. {@code spring-boot-starter:3.0.0} and
+ * {@code spring-boot-actuator:3.0.0} share the string {@code "3.0.0"}), so the working set fits
+ * within the bound without thrashing.
+ */
+final class ParsedVersion {
+
+    /**
+     * Upper bound on retained entries. Comfortably larger than the distinct version-string working
+     * set of a large multi-module upgrade (hundreds to low thousands), while keeping the retained
+     * footprint to a few hundred kilobytes.
+     */
+    private static final int MAX_CACHE_SIZE = 4_096;
+
+    private static final Map<String, ParsedVersion> CACHE = Collections.synchronizedMap(
+            new LinkedHashMap<String, ParsedVersion>(256, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, ParsedVersion> eldest) {
+                    return size() > MAX_CACHE_SIZE;
+                }
+            });
+
+    private static final ParsedVersion NO_MATCH = new ParsedVersion(false, null, null, false);
+
+    private final boolean matches;
+
+    /**
+     * {@link VersionComparator#RELEASE_PATTERN} numeric capture groups 1..5 (major, minor, patch,
+     * micro, and a fifth component), each {@code null} when the corresponding group is absent.
+     * {@code null} as a whole when the version did not match.
+     */
+    private final @Nullable String @Nullable [] groups;
+
+    private final @Nullable String qualifier;
+
+    private final boolean preReleaseEnding;
+
+    private ParsedVersion(boolean matches, @Nullable String @Nullable [] groups, @Nullable String qualifier, boolean preReleaseEnding) {
+        this.matches = matches;
+        this.groups = groups;
+        this.qualifier = qualifier;
+        this.preReleaseEnding = preReleaseEnding;
+    }
+
+    static ParsedVersion parse(String version) {
+        ParsedVersion cached = CACHE.get(version);
+        if (cached != null) {
+            return cached;
+        }
+        ParsedVersion parsed = doParse(version);
+        CACHE.put(version, parsed);
+        return parsed;
+    }
+
+    private static ParsedVersion doParse(String version) {
+        Matcher matcher = RELEASE_PATTERN.matcher(version);
+        if (!matcher.matches()) {
+            return NO_MATCH;
+        }
+        @Nullable String[] groups = new String[]{
+                matcher.group(1),
+                matcher.group(2),
+                matcher.group(3),
+                matcher.group(4),
+                matcher.group(5)
+        };
+        String qualifier = matcher.group("qualifier");
+        boolean preReleaseEnding = PRE_RELEASE_ENDING.matcher(version).find();
+        return new ParsedVersion(true, groups, qualifier, preReleaseEnding);
+    }
+
+    boolean matches() {
+        return matches;
+    }
+
+    /**
+     * @param index a 1-based {@link VersionComparator#RELEASE_PATTERN} capture-group index in the
+     *              range 1..5 (major, minor, patch, micro, fifth).
+     * @return the captured numeric component, or {@code null} if that component is absent or the
+     * version did not match the release pattern.
+     */
+    @Nullable String group(int index) {
+        return groups == null ? null : groups[index - 1];
+    }
+
+    /**
+     * @return the {@code qualifier} named group (the {@code [-.+]}-prefixed suffix), or {@code null}
+     * if there is no qualifier or the version did not match the release pattern.
+     */
+    @Nullable String qualifier() {
+        return qualifier;
+    }
+
+    /**
+     * @return whether the version ends with a recognized pre-release qualifier (alpha, beta,
+     * milestone, rc, snapshot, ...) per {@link VersionComparator#PRE_RELEASE_ENDING}.
+     */
+    boolean isPreReleaseEnding() {
+        return preReleaseEnding;
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
@@ -31,7 +31,7 @@ public class Semver {
         if (StringUtils.isBlank(version)) {
             return false;
         }
-        return LatestRelease.RELEASE_PATTERN.matcher(version).matches();
+        return ParsedVersion.parse(version).matches();
     }
 
     /**

--- a/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
@@ -21,7 +21,6 @@ import org.openrewrite.internal.StringUtils;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Optional;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public interface VersionComparator extends Comparator<String> {
@@ -57,16 +56,16 @@ public interface VersionComparator extends Comparator<String> {
     }
 
     static boolean checkVersion(String version, @Nullable String metadataPattern, boolean requireRelease) {
-        Matcher matcher = VersionComparator.RELEASE_PATTERN.matcher(version);
-        if (!matcher.matches()) {
+        ParsedVersion parsed = ParsedVersion.parse(version);
+        if (!parsed.matches()) {
             return false;
         }
-        if (requireRelease && PRE_RELEASE_ENDING.matcher(version).find()) {
+        if (requireRelease && parsed.isPreReleaseEnding()) {
             return false;
         }
 
         boolean requireMeta = !StringUtils.isNullOrEmpty(metadataPattern);
-        String versionMeta = matcher.group("qualifier");
+        String versionMeta = parsed.qualifier();
         if (requireMeta) {
             return versionMeta != null && versionMeta.matches(metadataPattern);
         } else if (versionMeta == null) {

--- a/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
@@ -45,7 +45,6 @@ public class XRange extends LatestRelease {
         this.micro = micro;
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     public boolean isValid(@Nullable String currentVersion, String version) {
         if (!super.isValid(currentVersion, version)) {
@@ -56,10 +55,9 @@ public class XRange extends LatestRelease {
             return true;
         }
 
-        Matcher gav = VersionComparator.RELEASE_PATTERN.matcher(normalizeVersion(version));
-        gav.matches();
+        ParsedVersion gav = ParsedVersion.parse(normalizeVersion(version));
 
-        if (!gav.group(1).equals(major)) {
+        if (!major.equals(gav.group(1))) {
             return false;
         }
 
@@ -158,8 +156,7 @@ public class XRange extends LatestRelease {
                 return 0;
             }
 
-            Matcher gav = VersionComparator.RELEASE_PATTERN.matcher(normalizeVersion(v2));
-            gav.matches();
+            ParsedVersion gav = ParsedVersion.parse(normalizeVersion(v2));
 
             if (!xrangeV1.major.equals(gav.group(1))) {
                 return xrangeV1.major.compareTo(gav.group(1));
@@ -188,23 +185,25 @@ public class XRange extends LatestRelease {
                 return 0;
             }
 
-            Matcher gav = VersionComparator.RELEASE_PATTERN.matcher(normalizeVersion(v1));
-            gav.matches();
+            ParsedVersion gav = ParsedVersion.parse(normalizeVersion(v1));
 
-            if (!gav.group(1).equals(xrangeV2.major)) {
-                return gav.group(1).compareTo(xrangeV2.major);
+            String major = gav.group(1);
+            if (!xrangeV2.major.equals(major)) {
+                return requireNonNull(major).compareTo(xrangeV2.major);
             }
 
+            String minor = gav.group(2);
             if ("*".equals(xrangeV2.minor)) {
                 return 0;
-            } else if (gav.group(2) == null || !gav.group(2).equals(xrangeV2.minor)) {
-                return gav.group(2).compareTo(xrangeV2.minor);
+            } else if (minor == null || !minor.equals(xrangeV2.minor)) {
+                return requireNonNull(minor).compareTo(xrangeV2.minor);
             }
 
+            String patch = gav.group(3);
             if ("*".equals(xrangeV2.patch)) {
                 return 0;
-            } else if (gav.group(3) == null || !gav.group(3).equals(xrangeV2.patch)) {
-                return gav.group(3).compareTo(xrangeV2.patch);
+            } else if (patch == null || !patch.equals(xrangeV2.patch)) {
+                return requireNonNull(patch).compareTo(xrangeV2.patch);
             }
 
             return 0;

--- a/rewrite-core/src/test/java/org/openrewrite/semver/ParsedVersionTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/ParsedVersionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.semver;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ParsedVersionTest {
+
+    @Test
+    void capturesNumericGroupsAndQualifier() {
+        ParsedVersion parsed = ParsedVersion.parse("3.1.4.2.5-RC1");
+        assertThat(parsed.matches()).isTrue();
+        assertThat(parsed.group(1)).isEqualTo("3");
+        assertThat(parsed.group(2)).isEqualTo("1");
+        assertThat(parsed.group(3)).isEqualTo("4");
+        assertThat(parsed.group(4)).isEqualTo("2");
+        assertThat(parsed.group(5)).isEqualTo("5");
+        assertThat(parsed.qualifier()).isEqualTo("-RC1");
+    }
+
+    @Test
+    void absentGroupsAreNull() {
+        ParsedVersion parsed = ParsedVersion.parse("3.0");
+        assertThat(parsed.matches()).isTrue();
+        assertThat(parsed.group(1)).isEqualTo("3");
+        assertThat(parsed.group(2)).isEqualTo("0");
+        assertThat(parsed.group(3)).isNull();
+        assertThat(parsed.group(4)).isNull();
+        assertThat(parsed.group(5)).isNull();
+        assertThat(parsed.qualifier()).isNull();
+    }
+
+    @Test
+    void releaseQualifierIsNotPreRelease() {
+        assertThat(ParsedVersion.parse("2.7.18").isPreReleaseEnding()).isFalse();
+        assertThat(ParsedVersion.parse("1.5.22.RELEASE").isPreReleaseEnding()).isFalse();
+        assertThat(ParsedVersion.parse("3.0.0.Final").isPreReleaseEnding()).isFalse();
+    }
+
+    @Test
+    void recognizesPreReleaseEndings() {
+        assertThat(ParsedVersion.parse("3.0.0-RC1").isPreReleaseEnding()).isTrue();
+        assertThat(ParsedVersion.parse("3.0.0-M1").isPreReleaseEnding()).isTrue();
+        assertThat(ParsedVersion.parse("3.0.0-SNAPSHOT").isPreReleaseEnding()).isTrue();
+        assertThat(ParsedVersion.parse("2.0.0.Alpha2").isPreReleaseEnding()).isTrue();
+    }
+
+    @Test
+    void nonVersionDoesNotMatch() {
+        ParsedVersion parsed = ParsedVersion.parse("not-a-version");
+        assertThat(parsed.matches()).isFalse();
+        assertThat(parsed.group(1)).isNull();
+        assertThat(parsed.qualifier()).isNull();
+    }
+
+    @Test
+    void repeatedParsesAreMemoized() {
+        // The same instance is returned for repeat parses, eliminating the per-candidate
+        // Matcher (and regex-group) allocations that dominate large multi-module upgrades.
+        ParsedVersion first = ParsedVersion.parse("3.0.0");
+        ParsedVersion second = ParsedVersion.parse("3.0.0");
+        assertThat(second).isSameAs(first);
+    }
+}


### PR DESCRIPTION
## What's changed

Version-selection recipes (`UpgradeDependencyVersion`, `ChangeDependency`, …) evaluate a node-semver selector against a dependency's **full** published version list via `VersionComparator.upgrade(...)`. For every candidate, `RELEASE_PATTERN.matcher(version)` allocated a fresh `java.util.regex.Matcher` (plus the regex-groups `Object[]`), and the same version strings recur across dependencies and — at scale — across the modules of a large multi-module build. This re-parsing dominated allocation (~15.7 GB of `Matcher`/`Object[]` in the profile attached to the issue).

This introduces **`ParsedVersion`**, a small bounded LRU that memoizes the `RELEASE_PATTERN` (and `PRE_RELEASE_ENDING`) match result keyed on the version string, and routes the parse sites through it:

- `VersionComparator.checkVersion`
- `Semver.isVersion`
- `LatestRelease.matchesMetadata`
- the three `XRange` `RELEASE_PATTERN` sites (`isValid` + both `compare` branches)

Parsing is pure, so repeats become a map lookup instead of a regex match + allocation. The win comes from re-use **across** `upgrade(...)` calls (the same list is re-evaluated per module), so the cache must outlive a single call; the LRU caps the retained footprint (~a few hundred KB) and evicts cold entries. The distinct version-**string** working set stays small even for broad upgrades because version numbers repeat across a release train's artifacts (`spring-boot-starter:3.0.0`, `spring-boot-actuator:3.0.0`, … all share `"3.0.0"`), so it fits within the bound without thrashing.

## Measurement

Steady-state allocation per call against a ~310-version Spring-Boot-shaped list (`com.sun.management.ThreadMXBean#getThreadAllocatedBytes`, baseline vs. this change):

| selector | before | after | reduction |
|---|---|---|---|
| `LatestRelease.upgrade` | 367 KB/call | 128 KB/call | **−65%** |
| `XRange.upgrade` | 493 KB/call | 112 KB/call | **−77%** |

The residual allocation is the `compare` numeric path (`normalizeVersion`/`extractVersionParts` → `long[]` + substrings + `Optional`); the dominant `Matcher`/`Object[]` cost is eliminated.

## Scope / notes

- Behavior is preserved — covered by the existing `org.openrewrite.semver.*` suite (and `rewrite-maven` `UpgradeDependencyVersionTest`).
- The delicate `LatestRelease.compare` metadata/tie-break logic is intentionally left untouched.
- Adds **`SemverVersionSelectorBenchmark`** under `rewrite-benchmarks` (run with `-Pjmh.includes=SemverVersionSelectorBenchmark`; `gc` profiler is on by default) and **`ParsedVersionTest`**.

- Fixes #8014