### PR TITLE
C#: harden RPC server for #nullable directives, dependency recipe activation, and NuGet-sourced files

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/InstallRecipesDependencyActivationTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/InstallRecipesDependencyActivationTest.cs
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Diagnostics;
+using OpenRewrite.Core;
+using OpenRewrite.CSharp.Rpc;
+
+namespace OpenRewrite.Tests.Rpc;
+
+/// <summary>
+/// Regression test for cross-package composite recipe resolution when a recipe package is
+/// registered as a loose DLL (file path) rather than a NuGet package.
+///
+/// A composite recipe in one package (here: PrimaryPlugin) commonly lists a recipe defined in a
+/// *referenced* package (here: DepPlugin) inside its <c>GetRecipeList()</c>. When installed via
+/// <c>InstallRecipes</c> from a loose DLL, only the primary assembly used to be activated; the
+/// dependency assembly's types loaded on demand but its <see cref="IRecipeActivator"/> never ran,
+/// so its recipes were missing from the marketplace and <c>PrepareRecipe</c> failed with
+/// "Recipe not found" (e.g. Migration.Dotnet's UpgradeToDotNet10 -> Core's
+/// ChangeDotNetTargetFramework). <c>InstallRecipes</c> now walks the primary's reference graph and
+/// activates plugin-private recipe assemblies too.
+/// </summary>
+public class InstallRecipesDependencyActivationTest : IDisposable
+{
+    private readonly string _root;
+    private readonly string _publishDir;
+
+    public InstallRecipesDependencyActivationTest()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "rewrite-dep-activation-test",
+            Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_root);
+
+        var hostDll = typeof(IRecipeActivator).Assembly.Location;
+
+        // Dependency package: contributes DepRecipe via its own activator.
+        var depDir = Path.Combine(_root, "DepPlugin");
+        Directory.CreateDirectory(depDir);
+        File.WriteAllText(Path.Combine(depDir, "DepPlugin.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <Reference Include="OpenRewrite">
+                  <HintPath>{hostDll}</HintPath>
+                  <Private>false</Private>
+                </Reference>
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(depDir, "Dep.cs"), """
+            using OpenRewrite.Core;
+            using OpenRewrite.CSharp;
+            using OpenRewrite.Java;
+
+            namespace DepPlugin;
+
+            public class DepActivator : IRecipeActivator
+            {
+                public void Activate(RecipeMarketplace marketplace) =>
+                    marketplace.Install(new DepRecipe(), new CategoryDescriptor("Dep"));
+            }
+
+            public class DepRecipe : Recipe
+            {
+                public override string DisplayName => "Dependency recipe";
+                public override string Description => "A recipe contributed by a referenced package.";
+                public override JavaVisitor<ExecutionContext> GetVisitor() =>
+                    new CSharpVisitor<ExecutionContext>();
+            }
+            """);
+
+        // Primary package: composes DepRecipe (so the compiled assembly retains the reference)
+        // but only activates its own PrimaryRecipe.
+        var primaryDir = Path.Combine(_root, "PrimaryPlugin");
+        Directory.CreateDirectory(primaryDir);
+        File.WriteAllText(Path.Combine(primaryDir, "PrimaryPlugin.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <Reference Include="OpenRewrite">
+                  <HintPath>{hostDll}</HintPath>
+                  <Private>false</Private>
+                </Reference>
+                <ProjectReference Include="../DepPlugin/DepPlugin.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(primaryDir, "Primary.cs"), """
+            using System.Collections.Generic;
+            using DepPlugin;
+            using OpenRewrite.Core;
+            using OpenRewrite.CSharp;
+            using OpenRewrite.Java;
+
+            namespace PrimaryPlugin;
+
+            public class PrimaryActivator : IRecipeActivator
+            {
+                public void Activate(RecipeMarketplace marketplace) =>
+                    marketplace.Install(new PrimaryRecipe(), new CategoryDescriptor("Primary"));
+            }
+
+            public class PrimaryRecipe : Recipe
+            {
+                public override string DisplayName => "Primary composite recipe";
+                public override string Description => "Composes a recipe from a referenced package.";
+
+                // Referencing DepRecipe keeps DepPlugin in this assembly's reference graph.
+                public override List<Recipe> GetRecipeList() => [new DepRecipe()];
+            }
+            """);
+
+        _publishDir = Path.Combine(_root, "publish");
+        RunDotnet($"publish \"{Path.Combine(primaryDir, "PrimaryPlugin.csproj")}\" " +
+                  $"-c Release -o \"{_publishDir}\"");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, true); }
+        catch { /* best-effort cleanup */ }
+    }
+
+    [Fact]
+    public void InstallRecipes_FromLooseDll_ActivatesReferencedRecipePackages()
+    {
+        var primaryDll = Path.Combine(_publishDir, "PrimaryPlugin.dll");
+        Assert.True(File.Exists(primaryDll), $"Primary plugin DLL not found at {primaryDll}");
+        Assert.True(File.Exists(Path.Combine(_publishDir, "DepPlugin.dll")),
+            "DepPlugin.dll must be published as a private dependency of the primary plugin");
+
+        var marketplace = new RecipeMarketplace();
+        var server = new RewriteRpcServer(marketplace);
+
+        server.InstallRecipes(new InstallRecipesRequest { Recipes = primaryDll })
+            .GetAwaiter().GetResult();
+
+        var names = marketplace.AllRecipes().Select(r => r.Name).ToHashSet();
+
+        Assert.Contains("PrimaryPlugin.PrimaryRecipe", names);
+        // The fix: the referenced package's recipe is registered even though only the primary
+        // DLL was installed by path. Without dependency activation this is absent and a
+        // composite run fails with "Recipe not found: DepPlugin.DepRecipe".
+        Assert.Contains("DepPlugin.DepRecipe", names);
+    }
+
+    private static void RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi)
+                            ?? throw new InvalidOperationException("Failed to start dotnet process");
+
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"dotnet {arguments} failed (exit code {process.ExitCode}):\n{stderr}\n{stdout}");
+        }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/NullableDirectiveReceiveTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/NullableDirectiveReceiveTest.cs
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Text.Json;
+using OpenRewrite.Core;
+using OpenRewrite.Core.Rpc;
+using OpenRewrite.CSharp;
+using OpenRewrite.CSharp.Rpc;
+
+namespace OpenRewrite.Tests.Rpc;
+
+/// <summary>
+/// Regression test for the `#nullable` directive RPC receive bug. The optional
+/// <see cref="NullableTarget"/> enum (the target of e.g. <c>#nullable enable annotations</c>)
+/// arrives over the wire as a System.Text.Json <see cref="JsonElement"/>. The receiver
+/// previously fell through to a hard <c>(NullableTarget)jsonElement</c> cast that threw
+/// <see cref="InvalidCastException"/>, aborting receipt of the entire CompilationUnit for
+/// any source file containing a targeted <c>#nullable</c> directive (observed building
+/// ClosedXML), leaving a partially-built tree that later surfaced as NPEs during recipe runs.
+/// </summary>
+public class NullableDirectiveReceiveTest
+{
+    [Theory]
+    [InlineData("Annotations", NullableTarget.Annotations)]
+    [InlineData("Warnings", NullableTarget.Warnings)]
+    public void ReceivesJsonElementEncodedTarget(string wireValue, NullableTarget expected)
+    {
+        // before: `#nullable enable` (no explicit target)
+        var before = new NullableDirective(Guid.NewGuid(), Space.Empty, Markers.Empty,
+            NullableSetting.Enable, target: null);
+
+        // Messages consumed in order: ConsumePreVisit reads id/prefix/markers, then
+        // VisitNullableDirective reads setting/target/hashSpacing/trailingComment/keywordSpacing.
+        // Only Target changes, arriving as a JsonElement — the real System.Text.Json wire shape.
+        var noChange = new RpcObjectData { State = RpcObjectData.ObjectState.NO_CHANGE };
+        var data = new List<RpcObjectData>
+        {
+            noChange, // id
+            noChange, // prefix
+            noChange, // markers
+            noChange, // setting
+            new()
+            {
+                State = RpcObjectData.ObjectState.CHANGE,
+                Value = JsonSerializer.SerializeToElement(wireValue, RpcJson.Options),
+            }, // target
+            noChange, // hashSpacing
+            noChange, // trailingComment
+            noChange, // keywordSpacing
+        };
+
+        var queue = new RpcReceiveQueue(data, new Dictionary<int, object>(), sourceFileType: null);
+
+        var result = (NullableDirective)new CSharpReceiver().Visit(before, queue)!;
+
+        Assert.Equal(expected, result.Target);
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/CSharpReceiver.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System.Text.Json;
 using OpenRewrite.Core;
 using OpenRewrite.Core.Rpc;
 using OpenRewrite.Java;
@@ -507,12 +508,19 @@ public class CSharpReceiver : CSharpVisitor<RpcReceiveQueue>
     public override J VisitNullableDirective(NullableDirective nd, RpcReceiveQueue q)
     {
         var setting = q.ReceiveAndGet(nd.Setting, RpcReceiveQueue.ToEnum<NullableSetting>());
-        // Target is a nullable enum — receive as object and convert
+        // Target is a nullable enum. NO_CHANGE echoes back the string we seed below;
+        // ADD/CHANGE arrives as a JsonElement (string- or number-encoded enum). The prior
+        // `(NullableTarget)targetObj` fallback threw InvalidCastException on the JsonElement,
+        // aborting receipt of the whole CompilationUnit for any file with a `#nullable`
+        // directive and leaving a partially-built tree (later surfacing as NPEs downstream).
         var targetObj = q.Receive<object?>(nd.Target != null ? nd.Target.Value.ToString() : null);
         NullableTarget? target = targetObj switch
         {
-            string s => Enum.Parse<NullableTarget>(s, true),
             null => null,
+            NullableTarget nt => nt,
+            string s => Enum.Parse<NullableTarget>(s, true),
+            JsonElement { ValueKind: JsonValueKind.String } je => Enum.Parse<NullableTarget>(je.GetString()!, true),
+            JsonElement { ValueKind: JsonValueKind.Number } je => (NullableTarget)je.GetInt32(),
             _ => (NullableTarget)targetObj
         };
         var hashSpacing = q.Receive(nd.HashSpacing)!;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/PluginLoadContext.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/PluginLoadContext.cs
@@ -36,6 +36,15 @@ public class PluginLoadContext : AssemblyLoadContext
         _resolver = new AssemblyDependencyResolver(pluginMainDllPath);
     }
 
+    /// <summary>
+    /// Returns the plugin-private path for <paramref name="assemblyName"/> as declared by the
+    /// plugin's <c>.deps.json</c>, or <c>null</c> when the assembly is not part of the plugin's
+    /// private dependency graph (host/framework assemblies resolve to <c>null</c>). Lets callers
+    /// distinguish a plugin-bundled dependency from a shared host assembly without loading it.
+    /// </summary>
+    public string? ResolvePluginPath(AssemblyName assemblyName) =>
+        _resolver.ResolveAssemblyToPath(assemblyName);
+
     protected override Assembly? Load(AssemblyName assemblyName)
     {
         // If the assembly is already loaded in the Default ALC, return it directly.

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -573,6 +573,7 @@ public class RewriteRpcServer
             var assembly = context.LoadFromAssemblyPath(absolutePath);
             CheckVersionCompatibility(assembly);
             ActivateAssembly(assembly);
+            ActivateDependencyRecipeAssemblies(assembly, context);
         }
         else if (recipesObject is { } packageObj)
         {
@@ -587,6 +588,7 @@ public class RewriteRpcServer
                 var assembly = context.LoadFromAssemblyPath(absolutePath);
                 CheckVersionCompatibility(assembly);
                 ActivateAssembly(assembly);
+                ActivateDependencyRecipeAssemblies(assembly, context);
             }
             else
             {
@@ -647,6 +649,63 @@ public class RewriteRpcServer
             {
                 var activator = (IRecipeActivator)Activator.CreateInstance(type)!;
                 activator.Activate(_marketplace);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Activates the recipe-bearing dependency assemblies of a plugin loaded from a loose DLL.
+    /// </summary>
+    /// <remarks>
+    /// The NuGet install path runs <c>dotnet publish</c>, which surfaces every dependency
+    /// assembly so each gets <see cref="ActivateAssembly"/>'d. A loose DLL registered by file
+    /// path has no such enumeration: the ALC loads a referenced recipe package's types on demand
+    /// (to satisfy a <c>new SomeOtherRecipe()</c> reference) but never runs that package's
+    /// <see cref="IRecipeActivator"/>, so its recipes stay absent from the marketplace. A composite
+    /// recipe that lists a recipe from a referenced package then fails <c>PrepareRecipe</c> with
+    /// "Recipe not found" (e.g. Migration.Dotnet's UpgradeToDotNet10 -> Core's
+    /// ChangeDotNetTargetFramework). Walk the reference graph and activate any plugin-private
+    /// assembly that exposes an activator; host/framework assemblies (including the SDK, already
+    /// activated at startup) resolve to no plugin path and are skipped.
+    /// </remarks>
+    private void ActivateDependencyRecipeAssemblies(Assembly primary, PluginLoadContext context)
+    {
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // The SDK assembly is activated once at startup; the primary plugin just above.
+            Assembly.GetExecutingAssembly().GetName().Name!,
+            primary.GetName().Name!,
+        };
+
+        var queue = new Queue<Assembly>();
+        queue.Enqueue(primary);
+        while (queue.Count > 0)
+        {
+            foreach (var reference in queue.Dequeue().GetReferencedAssemblies())
+            {
+                if (reference.Name == null || !visited.Add(reference.Name))
+                    continue;
+
+                // Only follow plugin-private dependencies (those listed in the plugin's
+                // .deps.json). Shared host/framework assemblies resolve to null here, so the
+                // SDK's activator is never re-run and core recipes are not double-registered.
+                if (context.ResolvePluginPath(reference) == null)
+                    continue;
+
+                Assembly dependency;
+                try
+                {
+                    dependency = context.LoadFromAssemblyName(reference);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning("Could not load dependency {Assembly} for recipe activation: {Error}",
+                        reference.Name, ex.Message);
+                    continue;
+                }
+
+                ActivateAssembly(dependency);
+                queue.Enqueue(dependency);
             }
         }
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -786,7 +786,54 @@ public class SolutionParser
             relativePath.StartsWith("obj/", StringComparison.OrdinalIgnoreCase))
             return false;
 
+        // Skip source files supplied by NuGet packages. Source-only packages (e.g. *.sources,
+        // and any package shipping contentFiles/cs/**) inject .cs files from the global package
+        // cache into the compilation. That is third-party code living outside the repository, so
+        // it must not be parsed into the LST, transformed by recipes, or emitted into fix patches
+        // (which would otherwise target unwritable cache paths and fail to apply).
+        if (IsUnderNuGetCache(doc.FilePath))
+            return false;
+
         return true;
+    }
+
+    private static readonly string[] NuGetCacheRoots = BuildNuGetCacheRoots();
+
+    private static string[] BuildNuGetCacheRoots()
+    {
+        var roots = new List<string>();
+        var configured = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (!string.IsNullOrEmpty(configured))
+        {
+            try { roots.Add(Path.TrimEndingDirectorySeparator(Path.GetFullPath(configured))); }
+            catch { /* ignore malformed NUGET_PACKAGES */ }
+        }
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrEmpty(home))
+            roots.Add(Path.Combine(home, ".nuget", "packages"));
+        return roots.ToArray();
+    }
+
+    /// <summary>
+    /// True when the file lives under the NuGet global package cache (so it is package-provided
+    /// source, not repository source). Matches only the resolved cache roots (NUGET_PACKAGES env
+    /// and the per-user default <c>~/.nuget/packages</c>). A repository may legitimately contain a
+    /// local <c>.nuget/packages</c> directory of its own source, so a bare path-segment match is
+    /// intentionally avoided.
+    /// </summary>
+    private static bool IsUnderNuGetCache(string filePath)
+    {
+        string full;
+        try { full = Path.GetFullPath(filePath); }
+        catch { return false; }
+
+        foreach (var root in NuGetCacheRoots)
+        {
+            if (full.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes three independent robustness bugs in the C# RPC server, each with a regression test. `CSharpReceiver` now handles the `JsonElement`-encoded `NullableTarget` enum instead of throwing `InvalidCastException`, which had aborted receipt of any CompilationUnit containing a targeted `#nullable` directive and left a partially-built tree. `RewriteRpcServer.InstallRecipes` now walks a loose-DLL plugin's reference graph and activates plugin-private dependency recipe assemblies, so cross-package composite recipes resolve instead of failing `PrepareRecipe` with "Recipe not found". `SolutionParser` now skips source files supplied from the NuGet global package cache so third-party package source is not parsed, transformed, or emitted into fix patches targeting unwritable cache paths.