### PR TITLE
Publish NPM snapshot for scheduled CI runs too

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,9 +1,12 @@
 ---
 name: npm-publish
 
-# Publishes after `ci` succeeds for a push to (or manual dispatch on) main, or
-# `publish` succeeds for a version tag. `ci` also runs for PRs and schedules;
-# those must not publish to npm.
+# Publishes after `ci` succeeds for any non-PR event on main (push, manual
+# dispatch, or the daily schedule), or `publish` succeeds for a version tag.
+# This mirrors the Maven snapshot publish in gh-automation's ci-gradle.yml,
+# which publishes for `event_name != 'pull_request'` on main — so npm gets a
+# counterpart for every Maven snapshot. `ci` also runs for PRs; those must not
+# publish to npm.
 on:
   workflow_run:
     workflows:
@@ -24,8 +27,7 @@ jobs:
       (
         (
           github.event.workflow_run.name == 'ci' &&
-          (github.event.workflow_run.event == 'push' ||
-           github.event.workflow_run.event == 'workflow_dispatch') &&
+          github.event.workflow_run.event != 'pull_request' &&
           github.event.workflow_run.head_branch == 'main'
         ) ||
         (


### PR DESCRIPTION
**Why**:
We have observed that at times there would be a snapshot version published to Maven, while there would be no corresponding snapshot published to NPM. Which is a problem as our JavaScript RPC architecture assumes there's a NPM corresponding artifact with the same version number.
The most recent example is:
- rewrite-core-8.85.0-20260615.175709-75.jar published to Maven 👍 
- no corresponding artifact in NPM

**What**:
Changing the trigger conditions for the `npm-publish` flow to mimic closer what we have for the Maven flow.