### PR TITLE
Scala: introduce `S.Try` for complicated cases of try-catch

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaIsoVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaIsoVisitor.java
@@ -224,6 +224,11 @@ public class ScalaIsoVisitor<P> extends ScalaVisitor<P> {
     }
 
     @Override
+    public S.Try visitSTry(S.Try tryable, P p) {
+        return (S.Try) super.visitSTry(tryable, p);
+    }
+
+    @Override
     public J.InstanceOf visitInstanceOf(J.InstanceOf instanceOf, P p) {
         return (J.InstanceOf) super.visitInstanceOf(instanceOf, p);
     }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -301,6 +301,42 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
         return tryable;
     }
 
+    public J visitSTry(S.Try tryable, PrintOutputCapture<P> p) {
+        beforeSyntax(tryable, Space.Location.TRY_PREFIX, p);
+        p.append("try");
+        visit(tryable.getBody(), p);
+        JLeftPadded<J.Block> catches = tryable.getPadding().getCatches();
+        if (catches != null) {
+            visitSpace(catches.getBefore(), Space.Location.CATCH_PREFIX, p);
+            p.append("catch");
+            J.Block cases = catches.getElement();
+            boolean omitBraces = cases.getMarkers().findFirst(org.openrewrite.scala.marker.OmitBraces.class).isPresent();
+            visitSpace(cases.getPrefix(), Space.Location.BLOCK_PREFIX, p);
+            if (!omitBraces) {
+                p.append("{");
+            }
+            for (JRightPadded<Statement> rp : cases.getPadding().getStatements()) {
+                visit(rp.getElement(), p);
+                visitSpace(rp.getAfter(), Space.Location.LANGUAGE_EXTENSION, p);
+                if (rp.getMarkers().findFirst(Semicolon.class).isPresent()) {
+                    p.append(';');
+                }
+            }
+            visitSpace(cases.getEnd(), Space.Location.BLOCK_END, p);
+            if (!omitBraces) {
+                p.append("}");
+            }
+        }
+        JLeftPadded<J.Block> finalizer = tryable.getPadding().getFinalizer();
+        if (finalizer != null) {
+            visitSpace(finalizer.getBefore(), Space.Location.TRY_FINALLY, p);
+            p.append("finally");
+            visit(finalizer.getElement(), p);
+        }
+        afterSyntax(tryable, p);
+        return tryable;
+    }
+
     @Override
     public J visitSwitch(J.Switch switch_, PrintOutputCapture<P> p) {
         beforeSyntax(switch_, Space.Location.SWITCH_PREFIX, p);
@@ -672,6 +708,8 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             return visitFor((S.For) tree, p);
         } else if (tree instanceof S.For.Enumerator) {
             return visitForEnumerator((S.For.Enumerator) tree, p);
+        } else if (tree instanceof S.Try) {
+            return visitSTry((S.Try) tree, p);
         }
         return super.visit(tree, p);
     }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaVisitor.java
@@ -409,6 +409,20 @@ public class ScalaVisitor<P> extends JavaVisitor<P> {
         return f;
     }
 
+    public J visitSTry(S.Try tryable, P p) {
+        S.Try t = tryable;
+        t = t.withPrefix(visitSpace(t.getPrefix(), Space.Location.TRY_PREFIX, p));
+        t = t.withMarkers(visitMarkers(t.getMarkers(), p));
+        t = t.withBody(visitAndCast(t.getBody(), p));
+        if (t.getPadding().getCatches() != null) {
+            t = t.getPadding().withCatches(visitLeftPadded(t.getPadding().getCatches(), JLeftPadded.Location.LANGUAGE_EXTENSION, p));
+        }
+        if (t.getPadding().getFinalizer() != null) {
+            t = t.getPadding().withFinalizer(visitLeftPadded(t.getPadding().getFinalizer(), JLeftPadded.Location.TRY_FINALLY, p));
+        }
+        return t;
+    }
+
     public J visitForEnumerator(S.For.Enumerator enumerator, P p) {
         S.For.Enumerator e = enumerator;
         e = e.withPrefix(visitSpace(e.getPrefix(), Space.Location.LANGUAGE_EXTENSION, p));

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/internal/ScalaTryBuilder.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/internal/ScalaTryBuilder.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.internal;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.scala.marker.IndentedSyntax;
+import org.openrewrite.scala.marker.OmitBraces;
+import org.openrewrite.scala.marker.Semicolon;
+import org.openrewrite.scala.marker.TypeAscriptionColonPrefix;
+import org.openrewrite.scala.tree.S;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Builds the LST node for a Scala {@code try}/{@code catch}/{@code finally}, deciding between
+ * the Java model ({@link J.Try}) and the Scala-specific {@link S.Try}.
+ * <p>
+ * OpenRewrite favours fitting Scala into {@code J.*} types so Java recipes apply: the common
+ * {@code [name][: Type]} (guard-free) catch maps cleanly onto {@link J.Try.Catch}
+ * ({@code catch (Type name)}), so a {@link J.Try} is emitted whenever every clause fits. Only
+ * Scala-specific patterns (extractors, alternatives, at-bindings) or guards — which
+ * {@code J.Try.Catch}'s fixed {@code ControlParentheses<VariableDeclarations>} cannot hold —
+ * fall back to {@link S.Try} (which models the handler as a {@code J.Block} of {@code J.Case}).
+ * <p>
+ * This logic lives in Java rather than {@code ScalaTreeVisitor.scala} because it reads
+ * Lombok-generated getters on same-module {@code S.*} types, which are invisible to the Scala
+ * joint compiler (it sees {@code S.java} as source, before Lombok runs).
+ */
+public final class ScalaTryBuilder {
+
+    private ScalaTryBuilder() {
+    }
+
+    /**
+     * @param prefix    space before the {@code try} keyword
+     * @param body      the try body
+     * @param catches   the catch handler as a {@code J.Block} of {@code J.Case}; before-space is
+     *                  the space before {@code catch}, an {@code OmitBraces} marker means Scala 3's
+     *                  brace-less {@code catch case} form. {@code null} when there is no catch.
+     * @param finalizer the finalizer block; before-space is the space before {@code finally}
+     */
+    public static J buildTry(Space prefix, J.Block body, @Nullable JLeftPadded<J.Block> catches,
+                             @Nullable JLeftPadded<J.Block> finalizer) {
+        if (catches == null || catchesFitJModel(catches.getElement())) {
+            return buildJTry(prefix, body, catches, finalizer);
+        }
+        boolean braceless = catches.getElement().getMarkers().findFirst(OmitBraces.class).isPresent();
+        Markers tryMarkers = braceless ?
+                Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId()))) :
+                Markers.EMPTY;
+        return S.Try.build(Tree.randomId(), prefix, tryMarkers, body, catches, finalizer, null);
+    }
+
+    /** True when every clause is a guard-free {@code [name][: Type]} catch, expressible as a {@code J.Try.Catch}. */
+    private static boolean catchesFitJModel(J.Block casesBlock) {
+        for (JRightPadded<Statement> rp : casesBlock.getPadding().getStatements()) {
+            if (rp.getMarkers().findFirst(Semicolon.class).isPresent()) {
+                return false;
+            }
+            if (!(rp.getElement() instanceof J.Case)) {
+                return false;
+            }
+            J.Case c = (J.Case) rp.getElement();
+            if (c.getGuard() != null || c.getPadding().getCaseLabels().getElements().size() != 1) {
+                return false;
+            }
+            J label = c.getPadding().getCaseLabels().getElements().get(0);
+            if (label instanceof S.TypeAscription) {
+                S.TypeAscription ta = (S.TypeAscription) label;
+                boolean nameOk = ta.getExpression() instanceof J.Identifier || ta.getExpression() instanceof S.Wildcard;
+                boolean typeOk = ta.getTypeTree() instanceof J.Identifier || ta.getTypeTree() instanceof J.FieldAccess;
+                if (!nameOk || !typeOk) {
+                    return false;
+                }
+            } else if (!(label instanceof J.Identifier) && !(label instanceof S.Wildcard)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Convert the {@code J.Block} of {@code J.Case} catch handler into {@code J.Try}'s list of {@code J.Try.Catch}. */
+    private static J.Try buildJTry(Space prefix, J.Block body, @Nullable JLeftPadded<J.Block> catches,
+                                   @Nullable JLeftPadded<J.Block> finalizer) {
+        List<J.Try.Catch> catchList = new ArrayList<>();
+        boolean braceless = false;
+        if (catches != null) {
+            J.Block casesBlock = catches.getElement();
+            braceless = casesBlock.getMarkers().findFirst(OmitBraces.class).isPresent();
+            Space beforeCatch = catches.getBefore();
+            Space blockPrefix = casesBlock.getPrefix();
+            List<JRightPadded<Statement>> rps = casesBlock.getPadding().getStatements();
+            for (int i = 0; i < rps.size(); i++) {
+                J.Case c = (J.Case) rps.get(i).getElement();
+                JRightPadded<J> labelRp = c.getPadding().getCaseLabels().getPadding().getElements().get(0);
+                J label = labelRp.getElement();
+
+                J.Identifier nameId;
+                TypeTree typeTree;
+                Space beforeColon;
+                if (label instanceof S.TypeAscription) {
+                    S.TypeAscription ta = (S.TypeAscription) label;
+                    // The space after `case` is on the ascription's own prefix, not the inner expr.
+                    nameId = ta.getExpression() instanceof J.Identifier ?
+                            ((J.Identifier) ta.getExpression()).withPrefix(ta.getPrefix()) :
+                            ident("_", ta.getPrefix());
+                    Optional<TypeAscriptionColonPrefix> bc = ta.getMarkers().findFirst(TypeAscriptionColonPrefix.class);
+                    beforeColon = bc.map(TypeAscriptionColonPrefix::getPrefix).orElse(null);
+                    typeTree = ta.getTypeTree();
+                } else if (label instanceof S.Wildcard) {
+                    nameId = ident("_", ((S.Wildcard) label).getPrefix());
+                    typeTree = null;
+                    beforeColon = null;
+                } else {
+                    nameId = (J.Identifier) label;
+                    typeTree = null;
+                    beforeColon = null;
+                }
+
+                J.Block caseBody = wrapCatchBody(c.getPadding().getBody());
+                J.VariableDeclarations.NamedVariable namedVar = new J.VariableDeclarations.NamedVariable(
+                        Tree.randomId(), Space.EMPTY, Markers.EMPTY, nameId, Collections.emptyList(), null, null);
+                J.VariableDeclarations varDecl = new J.VariableDeclarations(Tree.randomId(), c.getPrefix(), Markers.EMPTY,
+                        Collections.emptyList(), Collections.emptyList(), typeTree, beforeColon,
+                        Collections.emptyList(), Collections.singletonList(JRightPadded.build(namedVar)));
+                // For the first catch the J.Try printer emits the catch keyword then the brace, so its
+                // parameter prefix carries the space before `{`; subsequent catches don't reprint it.
+                Space controlPrefix = i == 0 ? blockPrefix : Space.EMPTY;
+                J.ControlParentheses<J.VariableDeclarations> controlParens = new J.ControlParentheses<>(
+                        Tree.randomId(), controlPrefix, Markers.EMPTY,
+                        JRightPadded.build(varDecl).withAfter(labelRp.getAfter()));
+                Space catchPrefix = i == 0 ? beforeCatch : c.getPrefix();
+                catchList.add(new J.Try.Catch(Tree.randomId(), catchPrefix, Markers.EMPTY, controlParens, caseBody));
+            }
+            // The space before the closing `}` lives on the cases-block end; in J.Try it belongs to
+            // the last catch body's end space.
+            if (!braceless && !catchList.isEmpty()) {
+                J.Try.Catch last = catchList.get(catchList.size() - 1);
+                catchList.set(catchList.size() - 1, last.withBody(last.getBody().withEnd(casesBlock.getEnd())));
+            }
+        }
+        Markers tryMarkers = braceless ?
+                Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId()))) :
+                Markers.EMPTY;
+        return new J.Try(Tree.randomId(), prefix, tryMarkers, null, body, catchList, finalizer);
+    }
+
+    /** Wrap a catch-clause body (a bare {@code J} on {@code J.Case}) in an OmitBraces {@code J.Block} as {@code J.Try.Catch} requires. */
+    private static J.Block wrapCatchBody(@Nullable JRightPadded<J> bodyRp) {
+        Markers omit = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())));
+        if (bodyRp == null) {
+            return emptyBlock(omit);
+        }
+        J body = bodyRp.getElement();
+        if (body instanceof J.Block && ((J.Block) body).getMarkers().findFirst(OmitBraces.class).isPresent()) {
+            return (J.Block) body;
+        } else if (body instanceof J.Block) {
+            return shell(omit, (J.Block) body);
+        } else if (body instanceof Statement) {
+            return shell(omit, (Statement) body);
+        } else if (body instanceof Expression) {
+            return shell(omit, new S.ExpressionStatement(Tree.randomId(), (Expression) body));
+        }
+        return emptyBlock(omit);
+    }
+
+    private static J.Block shell(Markers omit, Statement stmt) {
+        List<JRightPadded<Statement>> s = new ArrayList<>();
+        s.add(JRightPadded.build(stmt));
+        return new J.Block(Tree.randomId(), Space.EMPTY, omit, JRightPadded.build(false), s, Space.EMPTY);
+    }
+
+    private static J.Block emptyBlock(Markers omit) {
+        return new J.Block(Tree.randomId(), Space.EMPTY, omit, JRightPadded.build(false), new ArrayList<>(), Space.EMPTY);
+    }
+
+    private static J.Identifier ident(String name, Space prefix) {
+        return new J.Identifier(Tree.randomId(), prefix, Markers.EMPTY, Collections.emptyList(), name, null, null);
+    }
+}

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -2778,4 +2778,134 @@ public interface S extends J {
             return new CoordinateBuilder.Expression(this);
         }
     }
+
+    /**
+     * Scala {@code try}/{@code catch}/{@code finally}. Unlike {@link J.Try}, whose catch
+     * clauses are restricted to {@code ControlParentheses<VariableDeclarations>}, the catch
+     * handler in Scala is a partial function whose clauses can hold arbitrary patterns
+     * (extractors like {@code NonFatal(e)}, alternatives like {@code _: A | _: B}, and
+     * at-bindings like {@code e @ (_: C)}). The handler is therefore modelled as a
+     * {@link J.Block} of {@link J.Case}, exactly like a {@code match} block, so those rich
+     * patterns are preserved instead of being crammed into an identifier name.
+     * <p>
+     * Examples:
+     * <pre>{@code
+     * try { risky() } catch { case NonFatal(e) => log(e) } finally { cleanup() }
+     * try risky() catch case _: IOException => recover()   // Scala 3 brace-less
+     * }</pre>
+     */
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class Try implements S, Expression, Statement {
+
+        @Nullable
+        @NonFinal
+        transient WeakReference<Padding> padding;
+
+        @With @Getter @EqualsAndHashCode.Include
+        UUID id;
+
+        @With @Getter
+        Space prefix;
+
+        @With @Getter
+        Markers markers;
+
+        @With @Getter
+        J.Block body;
+
+        /**
+         * The catch handler. The padding's before-space is the space before the
+         * {@code catch} keyword; the element is a {@link J.Block} of {@link J.Case} whose
+         * prefix is the space before the opening {@code {} (empty for the brace-less form,
+         * flagged by an {@code OmitBraces} marker on the block).
+         */
+        @Nullable
+        JLeftPadded<J.Block> catches;
+
+        /**
+         * The finalizer. The padding's before-space is the space before the
+         * {@code finally} keyword; the element is the finalizer block.
+         */
+        @Nullable
+        JLeftPadded<J.Block> finalizer;
+
+        @With @Getter
+        @Nullable
+        JavaType type;
+
+        public static S.Try build(UUID id, Space prefix, Markers markers, J.Block body,
+                                @Nullable JLeftPadded<J.Block> catches,
+                                @Nullable JLeftPadded<J.Block> finalizer, @Nullable JavaType type) {
+            return new S.Try(null, id, prefix, markers, body, catches, finalizer, type);
+        }
+
+        public J.@Nullable Block getCatches() {
+            return catches == null ? null : catches.getElement();
+        }
+
+        public S.Try withCatches(J.@Nullable Block catches) {
+            return getPadding().withCatches(catches == null ? null :
+                    (this.catches == null ? JLeftPadded.build(catches) : this.catches.withElement(catches)));
+        }
+
+        public J.@Nullable Block getFinalizer() {
+            return finalizer == null ? null : finalizer.getElement();
+        }
+
+        public S.Try withFinalizer(J.@Nullable Block finalizer) {
+            return getPadding().withFinalizer(finalizer == null ? null :
+                    (this.finalizer == null ? JLeftPadded.build(finalizer) : this.finalizer.withElement(finalizer)));
+        }
+
+        @Override
+        public <P> J acceptScala(ScalaVisitor<P> v, P p) {
+            return v.visitSTry(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Statement getCoordinates() {
+            return new CoordinateBuilder.Statement(this);
+        }
+
+        public Padding getPadding() {
+            Padding p;
+            if (this.padding == null) {
+                p = new Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final S.Try t;
+
+            public @Nullable JLeftPadded<J.Block> getCatches() {
+                return t.catches;
+            }
+
+            public S.Try withCatches(@Nullable JLeftPadded<J.Block> catches) {
+                return t.catches == catches ? t :
+                        new S.Try(null, t.id, t.prefix, t.markers, t.body, catches, t.finalizer, t.type);
+            }
+
+            public @Nullable JLeftPadded<J.Block> getFinalizer() {
+                return t.finalizer;
+            }
+
+            public S.Try withFinalizer(@Nullable JLeftPadded<J.Block> finalizer) {
+                return t.finalizer == finalizer ? t :
+                        new S.Try(null, t.id, t.prefix, t.markers, t.body, t.catches, finalizer, t.type);
+            }
+        }
+    }
 }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -6924,7 +6924,6 @@ class ScalaTreeVisitor(
 
   private def visitParsedTry(parsedTry: untpd.ParsedTry): J = {
     // ParsedTry is the untpd version: has expr, handler (a Match), finalizer
-    // Extract cases from the handler Match and delegate to common try logic
     val prefix = extractPrefix(parsedTry.span)
 
     // Advance past "try" keyword
@@ -6935,324 +6934,120 @@ class ScalaTreeVisitor(
       if (tryIdx >= 0) cursor = cursor + tryIdx + 3
     }
 
-    // Visit the try body
-    val omitBracesMarkers = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
-    val body = visitTree(parsedTry.expr) match {
-      case block: J.Block => block
-      case stmt: Statement =>
-        val stmts = new util.ArrayList[JRightPadded[Statement]]()
-        stmts.add(JRightPadded.build(stmt))
-        new J.Block(Tree.randomId(), Space.EMPTY, omitBracesMarkers, JRightPadded.build(false), stmts, Space.EMPTY)
-      case expr: Expression =>
-        val stmts = new util.ArrayList[JRightPadded[Statement]]()
-        stmts.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
-        new J.Block(Tree.randomId(), Space.EMPTY, omitBracesMarkers, JRightPadded.build(false), stmts, Space.EMPTY)
-      case _ => visitUnknown(parsedTry)
-    }
+    val body = buildTryBody(parsedTry.expr)
 
-    // Handle catch handler
-      val catches = new util.ArrayList[J.Try.Catch]()
-    var catchHasBraces = true
-    if (!parsedTry.handler.isEmpty && parsedTry.handler.span.exists) {
-      val catchAbs = positionOfNext("catch")
-      val catchPrefix = if (catchAbs > cursor) ScalaSpace.format(source, cursor, catchAbs) else Space.EMPTY
-      if (catchAbs >= cursor) cursor = catchAbs + 5
-      // Scala 3 `catch case ... =>` (no braces) — only consume `{` if it appears before the first `case`.
-      val braceSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 200, source.length)) else ""
-      val braceIdx = positionOfNextIn(braceSearch, "{", 0)
-      val firstCaseIdx = positionOfNextIn(braceSearch, "case", 0)
-      catchHasBraces = braceIdx >= 0 && (firstCaseIdx < 0 || braceIdx < firstCaseIdx)
-      val catchBraceSpace = if (catchHasBraces && braceIdx > 0) Space.format(braceSearch.substring(0, braceIdx)) else Space.EMPTY
-      if (catchHasBraces) cursor = cursor + braceIdx + 1
-
-      // The handler should be a Match tree containing the case defs
-      val cases: List[Trees.CaseDef[?]] = parsedTry.handler match {
-        case matchTree: Trees.Match[?] => matchTree.cases
-        case _ => Nil
-      }
-
-      for (caseDef <- cases) {
-        val casePrefix = extractPrefix(caseDef.span)
-        val caseStart = Math.max(0, caseDef.span.start - offsetAdjustment)
-        if (caseStart >= cursor) cursor = caseStart
-        val caseSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 20, source.length)) else ""
-        val caseKwIdx = positionOfNextIn(caseSearch, "case", 0)
-        if (caseKwIdx >= 0) cursor = cursor + caseKwIdx + 4
-
-        val arrowSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 200, source.length)) else ""
-        val arrowIdx = positionOfNextIn(arrowSearch, "=>", 0)
-
-        // Extract param name and type from the catch pattern without disturbing cursor.
-        // Handles: `e: Exception`, `_: A | _: B` (Alternative), `_` (wildcard)
-        val (paramName, paramType): (String, TypeTree) = caseDef.pat match {
-          case bind: Trees.Bind[?] => bind.body match {
-            case typed: Trees.Typed[?] =>
-              val tpeName = typed.tpt match { case id: Trees.Ident[?] => id.name.toString; case sel: Trees.Select[?] => extractSource(sel.span); case _ => null }
-              (bind.name.toString, if (tpeName != null) ident(tpeName, Space.format(" ")) else null)
-            case _ =>
-              // e.g. `e @ (_: A | _: B)` — bind over an Alternative (or other pattern);
-              // preserve the full source so the `@ (...)` part isn't lost on print.
-              val patSource = if (caseDef.pat.span.exists) extractSource(caseDef.pat.span) else ""
-              (if (patSource.nonEmpty) patSource else bind.name.toString, null)
-          }
-          case typed: Trees.Typed[?] =>
-            val name = typed.expr match { case id: Trees.Ident[?] => id.name.toString; case _ => "_" }
-            val tpeName = typed.tpt match { case id: Trees.Ident[?] => id.name.toString; case sel: Trees.Select[?] => extractSource(sel.span); case _ => null }
-            (name, if (tpeName != null) ident(tpeName, Space.format(" ")) else null)
-          case alt: Trees.Alternative[?] =>
-            // Multi-pattern: `_: A | _: B` — preserve full source as the "name", no separate type
-            val patSource = extractSource(caseDef.pat.span)
-            (patSource, null)
-          case _ =>
-            // Any other pattern (e.g. UnApply extractor `NonFatal(e)`, tuple, literal) —
-            // preserve the full source text so the binding/extractor isn't lost on print.
-            val patSource = if (caseDef.pat.span.exists) extractSource(caseDef.pat.span) else ""
-            (if (patSource.nonEmpty) patSource else "_", null)
+    // The handler is a synthetic Match whose case clauses are the catch patterns.
+    val catches: JLeftPadded[J.Block] =
+      if (!parsedTry.handler.isEmpty && parsedTry.handler.span.exists) {
+        val cases: List[Trees.CaseDef[?]] = parsedTry.handler match {
+          case matchTree: Trees.Match[?] => matchTree.cases
+          case _ => Nil
         }
-        // Capture the whitespace between the param name and `:` (e.g. `e : Exception`).
-        val beforeColon: Space = if (paramType != null && caseDef.pat.span.exists) {
-          val patStart = Math.max(0, caseDef.pat.span.start - offsetAdjustment)
-          val patEnd = Math.max(0, caseDef.pat.span.end - offsetAdjustment)
-          val patSrc = if (patStart < patEnd && patEnd <= source.length) source.substring(patStart, patEnd) else ""
-          val colonAt = positionOfNextIn(patSrc, ":", 0)
-          val nameAt = if (paramName.nonEmpty) positionOfNextIn(patSrc, paramName, 0) else -1
-          if (colonAt > 0 && nameAt >= 0 && nameAt + paramName.length <= colonAt) {
-            Space.format(patSrc.substring(nameAt + paramName.length, colonAt))
-          } else Space.EMPTY
-        } else Space.EMPTY
-        updateCursor(caseDef.pat.span.end)
-        val arrowAbs = positionOfNext("=>", cursor)
-        val spaceBeforeArrow = if (arrowAbs >= cursor) ScalaSpace.format(source, cursor, arrowAbs) else Space.EMPTY
-        if (arrowIdx >= 0 && arrowAbs >= 0) cursor = arrowAbs + 2
+        buildCatchBlock(cases)
+      } else null
 
-        val paramId = ident(paramName, Space.format(" "))
-        val namedVar = new J.VariableDeclarations.NamedVariable(Tree.randomId(), Space.EMPTY, Markers.EMPTY, paramId, Collections.emptyList(), null, null)
-        val varDecl = new J.VariableDeclarations(Tree.randomId(), casePrefix, Markers.EMPTY,
-          Collections.emptyList(), Collections.emptyList(), paramType,
-          if (beforeColon != Space.EMPTY) beforeColon else null,
-          Collections.emptyList(),
-          Collections.singletonList(JRightPadded.build(namedVar)))
-        val controlPrefix = if (catches.isEmpty) catchBraceSpace else Space.EMPTY
-        val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), controlPrefix, Markers.EMPTY, JRightPadded.build(varDecl).withAfter(spaceBeforeArrow))
-
-        val caseBodyOmitBraces = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
-        val caseBody = visitTree(caseDef.body) match {
-          case block: J.Block if block.getMarkers.findFirst(classOf[OmitBraces]).isPresent => block
-          case block: J.Block =>
-            // Block has its own braces (e.g. `case _ => { stmts }`). Wrap it in an
-            // OmitBraces shell so the inner block keeps its own end space and the
-            // shell can carry the catch's trailing space (before the outer `}`).
-            val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(block))
-            new J.Block(Tree.randomId(), Space.EMPTY, caseBodyOmitBraces,
-              JRightPadded.build(false), s, Space.EMPTY)
-          case stmt: Statement =>
-            val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(stmt))
-            new J.Block(Tree.randomId(), Space.EMPTY, caseBodyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
-          case expr: Expression =>
-            val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
-            new J.Block(Tree.randomId(), Space.EMPTY, caseBodyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
-          case _ => new J.Block(Tree.randomId(), Space.EMPTY, caseBodyOmitBraces, JRightPadded.build(false), new util.ArrayList(), Space.EMPTY)
-        }
-        updateCursor(caseDef.span.end)
-        val thisCatchPrefix = if (catches.isEmpty) catchPrefix else casePrefix
-        catches.add(new J.Try.Catch(Tree.randomId(), thisCatchPrefix, Markers.EMPTY, controlParens, caseBody))
-      }
-      // Extract end space before closing '}'  and set it on the last catch body
-      if (catchHasBraces && cursor < source.length) {
-        val ci = positionOfNext("}")
-        if (ci >= cursor) {
-          val endSpace = if (ci > cursor) ScalaSpace.format(source, cursor, ci) else Space.EMPTY
-          // Update last catch body's end space
-          if (!catches.isEmpty) {
-            val lastCatch = catches.get(catches.size - 1)
-            val updatedBody = lastCatch.getBody.withEnd(endSpace)
-            catches.set(catches.size - 1, lastCatch.withBody(updatedBody))
-          }
-          cursor = ci + 1
-        }
-      }
-    }
-
-    // Handle finalizer
-    val finallyBlock: JLeftPadded[J.Block] = if (!parsedTry.finalizer.isEmpty && parsedTry.finalizer.span.exists) {
-      val finallyAbs = positionOfNext("finally")
-      val fSpace = if (finallyAbs > cursor) ScalaSpace.format(source, cursor, finallyAbs) else Space.EMPTY
-      if (finallyAbs >= cursor) cursor = finallyAbs + 7
-      val parsedFinallyOmitBraces = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
-      val fb = visitTree(parsedTry.finalizer) match {
-        case block: J.Block => block
-        case stmt: Statement =>
-          val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(stmt))
-          new J.Block(Tree.randomId(), Space.EMPTY, parsedFinallyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
-        case expr: Expression =>
-          val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
-          new J.Block(Tree.randomId(), Space.EMPTY, parsedFinallyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
-        case _ => null
-      }
-      if (fb != null) JLeftPadded.build(fb).withBefore(fSpace) else null
-    } else null
+    val finallyBlock = buildTryFinalizer(parsedTry.finalizer)
 
     updateCursor(parsedTry.span.end)
-    val tryMarkers = if (catchHasBraces) Markers.EMPTY
-      else Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId())))
-    new J.Try(Tree.randomId(), prefix, tryMarkers, null, body, catches, finallyBlock)
+    buildSTry(prefix, body, catches, finallyBlock)
   }
 
-  private def visitTryImpl(tryTree: Trees.Try[?]): J.Try = {
+  private def visitTryImpl(tryTree: Trees.Try[?]): J = {
     val prefix = extractPrefix(tryTree.span)
     val tryStart = Math.max(0, tryTree.span.start - offsetAdjustment)
     if (tryStart >= cursor && tryStart + 3 <= source.length) cursor = tryStart + 3
 
+    val body = buildTryBody(tryTree.expr)
+
+    val catches: JLeftPadded[J.Block] =
+      if (tryTree.cases.nonEmpty) buildCatchBlock(tryTree.cases.toList) else null
+
+    val finallyBlock = buildTryFinalizer(tryTree.finalizer)
+
+    updateCursor(tryTree.span.end)
+    buildSTry(prefix, body, catches, finallyBlock)
+  }
+
+  /** Visit the `try` body, wrapping a bare statement/expression in an OmitBraces block. */
+  private def buildTryBody(expr: Trees.Tree[?]): J.Block = {
     val omitBracesMarkers = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
-    val body = visitTree(tryTree.expr) match {
+    visitTree(expr) match {
       case block: J.Block => block
       case stmt: Statement =>
         val stmts = new util.ArrayList[JRightPadded[Statement]]()
         stmts.add(JRightPadded.build(stmt))
         new J.Block(Tree.randomId(), Space.EMPTY, omitBracesMarkers, JRightPadded.build(false), stmts, Space.EMPTY)
-      case expr: Expression =>
+      case e: Expression =>
         val stmts = new util.ArrayList[JRightPadded[Statement]]()
-        stmts.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
+        stmts.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), e)))
         new J.Block(Tree.randomId(), Space.EMPTY, omitBracesMarkers, JRightPadded.build(false), stmts, Space.EMPTY)
-      case _ => return visitUnknown(tryTree).asInstanceOf[J.Try]
+      case other => throw new IllegalStateException(
+        s"try body must map to a Block, Statement, or Expression, got: ${if (other == null) "null" else other.getClass.getName}")
     }
+  }
 
-    val catches = new util.ArrayList[J.Try.Catch]()
-    var catchHasBraces = true
-    if (tryTree.cases.nonEmpty) {
-      // Extract space before "catch" keyword — this becomes the first Catch's prefix
-      val catchAbs = positionOfNext("catch")
-      val catchPrefix = if (catchAbs > cursor) ScalaSpace.format(source, cursor, catchAbs) else Space.EMPTY
-      if (catchAbs >= cursor) cursor = catchAbs + 5
-      // Scala 3 `catch case ... =>` (no braces) — only consume `{` if it appears before the first `case`.
-      val braceSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 200, source.length)) else ""
-      val braceIdx = positionOfNextIn(braceSearch, "{", 0)
-      val firstCaseIdx = positionOfNextIn(braceSearch, "case", 0)
-      catchHasBraces = braceIdx >= 0 && (firstCaseIdx < 0 || braceIdx < firstCaseIdx)
-      val catchBraceSpace = if (catchHasBraces && braceIdx > 0) Space.format(braceSearch.substring(0, braceIdx)) else Space.EMPTY
-      if (catchHasBraces) cursor = cursor + braceIdx + 1
+  /**
+   * Build the catch handler as a `J.Block` of `J.Case`, reusing [[buildCase]] so the
+   * patterns (extractors, alternatives, at-bindings) are richly modelled rather than
+   * crammed into an identifier. The returned padding's before-space is the space before
+   * `catch`; the block prefix is the space before `{` (empty + OmitBraces for Scala 3's
+   * brace-less `catch case` form).
+   */
+  private def buildCatchBlock(cases: List[Trees.CaseDef[?]]): JLeftPadded[J.Block] = {
+    val catchAbs = positionOfNext("catch")
+    val beforeCatch = if (catchAbs > cursor) ScalaSpace.format(source, cursor, catchAbs) else Space.EMPTY
+    if (catchAbs >= cursor) cursor = catchAbs + 5
+    // Scala 3 `catch case ... =>` (no braces) — only consume `{` if it appears before the first `case`.
+    val braceSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 200, source.length)) else ""
+    val braceIdx = positionOfNextIn(braceSearch, "{", 0)
+    val firstCaseIdx = positionOfNextIn(braceSearch, "case", 0)
+    val hasBraces = braceIdx >= 0 && (firstCaseIdx < 0 || braceIdx < firstCaseIdx)
+    val blockPrefix = if (hasBraces && braceIdx > 0) Space.format(braceSearch.substring(0, braceIdx)) else Space.EMPTY
+    if (hasBraces) cursor = cursor + braceIdx + 1
 
-      for (caseDef <- tryTree.cases) {
-        val casePrefix = extractPrefix(caseDef.span)
-        val caseStart = Math.max(0, caseDef.span.start - offsetAdjustment)
-        if (caseStart >= cursor) cursor = caseStart
-        val caseSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 20, source.length)) else ""
-        val caseKwIdx = positionOfNextIn(caseSearch, "case", 0)
-        if (caseKwIdx >= 0) cursor = cursor + caseKwIdx + 4
+    val caseStatements = new util.ArrayList[JRightPadded[Statement]]()
+    for (caseDef <- cases) caseStatements.add(buildCase(caseDef))
 
-        val arrowSearch = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 200, source.length)) else ""
-        val arrowIdx = positionOfNextIn(arrowSearch, "=>", 0)
-
-        // Extract param name and type from the catch pattern without disturbing cursor.
-        // Handles: `e: Exception`, `_: A | _: B` (Alternative), `_` (wildcard)
-        val (paramName, paramType): (String, TypeTree) = caseDef.pat match {
-          case bind: Trees.Bind[?] => bind.body match {
-            case typed: Trees.Typed[?] =>
-              val tpeName = typed.tpt match { case id: Trees.Ident[?] => id.name.toString; case sel: Trees.Select[?] => extractSource(sel.span); case _ => null }
-              (bind.name.toString, if (tpeName != null) ident(tpeName, Space.format(" ")) else null)
-            case _ =>
-              // e.g. `e @ (_: A | _: B)` — bind over an Alternative (or other pattern);
-              // preserve the full source so the `@ (...)` part isn't lost on print.
-              val patSource = if (caseDef.pat.span.exists) extractSource(caseDef.pat.span) else ""
-              (if (patSource.nonEmpty) patSource else bind.name.toString, null)
-          }
-          case typed: Trees.Typed[?] =>
-            val name = typed.expr match { case id: Trees.Ident[?] => id.name.toString; case _ => "_" }
-            val tpeName = typed.tpt match { case id: Trees.Ident[?] => id.name.toString; case sel: Trees.Select[?] => extractSource(sel.span); case _ => null }
-            (name, if (tpeName != null) ident(tpeName, Space.format(" ")) else null)
-          case alt: Trees.Alternative[?] =>
-            // Multi-pattern: `_: A | _: B` — preserve full source as the "name", no separate type
-            val patSource = extractSource(caseDef.pat.span)
-            (patSource, null)
-          case _ =>
-            // Any other pattern (e.g. UnApply extractor `NonFatal(e)`, tuple, literal) —
-            // preserve the full source text so the binding/extractor isn't lost on print.
-            val patSource = if (caseDef.pat.span.exists) extractSource(caseDef.pat.span) else ""
-            (if (patSource.nonEmpty) patSource else "_", null)
-        }
-        // Capture the whitespace between the param name and `:` (e.g. `e : Exception`).
-        val beforeColon: Space = if (paramType != null && caseDef.pat.span.exists) {
-          val patStart = Math.max(0, caseDef.pat.span.start - offsetAdjustment)
-          val patEnd = Math.max(0, caseDef.pat.span.end - offsetAdjustment)
-          val patSrc = if (patStart < patEnd && patEnd <= source.length) source.substring(patStart, patEnd) else ""
-          val colonAt = positionOfNextIn(patSrc, ":", 0)
-          val nameAt = if (paramName.nonEmpty) positionOfNextIn(patSrc, paramName, 0) else -1
-          if (colonAt > 0 && nameAt >= 0 && nameAt + paramName.length <= colonAt) {
-            Space.format(patSrc.substring(nameAt + paramName.length, colonAt))
-          } else Space.EMPTY
-        } else Space.EMPTY
-        updateCursor(caseDef.pat.span.end)
-        val arrowAbs = positionOfNext("=>", cursor)
-        val spaceBeforeArrow = if (arrowAbs >= cursor) ScalaSpace.format(source, cursor, arrowAbs) else Space.EMPTY
-        if (arrowIdx >= 0 && arrowAbs >= 0) cursor = arrowAbs + 2
-
-        val paramId = ident(paramName, Space.format(" "))
-        val namedVar = new J.VariableDeclarations.NamedVariable(Tree.randomId(), Space.EMPTY, Markers.EMPTY, paramId, Collections.emptyList(), null, null)
-        val varDecl = new J.VariableDeclarations(Tree.randomId(), casePrefix, Markers.EMPTY,
-          Collections.emptyList(), Collections.emptyList(), paramType,
-          if (beforeColon != Space.EMPTY) beforeColon else null,
-          Collections.emptyList(),
-          Collections.singletonList(JRightPadded.build(namedVar)))
-        val controlPrefix = if (catches.isEmpty) catchBraceSpace else Space.EMPTY
-        val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), controlPrefix, Markers.EMPTY, JRightPadded.build(varDecl).withAfter(spaceBeforeArrow))
-
-        val caseBodyOmitBraces = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
-        val caseBody = visitTree(caseDef.body) match {
-          case block: J.Block if block.getMarkers.findFirst(classOf[OmitBraces]).isPresent => block
-          case block: J.Block =>
-            val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(block))
-            new J.Block(Tree.randomId(), Space.EMPTY, caseBodyOmitBraces,
-              JRightPadded.build(false), s, Space.EMPTY)
-          case stmt: Statement =>
-            val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(stmt))
-            new J.Block(Tree.randomId(), Space.EMPTY, caseBodyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
-          case expr: Expression =>
-            val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
-            new J.Block(Tree.randomId(), Space.EMPTY, caseBodyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
-          case _ => new J.Block(Tree.randomId(), Space.EMPTY, caseBodyOmitBraces, JRightPadded.build(false), new util.ArrayList(), Space.EMPTY)
-        }
-        updateCursor(caseDef.span.end)
-        // First catch gets catchPrefix (space before "catch"); subsequent get casePrefix
-        val thisCatchPrefix = if (catches.isEmpty) catchPrefix else casePrefix
-        catches.add(new J.Try.Catch(Tree.randomId(), thisCatchPrefix, Markers.EMPTY, controlParens, caseBody))
-      }
-      // Extract end space before closing '}' and set it on the last catch body
-      if (catchHasBraces && cursor < source.length) {
-        val ci = positionOfNext("}")
-        if (ci >= cursor) {
-          val endSpace = if (ci > cursor) ScalaSpace.format(source, cursor, ci) else Space.EMPTY
-          if (!catches.isEmpty) {
-            val lastCatch = catches.get(catches.size - 1)
-            val updatedBody = lastCatch.getBody.withEnd(endSpace)
-            catches.set(catches.size - 1, lastCatch.withBody(updatedBody))
-          }
-          cursor = ci + 1
-        }
+    var endSpace = Space.EMPTY
+    if (hasBraces && cursor < source.length) {
+      val ci = positionOfNext("}")
+      if (ci >= cursor) {
+        endSpace = if (ci > cursor) ScalaSpace.format(source, cursor, ci) else Space.EMPTY
+        cursor = ci + 1
       }
     }
+    val blockMarkers = if (hasBraces) Markers.EMPTY
+      else Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
+    val casesBlock = new J.Block(Tree.randomId(), blockPrefix, blockMarkers, JRightPadded.build(false), caseStatements, endSpace)
+    JLeftPadded.build(casesBlock).withBefore(beforeCatch)
+  }
 
-    val finallyBlock: JLeftPadded[J.Block] = if (!tryTree.finalizer.isEmpty && tryTree.finalizer.span.exists) {
-      val finallyAbs = positionOfNext("finally")
-      val fSpace = if (finallyAbs > cursor) ScalaSpace.format(source, cursor, finallyAbs) else Space.EMPTY
-      if (finallyAbs >= cursor) cursor = finallyAbs + 7
-      val finallyOmitBraces = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
-      val fb = visitTree(tryTree.finalizer) match {
-        case block: J.Block => block
-        case stmt: Statement =>
-          val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(stmt))
-          new J.Block(Tree.randomId(), Space.EMPTY, finallyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
-        case expr: Expression =>
-          val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), expr)))
-          new J.Block(Tree.randomId(), Space.EMPTY, finallyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
-        case _ => null
-      }
-      if (fb != null) JLeftPadded.build(fb).withBefore(fSpace) else null
-    } else null
+  /** Visit the `finally` block, if present, capturing the space before the `finally` keyword. */
+  private def buildTryFinalizer(finalizer: Trees.Tree[?]): JLeftPadded[J.Block] = {
+    if (finalizer.isEmpty || !finalizer.span.exists) return null
+    val finallyAbs = positionOfNext("finally")
+    val fSpace = if (finallyAbs > cursor) ScalaSpace.format(source, cursor, finallyAbs) else Space.EMPTY
+    if (finallyAbs >= cursor) cursor = finallyAbs + 7
+    val finallyOmitBraces = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
+    val fb = visitTree(finalizer) match {
+      case block: J.Block => block
+      case stmt: Statement =>
+        val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(stmt))
+        new J.Block(Tree.randomId(), Space.EMPTY, finallyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
+      case e: Expression =>
+        val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(new S.ExpressionStatement(Tree.randomId(), e)))
+        new J.Block(Tree.randomId(), Space.EMPTY, finallyOmitBraces, JRightPadded.build(false), s, Space.EMPTY)
+      case _ => null
+    }
+    if (fb != null) JLeftPadded.build(fb).withBefore(fSpace) else null
+  }
 
-    updateCursor(tryTree.span.end)
-    val tryMarkers = if (catchHasBraces) Markers.EMPTY
-      else Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId())))
-    new J.Try(Tree.randomId(), prefix, tryMarkers, null, body, catches, finallyBlock)
+  private def buildSTry(prefix: Space, body: J.Block, catches: JLeftPadded[J.Block], finallyBlock: JLeftPadded[J.Block]): S.Try = {
+    // A brace-less catch (Scala 3 `catch case`) flags indented syntax on the whole try.
+    val braceless = catches != null && catches.getElement.getMarkers.findFirst(classOf[OmitBraces]).isPresent
+    val tryMarkers = if (braceless) Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId())))
+      else Markers.EMPTY
+    S.Try.build(Tree.randomId(), prefix, tryMarkers, body, catches, finallyBlock, null)
   }
 
   private def visitMatchTree(matchTree: Trees.Match[?]): J = {
@@ -7322,76 +7117,87 @@ class ScalaTreeVisitor(
     new J.Switch(Tree.randomId(), prefix, Markers.build(markersList), selectorParens, casesBlock)
   }
 
+  /**
+   * Build a single `case pat [if guard] => body` clause as a J.Case wrapped in a
+   * JRightPadded (carrying a Semicolon marker when the case is `;`-terminated).
+   * Shared by match blocks ([[buildCasesBlock]]) and try/catch handlers so that
+   * catch patterns get the same rich modelling (extractors, alternatives, bindings)
+   * instead of being crammed into an identifier name.
+   */
+  private def buildCase(caseDef: Trees.CaseDef[?]): JRightPadded[Statement] = {
+    val casePrefix = extractPrefix(caseDef.span)
+    val cs = Math.max(0, caseDef.span.start - offsetAdjustment); if (cs >= cursor) cursor = cs
+    val ck = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 20, source.length)) else ""
+    val cki = positionOfNextIn(ck, "case", 0); if (cki >= 0) cursor = cursor + cki + 4
+
+    val patternJ = visitTree(caseDef.pat) match { case j: J => j; case _ => ident("_", Space.format(" ")) }
+
+    // Handle guard: `case x if condition =>`
+    // Store space-before-if in label's after space so the printer can emit it.
+    // Store space between guard expression end and `=>` in the statements
+    // container's `before` space (matching the Java printer's convention).
+    var guard: Expression = null
+    var labelAfter = Space.EMPTY
+    var guardArrowSpace = Space.EMPTY
+    if (!caseDef.guard.isEmpty && caseDef.guard.span.exists) {
+      val ifPos = positionOfNext("if")
+      if (ifPos > cursor) labelAfter = ScalaSpace.format(source, cursor, ifPos)
+      if (ifPos >= 0) cursor = ifPos + 2  // past "if"
+      val guardResult = visitTree(caseDef.guard)
+      guardResult match {
+        case expr: Expression => guard = expr
+        case j: J => guard = new S.StatementExpression(Tree.randomId(), j)
+        case _ =>
+      }
+      val arrowPos = positionOfNext("=>", cursor)
+      if (arrowPos >= cursor) guardArrowSpace = ScalaSpace.format(source, cursor, arrowPos)
+    } else {
+      val arrowPos = positionOfNext("=>", cursor)
+      if (arrowPos >= cursor) labelAfter = ScalaSpace.format(source, cursor, arrowPos)
+    }
+    val labels = new util.ArrayList[JRightPadded[J]]()
+    labels.add(JRightPadded.build(patternJ).withAfter(labelAfter))
+
+    val as = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 200, source.length)) else ""
+    val ai = positionOfNextIn(as, "=>", 0); if (ai >= 0) { val aa = positionOfNext("=>", cursor); if (aa >= 0) cursor = aa + 2 }
+
+    val caseBodyJ = visitTree(caseDef.body) match { case j: J => JRightPadded.build(j); case _ => null }
+    // Compute the end of the body's actual content from the AST (not from
+    // the cursor, which may have overshot when Dotty's body span included
+    // the `;` or part of the next case).
+    val bodyContentEnd: Int = caseDef.body match {
+      case b: Trees.Block[?] =>
+        if (!b.expr.isEmpty && b.expr.span.exists) Math.max(0, b.expr.span.end - offsetAdjustment)
+        else if (b.stats.nonEmpty && b.stats.last.span.exists) Math.max(0, b.stats.last.span.end - offsetAdjustment)
+        else if (b.span.exists) Math.max(0, b.span.end - offsetAdjustment)
+        else cursor
+      case t if t.span.exists => Math.max(0, t.span.end - offsetAdjustment)
+      case _ => cursor
+    }
+    updateCursor(caseDef.span.end)
+
+    // If the next non-whitespace token immediately after the body content is
+    // `;`, preserve it via a Semicolon marker on the JRightPadded wrapping
+    // the case (e.g. `case a => x; case b => y`).
+    var caseRpMarkers = Markers.EMPTY
+    val caseRpAfter = Space.EMPTY
+    val nextNonWs = indexOfNextNonWhitespace(bodyContentEnd)
+    if (nextNonWs < source.length && source.charAt(nextNonWs) == ';') {
+      caseRpMarkers = Markers.EMPTY.add(new Semicolon(Tree.randomId()))
+      cursor = nextNonWs + 1
+    }
+
+    val statementsContainer: JContainer[Statement] =
+      JContainer.build(guardArrowSpace, java.util.Collections.emptyList[JRightPadded[Statement]](), Markers.EMPTY)
+    val jCase = new J.Case(Tree.randomId(), casePrefix, Markers.EMPTY, J.Case.Type.Rule,
+      null, null, JContainer.build(Space.EMPTY, labels, Markers.EMPTY), guard, statementsContainer, caseBodyJ)
+    new JRightPadded[Statement](jCase.asInstanceOf[Statement], caseRpAfter, caseRpMarkers)
+  }
+
   private def buildCasesBlock(matchTree: Trees.Match[?], hasClosingBrace: Boolean = true): J.Block = {
     val caseStatements = new util.ArrayList[JRightPadded[Statement]]()
     for (caseDef <- matchTree.cases) {
-      val casePrefix = extractPrefix(caseDef.span)
-      val cs = Math.max(0, caseDef.span.start - offsetAdjustment); if (cs >= cursor) cursor = cs
-      val ck = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 20, source.length)) else ""
-      val cki = positionOfNextIn(ck, "case", 0); if (cki >= 0) cursor = cursor + cki + 4
-
-      val patternJ = visitTree(caseDef.pat) match { case j: J => j; case _ => ident("_", Space.format(" ")) }
-
-      // Handle guard: `case x if condition =>`
-      // Store space-before-if in label's after space so the printer can emit it.
-      // Store space between guard expression end and `=>` in the statements
-      // container's `before` space (matching the Java printer's convention).
-      var guard: Expression = null
-      var labelAfter = Space.EMPTY
-      var guardArrowSpace = Space.EMPTY
-      if (!caseDef.guard.isEmpty && caseDef.guard.span.exists) {
-        val ifPos = positionOfNext("if")
-        if (ifPos > cursor) labelAfter = ScalaSpace.format(source, cursor, ifPos)
-        if (ifPos >= 0) cursor = ifPos + 2  // past "if"
-        val guardResult = visitTree(caseDef.guard)
-        guardResult match {
-          case expr: Expression => guard = expr
-          case j: J => guard = new S.StatementExpression(Tree.randomId(), j)
-          case _ =>
-        }
-        val arrowPos = positionOfNext("=>", cursor)
-        if (arrowPos >= cursor) guardArrowSpace = ScalaSpace.format(source, cursor, arrowPos)
-      } else {
-        val arrowPos = positionOfNext("=>", cursor)
-        if (arrowPos >= cursor) labelAfter = ScalaSpace.format(source, cursor, arrowPos)
-      }
-      val labels = new util.ArrayList[JRightPadded[J]]()
-      labels.add(JRightPadded.build(patternJ).withAfter(labelAfter))
-
-      val as = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 200, source.length)) else ""
-      val ai = positionOfNextIn(as, "=>", 0); if (ai >= 0) { val aa = positionOfNext("=>", cursor); if (aa >= 0) cursor = aa + 2 }
-
-      val caseBodyJ = visitTree(caseDef.body) match { case j: J => JRightPadded.build(j); case _ => null }
-      // Compute the end of the body's actual content from the AST (not from
-      // the cursor, which may have overshot when Dotty's body span included
-      // the `;` or part of the next case).
-      val bodyContentEnd: Int = caseDef.body match {
-        case b: Trees.Block[?] =>
-          if (!b.expr.isEmpty && b.expr.span.exists) Math.max(0, b.expr.span.end - offsetAdjustment)
-          else if (b.stats.nonEmpty && b.stats.last.span.exists) Math.max(0, b.stats.last.span.end - offsetAdjustment)
-          else if (b.span.exists) Math.max(0, b.span.end - offsetAdjustment)
-          else cursor
-        case t if t.span.exists => Math.max(0, t.span.end - offsetAdjustment)
-        case _ => cursor
-      }
-      updateCursor(caseDef.span.end)
-
-      // If the next non-whitespace token immediately after the body content is
-      // `;`, preserve it via a Semicolon marker on the JRightPadded wrapping
-      // the case (e.g. `case a => x; case b => y`).
-      var caseRpMarkers = Markers.EMPTY
-      val caseRpAfter = Space.EMPTY
-      val nextNonWs = indexOfNextNonWhitespace(bodyContentEnd)
-      if (nextNonWs < source.length && source.charAt(nextNonWs) == ';') {
-        caseRpMarkers = Markers.EMPTY.add(new Semicolon(Tree.randomId()))
-        cursor = nextNonWs + 1
-      }
-
-      val statementsContainer: JContainer[Statement] =
-        JContainer.build(guardArrowSpace, java.util.Collections.emptyList[JRightPadded[Statement]](), Markers.EMPTY)
-      val jCase = new J.Case(Tree.randomId(), casePrefix, Markers.EMPTY, J.Case.Type.Rule,
-        null, null, JContainer.build(Space.EMPTY, labels, Markers.EMPTY), guard, statementsContainer, caseBodyJ)
-      caseStatements.add(new JRightPadded[Statement](jCase.asInstanceOf[Statement], caseRpAfter, caseRpMarkers))
+      caseStatements.add(buildCase(caseDef))
     }
 
     // Extract space before closing brace of match block (or up to span end for indented form)

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7050,106 +7050,14 @@ class ScalaTreeVisitor(
    * which `J.Try.Catch`'s fixed `ControlParentheses<VariableDeclarations>` cannot hold — fall
    * back to [[S.Try]] (which models the handler as a `J.Block` of `J.Case`).
    */
+  /**
+   * Build the try node, preferring the Java model. The decision (J.Try vs S.Try) and the
+   * J.Case→J.Try.Catch conversion live in [[ScalaTryBuilder]] (Java) because they read
+   * Lombok-generated getters on same-module `S.*` types, which the Scala joint compiler
+   * cannot see (it reads `S.java` as source, before Lombok runs).
+   */
   private def buildTryNode(prefix: Space, body: J.Block, catches: JLeftPadded[J.Block], finallyBlock: JLeftPadded[J.Block]): J = {
-    if (catches == null || catchesFitJModel(catches.getElement)) {
-      buildJTry(prefix, body, catches, finallyBlock)
-    } else {
-      val braceless = catches.getElement.getMarkers.findFirst(classOf[OmitBraces]).isPresent
-      val tryMarkers = if (braceless) Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId())))
-        else Markers.EMPTY
-      S.Try.build(Tree.randomId(), prefix, tryMarkers, body, catches, finallyBlock, null)
-    }
-  }
-
-  /** True when every clause is a guard-free `[name][: Type]` catch, expressible as a `J.Try.Catch`. */
-  private def catchesFitJModel(casesBlock: J.Block): Boolean = {
-    casesBlock.getPadding.getStatements.asScala.forall { rp =>
-      if (rp.getMarkers.findFirst(classOf[Semicolon]).isPresent) false
-      else rp.getElement match {
-        case c: J.Case if c.getGuard == null && c.getPadding.getCaseLabels.getElements.size == 1 =>
-          c.getPadding.getCaseLabels.getElements.get(0) match {
-            case ta: S.TypeAscription =>
-              (ta.getExpression.isInstanceOf[J.Identifier] || ta.getExpression.isInstanceOf[S.Wildcard]) &&
-                (ta.getTypeTree.isInstanceOf[J.Identifier] || ta.getTypeTree.isInstanceOf[J.FieldAccess])
-            case _: J.Identifier => true
-            case _: S.Wildcard => true
-            case _ => false
-          }
-        case _ => false
-      }
-    }
-  }
-
-  /** Convert the `J.Block` of `J.Case` catch handler into `J.Try`'s list of `J.Try.Catch`. */
-  private def buildJTry(prefix: Space, body: J.Block, catches: JLeftPadded[J.Block], finallyBlock: JLeftPadded[J.Block]): J.Try = {
-    val catchList = new util.ArrayList[J.Try.Catch]()
-    var braceless = false
-    if (catches != null) {
-      val casesBlock = catches.getElement
-      braceless = casesBlock.getMarkers.findFirst(classOf[OmitBraces]).isPresent
-      val beforeCatch = catches.getBefore
-      val blockPrefix = casesBlock.getPrefix
-      val rps = casesBlock.getPadding.getStatements
-      var i = 0
-      while (i < rps.size) {
-        val c = rps.get(i).getElement.asInstanceOf[J.Case]
-        val labelRp = c.getPadding.getCaseLabels.getPadding.getElements.get(0)
-        val (nameId, typeTree, beforeColon): (J.Identifier, TypeTree, Space) = labelRp.getElement match {
-          case ta: S.TypeAscription =>
-            // The space after `case` is on the ascription's own prefix, not the inner expr.
-            val nm = ta.getExpression match {
-              case id: J.Identifier => id.withPrefix(ta.getPrefix)
-              case _ => ident("_", ta.getPrefix)
-            }
-            val bcOpt = ta.getMarkers.findFirst(classOf[org.openrewrite.scala.marker.TypeAscriptionColonPrefix])
-            val bc = if (bcOpt.isPresent) bcOpt.get.getPrefix else null
-            (nm, ta.getTypeTree, bc)
-          case id: J.Identifier => (id, null, null)
-          case w: S.Wildcard => (ident("_", w.getPrefix), null, null)
-          case _ => (ident("_", Space.EMPTY), null, null)
-        }
-        val caseBody = wrapCatchBody(c.getPadding.getBody)
-        val namedVar = new J.VariableDeclarations.NamedVariable(Tree.randomId(), Space.EMPTY, Markers.EMPTY, nameId, Collections.emptyList(), null, null)
-        val varDecl = new J.VariableDeclarations(Tree.randomId(), c.getPrefix, Markers.EMPTY,
-          Collections.emptyList(), Collections.emptyList(), typeTree, beforeColon,
-          Collections.emptyList(), Collections.singletonList(JRightPadded.build(namedVar)))
-        // For the first catch the J.Try printer emits the catch keyword then the brace, so
-        // its parameter prefix carries the space before `{`; subsequent catches don't reprint it.
-        val controlPrefix = if (i == 0) blockPrefix else Space.EMPTY
-        val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), controlPrefix, Markers.EMPTY,
-          JRightPadded.build(varDecl).withAfter(labelRp.getAfter))
-        val catchPrefix = if (i == 0) beforeCatch else c.getPrefix
-        catchList.add(new J.Try.Catch(Tree.randomId(), catchPrefix, Markers.EMPTY, controlParens, caseBody))
-        i += 1
-      }
-      // The space before the closing `}` lives on the cases-block end; in J.Try it
-      // belongs to the last catch body's end space.
-      if (!braceless && !catchList.isEmpty) {
-        val last = catchList.get(catchList.size - 1)
-        catchList.set(catchList.size - 1, last.withBody(last.getBody.withEnd(casesBlock.getEnd)))
-      }
-    }
-    val tryMarkers = if (braceless) Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId())))
-      else Markers.EMPTY
-    new J.Try(Tree.randomId(), prefix, tryMarkers, null, body, catchList, finallyBlock)
-  }
-
-  /** Wrap a catch-clause body (a bare J on `J.Case`) in an OmitBraces `J.Block` as `J.Try.Catch` requires. */
-  private def wrapCatchBody(bodyRp: JRightPadded[J]): J.Block = {
-    val omit = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
-    def shell(stmt: Statement): J.Block = {
-      val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(stmt))
-      new J.Block(Tree.randomId(), Space.EMPTY, omit, JRightPadded.build(false), s, Space.EMPTY)
-    }
-    def empty: J.Block = new J.Block(Tree.randomId(), Space.EMPTY, omit, JRightPadded.build(false), new util.ArrayList(), Space.EMPTY)
-    if (bodyRp == null) empty
-    else bodyRp.getElement match {
-      case b: J.Block if b.getMarkers.findFirst(classOf[OmitBraces]).isPresent => b
-      case b: J.Block => shell(b)
-      case stmt: Statement => shell(stmt)
-      case e: Expression => shell(new S.ExpressionStatement(Tree.randomId(), e))
-      case _ => empty
-    }
+    ScalaTryBuilder.buildTry(prefix, body, catches, finallyBlock)
   }
 
   private def visitMatchTree(matchTree: Trees.Match[?]): J = {

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -6949,7 +6949,7 @@ class ScalaTreeVisitor(
     val finallyBlock = buildTryFinalizer(parsedTry.finalizer)
 
     updateCursor(parsedTry.span.end)
-    buildSTry(prefix, body, catches, finallyBlock)
+    buildTryNode(prefix, body, catches, finallyBlock)
   }
 
   private def visitTryImpl(tryTree: Trees.Try[?]): J = {
@@ -6965,7 +6965,7 @@ class ScalaTreeVisitor(
     val finallyBlock = buildTryFinalizer(tryTree.finalizer)
 
     updateCursor(tryTree.span.end)
-    buildSTry(prefix, body, catches, finallyBlock)
+    buildTryNode(prefix, body, catches, finallyBlock)
   }
 
   /** Visit the `try` body, wrapping a bare statement/expression in an OmitBraces block. */
@@ -7042,12 +7042,114 @@ class ScalaTreeVisitor(
     if (fb != null) JLeftPadded.build(fb).withBefore(fSpace) else null
   }
 
-  private def buildSTry(prefix: Space, body: J.Block, catches: JLeftPadded[J.Block], finallyBlock: JLeftPadded[J.Block]): S.Try = {
-    // A brace-less catch (Scala 3 `catch case`) flags indented syntax on the whole try.
-    val braceless = catches != null && catches.getElement.getMarkers.findFirst(classOf[OmitBraces]).isPresent
+  /**
+   * Build the try node, preferring the Java model. OpenRewrite favours fitting Scala into
+   * `J.*` types so Java recipes apply: the common `[name][: Type]` (guard-free) catch maps
+   * cleanly onto `J.Try.Catch` (`catch (Type name)`), so emit `J.Try` whenever every clause
+   * fits. Only Scala-specific patterns (extractors, alternatives, at-bindings) or guards —
+   * which `J.Try.Catch`'s fixed `ControlParentheses<VariableDeclarations>` cannot hold — fall
+   * back to [[S.Try]] (which models the handler as a `J.Block` of `J.Case`).
+   */
+  private def buildTryNode(prefix: Space, body: J.Block, catches: JLeftPadded[J.Block], finallyBlock: JLeftPadded[J.Block]): J = {
+    if (catches == null || catchesFitJModel(catches.getElement)) {
+      buildJTry(prefix, body, catches, finallyBlock)
+    } else {
+      val braceless = catches.getElement.getMarkers.findFirst(classOf[OmitBraces]).isPresent
+      val tryMarkers = if (braceless) Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId())))
+        else Markers.EMPTY
+      S.Try.build(Tree.randomId(), prefix, tryMarkers, body, catches, finallyBlock, null)
+    }
+  }
+
+  /** True when every clause is a guard-free `[name][: Type]` catch, expressible as a `J.Try.Catch`. */
+  private def catchesFitJModel(casesBlock: J.Block): Boolean = {
+    casesBlock.getPadding.getStatements.asScala.forall { rp =>
+      if (rp.getMarkers.findFirst(classOf[Semicolon]).isPresent) false
+      else rp.getElement match {
+        case c: J.Case if c.getGuard == null && c.getPadding.getCaseLabels.getElements.size == 1 =>
+          c.getPadding.getCaseLabels.getElements.get(0) match {
+            case ta: S.TypeAscription =>
+              (ta.getExpression.isInstanceOf[J.Identifier] || ta.getExpression.isInstanceOf[S.Wildcard]) &&
+                (ta.getTypeTree.isInstanceOf[J.Identifier] || ta.getTypeTree.isInstanceOf[J.FieldAccess])
+            case _: J.Identifier => true
+            case _: S.Wildcard => true
+            case _ => false
+          }
+        case _ => false
+      }
+    }
+  }
+
+  /** Convert the `J.Block` of `J.Case` catch handler into `J.Try`'s list of `J.Try.Catch`. */
+  private def buildJTry(prefix: Space, body: J.Block, catches: JLeftPadded[J.Block], finallyBlock: JLeftPadded[J.Block]): J.Try = {
+    val catchList = new util.ArrayList[J.Try.Catch]()
+    var braceless = false
+    if (catches != null) {
+      val casesBlock = catches.getElement
+      braceless = casesBlock.getMarkers.findFirst(classOf[OmitBraces]).isPresent
+      val beforeCatch = catches.getBefore
+      val blockPrefix = casesBlock.getPrefix
+      val rps = casesBlock.getPadding.getStatements
+      var i = 0
+      while (i < rps.size) {
+        val c = rps.get(i).getElement.asInstanceOf[J.Case]
+        val labelRp = c.getPadding.getCaseLabels.getPadding.getElements.get(0)
+        val (nameId, typeTree, beforeColon): (J.Identifier, TypeTree, Space) = labelRp.getElement match {
+          case ta: S.TypeAscription =>
+            // The space after `case` is on the ascription's own prefix, not the inner expr.
+            val nm = ta.getExpression match {
+              case id: J.Identifier => id.withPrefix(ta.getPrefix)
+              case _ => ident("_", ta.getPrefix)
+            }
+            val bcOpt = ta.getMarkers.findFirst(classOf[org.openrewrite.scala.marker.TypeAscriptionColonPrefix])
+            val bc = if (bcOpt.isPresent) bcOpt.get.getPrefix else null
+            (nm, ta.getTypeTree, bc)
+          case id: J.Identifier => (id, null, null)
+          case w: S.Wildcard => (ident("_", w.getPrefix), null, null)
+          case _ => (ident("_", Space.EMPTY), null, null)
+        }
+        val caseBody = wrapCatchBody(c.getPadding.getBody)
+        val namedVar = new J.VariableDeclarations.NamedVariable(Tree.randomId(), Space.EMPTY, Markers.EMPTY, nameId, Collections.emptyList(), null, null)
+        val varDecl = new J.VariableDeclarations(Tree.randomId(), c.getPrefix, Markers.EMPTY,
+          Collections.emptyList(), Collections.emptyList(), typeTree, beforeColon,
+          Collections.emptyList(), Collections.singletonList(JRightPadded.build(namedVar)))
+        // For the first catch the J.Try printer emits the catch keyword then the brace, so
+        // its parameter prefix carries the space before `{`; subsequent catches don't reprint it.
+        val controlPrefix = if (i == 0) blockPrefix else Space.EMPTY
+        val controlParens = new J.ControlParentheses[J.VariableDeclarations](Tree.randomId(), controlPrefix, Markers.EMPTY,
+          JRightPadded.build(varDecl).withAfter(labelRp.getAfter))
+        val catchPrefix = if (i == 0) beforeCatch else c.getPrefix
+        catchList.add(new J.Try.Catch(Tree.randomId(), catchPrefix, Markers.EMPTY, controlParens, caseBody))
+        i += 1
+      }
+      // The space before the closing `}` lives on the cases-block end; in J.Try it
+      // belongs to the last catch body's end space.
+      if (!braceless && !catchList.isEmpty) {
+        val last = catchList.get(catchList.size - 1)
+        catchList.set(catchList.size - 1, last.withBody(last.getBody.withEnd(casesBlock.getEnd)))
+      }
+    }
     val tryMarkers = if (braceless) Markers.build(Collections.singletonList(new IndentedSyntax(Tree.randomId())))
       else Markers.EMPTY
-    S.Try.build(Tree.randomId(), prefix, tryMarkers, body, catches, finallyBlock, null)
+    new J.Try(Tree.randomId(), prefix, tryMarkers, null, body, catchList, finallyBlock)
+  }
+
+  /** Wrap a catch-clause body (a bare J on `J.Case`) in an OmitBraces `J.Block` as `J.Try.Catch` requires. */
+  private def wrapCatchBody(bodyRp: JRightPadded[J]): J.Block = {
+    val omit = Markers.build(Collections.singletonList(new OmitBraces(Tree.randomId())))
+    def shell(stmt: Statement): J.Block = {
+      val s = new util.ArrayList[JRightPadded[Statement]](); s.add(JRightPadded.build(stmt))
+      new J.Block(Tree.randomId(), Space.EMPTY, omit, JRightPadded.build(false), s, Space.EMPTY)
+    }
+    def empty: J.Block = new J.Block(Tree.randomId(), Space.EMPTY, omit, JRightPadded.build(false), new util.ArrayList(), Space.EMPTY)
+    if (bodyRp == null) empty
+    else bodyRp.getElement match {
+      case b: J.Block if b.getMarkers.findFirst(classOf[OmitBraces]).isPresent => b
+      case b: J.Block => shell(b)
+      case stmt: Statement => shell(stmt)
+      case e: Expression => shell(new S.ExpressionStatement(Tree.randomId(), e))
+      case _ => empty
+    }
   }
 
   private def visitMatchTree(matchTree: Trees.Match[?]): J = {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
@@ -16,8 +16,14 @@
 package org.openrewrite.scala.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.scala.Assertions.scala;
 
 class TryTest implements RewriteTest {
@@ -389,6 +395,73 @@ class TryTest implements RewriteTest {
             }
             """
         ));
+    }
+
+    @Test
+    void catchPatternsNotCrammedIntoIdentifier() {
+        assertNoPatternInIdentifier(
+            """
+            object Test {
+              try {
+                println("risky")
+              } catch {
+                case NonFatal(e) => println(e)
+                case _: IllegalArgumentException | _: IllegalStateException => println("illegal")
+                case e @ (_: ClassNotFoundException) => println(e)
+              }
+            }
+            """
+        );
+    }
+
+    @Test
+    void scala3BracelessCatch() {
+        rewriteRun(scala(
+            """
+            object Test {
+              def run(): Unit =
+                try risky()
+                catch
+                  case _: RuntimeException => recover()
+                  case NonFatal(e) => log(e)
+            }
+            """
+        ));
+    }
+
+    @Test
+    void scala3BracelessCatchWithFinally() {
+        rewriteRun(scala(
+            """
+            object Test {
+              def run(): Unit =
+                try risky()
+                catch case _: Exception => recover()
+                finally cleanup()
+            }
+            """
+        ));
+    }
+
+    private void assertNoPatternInIdentifier(String source) {
+        rewriteRun(
+            scala(
+                source,
+                spec -> spec.afterRecipe(cu -> {
+                    List<String> identifierNames = new ArrayList<>();
+                    new JavaIsoVisitor<Integer>() {
+                        @Override
+                        public J.Identifier visitIdentifier(J.Identifier identifier, Integer p) {
+                            identifierNames.add(identifier.getSimpleName());
+                            return super.visitIdentifier(identifier, p);
+                        }
+                    }.visit(cu, 0);
+                    assertThat(identifierNames)
+                      .as("catch-pattern source text should not be crammed into an identifier name")
+                      .allSatisfy(name -> assertThat(name).doesNotContain("(", "|", "@", ":"));
+                })
+            )
+        );
     }
 
     @Test

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TryTest.java
@@ -18,10 +18,13 @@ package org.openrewrite.scala.tree;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.scala.ScalaIsoVisitor;
+import org.openrewrite.scala.tree.S;
 import org.openrewrite.test.RewriteTest;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.scala.Assertions.scala;
@@ -441,6 +444,62 @@ class TryTest implements RewriteTest {
             }
             """
         ));
+    }
+
+    @Test
+    void commonCatchesFitJavaTryModel() {
+        // OpenRewrite prefers reusing J.* types so Java recipes apply: the common
+        // `[name][: Type]` (guard-free) catch maps onto J.Try.Catch and must stay J.Try.
+        assertTryKind(
+            """
+            object Test {
+              def run(): Unit =
+                try { a() } catch {
+                  case e: Exception => 1
+                  case _: java.io.IOException => 2
+                  case e => 3
+                  case _ => 4
+                } finally { b() }
+            }
+            """, 1, 0);
+    }
+
+    @Test
+    void scalaSpecificCatchesUseSTry() {
+        // Patterns J.Try.Catch cannot hold (extractors, alternatives, guards) fall back to S.Try.
+        assertTryKind("object T { try { a() } catch { case NonFatal(e) => 1 } }", 0, 1);
+        assertTryKind("object T { try { a() } catch { case _: A | _: B => 1 } }", 0, 1);
+        assertTryKind("object T { try { a() } catch { case e: Exception if e != null => 1 } }", 0, 1);
+        // A single non-fitting clause routes the whole try to S.Try.
+        assertTryKind("object T { try { a() } catch { case e: A => 1\n case NonFatal(e) => 2 } }", 0, 1);
+    }
+
+    private void assertTryKind(String source, int expectedJTry, int expectedSTry) {
+        AtomicInteger jTry = new AtomicInteger();
+        AtomicInteger sTry = new AtomicInteger();
+        rewriteRun(
+            scala(
+                source,
+                spec -> spec.afterRecipe(cu -> {
+                    new JavaIsoVisitor<Integer>() {
+                        @Override
+                        public J.Try visitTry(J.Try t, Integer p) {
+                            jTry.incrementAndGet();
+                            return super.visitTry(t, p);
+                        }
+                    }.visit(cu, 0);
+                    new ScalaIsoVisitor<Integer>() {
+                        @Override
+                        public S.Try visitSTry(S.Try t, Integer p) {
+                            sTry.incrementAndGet();
+                            return super.visitSTry(t, p);
+                        }
+                    }.visit(cu, 0);
+                    assertThat(jTry.get()).as("J.Try count").isEqualTo(expectedJTry);
+                    assertThat(sTry.get()).as("S.Try count").isEqualTo(expectedSTry);
+                })
+            )
+        );
     }
 
     private void assertNoPatternInIdentifier(String source) {


### PR DESCRIPTION
## What's changed?

Introduce new LST element in Scala LSTs: `S.Try`.

## What's your motivation?

This is to model these try-catch statements which don't fit into `J.Try`. Scala has richer syntax allowed there.