### PR TITLE
Scala: fix parsing of function type references `A => B`

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5471,8 +5471,10 @@ class ScalaTreeVisitor(
             Space.EMPTY
           }
           
-          // Visit the target type
-          val targetType = visitTree(ta.args.head) match {
+          // Visit the target type. Use the type-position helper so that function types
+          // (`A => B`), tuple types, union/intersection types, etc. are mapped to a
+          // `TypeTree` rather than being misread as expressions.
+          val targetType = visitTypeTree(ta.args.head) match {
             case tt: TypeTree => tt
             case _ => return visitUnknown(ta)
           }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -3502,9 +3502,9 @@ class ScalaTreeVisitor(
         ScalaSpace.format(source, cursor, typeStart)
       else Space.SINGLE_SPACE
       cursor = typeStart
-      visitTree(vd.tpt) match {
+      visitTypeTree(vd.tpt) match {
         case tt: TypeTree => tt.withPrefix(typePrefix)
-        case other =>
+        case _ =>
           // Fall back to source-text identifier — preserves printing fidelity but
           // intentionally drops rich typing for unmapped type expressions.
           val tText = extractSource(vd.tpt.span)
@@ -5548,8 +5548,9 @@ class ScalaTreeVisitor(
             cursor = Math.max(0, ta.args.head.span.start - offsetAdjustment)
           }
 
-          // Visit the target type
-          val clazz = visitTree(ta.args.head) match {
+          // Visit the target type via the type-position helper so function types
+          // (`A => B`), tuple/union/intersection types map to a `TypeTree`.
+          val clazz = visitTypeTree(ta.args.head) match {
             case tt: TypeTree => tt
             case _ => return visitUnknown(ta)
           }
@@ -5683,11 +5684,17 @@ class ScalaTreeVisitor(
     val beforeBracket = sourceBefore("[")
     buildArgumentContainer[Trees.Tree[?], Expression](
       ta.args,
-      arg => visitTree(arg) match {
-        case e: Expression => e
-        case tt: TypeTree => tt.asInstanceOf[Expression]
-        case j: J => new S.StatementExpression(Tree.randomId(), j)
-        case _ => visitUnknown(arg)
+      arg => {
+        // These are type arguments, so prefer the type-position helper: it maps
+        // function types (`A => B`), tuple/union/intersection types to a TypeTree
+        // rather than letting `visitTree` misread them as expressions (e.g. a lambda).
+        val tt = visitTypeTree(arg)
+        if (tt != null) tt.asInstanceOf[Expression]
+        else visitTree(arg) match {
+          case e: Expression => e
+          case j: J => new S.StatementExpression(Tree.randomId(), j)
+          case _ => visitUnknown(arg)
+        }
       },
       "]",
       beforeBracket
@@ -5749,7 +5756,11 @@ class ScalaTreeVisitor(
 
       for (i <- at.args.indices) {
         val arg = at.args(i)
-        val argTree = visitTree(arg) match {
+        // Prefer the type-position helper so function types (`A => B`), tuple/union/
+        // intersection types map to a TypeTree rather than being misread as expressions.
+        val tt = visitTypeTree(arg)
+        val argTree: Expression = if (tt != null) tt.asInstanceOf[Expression]
+        else visitTree(arg) match {
           case expr: Expression => expr
           case j: J => new S.StatementExpression(Tree.randomId(), j)
           case _ => cursor = savedCursor; return visitUnknown(at)
@@ -7683,12 +7694,7 @@ class ScalaTreeVisitor(
     } else Space.EMPTY
 
     val parent: TypeTree = if (rtt.tpt != null && !rtt.tpt.isEmpty && rtt.tpt.span.exists) {
-      visitTree(rtt.tpt) match {
-        case t: TypeTree => t
-        case e: Expression => new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-          Collections.emptyList(), e.toString, null, null)
-        case _ => null
-      }
+      visitTypeTree(rtt.tpt)
     } else null
 
     // Find opening brace
@@ -9247,7 +9253,7 @@ class ScalaTreeVisitor(
             val loPrefix = if (loOpIdx > cursor) ScalaSpace.format(source, cursor, loOpIdx) else Space.EMPTY
             if (loOpIdx >= 0) cursor = loOpIdx + 2
             val savedC = cursor
-            visitTree(innerBounds.lo) match {
+            visitTypeTree(innerBounds.lo) match {
               case tt: TypeTree =>
                 val loBound: TypeTree = new J.TypeBound(Tree.randomId(), loPrefix, Markers.EMPTY, J.TypeBound.Kind.Lower, tt)
                 boundList.add(JRightPadded.build(loBound))
@@ -9259,7 +9265,7 @@ class ScalaTreeVisitor(
             val hiPrefix = if (hiOpIdx > cursor) ScalaSpace.format(source, cursor, hiOpIdx) else Space.EMPTY
             if (hiOpIdx >= 0) cursor = hiOpIdx + 2
             val savedC = cursor
-            visitTree(innerBounds.hi) match {
+            visitTypeTree(innerBounds.hi) match {
               case tt: TypeTree =>
                 val hiBound: TypeTree = new J.TypeBound(Tree.randomId(), hiPrefix, Markers.EMPTY, J.TypeBound.Kind.Upper, tt)
                 boundList.add(JRightPadded.build(hiBound))

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/FunctionTypeTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/FunctionTypeTest.java
@@ -86,6 +86,66 @@ class FunctionTypeTest implements RewriteTest {
         );
     }
 
+    @Test
+    void functionTypeAsTypeArgument() {
+        rewriteRun(
+          scala(
+            """
+            val xs: List[A => B] = ???
+            """,
+            spec -> spec.afterRecipe(cu -> firstFunctionType(cu))
+          )
+        );
+    }
+
+    @Test
+    void functionTypeInSummon() {
+        rewriteRun(
+          scala(
+            """
+            val f = summon[A => B]
+            """,
+            spec -> spec.afterRecipe(cu -> firstFunctionType(cu))
+          )
+        );
+    }
+
+    @Test
+    void functionTypeInIsInstanceOf() {
+        rewriteRun(
+          scala(
+            """
+            val b = x.isInstanceOf[A => B]
+            """,
+            spec -> spec.afterRecipe(cu -> firstFunctionType(cu))
+          )
+        );
+    }
+
+    @Test
+    void functionTypeInRefinement() {
+        rewriteRun(
+          scala(
+            """
+            val x: (A => B) { def foo: Int } = ???
+            """,
+            spec -> spec.afterRecipe(cu -> firstFunctionType(cu))
+          )
+        );
+    }
+
+    @Test
+    void functionTypeInGiven() {
+        rewriteRun(
+          scala(
+            """
+            given (A => B) = ???
+            """,
+            spec -> spec.afterRecipe(cu -> firstFunctionType(cu))
+          )
+        );
+    }
+
     private static S.FunctionType firstFunctionType(J tree) {
         AtomicReference<S.FunctionType> ref = new AtomicReference<>();
         new ScalaIsoVisitor<Integer>() {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TypeCastTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/TypeCastTest.java
@@ -147,4 +147,15 @@ class TypeCastTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void castToFunctionType() {
+        rewriteRun(
+          scala(
+            """
+            val f = x.asInstanceOf[A => B]
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fix several cases/contexts of function type reference in Scala, e.g. `A => B`.

## What's your motivation?

They would be parsed improperly.