### PR TITLE
Enforce proper identifiers in tests

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/IdentifierValidationService.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/IdentifierValidationService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.internal;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.TreeVisitor;
+
+/**
+ * Return a visitor suitable for use by the test framework to validate that identifier names contain no characters
+ * that cannot appear in an identifier of the source language. A common parser bug is to store raw source text
+ * (e.g. a type expression or a constructor call) into a {@code J.Identifier} name; this service catches that.
+ */
+public interface IdentifierValidationService {
+
+    TreeVisitor<?, ExecutionContext> getVisitor();
+}

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/internal/CSharpIdentifierValidationService.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/internal/CSharpIdentifierValidationService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.internal;
+
+import org.openrewrite.java.internal.JavaIdentifierValidationService;
+
+public class CSharpIdentifierValidationService extends JavaIdentifierValidationService {
+
+    @Override
+    protected boolean isValidChar(char c) {
+        // C# identifiers permit letters, digits and '_'. A verbatim identifier may be prefixed with '@' (e.g. @class).
+        return Character.isLetterOrDigit(c) || c == '_' || c == '@';
+    }
+}

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/tree/Cs.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/tree/Cs.java
@@ -22,9 +22,11 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.csharp.CSharpVisitor;
 import org.openrewrite.csharp.rpc.CSharpRewriteRpc;
+import org.openrewrite.csharp.internal.CSharpIdentifierValidationService;
 import org.openrewrite.csharp.service.CSharpAutoFormatService;
 import org.openrewrite.csharp.service.CSharpNamingService;
 import org.openrewrite.csharp.service.CSharpWhitespaceValidationService;
+import org.openrewrite.internal.IdentifierValidationService;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.NamingService;
 import org.openrewrite.internal.WhitespaceValidationService;
@@ -295,6 +297,9 @@ public interface Cs extends J {
             }
             if (WhitespaceValidationService.class.getName().equals(service.getName())) {
                 return (T) new CSharpWhitespaceValidationService();
+            }
+            if (IdentifierValidationService.class.getName().equals(service.getName())) {
+                return (T) new CSharpIdentifierValidationService();
             }
             return JavaSourceFile.super.service(service);
         }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/GoIdentifierValidationService.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/GoIdentifierValidationService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.internal;
+
+import org.openrewrite.java.internal.JavaIdentifierValidationService;
+
+public class GoIdentifierValidationService extends JavaIdentifierValidationService {
+
+    @Override
+    protected boolean isValidChar(char c) {
+        // Go identifiers permit Unicode letters, digits and '_' (no '$').
+        return Character.isLetterOrDigit(c) || c == '_';
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
@@ -224,6 +224,11 @@ public interface Go extends J {
                 T t = (T) new org.openrewrite.golang.service.GolangImportService();
                 return t;
             }
+            if (org.openrewrite.internal.IdentifierValidationService.class.getName().equals(service.getName())) {
+                @SuppressWarnings("unchecked")
+                T t = (T) new org.openrewrite.golang.internal.GoIdentifierValidationService();
+                return t;
+            }
             return JavaSourceFile.super.service(service);
         }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/GroovyIdentifierValidationService.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/GroovyIdentifierValidationService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.internal;
+
+import org.openrewrite.java.internal.JavaIdentifierValidationService;
+
+public class GroovyIdentifierValidationService extends JavaIdentifierValidationService {
+
+    @Override
+    protected boolean isValidChar(char c) {
+        // Groovy permits the Java identifier characters plus '@' for attribute (field) access, e.g. obj.@field.
+        return super.isValidChar(c) || c == '@';
+    }
+
+    @Override
+    protected boolean isWhitelisted(String name) {
+        // Groovy allows quoted identifiers (e.g. foo.'some name' or foo."name"), which may contain any character.
+        if (super.isWhitelisted(name)) {
+            return true;
+        }
+        if (name.length() < 2) {
+            return false;
+        }
+        char first = name.charAt(0);
+        return (first == '\'' || first == '"') && name.charAt(name.length() - 1) == first;
+    }
+}

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
@@ -149,20 +149,18 @@ public interface G extends J {
         public <S, T extends S> T service(Class<S> service) {
             String serviceName = service.getName();
             try {
-                Class<S> serviceClass;
                 if (GroovyAutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = service;
+                    return (T) service.getConstructor().newInstance();
                 } else if (AutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = (Class<S>) service.getClassLoader().loadClass(GroovyAutoFormatService.class.getName());
+                    return (T) service.getClassLoader().loadClass(GroovyAutoFormatService.class.getName()).getConstructor().newInstance();
                 } else if (WhitespaceValidationService.class.getName().equals(serviceName)) {
-                    serviceClass = (Class<S>) service.getClassLoader().loadClass(GroovyWhitespaceValidationService.class.getName());
-                } else {
-                    return JavaSourceFile.super.service(service);
+                    return (T) service.getClassLoader().loadClass(GroovyWhitespaceValidationService.class.getName()).getConstructor().newInstance();
                 }
-                return (T) serviceClass.getConstructor().newInstance();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
+            // Delegate unknown services outside the try so an UnsupportedOperationException is not re-wrapped.
+            return JavaSourceFile.super.service(service);
         }
 
         List<JRightPadded<Statement>> statements;

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
@@ -22,8 +22,10 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.groovy.GroovyPrinter;
 import org.openrewrite.groovy.GroovyVisitor;
+import org.openrewrite.groovy.internal.GroovyIdentifierValidationService;
 import org.openrewrite.groovy.internal.GroovyWhitespaceValidationService;
 import org.openrewrite.groovy.service.GroovyAutoFormatService;
+import org.openrewrite.internal.IdentifierValidationService;
 import org.openrewrite.internal.WhitespaceValidationService;
 import org.openrewrite.java.internal.TypesInUse;
 import org.openrewrite.java.service.AutoFormatService;
@@ -155,6 +157,8 @@ public interface G extends J {
                     return (T) service.getClassLoader().loadClass(GroovyAutoFormatService.class.getName()).getConstructor().newInstance();
                 } else if (WhitespaceValidationService.class.getName().equals(serviceName)) {
                     return (T) service.getClassLoader().loadClass(GroovyWhitespaceValidationService.class.getName()).getConstructor().newInstance();
+                } else if (IdentifierValidationService.class.getName().equals(serviceName)) {
+                    return (T) service.getClassLoader().loadClass(GroovyIdentifierValidationService.class.getName()).getConstructor().newInstance();
                 }
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AssignmentTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AssignmentTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.groovy.tree;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.groovy.Assertions.groovy;
 
@@ -311,6 +312,9 @@ class AssignmentTest implements RewriteTest {
     @Test
     void destructuringAssignmentWithFullyQualifiedType() {
         rewriteRun(
+          // The fully-qualified type `java.lang.String` is stored as a single dotted J.Identifier rather than a
+          // J.FieldAccess, which the identifier-name validation flags. Allow it until the parser models this as a FieldAccess.
+          spec -> spec.typeValidationOptions(TypeValidation.builder().allowInvalidIdentifierNames(true).build()),
           groovy(
             """
               def (String key, java.lang.String value) = "a1:b2".split(":")

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaIdentifierValidationService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaIdentifierValidationService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.IdentifierValidationService;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+
+/**
+ * Validates that identifier names contain no characters that cannot appear in an identifier of a J-based language.
+ * A common parser bug is to store raw source text (e.g. a type expression or a constructor call) into a
+ * {@code J.Identifier} name; this service catches that.
+ * <p>
+ * The default rule flags the structural characters (whitespace, brackets, parentheses, braces, comma, semicolon)
+ * that cannot appear in an identifier of any of these languages, while whitelisting quoted/backtick-quoted names
+ * (e.g. Groovy {@code 'some name'} or Kotlin {@code `some name`}) which may contain any character. Languages that
+ * need different rules can subclass and override {@link #isWhitelisted(String)}.
+ */
+public class JavaIdentifierValidationService implements IdentifierValidationService {
+
+    private static final String INVALID_CHARS = " \t\r\n()[]{},;";
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Identifier visitIdentifier(J.Identifier identifier, ExecutionContext ctx) {
+                if (isInvalid(identifier)) {
+                    return identifier.withSimpleName("~~(invalid-identifier)~~>" + identifier.getSimpleName() + "<~~");
+                }
+                return identifier;
+            }
+        };
+    }
+
+    /**
+     * Whether the given identifier's name contains characters that cannot appear in an identifier of this language.
+     * Subclasses can override to account for language-specific quoting (e.g. a marker indicating the name was quoted).
+     */
+    protected boolean isInvalid(J.Identifier identifier) {
+        String name = identifier.getSimpleName();
+        return !isWhitelisted(name) && containsInvalidChar(name);
+    }
+
+    /**
+     * Names that may legitimately contain otherwise-invalid characters. Covers quoted identifiers wrapped in
+     * backticks (Kotlin), single quotes or double quotes (Groovy).
+     */
+    protected boolean isWhitelisted(String name) {
+        if (name.length() < 2) {
+            return false;
+        }
+        char first = name.charAt(0);
+        return (first == '`' || first == '\'' || first == '"') && name.charAt(name.length() - 1) == first;
+    }
+
+    protected static boolean containsInvalidChar(String name) {
+        for (int i = 0; i < name.length(); i++) {
+            if (INVALID_CHARS.indexOf(name.charAt(i)) >= 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaIdentifierValidationService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaIdentifierValidationService.java
@@ -22,18 +22,19 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
 
 /**
- * Validates that identifier names contain no characters that cannot appear in an identifier of a J-based language.
+ * Validates that identifier names contain only characters that can appear in an identifier of the source language.
  * A common parser bug is to store raw source text (e.g. a type expression or a constructor call) into a
  * {@code J.Identifier} name; this service catches that.
  * <p>
- * The default rule flags the structural characters (whitespace, brackets, parentheses, braces, comma, semicolon)
- * that cannot appear in an identifier of any of these languages, while whitelisting quoted/backtick-quoted names
- * (e.g. Groovy {@code 'some name'} or Kotlin {@code `some name`}) which may contain any character. Languages that
- * need different rules can subclass and override {@link #isWhitelisted(String)}.
+ * The rule is an allow-list of characters, so it is specific to each language. This base implementation encodes the
+ * Java rule ({@link Character#isJavaIdentifierPart}, which permits letters, digits, {@code _} and {@code $} plus the
+ * corresponding Unicode categories). Other languages subclass and override {@link #isValidChar(char)} (and, where the
+ * language quotes identifiers, {@link #isWhitelisted(String)} / {@link #isInvalid(J.Identifier)}).
+ * <p>
+ * Only the character set is validated, not start-of-identifier rules; an LST may legitimately carry synthesized names
+ * that would not be legal at the start of a source identifier.
  */
 public class JavaIdentifierValidationService implements IdentifierValidationService {
-
-    private static final String INVALID_CHARS = " \t\r\n()[]{},;";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
@@ -49,32 +50,39 @@ public class JavaIdentifierValidationService implements IdentifierValidationServ
     }
 
     /**
-     * Whether the given identifier's name contains characters that cannot appear in an identifier of this language.
+     * Whether the identifier's name contains a character that cannot appear in an identifier of this language.
      * Subclasses can override to account for language-specific quoting (e.g. a marker indicating the name was quoted).
      */
     protected boolean isInvalid(J.Identifier identifier) {
         String name = identifier.getSimpleName();
-        return !isWhitelisted(name) && containsInvalidChar(name);
-    }
-
-    /**
-     * Names that may legitimately contain otherwise-invalid characters. Covers quoted identifiers wrapped in
-     * backticks (Kotlin), single quotes or double quotes (Groovy).
-     */
-    protected boolean isWhitelisted(String name) {
-        if (name.length() < 2) {
+        if (name.isEmpty() || isWhitelisted(name)) {
             return false;
         }
-        char first = name.charAt(0);
-        return (first == '`' || first == '\'' || first == '"') && name.charAt(name.length() - 1) == first;
-    }
-
-    protected static boolean containsInvalidChar(String name) {
         for (int i = 0; i < name.length(); i++) {
-            if (INVALID_CHARS.indexOf(name.charAt(i)) >= 0) {
+            if (!isValidChar(name.charAt(i))) {
                 return true;
             }
         }
         return false;
+    }
+
+    /**
+     * Whether {@code c} may appear anywhere in a bare (unquoted) identifier of this language. The Java rule permits
+     * letters, digits, {@code _}, {@code $} and the Unicode categories recognized by {@link Character#isJavaIdentifierPart}.
+     */
+    protected boolean isValidChar(char c) {
+        return Character.isJavaIdentifierPart(c);
+    }
+
+    /**
+     * Names allowed despite containing otherwise-invalid characters:
+     * <ul>
+     *     <li>{@code *} — wildcard imports (e.g. {@code import a.b.*}) represent the wildcard as a {@code J.Identifier}.</li>
+     *     <li>Names beginning with {@code <} — compiler-synthesized names (e.g. {@code <init>}, Kotlin {@code <get>}/{@code <destruct>},
+     *     C# {@code <Main>$}) follow this convention; no source identifier in these languages starts with {@code <}.</li>
+     * </ul>
+     */
+    protected boolean isWhitelisted(String name) {
+        return "*".equals(name) || name.charAt(0) == '<';
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
@@ -18,8 +18,10 @@ package org.openrewrite.java.tree;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Incubating;
 import org.openrewrite.SourceFile;
+import org.openrewrite.internal.IdentifierValidationService;
 import org.openrewrite.internal.NamingService;
 import org.openrewrite.internal.WhitespaceValidationService;
+import org.openrewrite.java.internal.JavaIdentifierValidationService;
 import org.openrewrite.java.internal.JavaWhitespaceValidationService;
 import org.openrewrite.java.internal.TypesInUse;
 import org.openrewrite.java.service.*;
@@ -74,6 +76,9 @@ public interface JavaSourceFile extends J, SourceFile {
             } else if (WhitespaceValidationService.class.getName().equals(service.getName())) {
                 // Only unit tests should need to use this service, so no classloading concerns
                 return (T) new JavaWhitespaceValidationService();
+            } else if (IdentifierValidationService.class.getName().equals(service.getName())) {
+                // Only unit tests should need to use this service, so no classloading concerns
+                return (T) new JavaIdentifierValidationService();
             } else if (NamingService.class.getName().equals(service.getName())) {
                 return (T) new JavaNamingService();
             } else if (SourcePositionService.class.getName().equals(service.getName())) {

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/JavaScriptIdentifierValidationService.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/JavaScriptIdentifierValidationService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript.internal;
+
+import org.openrewrite.java.internal.JavaIdentifierValidationService;
+
+public class JavaScriptIdentifierValidationService extends JavaIdentifierValidationService {
+
+    @Override
+    protected boolean isValidChar(char c) {
+        // ECMAScript identifiers permit letters, digits, '_', '$' and (for private class members) a leading '#'.
+        return Character.isLetterOrDigit(c) || c == '_' || c == '$' || c == '#';
+    }
+}

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
@@ -227,16 +227,14 @@ public interface JS extends J {
         public <S, T extends S> T service(Class<S> service) {
             String serviceName = service.getName();
             try {
-                Class<S> serviceClass;
                 if (AutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = (Class<S>) service.getClassLoader().loadClass(JavaScriptAutoFormatService.class.getName());
-                } else {
-                    return JavaSourceFile.super.service(service);
+                    return (T) service.getClassLoader().loadClass(JavaScriptAutoFormatService.class.getName()).getConstructor().newInstance();
                 }
-                return (T) serviceClass.getConstructor().newInstance();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
+            // Delegate unknown services outside the try so an UnsupportedOperationException is not re-wrapped.
+            return JavaSourceFile.super.service(service);
         }
 
         @Transient

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
@@ -23,8 +23,10 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.JavaPrinter;
 import org.openrewrite.java.JavaTypeVisitor;
+import org.openrewrite.internal.IdentifierValidationService;
 import org.openrewrite.java.internal.TypesInUse;
 import org.openrewrite.java.service.AutoFormatService;
+import org.openrewrite.javascript.internal.JavaScriptIdentifierValidationService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.javascript.JavaScriptVisitor;
 import org.openrewrite.javascript.rpc.JavaScriptRewriteRpc;
@@ -229,6 +231,8 @@ public interface JS extends J {
             try {
                 if (AutoFormatService.class.getName().equals(serviceName)) {
                     return (T) service.getClassLoader().loadClass(JavaScriptAutoFormatService.class.getName()).getConstructor().newInstance();
+                } else if (IdentifierValidationService.class.getName().equals(serviceName)) {
+                    return (T) service.getClassLoader().loadClass(JavaScriptIdentifierValidationService.class.getName()).getConstructor().newInstance();
                 }
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinIdentifierValidationService.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinIdentifierValidationService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.internal;
+
+import org.openrewrite.java.internal.JavaIdentifierValidationService;
+import org.openrewrite.java.marker.Quoted;
+import org.openrewrite.java.tree.J;
+
+public class KotlinIdentifierValidationService extends JavaIdentifierValidationService {
+
+    @Override
+    protected boolean isInvalid(J.Identifier identifier) {
+        // Kotlin stores backtick-quoted identifiers without the backticks and marks them with Quoted;
+        // such names may contain any character.
+        if (identifier.getMarkers().findFirst(Quoted.class).isPresent()) {
+            return false;
+        }
+        return super.isInvalid(identifier);
+    }
+}

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinIdentifierValidationService.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinIdentifierValidationService.java
@@ -18,16 +18,27 @@ package org.openrewrite.kotlin.internal;
 import org.openrewrite.java.internal.JavaIdentifierValidationService;
 import org.openrewrite.java.marker.Quoted;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.kotlin.marker.Implicit;
 
 public class KotlinIdentifierValidationService extends JavaIdentifierValidationService {
 
     @Override
     protected boolean isInvalid(J.Identifier identifier) {
+        // Compiler-synthesized identifiers (e.g. implicit receivers) are not source identifiers and are not printed.
+        if (identifier.getMarkers().findFirst(Implicit.class).isPresent()) {
+            return false;
+        }
         // Kotlin stores backtick-quoted identifiers without the backticks and marks them with Quoted;
         // such names may contain any character.
         if (identifier.getMarkers().findFirst(Quoted.class).isPresent()) {
             return false;
         }
         return super.isInvalid(identifier);
+    }
+
+    @Override
+    protected boolean isValidChar(char c) {
+        // Kotlin bare identifiers permit letters, digits and underscore, but not '$' (reserved for string templates).
+        return Character.isLetterOrDigit(c) || c == '_';
     }
 }

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -20,6 +20,7 @@ import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.internal.IdentifierValidationService;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaPrinter;
 import org.openrewrite.java.JavaTypeVisitor;
@@ -28,6 +29,7 @@ import org.openrewrite.java.service.AutoFormatService;
 import org.openrewrite.java.service.ImportService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.kotlin.KotlinVisitor;
+import org.openrewrite.kotlin.internal.KotlinIdentifierValidationService;
 import org.openrewrite.kotlin.internal.KotlinPrinter;
 import org.openrewrite.kotlin.service.KotlinAutoFormatService;
 import org.openrewrite.kotlin.service.KotlinImportService;
@@ -354,6 +356,8 @@ public interface K extends J {
                     return (T) service.getConstructor().newInstance();
                 } else if (AutoFormatService.class.getName().equals(serviceName)) {
                     return (T) service.getClassLoader().loadClass(KotlinAutoFormatService.class.getName()).getConstructor().newInstance();
+                } else if (IdentifierValidationService.class.getName().equals(serviceName)) {
+                    return (T) service.getClassLoader().loadClass(KotlinIdentifierValidationService.class.getName()).getConstructor().newInstance();
                 }
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -346,22 +346,20 @@ public interface K extends J {
         public <S, T extends S> T service(Class<S> service) {
             String serviceName = service.getName();
             try {
-                Class<S> serviceClass;
                 if (KotlinImportService.class.getName().equals(serviceName)) {
-                    serviceClass = service;
+                    return (T) service.getConstructor().newInstance();
                 } else if (ImportService.class.getName().equals(serviceName)) {
-                    serviceClass = (Class<S>) service.getClassLoader().loadClass(KotlinImportService.class.getName());
+                    return (T) service.getClassLoader().loadClass(KotlinImportService.class.getName()).getConstructor().newInstance();
                 } else if (KotlinAutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = service;
+                    return (T) service.getConstructor().newInstance();
                 } else if (AutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = (Class<S>) service.getClassLoader().loadClass(KotlinAutoFormatService.class.getName());
-                } else {
-                    return JavaSourceFile.super.service(service);
+                    return (T) service.getClassLoader().loadClass(KotlinAutoFormatService.class.getName()).getConstructor().newInstance();
                 }
-                return (T) serviceClass.getConstructor().newInstance();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
+            // Delegate unknown services outside the try so an UnsupportedOperationException is not re-wrapped.
+            return JavaSourceFile.super.service(service);
         }
     }
 

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonIdentifierValidationService.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonIdentifierValidationService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.internal;
+
+import org.openrewrite.java.internal.JavaIdentifierValidationService;
+
+public class PythonIdentifierValidationService extends JavaIdentifierValidationService {
+
+    @Override
+    protected boolean isValidChar(char c) {
+        // Python identifiers permit Unicode letters, digits and '_' (no '$'), per PEP 3131.
+        return Character.isLetterOrDigit(c) || c == '_';
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/tree/Py.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/tree/Py.java
@@ -21,8 +21,10 @@ import lombok.experimental.NonFinal;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.JavaPrinter;
+import org.openrewrite.internal.IdentifierValidationService;
 import org.openrewrite.java.internal.TypesInUse;
 import org.openrewrite.java.service.AutoFormatService;
+import org.openrewrite.python.internal.PythonIdentifierValidationService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.python.PythonVisitor;
@@ -555,6 +557,9 @@ public interface Py extends J {
         public <S, T extends S> T service(Class<S> service) {
             if (AutoFormatService.class.getName().equals(service.getName())) {
                 return (T) new PythonAutoFormatService();
+            }
+            if (IdentifierValidationService.class.getName().equals(service.getName())) {
+                return (T) new PythonIdentifierValidationService();
             }
             return JavaSourceFile.super.service(service);
         }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/internal/ScalaIdentifierValidationService.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/internal/ScalaIdentifierValidationService.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.internal;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.IdentifierValidationService;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.scala.ScalaIsoVisitor;
+
+public class ScalaIdentifierValidationService implements IdentifierValidationService {
+
+    /**
+     * Characters that can never appear in a Scala identifier: whitespace, brackets, parentheses, braces,
+     * comma, semicolon and double quote. Operator identifiers (e.g. {@code <=}, {@code ::}, {@code +}) are
+     * intentionally not flagged, and backtick-quoted identifiers (which may contain any character) are
+     * whitelisted separately.
+     */
+    private static final String INVALID_CHARS = " \t\r\n()[]{},;\"";
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new ScalaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Identifier visitIdentifier(J.Identifier identifier, ExecutionContext ctx) {
+                String name = identifier.getSimpleName();
+                if (!isBacktickQuoted(name) && containsInvalidChar(name)) {
+                    return identifier.withSimpleName("~~(invalid-identifier)~~>" + name + "<~~");
+                }
+                return identifier;
+            }
+        };
+    }
+
+    private static boolean isBacktickQuoted(String name) {
+        return name.length() >= 2 && name.charAt(0) == '`' && name.charAt(name.length() - 1) == '`';
+    }
+
+    private static boolean containsInvalidChar(String name) {
+        for (int i = 0; i < name.length(); i++) {
+            if (INVALID_CHARS.indexOf(name.charAt(i)) >= 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -20,12 +20,14 @@ import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.internal.IdentifierValidationService;
 import org.openrewrite.java.internal.TypesInUse;
 import org.openrewrite.java.service.AutoFormatService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.scala.ScalaPrinter;
 import org.openrewrite.scala.ScalaVisitor;
+import org.openrewrite.scala.internal.ScalaIdentifierValidationService;
 import org.openrewrite.scala.service.ScalaAutoFormatService;
 
 import java.lang.ref.SoftReference;
@@ -260,6 +262,8 @@ public interface S extends J {
                     serviceClass = service;
                 } else if (AutoFormatService.class.getName().equals(serviceName)) {
                     serviceClass = (Class<S>) service.getClassLoader().loadClass(ScalaAutoFormatService.class.getName());
+                } else if (IdentifierValidationService.class.getName().equals(serviceName)) {
+                    serviceClass = (Class<S>) service.getClassLoader().loadClass(ScalaIdentifierValidationService.class.getName());
                 } else {
                     return JavaSourceFile.super.service(service);
                 }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -257,20 +257,18 @@ public interface S extends J {
         public <S, T extends S> T service(Class<S> service) {
             String serviceName = service.getName();
             try {
-                Class<S> serviceClass;
                 if (ScalaAutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = service;
+                    return (T) service.getConstructor().newInstance();
                 } else if (AutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = (Class<S>) service.getClassLoader().loadClass(ScalaAutoFormatService.class.getName());
+                    return (T) service.getClassLoader().loadClass(ScalaAutoFormatService.class.getName()).getConstructor().newInstance();
                 } else if (IdentifierValidationService.class.getName().equals(serviceName)) {
-                    serviceClass = (Class<S>) service.getClassLoader().loadClass(ScalaIdentifierValidationService.class.getName());
-                } else {
-                    return JavaSourceFile.super.service(service);
+                    return (T) service.getClassLoader().loadClass(ScalaIdentifierValidationService.class.getName()).getConstructor().newInstance();
                 }
-                return (T) serviceClass.getConstructor().newInstance();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
+            // Delegate unknown services outside the try so an UnsupportedOperationException is not re-wrapped.
+            return JavaSourceFile.super.service(service);
         }
 
         @Override

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaIdentifierValidationServiceTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaIdentifierValidationServiceTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.scala.internal.ScalaIdentifierValidationService;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.Tree.randomId;
+
+class ScalaIdentifierValidationServiceTest {
+
+    private final ScalaIdentifierValidationService service = new ScalaIdentifierValidationService();
+
+    private J.Identifier identifier(String name) {
+        return new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), name, null, null);
+    }
+
+    private boolean isFlagged(String name) {
+        // given an identifier with the given name
+        J.Identifier id = identifier(name);
+        // when the validation visitor runs
+        J.Identifier visited = (J.Identifier) service.getVisitor().visit(id, new InMemoryExecutionContext());
+        // then it is flagged iff the visitor mutated the name
+        return visited != null && !name.equals(visited.getSimpleName());
+    }
+
+    @Test
+    void flagsSourceTextStuffedIntoIdentifierNames() {
+        assertThat(isFlagged("Int | String")).isTrue();
+        assertThat(isFlagged("Serializable & Comparable[String]")).isTrue();
+        assertThat(isFlagged("Array[Int]()")).isTrue();
+        assertThat(isFlagged("Exception(msg)")).isTrue();
+        assertThat(isFlagged("F[_]")).isTrue();
+        assertThat(isFlagged("e @ (_: A | _: B)")).isTrue();
+    }
+
+    @Test
+    void allowsLegitimateScalaIdentifiers() {
+        assertThat(isFlagged("x")).isFalse();
+        assertThat(isFlagged("myVariable")).isFalse();
+        assertThat(isFlagged("_value")).isFalse();
+        assertThat(isFlagged("$value")).isFalse();
+        // operator identifiers are legal Scala identifiers
+        assertThat(isFlagged("::")).isFalse();
+        assertThat(isFlagged("<=")).isFalse();
+        assertThat(isFlagged("+")).isFalse();
+        assertThat(isFlagged("->")).isFalse();
+    }
+
+    @Test
+    void allowsBacktickQuotedIdentifiers() {
+        // backtick-quoted identifiers may contain any character
+        assertThat(isFlagged("`my variable`")).isFalse();
+        assertThat(isFlagged("`text/html(UTF-8)`")).isFalse();
+        assertThat(isFlagged("`type`")).isFalse();
+    }
+}

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -392,6 +392,19 @@ public interface RewriteTest extends SourceSpecs {
                                 // Language/parser does not provide whitespace validation and that's OK for now
                             }
                         }
+                        if (!beforeValidations.allowInvalidIdentifierNames()) {
+                            try {
+                                IdentifierValidationService service = sourceFile.service(IdentifierValidationService.class);
+                                SourceFile identifierValidated = (SourceFile) service.getVisitor().visit(sourceFile, ctx);
+                                if (identifierValidated != null && identifierValidated != sourceFile) {
+                                    fail("Source file was parsed into an LST that contains identifiers with characters that cannot appear " +
+                                         "in an identifier of this language. This usually means the parser stored raw source text (such as a " +
+                                         "type expression or constructor call) into a J.Identifier name. \n" + identifierValidated.printAll());
+                                }
+                            } catch (UnsupportedOperationException e) {
+                                // Language/parser does not provide identifier validation and that's OK for now
+                            }
+                        }
                     }
                 }
 

--- a/rewrite-test/src/main/java/org/openrewrite/test/TypeValidation.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/TypeValidation.java
@@ -140,6 +140,15 @@ public class TypeValidation {
     private boolean parseAndPrintEquality = true;
 
     /**
+     * It is almost always a parser bug if an identifier's name contains characters that cannot appear in an identifier
+     * of the source language (for example raw source text such as a type expression or constructor call being stored
+     * into a {@code J.Identifier} name). In some edge cases with parsers this may be allowed.
+     * If you find yourself using this setting in a normal recipe test consider reporting a bug on the parser instead.
+     */
+    @Builder.Default
+    private boolean allowInvalidIdentifierNames = false;
+
+    /**
      * Enable all invariant validation checks.
      */
     public static TypeValidation all() {
@@ -150,7 +159,7 @@ public class TypeValidation {
      * Skip all invariant validation checks.
      */
     public static TypeValidation none() {
-        return new TypeValidation(false, false, false, false, false, false, false, false, o -> false, false, false, false, false, false, false);
+        return new TypeValidation(false, false, false, false, false, false, false, false, o -> false, false, false, false, false, false, false, false);
     }
 
     static TypeValidation before(RecipeSpec testMethodSpec, RecipeSpec testClassSpec) {


### PR DESCRIPTION
## What's changed?

Amending the test harness to add a new check. This is for enforcing that the identifiers contain only these characters which are allowed for given language.

## What's your motivation?

The typical situation this check catches is when the parsing stuffs too much into a single `J.Identifier`. The round-trip idempotency printing test doesn't necessarily catch that.

I caught several cases like this recently in Scala. But the idea is more universal, thus the generic solution.