### PR TITLE
Scala: fix parsing of qualified this

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7160,10 +7160,32 @@ class ScalaTreeVisitor(
     new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), caseStatements, matchEndSpace)
   }
 
-  private def visitThis(thisTree: Trees.This[?]): J.Identifier = {
+  private def visitThis(thisTree: Trees.This[?]): J = {
     val prefix = extractPrefix(thisTree.span)
-    updateCursor(thisTree.span.end)
-    ident("this", prefix, typeFor(thisTree.span))
+    val qual = thisTree.qual
+    val qualName: String = qual match {
+      case ident: Trees.Ident[?] if ident.name != null && !ident.name.isEmpty =>
+        ident.name.toString
+      case _ => null
+    }
+    if (qualName == null) {
+      updateCursor(thisTree.span.end)
+      ident("this", prefix, typeFor(thisTree.span))
+    } else {
+      // Qualified `this`, e.g. `Outer.this`, modeled as a field access onto the `this` keyword.
+      val afterQual = Math.max(0, thisTree.span.start - offsetAdjustment) + qualName.length
+      val thisEnd = Math.max(0, thisTree.span.end - offsetAdjustment)
+      val dotIdx = source.indexOf('.', afterQual)
+      val thisStart = thisEnd - "this".length
+      val beforeDot = ScalaSpace.format(source, afterQual, dotIdx)
+      val namePrefix = ScalaSpace.format(source, dotIdx + 1, thisStart)
+      val qualifier = new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+        Collections.emptyList(), qualName, null, null)
+      val thisName = ident("this", namePrefix, typeFor(thisTree.span))
+      updateCursor(thisTree.span.end)
+      new J.FieldAccess(Tree.randomId(), prefix, Markers.EMPTY, qualifier,
+        new JLeftPadded(beforeDot, thisName, Markers.EMPTY), typeFor(thisTree.span))
+    }
   }
 
   private def visitSuper(superTree: Trees.Super[?]): J = {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/FieldAccessTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/FieldAccessTest.java
@@ -91,6 +91,18 @@ class FieldAccessTest implements RewriteTest {
     }
 
     @Test
+    void qualifiedThis() {
+        rewriteRun(
+          scala(
+            """
+              class Status:
+                val name = Status.this.toString
+              """
+          )
+        );
+    }
+
+    @Test
     void fieldAccessWithParentheses() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

Fix parsing of qualified this in Scala, e.g. `Status.this.toString`.

## What's your motivation?

It suffers from idempotency issues, the `Status.` is swallowed.