### PR TITLE
Optimize `Markers.findFirst` to avoid stream allocation

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/Markers.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/Markers.java
@@ -165,10 +165,12 @@ public class Markers implements RpcCodec<Markers> {
     }
 
     public <M extends Marker> Optional<M> findFirst(Class<M> markerType) {
-        return markers.stream()
-                .filter(markerType::isInstance)
-                .map(markerType::cast)
-                .findFirst();
+        for (Marker marker : markers) {
+            if (markerType.isInstance(marker)) {
+                return Optional.of(markerType.cast(marker));
+            }
+        }
+        return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
## Motivation

`Markers.findFirst` is called heavily during LST traversal — visitors routinely probe markers on the nodes they visit. The current implementation builds a `Stream` pipeline (with two bound method-reference lambdas and the associated pipeline machinery) on every call, which adds up to meaningful allocation pressure on the hot path.

## Summary

- Replaced the stream pipeline in `findFirst` with a plain loop that returns early on the first match, avoiding the per-call `Stream` and lambda capture allocations. Behavior is identical (first matching marker, or `Optional.empty()`).
- Kept the enhanced-for loop style to match the existing `add` method in the same class.

## Test plan

- `./gradlew :rewrite-core:compileJava` succeeds.
- Behavior is unchanged, so existing tests covering marker lookups continue to apply.