### PR TITLE
Reduce allocation in ResolvedDependency.findDependency/findDependencies

### DIFF
--- a/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/maven/FindDependencyBenchmark.java
+++ b/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/maven/FindDependencyBenchmark.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.maven;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.maven.MavenExecutionContextView;
+import org.openrewrite.maven.MavenParser;
+import org.openrewrite.maven.cache.CompositeMavenPomCache;
+import org.openrewrite.maven.cache.InMemoryMavenPomCache;
+import org.openrewrite.maven.cache.RocksdbMavenPomCache;
+import org.openrewrite.maven.tree.MavenResolutionResult;
+import org.openrewrite.maven.tree.ResolvedDependency;
+
+import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Exercises the hot {@link ResolvedDependency#findDependency} / {@link ResolvedDependency#findDependencies}
+ * recursive graph walk against a realistic resolved {@code spring-boot-starter-web} tree. Run with the
+ * {@code gc} profiler (the default in this module) to observe per-lookup allocation.
+ */
+@Fork(1)
+@Measurement(iterations = 2)
+@Warmup(iterations = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class FindDependencyBenchmark {
+
+    CompositeMavenPomCache pomCache = new CompositeMavenPomCache(
+            new InMemoryMavenPomCache(),
+            new RocksdbMavenPomCache(Paths.get(System.getProperty("user.home")))
+    );
+
+    ResolvedDependency root;
+
+    /**
+     * Coordinates of the deepest dependency in {@link #root}'s subtree, so a lookup walks the full graph
+     * before finding a match.
+     */
+    String deepGroupId;
+    String deepArtifactId;
+
+    @Setup
+    public void setup() {
+        MavenExecutionContextView ctx = MavenExecutionContextView.view(new InMemoryExecutionContext());
+        ctx.setPomCache(pomCache);
+
+        //noinspection OptionalGetWithoutIsPresent
+        SourceFile pom = MavenParser.builder().build().parse(ctx,
+                "" +
+                "<project>" +
+                "  <parent>" +
+                "    <groupId>org.springframework.boot</groupId>" +
+                "    <artifactId>spring-boot-starter-parent</artifactId>" +
+                "    <version>2.6.3</version>" +
+                "  </parent>" +
+                "  <groupId>com.mycompany.app</groupId>" +
+                "  <artifactId>my-app</artifactId>" +
+                "  <version>1</version>" +
+                "  <dependencies>" +
+                "    <dependency>" +
+                "      <groupId>org.springframework.boot</groupId>" +
+                "      <artifactId>spring-boot-starter-web</artifactId>" +
+                "    </dependency>" +
+                "  </dependencies>" +
+                "</project>"
+        ).findFirst().get();
+
+        MavenResolutionResult mrr = pom.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+        List<ResolvedDependency> compile = mrr.getDependencies().get(org.openrewrite.maven.tree.Scope.Compile);
+
+        // The direct dependency with the largest subtree, to make the recursive walk meaningful.
+        ResolvedDependency widest = null;
+        int widestSize = -1;
+        for (ResolvedDependency d : compile) {
+            if (d.getDepth() == 0) {
+                int size = countSubtree(d);
+                if (size > widestSize) {
+                    widestSize = size;
+                    widest = d;
+                }
+            }
+        }
+        root = widest == null ? compile.get(0) : widest;
+
+        ResolvedDependency deepest = deepest(root);
+        deepGroupId = deepest.getGroupId();
+        deepArtifactId = deepest.getArtifactId();
+    }
+
+    private static int countSubtree(ResolvedDependency d) {
+        int count = 1;
+        for (ResolvedDependency child : d.getDependencies()) {
+            count += countSubtree(child);
+        }
+        return count;
+    }
+
+    /**
+     * @return the dependency with the greatest depth in {@code root}'s subtree, so that looking it up by exact
+     * coordinate forces the recursive walk to descend as far as possible before matching.
+     */
+    private static ResolvedDependency deepest(ResolvedDependency root) {
+        ResolvedDependency deepest = root;
+        Deque<ResolvedDependency> stack = new ArrayDeque<>();
+        stack.push(root);
+        while (!stack.isEmpty()) {
+            ResolvedDependency d = stack.pop();
+            if (d.getDepth() > deepest.getDepth()) {
+                deepest = d;
+            }
+            for (ResolvedDependency child : d.getDependencies()) {
+                stack.push(child);
+            }
+        }
+        return deepest;
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(FindDependencyBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opt).run();
+    }
+
+    /**
+     * Exact-coordinate lookup that walks the whole subtree before matching the deepest transitive dependency.
+     */
+    @Benchmark
+    public void findDependencyDeepHit(Blackhole blackhole) {
+        blackhole.consume(root.findDependency(deepGroupId, deepArtifactId));
+    }
+
+    /**
+     * Exact-coordinate lookup for a coordinate that is absent, forcing a full graph walk.
+     */
+    @Benchmark
+    public void findDependencyMiss(Blackhole blackhole) {
+        blackhole.consume(root.findDependency("com.example.absent", "does-not-exist"));
+    }
+
+    /**
+     * Glob lookup that collects every Spring artifact in the subtree.
+     */
+    @Benchmark
+    public void findDependenciesGlob(Blackhole blackhole) {
+        blackhole.consume(root.findDependencies("org.springframework*", "*"));
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
@@ -121,59 +121,106 @@ public class ResolvedDependency implements Serializable {
     }
 
     public List<ResolvedDependency> findDependencies(String groupId, String artifactId) {
-        return findDependencies0(groupId, artifactId, newSetFromMap(new IdentityHashMap<>()));
+        List<ResolvedDependency> found = new ArrayList<>();
+        findDependencies0(groupId, artifactId, isExact(groupId), isExact(artifactId), null, found);
+        return found;
     }
 
-    private List<ResolvedDependency> findDependencies0(String groupId, String artifactId, Set<ResolvedDependency> visited) {
-        List<ResolvedDependency> dependencies = new ArrayList<>();
-        if (matchesGlob(getGroupId(), groupId) && matchesGlob(getArtifactId(), artifactId)) {
-            dependencies.add(this);
-        } else if (!visited.add(this)) {
-            return emptyList();
+    private void findDependencies0(@Nullable String groupId, @Nullable String artifactId, boolean groupExact,
+                                   boolean artifactExact, @Nullable Set<ResolvedDependency> visited,
+                                   List<ResolvedDependency> found) {
+        if (matches(getGroupId(), groupId, groupExact) && matches(getArtifactId(), artifactId, artifactExact)) {
+            found.add(this);
+        } else {
+            if (visited == null) {
+                visited = newSetFromMap(new IdentityHashMap<>());
+            }
+            if (!visited.add(this)) {
+                return;
+            }
         }
-        for (ResolvedDependency dependency : this.dependencies) {
-            dependency.findDependencies0(groupId, artifactId, visited).stream()
-                    .filter(found -> {
-                        if (getRequested().getExclusions() != null) {
-                            for (GroupArtifact exclusion : getRequested().getExclusions()) {
-                                if (matchesGlob(found.getGroupId(), exclusion.getGroupId()) &&
-                                        matchesGlob(found.getArtifactId(), exclusion.getArtifactId())) {
-                                    return false;
-                                }
-                            }
-                        }
-                        return true;
-                    }).forEach(dependencies::add);
+        List<ResolvedDependency> dependencies = this.dependencies;
+        if (dependencies.isEmpty()) {
+            return;
         }
-        return dependencies;
+        if (visited == null) {
+            // Reached only when this dependency matched (and so was not added above); allocate for the recursion.
+            visited = newSetFromMap(new IdentityHashMap<>());
+        }
+        List<GroupArtifact> exclusions = requested == null ? null : requested.getExclusions();
+        boolean hasExclusions = exclusions != null && !exclusions.isEmpty();
+        for (int i = 0, size = dependencies.size(); i < size; i++) {
+            ResolvedDependency dependency = dependencies.get(i);
+            if (hasExclusions) {
+                int start = found.size();
+                dependency.findDependencies0(groupId, artifactId, groupExact, artifactExact, visited, found);
+                for (int j = found.size() - 1; j >= start; j--) {
+                    if (isExcluded(found.get(j), exclusions)) {
+                        found.remove(j);
+                    }
+                }
+            } else {
+                dependency.findDependencies0(groupId, artifactId, groupExact, artifactExact, visited, found);
+            }
+        }
     }
 
     public @Nullable ResolvedDependency findDependency(@Nullable String groupId, @Nullable String artifactId) {
-        return findDependency0(groupId, artifactId, newSetFromMap(new IdentityHashMap<>()));
+        return findDependency0(groupId, artifactId, isExact(groupId), isExact(artifactId), null);
     }
 
-    private @Nullable ResolvedDependency findDependency0(@Nullable String groupId, @Nullable String artifactId, Set<ResolvedDependency> visited) {
-        if (matchesGlob(getGroupId(), groupId) && matchesGlob(getArtifactId(), artifactId)) {
+    private @Nullable ResolvedDependency findDependency0(@Nullable String groupId, @Nullable String artifactId,
+                                                         boolean groupExact, boolean artifactExact,
+                                                         @Nullable Set<ResolvedDependency> visited) {
+        if (matches(getGroupId(), groupId, groupExact) && matches(getArtifactId(), artifactId, artifactExact)) {
             return this;
-        } else if (!visited.add(this)) {
+        }
+        List<ResolvedDependency> dependencies = this.dependencies;
+        if (dependencies.isEmpty()) {
             return null;
         }
-        outer:
-        for (ResolvedDependency dependency : this.dependencies) {
-            ResolvedDependency found = dependency.findDependency0(groupId, artifactId, visited);
-            if (found != null) {
-                if (getRequested().getExclusions() != null) {
-                    for (GroupArtifact exclusion : getRequested().getExclusions()) {
-                        if (matchesGlob(found.getGroupId(), exclusion.getGroupId()) &&
-                                matchesGlob(found.getArtifactId(), exclusion.getArtifactId())) {
-                            continue outer;
-                        }
-                    }
-                }
+        if (visited == null) {
+            visited = newSetFromMap(new IdentityHashMap<>());
+        }
+        if (!visited.add(this)) {
+            return null;
+        }
+        List<GroupArtifact> exclusions = requested == null ? null : requested.getExclusions();
+        for (int i = 0, size = dependencies.size(); i < size; i++) {
+            ResolvedDependency found = dependencies.get(i).findDependency0(groupId, artifactId, groupExact, artifactExact, visited);
+            if (found != null && !isExcluded(found, exclusions)) {
                 return found;
             }
         }
         return null;
+    }
+
+    /**
+     * @param pattern a groupId or artifactId glob pattern
+     * @return {@code true} when {@code pattern} contains no glob metacharacters and so can be compared with a
+     * case-insensitive {@link String#equalsIgnoreCase} rather than the more expensive
+     * {@link org.openrewrite.internal.StringUtils#matchesGlob}.
+     * {@code null} (matches everything) and patterns containing {@code *}/{@code ?} return {@code false}.
+     */
+    private static boolean isExact(@Nullable String pattern) {
+        return pattern != null && pattern.indexOf('*') < 0 && pattern.indexOf('?') < 0;
+    }
+
+    private static boolean matches(String value, @Nullable String pattern, boolean exact) {
+        return exact ? value.equalsIgnoreCase(pattern) : matchesGlob(value, pattern);
+    }
+
+    private static boolean isExcluded(ResolvedDependency found, @Nullable List<GroupArtifact> exclusions) {
+        if (exclusions != null) {
+            for (int i = 0, size = exclusions.size(); i < size; i++) {
+                GroupArtifact exclusion = exclusions.get(i);
+                if (matchesGlob(found.getGroupId(), exclusion.getGroupId()) &&
+                        matchesGlob(found.getArtifactId(), exclusion.getArtifactId())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Override

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/tree/ResolvedDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/tree/ResolvedDependencyTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.tree;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResolvedDependencyTest {
+
+    private static ResolvedDependency dep(String groupId, String artifactId, List<GroupArtifact> exclusions, ResolvedDependency... children) {
+        return ResolvedDependency.builder()
+          .gav(new ResolvedGroupArtifactVersion(null, groupId, artifactId, "1.0", null))
+          .requested(Dependency.builder()
+            .gav(new GroupArtifactVersion(groupId, artifactId, "1.0"))
+            .exclusions(exclusions)
+            .build())
+          .dependencies(List.of(children))
+          .build();
+    }
+
+    private static ResolvedDependency dep(String groupId, String artifactId, ResolvedDependency... children) {
+        return dep(groupId, artifactId, emptyList(), children);
+    }
+
+    @Test
+    void findDirectExactMatch() {
+        ResolvedDependency root = dep("com.example", "root",
+          dep("org.apache.commons", "commons-lang3"));
+        ResolvedDependency found = root.findDependency("org.apache.commons", "commons-lang3");
+        assertThat(found).isNotNull();
+        assertThat(found.getArtifactId()).isEqualTo("commons-lang3");
+    }
+
+    @Test
+    void selfMatchReturnsThis() {
+        ResolvedDependency root = dep("com.example", "root");
+        assertThat(root.findDependency("com.example", "root")).isSameAs(root);
+    }
+
+    @Test
+    void exactMatchIsCaseInsensitiveLikeGlob() {
+        // matchesGlob is case-insensitive; the exact-match fast path must preserve that.
+        ResolvedDependency root = dep("com.example", "root",
+          dep("org.apache.commons", "commons-lang3"));
+        assertThat(root.findDependency("ORG.APACHE.COMMONS", "Commons-Lang3")).isNotNull();
+    }
+
+    @Test
+    void noMatchReturnsNull() {
+        ResolvedDependency root = dep("com.example", "root",
+          dep("org.apache.commons", "commons-lang3"));
+        assertThat(root.findDependency("com.google.guava", "guava")).isNull();
+    }
+
+    @Test
+    void globMatchStillWorks() {
+        ResolvedDependency root = dep("com.example", "root",
+          dep("org.apache.commons", "commons-lang3"),
+          dep("org.apache.logging.log4j", "log4j-core"));
+        assertThat(root.findDependencies("org.apache.*", "*"))
+          .extracting(ResolvedDependency::getArtifactId)
+          .containsExactly("commons-lang3", "log4j-core");
+    }
+
+    @Test
+    void findsTransitiveDependency() {
+        ResolvedDependency root = dep("com.example", "root",
+          dep("org.springframework", "spring-core",
+            dep("org.springframework", "spring-jcl")));
+        assertThat(root.findDependency("org.springframework", "spring-jcl")).isNotNull();
+    }
+
+    @Test
+    void exclusionHidesTransitiveMatch() {
+        ResolvedDependency root = dep("com.example", "root",
+          dep("org.springframework", "spring-core",
+            singletonList(new GroupArtifact("commons-logging", "commons-logging")),
+            dep("commons-logging", "commons-logging")));
+        assertThat(root.findDependency("commons-logging", "commons-logging")).isNull();
+        assertThat(root.findDependencies("commons-logging", "commons-logging")).isEmpty();
+    }
+
+    @Test
+    void exclusionWithGlobPattern() {
+        ResolvedDependency root = dep("com.example", "root",
+          dep("org.springframework", "spring-core",
+            singletonList(new GroupArtifact("commons-logging", "*")),
+            dep("commons-logging", "commons-logging")));
+        assertThat(root.findDependency("commons-logging", "commons-logging")).isNull();
+    }
+
+    @Test
+    void findDependenciesIncludesSelfAndDescendants() {
+        ResolvedDependency root = dep("org.apache.commons", "commons-lang3",
+          dep("org.apache.commons", "commons-lang3-extra"));
+        assertThat(root.findDependencies("org.apache.commons", "*"))
+          .extracting(ResolvedDependency::getArtifactId)
+          .containsExactly("commons-lang3", "commons-lang3-extra");
+    }
+
+    @Test
+    void diamondGraphDeduplicatesSharedNonMatchingSubtree() {
+        // 'target' sits below 'shared', and 'shared' is reachable through both 'a' and 'b'.
+        ResolvedDependency target = dep("org.slf4j", "slf4j-api");
+        ResolvedDependency shared = dep("shared", "shared", target);
+        ResolvedDependency root = dep("com.example", "root",
+          dep("a", "a", shared),
+          dep("b", "b", shared));
+        assertThat(root.findDependency("org.slf4j", "slf4j-api")).isSameAs(target);
+        // The shared, non-matching node is visited once, so the match below it is reported once.
+        assertThat(root.findDependencies("org.slf4j", "slf4j-api")).hasSize(1);
+    }
+
+    @Test
+    void wildcardPatternMatchesEverything() {
+        ResolvedDependency root = dep("com.example", "root",
+          dep("a", "a"),
+          dep("b", "b"));
+        assertThat(root.findDependencies("*", "*")).hasSize(3);
+    }
+}


### PR DESCRIPTION
## What's changed?

- `ResolvedDependency.findDependency(...)` / `findDependencies(...)` did a full recursive walk of the resolved dependency graph **on every lookup**, allocating a for-each iterator per graph level, a per-node `ArrayList` + `Stream` pipeline in `findDependencies0`, and an `IdentityHashMap` visited-set per top-level call — and calling `StringUtils.matchesGlob` for every node even when the coordinate is an exact (non-glob) string. Dependency-upgrade recipes call these repeatedly (per dependency, per module), so they dominate allocation, and `findDependency` shows up as the #1 application self-method on CPU.

This PR addresses the per-lookup allocation and the redundant glob matching:

- **Exact-match fast path** — when a coordinate has no glob metacharacter (the common case), compare with `equalsIgnoreCase` instead of `matchesGlob`. `matchesGlob` is case-insensitive (`Character.toUpperCase`), so the fast path uses `equalsIgnoreCase` to preserve the exact same semantics. The glob/exact decision is made **once per top-level lookup** and threaded down the recursion, amortizing the metacharacter scan across the whole graph.
- **Indexed iteration** replaces the for-each loops, dropping the per-graph-level iterator allocation.
- **`findDependencies0` accumulates into a single passed-down list** instead of allocating a `new ArrayList<>()` + `stream().filter()` per node. The current node's exclusions are applied to the slice of results each child contributed — behaviourally identical to the previous per-child filter (exclusion stacking, transitive matching, and diamond de-duplication all preserved).
- **Lazy visited-set allocation** — the `IdentityHashMap`-backed set is no longer allocated for leaf lookups or when the root matches immediately.

Public method signatures are unchanged, so no callers needed touching.

The third proposal in the issue (a `Map<GroupArtifact, ResolvedDependency>` index built once per resolution for callers that look up many coordinates) is intentionally left for a follow-up: exclusions are path-dependent, so a flat coordinate→dependency map cannot faithfully preserve exclusion/transitive semantics for arbitrary lookups, and it touches several recipes across rewrite-maven and rewrite-gradle. It deserves its own PR and discussion.

## Testing

- New `ResolvedDependencyTest` (11 tests) directly covers the changed paths: exact match, case-insensitivity, glob, transitive lookups, exclusions (exact + glob pattern), diamond de-duplication, and wildcard matching.
- Existing maven dependency-resolution and recipe tests pass (`MavenParserTest`, `UpgradeDependencyVersionTest`, `ExcludeDependencyTest`, `RemoveExclusionTest`, `AddManagedDependencyTest`, `ModuleHasDependencyTest`, `DependencyInsightTest`).
- Gradle tests exercising the recursive walk pass (`ModuleHasDependencyTest`, `RemoveRedundantDependencyVersionsTest`, `ChangeDependencyGroupIdTest`, `ChangeDependencyArtifactIdTest`).
- Adds `FindDependencyBenchmark` under `rewrite-benchmarks`, the JMH baseline recommended in the issue: it walks a resolved `spring-boot-starter-web` tree for a deep hit, a full-walk miss, and a glob lookup, with the `gc` profiler.

## Benchmark results

`FindDependencyBenchmark` against a resolved `spring-boot-starter-web` tree, with JMH's `gc` profiler. "Before" is `ResolvedDependency` reverted to its pre-PR version, run back-to-back on the same machine with the same benchmark.

| Benchmark | Throughput (before → after) | Allocation/op (before → after) |
|---|---|---|
| `findDependencyDeepHit` — exact coord, deep transitive match | 3,938 → **10,818 ops/ms** (≈2.7×) | 512 → **352 B/op** (−31%) |
| `findDependencyMiss` — exact coord, full walk, no match | 2,655 → **8,084 ops/ms** (≈3.0×) | 1,232 → **352 B/op** (−71%) |
| `findDependenciesGlob` — glob, collect all matches | 559 → **1,240 ops/ms** (≈2.2×) | 9,336 → **512 B/op** (−95%, ≈18×) |

- Throughput is ~2–3× higher across all three shapes.
- `findDependenciesGlob` shows the largest allocation drop (9,336 → 512 B/op) — that path previously allocated a `new ArrayList<>()` + `stream().filter()` per node, matching the `ArrayList$Itr` + `Object[]` hot spots in the issue's profile.
- The residual 352 B/op on the `findDependency*` cases is the single `IdentityHashMap`-backed visited-set allocated once per call (needed for cycle/diamond safety); previously that set was allocated *plus* per-node iterators.

These are single-fork runs with the module's lightweight JMH config (minimal warmup/measurement iterations, so no error bars), so treat them as directional rather than publication-grade — but the magnitude and direction are reproducible and consistent with the allocation profile in the issue.

- Fixes #8015
