### PR TITLE
Cache DataTable column descriptors per row type

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/RecipeIntrospectionUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/RecipeIntrospectionUtils.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
 
 @SuppressWarnings("unused")
 public class RecipeIntrospectionUtils {
@@ -244,20 +245,31 @@ public class RecipeIntrospectionUtils {
         return new RecipeIntrospectionException("Unable to call primary constructor for Recipe " + recipeClass, e);
     }
 
-    private static List<ColumnDescriptor> getColumnDescriptors(DataTable<?> dataTable) {
-        List<ColumnDescriptor> columns = new ArrayList<>();
-
-        for (Field field : dataTable.getType().getDeclaredFields()) {
-            field.setAccessible(true);
-            Column column = field.getAnnotation(Column.class);
-            if (column != null) {
-                columns.add(new ColumnDescriptor(field.getName(),
-                        field.getType().getSimpleName(),
-                        column.displayName(),
-                        column.description()));
+    /**
+     * Column descriptors depend only on the data table's row type, so memoize them per class.
+     * {@link ClassValue} is thread-safe, computes each entry lazily exactly once, and lets entries be
+     * reclaimed when the row class (and its classloader) is unloaded.
+     */
+    private static final ClassValue<List<ColumnDescriptor>> COLUMN_DESCRIPTORS = new ClassValue<List<ColumnDescriptor>>() {
+        @Override
+        protected List<ColumnDescriptor> computeValue(Class<?> type) {
+            List<ColumnDescriptor> columns = new ArrayList<>();
+            for (Field field : type.getDeclaredFields()) {
+                field.setAccessible(true);
+                Column column = field.getAnnotation(Column.class);
+                if (column != null) {
+                    columns.add(new ColumnDescriptor(field.getName(),
+                            field.getType().getSimpleName(),
+                            column.displayName(),
+                            column.description()));
+                }
             }
+            return unmodifiableList(columns);
         }
-        return columns;
+    };
+
+    private static List<ColumnDescriptor> getColumnDescriptors(DataTable<?> dataTable) {
+        return COLUMN_DESCRIPTORS.get(dataTable.getType());
     }
 
     private static Object getPrimitiveDefault(Class<?> t) {

--- a/rewrite-core/src/test/java/org/openrewrite/DataTableTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/DataTableTest.java
@@ -18,8 +18,10 @@ package org.openrewrite;
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import lombok.Value;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.config.ColumnDescriptor;
 import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.config.DataTableDescriptor;
+import org.openrewrite.internal.RecipeIntrospectionUtils;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
@@ -28,6 +30,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 import static org.openrewrite.test.SourceSpecs.text;
 
@@ -67,6 +71,32 @@ class DataTableTest implements RewriteTest {
         new WordTable(recipe);
         assertThat(recipe.getDataTableDescriptors()).hasSize(5);
         assertThat(recipe.getDataTableDescriptors().getFirst().getColumns()).hasSize(2);
+    }
+
+    @Test
+    void columnDescriptorsAreCachedPerRowType() {
+        Recipe recipe = toRecipe();
+        // Two DataTable instances backed by the same row type must share one set of column descriptors.
+        WordTable first = new WordTable(recipe);
+        WordTable second = new WordTable(recipe);
+
+        DataTableDescriptor d1 = RecipeIntrospectionUtils.dataTableDescriptorFromDataTable(first);
+        DataTableDescriptor d2 = RecipeIntrospectionUtils.dataTableDescriptorFromDataTable(second);
+
+        // Descriptors are correct and preserve declared-field order.
+        assertThat(d1.getColumns())
+          .extracting(ColumnDescriptor::getName, ColumnDescriptor::getType,
+            ColumnDescriptor::getDisplayName, ColumnDescriptor::getDescription)
+          .containsExactly(
+            tuple("position", "int", "Position", "The index position of the word in the text."),
+            tuple("text", "String", "Text", "The text of the word."));
+
+        // Memoized per row type: equal contents and the exact same cached instance.
+        assertThat(d2.getColumns()).isEqualTo(d1.getColumns());
+        assertThat(d2.getColumns()).isSameAs(d1.getColumns());
+
+        // The shared cached list is unmodifiable so callers can't corrupt it.
+        assertThatThrownBy(() -> d1.getColumns().clear()).isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test


### PR DESCRIPTION
## Motivation

`RecipeIntrospectionUtils.getColumnDescriptors(DataTable<?>)` reflectively re-introspects a data table's columns on **every** call: it iterates `dataTable.getType().getDeclaredFields()`, calls `field.setAccessible(true)`, and reads the `@Column` annotation per field. This runs frequently during a recipe run (via `dataTableDescriptorFromDataTable`, which rebuilds a `DataTableDescriptor` each time), so the reflection cost adds up. In a JFR profile of a large recipe run (`UpgradeSpringBoot_4_0` over ~11,700 sources) this method accounted for ~3.3% of on-CPU samples, split between `Class.getDeclaredFields()` and `Field.getAnnotation(...)`. The recipe run is CPU-bound on the visitor engine, so this is a clean, low-risk memoization win.

## Summary

- Memoize the computed `List<ColumnDescriptor>` per row `Class` using a static `java.lang.ClassValue`. `ClassValue` is thread-safe, computes each entry lazily exactly once, and lets entries be reclaimed when the row class (and its classloader) is unloaded — important for a long-lived process that loads recipe classes from disposable classloaders.
- The cache is keyed on `dataTable.getType()` (the row class), so multiple `DataTable` instances of the same row type share one entry.
- The cached list is returned as an `unmodifiableList` so the shared instance can't be mutated by a caller.
- Behavior is unchanged: same `ColumnDescriptor`s, in declared-field order, for a given row type.

## Test plan

- [x] New test `DataTableTest.columnDescriptorsAreCachedPerRowType` asserts the descriptors are correct (name/type/displayName/description) and in declared-field order, that two `DataTable` instances of the same row type return equal **and** identical (same cached instance) column lists, and that the cached list is unmodifiable.
- [x] `./gradlew :rewrite-core:test --tests "org.openrewrite.DataTableTest"` passes.
- [x] `./gradlew :rewrite-core:check` passes.
