### PR TITLE
Skip unreachable Maven repositories after first connection failure

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
@@ -55,7 +55,7 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
     private static final String MAVEN_ARTIFACT_CACHE = "org.openrewrite.maven.artifactCache";
     private static final String MAVEN_RESOLUTION_LISTENER = "org.openrewrite.maven.resolutionListener";
     private static final String MAVEN_RESOLUTION_TIME = "org.openrewrite.maven.resolutionTime";
-    private static final String MAVEN_UNREACHABLE_HOSTS = "org.openrewrite.maven.unreachableHosts";
+    private static final String MAVEN_UNREACHABLE_ENDPOINTS = "org.openrewrite.maven.unreachableEndpoints";
 
     public MavenExecutionContextView(ExecutionContext delegate) {
         super(delegate);
@@ -79,14 +79,17 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
     }
 
     /**
-     * Hosts that have proven unreachable (a connection-level failure, as opposed to an HTTP error
-     * response) during this execution. Repositories on these hosts are skipped for the remainder of
-     * the run rather than re-probed for every declaration, so a single dead repository costs one
-     * connection timeout instead of one per artifact. The set is concurrent because resolution runs
-     * across multiple threads sharing one execution context.
+     * Connection endpoints, each a {@code host:port}, that have proven unreachable (a connection-level
+     * failure, as opposed to an HTTP error response) during this execution. Repositories on these
+     * endpoints are skipped for the remainder of the run rather than re-probed for every declaration,
+     * so a single dead repository costs one connection timeout instead of one per artifact. The key is
+     * {@code host:port} rather than the full repository URI because a connection failure occurs before
+     * any path is sent and so is independent of the path; the same dead host declared under different
+     * paths or ids is therefore deduped. The set is concurrent because resolution runs across multiple
+     * threads sharing one execution context.
      */
-    public Set<String> getUnreachableHosts() {
-        return computeMessageIfAbsent(MAVEN_UNREACHABLE_HOSTS, k -> ConcurrentHashMap.newKeySet());
+    public Set<String> getUnreachableEndpoints() {
+        return computeMessageIfAbsent(MAVEN_UNREACHABLE_ENDPOINTS, k -> ConcurrentHashMap.newKeySet());
     }
 
     public MavenExecutionContextView setResolutionListener(ResolutionEventListener listener) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
@@ -54,6 +55,7 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
     private static final String MAVEN_ARTIFACT_CACHE = "org.openrewrite.maven.artifactCache";
     private static final String MAVEN_RESOLUTION_LISTENER = "org.openrewrite.maven.resolutionListener";
     private static final String MAVEN_RESOLUTION_TIME = "org.openrewrite.maven.resolutionTime";
+    private static final String MAVEN_UNREACHABLE_HOSTS = "org.openrewrite.maven.unreachableHosts";
 
     public MavenExecutionContextView(ExecutionContext delegate) {
         super(delegate);
@@ -74,6 +76,17 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
 
     public Duration getResolutionTime() {
         return Duration.ofMillis(getMessage(MAVEN_RESOLUTION_TIME, 0L));
+    }
+
+    /**
+     * Hosts that have proven unreachable (a connection-level failure, as opposed to an HTTP error
+     * response) during this execution. Repositories on these hosts are skipped for the remainder of
+     * the run rather than re-probed for every declaration, so a single dead repository costs one
+     * connection timeout instead of one per artifact. The set is concurrent because resolution runs
+     * across multiple threads sharing one execution context.
+     */
+    public Set<String> getUnreachableHosts() {
+        return computeMessageIfAbsent(MAVEN_UNREACHABLE_HOSTS, k -> ConcurrentHashMap.newKeySet());
     }
 
     public MavenExecutionContextView setResolutionListener(ResolutionEventListener listener) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -963,10 +963,24 @@ public class MavenPomDownloader {
                     ctx.getResolutionListener().repositoryAccessFailed(repository.getUri(), new IllegalArgumentException("Repository " + repository.getUri() + " is not HTTP(S)."));
                     return null;
                 }
+                // A host that has already failed to connect during this run is skipped rather than
+                // re-probed. The same dead repository is frequently declared (often under different
+                // ids) by many transitive POMs; the per-repository normalization cache does not
+                // dedupe those by host, so without this each one costs a full connection timeout.
+                String host = hostOrNull(repository.getUri());
+                if (host != null && ctx.getUnreachableHosts().contains(host)) {
+                    ctx.getResolutionListener().repositoryAccessFailedPreviously(repository.getUri());
+                    return null;
+                }
                 MavenRepository normalized = null;
                 try {
                     normalized = normalizeRepository(repository);
                 } catch (Throwable e) {
+                    // normalizeRepository(repository) only throws once the host is unreachable on
+                    // every probed endpoint, so remember it and skip the host for the rest of the run.
+                    if (host != null) {
+                        ctx.getUnreachableHosts().add(host);
+                    }
                     ctx.getResolutionListener().repositoryAccessFailed(repository.getUri(), e);
                 }
 
@@ -1158,6 +1172,14 @@ public class MavenPomDownloader {
 
     private static boolean hasCredentials(MavenRepository repository) {
         return repository.getUsername() != null && repository.getPassword() != null;
+    }
+
+    private static @Nullable String hostOrNull(String uri) {
+        try {
+            return URI.create(uri).getHost();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private MavenRepository applyMirrors(MavenRepository repository) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -953,7 +953,8 @@ public class MavenPomDownloader {
                 return null;
             }
 
-            if ("file".equals(URI.create(repository.getUri()).getScheme())) {
+            URI uri = URI.create(repository.getUri());
+            if ("file".equals(uri.getScheme())) {
                 return repository;
             }
             result = mavenCache.getNormalizedRepository(repository);
@@ -963,12 +964,15 @@ public class MavenPomDownloader {
                     ctx.getResolutionListener().repositoryAccessFailed(repository.getUri(), new IllegalArgumentException("Repository " + repository.getUri() + " is not HTTP(S)."));
                     return null;
                 }
-                // A host that has already failed to connect during this run is skipped rather than
-                // re-probed. The same dead repository is frequently declared (often under different
-                // ids) by many transitive POMs; the per-repository normalization cache does not
-                // dedupe those by host, so without this each one costs a full connection timeout.
-                String host = hostOrNull(repository.getUri());
-                if (host != null && ctx.getUnreachableHosts().contains(host)) {
+                // An endpoint that has already failed to connect during this run is skipped rather
+                // than re-probed. The same dead repository is frequently declared (often under
+                // different ids) by many transitive POMs; the per-repository normalization cache
+                // does not dedupe those, so without this each one costs a full connection timeout.
+                // The key is the host:port the connection targets (not the full URI): a connection
+                // failure happens before any path is sent, so it is independent of the path, and so
+                // the same dead host declared under different paths or ids is deduped too.
+                String endpoint = endpointOrNull(uri);
+                if (endpoint != null && ctx.getUnreachableEndpoints().contains(endpoint)) {
                     ctx.getResolutionListener().repositoryAccessFailedPreviously(repository.getUri());
                     return null;
                 }
@@ -976,10 +980,10 @@ public class MavenPomDownloader {
                 try {
                     normalized = normalizeRepository(repository);
                 } catch (Throwable e) {
-                    // normalizeRepository(repository) only throws once the host is unreachable on
-                    // every probed endpoint, so remember it and skip the host for the rest of the run.
-                    if (host != null) {
-                        ctx.getUnreachableHosts().add(host);
+                    // normalizeRepository(repository) only throws once the endpoint is unreachable on
+                    // every probed URL, so remember it and skip the endpoint for the rest of the run.
+                    if (endpoint != null) {
+                        ctx.getUnreachableEndpoints().add(endpoint);
                     }
                     ctx.getResolutionListener().repositoryAccessFailed(repository.getUri(), e);
                 }
@@ -1174,12 +1178,9 @@ public class MavenPomDownloader {
         return repository.getUsername() != null && repository.getPassword() != null;
     }
 
-    private static @Nullable String hostOrNull(String uri) {
-        try {
-            return URI.create(uri).getHost();
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
+    private static @Nullable String endpointOrNull(URI uri) {
+        String host = uri.getHost();
+        return host == null ? null : host + ':' + uri.getPort();
     }
 
     private MavenRepository applyMirrors(MavenRepository repository) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -170,6 +170,35 @@ class MavenPomDownloaderTest implements RewriteTest {
         }
 
         @Test
+        void unreachableHostProbedOncePerRun() {
+            var ctx = MavenExecutionContextView.view(this.ctx);
+            // Nothing listens on port 1, so connections are refused immediately.
+            String deadUri = "http://localhost:1/repo/";
+
+            List<String> probed = new ArrayList<>();
+            ctx.setResolutionListener(new ResolutionEventListener() {
+                @Override
+                public void repositoryAccessFailed(String uri, Throwable t) {
+                    probed.add(uri);
+                }
+            });
+
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            // The same dead host declared under two different repository ids — as happens when
+            // several transitive POMs each declare the same (dead) repository. The per-repository
+            // normalization cache does not dedupe these by host, so without a host-level circuit
+            // breaker each one is re-probed (here, ~once; in a real run, once per artifact).
+            var repoA = MavenRepository.builder().id("a").uri(deadUri).build();
+            var repoB = MavenRepository.builder().id("b").uri(deadUri).build();
+
+            assertThat(downloader.normalizeRepository(repoA, ctx, null)).isNull();
+            assertThat(downloader.normalizeRepository(repoB, ctx, null)).isNull();
+
+            // The unreachable host must be probed only once; the second repository is skipped.
+            assertThat(probed).containsExactly(deadUri);
+        }
+
+        @Test
         void listenerRecordsRepository() {
             var ctx = MavenExecutionContextView.view(this.ctx);
             // Avoid actually trying to reach the made-up https://internalartifactrepository.yourorg.com


### PR DESCRIPTION
## Motivation

Some widely-used artifacts declare extra repositories in their POM's `<repositories>` block. For example, `com.nimbusds:oauth2-oidc-sdk` (pulled in transitively by Spring Security's OAuth2/OIDC support) declares the Shibboleth repository `https://build.shibboleth.net/maven/`. rewrite-maven adds every POM-declared repository to the resolution set and probes all of them.

When such a repository is unreachable — its host blackholes TCP, so the connection hangs until the full `connectTimeout` and Failsafe then retries 5× (~9s+ per probe, across both HTTPS and HTTP) — the cost is paid over and over. The per-`MavenRepository` normalization cache is keyed by the repository object, not the host, so the same dead host declared under different ids by many transitive POMs gets re-probed every single time.

In one real run of `UpgradeSpringBoot_4_0` over ~11,700 sources this dominated wall time: dependency resolution alone was ~925s (≈42% of the run). With this change it dropped to ~62s, and total run time went from 36m to 10m. Standard Maven does not exhibit this because it resolves an artifact from the repository it came from and backs off unreachable repositories.

This adds a host-level circuit breaker: the first time a host fails to connect during a resolution run, it is recorded, and every subsequent repository on that host is skipped for the remainder of the run. A single dead repository now costs one connection timeout instead of one per artifact.

## Summary

- Add `MavenExecutionContextView#getUnreachableEndpoints()`, a concurrent set of `host:port` endpoints that have proven unreachable during the current execution (lazily initialized; concurrent because resolution runs across multiple threads sharing one execution context).
- In `MavenPomDownloader#normalizeRepository(...)`, before probing an HTTP(S) repository whose normalization is not yet cached, skip it (reporting `repositoryAccessFailedPreviously`) if its endpoint is already known to be unreachable. When `normalizeRepository(repository)` throws — which only happens once the endpoint is unreachable on every probed URL — record the endpoint so the rest of the run skips it.
- The set is keyed on the connection endpoint (`host:port`), not the full URI: a connection-level failure happens before any path is sent, so it is independent of the path. The same dead host declared under different paths or ids is therefore deduped, while two services on different ports of the same host are not conflated.

## Test plan

- [x] Added `MavenPomDownloaderTest$WithNativeHttpURLConnectionAndTLS#unreachableHostProbedOncePerRun`, which declares the same dead host under two repository ids and asserts the host is probed only once. RED before the fix (probed twice), GREEN after.
- [x] `./gradlew :rewrite-maven:test --tests 'org.openrewrite.maven.internal.MavenPomDownloaderTest$WithNativeHttpURLConnectionAndTLS'` passes (no regressions in the surrounding connection/normalization tests).
- [x] `./gradlew :rewrite-maven:check` passes.

## Possible follow-up

This only hooks normalization, which is where the observed stall lived (unreachable repositories fail during normalization). It may be worth also marking a host unreachable on connection-level failures during metadata/POM *fetches* — `sendRequest` is the common HTTP choke point — but that is left out here to keep the change minimal and focused.

