### PR TITLE
Make Maven coordinate matching case-sensitive

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
@@ -447,8 +447,27 @@ public class StringUtils {
      * @param pattern the glob pattern to evaluate. null and "*" both match everything.
      * @return true if the input string matches the glob pattern, false otherwise
      * @see org.openrewrite.PathUtils#matchesGlob(Path, String)
+     * @see #matchesGlob(String, String, boolean)
      */
     public static boolean matchesGlob(@Nullable String str, @Nullable String pattern) {
+        return matchesGlob(str, pattern, false);
+    }
+
+    /**
+     * Checks if a given string matches a specified glob pattern, optionally honoring case. A glob
+     * pattern may include special characters such as '*' to represent any sequence of characters
+     * and '?' to represent any single character.
+     * <p>
+     * For file path matching, use {@link org.openrewrite.PathUtils#matchesGlob(Path, String)},
+     * which properly interprets '*' and '**' wildcards for file paths.
+     *
+     * @param str the input string to match against the pattern, can be null
+     * @param pattern the glob pattern to evaluate. null and "*" both match everything.
+     * @param caseSensitive whether literal characters must match exactly with respect to case
+     * @return true if the input string matches the glob pattern, false otherwise
+     * @see org.openrewrite.PathUtils#matchesGlob(Path, String)
+     */
+    public static boolean matchesGlob(@Nullable String str, @Nullable String pattern, boolean caseSensitive) {
         if ("*".equals(pattern) || pattern == null) {
             return true;
         }
@@ -474,7 +493,7 @@ public class StringUtils {
             if (ch == '*') {
                 break;
             }
-            if (ch != '?' && different(ch, str.charAt(strIdxStart))) {
+            if (ch != '?' && different(ch, str.charAt(strIdxStart), caseSensitive)) {
                 return false; // Character mismatch
             }
             patIdxStart++;
@@ -495,7 +514,7 @@ public class StringUtils {
             if (ch == '*') {
                 break;
             }
-            if (ch != '?' && different(ch, str.charAt(strIdxEnd))) {
+            if (ch != '?' && different(ch, str.charAt(strIdxEnd), caseSensitive)) {
                 return false; // Character mismatch
             }
             patIdxEnd--;
@@ -528,7 +547,7 @@ public class StringUtils {
             int strLength = (strIdxEnd - strIdxStart + 1);
 
             int foundIdx = findPatternInString(pattern, patIdxStart + 1, patLength,
-                    str, strIdxStart, strLength);
+                    str, strIdxStart, strLength, caseSensitive);
 
             if (foundIdx == -1) {
                 return false;
@@ -543,12 +562,12 @@ public class StringUtils {
     }
 
     private static int findPatternInString(String pattern, int patStart, int patLength,
-                                           String str, int strStart, int strLength) {
+                                           String str, int strStart, int strLength, boolean caseSensitive) {
         strLoop:
         for (int i = 0; i <= strLength - patLength; i++) {
             for (int j = 0; j < patLength; j++) {
                 char ch = pattern.charAt(patStart + j);
-                if (ch != '?' && different(ch, str.charAt(strStart + i + j))) {
+                if (ch != '?' && different(ch, str.charAt(strStart + i + j), caseSensitive)) {
                     continue strLoop;
                 }
             }
@@ -566,8 +585,13 @@ public class StringUtils {
         return true;
     }
 
-    private static boolean different(char ch, char other) {
-        return Character.toUpperCase(ch) != Character.toUpperCase(other);
+    private static boolean different(char ch, char other, boolean caseSensitive) {
+        // Equal characters are the common case (e.g. matching coordinate prefixes); short-circuiting
+        // here avoids the relatively expensive Character.toUpperCase pair for all callers.
+        if (ch == other) {
+            return false;
+        }
+        return caseSensitive || Character.toUpperCase(ch) != Character.toUpperCase(other);
     }
 
     public static String indent(String text) {

--- a/rewrite-core/src/test/java/org/openrewrite/internal/StringUtilsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/StringUtilsTest.java
@@ -123,6 +123,30 @@ class StringUtilsTest {
         assertThat(matchesGlob("test.test.txt", "*.*")).isTrue();
     }
 
+    @Test
+    void globMatchingCaseSensitive() {
+        // The default two-arg overload is case-insensitive.
+        assertThat(matchesGlob("Test", "test")).isTrue();
+        assertThat(matchesGlob("Test", "test", false)).isTrue();
+
+        // Case-sensitive literal matching.
+        assertThat(matchesGlob("test", "test", true)).isTrue();
+        assertThat(matchesGlob("Test", "test", true)).isFalse();
+        assertThat(matchesGlob("test", "Test", true)).isFalse();
+        assertThat(matchesGlob("com.example", "com.example", true)).isTrue();
+        assertThat(matchesGlob("com.example", "Com.Example", true)).isFalse();
+
+        // Wildcards still work case-sensitively.
+        assertThat(matchesGlob("com.fasterxml.jackson", "com.fasterxml.*", true)).isTrue();
+        assertThat(matchesGlob("com.fasterxml.jackson", "Com.*", true)).isFalse();
+        assertThat(matchesGlob("com.fasterxml.jackson", "*", true)).isTrue();
+        assertThat(matchesGlob("com.fasterxml.jackson", null, true)).isTrue();
+        assertThat(matchesGlob("comXexample", "com?example", true)).isTrue();
+        assertThat(matchesGlob("comXexample", "com?Example", true)).isFalse();
+        assertThat(matchesGlob("com.fasterxml.core", "com.*.core", true)).isTrue();
+        assertThat(matchesGlob("com.fasterxml.Core", "com.*.core", true)).isFalse();
+    }
+
     @SuppressWarnings("TextBlockMigration")
     @Test
     void greatestCommonMargin() {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
@@ -122,7 +122,7 @@ public class MavenResolutionResult implements Marker {
      * @return A list of matching dependencies
      */
     public List<ResolvedDependency> findDependencies(String groupId, String artifactId, @Nullable Scope scope) {
-        return findDependencies(d -> matchesGlob(d.getGroupId(), groupId) && matchesGlob(d.getArtifactId(), artifactId), scope);
+        return findDependencies(d -> matchesGlob(d.getGroupId(), groupId, true) && matchesGlob(d.getArtifactId(), artifactId, true), scope);
     }
 
     /**

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
@@ -126,7 +126,7 @@ public class ResolvedDependency implements Serializable {
 
     private List<ResolvedDependency> findDependencies0(String groupId, String artifactId, Set<ResolvedDependency> visited) {
         List<ResolvedDependency> dependencies = new ArrayList<>();
-        if (matchesGlob(getGroupId(), groupId) && matchesGlob(getArtifactId(), artifactId)) {
+        if (matchesGlob(getGroupId(), groupId, true) && matchesGlob(getArtifactId(), artifactId, true)) {
             dependencies.add(this);
         } else if (!visited.add(this)) {
             return emptyList();
@@ -136,8 +136,8 @@ public class ResolvedDependency implements Serializable {
                     .filter(found -> {
                         if (getRequested().getExclusions() != null) {
                             for (GroupArtifact exclusion : getRequested().getExclusions()) {
-                                if (matchesGlob(found.getGroupId(), exclusion.getGroupId()) &&
-                                        matchesGlob(found.getArtifactId(), exclusion.getArtifactId())) {
+                                if (matchesGlob(found.getGroupId(), exclusion.getGroupId(), true) &&
+                                        matchesGlob(found.getArtifactId(), exclusion.getArtifactId(), true)) {
                                     return false;
                                 }
                             }
@@ -153,7 +153,7 @@ public class ResolvedDependency implements Serializable {
     }
 
     private @Nullable ResolvedDependency findDependency0(@Nullable String groupId, @Nullable String artifactId, Set<ResolvedDependency> visited) {
-        if (matchesGlob(getGroupId(), groupId) && matchesGlob(getArtifactId(), artifactId)) {
+        if (matchesGlob(getGroupId(), groupId, true) && matchesGlob(getArtifactId(), artifactId, true)) {
             return this;
         } else if (!visited.add(this)) {
             return null;
@@ -164,8 +164,8 @@ public class ResolvedDependency implements Serializable {
             if (found != null) {
                 if (getRequested().getExclusions() != null) {
                     for (GroupArtifact exclusion : getRequested().getExclusions()) {
-                        if (matchesGlob(found.getGroupId(), exclusion.getGroupId()) &&
-                                matchesGlob(found.getArtifactId(), exclusion.getArtifactId())) {
+                        if (matchesGlob(found.getGroupId(), exclusion.getGroupId(), true) &&
+                                matchesGlob(found.getArtifactId(), exclusion.getArtifactId(), true)) {
                             continue outer;
                         }
                     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -1173,8 +1173,8 @@ public class ResolvedPom {
                         if (d.getExclusions() != null) {
                             d2 = d2.withExclusions(ListUtils.concatAll(d2.getExclusions(), d.getExclusions()));
                             for (GroupArtifact exclusion : d.getExclusions()) {
-                                if (matchesGlob(getValue(d2.getGroupId()), getValue(exclusion.getGroupId())) &&
-                                        matchesGlob(getValue(d2.getArtifactId()), getValue(exclusion.getArtifactId()))) {
+                                if (matchesGlob(getValue(d2.getGroupId()), getValue(exclusion.getGroupId()), true) &&
+                                        matchesGlob(getValue(d2.getArtifactId()), getValue(exclusion.getArtifactId()), true)) {
                                     if (resolved.getEffectiveExclusions().isEmpty()) {
                                         resolved.unsafeSetEffectiveExclusions(new ArrayList<>());
                                     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -513,6 +513,45 @@ class MavenParserTest implements RewriteTest {
     }
 
     @Test
+    void coordinateMatchingIsCaseSensitive() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencies>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>14.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.afterRecipe(pomXml -> {
+                MavenResolutionResult result = pomXml.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+
+                // Exact-case coordinates match.
+                assertThat(result.findDependencies("com.google.guava", "guava", null)).isNotEmpty();
+                // Case-sensitive globs match case-sensitively.
+                assertThat(result.findDependencies("com.google.*", "guava", null)).isNotEmpty();
+
+                // Mismatched case does not match.
+                assertThat(result.findDependencies("Com.Google.Guava", "guava", null)).isEmpty();
+                assertThat(result.findDependencies("com.google.guava", "Guava", null)).isEmpty();
+                assertThat(result.findDependencies("Com.Google.*", "guava", null)).isEmpty();
+
+                ResolvedDependency guava = result.findDependencies("com.google.guava", "guava", null).getFirst();
+                assertThat(guava.findDependency("com.google.guava", "guava")).isNotNull();
+                assertThat(guava.findDependency("Com.Google.Guava", "guava")).isNull();
+            })
+          )
+        );
+    }
+
+    @Test
     void parseMergeExclusions() {
         rewriteRun(
           mavenProject("my-dep",


### PR DESCRIPTION
## Motivation

Maven `groupId` and `artifactId` coordinates are case-sensitive, but `ResolvedDependency` (and its siblings `ResolvedPom` and `MavenResolutionResult`) matched them with `StringUtils.matchesGlob(...)`, which is case-insensitive: it compares characters via `Character.toUpperCase(ch) != Character.toUpperCase(other)`. This is both semantically wrong — case-insensitive matching can produce false coordinate matches — and a measurable hot spot. In a JFR profile of a large recipe run (`UpgradeSpringBoot_4_0` over ~11,700 sources), `CharacterDataLatin1.toUpperCase` reached ~3.5% of on-CPU time, dominated by `StringUtils.different` reached through `matchesGlob` from `ResolvedDependency`.

Because the second argument to `matchesGlob` is a glob pattern (callers may pass `*`/`?`), this can't simply become `equals()` — it needs case-sensitive matching that still honors glob wildcards.

## Examples

```java
// New case-sensitive overload (existing 2-arg form is unchanged and remains case-insensitive):
StringUtils.matchesGlob("com.example", "com.example", true);   // true
StringUtils.matchesGlob("com.example", "Com.Example", true);   // false — case matters
StringUtils.matchesGlob("com.fasterxml.jackson", "com.fasterxml.*", true); // true — wildcards still work
StringUtils.matchesGlob("com.fasterxml.jackson", "Com.*", true);           // false

// Maven coordinate lookups are now case-sensitive:
resolvedDependency.findDependency("com.google.guava", "guava"); // matches
resolvedDependency.findDependency("Com.Google.Guava", "guava"); // no longer matches
```

## Summary

- Added `StringUtils.matchesGlob(String, String, boolean caseSensitive)`. The existing 2-arg `matchesGlob` now delegates to it with `caseSensitive = false`, so its behavior is unchanged for all current callers.
- Threaded the flag down to the per-character comparison; in the case-sensitive path the compare is a plain `ch != other` (no `toUpperCase`).
- `different(ch, other, caseSensitive)` now short-circuits with `if (ch == other) return false;` before the `toUpperCase` pair. Equal characters are the common case (matching coordinate prefixes), so this eliminates most `toUpperCase` calls for **all** `matchesGlob` callers, with zero semantic change — a strictly-safe win independent of the case-sensitivity change.
- Switched the coordinate-matching call sites to the case-sensitive variant: `ResolvedDependency.findDependency0` / `findDependencies0` (groupId, artifactId, and exclusion matching), `ResolvedPom` effective-exclusion matching, and `MavenResolutionResult.findDependencies`.

Real-world `groupId`/`artifactId` are lowercase by convention, so the functional impact of the case-sensitivity change should be nil in practice; it only changes behavior for coordinates that differ only in case.

## Test plan

- Added `StringUtilsTest#globMatchingCaseSensitive` asserting case-sensitive literal and wildcard matching, and that the 2-arg overload stays case-insensitive.
- Added `MavenParserTest#coordinateMatchingIsCaseSensitive` asserting that `findDependencies`/`findDependency` match exact-case and case-sensitive globs but not mismatched case.
- `./gradlew :rewrite-core:test :rewrite-maven:test` — both green; no existing test relied on case-insensitive coordinate matching.
