### PR TITLE
Add TypeUtils.isOfTypeIgnoringGenerics for matching invocations to declarations

### DIFF
--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
@@ -185,6 +185,154 @@ class TypeUtilsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/877")
+    @Test
+    void isOfTypeIgnoringGenericsMatchesRawCollectionInvocation() {
+        rewriteRun(
+          java(
+            """
+              import java.util.Collection;
+              import java.util.Map;
+              import java.util.Set;
+
+              class Main {
+                  Main(Map templates) {
+                      compileTemplates(templates.keySet(), templates.values());
+                  }
+
+                  private Set<String> compileTemplates(Set<String> compiledParam, Collection<String> toCheck) {
+                      return compiledParam;
+                  }
+              }
+              """,
+            s -> s.afterRecipe(cu -> {
+                // `templates` is raw, so the call is an unchecked invocation: javac erases the
+                // result type of `compileTemplates` to raw `Set`, so the recorded usage is neither
+                // `==` nor `.equals` to the declaration, but it is the same method ignoring generics.
+                JavaType.Method declaration = methodType(cu, "compileTemplates");
+                JavaType.Method use = usedMethod(cu, "compileTemplates");
+                assertThat(declaration).isNotEqualTo(use);
+                assertThat(TypeUtils.isOfTypeIgnoringGenerics(declaration, use)).isTrue();
+            })
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/877")
+    @Test
+    void isOfTypeIgnoringGenericsMatchesParameterizedMapInvocation() {
+        rewriteRun(
+          java(
+            """
+              import java.util.Collection;
+              import java.util.Map;
+              import java.util.Set;
+
+              class Main {
+                  Main(Map<String, String> templates) {
+                      compileTemplates(templates.keySet(), templates.values());
+                  }
+
+                  private Set<String> compileTemplates(Set<String> compiledParam, Collection<String> toCheck) {
+                      return compiledParam;
+                  }
+              }
+              """,
+            s -> s.afterRecipe(cu -> {
+                JavaType.Method declaration = methodType(cu, "compileTemplates");
+                assertThat(TypeUtils.isOfTypeIgnoringGenerics(declaration, usedMethod(cu, "compileTemplates"))).isTrue();
+            })
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1536")
+    @Test
+    void isOfTypeIgnoringGenericsMatchesGenericOverloads() {
+        rewriteRun(
+          java(
+            """
+              public class TestClass {
+                  void method() {
+                      checkMethodInUse("String", "String");
+                  }
+
+                  private static void checkMethodInUse(String arg0, String arg1) {
+                  }
+
+                  private static <T> void checkMethodInUse(String arg0, T arg1) {
+                  }
+              }
+              """,
+            s -> s.afterRecipe(cu -> {
+                var statements = cu.getClasses().get(0).getBody().getStatements();
+                JavaType.Method nonGenericOverload = ((J.MethodDeclaration) statements.get(1)).getMethodType();
+                JavaType.Method genericOverload = ((J.MethodDeclaration) statements.get(2)).getMethodType();
+                JavaType.Method use = usedMethod(cu, "checkMethodInUse");
+
+                // The call binds to the non-generic overload, but a use ignoring generics matches
+                // both overloads: the generic parameter `T` is treated as a wildcard. This keeps a
+                // generic method that is actually invoked from looking unused.
+                assertThat(TypeUtils.isOfTypeIgnoringGenerics(nonGenericOverload, use)).isTrue();
+                assertThat(TypeUtils.isOfTypeIgnoringGenerics(genericOverload, use)).isTrue();
+            })
+          )
+        );
+    }
+
+    @Test
+    void isOfTypeIgnoringGenericsDistinguishesDifferentMethods() {
+        rewriteRun(
+          java(
+            """
+              class Main {
+                  void method() {
+                      a("x");
+                  }
+
+                  private void a(String s) {
+                  }
+
+                  private void a(Integer i) {
+                  }
+
+                  private void b(String s) {
+                  }
+              }
+              """,
+            s -> s.afterRecipe(cu -> {
+                var statements = cu.getClasses().get(0).getBody().getStatements();
+                JavaType.Method aString = ((J.MethodDeclaration) statements.get(1)).getMethodType();
+                JavaType.Method aInteger = ((J.MethodDeclaration) statements.get(2)).getMethodType();
+                JavaType.Method b = ((J.MethodDeclaration) statements.get(3)).getMethodType();
+                JavaType.Method use = usedMethod(cu, "a");
+
+                assertThat(TypeUtils.isOfTypeIgnoringGenerics(aString, use)).isTrue();
+                // Differing parameter type and differing name are not matched.
+                assertThat(TypeUtils.isOfTypeIgnoringGenerics(aInteger, use)).isFalse();
+                assertThat(TypeUtils.isOfTypeIgnoringGenerics(b, use)).isFalse();
+            })
+          )
+        );
+    }
+
+    private static JavaType.Method methodType(J.CompilationUnit cu, String name) {
+        return cu.getClasses().get(0).getBody().getStatements().stream()
+          .filter(J.MethodDeclaration.class::isInstance)
+          .map(J.MethodDeclaration.class::cast)
+          .map(J.MethodDeclaration::getMethodType)
+          .filter(m -> m != null && name.equals(m.getName()))
+          .findFirst()
+          .orElseThrow(() -> new AssertionError("No method declaration named " + name));
+    }
+
+    private static JavaType.Method usedMethod(J.CompilationUnit cu, String name) {
+        return cu.getTypesInUse().getUsedMethods().stream()
+          .filter(m -> name.equals(m.getName()))
+          .findFirst()
+          .orElseThrow(() -> new AssertionError("No used method named " + name));
+    }
+
     @Test
     void arrayIsFullyQualifiedOfType() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -161,6 +161,64 @@ public class TypeUtils {
         return isOfTypeCore(type1, type2, context);
     }
 
+    /**
+     * Compares two method types for being the same method, ignoring differences that arise purely
+     * from generic parameterization at the use site. This is looser than
+     * {@link #isOfType(JavaType, JavaType)}: a raw type matches its parameterized form (e.g. raw
+     * {@code Set} matches {@code Set<String>}) and a generic type variable matches any type.
+     * <p>
+     * It is intended for matching the {@link JavaType.Method} recorded for an invocation (such as
+     * the entries of {@code JavaSourceFile.getTypesInUse().getUsedMethods()}) back to the
+     * declaration it resolves to. The recorded call-site type can diverge from the declaration when
+     * the invocation is an unchecked invocation (the result type is erased to its raw form) or when
+     * the call binds a generic parameter to a concrete type, so neither {@link Object#equals} nor
+     * {@link #isOfType(JavaType, JavaType)} reliably matches the two.
+     */
+    public static boolean isOfTypeIgnoringGenerics(JavaType.@Nullable Method declaration, JavaType.@Nullable Method use) {
+        if (declaration == use) {
+            return true;
+        }
+        if (declaration == null || use == null ||
+            !declaration.getName().equals(use.getName()) ||
+            declaration.getParameterTypes().size() != use.getParameterTypes().size() ||
+            !isOfTypeIgnoringGenerics(declaration.getDeclaringType(), use.getDeclaringType()) ||
+            !isOfTypeIgnoringGenerics(declaration.getReturnType(), use.getReturnType())) {
+            return false;
+        }
+        for (int i = 0; i < declaration.getParameterTypes().size(); i++) {
+            if (!isOfTypeIgnoringGenerics(declaration.getParameterTypes().get(i), use.getParameterTypes().get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isOfTypeIgnoringGenerics(@Nullable JavaType type1, @Nullable JavaType type2) {
+        if (type1 == type2) {
+            return true;
+        }
+        if (type1 == null || type2 == null) {
+            return false;
+        }
+        // A generic type variable can be bound to any type at a use site, so treat it as a wildcard.
+        if (type1 instanceof JavaType.GenericTypeVariable || type2 instanceof JavaType.GenericTypeVariable) {
+            return true;
+        }
+        if (isString(type1) && isString(type2)) {
+            return true;
+        }
+        if (type1 instanceof JavaType.Primitive || type2 instanceof JavaType.Primitive) {
+            return type1 == type2;
+        }
+        if (type1 instanceof JavaType.Array && type2 instanceof JavaType.Array) {
+            return isOfTypeIgnoringGenerics(((JavaType.Array) type1).getElemType(), ((JavaType.Array) type2).getElemType());
+        }
+        // Ignore any type parameters: compare only the raw fully qualified names.
+        JavaType.FullyQualified fq1 = asFullyQualified(type1);
+        JavaType.FullyQualified fq2 = asFullyQualified(type2);
+        return fq1 != null && fq2 != null && fullyQualifiedNamesAreEqual(fq1.getFullyQualifiedName(), fq2.getFullyQualifiedName());
+    }
+
     private static boolean isOfTypeMethod(JavaType.Method type1, JavaType.Method type2, ComparisonContext context) {
         if (!type1.getName().equals(type2.getName()) ||
             type1.getFlagsBitMap() != type2.getFlagsBitMap() ||


### PR DESCRIPTION
`JavaSourceFile#getTypesInUse().getUsedMethods()` is the standard way recipes find usages of a method declaration, but the `JavaType.Method` recorded for an invocation can diverge from the declaration's instance: an unchecked invocation (raw arguments) erases the result type to its raw form (e.g. `Set<String>` becomes raw `Set`), and a call binding a generic parameter records the concrete type — so `declaration.equals(used)` and `TypeUtils.isOfType` return false even though there's no ambiguity about which declaration the invocation resolves to. This adds `TypeUtils.isOfTypeIgnoringGenerics(JavaType.Method, JavaType.Method)`, a comparison that matches two method types insensitive to generic parameterization: a raw type matches its parameterized form and a generic type variable matches any type. The LST attribution is left untouched, so the call-site generic information on invocations is preserved. Recipes such as `RemoveUnusedPrivateMethods` can use this instead of hand-rolled bidirectional matchers, which fixes both the raw-collection case (openrewrite/rewrite-static-analysis#877) and generic methods that look unused when invoked (#1536).