### PR TITLE
Groovy: fix parsing of groovy code that has default method with 'this' keyword

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2676,6 +2676,7 @@ public class GroovyParserVisitor {
                     }
                     select = JRightPadded.build(selectExpr).withAfter(afterSelect);
                 }
+
                 // Handle explicit "this." receiver when Groovy's AST marks the call as implicit-this.
                 // This occurs in interface default methods where `this.method()` is represented
                 // with isImplicitThis() == true despite the explicit receiver in source.
@@ -2686,6 +2687,7 @@ public class GroovyParserVisitor {
                     Space afterSelect = sourceBefore(".");
                     select = JRightPadded.build(thisIdent).withAfter(afterSelect);
                 }
+
                 JContainer<Expression> typeParameters = call.getGenericsTypes() != null ? visitTypeParameterizations(call.getGenericsTypes()) : null;
                 // Closure invocations that are written as closure.call() and closure() are parsed into identical MethodCallExpression
                 // closure() has implicitThis set to false

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2676,6 +2676,16 @@ public class GroovyParserVisitor {
                     }
                     select = JRightPadded.build(selectExpr).withAfter(afterSelect);
                 }
+                // Handle explicit "this." receiver when Groovy's AST marks the call as implicit-this.
+                // This occurs in interface default methods where `this.method()` is represented
+                // with isImplicitThis() == true despite the explicit receiver in source.
+                if (select == null && source.startsWith("this", cursor) &&
+                        cursor + 4 < source.length() && source.charAt(cursor + 4) == '.') {
+                    Expression thisIdent = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), "this", null, null);
+                    skip("this");
+                    Space afterSelect = sourceBefore(".");
+                    select = JRightPadded.build(thisIdent).withAfter(afterSelect);
+                }
                 JContainer<Expression> typeParameters = call.getGenericsTypes() != null ? visitTypeParameterizations(call.getGenericsTypes()) : null;
                 // Closure invocations that are written as closure.call() and closure() are parsed into identical MethodCallExpression
                 // closure() has implicitThis set to false

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -414,4 +414,23 @@ class GroovyParserTest implements RewriteTest {
         );
     }
 
+    @Test
+    void defaultMethodWithThis() {
+        rewriteRun(
+          groovy(
+            """
+            interface A {
+            
+                default void a() {
+                    this.a(false)
+                }
+            
+                void a(boolean b)
+            
+            }
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
In visitMethodCallExpression(), added a check after the normal select resolution: when no select was produced but the source has `this.` at the cursor position, it manually constructs a `this` identifier as the select, consumes `this` from source, and captures the `.` whitespace.  

Added test to showcase the bug and fix.


 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
