### PR TITLE
Scala: fix parsing of `asinstanceof` followed by a newline

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5480,10 +5480,8 @@ class ScalaTreeVisitor(
           }
           
           // Update cursor past the closing bracket
-          if (ta.span.end > cursor) {
-            cursor = ta.span.end
-          }
-          
+          updateCursor(ta.span.end)
+
           val typeCastMarkers =
             if (asInstanceOfPrefix.getWhitespace.nonEmpty || !asInstanceOfPrefix.getComments.isEmpty) {
               Markers.EMPTY.addIfAbsent(AsInstanceOfPrefix.create(asInstanceOfPrefix))

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -652,11 +652,7 @@ class ScalaTreeVisitor(
       arguments
     )
     
-    // Update cursor to the end of the annotation
-    val adjustedEnd = Math.max(0, app.span.end - offsetAdjustment)
-    if (adjustedEnd > cursor) {
-      cursor = adjustedEnd
-    }
+    updateCursor(app.span.end)
     
     
     annotation
@@ -969,12 +965,8 @@ class ScalaTreeVisitor(
         } else Space.EMPTY
         if (dotPos >= 0) cursor = dotPos + 1
 
-        // Update cursor position to after the method name
         if (sel.nameSpan.exists) {
-          val nameEnd = Math.max(0, sel.nameSpan.end - offsetAdjustment)
-          if (nameEnd > cursor) {
-            cursor = nameEnd
-          }
+          updateCursor(sel.nameSpan.end)
         }
 
         select = target
@@ -1250,12 +1242,8 @@ class ScalaTreeVisitor(
       Markers.EMPTY
     )
 
-    // Update cursor to end of the apply expression
     if (app.span.exists) {
-      val adjustedEnd = Math.max(0, app.span.end - offsetAdjustment)
-      if (adjustedEnd > cursor && adjustedEnd <= source.length) {
-        cursor = adjustedEnd
-      }
+      updateCursor(app.span.end)
     }
 
     val markers = if (isBlockArg) {
@@ -1390,13 +1378,9 @@ class ScalaTreeVisitor(
     val operator = mapOperator(sel.name.toString)
     val rightExpr = visitTree(right).asInstanceOf[Expression]
     
-    // Extract any remaining source from the Apply span if provided
     appSpan.foreach { span =>
       if (span.exists) {
-        val adjustedEnd = Math.max(0, span.end - offsetAdjustment)
-        if (adjustedEnd > cursor && adjustedEnd <= source.length) {
-          cursor = adjustedEnd
-        }
+        updateCursor(span.end)
       }
     }
     
@@ -1506,12 +1490,8 @@ class ScalaTreeVisitor(
       }
       val name = ident(nameStr, dotSpace, typeOfTree(sel), variableTypeOfTree(sel))
       
-      // Consume up to the end of the selection
       if (sel.span.exists) {
-        val adjustedEnd = Math.max(0, sel.span.end - offsetAdjustment)
-        if (adjustedEnd > cursor && adjustedEnd <= source.length) {
-          cursor = adjustedEnd
-        }
+        updateCursor(sel.span.end)
       }
       
       val faMarkers = if (isTypeProjection) {
@@ -5330,12 +5310,8 @@ class ScalaTreeVisitor(
       null
     }
     
-    // Update cursor to end of the class
     if (td.span.exists) {
-      val adjustedEnd = Math.max(0, td.span.end - offsetAdjustment)
-      if (adjustedEnd > cursor && adjustedEnd <= source.length) {
-        cursor = adjustedEnd
-      }
+      updateCursor(td.span.end)
     }
     
     val classDeclMarkers = if (isEnumCaseClass) {
@@ -5449,10 +5425,7 @@ class ScalaTreeVisitor(
               Space.EMPTY
             }
 
-          // Update cursor past ".asInstanceOf"
-          if (asInstanceOfEnd > cursor) {
-            cursor = asInstanceOfEnd
-          }
+          updateCursor(sel.span.end)
           
           // Now handle the type argument in brackets
           // Extract any space before the opening bracket

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -905,6 +905,25 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void asInstanceOfInProcedureSyntaxBody() {
+        // Procedure-syntax bodies are reparsed with a nonzero offset; the cursor update
+        // after `asInstanceOf[...]` must apply that offset or it swallows the following
+        // statement's leading whitespace (`x.asInstanceOf[B]\ny` -> `x.asInstanceOf[B]y`).
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              def m() {
+                x.asInstanceOf[B]
+                y
+              }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void procedureSyntaxSetter() {
         rewriteRun(
           scala(


### PR DESCRIPTION
## What's changed?

Fix a Scala parsing corner case with `.asInstanceOf[B]` as the last thing in the line, followed by some other statements.

## What's your motivation?

It suffers from idempotency issues.