### PR TITLE
Groovy: parse try-with-resources without a catch block

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1744,6 +1744,15 @@ public class GroovyParserVisitor {
 
         @Override
         public void visitBlockStatement(BlockStatement block) {
+            if (isUnwrappedDesugaredResourceBlock(block)) {
+                // A try-with-resources without a catch or finally clause is desugared by Groovy 4 into a
+                // bare block (rather than being wrapped in a TryCatchStatement like the cases that have a
+                // catch/finally). Re-wrap it so the try-with-resources handling in visitTryCatchFinally applies.
+                BlockStatement wrapper = new BlockStatement();
+                wrapper.addStatement(block);
+                visitTryCatchFinally(new TryCatchStatement(wrapper, EmptyStatement.INSTANCE));
+                return;
+            }
             Space fmt = EMPTY;
             Space staticInitPadding = EMPTY;
             boolean isStaticInit = sourceStartsWith("static");
@@ -3160,6 +3169,9 @@ public class GroovyParserVisitor {
             // Groovy 4 desugars try-with-resources at parse time (getResourceStatements() is always empty).
             // Detect from source: if "(" follows "try", parse resources from source text.
             JContainer<J.Try.Resource> resources = null;
+            // The body lives at the bottom of the nested resource structure; it defaults to the try
+            // statement itself when there are no resources, and is reassigned as resources are consumed.
+            org.codehaus.groovy.ast.stmt.Statement bodyStatement = node.getTryStatement();
             boolean hasTryWithResources = source.charAt(indexOfNextNonWhitespace(cursor, source)) == '(';
             if (hasTryWithResources) {
                 Space beforeParen = sourceBefore("(");
@@ -3177,7 +3189,6 @@ public class GroovyParserVisitor {
                     resourceVar = resourceVar.withPrefix(EMPTY);
 
                     TryCatchStatement innerTry = (TryCatchStatement) innerBlock.getStatements().get(innerBlock.getStatements().size() - 1);
-                    boolean hasMoreResources = isDesugaredResourceBlock(innerTry.getTryStatement());
 
                     int nextNonWs = indexOfNextNonWhitespace(cursor, source);
                     boolean semicolonPresent = nextNonWs < source.length() && source.charAt(nextNonWs) == ';';
@@ -3191,36 +3202,23 @@ public class GroovyParserVisitor {
                             resourceVar.withPrefix(EMPTY), semicolonPresent);
                     skip(";");
 
+                    // Whether another resource follows must be decided from the source, not the AST:
+                    // a nested try-with-resources in the body desugars to the same shape as an additional
+                    // resource, so only the closing ')' of the resource list can disambiguate them.
+                    boolean hasMoreResources = source.charAt(indexOfNextNonWhitespace(cursor, source)) != ')';
                     if (hasMoreResources) {
                         resourceList.add(padRight(tryResource, EMPTY));
                         current = innerTry.getTryStatement();
                     } else {
                         resourceList.add(padRight(tryResource, sourceBefore(")")));
+                        bodyStatement = innerTry.getTryStatement();
                         break;
                     }
                 }
                 resources = JContainer.build(beforeParen, resourceList, Markers.EMPTY);
             }
 
-            // When try-with-resources, find the actual body by walking down the nested structure
-            // to the innermost TryCatchStatement's tryStmt.
-            J.Block body;
-            if (hasTryWithResources) {
-                org.codehaus.groovy.ast.stmt.Statement current = node.getTryStatement();
-                TryCatchStatement innerTry = null;
-                while (isDesugaredResourceBlock(current)) {
-                    BlockStatement innerBlock = (BlockStatement) ((BlockStatement) current).getStatements().get(0);
-                    innerTry = (TryCatchStatement) innerBlock.getStatements().get(innerBlock.getStatements().size() - 1);
-                    if (isDesugaredResourceBlock(innerTry.getTryStatement())) {
-                        current = innerTry.getTryStatement();
-                    } else {
-                        break;
-                    }
-                }
-                body = doVisit(innerTry != null ? innerTry.getTryStatement() : node.getTryStatement());
-            } else {
-                body = doVisit(node.getTryStatement());
-            }
+            J.Block body = doVisit(bodyStatement);
 
             // Handle catches, merging multi-catch statements.
             // Groovy 4 splits catch(A | B e) into separate CatchStatements at the same source position.
@@ -3631,6 +3629,27 @@ public class GroovyParserVisitor {
 
     private <T> JRightPadded<T> padRight(T tree, Space right, Markers markers) {
         return new JRightPadded<>(tree, right, markers);
+    }
+
+    /**
+     * Detects the "unwrapped" desugared form of a try-with-resources that has no catch or finally clause.
+     * Groovy 4 desugars such a statement into a bare block of the shape
+     * {@code [resourceDecl, __$$primaryExc decl, TryCatchStatement]} rather than wrapping it in an
+     * enclosing {@link TryCatchStatement}. The synthetic {@code __$$primaryExc} primary-exception holder is
+     * what distinguishes it from an ordinary user-authored block.
+     */
+    private static boolean isUnwrappedDesugaredResourceBlock(BlockStatement block) {
+        List<org.codehaus.groovy.ast.stmt.Statement> stmts = block.getStatements();
+        if (stmts.size() < 3 || !(stmts.get(stmts.size() - 1) instanceof TryCatchStatement)) {
+            return false;
+        }
+        org.codehaus.groovy.ast.stmt.Statement primaryExc = stmts.get(stmts.size() - 2);
+        if (primaryExc instanceof ExpressionStatement &&
+                ((ExpressionStatement) primaryExc).getExpression() instanceof DeclarationExpression) {
+            org.codehaus.groovy.ast.expr.Expression left = ((DeclarationExpression) ((ExpressionStatement) primaryExc).getExpression()).getLeftExpression();
+            return left instanceof VariableExpression && ((VariableExpression) left).getName().startsWith("__$$primaryExc");
+        }
+        return false;
     }
 
     /**

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/TryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/TryTest.java
@@ -167,6 +167,65 @@ class TryTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/8040")
+    @Test
+    void tryWithResourcesWithoutCatch() {
+        rewriteRun(
+          groovy(
+            """
+              try(ByteArrayInputStream a = new ByteArrayInputStream("".getBytes()); ByteArrayInputStream b = new ByteArrayInputStream("".getBytes())) {
+
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8040")
+    @Test
+    void tryWithResourcesWithoutCatchNested() {
+        rewriteRun(
+          groovy(
+            """
+              try(ByteArrayInputStream a = new ByteArrayInputStream("".getBytes()); ByteArrayInputStream b = new ByteArrayInputStream("".getBytes())) {
+                            try(ByteArrayInputStream c = new ByteArrayInputStream("".getBytes()); ByteArrayInputStream d = new ByteArrayInputStream("".getBytes())) {
+
+                             }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8040")
+    @Test
+    void tryWithResourceWithoutCatch() {
+        rewriteRun(
+          groovy(
+            """
+              try (ByteArrayInputStream a = new ByteArrayInputStream("".getBytes())) {
+                  def x = a.read()
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8040")
+    @Test
+    void tryWithResourcesWithoutCatchButFinally() {
+        rewriteRun(
+          groovy(
+            """
+              try (ByteArrayInputStream a = new ByteArrayInputStream("".getBytes()); ByteArrayInputStream b = new ByteArrayInputStream("".getBytes())) {
+              } finally {
+                  println "done"
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void whitespace() {
         rewriteRun(


### PR DESCRIPTION
- Fixes #8040

## Problem
Groovy fails to parse a `try`-with-resources statement that has no `catch` (or `finally`) clause:

```groovy
try (ByteArrayInputStream a = new ByteArrayInputStream("".getBytes()); ByteArrayInputStream b = new ByteArrayInputStream("".getBytes())) {
}
```

## Root cause
Groovy 4 desugars try-with-resources at parse time. When there **is** a `catch`/`finally`, the top node stays a `TryCatchStatement` (handled by `visitTryCatchFinally`). When there is **no** `catch`/`finally`, Groovy emits the desugared form as a *bare* `BlockStatement` (`[resourceDecl, __$$primaryExc decl, TryCatchStatement]`), which fell through to `visitBlockStatement` and threw.

A second, deeper bug surfaced for the nested case: a nested try-with-resources in the body desugars to the *same shape* as an additional resource of the outer `try`, so the resource-walking loop (which used the AST structure to decide "are there more resources?") consumed the inner try's resources as if they belonged to the outer.

## Fix
1. Detect the unwrapped desugared form in `visitBlockStatement` (keyed on the synthetic `__$$primaryExc` primary-exception holder) and re-wrap it into a synthetic `TryCatchStatement` so the existing try-with-resources handling applies.
2. Decide whether more resources follow from the **source** (the closing `)` of the resource list) rather than the AST structure, and capture the body in the same pass — removing the now-redundant second walk.

## Tests
Added `TryTest` cases covering single/multiple resources without catch, the nested variants from the issue, and a resources-with-`finally`-but-no-`catch` case. Full `:rewrite-groovy:test` and `:rewrite-gradle:test` suites pass.