### PR TITLE
Resolve plugin marker current version from buildscript classpath

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyVersionSelector.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyVersionSelector.java
@@ -69,11 +69,24 @@ public class DependencyVersionSelector {
                          @Nullable String versionPattern,
                          ExecutionContext ctx) throws MavenDownloadingException {
         String currentVersion = "0";
-        if (gradleProject != null && configuration != null) {
-            GradleDependencyConfiguration gdc = gradleProject.getConfiguration(configuration);
-            if(gdc != null) {
+        if (configuration != null) {
+            // For "classpath" lookups (plugin markers, buildscript classpath deps), the requested
+            // dependency lives on the buildscript or settings buildscript, not the project's configs.
+            GradleDependencyConfiguration gdc = null;
+            if ("classpath".equals(configuration)) {
+                if (gradleSettings != null) {
+                    gdc = gradleSettings.getBuildscript().getConfiguration(configuration);
+                }
+                if (gdc == null && gradleProject != null) {
+                    gdc = gradleProject.getBuildscript().getConfiguration(configuration);
+                }
+            }
+            if (gdc == null && gradleProject != null) {
+                gdc = gradleProject.getConfiguration(configuration);
+            }
+            if (gdc != null) {
                 Dependency requested = gdc.findRequestedDependency(ga.getGroupId(), ga.getArtifactId());
-                if(requested != null && requested.getVersion() != null) {
+                if (requested != null && requested.getVersion() != null) {
                     currentVersion = requested.getVersion();
                 }
             }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
@@ -202,6 +202,29 @@ class UpgradePluginVersionTest implements RewriteTest {
     }
 
     @Test
+    void latestPatchPluginVersionInProperties() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion("org.openrewrite.rewrite", "latest.patch", null)),
+          properties(
+            """
+              rewriteVersion=5.40.0
+              """,
+            """
+              rewriteVersion=5.40.6
+              """,
+            spec -> spec.path("gradle.properties")
+          ),
+          buildGradle(
+            """
+              plugins {
+                  id 'org.openrewrite.rewrite' version "$rewriteVersion"
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void change() {
         rewriteRun(
           spec -> spec.recipe(new UpgradePluginVersion("org.openrewrite.rewrite", "5.x", null)),


### PR DESCRIPTION
## What

When `DependencyVersionSelector.select(GroupArtifact, ...)` is asked for a `"classpath"` configuration, look up the requested dependency on `gradleProject.getBuildscript().getConfiguration("classpath")` (and `gradleSettings.getBuildscript().getConfiguration(...)` when applicable) before falling back to the project's own configs.

## Why

`UpgradePluginVersion` against a plugin whose version is interpolated from `gradle.properties` (e.g. `id 'org.springframework.boot' version "${springBootVersion}"`) silently makes no change when invoked with `newVersion=latest.patch`, while an exact version like `3.5.9` does update the property.

Root cause: the selector tried to recover the current version from `gradleProject.getConfiguration("classpath")`, but plugin-marker GAVs (`${pluginId}.gradle.plugin`) live on the **buildscript** classpath, not the project's. `currentVersion` therefore fell back to `"0"`, which triggered the `latest.patch → latest.release` coercion intended for genuinely-unknown current versions. The selector returned the absolute latest version available, and the visitor's `LatestPatch.upgrade(currentVersion, [latestRelease])` then correctly rejected it as out-of-range — silently dropping the upgrade.

The same file's `determineRepos` already routes `"classpath"` to `gradleProject.getBuildscript().getMavenRepositories()`; this PR brings the requested-dependency lookup in line with that.

## Test

`UpgradePluginVersionTest.latestPatchPluginVersionInProperties` reproduces the issue (interpolated plugin version + `latest.patch`). Full `org.openrewrite.gradle.plugins.*`, `UpgradeDependencyVersionTest`, `ChangeDependencyTest`, and `AddDependencyTest` stay green locally.