### PR TITLE
Experiment: opt-in Cursor pooling (-Dorg.openrewrite.cursorPool)

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Cursor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Cursor.java
@@ -50,6 +50,16 @@ public class Cursor {
         this.value = value;
     }
 
+    /**
+     * Create a standalone copy of this cursor and its entire parent chain, detached from the traversal
+     * that produced it. Use this whenever a cursor (or its path) must outlive the visit of its node —
+     * e.g. when storing it as a long-lived map key or in a field — so that it stays valid even if the
+     * originating cursors are later reused/recycled by the visitor. Messages are not copied.
+     */
+    public Cursor detach() {
+        return new Cursor(parent == null ? null : parent.detach(), value);
+    }
+
     public Cursor getRoot() {
         Cursor c = this;
         while (c.parent != null) {

--- a/rewrite-core/src/main/java/org/openrewrite/Cursor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Cursor.java
@@ -37,10 +37,10 @@ public class Cursor {
     public static final String ROOT_VALUE = "root";
 
     @Nullable
-    private final Cursor parent;
+    private Cursor parent;
 
     @With
-    private final Object value;
+    private Object value;
 
     @Nullable
     private Map<String, Object> messages;
@@ -48,6 +48,22 @@ public class Cursor {
     public Cursor(@Nullable Cursor parent, Object value) {
         this.parent = parent;
         this.value = value;
+    }
+
+    /**
+     * Re-point this cursor at a new position so a {@link CursorPool} can recycle the object
+     * instead of allocating a fresh {@code new Cursor(...)} for every visited node. Messages
+     * are dropped, matching a newly constructed cursor.
+     * <p>
+     * Package-private and intended <strong>only</strong> for the pool driven by the visitor's
+     * own push/pop. Any cursor that must outlive the visit of its node must instead be copied
+     * with {@link #detach()} (which allocates a separate, never-pooled object), so that the
+     * cursor being reset here is provably dead.
+     */
+    void reset(@Nullable Cursor parent, Object value) {
+        this.parent = parent;
+        this.value = value;
+        this.messages = null;
     }
 
     /**

--- a/rewrite-core/src/main/java/org/openrewrite/CursorPool.java
+++ b/rewrite-core/src/main/java/org/openrewrite/CursorPool.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * A per-thread free list of {@link Cursor} objects, used to recycle the cursor that the visitor
+ * creates for every node it descends into instead of allocating a fresh one each time. Allocation
+ * profiling of large recipe runs showed {@code new Cursor(...)} accounting for roughly 40% of all
+ * allocation — pure churn (one cursor per node per pass), since a cursor is logically dead the
+ * instant the visitor ascends back above its node.
+ * <p>
+ * Recycling is sound only because a cursor that must outlive its visit is copied via
+ * {@link Cursor#detach()} into a fresh, never-pooled object, leaving the original free to be reset
+ * and reused. {@link org.openrewrite.internal.CursorEscapeDetector} is the gate that proves no
+ * un-detached cursor is actually retained past the visit that created it.
+ * <p>
+ * The pool is per-thread because recipe runs are parallel across source files but a single node's
+ * visit (acquire through release) always happens on one thread, so a thread only ever touches its
+ * own free list and no synchronization is needed.
+ * <p>
+ * Entirely disabled (every cursor is freshly allocated) unless {@code -Dorg.openrewrite.cursorPool=true}.
+ */
+public final class CursorPool {
+
+    public static final boolean ENABLED = Boolean.getBoolean("org.openrewrite.cursorPool");
+
+    private static final ThreadLocal<Deque<Cursor>> FREE = ThreadLocal.withInitial(ArrayDeque::new);
+
+    private CursorPool() {
+    }
+
+    /**
+     * Reuse a recycled cursor for the given position if one is available on this thread, otherwise
+     * allocate a new one.
+     */
+    public static Cursor acquire(@Nullable Cursor parent, Object value) {
+        Cursor cursor = FREE.get().poll();
+        if (cursor == null) {
+            return new Cursor(parent, value);
+        }
+        cursor.reset(parent, value);
+        return cursor;
+    }
+
+    /**
+     * Return a cursor to this thread's free list once the visitor has ascended above its node.
+     * Root cursors are never recycled: they are held for the lifetime of a recipe run (by the
+     * {@code RecipeScheduler} / {@code RecipeRunCycle} / prepared-recipe cache) and resetting one
+     * would corrupt that long-lived state.
+     */
+    public static void release(Cursor cursor) {
+        if (cursor.getParent() == null || cursor.isRoot()) {
+            return;
+        }
+        FREE.get().push(cursor);
+    }
+
+    /**
+     * Discard this thread's recycled cursors. Intended for tests that want an isolated pool; the
+     * pool is otherwise meant to persist on long-lived worker threads across many source files.
+     */
+    public static void clear() {
+        FREE.remove();
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -83,6 +83,41 @@ public abstract class TreeVisitor<T extends @Nullable Tree, P> {
     }
 
     /**
+     * Descend the cursor onto {@code value}, recycling a cursor from the {@link CursorPool} when
+     * enabled instead of allocating one, and return the cursor that was acquired. Visitors that
+     * manage the cursor by hand (e.g. for padding wrappers) should pair this with
+     * {@link #popCursor(Cursor)} — passing back the returned cursor — rather than calling
+     * {@code new Cursor} and {@code setCursor(getCursor().getParent())} directly, so they share the
+     * pooling discipline.
+     */
+    protected final Cursor pushCursor(Object value) {
+        Cursor acquired = CursorPool.ENABLED ? CursorPool.acquire(cursor, value) : new Cursor(cursor, value);
+        setCursor(acquired);
+        if (CursorEscapeDetector.ENABLED) {
+            CursorEscapeDetector.onCursorCreated(acquired, value);
+        }
+        return acquired;
+    }
+
+    /**
+     * Ascend the cursor back to its parent and return the cursor acquired by the matching
+     * {@link #pushCursor(Object)} to the {@link CursorPool} when enabled.
+     * <p>
+     * Only the {@code pushed} cursor is recycled — never the current {@code cursor} — because a
+     * visit may legitimately re-point its own {@code cursor} field at an unrelated cursor (e.g.
+     * {@code SourcePositionService}'s printer adopts the caller's cursor via {@code setCursor},
+     * and {@code updateCursor} swaps in a fresh value). Recycling the field rather than what this
+     * frame actually allocated would return someone else's still-live cursor to the pool and
+     * corrupt its parent chain.
+     */
+    protected final void popCursor(Cursor pushed) {
+        setCursor(cursor.getParent());
+        if (CursorPool.ENABLED) {
+            CursorPool.release(pushed);
+        }
+    }
+
+    /**
      * @return Describes the language type that this visitor applies to, e.g. java, xml, properties.
      */
     public @Nullable String getLanguage() {
@@ -231,10 +266,7 @@ public abstract class TreeVisitor<T extends @Nullable Tree, P> {
         }
 
         visitCount++;
-        setCursor(new Cursor(cursor, tree));
-        if (CursorEscapeDetector.ENABLED) {
-            CursorEscapeDetector.onCursorCreated(cursor, tree);
-        }
+        Cursor pushed = pushCursor(tree);
 
         T t = null;
         // Do you visitor take tree and do you tree take visitor?
@@ -262,7 +294,7 @@ public abstract class TreeVisitor<T extends @Nullable Tree, P> {
                 }
             }
 
-            setCursor(cursor.getParent());
+            popCursor(pushed);
 
             if (topLevel) {
                 if (t != null && afterVisit != null) {

--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -17,6 +17,7 @@ package org.openrewrite;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.internal.CursorEscapeDetector;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.RecipeRunException;
 import org.openrewrite.internal.TreeVisitorAdapter;
@@ -225,9 +226,15 @@ public abstract class TreeVisitor<T extends @Nullable Tree, P> {
         }
 
         boolean topLevel = visitCount == 0;
+        if (CursorEscapeDetector.ENABLED && topLevel) {
+            CursorEscapeDetector.pushVisitor(getClass().getName());
+        }
 
         visitCount++;
         setCursor(new Cursor(cursor, tree));
+        if (CursorEscapeDetector.ENABLED) {
+            CursorEscapeDetector.onCursorCreated(cursor, tree);
+        }
 
         T t = null;
         // Do you visitor take tree and do you tree take visitor?
@@ -268,6 +275,10 @@ public abstract class TreeVisitor<T extends @Nullable Tree, P> {
 
                 afterVisit = null;
                 visitCount = 0;
+                if (CursorEscapeDetector.ENABLED) {
+                    CursorEscapeDetector.onTopLevelEnd();
+                    CursorEscapeDetector.popVisitor();
+                }
             }
         } catch (Throwable e) {
             if (e instanceof RecipeRunException) {

--- a/rewrite-core/src/main/java/org/openrewrite/internal/CursorEscapeDetector.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/CursorEscapeDetector.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.internal;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayDeque;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Diagnostic, opt-in detector for {@link org.openrewrite.Cursor} objects that survive
+ * past the top-level visit (one recipe applied to one source file) that created them.
+ * <p>
+ * A cursor is created for every visited tree node and is logically dead once its
+ * top-level visit completes — unless a recipe stashes it into longer-lived state
+ * (an {@code ExecutionContext} message, a {@code ScanningRecipe} accumulator, an
+ * instance field, …). Such retention is what a per-source-file cursor pool would
+ * have to forbid. This class measures whether it actually happens, without changing
+ * allocation behavior: it weakly tracks a sample of cursors, advances an epoch per
+ * top-level visit, and periodically forces a GC and reports any sampled cursor that
+ * is still strongly reachable several epochs after its own visit ended.
+ * <p>
+ * Entirely disabled (zero overhead) unless {@code -Dorg.openrewrite.cursorEscapeCheck=true}.
+ * Tuning: {@code cursorEscapeSample} (1/N sampling, default 16),
+ * {@code cursorEscapeCheckEvery} (visits between sweeps, default 100),
+ * {@code cursorEscapeGrace} (epochs of grace before a survivor counts as leaked, default 3).
+ */
+public final class CursorEscapeDetector {
+
+    public static final boolean ENABLED = Boolean.getBoolean("org.openrewrite.cursorEscapeCheck");
+
+    private static int SAMPLE = Integer.getInteger("org.openrewrite.cursorEscapeSample", 16);
+    private static int CHECK_EVERY = Integer.getInteger("org.openrewrite.cursorEscapeCheckEvery", 100);
+    private static long GRACE = Integer.getInteger("org.openrewrite.cursorEscapeGrace", 3);
+
+    /** Capture a creation stack for cursors whose value type (lowercased) contains one of these tokens. */
+    private static final java.util.Set<String> STACK_FILTER = parseFilter(System.getProperty("org.openrewrite.cursorEscapeStackFilter", ""));
+    private static final int STACK_FRAMES = Integer.getInteger("org.openrewrite.cursorEscapeStackFrames", 40);
+    private static final int LEAK_STACK_CAP = 12;
+
+    private static java.util.Set<String> parseFilter(String s) {
+        java.util.Set<String> set = new java.util.HashSet<>();
+        for (String tok : s.split(",")) {
+            tok = tok.trim().toLowerCase();
+            if (!tok.isEmpty()) {
+                set.add(tok);
+            }
+        }
+        return set;
+    }
+
+    // Per-thread epoch: a cursor is aged against its OWN thread's progress, not a global counter. The
+    // run is parallel across source files (a ForkJoinPool), so a long file-visit on one worker must not
+    // be "aged out" by other workers racing a shared counter while its cursors are still legitimately live.
+    private static final ThreadLocal<long[]> threadEpoch = ThreadLocal.withInitial(() -> new long[1]);
+    private static final Map<Long, long[]> allThreadEpochs = new ConcurrentHashMap<>();
+    private static final AtomicLong createdCount = new AtomicLong();
+    private static final AtomicLong sampledCount = new AtomicLong();
+    private static final AtomicLong visitsSinceSweep = new AtomicLong();
+    private static final AtomicLong leakedCount = new AtomicLong();
+
+    private static final Queue<Tracked> tracked = new ConcurrentLinkedQueue<>();
+    private static final Map<String, Long> leaksByType = new ConcurrentHashMap<>();
+    private static final Queue<String> leakStacks = new ConcurrentLinkedQueue<>();
+
+    /** Per-thread stack of the class names of currently-active top-level visitors. */
+    private static final ThreadLocal<ArrayDeque<String>> creatorStack = ThreadLocal.withInitial(ArrayDeque::new);
+
+    private static final class Tracked extends WeakReference<Object> {
+        final long threadId;
+        final long epoch;
+        final String valueType;
+        final String creator;
+        final String stack;
+
+        Tracked(Object cursor, long threadId, long epoch, String valueType, String creator, String stack) {
+            super(cursor);
+            this.threadId = threadId;
+            this.epoch = epoch;
+            this.valueType = valueType;
+            this.creator = creator;
+            this.stack = stack;
+        }
+    }
+
+    /** The current thread's epoch counter, registered so the sweep (on any thread) can read it. */
+    private static long[] myEpoch() {
+        long[] te = threadEpoch.get();
+        allThreadEpochs.putIfAbsent(Thread.currentThread().getId(), te);
+        return te;
+    }
+
+    /** Called at the start of a top-level visit so created cursors can be attributed to the visitor. */
+    public static void pushVisitor(String visitorClass) {
+        creatorStack.get().push(visitorClass);
+    }
+
+    /** Called at the end of a top-level visit. */
+    public static void popVisitor() {
+        ArrayDeque<String> d = creatorStack.get();
+        if (!d.isEmpty()) {
+            d.pop();
+        }
+    }
+
+    static {
+        if (ENABLED) {
+            Runtime.getRuntime().addShutdownHook(new Thread(CursorEscapeDetector::report, "cursor-escape-report"));
+        }
+    }
+
+    private CursorEscapeDetector() {
+    }
+
+    /** Test-only: set tunables and clear all state for an isolated run. */
+    public static void configureForTest(int sample, int checkEvery, long grace) {
+        SAMPLE = sample;
+        CHECK_EVERY = checkEvery;
+        GRACE = grace;
+        threadEpoch.remove();
+        allThreadEpochs.clear();
+        createdCount.set(0);
+        sampledCount.set(0);
+        visitsSinceSweep.set(0);
+        leakedCount.set(0);
+        tracked.clear();
+        leaksByType.clear();
+        leakStacks.clear();
+    }
+
+    /** Registers a sampled cursor against the current epoch. Called right after each {@code new Cursor(...)}. */
+    public static void onCursorCreated(Object cursor, Object value) {
+        if (createdCount.incrementAndGet() % SAMPLE != 0) {
+            return;
+        }
+        sampledCount.incrementAndGet();
+        String creator = creatorStack.get().peek();
+        String valueType = value == null ? "null" : value.getClass().getName();
+        String stack = null;
+        if (!STACK_FILTER.isEmpty()) {
+            String vt = valueType.toLowerCase();
+            for (String f : STACK_FILTER) {
+                if (vt.contains(f)) {
+                    stack = captureStack();
+                    break;
+                }
+            }
+        }
+        tracked.add(new Tracked(cursor, Thread.currentThread().getId(), myEpoch()[0], valueType,
+                creator == null ? "<none>" : creator, stack));
+    }
+
+    private static String captureStack() {
+        StackTraceElement[] els = new Throwable().getStackTrace();
+        StringBuilder sb = new StringBuilder();
+        int shown = 0;
+        for (StackTraceElement e : els) {
+            if (CursorEscapeDetector.class.getName().equals(e.getClassName())) {
+                continue; // skip the detector's own frames
+            }
+            sb.append("        at ").append(e.getClassName()).append('.').append(e.getMethodName()).append('\n');
+            if (++shown >= STACK_FRAMES) {
+                break;
+            }
+        }
+        return sb.toString();
+    }
+
+    /** Advances the epoch and periodically sweeps for survivors. Called at the end of each top-level visit. */
+    public static void onTopLevelEnd() {
+        myEpoch()[0]++;
+        if (visitsSinceSweep.incrementAndGet() < CHECK_EVERY) {
+            return;
+        }
+        visitsSinceSweep.set(0);
+        sweep(false);
+    }
+
+    private static void sweep(boolean finalSweep) {
+        // Aggressive reclaim so a survivor is provably retained, not just GC-timing lag: multiple full
+        // GCs + finalization with a pause between, on the assumption truly-dead cursors get collected.
+        for (int i = 0; i < 3; i++) {
+            System.gc();
+            System.runFinalization();
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        for (Iterator<Tracked> it = tracked.iterator(); it.hasNext(); ) {
+            Tracked t = it.next();
+            Object c = t.get();
+            if (c == null) {
+                it.remove(); // collected on schedule — not retained
+                continue;
+            }
+            // age against the cursor's OWN thread's current epoch, not a global one
+            long[] te = allThreadEpochs.get(t.threadId);
+            long threadNow = te == null ? Long.MAX_VALUE : te[0];
+            if (finalSweep || threadNow - t.epoch >= GRACE) {
+                // still strongly reachable many of its own thread's visits after its visit ended => retained
+                leakedCount.incrementAndGet();
+                leaksByType.merge(t.creator + "  ::  " + t.valueType, 1L, Long::sum);
+                if (t.stack != null && leakStacks.size() < LEAK_STACK_CAP) {
+                    leakStacks.add("LEAK  " + t.creator + "  ::  " + t.valueType +
+                            "  (created epoch " + t.epoch + " on thread " + t.threadId + ", thread now " + threadNow + ")\n" + t.stack);
+                }
+                it.remove();
+            }
+        }
+    }
+
+    /** Number of sampled cursors confirmed retained past their visit (for tests). */
+    public static long leakCount() {
+        return leakedCount.get();
+    }
+
+    public static void report() {
+        sweep(true); // final sweep: every visit is done, so anything still alive is genuinely retained
+        StringBuilder sb = new StringBuilder("\n[CursorEscapeDetector] sampling 1/").append(SAMPLE)
+                .append(" — created(sampled)=").append(sampledCount.get())
+                .append(" leaked(sampled)=").append(leakedCount.get())
+                .append(" estimatedTotalLeaked≈").append(leakedCount.get() * SAMPLE).append('\n');
+        if (leaksByType.isEmpty()) {
+            sb.append("   no cursors retained past their top-level visit — contract holds for this run\n");
+        } else {
+            sb.append("   count  creator-visitor  ::  retained-node-type\n");
+            leaksByType.entrySet().stream()
+                    .sorted((a, b) -> Long.compare(b.getValue(), a.getValue()))
+                    .limit(40)
+                    .forEach(e -> sb.append("   ").append(e.getValue()).append("  ").append(e.getKey()).append('\n'));
+        }
+        if (!leakStacks.isEmpty()) {
+            sb.append("   --- creation stacks of leaked cursors (").append(leakStacks.size()).append(") ---\n");
+            for (String s : leakStacks) {
+                sb.append("   ").append(s).append('\n');
+            }
+        }
+        System.err.print(sb);
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/text/trait/ServiceProviderReference.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/trait/ServiceProviderReference.java
@@ -31,13 +31,13 @@ import java.util.regex.Pattern;
 
 @Value
 public class ServiceProviderReference implements Reference {
-    Cursor cursor;
+    Tree tree;
     Kind kind;
     String value;
 
     @Override
-    public Tree getTree() {
-        return cursor.getValue();
+    public Cursor getCursor() {
+        throw new UnsupportedOperationException("References are cursor-free; use getTree()");
     }
 
     @Override
@@ -104,19 +104,18 @@ public class ServiceProviderReference implements Reference {
         public Set<Reference> getReferences(SourceFile sourceFile) {
             PlainText plainText = (PlainText) sourceFile;
             Set<Reference> references = new HashSet<>();
-            Cursor cursor = new Cursor(new Cursor(null, Cursor.ROOT_VALUE), plainText);
 
             // Reference for the filename (the service interface FQCN)
             String fileName = plainText.getSourcePath().getFileName().toString();
             if (JAVA_FQCN.test(fileName)) {
-                references.add(new ServiceProviderReference(cursor, Reference.Kind.TYPE, fileName));
+                references.add(new ServiceProviderReference(plainText, Reference.Kind.TYPE, fileName));
             }
 
             // References for each implementation class in the content
             for (String line : plainText.getText().split("\n", -1)) {
                 String trimmed = line.trim();
                 if (!trimmed.isEmpty() && !trimmed.startsWith("#") && JAVA_FQCN.test(trimmed)) {
-                    references.add(new ServiceProviderReference(cursor, Reference.Kind.TYPE, trimmed));
+                    references.add(new ServiceProviderReference(plainText, Reference.Kind.TYPE, trimmed));
                 }
             }
 

--- a/rewrite-core/src/main/java/org/openrewrite/trait/Reference.java
+++ b/rewrite-core/src/main/java/org/openrewrite/trait/Reference.java
@@ -44,9 +44,10 @@ public interface Reference extends Trait<Tree> {
     /**
      * Applies the {@link org.openrewrite.trait.Reference.Renamer} to the provided cursor to compute a new reference value.
      * Note that this method only provides the logic for computing a new {@link org.openrewrite.Tree} with a renamed value,
-     * specific to the reference type. Hence, the reference itself is not changed, nor are the reference cursor
-     * {@link org.openrewrite.trait.Reference#getCursor()} or value {@link org.openrewrite.trait.Reference#getValue()}
-     * used to compute the new value.
+     * specific to the reference type. Hence, the reference itself is not changed, and the new value is computed from the
+     * provided {@code cursor} (which the caller supplies fresh during its own traversal), not from the reference's own
+     * {@link org.openrewrite.trait.Reference#getTree()} or {@link org.openrewrite.trait.Reference#getValue()}. References
+     * are cursor-free: {@link Trait#getCursor()} is not available on a cached reference.
      */
     default Tree rename(Renamer renamer, Cursor cursor, ExecutionContext ctx) {
         throw new UnsupportedOperationException();

--- a/rewrite-core/src/test/java/org/openrewrite/internal/CursorEscapeDetectorTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/CursorEscapeDetectorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.internal;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Positive/negative control for {@link CursorEscapeDetector}: proves it flags a cursor
+ * deliberately retained past its visit and does not flag ephemeral ones. Without this,
+ * a "0 leaks" measurement would be meaningless.
+ */
+class CursorEscapeDetectorTest {
+
+    @Test
+    void detectsAnObjectRetainedPastItsVisit() {
+        CursorEscapeDetector.configureForTest(1, 1, 2);
+
+        // a "recipe" that stashes one cursor and lets the rest go
+        List<Object> retainedByRecipe = new ArrayList<>();
+
+        Object leaked = new Object();
+        retainedByRecipe.add(leaked);
+        CursorEscapeDetector.onCursorCreated(leaked, "retained");
+        for (int i = 0; i < 200; i++) {
+            CursorEscapeDetector.onCursorCreated(new Object(), "ephemeral"); // no strong ref kept
+        }
+        CursorEscapeDetector.onTopLevelEnd();
+
+        // age the retained object well past GRACE while ephemerals get collected
+        for (int e = 0; e < 6; e++) {
+            CursorEscapeDetector.onCursorCreated(new Object(), "ephemeral");
+            CursorEscapeDetector.onTopLevelEnd();
+        }
+
+        assertThat(CursorEscapeDetector.leakCount())
+                .as("retained object must be detected as a leak")
+                .isGreaterThanOrEqualTo(1);
+        assertThat(retainedByRecipe).hasSize(1); // keep alive until after the assertion
+    }
+
+    @Test
+    void doesNotFlagEphemeralCursors() {
+        CursorEscapeDetector.configureForTest(1, 1, 2);
+        for (int e = 0; e < 10; e++) {
+            for (int i = 0; i < 100; i++) {
+                CursorEscapeDetector.onCursorCreated(new Object(), "ephemeral");
+            }
+            CursorEscapeDetector.onTopLevelEnd();
+        }
+        assertThat(CursorEscapeDetector.leakCount())
+                .as("nothing retained => no leaks")
+                .isZero();
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -1342,7 +1342,7 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
             return null;
         }
 
-        setCursor(new Cursor(getCursor(), right));
+        Cursor pushed = pushCursor(right);
 
         T t = right.getElement();
         if (t instanceof J) {
@@ -1350,7 +1350,7 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
             t = visitAndCast((J) right.getElement(), p);
         }
 
-        setCursor(getCursor().getParent());
+        popCursor(pushed);
         if (t == null) {
             //noinspection ConstantConditions
             return null;
@@ -1368,7 +1368,7 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
             return null;
         }
 
-        setCursor(new Cursor(getCursor(), left));
+        Cursor pushed = pushCursor(left);
 
         Space before = visitSpace(left.getBefore(), loc.getBeforeLocation(), p);
         T t = left.getElement();
@@ -1378,7 +1378,7 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
             t = visitAndCast((J) left.getElement(), p);
         }
 
-        setCursor(getCursor().getParent());
+        popCursor(pushed);
         // If nothing changed leave AST node the same
         if (left.getElement() == t && before == left.getBefore()) {
             return left;
@@ -1394,12 +1394,12 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
             //noinspection ConstantConditions
             return null;
         }
-        setCursor(new Cursor(getCursor(), container));
+        Cursor pushed = pushCursor(container);
 
         Space before = visitSpace(container.getBefore(), loc.getBeforeLocation(), p);
         List<JRightPadded<J2>> js = ListUtils.map(container.getPadding().getElements(), t -> visitRightPadded(t, loc.getElementLocation(), p));
 
-        setCursor(getCursor().getParent());
+        popCursor(pushed);
 
         return js == container.getPadding().getElements() && before == container.getBefore() ?
                 container :

--- a/rewrite-java/src/main/java/org/openrewrite/java/VariableNameUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/VariableNameUtils.java
@@ -172,7 +172,9 @@ public class VariableNameUtils {
             Statement s = super.visitStatement(statement, namesInScope);
             Cursor aggregatedScope = aggregateNameScope();
             if (currentScope.isEmpty() || currentScope.peek() != aggregatedScope) {
-                Set<String> namesInAggregatedScope = nameScopes.computeIfAbsent(aggregatedScope, k -> new HashSet<>());
+                // detach() the map key so it stays valid after this scope is exited (and its live
+                // cursor may be recycled); lookups with live cursors still match by id-based equality.
+                Set<String> namesInAggregatedScope = nameScopes.computeIfAbsent(aggregatedScope.detach(), k -> new HashSet<>());
                 // Pass the name scopes available from a parent scope down to the child.
                 if (!currentScope.isEmpty() && aggregatedScope.isScopeInPath(currentScope.peek().getValue())) {
                     namesInAggregatedScope.addAll(nameScopes.get(currentScope.peek()));
@@ -232,7 +234,7 @@ public class VariableNameUtils {
                 if (o instanceof J.VariableDeclarations) {
                     J.VariableDeclarations variableDeclarations = (J.VariableDeclarations) o;
                     variableDeclarations.getVariables().forEach(v ->
-                            nameScopes.computeIfAbsent(getCursor(), k -> new HashSet<>()).add(v.getSimpleName()));
+                            nameScopes.computeIfAbsent(getCursor().detach(), k -> new HashSet<>()).add(v.getSimpleName()));
                 }
             });
 
@@ -279,7 +281,7 @@ public class VariableNameUtils {
                 imports.forEach(i -> {
                     if (i.isStatic()) {
                         // Note: Currently, adds all statically imported identifiers including method and classes rather than restricting the names to static fields.
-                        Set<String> namesAtCursor = nameScopes.computeIfAbsent(classCursor, k -> new HashSet<>());
+                        Set<String> namesAtCursor = nameScopes.computeIfAbsent(classCursor.detach(), k -> new HashSet<>());
                         if (isValidImportName(i.getQualid().getTarget().getType(), i.getQualid().getSimpleName())) {
                             namesAtCursor.add(i.getQualid().getSimpleName());
                         }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/trait/PropertiesReference.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/trait/PropertiesReference.java
@@ -30,8 +30,13 @@ import java.util.regex.Pattern;
 
 @Value
 public class PropertiesReference implements Reference {
-    Cursor cursor;
+    Tree tree;
     Kind kind;
+
+    @Override
+    public Cursor getCursor() {
+        throw new UnsupportedOperationException("References are cursor-free; use getTree()");
+    }
 
     @Override
     public String getValue() {
@@ -70,7 +75,7 @@ public class PropertiesReference implements Reference {
                 Object value = cursor.getValue();
                 if (value instanceof Properties.Entry &&
                         javaFullyQualifiedTypeMatcher.test(((Properties.Entry) value).getValue().getText())) {
-                    return new PropertiesReference(cursor, determineKind(((Properties.Entry) value).getValue().getText()));
+                    return new PropertiesReference((Properties.Entry) value, determineKind(((Properties.Entry) value).getValue().getText()));
                 }
                 return null;
             }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/trait/SpringXmlReference.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/trait/SpringXmlReference.java
@@ -20,6 +20,7 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.trait.Reference;
 import org.openrewrite.trait.SimpleTraitMatcher;
 import org.openrewrite.xml.XPathMatcher;
@@ -32,7 +33,7 @@ import java.util.regex.Pattern;
 @EqualsAndHashCode(callSuper = false)
 public class SpringXmlReference extends XmlReference {
 
-    Cursor cursor;
+    Tree tree;
     Kind kind;
 
     public static class Provider extends AbstractProvider<SpringXmlReference> {
@@ -52,7 +53,7 @@ public class SpringXmlReference extends XmlReference {
                     if (classXPath.matches(cursor) || typeXPath.matches(cursor) || keyTypeXPath.matches(cursor) || valueTypeXPath.matches(cursor)) {
                         String stringVal = attrib.getValueAsString();
                         if (referencePattern.matcher(stringVal).matches()) {
-                            return new SpringXmlReference(cursor, determineKind(stringVal));
+                            return new SpringXmlReference(attrib, determineKind(stringVal));
                         }
                     }
                 } else if (value instanceof Xml.Tag) {
@@ -60,7 +61,7 @@ public class SpringXmlReference extends XmlReference {
                     if (tags.matches(cursor)) {
                         Optional<String> stringVal = tag.getValue();
                         if (stringVal.isPresent() && referencePattern.matcher(stringVal.get()).matches()) {
-                            return new SpringXmlReference(cursor, determineKind(stringVal.get()));
+                            return new SpringXmlReference(tag, determineKind(stringVal.get()));
                         }
                     }
                 }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/trait/XmlReference.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/trait/XmlReference.java
@@ -24,8 +24,8 @@ import org.openrewrite.xml.tree.Xml;
 public abstract class XmlReference implements Reference {
 
     @Override
-    public Tree getTree() {
-        return Reference.super.getTree();
+    public Cursor getCursor() {
+        throw new UnsupportedOperationException("References are cursor-free; use getTree()");
     }
 
     @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/cleanup/RemoveUnusedVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/cleanup/RemoveUnusedVisitor.java
@@ -27,7 +27,9 @@ public class RemoveUnusedVisitor<P> extends YamlIsoVisitor<P> {
     private final Cursor cursor;
 
     public RemoveUnusedVisitor(@Nullable Cursor cursor) {
-        this.cursor = cursor;
+        // detach() so this retained cursor's path stays valid after the caller's traversal moves on
+        // (and its live cursors may be recycled); only isScopeInPath (a read-only path walk) uses it.
+        this.cursor = cursor == null ? null : cursor.detach();
     }
 
     @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/trait/YamlApplicationConfigReference.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/trait/YamlApplicationConfigReference.java
@@ -20,6 +20,7 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.trait.SimpleTraitMatcher;
 import org.openrewrite.yaml.tree.Yaml;
 
@@ -29,7 +30,7 @@ import java.util.regex.Pattern;
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class YamlApplicationConfigReference extends YamlReference {
-    Cursor cursor;
+    Tree tree;
     Kind kind;
 
     public static class Provider extends YamlProvider {
@@ -44,7 +45,7 @@ public class YamlApplicationConfigReference extends YamlReference {
             protected @Nullable YamlReference test(Cursor cursor) {
                 Object value = cursor.getValue();
                 if (value instanceof Yaml.Scalar && javaFullyQualifiedTypePattern.test(((Yaml.Scalar) value).getValue())) {
-                    return new YamlApplicationConfigReference(cursor, determineKind(((Yaml.Scalar) value).getValue()));
+                    return new YamlApplicationConfigReference((Yaml.Scalar) value, determineKind(((Yaml.Scalar) value).getValue()));
                 }
                 return null;
             }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/trait/YamlReference.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/trait/YamlReference.java
@@ -24,6 +24,11 @@ import org.openrewrite.yaml.tree.Yaml;
 
 public abstract class YamlReference implements Reference {
     @Override
+    public Cursor getCursor() {
+        throw new UnsupportedOperationException("References are cursor-free; use getTree()");
+    }
+
+    @Override
     public String getValue() {
         if (getTree() instanceof Yaml.Scalar) {
             return ((Yaml.Scalar) getTree()).getValue();


### PR DESCRIPTION
> **Status: experiment — opening to preserve the work, then closing immediately.**
> It is not ready to merge and may never be in this form (see *Why this is parked*).
> Default-off, so it changes nothing unless `-Dorg.openrewrite.cursorPool=true` is set.

## Motivation

Allocation profiling of large, visitor-heavy recipe runs (a Spring Boot migration over
the `spring-framework` codebase) shows `new Cursor(...)` is **~42% of all allocation**.
It is pure churn — one cursor per visited node per pass — and a cursor is logically dead
the instant the visitor ascends above its node. Trees are parsed once, so this is
allocation *rate*, not footprint.

## What this does

A per-thread free list that recycles the cursor the visitor creates on each descent
instead of allocating a new one:

- `Cursor.parent/value` become non-final + a package-private `reset(parent, value)`.
- `CursorPool` — `ThreadLocal<ArrayDeque<Cursor>>`, `acquire()/release()`. Roots are
  never recycled (held for the lifetime of a run). Per-thread because a single node's
  visit (acquire..release) always runs on one thread.
- `TreeVisitor.pushCursor/popCursor` encode acquire-on-descend / release-on-ascend,
  wired into `TreeVisitor.visit` and `JavaVisitor.visitRightPadded/visitLeftPadded/visitContainer`
  (together ~95% of cursor allocation by call site: visit 60%, right-padded 22%,
  left/container 7%/7%; the remaining ~4% are root cursors, not poolable).

Off by default; when off the helpers fold to the original `new Cursor` /
`setCursor(getParent())` (the flags are `static final`).

## Results (spring-framework, identical jar, flag the only variable)

| metric | pool off | pool on |
|---|---|---|
| Cursor share of allocation | 41.6% | **2.9%** (residual is ~all non-poolable root cursors) |
| GC pause count | 5620 | **3762 (-33%)** |
| wall-clock | 627.5s | **632.3s (+0.8%, flat)** |
| max RSS | 1455 MB | 1501 MB |

The allocation and GC-pause win is large and real, but **does not convert to wall-clock**:
G1 collection is largely concurrent, GC was only ~22% of CPU to begin with, and the
run's actual cost is elsewhere (type attribution, version/dependency resolution).

## Why this is parked

Comparing the set of files each run changed, **the pool-on run silently skipped 32
transformations** that pool-off applied (a strict subset; reproducible across runs).
All 32 are the instanceof-pattern rewrite, and the cause is a contract violation that
pooling makes fatal:

Recycling is only sound when a cursor that must outlive its visit is copied via
`Cursor.detach()`. A recipe that instead stashes a **live** `Cursor` in a long-lived
collection gets miscompiled under the pool — the recycled cursor's `equals/hashCode`
(parent + value) mutate, so the later lookup misses and the transformation is skipped.
`InstanceOfPatternMatch` (in `rewrite-static-analysis`) does exactly this:

```java
private final Map<J.InstanceOf, Set<Cursor>> contextScopes; // live cursors as set members
```

There is no reason to believe this is the only such site across the recipe ecosystem.
**A diagnostic `CursorEscapeDetector` exists** (committed earlier on this branch, opt-in
via `-Dorg.openrewrite.cursorEscapeCheck=true`) and confirms leaf cursors are never
retained, but it samples via weak refs and could not pin the coarse `CompilationUnit`/
`Block` retainers; it only instruments `TreeVisitor.visit`, not the padding cursors.

Net: an allocation-only optimization with no wall-clock benefit on the workload that
motivated it, and a real correctness hazard until cursor retention is universally
converted to `detach()`. Not worth shipping right now.

## If revived later — follow-up study

1. **Make output-safety provable, not hoped-for.** Improve the detector to *pin*
   retainers (heap-dump/MAT or a strong-ref breadcrumb), extend it to the padding
   cursors, and run it as a gate over the recipe ecosystem to enumerate every live-cursor
   retention. Then `detach()` each (same fix already applied to `VariableNameUtils` /
   `RemoveUnusedImports` on this branch; `InstanceOfPatternMatch.contextScopes`,
   `VariableNameStrategy.contextScopes`, and the `java/trait/Literal` cursor field are
   known next targets).
2. **Find a workload where the GC win matters.** This one isn't GC-throughput-bound;
   pooling may pay off on allocation-bound / memory-constrained runs. Measure before
   investing further.
3. **The unit suite is not a sufficient gate.** `rewrite-core` + `rewrite-java` were
   green under the flag (incl. the once-hung `SourcePositionServiceTest`); only the
   at-scale changed-file diff exposed the regression. Any future attempt needs a
   large-corpus output-equivalence gate.

### Engineering note (the one genuinely tricky bug)

`popCursor` recycles the cursor the frame *acquired at push*, never the current `cursor`
field, because a visit may legitimately re-point its own cursor: `SourcePositionService`'s
printer adopts the caller's cursor via `setCursor`, and `updateCursor` swaps in a fresh
value. Recycling the field instead returned a still-live foreign cursor to the pool and,
via the LIFO free list, made it its own child's parent — a 2-cycle that span forever in
`getParent()`-walking code. The fix is general against any `setCursor`/`updateCursor`
re-pointing.
