### PR TITLE
Groovy: added suppport for !instanceof

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1690,6 +1690,9 @@ public class GroovyParserVisitor {
                     case "!in":
                         gBinaryOp = G.Binary.Type.NotIn;
                         break;
+                    case "!instanceof":
+                        gBinaryOp = G.Binary.Type.NotInstanceOf;
+                        break;
                     case "<=>":
                         gBinaryOp = G.Binary.Type.Spaceship;
                         break;

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
@@ -166,6 +166,9 @@ public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
             case NotIn:
                 keyword = "!in";
                 break;
+            case NotInstanceOf:
+                keyword = "!instanceof";
+                break;
             case Spaceship:
                 keyword = "<=>";
                 break;

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
@@ -796,6 +796,7 @@ public interface G extends J {
             Match,
             In,
             NotIn,
+            NotInstanceOf,
             Access,
             Spaceship,
             ElvisAssignment,

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -460,4 +460,17 @@ class GroovyParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void notInstanceOfOperator() {
+        rewriteRun(
+          groovy(
+            """
+              if (a !instanceof B) {
+              }
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Added support for `!instanceof` operator
 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
