### PR TITLE
Groovy: fix IndexOutOfBoundsException when recipe adds @Annotation to a method in anonymous class

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/JavaTemplateMatchTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/JavaTemplateMatchTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.groovy;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.Expression;
@@ -24,10 +25,49 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.Comparator;
+
 import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
 class JavaTemplateMatchTest implements RewriteTest {
+
+    /**
+     * Adding an annotation via JavaTemplate to a method inside an anonymous class within a Groovy script
+     * (no top-level class declarations) crashes in AnnotationTemplateGenerator.template with IndexOutOfBoundsException
+     */
+    @Test
+    void addAnnotationToMethodInAnonymousClassInsideGroovyScript() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                  if ("a".equals(method.getSimpleName()) &&
+                    method.getLeadingAnnotations().stream().noneMatch(a -> "Ann".equals(a.getSimpleName()))) {
+                      return JavaTemplate.builder("@Ann")
+                        .build()
+                        .apply(getCursor(), method.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
+                  }
+                  return super.visitMethodDeclaration(method, ctx);
+              }
+          })),
+          groovy(
+            """
+              foo(new A() {
+                  void a() {
+                  }
+              })
+              """,
+            """
+              foo(new A() {
+                  @Ann
+                  void a() {
+                  }
+              })
+              """
+          )
+        );
+    }
 
     @Test
     void nonJavaCode() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
@@ -151,7 +151,7 @@ public class AnnotationTemplateGenerator {
                 before.insert(0, cu.getPackageDeclaration().withPrefix(Space.EMPTY).printTrimmed(cursor) + ";\n");
             }
             List<J.ClassDeclaration> classes = cu.getClasses();
-            if (!"$Placeholder".equals(classes.get(classes.size() - 1).getName().getSimpleName())) {
+            if (classes.isEmpty() || !"$Placeholder".equals(classes.get(classes.size() - 1).getName().getSimpleName())) {
                 addDummyAnnotationType(after);
             }
             return;


### PR DESCRIPTION
 

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
It fixes  IndexOutOfBoundsException that was being thrown when a recipe adds @Annotation to a method in anonymous class.  

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
One of the custom migration script is failing. Unit test shows the example of such recipe.
 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
