### PR TITLE
Optimize `RecipeStack` to eliminate per-node recipe-path copying

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipePath.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipePath.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scheduling;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Recipe;
+
+import java.util.AbstractList;
+
+/**
+ * A persistent, immutable path from the root recipe down to a descendant recipe.
+ * <p>
+ * Each node references its {@code parent}, so deriving a child path via {@link #child(Recipe)}
+ * is O(1) and shares the entire ancestor chain instead of copying it. This replaces the
+ * previous approach of copying a {@link java.util.Stack} for every node visited during a
+ * recipe-tree traversal, which is rebuilt identically for every source file and every cycle.
+ * <p>
+ * Because it implements {@link java.util.List List&lt;Recipe&gt;} (ordered root-first, leaf-last),
+ * it drops directly into consumers expecting the recipe path as a list, with no copying.
+ */
+class RecipePath extends AbstractList<Recipe> {
+    private final Recipe recipe;
+    private final @Nullable RecipePath parent;
+    private final int size;
+
+    RecipePath(Recipe recipe) {
+        this(recipe, null);
+    }
+
+    private RecipePath(Recipe recipe, @Nullable RecipePath parent) {
+        this.recipe = recipe;
+        this.parent = parent;
+        this.size = parent == null ? 1 : parent.size + 1;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public Recipe get(int index) {
+        if (index < 0 || index >= size) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
+        }
+        // Walk back from the leaf to the requested index.
+        RecipePath current = this;
+        for (int i = size - 1; i > index; i--) {
+            assert current.parent != null;
+            current = current.parent;
+        }
+        return current.recipe;
+    }
+
+    /**
+     * @return The recipe at the tip of this path (the deepest descendant).
+     */
+    Recipe leaf() {
+        return recipe;
+    }
+
+    /**
+     * @return A new path with {@code childRecipe} appended as the leaf, sharing this path as its
+     * ancestor chain. This is O(1) and performs no copying.
+     */
+    RecipePath child(Recipe childRecipe) {
+        return new RecipePath(childRecipe, this);
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -123,7 +123,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                 BatchState scanBatch = new BatchState();
 
                 SourceFile result = allRecipeStack.reduce(sourceSet, recipe, ctx, (source, recipeStack) -> {
-                    Recipe recipe = recipeStack.peek();
+                    Recipe recipe = leaf(recipeStack);
                     if (source == null) {
                         return null;
                     }
@@ -212,7 +212,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
             batch.rpc.batchVisit(source, ctx, rootCursor, batch.items);
         } catch (Throwable t) {
             if (!batch.recipeStacks.isEmpty()) {
-                handleError(batch.recipeStacks.get(0).peek(), source, source, t);
+                handleError(leaf(batch.recipeStacks.get(0)), source, source, t);
             }
         }
 
@@ -222,7 +222,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
     public LSS generateSources(LSS sourceSet) {
         if (isScanningRequired()) {
             List<SourceFile> generatedInThisCycle = allRecipeStack.reduce(sourceSet, recipe, ctx, (acc, recipeStack) -> {
-                Recipe recipe = recipeStack.peek();
+                Recipe recipe = leaf(recipeStack);
                 if (recipe instanceof ScanningRecipe) {
                     assert acc != null;
                     //noinspection unchecked
@@ -297,7 +297,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
     private static class BatchState {
         @Nullable RewriteRpc rpc;
         final List<BatchVisit.BatchVisitItem> items = new ArrayList<>();
-        final List<Stack<Recipe>> recipeStacks = new ArrayList<>();
+        final List<List<Recipe>> recipeStacks = new ArrayList<>();
         @Nullable SourceFile originalBeforeBatch;
 
         void clear() {
@@ -313,7 +313,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         BatchState batch = new BatchState();
 
         SourceFile result = allRecipeStack.reduce(sourceSet, recipe, ctx, (source, recipeStack) -> {
-            Recipe recipe = recipeStack.peek();
+            Recipe recipe = leaf(recipeStack);
             if (source == null) {
                 return null;
             }
@@ -463,7 +463,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                 if (!(t instanceof RecipeRunException)) {
                     source = Markup.error(source, t);
                 }
-                source = handleError(batch.recipeStacks.get(0).peek(), originalBefore, source, t);
+                source = handleError(leaf(batch.recipeStacks.get(0)), originalBefore, source, t);
                 if (source != null && source != beforeError) {
                     source = addRecipesThatMadeChanges(batch.recipeStacks.get(0), source);
                 }
@@ -479,8 +479,8 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
 
         for (int i = 0; i < response.getResults().size(); i++) {
             BatchVisitResponse.BatchVisitResult r = response.getResults().get(i);
-            Stack<Recipe> recipeStack = batch.recipeStacks.get(i);
-            Recipe recipe = recipeStack.peek();
+            List<Recipe> recipeStack = batch.recipeStacks.get(i);
+            Recipe recipe = leaf(recipeStack);
 
             if (r.isModified() || r.isHasNewMessages()) {
                 madeChangesInThisCycle.add(recipe);
@@ -639,12 +639,12 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
      * Avoids the O(recipes × treeSize) cost of traversing the tree per recipe.
      */
     private void recordBatchSourceFileResultFast(@Nullable SourceFile before, @Nullable SourceFile after,
-                                                  Stack<Recipe> recipeStack,
+                                                  List<Recipe> recipeStack,
                                                   Map<String, List<SearchResults.Row>> searchResultsByRecipe,
                                                   ExecutionContext ctx) {
         String beforePath = (before == null) ? "" : before.getSourcePath().toString();
         String afterPath = (after == null) ? "" : after.getSourcePath().toString();
-        Recipe recipe = recipeStack.peek();
+        Recipe recipe = leaf(recipeStack);
         Long effortSeconds = (recipe.getEstimatedEffortPerOccurrence() == null || Result.isLocalAndHasNoChanges(before, after)) ?
                 0L : recipe.getEstimatedEffortPerOccurrence().getSeconds();
 
@@ -679,12 +679,12 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
      * recipe in the batch).
      */
     private void recordBatchSourceFileResult(@Nullable SourceFile before, @Nullable SourceFile after,
-                                             Stack<Recipe> recipeStack,
+                                             List<Recipe> recipeStack,
                                              Map<UUID, String> attributionMap,
                                              ExecutionContext ctx) {
         String beforePath = (before == null) ? "" : before.getSourcePath().toString();
         String afterPath = (after == null) ? "" : after.getSourcePath().toString();
-        Recipe recipe = recipeStack.peek();
+        Recipe recipe = leaf(recipeStack);
         Long effortSeconds = (recipe.getEstimatedEffortPerOccurrence() == null || Result.isLocalAndHasNoChanges(before, after)) ?
                 0L : recipe.getEstimatedEffortPerOccurrence().getSeconds();
 
@@ -713,10 +713,10 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         }
     }
 
-    protected void recordSourceFileResultAndSearchResults(@Nullable SourceFile before, @Nullable SourceFile after, Stack<Recipe> recipeStack, ExecutionContext ctx) {
+    protected void recordSourceFileResultAndSearchResults(@Nullable SourceFile before, @Nullable SourceFile after, List<Recipe> recipeStack, ExecutionContext ctx) {
         String beforePath = (before == null) ? "" : before.getSourcePath().toString();
         String afterPath = (after == null) ? "" : after.getSourcePath().toString();
-        Recipe recipe = recipeStack.peek();
+        Recipe recipe = leaf(recipeStack);
         Long effortSeconds = (recipe.getEstimatedEffortPerOccurrence() == null || Result.isLocalAndHasNoChanges(before, after)) ?
                 0L : recipe.getEstimatedEffortPerOccurrence().getSeconds();
 
@@ -789,6 +789,13 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         ));
 
         return after;
+    }
+
+    /**
+     * @return The recipe at the tip of the path (the recipe currently doing work).
+     */
+    private static Recipe leaf(List<Recipe> recipeStack) {
+        return recipeStack.get(recipeStack.size() - 1);
     }
 
     private static <S extends SourceFile> S addRecipesThatMadeChanges(List<Recipe> recipeStack, S afterFile) {

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeStack.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeStack.java
@@ -22,10 +22,11 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.LargeSourceSet;
 import org.openrewrite.Recipe;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
@@ -35,7 +36,7 @@ class RecipeStack {
     private final Map<Recipe, List<Recipe>> recipeLists = new IdentityHashMap<>();
 
     @SuppressWarnings("NotNullFieldNotInitialized")
-    private Stack<Stack<Recipe>> allRecipesStack;
+    private Deque<RecipePath> allRecipesStack;
 
     /**
      * The zero-based position of the recipe that is currently doing a scan/generate/edit.
@@ -55,7 +56,7 @@ class RecipeStack {
     Recipe nextRecipe;
 
     public <T> @Nullable T reduce(LargeSourceSet sourceSet, Recipe recipe, ExecutionContext ctx,
-                                  BiFunction<@Nullable T, Stack<Recipe>, @Nullable T> consumer, @Nullable T acc) {
+                                  BiFunction<@Nullable T, List<Recipe>, @Nullable T> consumer, @Nullable T acc) {
         init(recipe);
         AtomicInteger recipePosition = new AtomicInteger(0);
         while (!allRecipesStack.isEmpty()) {
@@ -64,14 +65,14 @@ class RecipeStack {
             }
 
             this.recipePosition = recipePosition.getAndIncrement();
-            Stack<Recipe> recipeStack = allRecipesStack.pop();
-            if (recipeStack.peek().maxCycles() >= ctx.getCycle()) {
-                sourceSet.setRecipe(recipeStack);
-                recurseRecipeList(recipeStack);
-                this.nextRecipe = allRecipesStack.isEmpty() ? null : allRecipesStack.peek().peek();
-                acc = consumer.apply(acc, recipeStack);
+            RecipePath recipePath = allRecipesStack.pop();
+            if (recipePath.leaf().maxCycles() >= ctx.getCycle()) {
+                sourceSet.setRecipe(recipePath);
+                recurseRecipeList(recipePath);
+                this.nextRecipe = allRecipesStack.isEmpty() ? null : allRecipesStack.peek().leaf();
+                acc = consumer.apply(acc, recipePath);
             } else {
-                this.recipePosition = recipePosition.getAndAdd(countRecipes(recipeStack.peek()));
+                this.recipePosition = recipePosition.getAndAdd(countRecipes(recipePath.leaf()));
             }
         }
         this.nextRecipe = null;
@@ -79,20 +80,14 @@ class RecipeStack {
     }
 
     private void init(Recipe recipe) {
-        allRecipesStack = new Stack<>();
-        Stack<Recipe> rootRecipeStack = new Stack<>();
-        rootRecipeStack.push(recipe);
-        allRecipesStack.push(rootRecipeStack);
+        allRecipesStack = new ArrayDeque<>();
+        allRecipesStack.push(new RecipePath(recipe));
     }
 
-    private void recurseRecipeList(Stack<Recipe> recipeStack) {
-        List<Recipe> recipeList = getRecipeList(recipeStack.peek());
+    private void recurseRecipeList(RecipePath recipePath) {
+        List<Recipe> recipeList = getRecipeList(recipePath.leaf());
         for (int i = recipeList.size() - 1; i >= 0; i--) {
-            Recipe r = recipeList.get(i);
-            Stack<Recipe> nextStack = new Stack<>();
-            nextStack.addAll(recipeStack);
-            nextStack.push(r);
-            allRecipesStack.push(nextStack);
+            allRecipesStack.push(recipePath.child(recipeList.get(i)));
         }
     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeSchedulerTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeSchedulerTest.java
@@ -232,7 +232,7 @@ class RecipeSchedulerTest implements RewriteTest {
                     @Override
                     protected void recordSourceFileResultAndSearchResults(
                             @Nullable SourceFile before, @Nullable SourceFile after,
-                            java.util.Stack<Recipe> recipeStack, ExecutionContext ctx) {
+                            List<Recipe> recipeStack, ExecutionContext ctx) {
                         if (before instanceof PlainText) {
                             beforeContents.add(((PlainText) before).getText());
                         }
@@ -279,7 +279,7 @@ class RecipeSchedulerTest implements RewriteTest {
                     @Override
                     protected void recordSourceFileResultAndSearchResults(
                             @Nullable SourceFile before, @Nullable SourceFile after,
-                            java.util.Stack<Recipe> recipeStack, ExecutionContext ctx) {
+                            List<Recipe> recipeStack, ExecutionContext ctx) {
                         // Track files that were generated (before is null)
                         if (before == null && after != null) {
                             generatedPaths.add(after.getSourcePath().toString());

--- a/rewrite-core/src/test/java/org/openrewrite/scheduling/RecipePathTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/scheduling/RecipePathTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scheduling;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Recipe;
+import org.openrewrite.text.ChangeText;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RecipePathTest {
+
+    @Test
+    void rootPath() {
+        Recipe root = new ChangeText("a");
+        RecipePath path = new RecipePath(root);
+
+        assertThat(path.size()).isEqualTo(1);
+        assertThat(path.leaf()).isSameAs(root);
+        assertThat(path.get(0)).isSameAs(root);
+        assertThat((List<Recipe>) path).containsExactly(root);
+    }
+
+    @Test
+    void childIsRootFirstLeafLast() {
+        Recipe root = new ChangeText("root");
+        Recipe a = new ChangeText("a");
+        Recipe b = new ChangeText("b");
+
+        RecipePath path = new RecipePath(root).child(a).child(b);
+
+        assertThat(path.size()).isEqualTo(3);
+        assertThat(path.leaf()).isSameAs(b);
+        // Ordered root-first, leaf-last, mirroring the previous Stack representation.
+        assertThat((List<Recipe>) path).containsExactly(root, a, b);
+        assertThat(path.get(0)).isSameAs(root);
+        assertThat(path.get(1)).isSameAs(a);
+        assertThat(path.get(2)).isSameAs(b);
+    }
+
+    @Test
+    void childSharesParentWithoutMutatingIt() {
+        Recipe root = new ChangeText("root");
+        RecipePath parent = new RecipePath(root);
+
+        RecipePath childA = parent.child(new ChangeText("a"));
+        RecipePath childB = parent.child(new ChangeText("b"));
+
+        // Deriving children must not affect the parent or siblings.
+        assertThat(parent.size()).isEqualTo(1);
+        assertThat(childA.size()).isEqualTo(2);
+        assertThat(childB.size()).isEqualTo(2);
+        assertThat(childA.get(0)).isSameAs(root);
+        assertThat(childB.get(0)).isSameAs(root);
+    }
+
+    @Test
+    void subListYieldsParentPath() {
+        Recipe root = new ChangeText("root");
+        Recipe a = new ChangeText("a");
+        Recipe b = new ChangeText("b");
+        RecipePath path = new RecipePath(root).child(a).child(b);
+
+        assertThat(path.subList(0, path.size() - 1)).containsExactly(root, a);
+    }
+
+    @Test
+    void getOutOfBounds() {
+        RecipePath path = new RecipePath(new ChangeText("a"));
+        assertThatThrownBy(() -> path.get(1)).isInstanceOf(IndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> path.get(-1)).isInstanceOf(IndexOutOfBoundsException.class);
+    }
+}


### PR DESCRIPTION
## Motivation

`RecipeStack.reduce(...)` is the per-source edit driver: it runs once per source file per recipe cycle, and for every node in the recipe tree it copied the entire ancestor recipe path into a fresh `java.util.Stack`:

```java
Stack<Recipe> nextStack = new Stack<>();
nextStack.addAll(recipeStack);   // copies the entire ancestor path
nextStack.push(r);
allRecipesStack.push(nextStack);
```

Because `java.util.Stack` extends `java.util.Vector`, every `addAll`/`push` takes a synchronization lock and reallocates. For a large declarative recipe (hundreds of nested sub-recipes) run over thousands of files across multiple cycles, this is a measurable hotspot — and entirely wasted work, since the recipe-tree traversal is structurally identical for every file and every cycle yet is rebuilt and re-copied each time. In a JFR profile of a large declarative upgrade over ~11.7k files, `java.util.Vector.addAll` accounted for ~1.1% of CPU samples (100% attributable to `recurseRecipeList`) and `recurseRecipeList` for ~3.9% of allocation samples.

## Summary

- Add a package-private `RecipePath extends AbstractList<Recipe>`: a persistent, immutable path where each node holds `recipe`, a `@Nullable parent`, and `size`. `child(recipe)` is O(1) (shares the parent chain, no copy) and `leaf()` returns the tip. Because it *is* a `List<Recipe>` it drops into consumers with no copying.
- `RecipeStack` switches from `Stack<Stack<Recipe>>` to a non-synchronized `ArrayDeque<RecipePath>`, and `recurseRecipeList` pushes `recipePath.child(r)` for each child instead of copying the whole stack.
- The `reduce` consumer signature changes from `BiFunction<T, Stack<Recipe>, T>` to `BiFunction<T, List<Recipe>, T>`. This ripples into `RecipeRunCycle` (recipe-path parameters, a small `leaf(...)` helper replacing `Stack.peek()`) and the test overrides in `RecipeSchedulerTest`.
- Traversal order, `recipePosition` accounting, and `getNextRecipe()` behavior are preserved. In particular, `recurseRecipeList` still runs before the consumer so that `getNextRecipe()` (used for RPC scan/edit batch grouping) is populated when the consumer runs.

This is internal: `RecipeStack` and `RecipePath` are package-private, so there is no public API change.

## Test plan

- [x] `./gradlew :rewrite-core:test` is green, including `RecipeSchedulerTest` (recipe ordering and `recipePosition` assertions) and `DeclarativeRecipeTest`.
- [x] Added `RecipePathTest` covering `size`/`get`/`leaf`/`child`/`subList` semantics and parent-sharing immutability.
- [x] `./gradlew :rewrite-core:assemble` compiles cleanly.