### PR TITLE
Answer `delegatesTo` on a `PrepareRecipe` marketplace miss in all RPC servers

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -989,7 +989,28 @@ public class RewriteRpcServer
         var found = _marketplace.FindRecipe(request.Id);
         if (found == null)
         {
-            throw new InvalidOperationException($"Recipe not found: {request.Id}");
+            // The host re-prepares every sub-recipe of a composite by id while building
+            // RpcRecipe.getRecipeList(). A sub-recipe that delegates to a Java recipe is not in
+            // this marketplace, so a miss means the host owns this recipe: answer with delegatesTo
+            // so the host resolves the id locally (the Java recipe is on its classpath) rather than
+            // failing with "Recipe not found".
+            var delegateId = Guid.NewGuid().ToString();
+            return Task.FromResult(new PrepareRecipeResponse
+            {
+                Id = delegateId,
+                Descriptor = new RecipeDescriptorDto
+                {
+                    Name = request.Id,
+                    DisplayName = request.Id,
+                    InstanceName = request.Id
+                },
+                EditVisitor = $"edit:{delegateId}",
+                DelegatesTo = new DelegatesTo
+                {
+                    RecipeName = request.Id,
+                    Options = request.Options ?? new()
+                }
+            });
         }
 
         var (descriptor, recipe) = found.Value;

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -1180,6 +1180,26 @@ func (s *server) handleGetMarketplace(params json.RawMessage) (any, *rpcError) {
 // wire-format marketplaceDescriptor expected by Java. Recursive fields
 // (recipeList, preconditions) are populated. Cycle protection is handled
 // upstream by recipe.Describe.
+// delegateDescriptor builds a minimal stand-in descriptor for a recipe the host will resolve
+// locally via the delegatesTo response. The host reads only delegatesTo for delegated recipes
+// and ignores this descriptor, but the response type requires one.
+func delegateDescriptor(name string) marketplaceDescriptor {
+	return marketplaceDescriptor{
+		Name:          name,
+		DisplayName:   name,
+		InstanceName:  name,
+		Description:   "",
+		Tags:          []string{},
+		Options:       []marketplaceOption{},
+		Preconditions: []marketplaceDescriptor{},
+		RecipeList:    []marketplaceDescriptor{},
+		DataTables:    []any{},
+		Maintainers:   []any{},
+		Contributors:  []any{},
+		Examples:      []any{},
+	}
+}
+
 func marketplaceDescriptorFromRecipe(desc recipe.RecipeDescriptor) marketplaceDescriptor {
 	options := make([]marketplaceOption, 0, len(desc.Options))
 	for _, opt := range desc.Options {
@@ -1357,7 +1377,27 @@ func (s *server) handlePrepareRecipe(params json.RawMessage) (any, *rpcError) {
 
 	reg, ok := s.registry.FindRecipe(req.ID)
 	if !ok {
-		return nil, &rpcError{Code: -32602, Message: fmt.Sprintf("Unknown recipe: %s", req.ID)}
+		// The host re-prepares every sub-recipe of a composite by id while building
+		// RpcRecipe.getRecipeList(). A sub-recipe that delegates to a Java recipe is not
+		// registered here, so a miss means the host owns this recipe: answer with delegatesTo
+		// so the host resolves the id locally (the Java recipe is on its classpath) rather than
+		// failing with "Unknown recipe".
+		options := req.Options
+		if options == nil {
+			options = map[string]any{}
+		}
+		recipeID := uuid.New().String()
+		return prepareRecipeResponse{
+			ID:                recipeID,
+			Descriptor:        delegateDescriptor(req.ID),
+			EditVisitor:       "edit:" + recipeID,
+			EditPreconditions: []any{},
+			ScanPreconditions: []any{},
+			DelegatesTo: &delegatesToResponse{
+				RecipeName: req.ID,
+				Options:    options,
+			},
+		}, nil
 	}
 
 	// Create recipe instance with options

--- a/rewrite-javascript/rewrite/fixtures/composite-with-java-delegate.ts
+++ b/rewrite-javascript/rewrite/fixtures/composite-with-java-delegate.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {JavaScript, Recipe, RecipeMarketplace} from "@openrewrite/rewrite";
+import {prepareJavaRecipe} from "@openrewrite/rewrite/rpc";
+
+export async function activate(marketplace: RecipeMarketplace) {
+    await marketplace.install(CompositeWithJavaDelegate, JavaScript);
+}
+
+/**
+ * Mirrors the shape of Angular's `UpgradeToAngular19`: a JS composite whose
+ * {@code recipeList()} contains a recipe that delegates entirely to a Java recipe
+ * (here {@code org.openrewrite.javascript.UpgradeDependencyVersion}, via
+ * {@link prepareJavaRecipe}).
+ *
+ * The host re-prepares each child of this composite by id while building
+ * {@code RpcRecipe.getRecipeList()}. The Java-delegate child is an {@code RpcRecipe}
+ * that {@code installSubRecipes} does not register in this server's marketplace, so the
+ * re-prepare misses here and the server must answer with {@code delegatesTo} (rather than
+ * throwing) so the host resolves it from its own marketplace as a local Java recipe.
+ */
+class CompositeWithJavaDelegate extends Recipe {
+    name = "org.openrewrite.example.npm.composite-with-java-delegate";
+    displayName = "Composite with a Java-delegate child";
+    description = "A JS composite whose recipe list contains a recipe that delegates to a Java recipe.";
+
+    async recipeList(): Promise<Recipe[]> {
+        return [
+            await prepareJavaRecipe("org.openrewrite.javascript.UpgradeDependencyVersion", {
+                packagePattern: "@angular/*",
+                newVersion: "19.x"
+            })
+        ];
+    }
+}

--- a/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
@@ -43,7 +43,26 @@ export class PrepareRecipe {
                     const id = snowflake.generate();
                     const recipeCtor = marketplace.findRecipe(request.id);
                     if (!recipeCtor) {
-                        throw new Error(`Could not find recipe with id ${request.id}`);
+                        // The host re-prepares every sub-recipe of a composite by id while
+                        // building RpcRecipe.getRecipeList(). A sub-recipe that delegates to a
+                        // Java recipe (e.g. org.openrewrite.javascript.UpgradeDependencyVersion,
+                        // produced by upgradeDependencyVersion() -> prepareJavaRecipe) is an
+                        // RpcRecipe that installSubRecipes deliberately did not register here: it
+                        // has no no-arg constructor and is hosted on the peer. A miss therefore
+                        // means the host owns this recipe, so tell it to resolve the id locally
+                        // (the Java recipe is on the host's classpath) via delegatesTo, rather
+                        // than failing with "Could not find recipe with id ...".
+                        return {
+                            id: id,
+                            descriptor: PrepareRecipe.delegateDescriptor(request.id),
+                            editVisitor: `edit:${id}`,
+                            editPreconditions: [],
+                            scanPreconditions: [],
+                            delegatesTo: {
+                                recipeName: request.id,
+                                options: request.options ?? {}
+                            }
+                        };
                     }
                     if (!recipeCtor[1]) {
                         throw new Error(`Recipe ${request.id} was installed without a constructor`);
@@ -80,6 +99,29 @@ export class PrepareRecipe {
                 }
             )
         );
+    }
+
+    /**
+     * Minimal stand-in descriptor for a recipe the host will resolve locally via
+     * {@link PrepareRecipeResponse.delegatesTo}. The host reads only `delegatesTo` for
+     * delegated recipes and ignores this descriptor, but the response type requires one.
+     */
+    private static delegateDescriptor(name: string): RecipeDescriptor {
+        return {
+            name: name,
+            displayName: name,
+            instanceName: name,
+            description: "",
+            tags: [],
+            estimatedEffortPerOccurrence: 5,
+            options: [],
+            preconditions: [],
+            recipeList: [],
+            dataTables: [],
+            maintainers: [],
+            contributors: [],
+            examples: []
+        };
     }
 
     private static async installSubRecipes(recipe: Recipe, marketplace: RecipeMarketplace) {

--- a/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
@@ -34,6 +34,7 @@ import {
 } from "../../src/javascript";
 import {J} from "../../src/java";
 import {withDir} from "tmp-promise";
+import {PrepareRecipe, PrepareRecipeResponse} from "../../src/rpc/request/prepare-recipe";
 
 describe("Rewrite RPC", () => {
     const spec = new RecipeSpec();
@@ -263,6 +264,24 @@ describe("Rewrite RPC", () => {
         expect(descriptor.recipeList.map(r => r.name)).toContain(
             "org.openrewrite.example.text.remote-change-text"
         );
+    });
+
+    test("preparing an unknown recipe id delegates to the host instead of failing", async () => {
+        // When the host builds RpcRecipe.getRecipeList() it re-prepares every child by
+        // id over RPC. A child that delegates to a Java recipe (e.g. Angular's
+        // upgradeDependencyVersion() -> org.openrewrite.javascript.UpgradeDependencyVersion)
+        // is an RpcRecipe that installSubRecipes intentionally does NOT register in this
+        // marketplace, so findRecipe misses. Rather than throwing "Could not find recipe
+        // with id ...", the server must tell the host to resolve it locally via delegatesTo
+        // (the Java recipe is on the host's classpath).
+        const response: PrepareRecipeResponse = await (client as any).connection.sendRequest(
+            new rpc.RequestType<PrepareRecipe, PrepareRecipeResponse, Error>("PrepareRecipe"),
+            new PrepareRecipe("org.openrewrite.javascript.UpgradeDependencyVersion", {newVersion: "19.x"})
+        );
+        expect(response.delegatesTo).toEqual({
+            recipeName: "org.openrewrite.javascript.UpgradeDependencyVersion",
+            options: {newVersion: "19.x"}
+        });
     });
 
     test("runRecipeWithCrossModuleRecipeList", async () => {

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
@@ -23,15 +23,24 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.*;
+import org.openrewrite.config.Environment;
+import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.internal.RecipeLoader;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.javascript.JavaScriptIsoVisitor;
 import org.openrewrite.javascript.JavaScriptParser;
+import org.openrewrite.javascript.UpgradeDependencyVersion;
 import org.openrewrite.javascript.style.Autodetect;
 import org.openrewrite.marker.Markup;
 import org.openrewrite.marketplace.RecipeBundle;
+import org.openrewrite.marketplace.RecipeBundleReader;
+import org.openrewrite.marketplace.RecipeBundleResolver;
+import org.openrewrite.marketplace.RecipeListing;
+import org.openrewrite.marketplace.RecipeMarketplace;
+import org.openrewrite.rpc.RpcRecipe;
 import org.openrewrite.rpc.request.Print;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -618,6 +627,82 @@ class JavaScriptRewriteRpcTest implements RewriteTest {
             )
           )
         );
+    }
+
+    /**
+     * A JS composite whose {@code recipeList()} contains a recipe that delegates to a Java recipe
+     * (the shape of Angular's {@code UpgradeToAngular19}). The host re-prepares each child by id while
+     * building {@code RpcRecipe.getRecipeList()}; the Java-delegate child misses in the JS marketplace,
+     * so the JS server must answer {@code delegatesTo} (rather than throwing "Could not find recipe
+     * with id ...") and the host resolves it from its own marketplace as a LOCAL Java recipe.
+     * <p>
+     * The host (this JVM) is configured with a runtime-classpath marketplace + resolver that owns its
+     * bundled {@code org.openrewrite.javascript.*} recipes — mirroring the moderne-cli concession.
+     */
+    @Test
+    void jsCompositeWithJavaDelegateChild() {
+        Environment env = Environment.builder().scanRuntimeClasspath("org.openrewrite.javascript").build();
+        RecipeMarketplace marketplace = env.toMarketplace(RecipeBundle.runtimeClasspath());
+        JavaScriptRewriteRpc.setFactory(JavaScriptRewriteRpc.builder()
+          .recipeInstallDir(tempDir)
+          .marketplace(marketplace)
+          .resolvers(List.of(new RuntimeClasspathResolver(marketplace)))
+          .log(tempDir.resolve("rpc.log")));
+
+        assertThat(client().installRecipes(new File("rewrite/dist-fixtures/composite-with-java-delegate.js"))
+          .getRecipesInstalled()).isGreaterThan(0);
+
+        Recipe composite = client().prepareRecipe("org.openrewrite.example.npm.composite-with-java-delegate");
+
+        Recipe delegate = composite.getRecipeList().stream()
+          .filter(r -> "org.openrewrite.javascript.UpgradeDependencyVersion".equals(r.getName()))
+          .findFirst()
+          .orElseThrow(() -> new AssertionError("expected an org.openrewrite.javascript.UpgradeDependencyVersion child"));
+        assertThat(delegate)
+          .isInstanceOf(UpgradeDependencyVersion.class)
+          .isNotInstanceOf(RpcRecipe.class);
+    }
+
+    /**
+     * A runtime-classpath {@link RecipeBundleResolver} that materializes a bundled recipe by id straight
+     * off the JVM classpath, mirroring the moderne-cli {@code RuntimeClasspathRecipeBundleResolver}.
+     */
+    private static class RuntimeClasspathResolver implements RecipeBundleResolver {
+        private final RecipeMarketplace marketplace;
+
+        RuntimeClasspathResolver(RecipeMarketplace marketplace) {
+            this.marketplace = marketplace;
+        }
+
+        @Override
+        public String getEcosystem() {
+            return "runtime";
+        }
+
+        @Override
+        public RecipeBundleReader resolve(RecipeBundle bundle) {
+            return new RecipeBundleReader() {
+                @Override
+                public RecipeBundle getBundle() {
+                    return bundle;
+                }
+
+                @Override
+                public RecipeMarketplace read() {
+                    return marketplace;
+                }
+
+                @Override
+                public RecipeDescriptor describe(RecipeListing listing) {
+                    return new RecipeLoader(null).load(listing.getName(), Map.of()).getDescriptor();
+                }
+
+                @Override
+                public Recipe prepare(RecipeListing listing, Map<String, Object> options) {
+                    return new RecipeLoader(null).load(listing.getName(), options);
+                }
+            };
+        }
     }
 
     /**

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1082,6 +1082,26 @@ def _category_descriptor_to_dict(descriptor) -> dict:
     }
 
 
+def _delegate_descriptor(name: str) -> dict:
+    """Minimal stand-in descriptor for a recipe the host resolves locally via a delegatesTo
+    response. The host reads only delegatesTo for delegated recipes and ignores this descriptor,
+    but the response shape requires one."""
+    return {
+        'name': name,
+        'displayName': name,
+        'description': '',
+        'tags': [],
+        'estimatedEffortPerOccurrence': None,
+        'options': [],
+        'preconditions': [],
+        'recipeList': [],
+        'dataTables': [],
+        'maintainers': [],
+        'contributors': [],
+        'examples': [],
+    }
+
+
 def _recipe_descriptor_to_dict(descriptor) -> dict:
     """Convert a RecipeDescriptor to a dict for JSON serialization."""
     return {
@@ -1241,7 +1261,24 @@ def handle_prepare_recipe(params: dict) -> dict:
     # Look up the recipe - returns (RecipeDescriptor, Type[Recipe]) tuple
     recipe_info = marketplace.find_recipe(recipe_name)
     if recipe_info is None:
-        raise ValueError(f"Recipe not found: {recipe_name}")
+        # The host re-prepares every sub-recipe of a composite by id while building
+        # RpcRecipe.getRecipeList(). A sub-recipe that delegates to a Java recipe and was not
+        # captured in _delegating_recipes is not in this marketplace, so a miss means the host
+        # owns this recipe: answer with a delegatesTo response so the JVM resolves the id locally
+        # (the Java recipe is on its classpath), rather than failing with "Recipe not found".
+        prepared_id = generate_id()
+        return {
+            'id': prepared_id,
+            'descriptor': _delegate_descriptor(recipe_name),
+            'editVisitor': f'edit:{prepared_id}',
+            'editPreconditions': [],
+            'scanVisitor': None,
+            'scanPreconditions': [],
+            'delegatesTo': {
+                'recipeName': recipe_name,
+                'options': options,
+            },
+        }
 
     _descriptor, recipe_class = recipe_info
     if recipe_class is None:


### PR DESCRIPTION
## Motivation

A composite recipe in one language whose `recipeList()` contains a recipe that delegates to a Java recipe fails at run time with `Could not find recipe with id ...`. The canonical case is Angular's `org.openrewrite.angular.UpgradeToAngular19` (a JavaScript recipe), whose `recipeList()` calls `upgradeDependencyVersion(...)` → `prepareJavaRecipe("org.openrewrite.javascript.UpgradeDependencyVersion", ...)`. Running it fails with `Could not find recipe with id org.openrewrite.javascript.UpgradeDependencyVersion`.

When the host runs such a composite it re-prepares every child by id over RPC while building `RpcRecipe.getRecipeList()`. The delegated sub-recipe is an `RpcRecipe` proxy that the language server does not register in its own marketplace (it has no no-arg constructor and is hosted on the peer), so the re-prepare misses — and every server threw on that miss. The host never got a chance to resolve the recipe it actually owns.

- The fix makes each server answer with the existing `PrepareRecipeResponse.delegatesTo` field (introduced in #7038) on a marketplace miss: "not mine — you own it." The requesting host then resolves the id from its own marketplace via `RewriteRpc.prepareRecipe`'s existing `delegatesTo` branch and runs the recipe locally. This reuses the existing protocol rather than adding any new mechanism, and makes all four RPC servers behave uniformly on a miss.

## Example

A composite that previously could not be run end-to-end:

```ts
class UpgradeToAngular19 extends Recipe {
    name = "org.openrewrite.angular.UpgradeToAngular19";

    async recipeList(): Promise<Recipe[]> {
        return [
            new ExplicitStandaloneFlag(),
            // delegates to the Java recipe org.openrewrite.javascript.UpgradeDependencyVersion
            await upgradeDependencyVersion({ packagePattern: "@angular/*", newVersion: "19.x" }),
        ];
    }
}
```

Before: the host's `getRecipeList()` re-prepares `org.openrewrite.javascript.UpgradeDependencyVersion` by id; the JS server's `marketplace.findRecipe` misses and throws `Could not find recipe with id ...`.

After: the server returns `delegatesTo: { recipeName: "org.openrewrite.javascript.UpgradeDependencyVersion", options: { ... } }`; the host resolves it from its own marketplace and runs the Java recipe in-process.

## Summary

- **JavaScript** (`prepare-recipe.ts`): on a `marketplace.findRecipe` miss, return `delegatesTo` instead of throwing `Could not find recipe with id`.
- **Python** (`rpc/server.py`): the final `find_recipe` miss now returns `delegatesTo` instead of raising `Recipe not found`; the existing explicit `_delegating_recipes` fast path is unchanged.
- **C#** (`RewriteRpcServer.cs`): a `FindRecipe` miss returns `delegatesTo` instead of throwing `Recipe not found`.
- **Go** (`cmd/rpc/main.go`): a `FindRecipe` miss returns `delegatesTo` instead of an `Unknown recipe` error.
- Each server returns a minimal stub descriptor alongside `delegatesTo` — the host reads only `delegatesTo` for delegated recipes and ignores the descriptor, but the response shape requires one.
- Added a vitest case, a JavaScript integration test (`JavaScriptRewriteRpcTest.jsCompositeWithJavaDelegateChild`), and a fixture (`composite-with-java-delegate.ts`) for the exact composite-with-Java-delegate shape.

## Test plan

- [x] `rewrite-javascript` vitest `rewrite-rpc.test.ts`: preparing an unknown recipe id returns `delegatesTo` rather than throwing.
- [x] `rewrite-javascript` integTest `JavaScriptRewriteRpcTest` (26 tests, 0 failures): `jsCompositeWithJavaDelegateChild` starts the real `rewrite-rpc` server and asserts that a JS composite's Java-delegate child, re-prepared by id, resolves on the host as a local `org.openrewrite.javascript.UpgradeDependencyVersion` — not an `RpcRecipe`, and not a throw.
- [x] C#: `dotnet build` of `OpenRewrite.csproj` succeeds (0 errors).
- [x] Python: `server.py` passes `py_compile`.
- [ ] Go: `cmd/rpc` build — relying on CI (the change uses only existing types and mirrors the established response construction).
