### PR TITLE
Memoize `Semver.validate()` to cut regex CPU during recipe runs

### DIFF
--- a/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/core/SemverVersionSelectorBenchmark.java
+++ b/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/core/SemverVersionSelectorBenchmark.java
@@ -48,6 +48,13 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class SemverVersionSelectorBenchmark {
 
+    /**
+     * A mix of node-semver selector shapes that exercise the full selector-detection chain in
+     * {@link Semver#validate}: an exact version, an x-range, a hyphen range, a caret range, and a
+     * {@code latest.release} literal.
+     */
+    private static final String[] SELECTORS = {"1.5.1", "1.x", "1.5 - 2", "^1.5", "latest.release"};
+
     private List<String> versions;
     private VersionComparator latestRelease;
     private VersionComparator xRange;
@@ -74,6 +81,19 @@ public class SemverVersionSelectorBenchmark {
     @Benchmark
     public void upgradeHyphenRange(Blackhole bh) {
         bh.consume(hyphenRange.upgrade("3.0.0", versions));
+    }
+
+    /**
+     * Mimics the hot path of a recipe run: a (recipe-constant) version selector is repeatedly
+     * validated for every dependency and every visit. Exercises {@link Semver#validate} over the
+     * representative {@link #SELECTORS} mix; quantifies the selector-detection regex cost and the
+     * effect of memoizing it.
+     */
+    @Benchmark
+    public void validateSelectors(Blackhole bh) {
+        for (String selector : SELECTORS) {
+            bh.consume(Semver.validate(selector, null));
+        }
     }
 
     /**

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LruCache.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LruCache.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.semver;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Factory for the bounded, access-order LRU maps used to memoize the pure (but regex-heavy) results
+ * of semver parsing and selector validation. Recipe runs evaluate a recipe-constant version selector
+ * against the same recurring version strings across thousands of dependencies and visits, so caching
+ * collapses that work to a handful of computations.
+ * <p>
+ * The returned map is {@code synchronized} (recipes run on a {@link java.util.concurrent.ForkJoinPool})
+ * and evicts the least-recently-used entry once {@code maxSize} is exceeded, capping the retained
+ * footprint in a long-lived process.
+ */
+final class LruCache {
+
+    private LruCache() {
+    }
+
+    static <K, V> Map<K, V> bounded(int maxSize) {
+        return Collections.synchronizedMap(new LinkedHashMap<K, V>(256, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+                return size() > maxSize;
+            }
+        });
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/semver/ParsedVersion.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/ParsedVersion.java
@@ -17,8 +17,6 @@ package org.openrewrite.semver;
 
 import org.jspecify.annotations.Nullable;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 
@@ -53,13 +51,7 @@ final class ParsedVersion {
      */
     private static final int MAX_CACHE_SIZE = 4_096;
 
-    private static final Map<String, ParsedVersion> CACHE = Collections.synchronizedMap(
-            new LinkedHashMap<String, ParsedVersion>(256, 0.75f, true) {
-                @Override
-                protected boolean removeEldestEntry(Map.Entry<String, ParsedVersion> eldest) {
-                    return size() > MAX_CACHE_SIZE;
-                }
-            });
+    private static final Map<String, ParsedVersion> CACHE = LruCache.bounded(MAX_CACHE_SIZE);
 
     private static final ParsedVersion NO_MATCH = new ParsedVersion(false, null, null, false);
 

--- a/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
@@ -15,16 +15,33 @@
  */
 package org.openrewrite.semver;
 
+import lombok.EqualsAndHashCode;
 import lombok.experimental.UtilityClass;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Validated;
 import org.openrewrite.internal.StringUtils;
 
+import java.util.Map;
 import java.util.Scanner;
 import java.util.regex.Pattern;
 
 @UtilityClass
 public class Semver {
+
+    /**
+     * Memoizes {@link #validate(String, String)} keyed on its {@code (toVersion, metadataPattern)}
+     * arguments. A version selector is a recipe parameter, so it is constant for the duration of a
+     * run yet {@code validate} is otherwise re-invoked for every dependency and every visit. Each
+     * invocation runs the full chain of selector-detection regexes (one {@code Pattern.matcher} per
+     * comparator type), which dominates {@code java.util.regex} CPU time during large recipe runs.
+     * Caching collapses the thousands of repeated calls to one computation per distinct selector.
+     * <p>
+     * Both valid <em>and</em> invalid results are cached: an {@link Validated} carries its validation
+     * errors, and re-deriving them is just as costly. The cached {@link VersionComparator}
+     * implementations store only final parsed fields and are immutable, so sharing them across the
+     * {@link java.util.concurrent.ForkJoinPool} that runs recipes is safe.
+     */
+    private static final Map<CacheKey, Validated<VersionComparator>> VALIDATE_CACHE = LruCache.bounded(1_024);
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public static boolean isVersion(@Nullable String version) {
@@ -49,6 +66,17 @@ public class Semver {
      * @return the validation result
      */
     public static Validated<VersionComparator> validate(String toVersion, @Nullable String metadataPattern) {
+        CacheKey key = new CacheKey(toVersion, metadataPattern);
+        Validated<VersionComparator> cached = VALIDATE_CACHE.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        Validated<VersionComparator> result = doValidate(toVersion, metadataPattern);
+        VALIDATE_CACHE.put(key, result);
+        return result;
+    }
+
+    private static Validated<VersionComparator> doValidate(String toVersion, @Nullable String metadataPattern) {
         String canonicalPattern = canonicalizeMetadataPattern(metadataPattern);
         return Validated.<VersionComparator, String>testNone(
                 "metadataPattern",
@@ -67,6 +95,19 @@ public class Semver {
                 .or(ExactVersionWithPattern.build(toVersion, canonicalPattern))
                 .or(ExactVersion.build(toVersion))
         );
+    }
+
+    @EqualsAndHashCode
+    private static final class CacheKey {
+        private final String toVersion;
+
+        @Nullable
+        private final String metadataPattern;
+
+        private CacheKey(String toVersion, @Nullable String metadataPattern) {
+            this.toVersion = toVersion;
+            this.metadataPattern = metadataPattern;
+        }
     }
 
     private static @Nullable String canonicalizeMetadataPattern(@Nullable String metadataPattern) {

--- a/rewrite-core/src/test/java/org/openrewrite/semver/SemverTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/SemverTest.java
@@ -16,10 +16,70 @@
 package org.openrewrite.semver;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Validated;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SemverTest {
+    @Test
+    void cachesValidationResultByVersionAndMetadataPattern() {
+        Validated<VersionComparator> first = Semver.validate("1.5.1", null);
+        assertThat(first.isValid()).isTrue();
+        assertThat(Semver.validate("1.5.1", null)).isSameAs(first);
+    }
+
+    @Test
+    void cachesInvalidValidationResults() {
+        Validated<VersionComparator> first = Semver.validate("1 - 2.x", null);
+        assertThat(first.isValid()).isFalse();
+        assertThat(Semver.validate("1 - 2.x", null)).isSameAs(first);
+    }
+
+    @Test
+    void distinguishesNullAndNonNullMetadataPattern() {
+        Validated<VersionComparator> withoutPattern = Semver.validate("latest.patch", null);
+        Validated<VersionComparator> withPattern = Semver.validate("latest.patch", "+backpatch*");
+        assertThat(withPattern).isNotSameAs(withoutPattern);
+        assertThat(Semver.validate("latest.patch", null)).isSameAs(withoutPattern);
+        assertThat(Semver.validate("latest.patch", "+backpatch*")).isSameAs(withPattern);
+    }
+
+    @Test
+    void concurrentValidationReturnsConsistentResults() throws Exception {
+        String[] selectors = {"latest.release", "1.x", "1.5 - 2", "^1.5", "1.5.1"};
+        Class<?>[] expectedTypes = {LatestRelease.class, XRange.class, HyphenRange.class, CaretRange.class, ExactVersion.class};
+
+        int threads = 16;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            List<Callable<Void>> tasks = new ArrayList<>();
+            for (int t = 0; t < threads; t++) {
+                tasks.add(() -> {
+                    for (int iteration = 0; iteration < 1_000; iteration++) {
+                        for (int i = 0; i < selectors.length; i++) {
+                            Validated<VersionComparator> validated = Semver.validate(selectors[i], null);
+                            assertThat(validated.isValid()).isTrue();
+                            assertThat(validated.getValue()).isInstanceOf(expectedTypes[i]);
+                        }
+                    }
+                    return null;
+                });
+            }
+            for (Future<Void> future : executor.invokeAll(tasks)) {
+                future.get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
     @Test
     void validToVersion() {
         assertThat(Semver.validate("latest.release", null).getValue())


### PR DESCRIPTION
## Motivation

`org.openrewrite.semver.Semver.validate(toVersion, metadataPattern)` dominates `java.util.regex` CPU time during large recipe runs. In a profile of an `UpgradeSpringBoot_4_0` run over `spring-projects/spring-boot` (~11.7k files), `java.util.regex` was ~4% of all CPU samples (almost all of it actively matching), and ~60% of those regex stacks went through `org.openrewrite.semver`, entered via `Semver.validate`.

The cost is structural. `validate` builds its result through a chain of `or(...)` calls — `LatestRelease`, `LatestIntegration`, `HyphenRange`, `XRange`, `TildeRange`, `CaretRange`, `SetRange`, ... — and `Validated.or` takes an already-built value, so every `*.build(...)` argument is evaluated eagerly. Each `build()` runs a `static final Pattern` matcher to detect whether the selector is of that type, so ~11 regex matches run on every call even though the selector is almost always one simple type (commonly an exact version). And there was no caching: a version selector is a recipe parameter — constant for the whole run — yet `validate` re-ran the full regex gauntlet for every dependency and every visit.

## Summary

- Memoize `Semver.validate` on its `(toVersion, metadataPattern)` arguments, so the selector-detection regexes run once per distinct selector instead of once per call. The public signature and behavior are unchanged; the original body moved verbatim into a private `doValidate`.
- Cache both valid *and* invalid results — an invalid `Validated` carries its validation errors and is just as costly to re-derive.
- Back the cache with a bounded, access-order LRU (`synchronizedMap`-wrapped, capped at 1024 entries) so a long-lived process does not grow unboundedly. The cached `VersionComparator` implementations store only final parsed fields and are immutable, so sharing one instance across the `ForkJoinPool` that runs recipes is safe.
- This LRU is the same shape `ParsedVersion` already uses for the version-comparison path; extract it into a shared `LruCache.bounded(...)` factory and route both caches through it, so there is one implementation of the mechanism (each cache keeps its own instance, sized independently).
- Add a `validateSelectors` JMH benchmark to `SemverVersionSelectorBenchmark` exercising a representative selector mix (exact, x-range, hyphen, caret, `latest.release`).

## Test plan

- [x] New `SemverTest` cases: result is cached by `(toVersion, metadataPattern)`; invalid results are cached too; `null` vs non-null `metadataPattern` are keyed distinctly; a 16-thread concurrency stress test asserts consistent validity and comparator type.
- [x] `./gradlew :rewrite-core:test` green (full module suite, including the existing semver and `ParsedVersion` tests).
- [x] JMH `validateSelectors`, before/after the cache, over the representative selector mix: throughput 342 → 14,650 ops/ms (~43×); allocation 9,729 → 120 B/op (~81× less). Measured with `-prof gc`.