### PR TITLE
Speed up `ChangeType` precondition by gating the definition scan

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -83,16 +83,27 @@ public class ChangeType extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
+        // Normalize nested-class separators ($ -> .) so the package pre-filter can prefix-match the
+        // file's package declaration regardless of which form the old FQN was given in.
+        String normalizedOldName = oldFullyQualifiedTypeName.replace('$', '.');
         TreeVisitor<?, ExecutionContext> condition = new TreeVisitor<Tree, ExecutionContext>() {
             @Override
             public @Nullable Tree preVisit(@Nullable Tree tree, ExecutionContext ctx) {
                 stopAfterPreVisit();
                 if (tree instanceof JavaSourceFile) {
                     JavaSourceFile cu = (JavaSourceFile) tree;
-                    if (!Boolean.TRUE.equals(ignoreDefinition) && containsClassDefinition(cu, oldFullyQualifiedTypeName)) {
+                    // UsesType is an O(1) lookup against the cached type index; check it first and
+                    // only fall back to the definition scan when the type isn't used.
+                    Tree used = new UsesType<>(oldFullyQualifiedTypeName, true).visitNonNull(cu, ctx);
+                    if (used != cu) {
+                        return used;
+                    }
+                    if (!Boolean.TRUE.equals(ignoreDefinition) &&
+                            mayContainDefinition(cu, normalizedOldName, getCursor()) &&
+                            containsClassDefinition(cu, oldFullyQualifiedTypeName)) {
                         return SearchResult.found(cu);
                     }
-                    return new UsesType<>(oldFullyQualifiedTypeName, true).visitNonNull(cu, ctx);
+                    return cu;
                 } else if (tree instanceof SourceFileWithReferences) {
                     SourceFileWithReferences cu = (SourceFileWithReferences) tree;
                     return new UsesType<>(oldFullyQualifiedTypeName, true).visitNonNull(cu, ctx);
@@ -878,6 +889,31 @@ public class ChangeType extends Recipe {
             String newNestedFqn = targetFqn + nestedFqn.substring(originalFqn.length());
             return JavaType.ShallowClass.build(newNestedFqn);
         }
+    }
+
+    /**
+     * Cheap pre-filter for {@link #containsClassDefinition}: a Java file can only declare a type
+     * whose package equals the file's package declaration, so a file whose package is not a prefix
+     * of the old type's name can skip the (potentially full-tree) definition scan entirely. This
+     * invariant is Java-specific, so it is only applied to {@link J.CompilationUnit}; other
+     * {@link JavaSourceFile} dialects (e.g. {@code K.CompilationUnit}, {@code G.CompilationUnit})
+     * always fall through to the scan.
+     *
+     * @param normalizedOldName the old fully qualified type name with {@code $} normalized to {@code .}
+     */
+    private static boolean mayContainDefinition(JavaSourceFile sourceFile, String normalizedOldName, Cursor cursor) {
+        if (!(sourceFile instanceof J.CompilationUnit)) {
+            return true;
+        }
+        J.Package packageDeclaration = sourceFile.getPackageDeclaration();
+        if (packageDeclaration == null) {
+            // Default package: can't cheaply rule out a declaration here, so scan.
+            return true;
+        }
+        String filePackage = packageDeclaration.getExpression().printTrimmed(cursor).replaceAll("\\s", "");
+        // The declared type's package equals the file's, so the old name must begin with the file's
+        // package. Prefix-only: never rejects a file that actually declares the type.
+        return filePackage.isEmpty() || normalizedOldName.startsWith(filePackage + ".");
     }
 
     public static boolean containsClassDefinition(JavaSourceFile sourceFile, String fullyQualifiedTypeName) {


### PR DESCRIPTION
## Motivation

`ChangeType`'s precondition decides whether the (heavyweight) main visitor should run on a given source file. It did this by first calling `containsClassDefinition`, which is a full LST walk, and running it on **every** file before the cheap `UsesType` lookup. A precondition is only worthwhile if it is cheaper than the work it guards — but a full-tree walk on every file is roughly as expensive as just letting the recipe run, so for the common case (files that neither use nor define the old type) the precondition wasn't buying much. This is especially visible when running `ChangeType` across a large codebase, where the overwhelming majority of files are unrelated to the type being changed.

The key invariant that makes this cheap: a Java file can only *declare* a type whose package equals the file's own package declaration. So the definition scan only ever needs to run on files in the old type's package — a tiny fraction of a typical source set — and the rest can be rejected with a string comparison.

## Summary

- Run the O(1) `UsesType` lookup first; only fall back to the definition scan when the type isn't used.
- Gate `containsClassDefinition` behind a cheap package pre-filter (`mayContainDefinition`): the (normalized) old type name must begin with the file's package declaration. This is a prefix check, so it never rejects a file that actually declares the type — it only skips files that provably can't, preserving behavior exactly.
- `containsClassDefinition` itself is unchanged (same public API, same semantics, still catches nested and local classes); it just runs far less often.
- The package invariant is Java-specific, so the pre-filter only applies to `J.CompilationUnit`. Other `JavaSourceFile` dialects (e.g. `K.CompilationUnit`, `G.CompilationUnit`) always fall through to the full scan.

## Test plan

- [x] `ChangeTypeTest` (Java) passes, including the nested/dotted-FQN definition-only cases `replacePrivateNestedType` (`a.A.B1`) and `deeplyNestedInnerClass` (`a.A.B.C`), which exercise the pre-filter against false negatives.
- [x] Kotlin `ChangeTypeTest` passes, confirming `K.CompilationUnit` correctly bypasses the Java-only pre-filter and still has its definitions renamed.
- [x] Groovy `ChangeType` tests pass.