### PR TITLE
Fix SpacesStyle annotationArrayInitializerLeftBrace for annotation array initializers

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java
@@ -2054,6 +2054,102 @@ class SpacesTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/8053")
+    @Test
+    void beforeLeftBraceArrayInitializerTrueDoesNotAffectAnnotationArrayInitializer() {
+        rewriteRun(
+          spaces(style -> style.withBeforeLeftBrace(style.getBeforeLeftBrace()
+            .withArrayInitializerLeftBrace(true)
+            .withAnnotationArrayInitializerLeftBrace(false))),
+          java(
+            """
+              import java.lang.annotation.*;
+
+              @Retention(RetentionPolicy.RUNTIME)
+              @interface Produces {
+                  String[] value();
+              }
+
+              class A {
+                  @Produces({"a", "b"})
+                  public void getByUuid() {
+                  }
+
+                  public void foo() {
+                      int[] arr = new int[]{1, 2, 3};
+                  }
+              }
+              """,
+            """
+              import java.lang.annotation.*;
+
+              @Retention(RetentionPolicy.RUNTIME)
+              @interface Produces {
+                  String[] value();
+              }
+
+              class A {
+                  @Produces({"a", "b"})
+                  public void getByUuid() {
+                  }
+
+                  public void foo() {
+                      int[] arr = new int[] {1, 2, 3};
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8053")
+    @Test
+    void beforeLeftBraceAnnotationArrayInitializerTrueAddsSpace() {
+        rewriteRun(
+          spaces(style -> style.withBeforeLeftBrace(style.getBeforeLeftBrace()
+            .withArrayInitializerLeftBrace(false)
+            .withAnnotationArrayInitializerLeftBrace(true))),
+          java(
+            """
+              import java.lang.annotation.*;
+
+              @Retention(RetentionPolicy.RUNTIME)
+              @interface Produces {
+                  String[] value();
+              }
+
+              class A {
+                  @Produces({"a", "b"})
+                  public void getByUuid() {
+                  }
+
+                  public void foo() {
+                      int[] arr = new int[]{1, 2, 3};
+                  }
+              }
+              """,
+            """
+              import java.lang.annotation.*;
+
+              @Retention(RetentionPolicy.RUNTIME)
+              @interface Produces {
+                  String[] value();
+              }
+
+              class A {
+                  @Produces( {"a", "b"})
+                  public void getByUuid() {
+                  }
+
+                  public void foo() {
+                      int[] arr = new int[]{1, 2, 3};
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void beforeKeywordsElseKeywordFalse() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
@@ -606,7 +606,17 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
                 whitespace = evaluate(() -> spacesStyle.getBeforeParentheses().getMethodCall(), false) ? " " : "";
                 break;
             case NEW_ARRAY_INITIALIZER:
-                whitespace = evaluate(() -> spacesStyle.getBeforeLeftBrace().getArrayInitializerLeftBrace(), false) ? " " : "";
+                if (getCursor().firstEnclosing(J.Annotation.class) != null) {
+                    if (getCursor().getParentTreeCursor().getParentTreeCursor().getValue() instanceof J.Assignment) {
+                        // For a named annotation value pair (e.g. `value = {...}`) the space before the
+                        // brace is governed by the `=` spacing, so don't add another one here.
+                        whitespace = "";
+                    } else {
+                        whitespace = evaluate(() -> spacesStyle.getBeforeLeftBrace().getAnnotationArrayInitializerLeftBrace(), false) ? " " : "";
+                    }
+                } else {
+                    whitespace = evaluate(() -> spacesStyle.getBeforeLeftBrace().getArrayInitializerLeftBrace(), false) ? " " : "";
+                }
                 break;
             case UNARY_OPERATOR: //intelliJ does not format the i++ to i ++ when spacesStyle.getAroundOperators().getUnary() is true;
             case METHOD_SELECT_SUFFIX:


### PR DESCRIPTION
## What's changed?

`SpacesVisitor` handled the `NEW_ARRAY_INITIALIZER` location by always applying `beforeLeftBrace.arrayInitializerLeftBrace`, even when the array initializer was part of an annotation. The companion setting `beforeLeftBrace.annotationArrayInitializerLeftBrace` was never read anywhere in the main source.

As reported, this meant:
- `arrayInitializerLeftBrace` affected too much (it also controlled annotation array initializers), and
- `annotationArrayInitializerLeftBrace` did nothing.

Now array initializers enclosed by a `J.Annotation` use `annotationArrayInitializerLeftBrace`, while plain array initializers continue to use `arrayInitializerLeftBrace`. Named annotation value pairs (e.g. `value = {...}`) keep deriving their leading space from the `=` spacing (`other.aroundEqualInAnnotationValuePair`) to avoid doubling it.

## Example

With `arrayInitializerLeftBrace: true` and `annotationArrayInitializerLeftBrace: false`:

```java
@Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
```

is no longer rewritten to `@Produces( {...})` — the unwanted space before the annotation array brace is gone, while plain array initializers like `new int[] {1, 2, 3}` still get the space.

## Checklist
- [x] Added tests reproducing the reported scenario.

- Fixes #8053