### PR TITLE
Avoid streams in `Validated` iteration paths

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Validated.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Validated.java
@@ -346,14 +346,19 @@ public interface Validated<T> extends Iterable<Validated<T>> {
                 return right.iterator();
             } else {
                 //If both are valid/invalid, concat all validations.
-                List<Validated<T>> result = new ArrayList<>();
-                for (Validated<T> v : left) {
-                    result.add(v);
-                }
-                for (Validated<T> v : right) {
-                    result.add(v);
-                }
-                return result.iterator();
+                Iterator<Validated<T>> leftIt = left.iterator();
+                Iterator<Validated<T>> rightIt = right.iterator();
+                return new Iterator<Validated<T>>() {
+                    @Override
+                    public boolean hasNext() {
+                        return leftIt.hasNext() || rightIt.hasNext();
+                    }
+
+                    @Override
+                    public Validated<T> next() {
+                        return leftIt.hasNext() ? leftIt.next() : rightIt.next();
+                    }
+                };
             }
         }
     }

--- a/rewrite-core/src/main/java/org/openrewrite/Validated.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Validated.java
@@ -20,11 +20,9 @@ import org.openrewrite.internal.StringUtils;
 
 import java.util.*;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static java.util.Collections.emptyIterator;
-import static java.util.stream.StreamSupport.stream;
+import static java.util.Collections.singletonList;
 
 /**
  * A container object which may or may not contain a valid value.
@@ -223,7 +221,7 @@ public interface Validated<T> extends Iterable<Validated<T>> {
 
         @Override
         public Iterator<Validated<T>> iterator() {
-            return Stream.of((Validated<T>) this).iterator();
+            return singletonList((Validated<T>) this).iterator();
         }
 
         public String getProperty() {
@@ -274,7 +272,7 @@ public interface Validated<T> extends Iterable<Validated<T>> {
 
         @Override
         public Iterator<Validated<T>> iterator() {
-            return Stream.of((Validated<T>) this).iterator();
+            return singletonList((Validated<T>) this).iterator();
         }
 
         public String getMessage() {
@@ -324,9 +322,12 @@ public interface Validated<T> extends Iterable<Validated<T>> {
         }
 
         public Optional<Validated<T>> findAny() {
-            return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator(), Spliterator.CONCURRENT), false)
-                    .filter(Validated::isValid)
-                    .findAny();
+            for (Validated<T> v : this) {
+                if (v.isValid()) {
+                    return Optional.of(v);
+                }
+            }
+            return Optional.empty();
         }
 
         @Override
@@ -340,15 +341,19 @@ public interface Validated<T> extends Iterable<Validated<T>> {
         public Iterator<Validated<T>> iterator() {
             //If only one side is valid, this short circuits the invalid path.
             if (left.isValid() && right.isInvalid()) {
-                return stream(left.spliterator(), false).iterator();
+                return left.iterator();
             } else if (left.isInvalid() && right.isValid()) {
-                return stream(right.spliterator(), false).iterator();
+                return right.iterator();
             } else {
                 //If both are valid/invalid, concat all validations.
-                return Stream.concat(
-                        stream(left.spliterator(), false),
-                        stream(right.spliterator(), false)
-                ).iterator();
+                List<Validated<T>> result = new ArrayList<>();
+                for (Validated<T> v : left) {
+                    result.add(v);
+                }
+                for (Validated<T> v : right) {
+                    result.add(v);
+                }
+                return result.iterator();
             }
         }
     }


### PR DESCRIPTION
## Motivation

`Validated` is iterated during recipe and configuration validation, and its iterator implementations leaned on `java.util.stream` for what are fundamentally trivial traversals. The single-element `Valid`/`Invalid` iterators allocated a full stream pipeline plus a spliterator just to yield one element, and `Either` performed no-op spliterator round-trips (`stream(x.spliterator(), false).iterator()` is equivalent to `x.iterator()`) plus a `Stream.concat` where direct iteration suffices. These add allocation and indirection overhead on a hot validation path without buying any expressiveness.

## Summary

- `Valid.iterator()` / `Invalid.iterator()`: `Stream.of(this).iterator()` → `Collections.singletonList(this).iterator()`.
- `Either.iterator()`: single-valid-side branches now return the child's iterator directly (zero allocation); the both-sides branch uses a small lazy chaining iterator over the two children instead of `Stream.concat` — no backing array, no element copying.
- `Either.findAny()`: stream `filter`/`findAny` → a plain loop returning the first valid element.
- Dropped the now-unused `java.util.stream.*` imports.

No behavioral change — iteration order and short-circuit semantics are identical.

## Test plan

- `./gradlew :rewrite-core:compileJava`
- `./gradlew :rewrite-core:test --tests "org.openrewrite.RecipeValidationTest" --tests "org.openrewrite.semver.SemverTest"`
