### PR TITLE
Cursor-free shared `PackageNameUtils` for package-name access

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -23,6 +23,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
+import org.openrewrite.java.internal.PackageNameUtils;
 import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.search.FindMethods;
 import org.openrewrite.java.search.FindTypes;
@@ -114,7 +115,7 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
             }
             // Nor if the classes are within the same package
             if (!"Record".equals(typeName) && cu.getPackageDeclaration() != null &&
-                    packageName.equals(cu.getPackageDeclaration().getExpression().printTrimmed(getCursor()))) {
+                    packageName.equals(PackageNameUtils.getPackageName(cu.getPackageDeclaration()))) {
                 // For static imports, only skip if the target type is declared in this compilation unit
                 if (member == null) {
                     return cu;

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -21,6 +21,7 @@ import lombok.With;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.internal.PackageNameUtils;
 import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.SearchResult;
@@ -87,8 +88,7 @@ public class ChangePackage extends Recipe {
                 if (tree instanceof JavaSourceFile) {
                     JavaSourceFile cu = (JavaSourceFile) tree;
                     if (cu.getPackageDeclaration() != null) {
-                        String original = cu.getPackageDeclaration().getExpression()
-                                .printTrimmed(getCursor()).replaceAll("\\s", "");
+                        String original = PackageNameUtils.getPackageName(cu.getPackageDeclaration());
                         if (original.startsWith(oldPackageName)) {
                             return SearchResult.found(cu);
                         }
@@ -182,7 +182,7 @@ public class ChangePackage extends Recipe {
 
         @Override
         public J visitPackage(J.Package pkg, ExecutionContext ctx) {
-            String original = pkg.getExpression().printTrimmed(getCursor()).replaceAll("\\s", "");
+            String original = PackageNameUtils.getPackageName(pkg);
             getCursor().putMessageOnFirstEnclosing(JavaSourceFile.class, RENAME_FROM_KEY, original);
 
             pkg = pkg.withAnnotations(ListUtils.map(pkg.getAnnotations(), a -> visitAndCast(a, ctx)));

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -99,7 +99,7 @@ public class ChangeType extends Recipe {
                         return used;
                     }
                     if (!Boolean.TRUE.equals(ignoreDefinition) &&
-                            mayContainDefinition(cu, normalizedOldName, getCursor()) &&
+                            mayContainDefinition(cu, normalizedOldName) &&
                             containsClassDefinition(cu, oldFullyQualifiedTypeName)) {
                         return SearchResult.found(cu);
                     }
@@ -901,7 +901,7 @@ public class ChangeType extends Recipe {
      *
      * @param normalizedOldName the old fully qualified type name with {@code $} normalized to {@code .}
      */
-    private static boolean mayContainDefinition(JavaSourceFile sourceFile, String normalizedOldName, Cursor cursor) {
+    private static boolean mayContainDefinition(JavaSourceFile sourceFile, String normalizedOldName) {
         if (!(sourceFile instanceof J.CompilationUnit)) {
             return true;
         }
@@ -910,10 +910,51 @@ public class ChangeType extends Recipe {
             // Default package: can't cheaply rule out a declaration here, so scan.
             return true;
         }
-        String filePackage = packageDeclaration.getExpression().printTrimmed(cursor).replaceAll("\\s", "");
         // The declared type's package equals the file's, so the old name must begin with the file's
-        // package. Prefix-only: never rejects a file that actually declares the type.
-        return filePackage.isEmpty() || normalizedOldName.startsWith(filePackage + ".");
+        // package. Rather than printing the package name and comparing strings, walk the name tree
+        // and match it against the old name segment by segment, short-circuiting as soon as a segment
+        // diverges. Prefix-only: never rejects a file that actually declares the type.
+        int matched = matchPackagePrefix(packageDeclaration.getExpression(), normalizedOldName);
+        // A definitive mismatch is the only case where the scan can be skipped; a matched prefix or an
+        // expression we couldn't interpret both fall through to the scan.
+        return matched != PACKAGE_MISMATCH;
+    }
+
+    /** The package is definitively not a prefix of the old name, so the definition scan can be skipped. */
+    private static final int PACKAGE_MISMATCH = -1;
+    /** The package expression couldn't be interpreted, so the definition scan must run to be safe. */
+    private static final int PACKAGE_UNKNOWN = -2;
+
+    /**
+     * Matches the package described by {@code expression} against the leading segments of
+     * {@code normalizedOldName}, returning the offset just past the matched prefix (including its
+     * trailing {@code '.'}), or {@link #PACKAGE_MISMATCH} / {@link #PACKAGE_UNKNOWN}. The name tree is
+     * structured outermost-first, so recursion descends to the leftmost segment and matches on the way
+     * back up, comparing in left-to-right order without building an intermediate string.
+     */
+    private static int matchPackagePrefix(Expression expression, String normalizedOldName) {
+        String segment;
+        int start;
+        if (expression instanceof J.Identifier) {
+            segment = ((J.Identifier) expression).getSimpleName();
+            start = 0;
+        } else if (expression instanceof J.FieldAccess) {
+            J.FieldAccess fieldAccess = (J.FieldAccess) expression;
+            start = matchPackagePrefix(fieldAccess.getTarget(), normalizedOldName);
+            if (start < 0) {
+                return start; // propagate mismatch / unknown
+            }
+            segment = fieldAccess.getSimpleName();
+        } else {
+            return PACKAGE_UNKNOWN;
+        }
+        int end = start + segment.length();
+        if (end < normalizedOldName.length() &&
+                normalizedOldName.charAt(end) == '.' &&
+                normalizedOldName.regionMatches(start, segment, 0, segment.length())) {
+            return end + 1;
+        }
+        return PACKAGE_MISMATCH;
     }
 
     public static boolean containsClassDefinition(JavaSourceFile sourceFile, String fullyQualifiedTypeName) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -20,6 +20,7 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.internal.PackageNameUtils;
 import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
@@ -786,7 +787,7 @@ public class ChangeType extends Recipe {
         public J.@Nullable Package visitPackage(J.Package pkg, ExecutionContext ctx) {
             Boolean updatePackage = getCursor().pollNearestMessage("UPDATE_PACKAGE");
             if (updatePackage != null && updatePackage) {
-                String original = pkg.getExpression().printTrimmed(getCursor()).replaceAll("\\s", "");
+                String original = PackageNameUtils.getPackageName(pkg);
                 if (original.equals(originalType.getPackageName())) {
                     JavaType.FullyQualified fq = TypeUtils.asFullyQualified(targetType);
                     if (fq != null) {
@@ -911,50 +912,8 @@ public class ChangeType extends Recipe {
             return true;
         }
         // The declared type's package equals the file's, so the old name must begin with the file's
-        // package. Rather than printing the package name and comparing strings, walk the name tree
-        // and match it against the old name segment by segment, short-circuiting as soon as a segment
-        // diverges. Prefix-only: never rejects a file that actually declares the type.
-        int matched = matchPackagePrefix(packageDeclaration.getExpression(), normalizedOldName);
-        // A definitive mismatch is the only case where the scan can be skipped; a matched prefix or an
-        // expression we couldn't interpret both fall through to the scan.
-        return matched != PACKAGE_MISMATCH;
-    }
-
-    /** The package is definitively not a prefix of the old name, so the definition scan can be skipped. */
-    private static final int PACKAGE_MISMATCH = -1;
-    /** The package expression couldn't be interpreted, so the definition scan must run to be safe. */
-    private static final int PACKAGE_UNKNOWN = -2;
-
-    /**
-     * Matches the package described by {@code expression} against the leading segments of
-     * {@code normalizedOldName}, returning the offset just past the matched prefix (including its
-     * trailing {@code '.'}), or {@link #PACKAGE_MISMATCH} / {@link #PACKAGE_UNKNOWN}. The name tree is
-     * structured outermost-first, so recursion descends to the leftmost segment and matches on the way
-     * back up, comparing in left-to-right order without building an intermediate string.
-     */
-    private static int matchPackagePrefix(Expression expression, String normalizedOldName) {
-        String segment;
-        int start;
-        if (expression instanceof J.Identifier) {
-            segment = ((J.Identifier) expression).getSimpleName();
-            start = 0;
-        } else if (expression instanceof J.FieldAccess) {
-            J.FieldAccess fieldAccess = (J.FieldAccess) expression;
-            start = matchPackagePrefix(fieldAccess.getTarget(), normalizedOldName);
-            if (start < 0) {
-                return start; // propagate mismatch / unknown
-            }
-            segment = fieldAccess.getSimpleName();
-        } else {
-            return PACKAGE_UNKNOWN;
-        }
-        int end = start + segment.length();
-        if (end < normalizedOldName.length() &&
-                normalizedOldName.charAt(end) == '.' &&
-                normalizedOldName.regionMatches(start, segment, 0, segment.length())) {
-            return end + 1;
-        }
-        return PACKAGE_MISMATCH;
+        // package. The prefix check never rejects a file that actually declares the type.
+        return PackageNameUtils.isPrefixOf(packageDeclaration, normalizedOldName);
     }
 
     public static boolean containsClassDefinition(JavaSourceFile sourceFile, String fullyQualifiedTypeName) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/ExtractInterface.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ExtractInterface.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.internal.PackageNameUtils;
 import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
@@ -48,7 +49,7 @@ public class ExtractInterface {
                 JavaSourceFile c = (JavaSourceFile) requireNonNull(tree);
 
                 String pkg = c.getPackageDeclaration() == null ? "" :
-                        Arrays.stream(c.getPackageDeclaration().getExpression().printTrimmed(getCursor()).split("\\."))
+                        Arrays.stream(PackageNameUtils.getPackageName(c.getPackageDeclaration()).split("\\."))
                                 .map(subpackage -> "..")
                                 .collect(joining("/", "../", "/"));
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
@@ -18,6 +18,7 @@ package org.openrewrite.java;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
+import org.openrewrite.java.internal.PackageNameUtils;
 import org.openrewrite.java.style.ImportLayoutStyle;
 import org.openrewrite.java.style.IntelliJ;
 import org.openrewrite.java.tree.*;
@@ -66,7 +67,7 @@ public class RemoveUnusedImports extends Recipe {
             ImportLayoutStyle layoutStyle = Optional.ofNullable(Style.from(ImportLayoutStyle.class, cu))
                     .orElse(IntelliJ.importLayout());
             String sourcePackage = cu.getPackageDeclaration() == null ? "" :
-                    cu.getPackageDeclaration().getExpression().printTrimmed(getCursor()).replaceAll("\\s", "");
+                    PackageNameUtils.getPackageName(cu.getPackageDeclaration());
             Map<String, TreeSet<String>> methodsAndFieldsByTypeName = new HashMap<>();
             Map<String, Set<JavaType.FullyQualified>> typesByPackage = new HashMap<>();
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/PackageNameUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/PackageNameUtils.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal;
+
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+public final class PackageNameUtils {
+
+    /** A package segment diverged from the target: the package is definitively not a prefix. */
+    private static final int NO_MATCH = -1;
+    /** The name tree couldn't be interpreted; callers should fall back to a string comparison. */
+    private static final int UNINTERPRETABLE = -2;
+
+    private PackageNameUtils() {
+    }
+
+    /**
+     * Returns the canonical dotted name of a package declaration (e.g. {@code "org.openrewrite.java"}).
+     * <p>
+     * The name is reconstructed by walking the declaration's name tree ({@link J.Identifier} /
+     * {@link J.FieldAccess}) rather than printing it, which is comparatively expensive and requires a
+     * {@link org.openrewrite.Cursor}. Any whitespace a source file may place around the {@code .}
+     * separators is dropped, so the result is always a canonical fully qualified package name.
+     *
+     * @param pkg the package declaration
+     * @return the dotted package name
+     */
+    public static String getPackageName(J.Package pkg) {
+        StringBuilder name = new StringBuilder();
+        if (appendName(pkg.getExpression(), name)) {
+            return name.toString();
+        }
+        // Fallback for an unexpected expression shape (e.g. J.Unknown in unparseable source).
+        return packageNameByPrinting(pkg.getExpression());
+    }
+
+    /**
+     * Whether the package declaration's name is a prefix of {@code fullyQualifiedName} at a package
+     * boundary — e.g. package {@code a.b} matches {@code a.b.C} but not {@code a.bc.C}. Useful as a
+     * cheap pre-filter for "could a type named {@code fullyQualifiedName} be declared in this file?".
+     * <p>
+     * The package name tree is matched against {@code fullyQualifiedName} segment by segment without
+     * building an intermediate string, short-circuiting as soon as a segment diverges.
+     *
+     * @param pkg                 the package declaration
+     * @param fullyQualifiedName  the dotted name to test the package against
+     * @return whether the package name is a package-boundary prefix of {@code fullyQualifiedName}
+     */
+    public static boolean isPrefixOf(J.Package pkg, String fullyQualifiedName) {
+        int matched = matchPrefix(pkg.getExpression(), fullyQualifiedName);
+        if (matched == UNINTERPRETABLE) {
+            // Fall back to the string form to preserve behavior for exotic expression shapes.
+            return fullyQualifiedName.startsWith(getPackageName(pkg) + ".");
+        }
+        return matched != NO_MATCH;
+    }
+
+    private static boolean appendName(Expression expression, StringBuilder name) {
+        if (expression instanceof J.Identifier) {
+            name.append(((J.Identifier) expression).getSimpleName());
+            return true;
+        } else if (expression instanceof J.FieldAccess) {
+            J.FieldAccess fieldAccess = (J.FieldAccess) expression;
+            if (!appendName(fieldAccess.getTarget(), name)) {
+                return false;
+            }
+            name.append('.').append(fieldAccess.getSimpleName());
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Matches the package described by {@code expression} against the leading segments of
+     * {@code fullyQualifiedName}, returning the offset just past the matched prefix (including its
+     * trailing {@code '.'}), or {@link #NO_MATCH} / {@link #UNINTERPRETABLE}. The name tree is
+     * structured outermost-first, so recursion descends to the leftmost segment and matches on the way
+     * back up, comparing in left-to-right order without building an intermediate string.
+     */
+    private static int matchPrefix(Expression expression, String fullyQualifiedName) {
+        String segment;
+        int start;
+        if (expression instanceof J.Identifier) {
+            segment = ((J.Identifier) expression).getSimpleName();
+            start = 0;
+        } else if (expression instanceof J.FieldAccess) {
+            J.FieldAccess fieldAccess = (J.FieldAccess) expression;
+            start = matchPrefix(fieldAccess.getTarget(), fullyQualifiedName);
+            if (start < 0) {
+                return start; // propagate no-match / uninterpretable
+            }
+            segment = fieldAccess.getSimpleName();
+        } else {
+            return UNINTERPRETABLE;
+        }
+        int end = start + segment.length();
+        if (end < fullyQualifiedName.length() &&
+                fullyQualifiedName.charAt(end) == '.' &&
+                fullyQualifiedName.regionMatches(start, segment, 0, segment.length())) {
+            return end + 1;
+        }
+        return NO_MATCH;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static String packageNameByPrinting(Expression expression) {
+        return expression.printTrimmed().replaceAll("\\s", "");
+    }
+}


### PR DESCRIPTION
## Motivation

Several recipes need the dotted name of a file's package declaration, and they all reconstructed it the same expensive way: `cu.getPackageDeclaration().getExpression().printTrimmed(getCursor()).replaceAll("\\s", "")`. Printing spins up a `JavaPrinter` and runs the full visitor protocol over the name tree, the `replaceAll` compiles a `Pattern` and allocates on every call, and the whole thing requires a `Cursor`. For `ChangeType`/`ChangePackage` this runs once per source file as part of the recipe precondition — a hot path for two of the most heavily-used recipes.

A package declaration's name is always a name tree (`J.Identifier`, or nested `J.FieldAccess`), so it can be reconstructed by a cheap, cursor-free tree walk instead. For the precondition prefix checks, the name doesn't even need to be materialized — the package can be matched against the target segment by segment with no allocation at all.

## Summary

- Add `org.openrewrite.java.internal.PackageNameUtils` with two cursor-free helpers:
  - `getPackageName(J.Package)` — reconstructs the canonical dotted package name by walking the `Identifier`/`FieldAccess` tree (with a `printTrimmed` fallback for unparseable shapes).
  - `isPrefixOf(J.Package, fullyQualifiedName)` — tests whether the package name is a package-boundary prefix of a given fully qualified name by matching segment by segment, short-circuiting on the first divergence, with no intermediate string.
- Migrate the seven `printTrimmed`-on-package call sites (across five recipes) to the shared helper, each dropping its `getCursor()` call: `ChangeType` (precondition + `ChangeClassDefinition`), `ChangePackage` (precondition + `visitPackage`), `ExtractInterface`, `AddImport`, and `RemoveUnusedImports`.
- Behavior is preserved: the walk yields the same canonical name as `printTrimmed().replaceAll("\\s", "")` (whitespace around `.` separators is dropped), and the prefix pre-filter never rejects a file that actually declares the type.

A targeted JMH microbenchmark (not committed) measured the tree-walk at ~3.4–8× the throughput of `printTrimmed()+regex` for full-name extraction, and `isPrefixOf` at ~8–27× for the precondition prefix check, since it avoids both the printer and any string allocation.

## Test plan

- [x] `./gradlew :rewrite-java-test:test --tests "org.openrewrite.java.ChangeTypeTest" --tests "org.openrewrite.java.ChangePackageTest" --tests "org.openrewrite.java.RemoveUnusedImportsTest" --tests "org.openrewrite.java.AddImportTest" --tests "org.openrewrite.java.ExtractInterfaceTest"` passes
- [x] `./gradlew :rewrite-java:compileJava` succeeds
