### PR TITLE
Exact-match fast path for `DependencyMatcher`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/DependencyMatcher.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/DependencyMatcher.java
@@ -34,10 +34,38 @@ public class DependencyMatcher {
     @Nullable
     private final VersionComparator versionComparator;
 
+    /**
+     * Whether the corresponding pattern matches every coordinate ({@code null} or {@code "*"}), in which case the
+     * coordinate need not be inspected at all. The {@code $} prefix makes Lombok skip these derived fields when
+     * generating {@code @With}/{@code @Getter} members.
+     */
+    private final transient boolean $groupMatchesAll;
+    private final transient boolean $artifactMatchesAll;
+
+    /**
+     * Whether the corresponding pattern contains no glob metacharacter and so can be compared with the much cheaper
+     * case-insensitive {@link String#equalsIgnoreCase} rather than {@link StringUtils#matchesGlob}. The decision is made
+     * once here, at construction, rather than on every {@link #matches} call.
+     */
+    private final transient boolean $groupExact;
+    private final transient boolean $artifactExact;
+
     public DependencyMatcher(@Nullable String groupPattern, @Nullable String artifactPattern, @Nullable VersionComparator versionComparator) {
         this.groupPattern = groupPattern;
         this.artifactPattern = artifactPattern;
         this.versionComparator = versionComparator;
+        this.$groupMatchesAll = matchesAll(groupPattern);
+        this.$artifactMatchesAll = matchesAll(artifactPattern);
+        this.$groupExact = isExact(groupPattern);
+        this.$artifactExact = isExact(artifactPattern);
+    }
+
+    private static boolean matchesAll(@Nullable String pattern) {
+        return pattern == null || "*".equals(pattern);
+    }
+
+    private static boolean isExact(@Nullable String pattern) {
+        return pattern != null && pattern.indexOf('*') < 0 && pattern.indexOf('?') < 0;
     }
 
     public static Validated<DependencyMatcher> build(String pattern) {
@@ -68,13 +96,26 @@ public class DependencyMatcher {
     }
 
     public boolean matches(@Nullable String groupId, @Nullable String artifactId, String version) {
-        return StringUtils.matchesGlob(groupId, groupPattern) &&
-                StringUtils.matchesGlob(artifactId, artifactPattern) &&
+        return matchesGroup(groupId) && matchesArtifact(artifactId) &&
                 (versionComparator == null || versionComparator.isValid(null, version));
     }
 
     public boolean matches(@Nullable String groupId, @Nullable String artifactId) {
-        return StringUtils.matchesGlob(groupId, groupPattern) && StringUtils.matchesGlob(artifactId, artifactPattern);
+        return matchesGroup(groupId) && matchesArtifact(artifactId);
+    }
+
+    private boolean matchesGroup(@Nullable String groupId) {
+        if ($groupMatchesAll) {
+            return true;
+        }
+        return $groupExact ? groupPattern.equalsIgnoreCase(groupId) : StringUtils.matchesGlob(groupId, groupPattern);
+    }
+
+    private boolean matchesArtifact(@Nullable String artifactId) {
+        if ($artifactMatchesAll) {
+            return true;
+        }
+        return $artifactExact ? artifactPattern.equalsIgnoreCase(artifactId) : StringUtils.matchesGlob(artifactId, artifactPattern);
     }
 
     public boolean isValidVersion(@Nullable String currentVersion, String newVersion) {

--- a/rewrite-core/src/test/java/org/openrewrite/semver/DependencyMatcherTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/DependencyMatcherTest.java
@@ -25,4 +25,53 @@ class DependencyMatcherTest {
     void groupArtifact() {
         assertThat(DependencyMatcher.build("org.springframework.boot:*").isValid()).isTrue();
     }
+
+    @Test
+    void exactMatch() {
+        DependencyMatcher matcher = DependencyMatcher.build("com.google.guava:guava").getValue();
+        assertThat(matcher.matches("com.google.guava", "guava")).isTrue();
+        assertThat(matcher.matches("com.google.guava", "guava-testlib")).isFalse();
+        assertThat(matcher.matches("com.google.collect", "guava")).isFalse();
+    }
+
+    @Test
+    void exactMatchIsCaseInsensitive() {
+        // The exact fast path must preserve matchesGlob's case-insensitivity.
+        DependencyMatcher matcher = DependencyMatcher.build("com.google.guava:guava").getValue();
+        assertThat(matcher.matches("Com.Google.Guava", "Guava")).isTrue();
+    }
+
+    @Test
+    void globMatch() {
+        DependencyMatcher matcher = DependencyMatcher.build("com.google.*:gua?a").getValue();
+        assertThat(matcher.matches("com.google.guava", "guava")).isTrue();
+        assertThat(matcher.matches("com.google.collect", "guava")).isTrue();
+        assertThat(matcher.matches("com.amazonaws", "guava")).isFalse();
+        assertThat(matcher.matches("com.google.guava", "guava-testlib")).isFalse();
+    }
+
+    @Test
+    void matchAll() {
+        DependencyMatcher matcher = DependencyMatcher.build("*:*").getValue();
+        assertThat(matcher.matches("com.google.guava", "guava")).isTrue();
+        assertThat(matcher.matches(null, "guava")).isTrue();
+        assertThat(matcher.matches("com.google.guava", null)).isTrue();
+    }
+
+    @Test
+    void nullCoordinateAgainstExactPattern() {
+        DependencyMatcher matcher = DependencyMatcher.build("com.google.guava:guava").getValue();
+        assertThat(matcher.matches(null, "guava")).isFalse();
+        assertThat(matcher.matches("com.google.guava", null)).isFalse();
+    }
+
+    @Test
+    void withPatternRecomputesExactness() {
+        // @With must route through the canonical constructor so derived flags stay consistent.
+        DependencyMatcher matcher = DependencyMatcher.build("com.google.guava:guava").getValue()
+                .withArtifactPattern("gua?a");
+        assertThat(matcher.matches("com.google.guava", "guava")).isTrue();
+        assertThat(matcher.matches("com.google.guava", "guaba")).isTrue();
+        assertThat(matcher.matches("com.google.guava", "guava-testlib")).isFalse();
+    }
 }


### PR DESCRIPTION
## Motivation

`DependencyMatcher.matches` calls `StringUtils.matchesGlob` for both the groupId and artifactId on every invocation. For dependency-search recipes like `DependencyInsight` (Maven and Gradle), `matches` is called once per node while walking the entire resolved dependency graph against a single matcher, so this is a hot path. Most patterns contain no glob metacharacters (e.g. `com.google.guava:guava`), yet they still pay the full `matchesGlob` start/end/star index walk. `matchesGlob` is itself case-insensitive, so for a metacharacter-free pattern it is equivalent to the much cheaper `String.equalsIgnoreCase`, and for a `null`/`"*"` pattern it always matches.

- This mirrors the exact-match fast path introduced for `ResolvedDependency` in #8030, but takes it one step further: because a `DependencyMatcher`'s patterns are fixed at construction, the glob/exact decision is made **once per matcher** rather than once per lookup, so the `*`/`?` scan never runs on the hot path at all.

## Summary

- Compute, in the constructor, whether each pattern matches everything (`null` or `"*"`) and whether it is exact (contains no `*`/`?`), caching the results in `transient` fields. The `$` prefix keeps these derived fields out of Lombok's generated `@With`/`@Getter` members.
- `matches` now delegates to per-coordinate helpers: a match-all pattern short-circuits without inspecting the coordinate, an exact pattern uses `equalsIgnoreCase`, and only a genuine glob falls back to `matchesGlob`.
- Behavior is unchanged — `equalsIgnoreCase` is a faithful substitute because `matchesGlob` is already case-insensitive.

## Test plan

- Added `DependencyMatcherTest` cases for exact, case-insensitive exact, glob, match-all, null coordinates, and `@With` recomputing exactness — written and passing against the original `matchesGlob`-everywhere implementation before the refactor to lock in behavior.
- `:rewrite-core:test --tests "org.openrewrite.semver.*"` passes.
- `:rewrite-maven` and `:rewrite-gradle` `DependencyInsight` tests (hot callers of `matches`) pass.