### PR TITLE
Fix withToolingApi projectDir for multi-module builds

### DIFF
--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
@@ -64,17 +64,28 @@ public class Assertions {
         return sourceFiles -> {
             try {
                 Path tempDirectory = Files.createTempDirectory("project");
-                // Usage of Assertions.mavenProject() might result in gradle files inside a subdirectory
+                // Usage of Assertions.mavenProject() might result in gradle files inside a subdirectory.
+                // Determine the build root from the shallowest build/settings file so that, in a
+                // multi-module build, the wrapper lands at the root rather than the last-iterated subproject.
                 Path projectDir = tempDirectory;
+                int shallowest = Integer.MAX_VALUE;
+                for (SourceFile sourceFile : sourceFiles) {
+                    String path = sourceFile.getSourcePath().toString();
+                    if (path.endsWith("settings.gradle") || path.endsWith("settings.gradle.kts") ||
+                            path.endsWith("build.gradle") || path.endsWith("build.gradle.kts")) {
+                        int depth = sourceFile.getSourcePath().getNameCount();
+                        if (depth < shallowest) {
+                            shallowest = depth;
+                            projectDir = tempDirectory.resolve(sourceFile.getSourcePath()).getParent();
+                        }
+                    }
+                }
                 try {
                     for (SourceFile sourceFile : sourceFiles) {
                         if (sourceFile instanceof K.CompilationUnit) {
                             K.CompilationUnit k = (K.CompilationUnit) sourceFile;
                             if (k.getSourcePath().toString().endsWith(".gradle.kts")) {
                                 Path kotlinGradle = tempDirectory.resolve(k.getSourcePath());
-                                if (!tempDirectory.equals(kotlinGradle.getParent()) && tempDirectory.equals(kotlinGradle.getParent().getParent())) {
-                                    projectDir = kotlinGradle.getParent();
-                                }
                                 Files.createDirectories(kotlinGradle.getParent());
                                 Files.write(kotlinGradle, k.printAllAsBytes());
                             }
@@ -82,9 +93,6 @@ public class Assertions {
                             G.CompilationUnit g = (G.CompilationUnit) sourceFile;
                             if (g.getSourcePath().toString().endsWith(".gradle")) {
                                 Path groovyGradle = tempDirectory.resolve(g.getSourcePath());
-                                if (!tempDirectory.equals(groovyGradle.getParent()) && tempDirectory.equals(groovyGradle.getParent().getParent())) {
-                                    projectDir = groovyGradle.getParent();
-                                }
                                 Files.createDirectories(groovyGradle.getParent());
                                 Files.write(groovyGradle, g.printAllAsBytes());
                             }
@@ -92,9 +100,6 @@ public class Assertions {
                             Properties.File f = (Properties.File) sourceFile;
                             if (f.getSourcePath().endsWith("gradle.properties")) {
                                 Path gradleProperties = tempDirectory.resolve(f.getSourcePath());
-                                if (!tempDirectory.equals(gradleProperties.getParent()) && tempDirectory.equals(gradleProperties.getParent().getParent())) {
-                                    projectDir = gradleProperties.getParent();
-                                }
                                 Files.createDirectories(gradleProperties.getParent());
                                 Files.write(gradleProperties, f.printAllAsBytes());
                             }
@@ -109,9 +114,6 @@ public class Assertions {
                             PlainText plainText = (PlainText) sourceFile;
                             if (plainText.getSourcePath().endsWith("gradle.lockfile") || plainText.getSourcePath().endsWith("buildscript-gradle.lockfile")) {
                                 Path lockfile = tempDirectory.resolve(plainText.getSourcePath());
-                                if (!tempDirectory.equals(lockfile.getParent()) && tempDirectory.equals(lockfile.getParent().getParent())) {
-                                    projectDir = lockfile.getParent();
-                                }
                                 Files.createDirectories(lockfile.getParent());
                                 Files.write(lockfile, plainText.printAllAsBytes());
                             }

--- a/rewrite-gradle-tooling-model/model/src/test/java/org/openrewrite/gradle/toolingapi/AssertionsTest.java
+++ b/rewrite-gradle-tooling-model/model/src/test/java/org/openrewrite/gradle/toolingapi/AssertionsTest.java
@@ -218,4 +218,35 @@ class AssertionsTest implements RewriteTest {
           buildGradle("", spec -> spec.path("subproject2/build.gradle"))
         );
     }
+
+    @Test
+    void multimoduleResolvesAgainstBuildRoot() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(Assertions.withToolingApi(URI.create("https://downloads.gradle.org/distributions/gradle-9.5.1-bin.zip"))),
+          //language=groovy
+          settingsGradle(
+            """
+              rootProject.name = 'test'
+              include 'web'
+              include 'ear'
+              """
+          ),
+          buildGradle(
+            """
+              apply plugin: 'java'
+              """,
+            spec -> spec.path("web/build.gradle")
+          ),
+          buildGradle(
+            """
+              apply plugin: 'java'
+              
+              dependencies {
+                implementation project(path: ':web', configuration: 'archives')
+              }
+              """,
+            spec -> spec.path("ear/build.gradle")
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What

`Assertions.withToolingApi(...)` writes the test source files into a temp directory and places a Gradle wrapper into a computed `projectDir`. For a **multi-module** build with more than one Gradle file one directory deep, `projectDir` ended up pointing at the **last-iterated** subproject instead of the build root. The wrapper was written into that nested subproject, and the tooling-API model was then resolved against the wrong project directory, so internal/cross-module project references failed to resolve.

## Root cause

`projectDir` defaulted to the temp root but was reassigned inside the file-writing loop for every Gradle-ish file (`*.gradle(.kts)`, `gradle.properties`, lockfiles) sitting exactly one directory deep — last writer wins:

```java
if (!tempDirectory.equals(parent) && tempDirectory.equals(parent.getParent())) {
    projectDir = parent;   // last writer wins
}
```

With `build.gradle` (root), `web/build.gradle`, `ear/build.gradle`, `projectDir` became `<temp>/ear` (whichever subproject was iterated last). The Gradle wrapper was then written into `<temp>/ear`, and the model-building loop used `projectDir` as the project root for **every** build file. `OpenRewriteModelBuilder` keys off `projectDir/gradle/wrapper/gradle-wrapper.properties` and connects to `projectDir`, so the build connected to the nested subproject — the root `settings.gradle` (and its `include`s) was out of scope and cross-module references broke.

## Fix

Determine `projectDir` from the **shallowest** `build.gradle`/`settings.gradle(.kts)` file in a single pass before the write loop, and remove the inline `projectDir = parent` reassignments. Only build/settings files are considered candidates, so a stray nested `gradle.properties`/lockfile cannot define the root.

- Multi-module with a root build/settings file: the root file has the shortest path (`nameCount == 1`), so `projectDir` stays at the build root and the wrapper lands there.
- Subproject build files at any depth never override a shallower root.

## Test

Added `AssertionsTest.multimoduleResolvesAgainstBuildRoot`: a root `settings.gradle` including `web` and `ear`, plus `web/build.gradle` and an `ear/build.gradle` that declares an internal `project(':web')` dependency.

The test deliberately passes a **real Gradle wrapper distribution** rather than the no-wrapper `withToolingApi()`. That matters: without a wrapper, Gradle locates `settings.gradle` by walking up from the `-b` build file, which masks the misplaced `projectDir`. With a wrapper present, `OpenRewriteModelBuilder` reads the wrapper from `projectDir` and connects there, so the wrapper landing in the wrong subproject is what actually breaks resolution. The test fails before the fix (the build connects to the wrong directory and `project(':web')` cannot be resolved) and passes after.

- Fixes #8058
