### PR TITLE
Go: in RPC coerce empty collections to empty lists, not nil

### DIFF
--- a/rewrite-go/pkg/rpc/java_sender.go
+++ b/rewrite-go/pkg/rpc/java_sender.go
@@ -271,7 +271,7 @@ func (s *JavaSender) VisitMethodDeclaration(md *java.MethodDeclaration, p any) j
 		func(v any) any { return extractID(v) },
 		func(v any) { s.Visit(v.(java.Tree), q) })
 	// modifiers (empty for Go)
-	q.GetAndSendList(md, func(_ any) []any { return nil }, func(_ any) any { return nil }, nil)
+	q.GetAndSendList(md, func(_ any) []any { return []any{} }, func(_ any) any { return nil }, nil)
 	// typeParameters (`[T any]` declaration-site generics; nil for non-generic funcs)
 	q.GetAndSend(md, func(v any) any { return v.(*java.MethodDeclaration).TypeParameters },
 		func(v any) { s.Visit(v.(java.Tree), q) })
@@ -279,7 +279,7 @@ func (s *JavaSender) VisitMethodDeclaration(md *java.MethodDeclaration, p any) j
 	q.GetAndSend(md, func(v any) any { return v.(*java.MethodDeclaration).ReturnType },
 		func(v any) { s.Visit(v.(java.Tree), q) })
 	// name annotations (empty)
-	q.GetAndSendList(md, func(_ any) []any { return nil }, func(_ any) any { return nil }, nil)
+	q.GetAndSendList(md, func(_ any) []any { return []any{} }, func(_ any) any { return nil }, nil)
 	// name
 	q.GetAndSend(md, func(v any) any { return v.(*java.MethodDeclaration).Name },
 		func(v any) { s.Visit(v.(java.Tree), q) })
@@ -287,7 +287,7 @@ func (s *JavaSender) VisitMethodDeclaration(md *java.MethodDeclaration, p any) j
 	q.GetAndSend(md, func(v any) any { return v.(*java.MethodDeclaration).Parameters },
 		func(v any) { sendContainer(s, v, q) })
 	// dimensionsAfterName (empty for Go — no C-style array method returns)
-	q.GetAndSendList(md, func(_ any) []any { return nil }, func(_ any) any { return nil }, nil)
+	q.GetAndSendList(md, func(_ any) []any { return []any{} }, func(_ any) any { return nil }, nil)
 	// throws (nil for Go)
 	q.GetAndSend(md, func(_ any) any { return nil }, nil)
 	// body
@@ -304,7 +304,7 @@ func (s *JavaSender) VisitMethodDeclaration(md *java.MethodDeclaration, p any) j
 func (s *JavaSender) VisitTypeParameters(tps *java.TypeParameters, p any) java.J {
 	q := p.(*SendQueue)
 	// annotations (empty for Go)
-	q.GetAndSendList(tps, func(_ any) []any { return nil }, func(_ any) any { return nil }, nil)
+	q.GetAndSendList(tps, func(_ any) []any { return []any{} }, func(_ any) any { return nil }, nil)
 	// typeParameters (list of right-padded J$TypeParameter)
 	q.GetAndSendList(tps,
 		func(v any) []any {
@@ -323,9 +323,9 @@ func (s *JavaSender) VisitTypeParameters(tps *java.TypeParameters, p any) java.J
 func (s *JavaSender) VisitTypeParameter(tp *java.TypeParameter, p any) java.J {
 	q := p.(*SendQueue)
 	// annotations (empty for Go)
-	q.GetAndSendList(tp, func(_ any) []any { return nil }, func(_ any) any { return nil }, nil)
+	q.GetAndSendList(tp, func(_ any) []any { return []any{} }, func(_ any) any { return nil }, nil)
 	// modifiers (empty for Go)
-	q.GetAndSendList(tp, func(_ any) []any { return nil }, func(_ any) any { return nil }, nil)
+	q.GetAndSendList(tp, func(_ any) []any { return []any{} }, func(_ any) any { return nil }, nil)
 	// name
 	q.GetAndSend(tp, func(v any) any { return v.(*java.TypeParameter).Name },
 		func(v any) { s.Visit(v.(java.Tree), q) })
@@ -600,7 +600,7 @@ func (s *JavaSender) VisitVariableDeclarator(vd *java.VariableDeclarator, p any)
 	q.GetAndSend(vd, func(v any) any { return v.(*java.VariableDeclarator).Name },
 		func(v any) { s.Visit(v.(java.Tree), q) })
 	// dimensionsAfterName (empty for Go)
-	q.GetAndSendList(vd, func(_ any) []any { return nil }, func(_ any) any { return nil }, nil)
+	q.GetAndSendList(vd, func(_ any) []any { return []any{} }, func(_ any) any { return nil }, nil)
 	// initializer (left-padded, nullable) — dereference pointer
 	q.GetAndSend(vd, func(v any) any {
 		init := v.(*java.VariableDeclarator).Initializer
@@ -620,7 +620,7 @@ func (s *JavaSender) VisitArrayType(at *java.ArrayType, p any) java.J {
 	q.GetAndSend(at, func(v any) any { return v.(*java.ArrayType).ElementType },
 		func(v any) { s.Visit(v.(java.Tree), q) })
 	// annotations (empty for Go)
-	q.GetAndSendList(at, func(_ any) []any { return nil }, func(_ any) any { return nil }, nil)
+	q.GetAndSendList(at, func(_ any) []any { return []any{} }, func(_ any) any { return nil }, nil)
 	// dimension (left-padded)
 	q.GetAndSend(at, func(v any) any { return v.(*java.ArrayType).Dimension },
 		func(v any) { sendLeftPadded(s, v, q) })

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangRecipeIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangRecipeIntegTest.java
@@ -285,6 +285,38 @@ class GolangRecipeIntegTest implements RewriteTest {
         assertThat(result).isNotNull().isInstanceOf(SourceFile.class);
     }
 
+    /**
+     * A Java recipe that iterates {@code J.MethodDeclaration#getModifiers()} —
+     * exactly what {@code ModifierOrder} does — must not NPE on a Go function.
+     * Go functions have no modifiers, but {@code J.MethodDeclaration#modifiers}
+     * is a non-null Java contract; before the fix the Go sender emitted the
+     * modifiers list as a nil slice, which deserialized to {@code null} on the
+     * Java side and threw {@code NullPointerException: Cannot invoke
+     * "java.util.List.iterator()" because "modifiers" is null}.
+     */
+    @Test
+    void iteratingModifiersDoesNotNpe() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new org.openrewrite.java.JavaIsoVisitor<>() {
+              @Override
+              public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, org.openrewrite.ExecutionContext ctx) {
+                  for (J.Modifier modifier : method.getModifiers()) {
+                      assertThat(modifier).isNotNull();
+                  }
+                  return super.visitMethodDeclaration(method, ctx);
+              }
+          })),
+          go(
+            """
+              package main
+
+              func hello() {
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void renameIdentifier() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?

Changing how Go RPC handles empty collections.
Instead of converting them to `nil`, it provides `[]`.

## What's your motivation?

I think this is the safer way.
The direct trigger was observing a NPE with a Java recipe touching Go code:
```
java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "modifiers" is null 
```