### PR TITLE
Go: fix findMethodsByPattern integration test

### DIFF
--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangRecipeIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangRecipeIntegTest.java
@@ -372,8 +372,8 @@ class GolangRecipeIntegTest implements RewriteTest {
 
               import "fmt"
 
-              func main() {/*~~>*/
-              \tfmt.Println("hello")
+              func main() {
+              \t/*~~>*/fmt.Println("hello")
               }
               """
           )


### PR DESCRIPTION
## What's changed?

Fixing one of the integration tests for rewrite-go.

## What's your motivation?

It was failing.
- Likely after the whitespace attachment fixes in Go (#7953, #7977)