### PR TITLE
Replace stream with plain loop in `TypeTable.Reader.parseTsvAndProcess()`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -34,7 +34,6 @@ import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.jar.JarEntry;
@@ -271,23 +270,25 @@ public class TypeTable implements JavaParserClasspathLoader {
          */
         public void parseTsvAndProcess(InputStream is, Options options,
                                         ClassesProcessor processor) throws IOException {
-            AtomicReference<@Nullable GroupArtifactVersion> matchedGav = new AtomicReference<>();
+            GroupArtifactVersion matchedGav = null;
             Map<String, ClassDefinition> classesByName = new HashMap<>();
             // nested types appear first in type tables and therefore not stored in a `ClassDefinition` field
             Map<String, List<ClassDefinition>> nestedTypesByOwner = new HashMap<>();
             Map<String, byte[]> resourcesByPath = new LinkedHashMap<>();
 
             try (BufferedReader in = new BufferedReader(new InputStreamReader(is))) {
-                AtomicReference<@Nullable GroupArtifactVersion> lastGav = new AtomicReference<>();
-                in.lines().skip(1).forEach(line -> {
+                GroupArtifactVersion lastGav = null;
+                in.readLine(); // skip the header row
+                String line;
+                while ((line = in.readLine()) != null) {
                     TsvRow row = TsvRow.parse(line);
                     GroupArtifactVersion rowGav = new GroupArtifactVersion(row.getGroupId(), row.getArtifactId(), row.getVersion());
 
-                    if (!Objects.equals(rowGav, lastGav.get())) {
-                        if (matchedGav.get() != null) {
-                            processor.accept(matchedGav.get(), classesByName, nestedTypesByOwner, resourcesByPath);
+                    if (!Objects.equals(rowGav, lastGav)) {
+                        if (matchedGav != null) {
+                            processor.accept(matchedGav, classesByName, nestedTypesByOwner, resourcesByPath);
                         }
-                        matchedGav.set(null);
+                        matchedGav = null;
                         classesByName.clear();
                         nestedTypesByOwner.clear();
                         resourcesByPath.clear();
@@ -296,17 +297,17 @@ public class TypeTable implements JavaParserClasspathLoader {
 
                         // Check if this artifact matches our predicate
                         if (options.getArtifactMatcher().test(artifactVersion)) {
-                            matchedGav.set(rowGav);
+                            matchedGav = rowGav;
                         }
                     }
-                    lastGav.set(rowGav);
+                    lastGav = rowGav;
 
-                    if (matchedGav.get() != null) {
+                    if (matchedGav != null) {
                         switch (row.kind()) {
                             case RESOURCE: {
                                 resourcesByPath.put(row.getClassName(),
                                         Base64.getDecoder().decode(row.getConstantValue()));
-                                return;
+                                break;
                             }
                             case CLASS: {
                                 getOrCreateClassDefinition(row, classesByName, nestedTypesByOwner);
@@ -331,12 +332,12 @@ public class TypeTable implements JavaParserClasspathLoader {
                             }
                         }
                     }
-                });
+                }
             }
 
             // Process final GAV if any
-            if (matchedGav.get() != null) {
-                processor.accept(matchedGav.get(), classesByName, nestedTypesByOwner, resourcesByPath);
+            if (matchedGav != null) {
+                processor.accept(matchedGav, classesByName, nestedTypesByOwner, resourcesByPath);
             }
         }
 


### PR DESCRIPTION
## Motivation

Profiling type-table reads (the dominant cost when hydrating dependency types from a TypeTable) showed the Java stream pipeline framework itself — `Spliterators$IteratorSpliterator.forEachRemaining`, `AbstractPipeline.copyInto` / `wrapAndCopyInto` — sitting directly on top of the per-row parsing work in `TypeTable$Reader.parseTsvAndProcess`. `BufferedReader.lines()` wraps the reader in an `Iterator`-backed spliterator, and `.skip(1)` stacks a slice-spliterator on top of that, so every row pays for stream traversal machinery that a plain loop avoids entirely.

## Summary

- Replace `in.lines().skip(1).forEach(line -> { ... })` with a plain `while ((line = in.readLine()) != null)` loop, discarding the header row via a single `in.readLine()` instead of `.skip(1)`.
- With the lambda gone, the two `AtomicReference` captures (`matchedGav`, `lastGav`) — which existed only to satisfy the effectively-final capture rule — become plain local variables, dropping two allocations plus a `get()`/`set()` pair per row.
- The lambda's `return` in the `RESOURCE` branch becomes a `break` (equivalent, since the switch is the last statement in the loop body).
- Remove the now-unused `java.util.concurrent.atomic.AtomicReference` import.

Per-row work (`TsvRow.parse`, GAV bookkeeping, class/member accumulation) is unchanged; this only strips the iteration-framework overhead.

## Test plan

- [x] `./gradlew :rewrite-java:test --tests "org.openrewrite.java.internal.parser.TypeTable*"` passes (all TypeTable parser/serialization/annotation tests).
- [x] `./gradlew :rewrite-java:compileJava` succeeds.
