### PR TITLE
Slim Python and C# RPC server runtime dependencies

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/OpenRewrite.Tests.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/OpenRewrite.Tests.csproj
@@ -16,6 +16,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <!-- Test-only: fixtures build throwaway git repos with LibGit2Sharp. The production
+         tool resolves git through the host `git` CLI (see GitCli) and ships no native libs. -->
+    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/GitCli.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/GitCli.cs
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Diagnostics;
+using Serilog;
+
+namespace OpenRewrite.CSharp;
+
+/// <summary>
+/// Thin wrapper over the host <c>git</c> executable, used in place of an embedded
+/// git library so the tool ships no per-platform native binaries. The parser only
+/// ever runs against repositories already on disk in a developer/CI environment,
+/// where <c>git</c> is invariably on the PATH; every method degrades gracefully
+/// (returns "not a repo" / empty) when git is absent or errors, so the caller
+/// behaves exactly as it did when the working tree was not a git repository.
+/// </summary>
+internal static class GitCli
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Returns the absolute path of the working tree containing <paramref name="startDir"/>,
+    /// or <c>null</c> when it is not inside a git repository (or git is unavailable).
+    /// Equivalent to <c>git rev-parse --show-toplevel</c>.
+    /// </summary>
+    public static string? DiscoverWorkTree(string startDir)
+    {
+        var (exit, stdout, _) = Run(startDir, new[] { "rev-parse", "--show-toplevel" });
+        if (exit != 0)
+            return null;
+        var top = stdout.Trim();
+        return string.IsNullOrEmpty(top) ? null : top;
+    }
+
+    /// <summary>
+    /// Whether the repository has a resolvable <c>HEAD</c> commit. False on an unborn
+    /// branch (no commits yet), where there is nothing tracked to restore.
+    /// </summary>
+    public static bool HasHead(string workDir)
+    {
+        var (exit, _, _) = Run(workDir, new[] { "rev-parse", "--verify", "--quiet", "HEAD" });
+        return exit == 0;
+    }
+
+    /// <summary>
+    /// Repository-relative paths of tracked files whose final path segment equals
+    /// <paramref name="fileName"/>. Mirrors walking the git index filtered by name.
+    /// </summary>
+    public static IReadOnlyList<string> ListTrackedByName(string workDir, string fileName)
+    {
+        // -z: NUL-separated, so paths with spaces/newlines survive intact and no quoting is applied.
+        var (exit, stdout, _) = Run(workDir, new[] { "ls-files", "-z" });
+        if (exit != 0)
+            return Array.Empty<string>();
+        var result = new List<string>();
+        foreach (var rel in stdout.Split('\0', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (string.Equals(PosixBaseName(rel), fileName, StringComparison.OrdinalIgnoreCase))
+                result.Add(rel);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Subset of <paramref name="relPaths"/> (repository-relative, forward-slash) that git
+    /// considers ignored. Uses <c>git check-ignore</c> in its default (index-aware) mode, so
+    /// — exactly like the previous LibGit2Sharp logic — a tracked file is never reported as
+    /// ignored even when an ignore rule would otherwise match it.
+    /// </summary>
+    public static HashSet<string> CheckIgnored(string workDir, IReadOnlyCollection<string> relPaths)
+    {
+        var ignored = new HashSet<string>(StringComparer.Ordinal);
+        if (relPaths.Count == 0)
+            return ignored;
+
+        // Feed paths on stdin (NUL-delimited) to avoid command-line length limits and quoting.
+        var stdin = string.Join('\0', relPaths) + '\0';
+        var (exit, stdout, _) = Run(workDir, new[] { "check-ignore", "--stdin", "-z" }, stdin);
+
+        // git check-ignore exit codes: 0 = one or more paths ignored, 1 = none ignored,
+        // 128 = fatal error. Treat anything other than 0 as "nothing ignored".
+        if (exit != 0)
+            return ignored;
+
+        foreach (var rel in stdout.Split('\0', StringSplitOptions.RemoveEmptyEntries))
+            ignored.Add(rel);
+        return ignored;
+    }
+
+    /// <summary>
+    /// Force-restores the committed (HEAD) version of <paramref name="relPath"/> into the
+    /// working tree. Equivalent to <c>git checkout --force HEAD -- &lt;path&gt;</c>.
+    /// </summary>
+    public static bool RestoreFromHead(string workDir, string relPath)
+    {
+        var (exit, _, _) = Run(workDir, new[] { "checkout", "--force", "HEAD", "--", relPath });
+        return exit == 0;
+    }
+
+    private static string PosixBaseName(string path)
+    {
+        var slash = path.LastIndexOf('/');
+        return slash < 0 ? path : path[(slash + 1)..];
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) Run(string workDir, IReadOnlyList<string> args, string? stdin = null)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("git")
+            {
+                WorkingDirectory = workDir,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                RedirectStandardInput = stdin != null,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            foreach (var a in args)
+                psi.ArgumentList.Add(a);
+
+            using var process = Process.Start(psi);
+            if (process == null)
+                return (-1, "", "");
+
+            // Read stdout/stderr concurrently with the write below to avoid pipe-buffer deadlock.
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+
+            if (stdin != null)
+            {
+                process.StandardInput.Write(stdin);
+                process.StandardInput.Close();
+            }
+
+            if (!process.WaitForExit((int)Timeout.TotalMilliseconds))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+                Log.Debug("git {Args}: timed out after {Timeout}", string.Join(' ', args), Timeout);
+                return (-1, "", "");
+            }
+
+            return (process.ExitCode, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult());
+        }
+        catch (Exception ex)
+        {
+            // git not on PATH, or spawn failure: behave as "not a git repository".
+            Log.Debug("git {Args}: failed ({ExType}: {ExMessage})", string.Join(' ', args), ex.GetType().Name, ex.Message);
+            return (-1, "", "");
+        }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/GlobalJsonGuard.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/GlobalJsonGuard.cs
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-using LibGit2Sharp;
 using OpenRewrite.Core;
 using Serilog;
 
@@ -162,28 +161,21 @@ internal sealed class GlobalJsonGuard : IDisposable
     {
         try
         {
-            var gitDir = Repository.Discover(rootDir);
-            if (gitDir == null)
+            var workDir = GitCli.DiscoverWorkTree(rootDir);
+            if (workDir == null)
                 return; // Not inside a git repository — nothing to recover.
 
-            using var repo = new Repository(gitDir);
-            var head = repo.Head.Tip;
-            if (head == null)
+            if (!GitCli.HasHead(workDir))
                 return; // Unborn branch (no commits) — nothing is tracked yet.
 
-            var workDir = repo.Info.WorkingDirectory;
             var normRoot = RealPath(rootDir);
 
-            // Walk the index (tracked files) rather than scanning the whole working tree: there
-            // are only ever a handful of global.json files, and we touch disk solely to check
-            // whether each is missing. This mirrors `git ls-files --deleted` filtered to
-            // global.json, without a full status scan.
-            foreach (var entry in repo.Index)
+            // List the tracked global.json files (mirrors `git ls-files` filtered to
+            // global.json) rather than scanning the whole working tree: there are only ever a
+            // handful, and we touch disk solely to check whether each is missing.
+            foreach (var rel in GitCli.ListTrackedByName(workDir, FileName))
             {
-                if (!string.Equals(Path.GetFileName(entry.Path), FileName, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                var full = RealPath(Path.Combine(workDir, entry.Path));
+                var full = RealPath(Path.Combine(workDir, rel));
 
                 // Only recover files under the directory we were asked to guard.
                 if (!IsUnder(full, normRoot))
@@ -199,9 +191,8 @@ internal sealed class GlobalJsonGuard : IDisposable
                 }
 
                 // Force-restore the committed version into the working tree.
-                repo.CheckoutPaths(head.Sha, new[] { entry.Path },
-                    new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
-                Log.Debug("global.json: recovered {Path} from git (left deleted by a prior run)", full);
+                if (GitCli.RestoreFromHead(workDir, rel))
+                    Log.Debug("global.json: recovered {Path} from git (left deleted by a prior run)", full);
             }
         }
         catch (Exception ex)

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -15,7 +15,6 @@
  */
 using System.Diagnostics;
 using System.Xml.Linq;
-using LibGit2Sharp;
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
@@ -729,29 +728,30 @@ public class SolutionParser
 
         try
         {
-            var gitDir = Repository.Discover(rootDir);
-            if (gitDir == null) return ignored; // Not inside a git repository.
+            var workDir = GitCli.DiscoverWorkTree(rootDir);
+            if (workDir == null) return ignored; // Not inside a git repository.
+            workDir = PathUtil.Canonicalize(workDir);
 
-            using var repo = new Repository(gitDir);
-            var workDir = PathUtil.Canonicalize(repo.Info.WorkingDirectory);
-
+            // Evaluate ignore rules against repo-relative paths (forward slashes, as git
+            // expects), but report the original candidate string so the caller's membership
+            // check matches verbatim. `git check-ignore` is index-aware by default, so a
+            // tracked file is never reported as ignored even when a rule would match it.
+            var relToOriginal = new Dictionary<string, string>(StringComparer.Ordinal);
             foreach (var path in paths)
             {
-                // Evaluate ignore rules against the repo-relative path (forward slashes, as
-                // libgit2 expects), but report the original candidate string so the caller's
-                // membership check matches verbatim.
                 var rel = Path.GetRelativePath(workDir, PathUtil.Canonicalize(path));
                 if (rel.StartsWith("..", StringComparison.Ordinal) || Path.IsPathRooted(rel))
                     continue; // Outside the working tree — not subject to its ignore rules.
                 rel = rel.Replace('\\', '/');
+                relToOriginal[rel] = path;
+            }
 
-                // Mirror `git check-ignore`: tracked files are never reported as ignored, even
-                // when an ignore rule would otherwise match them.
-                if (repo.Index[rel] != null)
-                    continue;
+            if (relToOriginal.Count == 0) return ignored;
 
-                if (repo.Ignore.IsPathIgnored(rel))
-                    ignored.Add(path);
+            foreach (var rel in GitCli.CheckIgnored(workDir, relToOriginal.Keys))
+            {
+                if (relToOriginal.TryGetValue(rel, out var original))
+                    ignored.Add(original);
             }
         }
         catch (Exception ex)

--- a/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
@@ -37,7 +37,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" PrivateAssets="none" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" PrivateAssets="none" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
-    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="StreamJsonRpc" Version="2.20.20" />

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -761,22 +761,42 @@ public class PythonRewriteRpc extends RewriteRpc {
         }
 
         /**
+         * Whether Pyroscope profiling has been requested for the RPC subprocess, via
+         * either the configured builder environment or the inherited process environment.
+         * Drives whether the heavier, registry-only {@code [profiling]} extra is installed
+         * alongside the base engine.
+         */
+        private boolean isProfilingRequested() {
+            String fromBuilder = environment.get("PYROSCOPE_SERVER_ADDRESS");
+            if (fromBuilder != null && !fromBuilder.trim().isEmpty()) {
+                return true;
+            }
+            String fromProcess = System.getenv("PYROSCOPE_SERVER_ADDRESS");
+            return fromProcess != null && !fromProcess.trim().isEmpty();
+        }
+
+        /**
          * Installs the pinned openrewrite package into the given pip packages directory.
          */
         private void bootstrapOpenrewrite(Path pythonPath, Path pipPackagesPath, String version) {
             try {
                 Files.createDirectories(pipPackagesPath);
 
-                // Install with the [profiling] extra so pyroscope-io is available when
-                // PYROSCOPE_SERVER_ADDRESS is set in the rpc subprocess environment. The
-                // SDK init in rewrite.rpc.server is a no-op when the env var is unset, so
-                // adding the extra costs nothing for non-profiled deployments.
+                // Install the lean engine by default. The [profiling] extra pulls in
+                // pyroscope-io and its transitive (often native) dependencies, which most
+                // deployments never use; request it only when PYROSCOPE_SERVER_ADDRESS is
+                // set — the same signal the SDK init in rewrite.rpc.server gates on. The env
+                // var may arrive through either the configured builder environment or the
+                // inherited process environment, so check both. Keeping the default install
+                // free of the profiling deps makes it resolvable from a restricted or offline
+                // package source and keeps those extra packages off the parse path.
+                String packageSpec = (isProfilingRequested() ? "openrewrite[profiling]==" : "openrewrite==") + version;
                 ProcessBuilder pb = new ProcessBuilder(
                         pythonPath.toString(),
                         "-m", "pip", "install",
                         "--upgrade",
                         "--target=" + pipPackagesPath.toAbsolutePath().normalize(),
-                        "openrewrite[profiling]==" + version
+                        packageSpec
                 );
                 pb.environment().putAll(environment);
                 pb.redirectErrorStream(true);
@@ -796,12 +816,12 @@ public class PythonRewriteRpc extends RewriteRpc {
 
                 if (!completed) {
                     process.destroyForcibly();
-                    throw new RuntimeException("Timed out bootstrapping openrewrite==" + version);
+                    throw new RuntimeException("Timed out bootstrapping " + packageSpec);
                 }
 
                 int exitCode = process.exitValue();
                 if (exitCode != 0) {
-                    String message = "Failed to install openrewrite==" + version +
+                    String message = "Failed to install " + packageSpec +
                             " (pip exited with code " + exitCode + ")";
                     if (!pipOutput.isEmpty()) {
                         message += ":\n" + pipOutput.trim();


### PR DESCRIPTION
Two independent reductions to the runtime footprint of the polyglot RPC servers.

## Python: install the `[profiling]` extra only when profiling is requested

`PythonRewriteRpc` bootstrapped the engine with `pip install openrewrite[profiling]`, which always pulls in `pyroscope-io` and its transitive (often native) dependencies. The Pyroscope SDK in `rewrite.rpc.server` is a no-op unless `PYROSCOPE_SERVER_ADDRESS` is set, so the extra is dead weight for the overwhelming majority of runs.

Now the base `openrewrite` package is installed by default, and `[profiling]` is added only when `PYROSCOPE_SERVER_ADDRESS` is present (checked in both the builder-supplied environment and the inherited process environment). The default install is leaner and resolvable from restricted or offline package sources.

## C#: use the host `git` CLI instead of LibGit2Sharp

`LibGit2Sharp` ships native `libgit2` binaries for every platform (~19 MB on disk) into the published `OpenRewrite.CSharp.Tool`, yet it is used in only two places — discovering the enclosing repository (`GlobalJsonGuard`) and checking gitignore status (`SolutionParser`). Both map directly onto the host `git` executable, which is always present where the parser runs.

A small `GitCli` helper now shells out to `git` (`rev-parse --show-toplevel` / `ls-files` / `check-ignore` / `checkout`) and degrades to "not a repository" on any failure, preserving the previous behavior. `git check-ignore` is index-aware by default, so tracked files are never reported as ignored — matching the prior LibGit2Sharp logic. `LibGit2Sharp` moves to a test-only dependency (fixtures still build throwaway repos with it). The published tool ships no native binaries as a result.

## Verification

- `rewrite-python` compiles.
- `rewrite-csharp` builds; `GlobalJsonGuardTests` (7/7) and the gitignore-exclusion parser test pass; the published tool starts, warms up, and runs. The tool's `runtimes/` directory drops from ~19 MB to ~300 KB.
