### PR TITLE
Python: fix recipe pip install for version upgrades and local-path dependencies

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -761,17 +761,48 @@ def _pip_install_recipe_package(package_name: str, version: Optional[str], targe
     importlib.invalidate_caches()
 
 
+def _pip_install_local_path(local_path: Path, target_dir: Path) -> None:
+    import importlib
+    import subprocess
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    # Local recipe sources are mutable, so --force-reinstall picks up changed
+    # content even when the version is unchanged, and --upgrade lets pip replace
+    # the existing files under --target (which it otherwise refuses to do).
+    # `pip install <path>` also resolves and installs the local package's
+    # dependencies — a Python source dir, unlike a packaged npm/NuGet artifact,
+    # does not carry its dependencies alongside it.
+    cmd = [
+        sys.executable, "-m", "pip", "install",
+        "--force-reinstall", "--upgrade",
+        "--target", str(target_dir), str(local_path),
+    ]
+    logger.info(f"pip install: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"pip install failed for {local_path} (target={target_dir}):\n{result.stderr}"
+        )
+
+    target_str = str(target_dir.resolve())
+    if target_str not in sys.path:
+        sys.path.insert(0, target_str)
+    importlib.invalidate_caches()
+
+
 def handle_install_recipes(params: dict) -> dict:
     """Handle an InstallRecipes RPC request.
 
     Activates a recipe package in the marketplace. When `--recipe-install-dir`
-    is configured, a package spec that isn't already installed is pip-installed
-    into that directory before activation; otherwise the package must have been
+    is configured, the package is pip-installed into that directory before
+    activation — a named spec that isn't already installed, or a local path
+    together with its dependencies; otherwise the package must have been
     installed by the caller.
 
     Args:
         params: Dict containing either:
-            - 'recipes': str - A local file path (package already installed to target)
+            - 'recipes': str - A local file path (installed into the recipe-install
+              dir, with its dependencies, when one is configured)
             - 'recipes': {'packageName': str, 'version': str|None} - A package spec
 
     Returns:
@@ -795,9 +826,17 @@ def handle_install_recipes(params: dict) -> dict:
     recipes_added = 0
 
     if isinstance(recipes, str):
-        # Local file path - package should already be installed by caller
+        # Local file path. When a recipe-install dir is configured, install the
+        # local package (and its dependencies) into it before activating — a
+        # Python source dir doesn't carry its deps, so a direct import would fail
+        # for any recipe with third-party dependencies. Without an install dir,
+        # the package must have been provisioned by the caller.
         local_path = Path(recipes)
-        logger.info(f"Activating recipes from local path: {recipes}")
+        if _recipe_install_dir is not None:
+            logger.info(f"Installing recipes from local path: {recipes}")
+            _pip_install_local_path(local_path, _recipe_install_dir)
+        else:
+            logger.info(f"Activating recipes from local path: {recipes}")
 
         # Find and import the package
         # For local paths, we look for the package name from setup.py/pyproject.toml

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -742,7 +742,12 @@ def _pip_install_recipe_package(package_name: str, version: Optional[str], targe
         spec = f"{package_name}{version}" if version[0] in "=<>!~" else f"{package_name}=={version}"
     else:
         spec = package_name
-    cmd = [sys.executable, "-m", "pip", "install", "--target", str(target_dir), spec]
+    # --upgrade is required: `pip install --target` refuses to replace an
+    # already-populated package directory without it, otherwise leaving stale
+    # files from a previously-installed version. The caller only reaches here
+    # for a version not already present (see handle_install_recipes), so this
+    # is the version-change path that must overwrite cleanly.
+    cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "--target", str(target_dir), spec]
     logger.info(f"pip install: {' '.join(cmd)}")
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -144,6 +144,82 @@ def test_pip_install_recipe_package_comparator_spec(tmp_path, monkeypatch):
         ], f"version {version!r}: expected spec {expected_spec!r}"
 
 
+def test_pip_install_local_path_shape(tmp_path, monkeypatch):
+    # Local recipe sources are mutable, so --force-reinstall picks up changed
+    # content even when the version is unchanged, and --upgrade lets pip replace
+    # the existing files under --target. `pip install <path>` also resolves and
+    # installs the local package's dependencies — local sources don't carry them.
+    import subprocess
+
+    import rewrite.rpc.server as server
+
+    install_dir = tmp_path / "recipes"
+    local = tmp_path / "my-recipe"
+    captured = {}
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, capture_output=False, text=False):
+        captured["cmd"] = cmd
+        return FakeCompletedProcess()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    server._pip_install_local_path(local, install_dir)
+
+    assert install_dir.exists()
+    assert captured["cmd"][1:] == [
+        "-m", "pip", "install",
+        "--force-reinstall", "--upgrade",
+        "--target", str(install_dir),
+        str(local),
+    ]
+    assert str(install_dir.resolve()) in __import__("sys").path
+
+
+def test_handle_install_recipes_local_path_installs_with_deps(tmp_path, monkeypatch):
+    # A local-path install must pip-install the path (resolving its deps) when a
+    # recipe-install dir is configured. A Python source dir doesn't carry its
+    # dependencies, so importing it directly would fail for any recipe with
+    # third-party deps — unlike the prepackaged npm/NuGet local artifacts.
+    import subprocess
+
+    import rewrite.rpc.server as server
+    from rewrite.discovery import RecipeAttribution
+    from rewrite.marketplace import RecipeMarketplace
+
+    monkeypatch.setattr(server, "_marketplace", RecipeMarketplace())
+    monkeypatch.setattr(server, "_attribution", RecipeAttribution())
+    monkeypatch.setattr(server, "_recipe_install_dir", tmp_path / "install")
+
+    captured = {}
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, capture_output=False, text=False):
+        captured["cmd"] = cmd
+        return FakeCompletedProcess()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    # A bare directory (no pyproject/setup) makes _find_package_name return None,
+    # so activation is skipped — but the install must still have run.
+    local = tmp_path / "my-recipe"
+    local.mkdir()
+
+    server.handle_install_recipes({"recipes": str(local)})
+
+    assert "cmd" in captured, "expected a pip install for a local-path recipe"
+    assert "--force-reinstall" in captured["cmd"]
+    assert str(local) in captured["cmd"]
+
+
 def test_recipe_descriptor_to_dict_emits_all_collection_keys():
     from rewrite.recipe import RecipeDescriptor
     from rewrite.rpc.server import _recipe_descriptor_to_dict

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -72,10 +72,41 @@ def test_pip_install_recipe_package_shape(tmp_path, monkeypatch):
     assert install_dir.exists()
     assert captured["cmd"][1:] == [
         "-m", "pip", "install",
+        "--upgrade",
         "--target", str(install_dir),
         "openrewrite-recipes-python==1.2.3",
     ]
     assert str(install_dir.resolve()) in __import__("sys").path
+
+
+def test_pip_install_recipe_package_passes_upgrade(tmp_path, monkeypatch):
+    # `pip install --target` refuses to replace an already-populated package
+    # directory without --upgrade, silently leaving stale files from a prior
+    # version. Recipe versions are immutable, so reinstalling a version *change*
+    # into the shared install dir must overwrite cleanly.
+    import subprocess
+
+    import rewrite.rpc.server as server
+
+    install_dir = tmp_path / "recipes"
+    captured = {}
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, capture_output=False, text=False):
+        captured["cmd"] = cmd
+        return FakeCompletedProcess()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    server._pip_install_recipe_package(
+        "openrewrite-recipes-python", "1.2.3", install_dir
+    )
+
+    assert "--upgrade" in captured["cmd"]
 
 
 def test_pip_install_recipe_package_comparator_spec(tmp_path, monkeypatch):
@@ -107,6 +138,7 @@ def test_pip_install_recipe_package_comparator_spec(tmp_path, monkeypatch):
 
         assert captured["cmd"][1:] == [
             "-m", "pip", "install",
+            "--upgrade",
             "--target", str(install_dir),
             expected_spec,
         ], f"version {version!r}: expected spec {expected_spec!r}"


### PR DESCRIPTION
## What's changed?

The Python RPC server's `InstallRecipes` handler now installs recipe packages
correctly in two cases:

- **Registry installs** (`packageName`/`version`): pass `--upgrade` to
  `pip install --target` so a *version change* overwrites the prior version's
  files cleanly.
- **Local-path installs** (a path on disk): pip-install the local path into the
  recipe-install dir — with `--force-reinstall --upgrade` — so the package **and
  its dependencies** are materialized.

## What's your motivation?

Two `pip install --target` gaps:

1. `pip install --target` refuses to replace an already-populated package
   directory without `--upgrade` — it warns *"Target directory ... already
   exists. Specify --upgrade to force replacement"* and silently leaves stale
   files from the previous version. So a recipe **version upgrade** left old
   files behind.
2. The local-path (`str`) branch imported the source directly and relied on the
   caller to have installed it, so a local recipe with **third-party
   dependencies** failed at import (`ModuleNotFoundError`) — a Python source dir,
   unlike a packaged npm/NuGet artifact, doesn't carry its deps alongside it. It
   now pip-installs the path (dependencies included) when a recipe-install dir is
   configured.

## Anything in particular you'd like reviewers to focus on?

The two paths are deliberately asymmetric, matching the immutability of each:

- **Registry** versions are immutable, so the package branch stays **gated** on
  `_is_package_installed` (same-version reinstall is a no-op) and uses
  **`--upgrade` only** — no `--force-reinstall`.
- **Local** sources are mutable, so the local-path branch is **ungated** and uses
  **`--force-reinstall --upgrade`** to pick up changed content on every install.

This puts pip's local-path behavior in the same "resolve dependencies on demand"
bucket as Go's local-module install (`go mod tidy`), rather than the prepackaged
model npm/NuGet rely on.

## Have you considered any alternatives or workarounds?

- Treating local Python recipes as self-contained (npm/NuGet's prepackaged
  model): Python has no "dependencies alongside source" convention like
  `node_modules` or a .NET publish output, so that would only work for
  zero-dependency recipes.

### Checklist
- [x] I've added unit tests (command-shape and handler-wiring tests for both the registry `--upgrade` and the local-path install)
- [ ] ~~recipe conventions and best practices~~ — N/A (RPC server change, not a recipe)
- [x] Formatting verified with `ruff check` (no new findings); IntelliJ auto-formatter N/A for Python
