### PR TITLE
C#: synchronize installting CSharp.Tool to the same directory

### DIFF
--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -35,6 +35,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -182,6 +184,16 @@ public class CSharpRewriteRpc extends RewriteRpc {
     public static class Builder implements Supplier<CSharpRewriteRpc> {
         private static final String TOOL_COMMAND = "rewrite-csharp";
         private static final String NUGET_PACKAGE_ID = "OpenRewrite.CSharp.Tool";
+
+        /**
+         * Serializes tool installs within this JVM. {@code RewriteRpcProcessManager}
+         * holds one RPC per thread, so several threads can each trigger an install of
+         * the same version at once. A {@link FileLock} alone is per-JVM (a second
+         * channel lock from the same JVM throws {@code OverlappingFileLockException}
+         * rather than blocking), so cross-thread serialization needs this monitor in
+         * addition to the cross-process file lock.
+         */
+        private static final Object INSTALL_LOCK = new Object();
 
 
         private RecipeMarketplace marketplace = new RecipeMarketplace();
@@ -477,8 +489,9 @@ public class CSharpRewriteRpc extends RewriteRpc {
          * fails to authenticate against private NuGet feeds.
          * <p>
          * Uses {@code dotnet tool install --tool-path} which handles authentication
-         * correctly. The tool-path is version-specific so multiple versions can coexist
-         * without file-lock conflicts during parallel execution.
+         * correctly. The tool-path is version-specific so multiple versions can coexist;
+         * concurrent installs of the <em>same</em> version (parallel Gradle test forks
+         * hitting a fresh daily snapshot) are serialized by {@link #installToolPath}.
          */
         private Stream<@Nullable String> buildToolPathCommand(Path dotnetPath, String version) {
             Path toolPath = Paths.get(System.getProperty("user.home"),
@@ -486,7 +499,7 @@ public class CSharpRewriteRpc extends RewriteRpc {
             Path toolExecutable = toolPath.resolve(TOOL_COMMAND);
 
             if (!Files.isRegularFile(toolExecutable)) {
-                installTool(dotnetPath, version, toolPath);
+                installTool(dotnetPath, version, toolPath, toolExecutable);
             }
 
             return Stream.of(
@@ -497,7 +510,41 @@ public class CSharpRewriteRpc extends RewriteRpc {
             );
         }
 
-        private void installTool(Path dotnetPath, String version, Path toolPath) {
+        private void installTool(Path dotnetPath, String version, Path toolPath, Path toolExecutable) {
+            installToolPath(toolPath.getParent(), version, toolExecutable,
+                    () -> runDotnetInstall(dotnetPath, version, toolPath));
+        }
+
+        /**
+         * Runs {@code install} at most once for {@code toolExecutable}, serialized
+         * against other threads in this JVM and other processes on this host.
+         * {@code dotnet tool install} is not safe to run concurrently into a single
+         * {@code --tool-path}: racing installs of the same not-yet-cached version fail
+         * with "Directory not empty". Gradle runs test forks in parallel (one JVM per
+         * core), each lazily triggering an install of the same daily snapshot, so the
+         * install is guarded by an exclusive lock on a {@code <version>.lock} file in
+         * the shared tools directory. The executable presence is re-checked under the
+         * lock so a winner's install is reused rather than repeated.
+         */
+        static void installToolPath(Path toolsDir, String version, Path toolExecutable, Runnable install) {
+            synchronized (INSTALL_LOCK) {
+                try {
+                    Files.createDirectories(toolsDir);
+                    Path lockFile = toolsDir.resolve(version + ".lock");
+                    try (FileChannel channel = FileChannel.open(lockFile,
+                            StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                         FileLock ignored = channel.lock()) {
+                        if (!Files.isRegularFile(toolExecutable)) {
+                            install.run();
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Failed to install " + NUGET_PACKAGE_ID + "@" + version, e);
+                }
+            }
+        }
+
+        private void runDotnetInstall(Path dotnetPath, String version, Path toolPath) {
             Path installCwd = null;
             try {
                 Files.createDirectories(toolPath);

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/rpc/InstallToolPathConcurrencyTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/rpc/InstallToolPathConcurrencyTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.rpc;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code dotnet tool install} is not safe to run concurrently into one {@code --tool-path}.
+ * Parallel Gradle test forks (one JVM per core) each lazily install the same fresh daily
+ * snapshot, so the first install of a version races and intermittently fails with
+ * "Directory not empty". {@link CSharpRewriteRpc.Builder#installToolPath} serializes the
+ * install with a {@link java.nio.channels.FileLock} that is honored across processes.
+ * <p>
+ * This is exercised with real subprocesses because a {@code FileLock} is per-JVM — two
+ * lock attempts from one JVM throw {@code OverlappingFileLockException} instead of
+ * blocking, so cross-process serialization cannot be reproduced in a single JVM.
+ */
+class InstallToolPathConcurrencyTest {
+
+    private static final int PROCESSES = 4;
+    private static final String VERSION = "1.2.3-snapshot.test";
+
+    @Test
+    void concurrentInstallsIntoSameToolPathAreSerialized(@TempDir Path tempDir) throws Exception {
+        // given
+        Path toolsDir = tempDir.resolve("rewrite-tools");
+        Path toolExecutable = toolsDir.resolve(VERSION).resolve("rewrite-csharp");
+        Path barrier = tempDir.resolve("go");
+
+        // when
+        List<Process> processes = new ArrayList<>();
+        for (int i = 0; i < PROCESSES; i++) {
+            processes.add(new ProcessBuilder(
+                    Paths.get(System.getProperty("java.home"), "bin", "java").toString(),
+                    "-cp", System.getProperty("java.class.path"),
+                    Racer.class.getName(),
+                    toolsDir.toString(),
+                    toolExecutable.toString(),
+                    barrier.toString())
+                    .redirectErrorStream(true)
+                    .start());
+        }
+        // Release all racers at once to maximize overlap on the first (uncached) install.
+        Thread.sleep(500);
+        Files.createFile(barrier);
+
+        List<Integer> exitCodes = new ArrayList<>();
+        for (Process p : processes) {
+            assertThat(p.waitFor(60, SECONDS)).as("subprocess timed out").isTrue();
+            exitCodes.add(p.exitValue());
+        }
+
+        // then
+        assertThat(exitCodes)
+                .as("every racing install must succeed; %d indicates a detected concurrent install",
+                        Racer.EXIT_CONCURRENT)
+                .containsOnly(0);
+        assertThat(toolExecutable).exists();
+    }
+
+    /**
+     * Stands in for one Gradle test fork: it calls the production install path with a fake
+     * install that flags any overlap. With the file lock the installs are serialized (and
+     * the re-check skips redundant installs); without it the racers overlap and the loser
+     * exits {@link #EXIT_CONCURRENT}.
+     */
+    public static class Racer {
+        static final int EXIT_CONCURRENT = 2;
+
+        public static void main(String[] args) throws Exception {
+            Path toolsDir = Paths.get(args[0]);
+            Path toolExecutable = Paths.get(args[1]);
+            Path barrier = Paths.get(args[2]);
+
+            long deadline = System.nanoTime() + SECONDS.toNanos(30);
+            while (!Files.exists(barrier)) {
+                if (System.nanoTime() > deadline) {
+                    System.exit(3);
+                }
+                Thread.sleep(10);
+            }
+
+            try {
+                CSharpRewriteRpc.Builder.installToolPath(toolsDir, VERSION, toolExecutable, () -> fakeInstall(toolsDir, toolExecutable));
+            } catch (ConcurrentInstall e) {
+                System.exit(EXIT_CONCURRENT);
+            }
+            System.exit(0);
+        }
+
+        private static void fakeInstall(Path toolsDir, Path toolExecutable) {
+            Path inProgress = toolsDir.resolve("INSTALLING");
+            try {
+                Files.createDirectories(toolsDir);
+                // CREATE_NEW semantics: throws if another install is in flight.
+                Files.createFile(inProgress);
+            } catch (FileAlreadyExistsException e) {
+                throw new ConcurrentInstall();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            try {
+                Thread.sleep(500);
+                Files.createDirectories(toolExecutable.getParent());
+                Files.createFile(toolExecutable);
+                Files.delete(inProgress);
+            } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static class ConcurrentInstall extends RuntimeException {
+        }
+    }
+}


### PR DESCRIPTION
## What's changed?

Adding same-JVM synchronization for `CSharp.Tool` installation into the same directory (not to be confused with installing different versions to different directories).

## What's your motivation?

Tests suffer from a race condition resulting in flakiness in a derived module. The direct symptoms observed include:
```
    java.lang.RuntimeException: Failed to install OpenRewrite.CSharp.Tool@8.86.0-snapshot.20260618161036 to /home/runner/.dotnet/rewrite-tools/8.86.0-snapshot.20260618161036 (exit code 1): Unhandled exception: Directory not empty
        at org.openrewrite.csharp.rpc.CSharpRewriteRpc$Builder.installTool(CSharpRewriteRpc.java:538)
```