### PR TITLE
Gradle: avoid allocating a new GradleDependencies trait when nothing changes

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleDependencies.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleDependencies.java
@@ -82,7 +82,11 @@ public class GradleDependencies implements Trait<J.MethodInvocation> {
         if (arguments.isEmpty()) {
             return null;
         }
-        Cursor newCursor = new Cursor(this.cursor.getParent(), getTree().withArguments(arguments));
+        J.MethodInvocation newTree = getTree().withArguments(arguments);
+        if (getTree() == newTree) {
+            return this;
+        }
+        Cursor newCursor = new Cursor(this.cursor.getParent(), newTree);
 
         return new GradleDependencies(newCursor);
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/trait/GradleDependenciesTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/trait/GradleDependenciesTest.java
@@ -25,7 +25,9 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.trait.Trait;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
@@ -49,6 +51,45 @@ class GradleDependenciesTest implements RewriteTest {
                   return mi;
               }
           }));
+    }
+
+    @Test
+    void noNewTraitInstanceWhenNothingIsRemoved() {
+        AtomicReference<GradleDependencies> input = new AtomicReference<>();
+        AtomicReference<GradleDependencies> output = new AtomicReference<>();
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  var mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                  new GradleDependencies.Matcher().get(mi, getCursor().getParent()).ifPresent(deps -> {
+                      input.set(deps);
+                      // Try to remove a dependency that is not present, so nothing should change.
+                      output.set(deps.removeDependency("com.example", "does-not-exist"));
+                  });
+                  return mi;
+              }
+          })),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation 'org.apache.commons:commons-lang3:3.17.0'
+              }
+              """
+          )
+        );
+
+        assertThat(input.get()).isNotNull();
+        // When no statement is removed, no new trait (or underlying tree) should be allocated.
+        assertThat(output.get())
+          .as("removeDependency should return the same instance when nothing changes")
+          .isSameAs(input.get());
     }
 
     @DocumentExample


### PR DESCRIPTION
## What's changed

`GradleDependencies.mapStatements` always allocated a brand-new `GradleDependencies` trait, even when the mapping produced no change to the underlying `J.MethodInvocation`. Because `ListUtils.mapFirst` and `J.MethodInvocation.withArguments` already return the identical instance when nothing changes, the wrapper allocation was wasteful and broke reference-identity expectations for callers (e.g. recipes that check whether a trait actually changed).

This change returns `this` when `withArguments` yields the same tree:

```java
J.MethodInvocation newTree = getTree().withArguments(arguments);
if (getTree() == newTree) {
    return this;
}
```

## Test

`GradleDependenciesTest#noNewTraitInstanceWhenNothingIsRemoved` calls `removeDependency` for a dependency that is not present and asserts the returned trait is the **same instance** (`isSameAs`).

- With the fix: the test passes.
- Reverting the fix (always constructing a new `GradleDependencies`): the test fails because a new instance is allocated.
