### PR TITLE
JavaScript: shutdown current RPC in integration tests

### DIFF
--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaToJavaScriptRpcTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaToJavaScriptRpcTest.java
@@ -60,7 +60,7 @@ public class JavaToJavaScriptRpcTest {
                           stopAfterPreVisit();
                           return tree;
                       } finally {
-                          client.shutdown();
+                          JavaScriptRewriteRpc.shutdownCurrent();
                       }
                   }
               };


### PR DESCRIPTION
## What's changed?

Changing the JavaScript rewrite RPC test to use `JavaScriptRewriteRpc.shutdownCurrent` in the `finally` section.

## What's your motivation?

Otherwise the first test execution shuts down the RPC with no recovery for any subsequent (passing or failing tests). And all the subsequent tests fail with:
```
java.lang.AssertionError: Failed to parse sources or run recipe
Caused by: java.lang.IllegalStateException: RPC process shut down early with exit code 0
```