### PR TITLE
JavaScript: handle pnpm lock file version 9 too

### DIFF
--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/LockFileParserParityTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/LockFileParserParityTest.java
@@ -182,9 +182,11 @@ class LockFileParserParityTest {
     void parityPnpmTinyProject() throws Exception {
         Assumptions.assumeTrue(PackageManagerExecutor.PNPM.find() != null,
                 "pnpm not installed");
+        // No `packageManager` pin: use whatever pnpm is installed. The adapter handles both
+        // the lockfileVersion 6.0 (pnpm 8.x) and 9.0 (pnpm 9.x/10.x) formats, so we don't force
+        // corepack to download a specific old pnpm — that download crashes on newer Node runtimes.
         String packageJson = "{\n" +
                 "  \"name\": \"parity-pnpm\",\n" +
-                "  \"packageManager\": \"pnpm@8.15.4\",\n" +
                 "  \"dependencies\": { \"is-even\": \"1.0.0\" }\n" +
                 "}\n";
         Set<String> javaSet = parseLockInJavaForPm(packageJson, PackageManager.Pnpm);

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PnpmLockAdapter.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PnpmLockAdapter.java
@@ -29,8 +29,14 @@ import java.util.Set;
  * Converts a {@code pnpm-lock.yaml} into the npm v3 shape consumed by
  * {@link LockFileParser}.
  * <p>
- * pnpm-lock.yaml has explicit root-level top-level deps:
- * <pre>
+ * Three on-disk formats are supported:
+ * <ul>
+ *   <li><b>lockfileVersion 5.x</b> (pnpm 7.x and earlier) lists top-level deps at the root and
+ *   keys packages with a leading slash but a <em>slash</em> separating name and version
+ *   ({@code /lodash/4.17.21}), with the peer-dep suffix introduced by {@code _}.</li>
+ *   <li><b>lockfileVersion 6.0</b> (pnpm 8.x) lists top-level deps at the root and
+ *   keys packages with a leading slash, with dependencies inlined:
+ *   <pre>
  *   dependencies:
  *     lodash:
  *       specifier: ^4.17.21
@@ -38,10 +44,26 @@ import java.util.Set;
  *   packages:
  *     /lodash@4.17.21:
  *       resolution: {...}
- * </pre>
- * Top-level packages (those listed at root) get {@code node_modules/&lt;name&gt;}
- * paths; everything else in the {@code packages} map goes to a synthetic nested
- * path so it's preserved in {@code all} but not in {@code topLevel}.
+ *   </pre></li>
+ *   <li><b>lockfileVersion 9.0</b> (pnpm 9.x/10.x) moves top-level deps under
+ *   {@code importers} and splits package metadata (in {@code packages}, keyed
+ *   <em>without</em> a leading slash) from the dependency graph (in {@code snapshots}):
+ *   <pre>
+ *   importers:
+ *     .:
+ *       dependencies:
+ *         lodash: {specifier: ^4.17.21, version: 4.17.21}
+ *   packages:
+ *     lodash@4.17.21:
+ *       resolution: {...}
+ *   snapshots:
+ *     lodash@4.17.21: {}
+ *   </pre></li>
+ * </ul>
+ * Top-level packages (those listed at the root or under {@code importers}) get
+ * {@code node_modules/&lt;name&gt;} paths; everything else in the {@code packages} map
+ * goes to a synthetic nested path so it's preserved in {@code all} but not in
+ * {@code topLevel}.
  * <p>
  * pnpm encodes peer-dep variants in its package keys: {@code /foo@1.0.0(react@18.0.0)}.
  * The peer-dep suffix is stripped during name/version extraction.
@@ -65,12 +87,27 @@ public final class PnpmLockAdapter {
         }
         Map<String, Object> rootMap = (Map<String, Object>) loaded;
 
-        // Collect the names of top-level deps from the four root scopes.
+        // Collect the names of top-level deps. lockfileVersion 6.0 lists them at the root;
+        // 9.0 nests them under `importers.<dir>`. Reading both keeps the adapter format-agnostic.
         Set<String> topLevelNames = new LinkedHashSet<>();
-        collectScopeNames(rootMap.get("dependencies"), topLevelNames);
-        collectScopeNames(rootMap.get("devDependencies"), topLevelNames);
-        collectScopeNames(rootMap.get("peerDependencies"), topLevelNames);
-        collectScopeNames(rootMap.get("optionalDependencies"), topLevelNames);
+        collectAllScopeNames(rootMap, topLevelNames);
+        Object importers = rootMap.get("importers");
+        if (importers instanceof Map) {
+            for (Object importer : ((Map<String, Object>) importers).values()) {
+                if (importer instanceof Map) {
+                    collectAllScopeNames((Map<String, Object>) importer, topLevelNames);
+                }
+            }
+        }
+
+        // lockfileVersion 9.0 moves the dependency graph out of `packages` and into `snapshots`,
+        // keyed by the same package key. Older formats inline dependencies in each package body.
+        Object snapshotsObj = rootMap.get("snapshots");
+        Map<String, Object> snapshots = snapshotsObj instanceof Map ? (Map<String, Object>) snapshotsObj : null;
+
+        // pnpm 7 and earlier (lockfileVersion 5.x) separate name and version with a slash
+        // (`/is-even/1.0.0`) rather than the `@` used from 6.0 onward, so they need a different key parser.
+        boolean legacyKeys = lockfileVersion(rootMap.get("lockfileVersion")) < 6;
 
         ObjectNode root = MAPPER.createObjectNode();
         root.put("lockfileVersion", 3);
@@ -93,7 +130,7 @@ public final class PnpmLockAdapter {
             if (!(entry.getValue() instanceof Map)) {
                 continue;
             }
-            NameVersion nv = parsePackageKey(entry.getKey());
+            NameVersion nv = legacyKeys ? parseLegacyPackageKey(entry.getKey()) : parsePackageKey(entry.getKey());
             if (nv == null) {
                 continue;
             }
@@ -110,6 +147,12 @@ public final class PnpmLockAdapter {
             npmEntry.put("version", nv.version);
 
             Object deps = body.get("dependencies");
+            if (!(deps instanceof Map) && snapshots != null) {
+                Object snapshot = snapshots.get(entry.getKey());
+                if (snapshot instanceof Map) {
+                    deps = ((Map<String, Object>) snapshot).get("dependencies");
+                }
+            }
             if (deps instanceof Map && !((Map<?, ?>) deps).isEmpty()) {
                 ObjectNode depsNode = npmEntry.putObject("dependencies");
                 for (Map.Entry<String, Object> d : ((Map<String, Object>) deps).entrySet()) {
@@ -125,6 +168,13 @@ public final class PnpmLockAdapter {
         }
     }
 
+    private static void collectAllScopeNames(Map<String, Object> source, Set<String> sink) {
+        collectScopeNames(source.get("dependencies"), sink);
+        collectScopeNames(source.get("devDependencies"), sink);
+        collectScopeNames(source.get("peerDependencies"), sink);
+        collectScopeNames(source.get("optionalDependencies"), sink);
+    }
+
     @SuppressWarnings("unchecked")
     private static void collectScopeNames(Object scope, Set<String> sink) {
         if (scope instanceof Map) {
@@ -134,14 +184,16 @@ public final class PnpmLockAdapter {
 
     /**
      * Parse a pnpm package key like {@code /lodash@4.17.21}, {@code /@types/node@20.0.0},
-     * or {@code /react-redux@8.0.5(react@18.2.0)}. Returns null for unrecognized shapes.
+     * or {@code /react-redux@8.0.5(react@18.2.0)}. The leading slash is present in
+     * lockfileVersion 6.0 and absent in 9.0, so it is optional. Returns null for
+     * unrecognized shapes.
      */
     static NameVersion parsePackageKey(String key) {
-        if (key == null || !key.startsWith("/")) {
+        if (key == null || key.isEmpty()) {
             return null;
         }
-        // Strip the leading '/'.
-        String body = key.substring(1);
+        // Strip the leading '/' when present (lockfileVersion 6.0).
+        String body = key.startsWith("/") ? key.substring(1) : key;
         // Strip the trailing peer-dep suffix '(...)' if present.
         int parenStart = body.indexOf('(');
         if (parenStart >= 0) {
@@ -160,6 +212,53 @@ public final class PnpmLockAdapter {
         String name = body.substring(0, atIdx);
         String version = body.substring(atIdx + 1);
         return new NameVersion(name, version);
+    }
+
+    /**
+     * Parse a legacy pnpm package key (lockfileVersion 5.x and earlier) like
+     * {@code /lodash/4.17.21}, {@code /@types/node/20.0.0}, or
+     * {@code /react-redux/8.0.5_react@18.2.0}, where name and version are separated by a
+     * slash and the peer-dep suffix is introduced with {@code _}. Returns null for
+     * unrecognized shapes.
+     */
+    static NameVersion parseLegacyPackageKey(String key) {
+        if (key == null || !key.startsWith("/")) {
+            return null;
+        }
+        String body = key.substring(1);
+        // Name and version are separated by the last '/'; everything before it is the
+        // (possibly scoped) name.
+        int lastSlash = body.lastIndexOf('/');
+        if (lastSlash <= 0 || lastSlash == body.length() - 1) {
+            return null;
+        }
+        String name = body.substring(0, lastSlash);
+        String version = body.substring(lastSlash + 1);
+        // Strip the peer-dep suffix '_...' from the version segment.
+        int underscore = version.indexOf('_');
+        if (underscore >= 0) {
+            version = version.substring(0, underscore);
+        }
+        return version.isEmpty() ? null : new NameVersion(name, version);
+    }
+
+    /**
+     * Reads the {@code lockfileVersion} field, which snakeyaml surfaces either as a number
+     * (e.g. {@code 5.4}) or a quoted string (e.g. {@code '6.0'}). Unknown values default to a
+     * modern version so the {@code @}-style key parser is used.
+     */
+    private static double lockfileVersion(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Double.parseDouble((String) value);
+            } catch (NumberFormatException ignored) {
+                // Fall through to the modern default.
+            }
+        }
+        return 6;
     }
 
     private static String asString(Object o) {

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/PnpmLockAdapterTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/PnpmLockAdapterTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.javascript.internal;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.javascript.marker.NodeResolutionResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -147,6 +148,165 @@ class PnpmLockAdapterTest {
 
         assertThat(result.getTopLevel().keySet())
                 .containsExactlyInAnyOrder("prod-dep", "dev-dep", "peer-dep");
+    }
+
+    @Test
+    void convertsLockfileVersion5TopLevelAndTransitive() {
+        // pnpm 7.x and earlier: name and version are separated by '/', not '@'.
+        String pnpm = "lockfileVersion: 5.4\n" +
+                "\n" +
+                "specifiers:\n" +
+                "  is-even: 1.0.0\n" +
+                "\n" +
+                "dependencies:\n" +
+                "  is-even: 1.0.0\n" +
+                "\n" +
+                "packages:\n" +
+                "\n" +
+                "  /is-even/1.0.0:\n" +
+                "    resolution: {integrity: sha512-x}\n" +
+                "    engines: {node: '>=0.10.0'}\n" +
+                "    dependencies:\n" +
+                "      is-odd: 0.1.2\n" +
+                "    dev: false\n" +
+                "\n" +
+                "  /is-odd/0.1.2:\n" +
+                "    resolution: {integrity: sha512-y}\n" +
+                "    dev: false\n";
+        String npm = PnpmLockAdapter.toNpmV3(pnpm);
+        LockFileParser.ParseResult result = LockFileParser.parse(npm);
+
+        assertThat(result.getAll())
+                .extracting(d -> d.getName() + "@" + d.getVersion())
+                .containsExactlyInAnyOrder("is-even@1.0.0", "is-odd@0.1.2");
+        // Only is-even is top-level; is-odd is transitive.
+        assertThat(result.getTopLevel()).containsOnlyKeys("is-even");
+        assertThat(result.getTopLevel().get("is-even").getDependencies())
+                .extracting(NodeResolutionResult.Dependency::getName)
+                .containsExactly("is-odd");
+    }
+
+    @Test
+    void convertsLockfileVersion5ScopedAndPeerSuffix() {
+        String pnpm = "lockfileVersion: 5.4\n" +
+                "\n" +
+                "dependencies:\n" +
+                "  '@scope/foo': 1.0.0\n" +
+                "\n" +
+                "packages:\n" +
+                "\n" +
+                "  /@scope/foo/1.0.0_react@18.2.0:\n" +
+                "    resolution: {integrity: sha512-x}\n" +
+                "    dev: false\n";
+        String npm = PnpmLockAdapter.toNpmV3(pnpm);
+        LockFileParser.ParseResult result = LockFileParser.parse(npm);
+
+        assertThat(result.getAll().get(0).getName()).isEqualTo("@scope/foo");
+        assertThat(result.getAll().get(0).getVersion()).isEqualTo("1.0.0");
+        assertThat(result.getTopLevel()).containsKey("@scope/foo");
+    }
+
+    @Test
+    void parseLegacyPackageKeyHandlesShapes() {
+        var simple = PnpmLockAdapter.parseLegacyPackageKey("/lodash/4.17.21");
+        assertThat(simple).isNotNull();
+        assertThat(simple.name).isEqualTo("lodash");
+        assertThat(simple.version).isEqualTo("4.17.21");
+
+        var scoped = PnpmLockAdapter.parseLegacyPackageKey("/@types/node/20.0.0");
+        assertThat(scoped).isNotNull();
+        assertThat(scoped.name).isEqualTo("@types/node");
+        assertThat(scoped.version).isEqualTo("20.0.0");
+
+        var peer = PnpmLockAdapter.parseLegacyPackageKey("/react-redux/8.0.5_react@18.2.0");
+        assertThat(peer).isNotNull();
+        assertThat(peer.name).isEqualTo("react-redux");
+        assertThat(peer.version).isEqualTo("8.0.5");
+
+        assertThat(PnpmLockAdapter.parseLegacyPackageKey("/no-version-suffix")).isNull();
+        assertThat(PnpmLockAdapter.parseLegacyPackageKey("not-a-valid-key")).isNull();
+        assertThat(PnpmLockAdapter.parseLegacyPackageKey("")).isNull();
+        assertThat(PnpmLockAdapter.parseLegacyPackageKey(null)).isNull();
+    }
+
+    @Test
+    void convertsLockfileVersion9TopLevelAndTransitive() {
+        // pnpm 9.x/10.x: top-level deps live under `importers`, package keys have no
+        // leading slash, and the dependency graph lives in `snapshots`.
+        String pnpm = "lockfileVersion: '9.0'\n" +
+                "\n" +
+                "importers:\n" +
+                "\n" +
+                "  .:\n" +
+                "    dependencies:\n" +
+                "      is-even:\n" +
+                "        specifier: 1.0.0\n" +
+                "        version: 1.0.0\n" +
+                "\n" +
+                "packages:\n" +
+                "\n" +
+                "  is-even@1.0.0:\n" +
+                "    resolution: {integrity: sha512-x}\n" +
+                "    engines: {node: '>=0.10.0'}\n" +
+                "\n" +
+                "  is-odd@0.1.2:\n" +
+                "    resolution: {integrity: sha512-y}\n" +
+                "\n" +
+                "snapshots:\n" +
+                "\n" +
+                "  is-even@1.0.0:\n" +
+                "    dependencies:\n" +
+                "      is-odd: 0.1.2\n" +
+                "\n" +
+                "  is-odd@0.1.2: {}\n";
+        String npm = PnpmLockAdapter.toNpmV3(pnpm);
+        LockFileParser.ParseResult result = LockFileParser.parse(npm);
+
+        assertThat(result.getAll())
+                .extracting(d -> d.getName() + "@" + d.getVersion())
+                .containsExactlyInAnyOrder("is-even@1.0.0", "is-odd@0.1.2");
+        // Only is-even is top-level; is-odd is transitive.
+        assertThat(result.getTopLevel()).containsOnlyKeys("is-even");
+        assertThat(result.getTopLevel().get("is-even").getDependencies())
+                .extracting(NodeResolutionResult.Dependency::getName)
+                .containsExactly("is-odd");
+    }
+
+    @Test
+    void convertsLockfileVersion9ScopedAndPeerSuffix() {
+        String pnpm = "lockfileVersion: '9.0'\n" +
+                "\n" +
+                "importers:\n" +
+                "\n" +
+                "  .:\n" +
+                "    dependencies:\n" +
+                "      '@scope/foo':\n" +
+                "        specifier: ^1.0.0\n" +
+                "        version: 1.0.0(react@18.2.0)\n" +
+                "\n" +
+                "packages:\n" +
+                "\n" +
+                "  '@scope/foo@1.0.0':\n" +
+                "    resolution: {integrity: sha512-x}\n";
+        String npm = PnpmLockAdapter.toNpmV3(pnpm);
+        LockFileParser.ParseResult result = LockFileParser.parse(npm);
+
+        assertThat(result.getAll().get(0).getName()).isEqualTo("@scope/foo");
+        assertThat(result.getAll().get(0).getVersion()).isEqualTo("1.0.0");
+        assertThat(result.getTopLevel()).containsKey("@scope/foo");
+    }
+
+    @Test
+    void parsePackageKeyHandlesNoLeadingSlash() {
+        var nv = PnpmLockAdapter.parsePackageKey("is-even@1.0.0");
+        assertThat(nv).isNotNull();
+        assertThat(nv.name).isEqualTo("is-even");
+        assertThat(nv.version).isEqualTo("1.0.0");
+
+        var scoped = PnpmLockAdapter.parsePackageKey("@types/node@20.0.0");
+        assertThat(scoped).isNotNull();
+        assertThat(scoped.name).isEqualTo("@types/node");
+        assertThat(scoped.version).isEqualTo("20.0.0");
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

Adding support for pnpm lock file version 9, used by pnpm 9.x and 10.x

## What's your motivation?

The direct trigger was observing failures like:
```
pnpm install failed (exit 1): node:internal/bootstrap/...
```
but the solution applied is broader.