### PR TITLE
`ChangePackage`: cheaper javadoc reference precondition scan

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -539,28 +539,44 @@ public class ChangePackage extends Recipe {
 
     private static boolean hasJavadocReferenceToPackage(JavaSourceFile cu, String packageName, boolean recursive, String recursivePrefix) {
         return new JavaIsoVisitor<AtomicBoolean>() {
+            boolean inJavadocReference;
+
+            @Override
+            public @Nullable J visit(@Nullable Tree tree, AtomicBoolean f) {
+                // Once a matching reference is found, skip the rest of the traversal.
+                return f.get() ? (J) tree : super.visit(tree, f);
+            }
+
+            @Override
+            protected JavadocVisitor<AtomicBoolean> getJavadocVisitor() {
+                // Field accesses only carry a fully qualified package reference worth checking when
+                // they appear inside a Javadoc reference, so let the Javadoc delegate flag that scope
+                // rather than re-walking each field access's ancestors during the descent.
+                return new JavadocVisitor<AtomicBoolean>(this) {
+                    @Override
+                    public Javadoc visitReference(Javadoc.Reference reference, AtomicBoolean f) {
+                        inJavadocReference = true;
+                        try {
+                            return super.visitReference(reference, f);
+                        } finally {
+                            inJavadocReference = false;
+                        }
+                    }
+                };
+            }
+
             @Override
             public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, AtomicBoolean f) {
-                if (f.get()) {
-                    return fieldAccess;
-                }
-                for (Iterator<?> it = getCursor().getPath(); it.hasNext(); ) {
-                    Object o = it.next();
-                    if (o instanceof Javadoc.Reference) {
-                        JavaType type = fieldAccess.getType();
-                        if (type instanceof JavaType.FullyQualified) {
-                            String pkg = ((JavaType.FullyQualified) type).getPackageName();
-                            if (pkg.equals(packageName) || recursive && pkg.startsWith(recursivePrefix)) {
-                                f.set(true);
-                            }
+                if (inJavadocReference && !f.get()) {
+                    JavaType type = fieldAccess.getType();
+                    if (type instanceof JavaType.FullyQualified) {
+                        String pkg = ((JavaType.FullyQualified) type).getPackageName();
+                        if (pkg.equals(packageName) || recursive && pkg.startsWith(recursivePrefix)) {
+                            f.set(true);
                         }
-                        break;
-                    }
-                    if (o instanceof J.Block) {
-                        break;
                     }
                 }
-                return fieldAccess;
+                return super.visitFieldAccess(fieldAccess, f);
             }
         }.reduce(cu, new AtomicBoolean()).get();
     }


### PR DESCRIPTION
## Motivation

- `ChangePackage` runs its precondition on every Java source file, and the precondition is meant to be a cheap filter that rejects files not referencing the target package. PR #7284 added a fallback Javadoc scan (`hasJavadocReferenceToPackage`) to catch fully qualified `{@link}` references that `TypesInUse` deliberately omits. That scan runs on every file that did not already match by package declaration, import, or types-in-use — i.e. the overwhelming majority of files in a typical run — and for *every* `J.FieldAccess` in the compilation unit it walked the cursor's ancestors to determine whether the access sat inside a `Javadoc.Reference`. On the critical path this showed up in the profiler: a per-field-access ancestor walk across otherwise unrelated source.

This keeps the precondition self-contained (no change to `TypesInUse`) but makes the scan itself cheap.

## Summary

- Override `getJavadocVisitor()` so the `JavadocVisitor` delegate flags when traversal is inside a `Javadoc.Reference`, instead of re-deriving that per field access. `JavadocVisitor.visitReference` already delegates the reference's tree back to the main visitor, so `visitFieldAccess` still fires for references — but the in-Javadoc check collapses from an ancestor-path walk to a single boolean read.
- `visitFieldAccess` still calls `super`, so descent continues through field-access targets — Javadoc on an anonymous subclass nested anywhere is still reached; no subtree is pruned.
- Short-circuit the remaining traversal once a matching reference is found.

## Test plan

- [x] `./gradlew :rewrite-java-test:test --tests "org.openrewrite.java.ChangePackageTest"` passes, including the fully qualified `{@link}` and recursive-package-reference cases added in #7284.
