### PR TITLE
JavaScript: Yarn Berry to use Corepack

### DIFF
--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/DependencyWorkspace.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/DependencyWorkspace.java
@@ -136,12 +136,17 @@ class DependencyWorkspace {
                 try {
                     Files.move(tempDir, workspaceDir);
                 } catch (IOException e) {
-                    // If move fails, another thread might have created it
+                    // The move can fail because another thread already created the workspace, or
+                    // because a stale/corrupt directory (e.g. one missing package.json from an
+                    // interrupted prior run) is occupying the target.
                     if (isWorkspaceValid(workspaceDir)) {
                         // Use the other thread's workspace
                         cleanupDirectory(tempDir);
                     } else {
-                        throw e;
+                        // Target is stale/invalid; replace it with our freshly built workspace so a
+                        // corrupt directory can't permanently wedge workspace creation.
+                        cleanupDirectory(workspaceDir);
+                        Files.move(tempDir, workspaceDir);
                     }
                 }
 
@@ -183,8 +188,18 @@ class DependencyWorkspace {
                 args = new String[]{"install", "--ignore-scripts"};
                 break;
             case YarnBerry:
-                executor = PackageManagerExecutor.YARN;
-                args = new String[]{"install", "--mode", "skip-build"};
+                // Yarn Berry projects pin their version via the package.json "packageManager"
+                // field and rely on Corepack to provision it. A global Yarn Classic refuses to
+                // run such a project, so prefer Corepack when it is available and fall back to a
+                // plain yarn otherwise (e.g. when the yarn on PATH is already a Corepack shim).
+                String corepackExe = PackageManagerExecutor.COREPACK.find();
+                if (corepackExe != null) {
+                    executor = PackageManagerExecutor.COREPACK;
+                    args = new String[]{"yarn", "install", "--mode", "skip-build"};
+                } else {
+                    executor = PackageManagerExecutor.YARN;
+                    args = new String[]{"install", "--mode", "skip-build"};
+                }
                 break;
             case Pnpm:
                 executor = PackageManagerExecutor.PNPM;

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PackageManagerExecutor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PackageManagerExecutor.java
@@ -41,6 +41,7 @@ public final class PackageManagerExecutor {
     public static final PackageManagerExecutor YARN = new PackageManagerExecutor("yarn", 120);
     public static final PackageManagerExecutor PNPM = new PackageManagerExecutor("pnpm", 120);
     public static final PackageManagerExecutor BUN  = new PackageManagerExecutor("bun",  120);
+    public static final PackageManagerExecutor COREPACK = new PackageManagerExecutor("corepack", 120);
 
     private static final boolean IS_WINDOWS =
             System.getProperty("os.name").toLowerCase().contains("windows");

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/YarnBerryLockAdapter.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/YarnBerryLockAdapter.java
@@ -73,11 +73,20 @@ public final class YarnBerryLockAdapter {
             if ("__metadata".equals(entry.getKey())) {
                 continue;
             }
+            // Workspace entries (the project itself and any sibling workspace packages) use the
+            // "@workspace:" protocol and are not real installed dependencies; npm v3 represents the
+            // root under the "" key, so they must be skipped to stay in parity with the RPC marker.
+            if (entry.getKey().contains("@workspace:")) {
+                continue;
+            }
             if (!(entry.getValue() instanceof Map)) {
                 continue;
             }
             Map<String, Object> body = (Map<String, Object>) entry.getValue();
             String resolution = asString(body.get("resolution"));
+            if (resolution != null && resolution.contains("@workspace:")) {
+                continue;
+            }
             String version = asString(body.get("version"));
             // Prefer name from resolution (canonical); fallback to key.
             String name = extractName(resolution != null ? resolution : entry.getKey());


### PR DESCRIPTION
## What's changed?

Fixing JavaScript's Yarn Berry support by:
- using Corepack for Yarn Berry
- skipping `@workspace` entries
- dealing with stale/corrupt cached workspace on disk

## What's your motivation?

Fixing a broken integration test: `LockFileParserParityTest.parityYarnBerryTinyProject`