### PR TITLE
JavaScript: first prefer the `npm` next to the current `node`

### DIFF
--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PackageManagerExecutor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PackageManagerExecutor.java
@@ -108,27 +108,84 @@ public final class PackageManagerExecutor {
 
     /**
      * Find the executable on the system, returning {@code null} if not installed.
-     * Searches standard install locations first, then falls back to {@code which <name>}.
+     * <p>
+     * Resolution order, most to least preferred:
+     * <ol>
+     *     <li>The executable co-located with the active {@code node}. Package managers
+     *     re-invoke node through a {@code #!/usr/bin/env node} shebang, so the one sitting
+     *     next to the node on PATH is guaranteed to run under a compatible runtime. This
+     *     prevents npm's {@code validate-engines} failure (exit 7) when a hardcoded npm is
+     *     newer or older than the node that actually executes it.</li>
+     *     <li>The executable resolved through PATH ({@code which}/{@code where}), which
+     *     stays consistent with the user's shell environment (nvm, fnm, volta, ...).</li>
+     *     <li>Common install locations, for processes launched with a minimal PATH
+     *     (e.g. GUI-launched IDEs on macOS).</li>
+     * </ol>
      */
     public @Nullable String find() {
         if (cachedPath != null) {
             return cachedPath;
         }
         String exeName = IS_WINDOWS ? name + ".cmd" : name;
-        String[] locations = {
-                System.getProperty("user.home") + "/.local/bin/" + exeName,
-                "/opt/homebrew/bin/" + exeName,
-                "/usr/local/bin/" + exeName,
-                "/usr/bin/" + exeName
-        };
-        for (String location : locations) {
+
+        Path nodeDir = activeNodeDir();
+        if (nodeDir != null) {
+            Path colocated = nodeDir.resolve(exeName);
+            if (Files.isExecutable(colocated)) {
+                cachedPath = colocated.toAbsolutePath().toString();
+                return cachedPath;
+            }
+        }
+
+        String onPath = which(exeName);
+        if (onPath != null) {
+            cachedPath = onPath;
+            return cachedPath;
+        }
+
+        for (String location : standardLocations(exeName)) {
             Path path = Paths.get(location);
             if (Files.isExecutable(path)) {
                 cachedPath = path.toAbsolutePath().toString();
                 return cachedPath;
             }
         }
+        return null;
+    }
 
+    /** Directory of the {@code node} that will execute the package manager, or {@code null}. */
+    private static @Nullable Path activeNodeDir() {
+        String nodeExe = IS_WINDOWS ? "node.exe" : "node";
+        String onPath = which(nodeExe);
+        if (onPath != null) {
+            Path parent = Paths.get(onPath).toAbsolutePath().getParent();
+            if (parent != null) {
+                return parent;
+            }
+        }
+        for (String location : standardLocations(nodeExe)) {
+            Path path = Paths.get(location);
+            if (Files.isExecutable(path)) {
+                Path parent = path.toAbsolutePath().getParent();
+                if (parent != null) {
+                    return parent;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String[] standardLocations(String exeName) {
+        return new String[]{
+                System.getProperty("user.home") + "/.local/bin/" + exeName,
+                "/opt/homebrew/bin/" + exeName,
+                "/usr/local/bin/" + exeName,
+                "/usr/bin/" + exeName
+        };
+    }
+
+    /** Resolve an executable through the shell's PATH, returning {@code null} if not found. */
+    static @Nullable String which(String exeName) {
         try {
             ProcessBuilder pb = new ProcessBuilder(IS_WINDOWS ? "where" : "which", exeName);
             pb.redirectErrorStream(true);
@@ -143,12 +200,13 @@ public final class PackageManagerExecutor {
                 }
                 String output = sb.toString().trim();
                 if (process.waitFor() == 0 && !output.isEmpty()) {
-                    cachedPath = output;
-                    return cachedPath;
+                    return output;
                 }
             }
-        } catch (IOException | InterruptedException e) {
+        } catch (IOException e) {
             // Ignore and return null below.
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
         return null;
     }

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/PackageManagerExecutorTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/PackageManagerExecutorTest.java
@@ -17,7 +17,11 @@ package org.openrewrite.javascript.internal;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class PackageManagerExecutorTest {
 
@@ -35,5 +39,22 @@ class PackageManagerExecutorTest {
         PackageManagerExecutor missing =
                 PackageManagerExecutor.forTesting("definitely-not-a-real-binary-2026", 30);
         assertThat(missing.find()).isNull();
+    }
+
+    @Test
+    void npmResolvesAlongsideTheActiveNode() {
+        // given the node that will actually execute npm (npm re-invokes node via its
+        // `#!/usr/bin/env node` shebang, so it must run under a compatible runtime)
+        String node = PackageManagerExecutor.which("node");
+        assumeTrue(node != null, "node must be installed to validate the npm/node pairing");
+        Path nodeDir = Paths.get(node).toAbsolutePath().getParent();
+
+        // when locating npm
+        String npm = PackageManagerExecutor.NPM.find();
+        assumeTrue(npm != null, "npm must be installed");
+
+        // then it lives next to that node rather than some unrelated install whose
+        // engines may reject the active node (npm validate-engines, exit 7)
+        assertThat(Paths.get(npm).toAbsolutePath().getParent()).isEqualTo(nodeDir);
     }
 }


### PR DESCRIPTION
## What's changed?

Changing how `PackageManagerExtension` picks `npm` to be used.
Now the top priority is the `npm` next to the currently used `node`.

## What's your motivation?

The direct trigger to my change was failing integration test of `org.openrewrite.javascript.search.DependencyInsightTest.wildcardMatchesAllDirectDependencies` which failed with `npm install failed (exit 7): .../npm/lib/cli/validate-engines.js`