### PR TITLE
JavaScript: close PackageManagerExtension's pnpm stdin

### DIFF
--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PackageManagerExecutor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PackageManagerExecutor.java
@@ -87,6 +87,12 @@ public final class PackageManagerExecutor {
 
         Process process = pb.start();
 
+        // Close the child's stdin so any prompt sees EOF immediately instead of blocking forever.
+        // ProcessBuilder leaves stdin as an open pipe that never receives data or EOF; a package
+        // manager that reads stdin (e.g. pnpm during a cold-store install) would otherwise hang
+        // until the timeout. This mirrors the TS side's spawnSync, which feeds an empty stdin.
+        process.getOutputStream().close();
+
         StringBuilder stdout = new StringBuilder();
         StringBuilder stderr = new StringBuilder();
         Thread stdoutReader = new Thread(() -> drain(process.getInputStream(), stdout));

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/PackageManagerExecutorTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/PackageManagerExecutorTest.java
@@ -19,9 +19,12 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static java.time.Duration.ofSeconds;
 
 class PackageManagerExecutorTest {
 
@@ -39,6 +42,26 @@ class PackageManagerExecutorTest {
         PackageManagerExecutor missing =
                 PackageManagerExecutor.forTesting("definitely-not-a-real-binary-2026", 30);
         assertThat(missing.find()).isNull();
+    }
+
+    @Test
+    void closesChildStdinSoStdinReadingProcessesDoNotHang() {
+        // given a process whose timeout is far longer than this test is willing to wait, running a
+        // command that reads stdin until EOF (`cat`). If stdin stayed an open pipe it would block
+        // until the timeout, the exact failure mode behind pnpm's cold-store install hang.
+        assumeTrue(!System.getProperty("os.name").toLowerCase().contains("windows"),
+                "uses the POSIX `cat` to read stdin to EOF");
+        String cat = PackageManagerExecutor.which("cat");
+        assumeTrue(cat != null, "cat must be available");
+        PackageManagerExecutor executor = PackageManagerExecutor.forTesting("cat", 120);
+
+        // when run with no input provided
+        PackageManagerExecutor.RunResult result = assertTimeoutPreemptively(ofSeconds(15), () ->
+                executor.run(Paths.get("."), cat, Collections.<String, String>emptyMap()));
+
+        // then it sees EOF immediately and exits cleanly rather than hanging on the open pipe
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getExitCode()).isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

In JavaScript's PackageManagerExtension provide no stdout (stdin from subprocess perspective).

## What's your motivation?

Otherwise it might hang waiting for input if pnpm does a cold-store install (like in CI).
And as a result the `LockFileParserParityTest.parityPnpmTinyProject()` might fail with timeout.