### PR TITLE
Scala: fix handling the case of an extra semicolon at the end of the …

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -8757,6 +8757,13 @@ class ScalaTreeVisitor(
    */
   private def consumeTrailingSemicolon(statEnd: Int, nextStart: Int): (Space, Markers) = {
     val trailStart = Math.max(statEnd, cursor)
+    // When the statement's rhs sits on its own line, Dotty extends the statement
+    // span to include the trailing `;`, so the cursor already moved past it. The
+    // forward scan below would miss it, dropping the explicit separator on print.
+    // Recognize that already-absorbed `;` here so it is preserved via the marker.
+    if (trailStart > 0 && trailStart <= source.length && source.charAt(trailStart - 1) == ';') {
+      return (Space.EMPTY, Markers.EMPTY.add(new Semicolon(Tree.randomId())))
+    }
     if (trailStart >= nextStart || nextStart > source.length) {
       return (Space.EMPTY, Markers.EMPTY)
     }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
@@ -45,6 +45,22 @@ class CompilationUnitTest implements RewriteTest {
     }
 
     @Test
+    void trailingSemicolonWhenRhsOnNextLine() {
+        // Dotty extends the val span to include the trailing ';' when the rhs is on
+        // its own line, so the cursor moves past it; the ';' must still round-trip.
+        rewriteRun(
+          scala(
+            """
+            class Foo {
+              val x =
+                1;
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void emptyFile() {
         rewriteRun(
           scala("")


### PR DESCRIPTION
…program

## What's changed?

Scala - fixing parsing of a program ending with an optional semicolon, e.g.
```scala
val x = 1;
```

## What's your motivation?

Currently the semicolon is swallowed.
