### PR TITLE
Fix WrappingAndBracesVisitor crash for try-with-resources ChopIfTooLong

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/WrappingAndBracesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/WrappingAndBracesTest.java
@@ -1690,6 +1690,55 @@ class WrappingAndBracesTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/8073")
+    void tryWithResourcesChopIfTooLongWithBody() {
+        rewriteRun(
+          autoFormat(
+            spaces -> spaces,
+            wrap -> wrap.withTryWithResources(wrap.getTryWithResources().withWrap(ChopIfTooLong).withAlignWhenMultiline(true))
+          ),
+          java(
+            """
+              import java.io.*;
+
+              class Test {
+                  void test() {
+                      try (FileReader fr = new FileReader("input.txt"); BufferedReader br = new BufferedReader(fr); FileWriter fw = new FileWriter("output.txt")) {
+                          String line = br.readLine();
+                          while (line != null) {
+                              fw.write(line);
+                              line = br.readLine();
+                          }
+                      } catch (IOException e) {
+                          throw new RuntimeException(e);
+                      }
+                  }
+              }
+              """,
+            """
+              import java.io.*;
+
+              class Test {
+                  void test() {
+                      try (FileReader fr = new FileReader("input.txt");
+                           BufferedReader br = new BufferedReader(fr);
+                           FileWriter fw = new FileWriter("output.txt")) {
+                          String line = br.readLine();
+                          while (line != null) {
+                              fw.write(line);
+                              line = br.readLine();
+                          }
+                      } catch (IOException e) {
+                          throw new RuntimeException(e);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/8073")
     void tryWithResourcesChopIfTooLongNotLongEnough() {
         rewriteRun(
           autoFormat(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/WrappingAndBracesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/WrappingAndBracesTest.java
@@ -1654,6 +1654,64 @@ class WrappingAndBracesTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/8073")
+    void tryWithResourcesChopIfTooLong() {
+        rewriteRun(
+          autoFormat(
+            spaces -> spaces,
+            wrap -> wrap.withTryWithResources(wrap.getTryWithResources().withWrap(ChopIfTooLong).withAlignWhenMultiline(true))
+          ),
+          java(
+            """
+              import java.io.*;
+
+              class Test {
+                  void test() {
+                      try (FileReader fr = new FileReader("input.txt"); BufferedReader br = new BufferedReader(fr); FileWriter fw = new FileWriter("output.txt")) {
+                      }
+                  }
+              }
+              """,
+            """
+              import java.io.*;
+
+              class Test {
+                  void test() {
+                      try (FileReader fr = new FileReader("input.txt");
+                           BufferedReader br = new BufferedReader(fr);
+                           FileWriter fw = new FileWriter("output.txt")) {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/8073")
+    void tryWithResourcesChopIfTooLongNotLongEnough() {
+        rewriteRun(
+          autoFormat(
+            spaces -> spaces,
+            wrap -> wrap.withTryWithResources(wrap.getTryWithResources().withWrap(ChopIfTooLong).withAlignWhenMultiline(true))
+          ),
+          java(
+            """
+              import java.io.*;
+
+              class Test {
+                  void test() {
+                      try (FileReader fr = new FileReader("input.txt"); BufferedReader br = new BufferedReader(fr)) {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void tryCatchOnNewLine() {
         rewriteRun(
           autoFormat(

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/SourcePositionService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/SourcePositionService.java
@@ -218,6 +218,39 @@ public class SourcePositionService {
             }
 
             @Override
+            public J visitTry(J.Try tryable, PrintOutputCapture<TreeVisitor<?, ?>> p) {
+                JContainer<J.Try.Resource> resources = tryable.getPadding().getResources();
+                // JavaPrinter#visitTry prints the resources directly rather than through visitContainer/visitRightPadded,
+                // so the generic findJContainer search never matches. Replicate that printing here while tracking the span.
+                if (findJContainer == null || resources == null ||
+                        (List<?>) resources.getPadding().getElements() != (List<?>) findJContainer.getPadding().getElements()) {
+                    return super.visitTry(tryable, p);
+                }
+                beforeSyntax(tryable, Space.Location.TRY_PREFIX, p);
+                p.append("try");
+                visitSpace(resources.getBefore(), Space.Location.TRY_RESOURCES, p);
+                p.append('(');
+                List<JRightPadded<J.Try.Resource>> elements = resources.getPadding().getElements();
+                for (int i = 0; i < elements.size(); i++) {
+                    JRightPadded<J.Try.Resource> paddedResource = elements.get(i);
+                    J.Try.Resource resource = paddedResource.getElement();
+                    if (i == 0) {
+                        resource = startFind(resource, p);
+                    } else {
+                        visitSpace(resource.getPrefix(), Space.Location.TRY_RESOURCE, p);
+                    }
+                    visitMarkers(resource.getMarkers(), p);
+                    visit(resource.getVariableDeclarations(), p);
+                    if (resource.isTerminatedWithSemicolon()) {
+                        p.append(';');
+                    }
+                    visitSpace(paddedResource.getAfter(), Space.Location.TRY_RESOURCE_SUFFIX, p);
+                }
+                found.set(true);
+                return tryable;
+            }
+
+            @Override
             protected void visitRightPadded(List<? extends JRightPadded<? extends J>> nodes, JRightPadded.Location location, String suffixBetween, PrintOutputCapture<TreeVisitor<?, ?>> p) {
                 if (findJContainer != null && nodes == findJContainer.getPadding().getElements()) {
                     for (int i = 0; i < nodes.size(); i++) {


### PR DESCRIPTION
## What's changed?

`WrappingAndBracesVisitor` crashes with `IllegalArgumentException: The child was not found in the sourceFile` when `tryWithResources.wrap` is set to `ChopIfTooLong` and the source contains a try-with-resources statement.

For `ChopIfTooLong`, `shouldWrap` asks `SourcePositionService.columnsOf(cursor, container)` how wide the resources are. That service locates the container by re-printing the source and matching `findJContainer.getPadding().getElements()` inside its `visitRightPadded(List, ...)` override. However, `JavaPrinter#visitTry` prints try-with-resources resources *directly* (because the last resource may or may not be semicolon-terminated) rather than going through `visitContainer`/`visitRightPadded`, so the match never fired and the search fell through to the "child not found" exception.

This adds a `visitTry` override to the position-computing printer that replicates `JavaPrinter#visitTry`'s resource printing while tracking the found span, so the resources container can be located and measured.

## Reproduction

```java
class A {
    void test() {
        try (FileReader fr = new FileReader("input.txt"); BufferedReader br = new BufferedReader(fr); FileWriter fw = new FileWriter("output.txt")) {
        }
    }
}
```
with style:
```yaml
- org.openrewrite.java.style.WrappingAndBracesStyle:
    tryWithResources:
      wrap: ChopIfTooLong
```

## Tests

Added `tryWithResourcesChopIfTooLong` (wraps when too long) and `tryWithResourcesChopIfTooLongNotLongEnough` (leaves short resource lists unchanged) to `WrappingAndBracesTest`. Both failed before the fix with the reported exception and pass now.

- Fixes #8073