### PR TITLE
Record documentation-comment reference packages in `TypesInUse`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/internal/TypesInUseTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/internal/TypesInUseTest.java
@@ -66,6 +66,42 @@ class TypesInUseTest implements RewriteTest {
     }
 
     @Test
+    void recordsFullyQualifiedJavadocReferencesSeparately() {
+        rewriteRun(
+          java(
+            """
+              package org.openrewrite.other;
+              public class Target {}
+              """
+          ),
+          java(
+            """
+              package com.example;
+              /**
+               * See {@link org.openrewrite.other.Target} for details.
+               */
+              public class Bar {}
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                TypesInUse tiu = cu.getTypesInUse();
+
+                // Fully qualified Javadoc references stay out of the import-retention set (#5738)...
+                assertThat(tiu.getTypesInUse().stream()
+                  .filter(t -> t instanceof JavaType.FullyQualified)
+                  .map(t -> ((JavaType.FullyQualified) t).getFullyQualifiedName()))
+                  .doesNotContain("org.openrewrite.other.Target");
+
+                // ...but their packages are recorded separately so package-renaming recipes can find them.
+                assertThat(tiu.hasDocReferenceInPackage("org.openrewrite.other", false)).isTrue();
+                assertThat(tiu.hasDocReferenceInPackage("org.openrewrite", false)).isFalse();
+                assertThat(tiu.hasDocReferenceInPackage("org.openrewrite", true)).isTrue();
+                assertThat(tiu.hasDocReferenceInPackage("com.other", true)).isFalse();
+            })
+          )
+        );
+    }
+
+    @Test
     void publicFactoryReturnsInstanceWithSuppliedSets() {
         rewriteRun(
           java(

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -29,7 +29,6 @@ import org.openrewrite.trait.Reference;
 
 import java.nio.file.Paths;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.Tree.randomId;
@@ -109,9 +108,9 @@ public class ChangePackage extends Recipe {
                             }
                         }
                     }
-                    // Fully qualified javadoc references are excluded from TypesInUse
-                    // (they don't affect imports), but they still need package renaming.
-                    if (hasJavadocReferenceToPackage(cu, oldPackageName, recursive, recursivePackageNamePrefix)) {
+                    // Fully qualified documentation-comment references are excluded from TypesInUse's
+                    // import-retention set (they don't affect imports), but they still need package renaming.
+                    if (cu.getTypesInUse().hasDocReferenceInPackage(oldPackageName, recursive)) {
                         return SearchResult.found(cu);
                     }
                 } else if (tree instanceof SourceFileWithReferences) {
@@ -535,50 +534,6 @@ public class ChangePackage extends Recipe {
                    !packageName.startsWith(newPackageName);
         }
 
-    }
-
-    private static boolean hasJavadocReferenceToPackage(JavaSourceFile cu, String packageName, boolean recursive, String recursivePrefix) {
-        return new JavaIsoVisitor<AtomicBoolean>() {
-            boolean inJavadocReference;
-
-            @Override
-            public @Nullable J visit(@Nullable Tree tree, AtomicBoolean f) {
-                // Once a matching reference is found, skip the rest of the traversal.
-                return f.get() ? (J) tree : super.visit(tree, f);
-            }
-
-            @Override
-            protected JavadocVisitor<AtomicBoolean> getJavadocVisitor() {
-                // Field accesses only carry a fully qualified package reference worth checking when
-                // they appear inside a Javadoc reference, so let the Javadoc delegate flag that scope
-                // rather than re-walking each field access's ancestors during the descent.
-                return new JavadocVisitor<AtomicBoolean>(this) {
-                    @Override
-                    public Javadoc visitReference(Javadoc.Reference reference, AtomicBoolean f) {
-                        inJavadocReference = true;
-                        try {
-                            return super.visitReference(reference, f);
-                        } finally {
-                            inJavadocReference = false;
-                        }
-                    }
-                };
-            }
-
-            @Override
-            public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, AtomicBoolean f) {
-                if (inJavadocReference && !f.get()) {
-                    JavaType type = fieldAccess.getType();
-                    if (type instanceof JavaType.FullyQualified) {
-                        String pkg = ((JavaType.FullyQualified) type).getPackageName();
-                        if (pkg.equals(packageName) || recursive && pkg.startsWith(recursivePrefix)) {
-                            f.set(true);
-                        }
-                    }
-                }
-                return super.visitFieldAccess(fieldAccess, f);
-            }
-        }.reduce(cu, new AtomicBoolean()).get();
     }
 
     @Value

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/TypesInUse.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/TypesInUse.java
@@ -30,6 +30,7 @@ import org.openrewrite.java.tree.Javadoc;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
@@ -48,6 +49,22 @@ public class TypesInUse {
     private final Set<JavaType.Method> declaredMethods;
     private final Set<JavaType.Method> usedMethods;
     private final Set<JavaType.Variable> variables;
+
+    /**
+     * Packages of the fully qualified types referenced only from documentation comments — Javadoc
+     * {@code {@link com.foo.Bar}}, C# {@code <see cref="..."/>}, etc. — each contributing its package
+     * (e.g. {@code com.foo}). The types themselves are deliberately excluded from {@link #typesInUse}
+     * because a fully qualified doc reference needs no import, so it must not count toward import
+     * retention (see #5738). Their packages are recorded here so that package-renaming recipes can still
+     * discover them without re-walking the tree. Only the package is retained because that is all such
+     * recipes query.
+     * <p>
+     * This bucket is <em>transient</em>: it is populated only by {@link #build(JavaSourceFile)} and is left
+     * empty by {@link #of}, since a serialized type index carries no doc references. It is queried only via
+     * {@link #hasDocReferenceInPackage}; the raw set is intentionally not exposed.
+     */
+    @Getter(AccessLevel.NONE)
+    private final Set<String> docReferencePackages;
 
     /**
      * Lazily-built prefix tree over every fully qualified name reachable via
@@ -83,7 +100,8 @@ public class TypesInUse {
                 findTypesInUse.getTypes(),
                 findTypesInUse.getDeclaredMethods(),
                 findTypesInUse.getUsedMethods(),
-                findTypesInUse.getVariables());
+                findTypesInUse.getVariables(),
+                findTypesInUse.getDocReferencePackages());
     }
 
     /**
@@ -96,7 +114,23 @@ public class TypesInUse {
                                 Set<JavaType.Method> declaredMethods,
                                 Set<JavaType.Method> usedMethods,
                                 Set<JavaType.Variable> variables) {
-        return new TypesInUse(cu, typesInUse, declaredMethods, usedMethods, variables);
+        return new TypesInUse(cu, typesInUse, declaredMethods, usedMethods, variables, Collections.emptySet());
+    }
+
+    /**
+     * Whether any fully qualified documentation-comment reference in this compilation unit has a package
+     * equal to {@code packageName}, or (when {@code recursive}) starts with {@code packageName + '.'}.
+     * Mirrors the per-type package check that package-renaming recipes apply to {@link #typesInUse}, for
+     * the references that {@link #typesInUse} deliberately omits.
+     */
+    public boolean hasDocReferenceInPackage(String packageName, boolean recursive) {
+        String recursivePrefix = packageName + ".";
+        for (String pkg : docReferencePackages) {
+            if (pkg.equals(packageName) || recursive && pkg.startsWith(recursivePrefix)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -509,6 +543,7 @@ public class TypesInUse {
         private final Set<JavaType.Method> declaredMethods = newSetFromMap(new IdentityHashMap<>());
         private final Set<JavaType.Method> usedMethods = newSetFromMap(new IdentityHashMap<>());
         private final Set<JavaType.Variable> variables = newSetFromMap(new IdentityHashMap<>());
+        private final Set<String> docReferencePackages = new HashSet<>();
 
         @Override
         public J.Import visitImport(J.Import _import, Integer p) {
@@ -554,9 +589,14 @@ public class TypesInUse {
                         usedMethods.add((JavaType.Method) javaType);
                     }
                 } else if (!(cursor.getValue() instanceof J.ClassDeclaration) &&
-                        !(cursor.getValue() instanceof J.Lambda) &&
-                        !isFullyQualifiedJavaDocReference(cursor)) {
-                    types.add(javaType);
+                        !(cursor.getValue() instanceof J.Lambda)) {
+                    if (isFullyQualifiedJavaDocReference(cursor)) {
+                        if (javaType instanceof JavaType.FullyQualified) {
+                            docReferencePackages.add(((JavaType.FullyQualified) javaType).getPackageName());
+                        }
+                    } else {
+                        types.add(javaType);
+                    }
                 }
             }
             return javaType;


### PR DESCRIPTION
## Motivation

`TypesInUse` deliberately excludes fully qualified documentation-comment references (Javadoc `{@link com.foo.Bar}`, and the equivalent constructs in the other languages that share the `JavaType` attribution — C# `<see cref="..."/>`, etc.) from its import-retention set, because such a reference needs no import and must not count toward import retention (#5738). The consequence is that `ChangePackage` could not rely on `TypesInUse` to discover those references, so it grew its own dedicated full-compilation-unit walk to rediscover them for its precondition. That duplicated the "is this a fully qualified doc reference" predicate in two places with opposite intent — `FindTypesInUse` to *exclude*, `ChangePackage` to *recover* — which is precisely the kind of drift that produced the regression fixed in #7284. It also meant an extra per-file, per-recipe-instance traversal alongside the one `TypesInUse` already performs and caches.

This records the packages of those excluded references once, as a byproduct of the single `FindTypesInUse` walk, and lets `ChangePackage` consume them — removing the duplicated predicate and the redundant traversal. Only the package is retained, since that is all a package-renaming recipe asks of a doc reference; this also keeps the in-memory shape aligned with the package-keyed form a future serialized precondition would use.

## Examples

`ChangePackage`'s precondition doc-reference branch collapses from its own dedicated full-tree visitor to a single lookup against the already-cached `TypesInUse`:

```java
if (cu.getTypesInUse().hasDocReferenceInPackage(oldPackageName, recursive)) {
    return SearchResult.found(cu);
}
```

## Summary

- Add a separate `docReferencePackages` bucket to `TypesInUse`, populated during `FindTypesInUse` with the packages of fully qualified documentation-comment references — the references that are (still) excluded from the import-retention `typesInUse` set.
- The import-retention set is byte-for-byte unchanged, so `RemoveUnusedImports`, `UsesType`, and the FQN trie behave exactly as before. The new bucket is consulted only by callers that explicitly want it.
- Add `TypesInUse.hasDocReferenceInPackage(packageName, recursive)`, mirroring the per-type package check package-renaming recipes apply to `typesInUse`. The raw set is not exposed — the query method is the only entry point.
- Rewire `ChangePackage`'s precondition to call it and delete its bespoke documentation-comment walk, so the fully-qualified-doc-reference predicate now lives in exactly one place.
- The bucket is transient: it is populated only by `TypesInUse.build(...)` and left empty by `TypesInUse.of(...)`, since a serialized type index carries no doc references. No serialization-format change.

## Test plan

- [x] New `TypesInUseTest.recordsFullyQualifiedJavadocReferencesSeparately` — uses a Java `{@link}` fixture to verify the reference is excluded from `getTypesInUse()` yet its package is discoverable via `hasDocReferenceInPackage`, covering exact / recursive / non-matching package queries.
- [x] `ChangePackageTest` (including the `#2537` fully-qualified-Javadoc cases) stays green — behavior preserved.
- [x] `RemoveUnusedImportsTest` stays green — the import-retention set is unchanged (#5738 behavior intact).
- [x] Kotlin `ChangePackageTest` stays green — the shared recipe behaves the same on the extended `J` model.