### PR TITLE
Don't inject @c/@ref identity metadata into plain Maps over RPC

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcObjectData.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcObjectData.java
@@ -102,13 +102,20 @@ public class RpcObjectData {
             try {
                 Class<?> valueClass = Class.forName(valueType);
 
-                // While we know exactly what type of value we are converting to,
-                // Jackson will still require the '@c' field in the map when the type
-                // we are converting to is annotated with @JsonTypeInfo.
-                //noinspection unchecked
-                ((Map<String, Object>) value).put("@c", valueType);
-                //noinspection unchecked
-                ((Map<String, Object>) value).put("@ref", 1);
+                // A plain Map is serialized structurally and consumes no type/identity
+                // metadata, so the "@c"/"@ref" keys below would leak as real entries and
+                // corrupt it -- e.g. a Map<String, String> would gain an "@ref" -> Integer
+                // entry that breaks strict serialization downstream. Only inject them for
+                // POJOs (which may be annotated with @JsonTypeInfo/@JsonIdentityInfo).
+                if (!Map.class.isAssignableFrom(valueClass)) {
+                    // While we know exactly what type of value we are converting to,
+                    // Jackson will still require the '@c' field in the map when the type
+                    // we are converting to is annotated with @JsonTypeInfo.
+                    //noinspection unchecked
+                    ((Map<String, Object>) value).put("@c", valueType);
+                    //noinspection unchecked
+                    ((Map<String, Object>) value).put("@ref", 1);
+                }
 
                 //noinspection unchecked
                 return (V) mapper.convertValue(value, valueClass);

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -229,7 +229,12 @@ public class RpcSendQueue {
         protected @Nullable String computeValue(Class<?> afterType) {
             Package pkg = afterType.getPackage();
             if (afterType.isPrimitive() || afterType.isArray() || (pkg != null && pkg.getName().startsWith("java.lang")) ||
-                afterType.equals(UUID.class) || Iterable.class.isAssignableFrom(afterType)) {
+                afterType.equals(UUID.class) || Iterable.class.isAssignableFrom(afterType) ||
+                Map.class.isAssignableFrom(afterType)) {
+                // A plain Map (like a Collection) is serialized structurally and needs no
+                // valueType. Sending one would make the receiver treat the map as a typed
+                // object and inject type/identity metadata keys (e.g. "@c"/"@ref") that leak
+                // into the map as real entries, corrupting it (see RpcObjectData#getValue).
                 return null;
             } else if (Enum.class.isAssignableFrom(afterType) && !JAVA_TYPE_NAME.concat("$Primitive").equals(afterType.getName())) {
                 // FIXME special case for `JavaType.Primitive` here

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RpcReceiveQueueTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RpcReceiveQueueTest.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.rpc;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Checksum;
@@ -26,6 +28,7 @@ import java.nio.file.Path;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RpcReceiveQueueTest {
@@ -105,6 +108,32 @@ class RpcReceiveQueueTest {
 
         assertThat(received).isInstanceOf(Checksum.class);
         assertThat(((Checksum) received).getAlgorithm()).isEqualTo("SHA-256");
+    }
+
+    @Test
+    void plainMapRoundTripsWithoutLeakingRefMetadata() throws Exception {
+        // A Map<String, String> (e.g. NodeResolutionResult.Npmrc#properties) must survive
+        // the round trip without gaining "@c"/"@ref" entries. Those keys are only meaningful
+        // for POJOs annotated with @JsonTypeInfo/@JsonIdentityInfo; leaking them into a Map
+        // puts a String "@c" and an Integer "@ref" into a Map<String, String>.
+        Map<String, String> before = new LinkedHashMap<>();
+        before.put("registry", "https://registry.npmjs.org/");
+        before.put("save-exact", "true");
+
+        sq.send(before, null, null);
+        Map<String, String> after = rq.receive(null);
+
+        assertThat(after).doesNotContainKeys("@c", "@ref");
+        assertThat(after).isEqualTo(before);
+
+        // Serializing the received map the way the V2 edit writer does -- as a declared
+        // Map<String, String> -- must not throw. Before the fix the leaked "@ref" -> 1
+        // (Integer) entry blew up here with the exact failure customers reported:
+        // "java.lang.Integer cannot be cast to java.lang.String".
+        assertThatCode(() -> new ObjectMapper()
+                .writerFor(new TypeReference<Map<String, String>>() {})
+                .writeValueAsString(after))
+                .doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
## What's wrong

Any JavaScript recipe that **makes an edit** on a project with an `.npmrc` failed during result serialization with:

```
ClassCastException: java.lang.Integer cannot be cast to java.lang.String
reference chain: Json$Document["markers"]
  -> NodeResolutionResult["npmrcConfigs"]
  -> NodeResolutionResult$Npmrc["properties"]
  -> LinkedHashMap["@ref"]
  at io.moderne.serialization.v2.V2EditWriter.flushSegment(...)
  at org.openrewrite.scheduling.RecipeRunCycle.editSources(...)
Caused by: com.fasterxml.jackson.databind.ser.std.StringSerializer.serialize(...)
```

Recipes that produce no change still succeeded (no re-serialization), and a build alone was fine — only an *edit* round-trip tripped it.

## Root cause

`Npmrc#properties` is a `Map<String, String>`. A plain `Map` was being treated as a *typed object* on the RPC wire:

1. `RpcSendQueue.computeValue()` assigns a `valueType` of `java.util.LinkedHashMap` to a `Map`, because — unlike a `Collection` — a `Map` is not `Iterable` and so misses the existing "structural, no `valueType`" branch.
2. The receiver sees a `valueType` and treats the map as a typed object.
3. On the way back, `RpcObjectData.getValue()` injects `"@c"` and `"@ref"` keys before `mapper.convertValue(...)`. These are only meaningful for POJOs annotated with `@JsonTypeInfo`/`@JsonIdentityInfo`; a plain `LinkedHashMap` has neither, so Jackson can't consume them and they **leak in as real entries**: `"@c" -> String` (harmless) and, fatally, `"@ref" -> Integer` in a `Map<String, String>`.

Strict serialization downstream (`V2EditWriter`, declared `Map<String, String>`) then uses `StringSerializer` on the `Integer` value and throws.

## Fix

- **`RpcSendQueue`** (root cause): treat `Map` like `Collection`/`Iterable` — no `valueType` on the wire, so the receiver never treats it as a typed object.
- **`RpcObjectData.getValue()`** (defense-in-depth): never inject `"@c"`/`"@ref"` when the resolved target type is a `Map`, so a stray `Map` `valueType` from any engine can't corrupt the map.

## Test

`RpcReceiveQueueTest#plainMapRoundTripsWithoutLeakingRefMetadata` round-trips a `Map<String, String>` through the real `RpcSendQueue`/`RpcReceiveQueue` and then serializes it as a declared `Map<String, String>` the way the edit writer does. Without the fix the received map is `{"@c"="java.util.LinkedHashMap", "@ref"=1, ...}` and serialization throws the exact `Integer cannot be cast to String`; with the fix it round-trips clean.