### PR TITLE
Preserve non-String option values when applying options via `withOptions`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -618,12 +618,12 @@ public abstract class Recipe implements Cloneable {
                 m.putAll(options);
                 for (OptionDescriptor optionDescriptor : clone.getDescriptor().getOptions()) {
                     Object value = options.get(optionDescriptor.getName());
-                    if (value instanceof String) {
+                    if (value != null) {
                         Map<String, Object> option = new HashMap<>();
                         option.put("value", value);
                         objectMapper.updateValue(optionDescriptor, option);
 
-                        if (optionDescriptor.getType().equals("List")) {
+                        if (value instanceof String && optionDescriptor.getType().equals("List")) {
                             m.put(optionDescriptor.getName(), Arrays.asList(((String) value).split(",")));
                         }
                     }

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeBasicsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeBasicsTest.java
@@ -17,6 +17,7 @@ package org.openrewrite;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.config.OptionDescriptor;
 import org.openrewrite.config.RecipeDescriptor;
@@ -227,5 +228,48 @@ class RecipeBasicsTest {
         assertThat(result).isInstanceOf(RecipeWithListOption.class);
         assertThat(((RecipeWithListOption) result).fieldNames)
                 .containsExactly("firstName", "lastName", "email", "emailAddress");
+    }
+
+    @Test
+    void withOptionsPreservesNonStringOptionValuesInDescriptor() {
+        // given
+        RecipeWithMixedOptionTypes recipe = new RecipeWithMixedOptionTypes(null, null, null);
+        Map<String, Object> options = new HashMap<>();
+        options.put("text", "hello");
+        options.put("flag", true);
+        options.put("count", 5);
+
+        // when
+        Recipe result = recipe.withOptions(options);
+
+        // then the descriptor must report every supplied value, not just the String one
+        Map<String, Object> values = new HashMap<>();
+        for (OptionDescriptor o : result.getDescriptor().getOptions()) {
+            values.put(o.getName(), o.getValue());
+        }
+        assertThat(values.get("text")).isEqualTo("hello");
+        assertThat(values.get("flag")).isEqualTo(true);
+        assertThat(values.get("count")).isEqualTo(5);
+    }
+
+    @Getter
+    static class RecipeWithMixedOptionTypes extends Recipe {
+        private final String displayName = "Mixed option types recipe";
+        private final String description = "Mixed option types recipe.";
+
+        @Option(displayName = "Text", description = "A string option.", example = "hello")
+        final @Nullable String text;
+
+        @Option(displayName = "Flag", description = "A boolean option.", required = false)
+        final @Nullable Boolean flag;
+
+        @Option(displayName = "Count", description = "An integer option.", required = false)
+        final @Nullable Integer count;
+
+        public RecipeWithMixedOptionTypes(@Nullable String text, @Nullable Boolean flag, @Nullable Integer count) {
+            this.text = text;
+            this.flag = flag;
+            this.count = count;
+        }
     }
 }


### PR DESCRIPTION
## Problem
- `Recipe.withOptions(Map)` returns a recipe whose descriptor reports a supplied value only for `String` options; non-`String` values (`Boolean`, `Integer`, …) come back `null` from `getDescriptor()`, even though they were supplied and the recipe's fields are set correctly.
- It builds the descriptor from a default (unconfigured) clone, then writes each value back only inside `if (value instanceof String)`, so non-`String` option values never reach the cached descriptor.
- This surfaces through `MavenRecipeBundleReader.prepare`, which configures a recipe via `activateRecipes(name).withOptions(options)`: a composite recipe that sets a non-`String` option on a resolved sub-recipe exposes a descriptor with that option `null` — so any consumer reading the descriptor to render or re-serialize a configured recipe loses the value.

## Objectives
1. Make `getDescriptor()` on a recipe configured via `withOptions` report every supplied option value, regardless of type.
2. Preserve the existing comma-separated-`String` → `List` option handling.

<details>
<summary><b>Assumptions</b></summary>

- The recipe's fields are already populated for all types by `updateValue(clone, m)`; only the cached descriptor's option values were type-restricted.
- `OptionDescriptor.value` is typed `Object`, so it can hold an option value of any type.
- The comma-separated-`String` → `List` conversion is only meaningful for `String` input.
</details>

<details>
<summary><b>Changes</b></summary>

- `(1, 2)` `Recipe.withOptions` — write the descriptor value for every supplied non-`null` option (was `String`-only); keep the comma-separated-`String` → `List` conversion guarded to `String` input.
- `(1)` `RecipeBasicsTest` — add `withOptionsPreservesNonStringOptionValuesInDescriptor`, with a recipe exposing `String`/`Boolean`/`Integer` options, asserting all three survive in the descriptor.
</details>

<details>
<summary><b>Notes</b></summary>

- Recipe *execution* behavior is unchanged — the fields were already set correctly via `updateValue(clone, m)`; this only corrects the descriptor returned by `getDescriptor()`.
- The existing `withOptionsDeserializesCommaSeparatedStringToList` behavior is retained.
- Verified: `:rewrite-core:test` passes.
</details>
