### PR TITLE
Groovy: unbounded wildcard in method is appending '?extends'

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -4381,7 +4381,7 @@ public class GroovyParserVisitor {
             skip("?");
             JLeftPadded<J.Wildcard.Bound> bound = null;
             NameTree boundedType = null;
-            if (genericsType.getUpperBounds() != null) {
+            if (genericsType.getUpperBounds() != null && sourceStartsWith("extends")) {
                 bound = padLeft(sourceBefore("extends"), J.Wildcard.Bound.Extends);
                 boundedType = visitTypeTree(genericsType.getUpperBounds()[0]);
             } else if (genericsType.getLowerBound() != null) {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -473,4 +473,24 @@ class GroovyParserTest implements RewriteTest {
         );
     }
 
+    @Test
+    void unboundedWildcardInMethod() {
+        rewriteRun(
+          groovy(
+            """
+                    class C {
+                       // these two method together fails
+                        String a(def a1) {
+                            Map<String, ?> r = b(a1)
+                            return r.key
+                        }
+                        Map<String, ?> b(def b) {
+                        }
+                    }
+
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

Without the fix the `Map<String, ?> r = b(a1)` is transformed to `Map<String, ?extends> r = b(a1)` making it invalid code.

```
   // these two method together fails
    String a(def a1) {
        Map<String, ?extends> r = b(a1)
        return r.key
    }
    Map<String, ?> b(def b) {
    }
}
```

 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
