### PR TITLE
Instanceof non type use annotation cursor corruption

### DIFF
--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -857,11 +857,9 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
     }
 
     private J convertInstanceOfTree(InstanceOfTree node) {
-        if (!(node.getPattern() instanceof JCBindingPattern b)
-                || b.var.mods.annotations.isEmpty()
-                || node.getType() instanceof JCAnnotatedType) {
-                    return convert(node.getType());
-                }
+        if (!(node.getPattern() instanceof JCBindingPattern b) || b.var.mods.annotations.isEmpty()) {
+            return convert(node.getType());
+        }
 
         Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(b.var.mods.annotations, new HashMap<>());
         List<J.Annotation> typeAnnotations = collectAnnotations(annotationPosTable);

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -848,12 +848,31 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         if (node.getPattern() instanceof JCBindingPattern b && b.var.mods.flags == Flags.FINAL) {
             modifier = new J.Modifier(randomId(), sourceBefore("final"), Markers.EMPTY, null, J.Modifier.Type.Final, emptyList());
         }
-        J clazz = convert(node.getType());
+        J clazz = convertInstanceOfTree(node);
         if (node.getPattern() instanceof JCBindingPattern b) {
             pattern = new J.Identifier(randomId(), sourceBefore(b.getVariable().getName().toString()), Markers.EMPTY, emptyList(), b.getVariable().getName().toString(),
                     type, typeMapping.variableType(b.var.sym));
         }
         return new J.InstanceOf(randomId(), fmt, Markers.EMPTY, expression, clazz, pattern, type, modifier);
+    }
+
+    private J convertInstanceOfTree(InstanceOfTree node) {
+        if (!(node.getPattern() instanceof JCBindingPattern b)
+                || b.var.mods.annotations.isEmpty()
+                || node.getType() instanceof JCAnnotatedType) {
+                    return convert(node.getType());
+                }
+
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(b.var.mods.annotations, new HashMap<>());
+        List<J.Annotation> typeAnnotations = collectAnnotations(annotationPosTable);
+        TypeTree typeExpr = convert(node.getType());
+        if (typeAnnotations.isEmpty()) {
+            return typeExpr;
+        }
+
+        Space prefix = typeAnnotations.get(0).getPrefix();
+        return new J.AnnotatedType(randomId(), prefix, Markers.EMPTY,
+                ListUtils.mapFirst(typeAnnotations, a -> a.withPrefix(Space.EMPTY)), typeExpr);
     }
 
     @Override

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -853,9 +853,28 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         if (node.getPattern() instanceof JCBindingPattern b && b.var.mods.flags == Flags.FINAL) {
             modifier = new J.Modifier(randomId(), sourceBefore("final"), Markers.EMPTY, null, J.Modifier.Type.Final, emptyList());
         }
-        J clazz = convert(node.getType());
+        J clazz = convertInstanceOfTree(node);
         J pattern = getNodePattern(node.getPattern(), type);
         return new J.InstanceOf(randomId(), fmt, Markers.EMPTY, expression, clazz, pattern, type, modifier);
+    }
+
+    private @Nullable J convertInstanceOfTree(InstanceOfTree node) {
+        if (!(node.getPattern() instanceof JCBindingPattern b)
+                || b.var.mods.annotations.isEmpty()
+                || node.getType() instanceof JCAnnotatedType) {
+                    return convert(node.getType());
+                }
+
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(b.var.mods.annotations, new HashMap<>());
+        List<J.Annotation> typeAnnotations = collectAnnotations(annotationPosTable);
+        TypeTree typeExpr = convert(node.getType());
+        if (typeAnnotations.isEmpty()) {
+            return typeExpr;
+        }
+
+        Space prefix = typeAnnotations.getFirst().getPrefix();
+        return new J.AnnotatedType(randomId(), prefix, Markers.EMPTY,
+                ListUtils.mapFirst(typeAnnotations, a -> a.withPrefix(Space.EMPTY)), typeExpr);
     }
 
     @Override

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -858,12 +858,10 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         return new J.InstanceOf(randomId(), fmt, Markers.EMPTY, expression, clazz, pattern, type, modifier);
     }
 
-    private @Nullable J convertInstanceOfTree(InstanceOfTree node) {
-        if (!(node.getPattern() instanceof JCBindingPattern b)
-                || b.var.mods.annotations.isEmpty()
-                || node.getType() instanceof JCAnnotatedType) {
-                    return convert(node.getType());
-                }
+    private J convertInstanceOfTree(InstanceOfTree node) {
+        if (!(node.getPattern() instanceof JCBindingPattern b) || b.var.mods.annotations.isEmpty()) {
+            return convert(node.getType());
+        }
 
         Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(b.var.mods.annotations, new HashMap<>());
         List<J.Annotation> typeAnnotations = collectAnnotations(annotationPosTable);

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
@@ -875,12 +875,10 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
         return new J.InstanceOf(randomId(), fmt, Markers.EMPTY, expression, clazz, pattern, type, modifier);
     }
 
-    private @Nullable J convertInstanceOfTree(InstanceOfTree node) {
-        if (!(node.getPattern() instanceof JCBindingPattern b)
-                || b.var.mods.annotations.isEmpty()
-                || node.getType() instanceof JCAnnotatedType) {
-                    return convert(node.getType());
-                }
+    private J convertInstanceOfTree(InstanceOfTree node) {
+        if (!(node.getPattern() instanceof JCBindingPattern b) || b.var.mods.annotations.isEmpty()) {
+            return convert(node.getType());
+        }
 
         Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(b.var.mods.annotations, new HashMap<>());
         List<J.Annotation> typeAnnotations = collectAnnotations(annotationPosTable);

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
@@ -870,9 +870,28 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
         if (node.getPattern() instanceof JCBindingPattern b && b.var.mods.flags == Flags.FINAL) {
             modifier = new J.Modifier(randomId(), sourceBefore("final"), Markers.EMPTY, null, J.Modifier.Type.Final, emptyList());
         }
-        J clazz = convert(node.getType());
+        J clazz = convertInstanceOfTree(node);
         J pattern = getNodePattern(node.getPattern(), type);
         return new J.InstanceOf(randomId(), fmt, Markers.EMPTY, expression, clazz, pattern, type, modifier);
+    }
+
+    private @Nullable J convertInstanceOfTree(InstanceOfTree node) {
+        if (!(node.getPattern() instanceof JCBindingPattern b)
+                || b.var.mods.annotations.isEmpty()
+                || node.getType() instanceof JCAnnotatedType) {
+                    return convert(node.getType());
+                }
+
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(b.var.mods.annotations, new HashMap<>());
+        List<J.Annotation> typeAnnotations = collectAnnotations(annotationPosTable);
+        TypeTree typeExpr = convert(node.getType());
+        if (typeAnnotations.isEmpty()) {
+            return typeExpr;
+        }
+
+        Space prefix = typeAnnotations.getFirst().getPrefix();
+        return new J.AnnotatedType(randomId(), prefix, Markers.EMPTY,
+                ListUtils.mapFirst(typeAnnotations, a -> a.withPrefix(Space.EMPTY)), typeExpr);
     }
 
     @Override

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/InstanceOfTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/InstanceOfTest.java
@@ -174,8 +174,9 @@ class InstanceOfTest implements RewriteTest {
     @MinimumJava17
     @Test
     void instanceofPatternMatchWithTypeUseAnnotation() {
-        // A TYPE_USE annotation is placed by the compiler into JCAnnotatedType (the type node
-        // itself), not in mods.annotations. The fix must not interfere with this existing path.
+        // In a binding pattern a leading annotation is parsed as a modifier of the binding
+        // variable, so even a TYPE_USE annotation ends up in mods.annotations (not in a
+        // JCAnnotatedType type node). It must be consumed from source before the type is converted.
         rewriteRun(
           java(
             """
@@ -187,6 +188,31 @@ class InstanceOfTest implements RewriteTest {
                   void test(Object obj) {
                       if (obj instanceof @NotNull String s) {
                           System.out.println(s);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @MinimumJava17
+    @Test
+    void instanceofPatternMatchWithLeadingAndQualifiedTypeUseAnnotation() {
+        // A leading non-TYPE_USE annotation (in mods.annotations) combined with a TYPE_USE
+        // annotation in mid-qualified-name position (which makes node.getType() a JCAnnotatedType).
+        // The leading annotation must still be consumed from source before converting the type.
+        rewriteRun(
+          java(
+            """
+              import java.lang.annotation.*;
+              class Test {
+                  @Target(ElementType.TYPE_USE)
+                  @interface NotNull {}
+
+                  void test(Object actual) {
+                      if (actual instanceof @SuppressWarnings("rawtypes") java.util.@NotNull List list) {
+                          System.out.println(list.size());
                       }
                   }
               }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/InstanceOfTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/InstanceOfTest.java
@@ -105,4 +105,93 @@ class InstanceOfTest implements RewriteTest {
           )
         );
     }
+
+    @MinimumJava17
+    @Test
+    void instanceofPatternMatchWithNonTypeUseAnnotation() {
+        // @SuppressWarnings has no TYPE_USE target, so the compiler stores it in the binding
+        // variable's mods.annotations rather than in the type node (JCAnnotatedType). The
+        // parser must still consume it from source before converting the type, otherwise the
+        // cursor lands inside the annotation text and corrupts the resulting AST.
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+              class Test {
+                  void test(Object actual) {
+                      if (actual instanceof @SuppressWarnings("rawtypes") List list) {
+                          System.out.println(list.size());
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @MinimumJava17
+    @Test
+    void instanceofPatternMatchWithMultipleNonTypeUseAnnotations() {
+        // Both @SuppressWarnings and @Deprecated lack TYPE_USE target, so both end up in
+        // mods.annotations. collectAnnotations must consume them all before the type is converted.
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+              class Test {
+                  void test(Object actual) {
+                      if (actual instanceof @SuppressWarnings("rawtypes") @Deprecated List list) {
+                          System.out.println(list.size());
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @MinimumJava17
+    @Test
+    void instanceofPatternMatchWithFinalAndNonTypeUseAnnotation() {
+        // Both the final-modifier path and the non-TYPE_USE annotation path must activate
+        // without the cursor being mis-positioned between them.
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+              class Test {
+                  void test(Object actual) {
+                      if (actual instanceof final @SuppressWarnings("rawtypes") List list) {
+                          System.out.println(list.size());
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @MinimumJava17
+    @Test
+    void instanceofPatternMatchWithTypeUseAnnotation() {
+        // A TYPE_USE annotation is placed by the compiler into JCAnnotatedType (the type node
+        // itself), not in mods.annotations. The fix must not interfere with this existing path.
+        rewriteRun(
+          java(
+            """
+              import java.lang.annotation.*;
+              class Test {
+                  @Target(ElementType.TYPE_USE)
+                  @interface NotNull {}
+
+                  void test(Object obj) {
+                      if (obj instanceof @NotNull String s) {
+                          System.out.println(s);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Parsing of instanceOf special constructs is improved and tests are added.

## What's your motivation?
Trying to solve this issue:
```
[WARNING] java.lang.IllegalStateException: assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java is not print idempotent. 
diff --git a//Users/mariusbarbulescu/work/github/assertj/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java b//Users/mariusbarbulescu/work/github/assertj/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
index 3348720..a376166 100644
--- a//Users/mariusbarbulescu/work/github/assertj/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b//Users/mariusbarbulescu/work/github/assertj/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -2807,7 +2807,7 @@ 
 
   @SuppressWarnings("unchecked")
   private ELEMENT lastElement() {
-    if (actual instanceof @SuppressWarnings("rawtypes") List list) {
+    if (actual instanceof ListpressWarnings("rawtypes") List list) {
       return (ELEMENT) list.get(list.size() - 1);
     }
     Iterator<? extends ELEMENT> actualIterator = actual.iterator();
@@ -2942,7 +2942,7 @@
     assertThat(index).describedAs(navigationDescription("check index validity"))
                      .isBetween(0, IterableUtil.sizeOf(actual) - 1);
     ELEMENT elementAtIndex;
-    if (actual instanceof @SuppressWarnings("rawtypes") List list) {
+    if (actual instanceof ListpressWarnings("rawtypes") List list) {
       elementAtIndex = (ELEMENT) list.get(index);
     } else {
       Iterator<? extends ELEMENT> actualIterator = actual.iterator();

  org.openrewrite.Parser.requirePrintEqualsInput(Parser.java:52)

```

## Anything in particular you'd like reviewers to focus on?
I made it work but I am not sure whether it is the optimal solution.

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
Not aware of any.


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
