### PR TITLE
rewrite-python: add uses_import precondition and gate ChangeImport on it

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcObjectData.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcObjectData.java
@@ -102,13 +102,20 @@ public class RpcObjectData {
             try {
                 Class<?> valueClass = Class.forName(valueType);
 
-                // While we know exactly what type of value we are converting to,
-                // Jackson will still require the '@c' field in the map when the type
-                // we are converting to is annotated with @JsonTypeInfo.
-                //noinspection unchecked
-                ((Map<String, Object>) value).put("@c", valueType);
-                //noinspection unchecked
-                ((Map<String, Object>) value).put("@ref", 1);
+                // A plain Map is serialized structurally and consumes no type/identity
+                // metadata, so the "@c"/"@ref" keys below would leak as real entries and
+                // corrupt it -- e.g. a Map<String, String> would gain an "@ref" -> Integer
+                // entry that breaks strict serialization downstream. Only inject them for
+                // POJOs (which may be annotated with @JsonTypeInfo/@JsonIdentityInfo).
+                if (!Map.class.isAssignableFrom(valueClass)) {
+                    // While we know exactly what type of value we are converting to,
+                    // Jackson will still require the '@c' field in the map when the type
+                    // we are converting to is annotated with @JsonTypeInfo.
+                    //noinspection unchecked
+                    ((Map<String, Object>) value).put("@c", valueType);
+                    //noinspection unchecked
+                    ((Map<String, Object>) value).put("@ref", 1);
+                }
 
                 //noinspection unchecked
                 return (V) mapper.convertValue(value, valueClass);

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -229,7 +229,12 @@ public class RpcSendQueue {
         protected @Nullable String computeValue(Class<?> afterType) {
             Package pkg = afterType.getPackage();
             if (afterType.isPrimitive() || afterType.isArray() || (pkg != null && pkg.getName().startsWith("java.lang")) ||
-                afterType.equals(UUID.class) || Iterable.class.isAssignableFrom(afterType)) {
+                afterType.equals(UUID.class) || Iterable.class.isAssignableFrom(afterType) ||
+                Map.class.isAssignableFrom(afterType)) {
+                // A plain Map (like a Collection) is serialized structurally and needs no
+                // valueType. Sending one would make the receiver treat the map as a typed
+                // object and inject type/identity metadata keys (e.g. "@c"/"@ref") that leak
+                // into the map as real entries, corrupting it (see RpcObjectData#getValue).
                 return null;
             } else if (Enum.class.isAssignableFrom(afterType) && !JAVA_TYPE_NAME.concat("$Primitive").equals(afterType.getName())) {
                 // FIXME special case for `JavaType.Primitive` here

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RpcReceiveQueueTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RpcReceiveQueueTest.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.rpc;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Checksum;
@@ -26,6 +28,7 @@ import java.nio.file.Path;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RpcReceiveQueueTest {
@@ -105,6 +108,32 @@ class RpcReceiveQueueTest {
 
         assertThat(received).isInstanceOf(Checksum.class);
         assertThat(((Checksum) received).getAlgorithm()).isEqualTo("SHA-256");
+    }
+
+    @Test
+    void plainMapRoundTripsWithoutLeakingRefMetadata() throws Exception {
+        // A Map<String, String> (e.g. NodeResolutionResult.Npmrc#properties) must survive
+        // the round trip without gaining "@c"/"@ref" entries. Those keys are only meaningful
+        // for POJOs annotated with @JsonTypeInfo/@JsonIdentityInfo; leaking them into a Map
+        // puts a String "@c" and an Integer "@ref" into a Map<String, String>.
+        Map<String, String> before = new LinkedHashMap<>();
+        before.put("registry", "https://registry.npmjs.org/");
+        before.put("save-exact", "true");
+
+        sq.send(before, null, null);
+        Map<String, String> after = rq.receive(null);
+
+        assertThat(after).doesNotContainKeys("@c", "@ref");
+        assertThat(after).isEqualTo(before);
+
+        // Serializing the received map the way the V2 edit writer does -- as a declared
+        // Map<String, String> -- must not throw. Before the fix the leaked "@ref" -> 1
+        // (Integer) entry blew up here with the exact failure customers reported:
+        // "java.lang.Integer cannot be cast to java.lang.String".
+        assertThatCode(() -> new ObjectMapper()
+                .writerFor(new TypeReference<Map<String, String>>() {})
+                .writeValueAsString(after))
+                .doesNotThrowAnyException();
     }
 
     @Test

--- a/rewrite-python/rewrite/src/rewrite/python/preconditions.py
+++ b/rewrite-python/rewrite/src/rewrite/python/preconditions.py
@@ -35,7 +35,7 @@ callable in unit tests without an active RPC connection.
 from __future__ import annotations
 
 from rewrite.preconditions import RecipeRef
-from rewrite.python.search import IsSourceFile, UsesMethod, UsesType
+from rewrite.python.search import IsSourceFile, UsesImport, UsesMethod, UsesType
 
 
 def has_source_path(file_pattern: str) -> RecipeRef:
@@ -89,6 +89,28 @@ def uses_type(
             "checkAssignability": check_assignability,
         },
         UsesType(fully_qualified_type),
+    )
+
+
+def uses_import(module: str) -> RecipeRef:
+    """Match files that import ``module`` (delegates to ``org.openrewrite.python.search.UsesImport``).
+
+    Gates on the as-written import syntax, not type attribution, so it works
+    for deprecated-import migrations where the type checker either
+    canonicalizes the alias (``from typing import List`` -> ``list``) or cannot
+    resolve a removed symbol (``from base64 import encodestring``). In both
+    cases :func:`uses_type` would miss the file; ``uses_import`` does not.
+
+    ``module`` is a dotted module path; a file matches if it imports that
+    module, a submodule, or a parent module of it.
+
+    Bundles a native :class:`UsesImport` visitor so unit tests without an
+    active RPC connection still see real filtering behavior.
+    """
+    return RecipeRef(
+        "org.openrewrite.python.search.UsesImport",
+        {"module": module},
+        UsesImport(module),
     )
 
 

--- a/rewrite-python/rewrite/src/rewrite/python/recipes/change_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/recipes/change_import.py
@@ -439,4 +439,13 @@ class ChangeImport(Recipe):
                     )
                 return multi
 
-        return ChangeImportVisitor()
+        if not old_module:
+            return ChangeImportVisitor()
+        # Gate on the as-written import: a file can only contain `import old_module`
+        # or `from old_module import ...` if it imports old_module, so this is a
+        # correct superset. uses_import (not uses_type) because the type checker
+        # canonicalizes aliases and drops removed symbols, both of which would make
+        # a type-based gate skip files this recipe must change.
+        from rewrite import Preconditions
+        from rewrite.python.preconditions import uses_import
+        return Preconditions.check(uses_import(old_module), ChangeImportVisitor())

--- a/rewrite-python/rewrite/src/rewrite/python/search/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/search/__init__.py
@@ -166,6 +166,101 @@ class UsesMethod(TreeVisitor[Tree, Any]):
         return found[0]
 
 
+class UsesImport(TreeVisitor[Tree, Any]):
+    """Match files that import a given module, by import *syntax* rather than
+    type attribution.
+
+    Mirrors ``org.openrewrite.python.search.UsesImport``. Reads the as-written
+    import path off ``Py.MultiImport`` statements, so it is robust to two
+    failure modes that make :class:`UsesType` unusable for gating
+    import-migration recipes:
+
+    * the type checker canonicalizes aliases (``from typing import List``
+      resolves to ``list``), erasing the deprecated import path; and
+    * removed/unresolvable symbols (``from base64 import encodestring``) get
+      no type attribution at all.
+
+    ``module`` is a dotted module path (e.g. ``"datetime"``, ``"os.path"``).
+    A file matches if it imports that module, a submodule of it, or a parent
+    module of it — a generous superset, which is what a precondition wants
+    (over-matching merely runs the gated visitor; under-matching would skip a
+    file the recipe should change).
+    """
+
+    def __init__(self, module: str) -> None:
+        self._module = module
+
+    def visit(
+        self,
+        tree: Optional[Tree],
+        p: Any,
+        parent: Optional[Cursor] = None,
+    ) -> Optional[Tree]:
+        if not isinstance(tree, SourceFile):
+            return tree
+        if self._tree_uses_import(tree):
+            return SearchResult.found(tree)
+        return tree
+
+    def _tree_uses_import(self, tree: Tree) -> bool:
+        from rewrite.java.tree import Import
+        from rewrite.python.tree import MultiImport
+        from rewrite.python.import_utils import get_name_string, get_qualid_name
+
+        multi_imports: list = []
+        standalone_imports: list = []
+        child_ids: set = set()
+
+        def collect(node: Any) -> None:
+            if isinstance(node, MultiImport):
+                multi_imports.append(node)
+                for imp in node.names:
+                    child_ids.add(id(imp))
+            elif isinstance(node, Import):
+                standalone_imports.append(node)
+
+        _walk(tree, collect)
+
+        for multi in multi_imports:
+            if multi.from_ is not None:
+                # `from <module> import ...` — the module is the `from` clause.
+                if _import_path_matches(get_name_string(multi.from_), self._module):
+                    return True
+            else:
+                # `import <a>, <b>` — each name's qualid is itself a module.
+                for imp in multi.names:
+                    if _import_path_matches(get_qualid_name(imp.qualid), self._module):
+                        return True
+
+        # A truly standalone J.Import (not a MultiImport child) is an
+        # `import <module>` whose qualid is the module. Children of a `from`
+        # MultiImport are imported *names*, not modules, so they are excluded.
+        for imp in standalone_imports:
+            if id(imp) in child_ids:
+                continue
+            if _import_path_matches(get_qualid_name(imp.qualid), self._module):
+                return True
+
+        return False
+
+
+def _import_path_matches(imported: str, query: str) -> bool:
+    """True when an as-written import path references the queried module.
+
+    Matches the module exactly, a submodule of it (``import os.path`` for
+    query ``os``), or a parent of it (``import os`` for query ``os.path``,
+    since ``os.path`` is then reachable). Dotted-boundary aware so ``os`` does
+    not match ``ossaudiodev``.
+    """
+    if not imported or not query:
+        return False
+    return (
+        imported == query
+        or imported.startswith(query + ".")
+        or query.startswith(imported + ".")
+    )
+
+
 def _fully_qualified_name(type_obj: Any) -> Optional[str]:
     """Best-effort accessor for a ``JavaType.FullyQualified``-shaped
     object's fully-qualified name. Returns ``None`` when the type isn't
@@ -216,4 +311,4 @@ def _walk(node: Any, visit_fn) -> None:
                     stack.append(val)
 
 
-__all__ = ["IsSourceFile", "UsesType", "UsesMethod"]
+__all__ = ["IsSourceFile", "UsesType", "UsesMethod", "UsesImport"]

--- a/rewrite-python/rewrite/tests/recipes/test_uses_import.py
+++ b/rewrite-python/rewrite/tests/recipes/test_uses_import.py
@@ -1,0 +1,103 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the in-process UsesImport search visitor and uses_import helper.
+
+UsesImport gates on the as-written import path (not type attribution), so these
+tests parse with no ty-types client -- the point of UsesImport is that it works
+without type resolution.
+"""
+
+import ast
+
+from rewrite import InMemoryExecutionContext
+from rewrite.python._parser_visitor import ParserVisitor
+from rewrite.python.preconditions import uses_import
+from rewrite.python.search import UsesImport, _import_path_matches
+
+
+def _cu(src: str):
+    return ParserVisitor(src, "test.py", None).visit(ast.parse(src))
+
+
+def _matches(module: str, src: str) -> bool:
+    cu = _cu(src)
+    # visit() returns a SearchResult-marked (new) tree on match, the same tree
+    # otherwise, which is exactly what Preconditions.Check keys off of.
+    return UsesImport(module).visit(cu, InMemoryExecutionContext()) is not cu
+
+
+class TestUsesImport:
+    def test_from_import_matches_module(self):
+        assert _matches("datetime", "from datetime import datetime\n")
+
+    def test_plain_import_matches(self):
+        assert _matches("datetime", "import datetime\n")
+
+    def test_aliased_import_matches(self):
+        assert _matches("datetime", "import datetime as dt\n")
+
+    def test_multi_name_from_import(self):
+        assert _matches("typing", "from typing import Dict, List, Optional\n")
+
+    def test_comma_import_matches_each(self):
+        assert _matches("calendar", "import os, calendar, sys\n")
+
+    def test_submodule_matches_parent_query(self):
+        assert _matches("os", "import os.path\n")
+
+    def test_parent_import_matches_submodule_query(self):
+        # `import os` makes `os.path` reachable, so a recipe targeting os.path
+        # must still be gated in.
+        assert _matches("os.path", "import os\n")
+
+    def test_from_dotted_module(self):
+        assert _matches("os.path", "from os.path import join\n")
+
+    def test_canonicalization_safe_typing_list(self):
+        # ty-types canonicalizes List -> list, erasing typing.List from TypesInUse;
+        # uses_import reads syntax and matches regardless.
+        assert _matches("typing", "from typing import List\nx: List = []\n")
+
+    def test_removed_symbol_still_matches(self):
+        # ty-types cannot resolve a removed symbol, so it produces no attribution;
+        # uses_import still matches on the import statement.
+        assert _matches("base64", "from base64 import encodestring\n")
+
+    def test_no_match_when_not_imported(self):
+        assert not _matches("datetime", "import os\nx = 1\n")
+
+    def test_no_match_on_partial_module_name(self):
+        # `os` must not match `ossaudiodev` (dotted-boundary aware).
+        assert not _matches("os", "import ossaudiodev\n")
+
+    def test_from_imported_name_is_not_treated_as_module(self):
+        # `from os import path` imports the *name* path; querying module `path`
+        # must not match (only the `from` module `os` is a module here).
+        assert not _matches("path", "from os import path\n")
+
+    def test_helper_ships_java_recipe_identity(self):
+        ref = uses_import("datetime")
+        assert ref.recipe_name == "org.openrewrite.python.search.UsesImport"
+        assert ref.options == {"module": "datetime"}
+        assert isinstance(ref.local_visitor, UsesImport)
+
+
+def test_import_path_matches_unit():
+    assert _import_path_matches("os", "os")
+    assert _import_path_matches("os.path", "os")
+    assert _import_path_matches("os", "os.path")
+    assert not _import_path_matches("ossaudiodev", "os")
+    assert not _import_path_matches("os", "")
+    assert not _import_path_matches("", "os")

--- a/rewrite-python/src/main/java/org/openrewrite/python/search/UsesImport.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/search/UsesImport.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.python.PythonIsoVisitor;
+import org.openrewrite.python.tree.Py;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Match Python source files that import a given module, by the as-written
+ * import syntax rather than by type attribution.
+ * <p>
+ * This is the host-evaluable counterpart of the Python {@code uses_import(...)}
+ * precondition helper. It exists because {@link org.openrewrite.java.search.HasType}
+ * (the {@code uses_type} gate) cannot reliably gate import-migration recipes on
+ * Python: the type checker canonicalizes aliases (so {@code from typing import List}
+ * resolves to {@code list} and never to {@code typing.List}), removed symbols
+ * (e.g. {@code from base64 import encodestring}) get no attribution at all, and
+ * Python imports never reach {@code TypesInUse} in the first place. Reading the
+ * import path off {@link Py.MultiImport} sidesteps all of that.
+ * <p>
+ * The match is a deliberate superset (module, submodule, or parent module), which
+ * is what a precondition wants: over-matching merely runs the gated visitor, while
+ * under-matching would skip a file the recipe should change.
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class UsesImport extends Recipe {
+
+    @Option(displayName = "Module",
+            description = "The dotted module path to match against `import` statements, e.g. `datetime` " +
+                          "or `os.path`. A file matches if it imports that module, a submodule of it, or " +
+                          "a parent module of it. Matched against import syntax, not type attribution.",
+            example = "datetime")
+    String module;
+
+    String displayName = "Find Python files that import a module";
+
+    String description = "Marks Python source files that import the given module, matching the as-written " +
+                         "import path rather than type attribution. Robust to type-checker canonicalization " +
+                         "and to removed or unresolvable symbols, which makes it usable as a precondition for " +
+                         "import-migration recipes where `HasType` would miss the file.";
+
+    @Override
+    public String getInstanceNameSuffix() {
+        return String.format("`%s`", module);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+                return sourceFile instanceof Py.CompilationUnit;
+            }
+
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (!(tree instanceof Py.CompilationUnit)) {
+                    return tree;
+                }
+                Py.CompilationUnit cu = (Py.CompilationUnit) tree;
+                AtomicBoolean found = new AtomicBoolean(false);
+                new PythonIsoVisitor<AtomicBoolean>() {
+                    @Override
+                    public Py.MultiImport visitMultiImport(Py.MultiImport multiImport, AtomicBoolean f) {
+                        if (f.get()) {
+                            return multiImport;
+                        }
+                        if (multiImport.getFrom() != null) {
+                            // `from <module> import ...` — the module is the `from` clause. The
+                            // imported names are symbols, not modules, so we do not descend.
+                            if (importPathMatches(dottedName(multiImport.getFrom()), module)) {
+                                f.set(true);
+                            }
+                            return multiImport;
+                        }
+                        // `import <a>, <b>` — each name's qualid is itself a module.
+                        for (J.Import name : multiImport.getNames()) {
+                            if (importPathMatches(dottedName(name.getQualid()), module)) {
+                                f.set(true);
+                                return multiImport;
+                            }
+                        }
+                        return multiImport;
+                    }
+
+                    @Override
+                    public J.Import visitImport(J.Import import_, AtomicBoolean f) {
+                        // A standalone `import <module>` statement (the parser emits a bare
+                        // J.Import for these, not a MultiImport). Children of a MultiImport are
+                        // never reached here because visitMultiImport does not descend.
+                        if (f.get()) {
+                            return import_;
+                        }
+                        if (importPathMatches(dottedName(import_.getQualid()), module)) {
+                            f.set(true);
+                        }
+                        return import_;
+                    }
+                }.visit(cu, found);
+                return found.get() ? SearchResult.found(cu) : cu;
+            }
+        };
+    }
+
+    /**
+     * Reconstruct a dotted module path from an import qualid or `from` clause,
+     * handling both {@link J.Identifier} (single segment) and nested
+     * {@link J.FieldAccess} (e.g. {@code os.path}). Mirrors the Python parser's
+     * {@code get_name_string} / {@code get_qualid_name} helpers.
+     */
+    private static @Nullable String dottedName(@Nullable J expr) {
+        if (expr instanceof J.Identifier) {
+            return ((J.Identifier) expr).getSimpleName();
+        }
+        if (expr instanceof J.FieldAccess) {
+            J.FieldAccess fa = (J.FieldAccess) expr;
+            Expression target = fa.getTarget();
+            String targetName = dottedName(target);
+            return targetName == null ? fa.getSimpleName() : targetName + "." + fa.getSimpleName();
+        }
+        return null;
+    }
+
+    private static boolean importPathMatches(@Nullable String imported, String query) {
+        if (imported == null || imported.isEmpty() || query.isEmpty()) {
+            return false;
+        }
+        // Dotted-boundary aware so `os` does not match `ossaudiodev`.
+        return imported.equals(query) ||
+               imported.startsWith(query + ".") ||
+               query.startsWith(imported + ".");
+    }
+}

--- a/rewrite-python/src/test/java/org/openrewrite/python/search/UsesImportTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/search/UsesImportTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.python.PythonIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.python.Assertions.python;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+/**
+ * Exercises {@link UsesImport} the way it is actually used: as a precondition.
+ * The gated editor bumps the integer literal {@code 1} to {@code 2}, so a match
+ * applies the edit and a non-match leaves the file untouched -- which is exactly
+ * the "skip the visit when the module isn't imported" behavior the precondition
+ * provides on the recipe-execution host. (A normal text edit is used rather than
+ * a {@code SearchResult} marker because marker rendering on a Python LST round-
+ * trips to empty through the RPC printer, which would obscure the assertion.)
+ */
+class UsesImportTest implements RewriteTest {
+
+    /** Gate a "bump integer literal 1 -> 2" editor on {@code uses_import(module)}. */
+    private static Recipe gatedBumpLiteral(String module) {
+        return toRecipe(() -> Preconditions.check(
+          new UsesImport(module).getVisitor(),
+          new PythonIsoVisitor<ExecutionContext>() {
+              @Override
+              public J.Literal visitLiteral(J.Literal literal, ExecutionContext ctx) {
+                  if ("1".equals(literal.getValueSource())) {
+                      return literal.withValue(2).withValueSource("2");
+                  }
+                  return literal;
+              }
+          }));
+    }
+
+    @Test
+    void plainImportMatches() {
+        rewriteRun(
+          spec -> spec.recipe(gatedBumpLiteral("datetime")),
+          python(
+            """
+              import datetime
+              x = 1
+              """,
+            """
+              import datetime
+              x = 2
+              """
+          )
+        );
+    }
+
+    @Test
+    void fromImportMatchesModule() {
+        rewriteRun(
+          spec -> spec.recipe(gatedBumpLiteral("datetime")),
+          python(
+            """
+              from datetime import datetime
+              x = 1
+              """,
+            """
+              from datetime import datetime
+              x = 2
+              """
+          )
+        );
+    }
+
+    @Test
+    void submoduleMatchesParentQuery() {
+        rewriteRun(
+          spec -> spec.recipe(gatedBumpLiteral("os")),
+          python(
+            """
+              import os.path
+              x = 1
+              """,
+            """
+              import os.path
+              x = 2
+              """
+          )
+        );
+    }
+
+    @Test
+    void canonicalizationSafeTypingList() {
+        // ty-types canonicalizes List -> list, so HasType("typing.List") would miss this
+        // file. uses_import reads the import syntax and gates it in regardless.
+        rewriteRun(
+          spec -> spec.recipe(gatedBumpLiteral("typing")),
+          python(
+            """
+              from typing import List
+              x: List = []
+              y = 1
+              """,
+            """
+              from typing import List
+              x: List = []
+              y = 2
+              """
+          )
+        );
+    }
+
+    @Test
+    void noMatchWhenModuleNotImported() {
+        rewriteRun(
+          spec -> spec.recipe(gatedBumpLiteral("datetime")),
+          python(
+            """
+              import os
+              x = 1
+              """
+          )
+        );
+    }
+
+    @Test
+    void noMatchOnPartialModuleName() {
+        // `os` must not match `ossaudiodev`.
+        rewriteRun(
+          spec -> spec.recipe(gatedBumpLiteral("os")),
+          python(
+            """
+              import ossaudiodev
+              x = 1
+              """
+          )
+        );
+    }
+
+    @Test
+    void fromImportedNameIsNotTreatedAsModule() {
+        // `from os import path` imports the name `path`; querying module `path` must not match.
+        rewriteRun(
+          spec -> spec.recipe(gatedBumpLiteral("path")),
+          python(
+            """
+              from os import path
+              x = 1
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What

Adds a `uses_import` precondition for Python RPC recipes and gates the built-in `ChangeImport` recipe on it.

- `org.openrewrite.python.search.UsesImport` — a host-evaluable search recipe that marks a `Py.CompilationUnit` when it imports a given module, matched against the **as-written import syntax** (`Py.MultiImport` / `J.Import` qualids), not type attribution. Handles `import X`, `from X import Y`, and `import a, b`; is dotted-boundary aware (`os` does not match `ossaudiodev`); matches module, submodule, or parent module (a deliberate superset, which is what a precondition wants); and never mistakes a from-imported *name* for a module.
- `rewrite/python/search/UsesImport` (Python) + `uses_import(module)` helper in `rewrite/python/preconditions.py` — the in-process mirror and the `RecipeRef` that ships the recipe identity to the host.
- `ChangeImport.editor()` now returns `Preconditions.check(uses_import(old_module), V())` — a correct superset, since a file can only contain `import old_module` / `from old_module import ...` if it imports `old_module`.

## Why

The existing `uses_type` gate (`HasType`) cannot gate Python import-migration recipes:

- the type checker **canonicalizes** aliases, so `from typing import List` lands in `TypesInUse` as `list`, never `typing.List`;
- removed/unresolvable symbols (`from base64 import encodestring`) get **no** attribution at all; and
- Python imports never reach `TypesInUse` in the first place.

So a type-based gate would silently skip the very files an import-migration recipe must change. `uses_import` reads the import syntax and sidesteps all three failure modes.

This is the framework half of a perf effort: gating the many import/module recipes in `rewrite-migrate-python`'s `UpgradeToPython*` chain so the host skips a recipe's visit on files that don't import the relevant module. Measured 1.77x faster recipe execution (43% off) on a representative run, with identical results.

## Tests

- `tests/recipes/test_uses_import.py` (16, Python in-process) and `UsesImportTest` (7, host recipe as a precondition) pass; existing precondition/recipe suites green.
