### PR TITLE
Fix RemoveUnusedImports for inherited nested types

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
@@ -115,6 +115,38 @@ class RemoveUnusedImportsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/7569")
+    @Test
+    void doNotRemoveStaticImportForInheritedNestedType() {
+        rewriteRun(
+          java(
+            """
+              package com.helloworld;
+
+              import static com.helloworld.FakeUserAccountClient.UserAccountDataAuth;
+
+              import java.util.List;
+
+              class Main {
+                  List<UserAccountDataAuth> getUsers() {
+                      return List.of(UserAccountDataAuth.create());
+                  }
+              }
+
+              class FakeUserAccountClient implements UserAccountClient {}
+
+              interface UserAccountClient {
+                  record UserAccountDataAuth() {
+                      static UserAccountDataAuth create() {
+                          return new UserAccountDataAuth();
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void doNotRemoveImportUsedOnlyInNestedGeneric() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
@@ -153,17 +153,10 @@ public class RemoveUnusedImports extends Recipe {
                             .orElse(target);
                     SortedSet<String> targetMethodsAndFields = methodsAndFieldsByTypeName.get(modifiedTarget);
 
-                    Set<JavaType.FullyQualified> staticClasses = null;
-                    for (JavaType.FullyQualified maybeStatic : typesByPackage.getOrDefault(target, emptySet())) {
-                        if (maybeStatic.getOwningClass() != null && outerType.startsWith(maybeStatic.getOwningClass().getFullyQualifiedName())) {
-                            if (staticClasses == null) {
-                                staticClasses = new HashSet<>();
-                            }
-                            staticClasses.add(maybeStatic);
-                        }
-                    }
+                    Set<JavaType.FullyQualified> staticClasses = staticClassesInUse(typesByPackage, target,
+                            qualid.getTarget().getType(), qualid.getSimpleName());
 
-                    if (methodsAndFields == null && targetMethodsAndFields == null && staticClasses == null) {
+                    if (methodsAndFields == null && targetMethodsAndFields == null && staticClasses.isEmpty()) {
                         anImport.used = false;
                         changed = true;
                     } else if ("*".equals(qualid.getSimpleName())) {
@@ -171,7 +164,7 @@ public class RemoveUnusedImports extends Recipe {
                             anImport.used = true;
                             usedStaticWildcardImports.add(elem.getTypeName());
                         } else if (((methodsAndFields == null ? 0 : methodsAndFields.size()) +
-                                (staticClasses == null ? 0 : staticClasses.size())) < layoutStyle.getNameCountToUseStarImport()) {
+                                staticClasses.size()) < layoutStyle.getNameCountToUseStarImport()) {
                             // replacing the star with a series of unfolded imports
                             anImport.imports.clear();
 
@@ -185,7 +178,7 @@ public class RemoveUnusedImports extends Recipe {
                                 }
                             }
 
-                            if (staticClasses != null) {
+                            if (!staticClasses.isEmpty()) {
                                 for (JavaType.FullyQualified fqn : staticClasses) {
                                     anImport.imports.add(new JRightPadded<>(elem
                                             .withId(randomId())
@@ -204,9 +197,10 @@ public class RemoveUnusedImports extends Recipe {
                         } else {
                             usedStaticWildcardImports.add(elem.getTypeName());
                         }
-                    } else if (staticClasses != null && staticClasses.stream().anyMatch(c -> elem.getTypeName().equals(c.getFullyQualifiedName())) ||
+                    } else if (!staticClasses.isEmpty() ||
                             (methodsAndFields != null && methodsAndFields.contains(qualid.getSimpleName())) ||
-                            (targetMethodsAndFields != null && targetMethodsAndFields.contains(qualid.getSimpleName()))) {
+                            (targetMethodsAndFields != null &&
+                                    targetMethodsAndFields.contains(qualid.getSimpleName()))) {
                         anImport.used = true;
                     } else {
                         anImport.used = false;
@@ -333,6 +327,49 @@ public class RemoveUnusedImports extends Recipe {
             }
 
             return cu;
+        }
+
+        private static Set<JavaType.FullyQualified> staticClassesInUse(
+                Map<String, Set<JavaType.FullyQualified>> typesByPackage, String target, JavaType targetType,
+                String importedName) {
+            Set<String> targetTypes = staticClassTargets(target, targetType);
+            Set<JavaType.FullyQualified> staticClasses = new HashSet<>();
+            boolean wildcardImport = "*".equals(importedName);
+            for (String targetTypeName : targetTypes) {
+                for (JavaType.FullyQualified maybeStatic : typesByPackage.getOrDefault(targetTypeName, emptySet())) {
+                    JavaType.FullyQualified owningClass = maybeStatic.getOwningClass();
+                    if (owningClass != null &&
+                            targetTypes.contains(toFullyQualifiedName(owningClass.getFullyQualifiedName())) &&
+                            (wildcardImport || importedName.equals(simpleClassName(maybeStatic)))) {
+                        staticClasses.add(maybeStatic);
+                    }
+                }
+            }
+            return staticClasses;
+        }
+
+        private static Set<String> staticClassTargets(String target, JavaType targetType) {
+            Set<String> targets = new HashSet<>();
+            targets.add(target);
+            collectInheritedTypeNames(TypeUtils.asFullyQualified(targetType), targets, new HashSet<>());
+            return targets;
+        }
+
+        private static void collectInheritedTypeNames(JavaType.FullyQualified type, Set<String> targets,
+                                                      Set<String> seen) {
+            if (type == null || !seen.add(type.getFullyQualifiedName())) {
+                return;
+            }
+            targets.add(toFullyQualifiedName(type.getFullyQualifiedName()));
+            collectInheritedTypeNames(type.getSupertype(), targets, seen);
+            for (JavaType.FullyQualified anInterface : type.getInterfaces()) {
+                collectInheritedTypeNames(anInterface, targets, seen);
+            }
+        }
+
+        private static String simpleClassName(JavaType.FullyQualified type) {
+            String className = type.getClassName();
+            return className.contains(".") ? className.substring(className.lastIndexOf('.') + 1) : className;
         }
 
         private static Set<String> getAmbiguousStaticImportNames(J.CompilationUnit cu) {


### PR DESCRIPTION
- Fixes #7569

Preserves required static imports when a nested type is inherited through a superclass or implemented interface.

`RemoveUnusedImports` now considers the target type's inheritance hierarchy when determining whether a statically imported nested type is used. Named imports match only the requested nested type, while wildcard imports continue to consider all applicable nested types.

Added regression coverage for importing `UserAccountDataAuth` through `FakeUserAccountClient`, where the nested type is declared by the implemented `UserAccountClient` interface.

Tested with:

`./gradlew licenseFormat`

`./gradlew :rewrite-java-test:test --tests org.openrewrite.java.RemoveUnusedImportsTest`