### PR TITLE
rewrite-python: fix empty output when a Java recipe edits a Python LST (#8093)

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
@@ -1219,7 +1219,7 @@ def _receive_search_result(marker, q: RpcReceiveQueue):
     from rewrite.markers import SearchResult
 
     # SearchResult sends: id, description
-    before_id = str(marker.id) if marker and marker.id else None
+    before_id = id_to_str(marker._id) if marker is not None and marker._id is not None else None
     id_str = q.receive(before_id)
     description = q.receive(marker.description if marker else None)
 
@@ -1236,7 +1236,7 @@ def _receive_parse_exception_result(marker, q: RpcReceiveQueue):
     from rewrite.markers import ParseExceptionResult
 
     # Receive in Java's send order: id, parserType, exceptionType, message, treeType
-    id_str = q.receive(str(marker.id) if marker else None)
+    id_str = q.receive(id_to_str(marker._id) if marker is not None and marker._id is not None else None)
     parser_type = q.receive(marker.parser_type if marker else None)
     exception_type = q.receive(marker.exception_type if marker else None)
     message = q.receive(marker.message if marker else None)
@@ -1282,7 +1282,7 @@ def _receive_markup_marker(marker, q: RpcReceiveQueue, cls):
     Matches Java's Markup.{Warn,Error,Info,Debug}.rpcReceive().
     """
 
-    id_str = q.receive(str(marker.id) if marker else None)
+    id_str = q.receive(id_to_str(marker._id) if marker is not None and marker._id is not None else None)
     message = q.receive(marker.message if marker else None)
     detail = q.receive(marker.detail if marker else None)
 
@@ -1799,7 +1799,7 @@ def _receive_parse_error(parse_error, q: RpcReceiveQueue):
     from pathlib import Path
 
     # Receive all fields in order (matching Java's ParseError.rpcSend)
-    id_str = q.receive(str(parse_error.id) if parse_error else None)
+    id_str = q.receive(id_to_str(parse_error._id) if parse_error is not None and parse_error._id is not None else None)
     markers = q.receive_markers(parse_error.markers if parse_error else None)
     source_path = q.receive(str(parse_error.source_path) if parse_error else None)
     charset_name = q.receive(parse_error.charset_name if parse_error else None)

--- a/rewrite-python/rewrite/tests/rpc/test_marker_roundtrip.py
+++ b/rewrite-python/rewrite/tests/rpc/test_marker_roundtrip.py
@@ -1,0 +1,131 @@
+# Copyright 2025 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test for the RPC diff round-trip of a *modified* Python LST.
+
+A Java recipe that edits a Python LST (e.g. adds a ``SearchResult`` marker)
+sends the edited tree back to Python as a delta against the original. Python's
+receiver then applies that delta and prints the result. Issue #8093: after the
+LST memory-footprint rework (#7958) ids became a lazily-reconstructed UUID, so
+``marker.id`` raised ``TypeError`` for a factory-created marker (``_id is None``)
+on the ADD path. That broke RPC stream alignment and printed an empty file.
+
+These tests exercise the same ``RpcSendQueue`` -> ``RpcReceiveQueue`` path
+directly (no Java needed) so they run fast and never hang.
+"""
+import ast
+from dataclasses import fields, is_dataclass
+
+from rewrite import random_id
+from rewrite.java.tree import MethodInvocation
+from rewrite.markers import Markers, ParseExceptionResult, SearchResult
+from rewrite.python._parser_visitor import ParserVisitor
+from rewrite.python.printer import PythonPrinter
+from rewrite.rpc.python_receiver import PythonRpcReceiver
+from rewrite.rpc.receive_queue import RpcReceiveQueue
+from rewrite.rpc.send_queue import RpcSendQueue
+from rewrite.utils import replace_if_changed
+
+_CU_TYPE = 'org.openrewrite.python.tree.Py$CompilationUnit'
+
+
+def _parse(source: str):
+    return ParserVisitor(source, None, None).visit_Module(ast.parse(source))
+
+
+def _find_first(root, cls):
+    seen = set()
+    stack = [root]
+    while stack:
+        o = stack.pop()
+        if id(o) in seen:
+            continue
+        seen.add(id(o))
+        if isinstance(o, cls):
+            return o
+        if is_dataclass(o):
+            stack.extend(getattr(o, f.name, None) for f in fields(o))
+        elif isinstance(o, (list, tuple)):
+            stack.extend(o)
+    return None
+
+
+def _replace_node(o, old, new):
+    if o is old:
+        return new
+    if is_dataclass(o):
+        changes = {}
+        for f in fields(o):
+            v = getattr(o, f.name, None)
+            nv = _replace_node(v, old, new)
+            if nv is not v:
+                changes[f.name] = nv
+        return replace_if_changed(o, **changes) if changes else o
+    if isinstance(o, list):
+        nl = [_replace_node(x, old, new) for x in o]
+        return nl if any(a is not b for a, b in zip(nl, o)) else o
+    return o
+
+
+def _rpc_round_trip(before, after):
+    """Serialise ``after`` as a delta against ``before`` and rebuild it on the receiver."""
+    data = RpcSendQueue(_CU_TYPE).generate(after, before)
+    batch = list(data)
+
+    def pull():
+        out = batch[:]
+        batch.clear()
+        return out
+
+    queue = RpcReceiveQueue({}, _CU_TYPE, pull)
+    return PythonRpcReceiver().receive(before, queue)
+
+
+def _add_marker_to_first_call(cu, marker):
+    call = _find_first(cu, MethodInvocation)
+    assert call is not None, "expected a method invocation in the source"
+    edited = replace_if_changed(call, _markers=Markers(random_id(), [marker]))
+    return _replace_node(cu, call, edited)
+
+
+def test_search_result_marker_round_trip_preserves_content():
+    # Issue #8093: adding a SearchResult marker via RPC printed an empty file.
+    cu = _parse('def f():\n    print("hello")\n')
+    edited = _add_marker_to_first_call(cu, SearchResult(random_id(), "found"))
+
+    expected = 'def f():\n    /*~~(found)~~>*/print("hello")\n'
+    assert PythonPrinter().print(edited) == expected
+
+    rebuilt = _rpc_round_trip(cu, edited)
+    assert PythonPrinter().print(rebuilt) == expected
+
+
+def test_parse_exception_result_marker_round_trip_preserves_content():
+    # ParseExceptionResult uses the same factory (``_id is None`` on ADD).
+    cu = _parse('x = obj.foo()\n')
+    marker = ParseExceptionResult(
+        _id=random_id(),
+        _parser_type="PythonParser",
+        _exception_type="RuntimeException",
+        _message="boom",
+        _tree_type=None,
+    )
+    edited = _add_marker_to_first_call(cu, marker)
+
+    rebuilt = _rpc_round_trip(cu, edited)
+    assert PythonPrinter().print(rebuilt) == PythonPrinter().print(edited)
+
+    rebuilt_marker = _find_first(rebuilt, MethodInvocation).markers.find_first(ParseExceptionResult)
+    assert rebuilt_marker is not None
+    assert rebuilt_marker.message == "boom"


### PR DESCRIPTION
## What's changed

- Fixes #8093 — a regression introduced in `8.84.8` (#7958) where **any** Java recipe that *modifies* a Python/Starlark LST (e.g. a `Find*` recipe adding a `SearchResult` marker) prints an **empty** file.

## Root cause

- #7958 stored LST/marker ids as a 128-bit `int` and turned the public `.id` into a lazily-reconstructed property:

```python
@property
def id(self):
    return UUID(int=self._id)
```

The marker *receive* codecs (`_receive_search_result`, `_receive_parse_exception_result`, `_receive_markup_marker`, `_receive_parse_error`) still computed the "before" id via `marker.id`. On the **ADD** path the marker is first created by a `make_dataclass_factory` with every field `None`, so `marker._id is None` and `marker.id` raised:

```
TypeError: one of the hex, bytes, bytes_le, fields, or int arguments must be given
```

from `UUID(int=None)`. That exception desynchronised the RPC receive stream, so the Java→Python round-trip of an *edited* tree rebuilt an empty/detached statement list and the printer produced `""`.

This only manifests on the **edited-tree RPC round-trip** — pure parse→print round-trips never hit the ADD path, which is why unmodified trees and the pure-Python harness were unaffected.

## Fix

Compute the before-id from the internal `_id` int via `id_to_str`, guarding `None`, in all four marker receive codecs.

## Testing

- New `tests/rpc/test_marker_roundtrip.py` drives the `RpcSendQueue` → `RpcReceiveQueue` diff round-trip with `SearchResult`/`ParseExceptionResult` markers (Java-free, fast). Fails on baseline with the exact `TypeError`; passes with the fix.
- `FindMethodsIntegTest`, `FindTypesIntegTest`, `ChangeMethodNameIntegTest` (the real Java↔Python RPC reproducer) all green; `FindMethodsIntegTest.findPrint` fails on baseline (`--rerun-tasks`) and passes with the fix.
- Full Python tree/recipe suite (634 tests) green.