### PR TITLE
Fix double indentation of continued ternary as lambda body argument

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
@@ -2772,4 +2772,30 @@ class TabsAndIndentsTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8096")
+    @Test
+    void ternaryAsLambdaBodyArgument() {
+        rewriteRun(
+          java(
+            """
+              import java.util.Optional;
+
+              class A {
+                  Optional<String> repository(String in) {
+                      return Optional.of(in);
+                  }
+
+                  public String convert(String in) {
+                      var optionalConverter = repository(in);
+                      return optionalConverter.map(arg -> arg.isEmpty()
+                              ? in.toLowerCase()
+                              : in
+                      ).orElse(in);
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -299,7 +299,9 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
                         if (!elem.getPrefix().getLastWhitespace().contains("\n")) {
                             if (elem instanceof J.Lambda) {
                                 J body = ((J.Lambda) elem).getBody();
-                                if (!(body instanceof J.Binary)) {
+                                // Binary and ternary bodies introduce their own continuation indent
+                                // for their operands, so avoid double-indenting them here.
+                                if (!(body instanceof J.Binary) && !(body instanceof J.Ternary)) {
                                     if (!body.getPrefix().getLastWhitespace().contains("\n")) {
                                         getCursor().getParentOrThrow().putMessage("lastIndent", indent + style.getContinuationIndent());
                                     }


### PR DESCRIPTION
## What's changed

`TabsAndIndentsVisitor` adds a continuation indent when a lambda body is passed as a method invocation argument that spans multiple lines. It already skips this extra indent when the lambda body is a `J.Binary` (since binary expressions introduce their own continuation indent for their operands), but did not do the same for `J.Ternary`.

A ternary body likewise introduces its own continuation indent for its `?`/`:` operands, so the lambda handling was double-indenting them — producing 16 spaces of continuation indent where IntelliJ (and the rest of OpenRewrite's formatting) produces 8.

This change extends the existing exclusion to also cover `J.Ternary`.

### Before
```java
return optionalConverter.map(arg -> arg == LOWER
                ? in.toLowerCase()
                : in
).orElse(in);
```

### After
```java
return optionalConverter.map(arg -> arg == LOWER
        ? in.toLowerCase()
        : in
).orElse(in);
```

- Fixes #8096

## Testing
Added `TabsAndIndentsTest#ternaryAsLambdaBodyArgument`. All existing `org.openrewrite.java.format.*` tests continue to pass.