### PR TITLE
C#: fix lossless round-trip of XML doc comment attributes

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
@@ -22,6 +22,10 @@
     <!-- CS3021: need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute -->
     <!-- CA2255: ModuleInitializer used in library code is intentional for RPC type-name registration. -->
     <NoWarn>VSTHRD200;VSTHRD002;VSTHRD103;CS0114;CS8602;CS8603;CS8604;CS3021;CA2255</NoWarn>
+
+    <!-- Always emit a ref assembly. Consumers reference us as a ProjectReference (via symlink) -->
+    <!-- and MSBuild's reduced target set during cross-project compile expects obj/.../ref/OpenRewrite.dll. -->
+<!--    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/CsDocCommentParser.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/CsDocCommentParser.java
@@ -41,6 +41,12 @@ public class CsDocCommentParser {
      */
     public static CsDocComment.DocComment parse(CsDocCommentRawComment rawComment) {
         String text = rawComment.getText();
+        // The raw text starts with the third '/' of the opening "///" (the C# parser strips the
+        // first "//"). The structured printer re-emits the full "///" prefix, so the leading '/'
+        // must not be carried into the body or it prints as "////".
+        if (text.startsWith("/")) {
+            text = text.substring(1);
+        }
         List<CsDocComment> body = parseContent(text);
         return new CsDocComment.DocComment(
                 Tree.randomId(),
@@ -225,10 +231,12 @@ public class CsDocCommentParser {
             if (pos == nameStart) break;
             String attrName = tagContent.substring(nameStart, pos);
 
-            // Skip whitespace before =
+            // Capture whitespace before = (normally empty for standard XML attributes)
+            int wsBeforeEqStart = pos;
             while (pos < len && Character.isWhitespace(tagContent.charAt(pos))) {
                 pos++;
             }
+            String wsBeforeEquals = tagContent.substring(wsBeforeEqStart, pos);
 
             if (pos >= len || tagContent.charAt(pos) != '=') {
                 // Attribute without value
@@ -242,10 +250,12 @@ public class CsDocCommentParser {
             }
             pos++; // skip '='
 
-            // Skip whitespace after =
+            // Capture whitespace after = (normally empty); folded into the value so it round-trips
+            int wsAfterEqStart = pos;
             while (pos < len && Character.isWhitespace(tagContent.charAt(pos))) {
                 pos++;
             }
+            String wsAfterEquals = tagContent.substring(wsAfterEqStart, pos);
 
             // Parse quoted value
             String value = "";
@@ -262,25 +272,27 @@ public class CsDocCommentParser {
 
             // Create the appropriate attribute type
             CsDocComment.XmlText spaceText = xmlText(leadingSpace);
-            List<CsDocComment> valueList = Collections.singletonList(xmlText(value));
+            List<CsDocComment> valueList = Collections.singletonList(xmlText(wsAfterEquals + value));
+            List<CsDocComment> spaceBeforeEquals =
+                    wsBeforeEquals.isEmpty() ? null : Collections.singletonList(xmlText(wsBeforeEquals));
 
             if ("cref".equals(attrName)) {
                 attrs.add(spaceText);
                 attrs.add(new CsDocComment.XmlCrefAttribute(
                         Tree.randomId(), Markers.EMPTY,
-                        null, valueList, null // reference resolved later
+                        spaceBeforeEquals, valueList, null // reference resolved later
                 ));
             } else if ("name".equals(attrName)) {
                 attrs.add(spaceText);
                 attrs.add(new CsDocComment.XmlNameAttribute(
                         Tree.randomId(), Markers.EMPTY,
-                        null, valueList, null // paramName resolved later
+                        spaceBeforeEquals, valueList, null // paramName resolved later
                 ));
             } else {
                 attrs.add(spaceText);
                 attrs.add(new CsDocComment.XmlAttribute(
                         Tree.randomId(), Markers.EMPTY,
-                        attrName, null, valueList
+                        attrName, spaceBeforeEquals, valueList
                 ));
             }
         }

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/CsDocCommentPrinter.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/CsDocCommentPrinter.java
@@ -82,13 +82,7 @@ public class CsDocCommentPrinter<P> extends CsDocCommentVisitor<PrintOutputCaptu
     public CsDocComment visitXmlAttribute(CsDocComment.XmlAttribute attribute, PrintOutputCapture<P> p) {
         beforeSyntax(attribute, p);
         p.append(attribute.getName());
-        if (attribute.getSpaceBeforeEquals() != null && !attribute.getSpaceBeforeEquals().isEmpty()) {
-            visit(attribute.getSpaceBeforeEquals(), p);
-            if (attribute.getValue() != null) {
-                p.append('=');
-                visit(attribute.getValue(), p);
-            }
-        }
+        printAttributeValue(attribute.getSpaceBeforeEquals(), attribute.getValue(), p);
         afterSyntax(attribute, p);
         return attribute;
     }
@@ -97,13 +91,7 @@ public class CsDocCommentPrinter<P> extends CsDocCommentVisitor<PrintOutputCaptu
     public CsDocComment visitXmlCrefAttribute(CsDocComment.XmlCrefAttribute attribute, PrintOutputCapture<P> p) {
         beforeSyntax(attribute, p);
         p.append("cref");
-        if (attribute.getSpaceBeforeEquals() != null && !attribute.getSpaceBeforeEquals().isEmpty()) {
-            visit(attribute.getSpaceBeforeEquals(), p);
-            if (attribute.getValue() != null) {
-                p.append('=');
-                visit(attribute.getValue(), p);
-            }
-        }
+        printAttributeValue(attribute.getSpaceBeforeEquals(), attribute.getValue(), p);
         afterSyntax(attribute, p);
         return attribute;
     }
@@ -112,15 +100,26 @@ public class CsDocCommentPrinter<P> extends CsDocCommentVisitor<PrintOutputCaptu
     public CsDocComment visitXmlNameAttribute(CsDocComment.XmlNameAttribute attribute, PrintOutputCapture<P> p) {
         beforeSyntax(attribute, p);
         p.append("name");
-        if (attribute.getSpaceBeforeEquals() != null && !attribute.getSpaceBeforeEquals().isEmpty()) {
-            visit(attribute.getSpaceBeforeEquals(), p);
-            if (attribute.getValue() != null) {
-                p.append('=');
-                visit(attribute.getValue(), p);
-            }
-        }
+        printAttributeValue(attribute.getSpaceBeforeEquals(), attribute.getValue(), p);
         afterSyntax(attribute, p);
         return attribute;
+    }
+
+    /**
+     * Print the {@code =value} portion of an XML attribute. Standard XML attributes have no
+     * whitespace around the {@code =}, so {@code spaceBeforeEquals} is normally null/empty;
+     * the value must still be printed whenever it is present.
+     */
+    private void printAttributeValue(@Nullable List<? extends CsDocComment> spaceBeforeEquals,
+                                     @Nullable List<? extends CsDocComment> value, PrintOutputCapture<P> p) {
+        if (value == null) {
+            return;
+        }
+        if (spaceBeforeEquals != null) {
+            visit(spaceBeforeEquals, p);
+        }
+        p.append('=');
+        visit(value, p);
     }
 
     @Override

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/CsDocCommentLosslessTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/CsDocCommentLosslessTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Cursor;
+import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.csharp.tree.CsDocComment;
+import org.openrewrite.csharp.tree.CsDocCommentRawComment;
+import org.openrewrite.marker.Markers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The structured {@link CsDocComment.DocComment} produced by {@link CsDocCommentParser} must print
+ * back to the exact same text the original {@link CsDocCommentRawComment} would have produced.
+ * Otherwise any recipe that visits a file containing doc comments produces a non-applicable patch.
+ */
+class CsDocCommentLosslessTest {
+
+    private static String rawPrint(String rawText) {
+        // What the original (unparsed) comment prints: "//" + text
+        return "//" + rawText;
+    }
+
+    private static String structuredPrint(String rawText) {
+        CsDocCommentRawComment raw = new CsDocCommentRawComment(rawText, "\n", Markers.EMPTY);
+        CsDocComment.DocComment parsed = CsDocCommentParser.parse(raw);
+        PrintOutputCapture<Integer> out = new PrintOutputCapture<>(0);
+        new CsDocCommentPrinter<Integer>().visit(parsed, out, new Cursor(null, Cursor.ROOT_VALUE));
+        return out.getOut();
+    }
+
+    private void assertLossless(String rawText) {
+        assertThat(structuredPrint(rawText)).isEqualTo(rawPrint(rawText));
+    }
+
+    @Test
+    void singleLineSummary() {
+        assertLossless("/ <summary>doc</summary>");
+    }
+
+    @Test
+    void multilineSummary() {
+        assertLossless("/ <summary>\n" +
+                       "/// 传统方式\n" +
+                       "/// </summary>");
+    }
+
+    @Test
+    void nestedElements() {
+        assertLossless("/ <summary>\n" +
+                       "/// Adds <paramref name=\"a\"/> to <c>b</c>.\n" +
+                       "/// </summary>\n" +
+                       "/// <param name=\"a\">first</param>");
+    }
+}


### PR DESCRIPTION
Fixes lossless round-tripping of C# `///` XML doc comments so recipes visiting files with doc comments no longer produce spurious patches.

`CsDocCommentParser` now strips the leading `/` that the C# parser leaves on raw doc-comment text (the printer re-emits the full `///`, which otherwise rendered as `////`), and captures whitespace around attribute `=` signs so it survives a parse/print cycle. `CsDocCommentPrinter` is refactored to a shared `printAttributeValue` helper that always emits `=value` when a value is present, fixing attributes whose value was previously dropped when there was no space before `=`. Adds `CsDocCommentLosslessTest` asserting the structured printout matches the original raw text for single-line, multiline, and nested-element doc comments. The `OpenRewrite.csproj` change is a commented-out documentation note about ref-assembly emission.
