### PR TITLE
Nest relocated YAML property into existing prefix mapping at a different root

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
@@ -294,7 +294,7 @@ public class ChangePropertyKey extends Recipe {
                         // property's original tree was the first top-level entry and is fully removed, auto-format
                         // would otherwise introduce a blank line before the new first entry.
                         boolean atDocumentRoot = getCursor().getParentOrThrow().getValue() instanceof Yaml.Document;
-                        String firstEntryPrefix = mergedMapping.getEntries().get(0).getPrefix();
+                        String firstEntryPrefix = atDocumentRoot ? mergedMapping.getEntries().get(0).getPrefix() : null;
                         m = maybeAutoFormat(m, mergedMapping, p, getCursor().getParentOrThrow());
                         if (atDocumentRoot && !m.getEntries().isEmpty()) {
                             m = m.withEntries(ListUtils.mapFirst(m.getEntries(), e -> e.withPrefix(firstEntryPrefix)));
@@ -323,11 +323,13 @@ public class ChangePropertyKey extends Recipe {
             int consumed = 0;
             while (consumed < segments.length - 1) {
                 Yaml.Mapping.Entry match = null;
+                int matchLength = 0;
                 for (Yaml.Mapping.Entry e : current.getEntries()) {
                     if (e.getValue() instanceof Yaml.Mapping) {
                         String[] keyParts = e.getKey().getValue().split("\\.");
                         if (consumed + keyParts.length < segments.length && matchesPrefix(segments, consumed, keyParts)) {
                             match = e;
+                            matchLength = keyParts.length;
                             break;
                         }
                     }
@@ -337,7 +339,7 @@ public class ChangePropertyKey extends Recipe {
                 }
                 nestKeys.add(match.getKey().getValue());
                 current = (Yaml.Mapping) match.getValue();
-                consumed += match.getKey().getValue().split("\\.").length;
+                consumed += matchLength;
             }
             if (nestKeys.isEmpty()) {
                 return null;

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
@@ -283,14 +283,85 @@ public class ChangePropertyKey extends Recipe {
                         }));
                     } else {
                         m = (Yaml.Mapping) new DeletePropertyVisitor<>(entryToReplace).visitNonNull(m, p);
-                        Yaml.Mapping newMapping = m.withEntries(singletonList(newEntry));
-                        Yaml.Mapping mergedMapping = (Yaml.Mapping) new MergeYamlVisitor<>(m, newMapping, true, null, false, null, null).visitMapping(m, p);
+                        // If a prefix of the relocated key already exists as a mapping in this scope,
+                        // nest the remainder under it rather than inserting a dotted key at this level.
+                        Yaml.Mapping incoming = nestUnderExistingPrefix(m, newEntry);
+                        if (incoming == null) {
+                            incoming = m.withEntries(singletonList(newEntry));
+                        }
+                        Yaml.Mapping mergedMapping = (Yaml.Mapping) new MergeYamlVisitor<>(m, incoming, true, null, false, null, null).visitMapping(m, p);
+                        // Preserve the leading prefix of the first entry at the document root: when the relocated
+                        // property's original tree was the first top-level entry and is fully removed, auto-format
+                        // would otherwise introduce a blank line before the new first entry.
+                        boolean atDocumentRoot = getCursor().getParentOrThrow().getValue() instanceof Yaml.Document;
+                        String firstEntryPrefix = mergedMapping.getEntries().get(0).getPrefix();
                         m = maybeAutoFormat(m, mergedMapping, p, getCursor().getParentOrThrow());
+                        if (atDocumentRoot && !m.getEntries().isEmpty()) {
+                            m = m.withEntries(ListUtils.mapFirst(m.getEntries(), e -> e.withPrefix(firstEntryPrefix)));
+                        }
                     }
                 }
             }
 
             return m;
+        }
+
+        /**
+         * When relocating {@code newEntry} (a dot-separated key) into {@code mapping}, descend through any
+         * mapping entries whose keys already form a prefix of the relocated key and nest the remaining
+         * portion of the key under the deepest such mapping. Returns {@code null} when no prefix exists,
+         * in which case the caller inserts the dotted key at the current level as before.
+         */
+        private Yaml.@Nullable Mapping nestUnderExistingPrefix(Yaml.Mapping mapping, Yaml.Mapping.Entry newEntry) {
+            String[] segments = ((Yaml.Scalar) newEntry.getKey()).getValue().split("\\.");
+            if (segments.length < 2) {
+                return null;
+            }
+
+            List<String> nestKeys = new ArrayList<>();
+            Yaml.Mapping current = mapping;
+            int consumed = 0;
+            while (consumed < segments.length - 1) {
+                Yaml.Mapping.Entry match = null;
+                for (Yaml.Mapping.Entry e : current.getEntries()) {
+                    if (e.getValue() instanceof Yaml.Mapping) {
+                        String[] keyParts = e.getKey().getValue().split("\\.");
+                        if (consumed + keyParts.length < segments.length && matchesPrefix(segments, consumed, keyParts)) {
+                            match = e;
+                            break;
+                        }
+                    }
+                }
+                if (match == null) {
+                    break;
+                }
+                nestKeys.add(match.getKey().getValue());
+                current = (Yaml.Mapping) match.getValue();
+                consumed += match.getKey().getValue().split("\\.").length;
+            }
+            if (nestKeys.isEmpty()) {
+                return null;
+            }
+
+            String remainder = String.join(".", Arrays.copyOfRange(segments, consumed, segments.length));
+            Yaml.Mapping.Entry leaf = newEntry.withKey(((Yaml.Scalar) newEntry.getKey()).withValue(remainder));
+            Yaml.Mapping nested = new Yaml.Mapping(randomId(), Markers.EMPTY, null, singletonList(leaf), null, null, null);
+            for (int i = nestKeys.size() - 1; i >= 0; i--) {
+                Yaml.Mapping.Entry wrapper = new Yaml.Mapping.Entry(randomId(), "", Markers.EMPTY,
+                        new Yaml.Scalar(randomId(), "", Markers.EMPTY, Yaml.Scalar.Style.PLAIN, null, null, nestKeys.get(i)),
+                        "", nested);
+                nested = new Yaml.Mapping(randomId(), Markers.EMPTY, null, singletonList(wrapper), null, null, null);
+            }
+            return nested;
+        }
+
+        private boolean matchesPrefix(String[] segments, int start, String[] keyParts) {
+            for (int i = 0; i < keyParts.length; i++) {
+                if (!segments[start + i].equals(keyParts[i])) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         @Override

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyKeyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyKeyTest.java
@@ -852,6 +852,103 @@ class ChangePropertyKeyTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/1047")
+    @Test
+    void relocatesPropertyIntoExistingMappingAtDifferentRoot() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyKey(
+            "project.metrics.prometheus.enabled",
+            "management.prometheus.metrics.export.enabled",
+            true,
+            null,
+            null
+          )),
+          yaml(
+            """
+              project:
+                metrics:
+                  prometheus:
+                    enabled: true
+                    percentiles: [0.99, 0.9]
+              management:
+                prometheus:
+                  test: true
+              """,
+            """
+              project:
+                metrics:
+                  prometheus:
+                    percentiles: [0.99, 0.9]
+              management:
+                prometheus:
+                  test: true
+                  metrics.export.enabled: true
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/1047")
+    @Test
+    void relocatesPropertyToNewRootWhenNoExistingPrefix() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyKey(
+            "project.metrics.prometheus.enabled",
+            "management.prometheus.metrics.export.enabled",
+            true,
+            null,
+            null
+          )),
+          yaml(
+            """
+              project:
+                metrics:
+                  prometheus:
+                    enabled: true
+                    percentiles: [0.99, 0.9]
+              """,
+            """
+              project:
+                metrics:
+                  prometheus:
+                    percentiles: [0.99, 0.9]
+              management.prometheus.metrics.export.enabled: true
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/1047")
+    @Test
+    void relocatesSoleSequencePropertyIntoExistingMapping() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyKey(
+            "project.metrics.prometheus.enabled",
+            "management.prometheus.metrics.export.enabled",
+            true,
+            null,
+            null
+          )),
+          yaml(
+            """
+              project:
+                metrics:
+                  prometheus:
+                    enabled: [0.99, 0.9]
+              management:
+                prometheus:
+                  test: true
+              """,
+            """
+              management:
+                prometheus:
+                  test: true
+                  metrics.export.enabled: [0.99, 0.9]
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/2881")
     @Test
     void embedIndentedPropertyIntoExisting() {


### PR DESCRIPTION
### What's changed?

`ChangePropertyKey` now nests a relocated property into an existing prefix mapping when the new key lives under a different root, instead of emitting a dotted key at the document root.

Previously, renaming e.g. `project.metrics.prometheus.enabled` → `management.prometheus.metrics.export.enabled` produced:

```yaml
management:
  prometheus:
    test: true
management.prometheus.metrics.export.enabled: true   # wrong: dotted key at root
```

Now it descends into the deepest already-existing prefix mapping (`management.prometheus`) and nests the remaining dotted key there:

```yaml
management:
  prometheus:
    test: true
    metrics.export.enabled: true
```

When no prefix of the new key exists, the previous behavior (dotted key relocated to root, see `relocatesPropertyIfNothingElseInFamily`) is preserved. A small follow-up also avoids introducing a leading blank line when the relocated property's original top-level entry is fully removed.

### Anything you'd like reviewers to focus on?

The prefix match is exact per segment (it does not apply relaxed binding when comparing against existing YAML keys); when no matching prefix is found it cleanly falls back to the prior dotted-at-root behavior, so this is strictly additive.

### Checklist

- [x] I've added unit tests to cover my changes (in `ChangePropertyKeyTest`)

- Fixes openrewrite/rewrite-spring#1047