### PR TITLE
C#: give each singleton marker a distinct fixed UUID

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Core/SingletonMarkerIdTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Core/SingletonMarkerIdTests.cs
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp;
+using OpenRewrite.Java;
+
+namespace OpenRewrite.Tests.Core;
+
+/// <summary>
+/// Singleton markers must each carry a DISTINCT, non-empty UUID. They previously all
+/// used <c>Guid.Empty</c>, which collided across types in every UUID-keyed path of the
+/// V3 marker table (intern table, findById, multi-project extern resolveById): resolving
+/// any zero-UUID marker returned whichever type was stored first, silently swapping e.g.
+/// NullSafe for NullCoalescing and dropping <c>?.</c>/<c>??</c> from printed C# so .NET
+/// migration patches failed to apply. Guards against regression.
+/// </summary>
+public class SingletonMarkerIdTests
+{
+    private static readonly (string Name, Guid Id)[] Singletons =
+    [
+        (nameof(NullSafe), NullSafe.Instance.Id),
+        (nameof(OmitParentheses), OmitParentheses.Instance.Id),
+        (nameof(OmitBraces), OmitBraces.Instance.Id),
+        (nameof(PointerMemberAccess), PointerMemberAccess.Instance.Id),
+        (nameof(NullCoalescing), NullCoalescing.Instance.Id),
+        (nameof(DelegateInvocation), DelegateInvocation.Instance.Id),
+        (nameof(MultiDimensionalArray), MultiDimensionalArray.Instance.Id),
+        (nameof(PatternCombinator), PatternCombinator.Instance.Id),
+        (nameof(MultiDimensionContinuation), MultiDimensionContinuation.Instance.Id),
+    ];
+
+    [Fact]
+    public void AllSingletonMarkerIdsAreNonEmpty()
+    {
+        foreach (var (name, id) in Singletons)
+        {
+            Assert.True(id != Guid.Empty, $"{name}.Instance.Id must not be Guid.Empty");
+        }
+    }
+
+    [Fact]
+    public void AllSingletonMarkerIdsAreDistinct()
+    {
+        var distinct = Singletons.Select(s => s.Id).Distinct().Count();
+        Assert.Equal(Singletons.Length, distinct);
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
@@ -311,7 +311,7 @@ public sealed class DelegateInvocation(
     public DelegateInvocation RpcReceive(DelegateInvocation before, RpcReceiveQueue q) =>
         before.WithId(q.ReceiveAndGet<Guid, string>(before.Id, Guid.Parse));
 
-    public static DelegateInvocation Instance { get; } = new(Guid.Empty);
+    public static DelegateInvocation Instance { get; } = new(new Guid("1e5a0003-0000-4000-8000-000000000003"));
 
     public bool Equals(DelegateInvocation? other) => other is not null && Id == other.Id;
     public override bool Equals(object? obj) => Equals(obj as DelegateInvocation);
@@ -471,7 +471,7 @@ public sealed class NullCoalescing(
     public NullCoalescing RpcReceive(NullCoalescing before, RpcReceiveQueue q) =>
         before.WithId(q.ReceiveAndGet<Guid, string>(before.Id, Guid.Parse));
 
-    public static NullCoalescing Instance { get; } = new(Guid.Empty);
+    public static NullCoalescing Instance { get; } = new(new Guid("1e5a0004-0000-4000-8000-000000000004"));
 
     public bool Equals(NullCoalescing? other) => other is not null && Id == other.Id;
     public override bool Equals(object? obj) => Equals(obj as NullCoalescing);
@@ -496,7 +496,7 @@ public sealed class MultiDimensionalArray(
     public MultiDimensionalArray RpcReceive(MultiDimensionalArray before, RpcReceiveQueue q) =>
         before.WithId(q.ReceiveAndGet<Guid, string>(before.Id, Guid.Parse));
 
-    public static MultiDimensionalArray Instance { get; } = new(Guid.Empty);
+    public static MultiDimensionalArray Instance { get; } = new(new Guid("1e5a0005-0000-4000-8000-000000000005"));
 
     public bool Equals(MultiDimensionalArray? other) => other is not null && Id == other.Id;
     public override bool Equals(object? obj) => Equals(obj as MultiDimensionalArray);
@@ -515,7 +515,7 @@ public sealed class PatternCombinator(Guid id)
     public PatternCombinator WithId(Guid id) =>
         id == Id ? this : new(id);
 
-    public static PatternCombinator Instance { get; } = new(Guid.Empty);
+    public static PatternCombinator Instance { get; } = new(new Guid("1e5a0006-0000-4000-8000-000000000006"));
     public void RpcSend(PatternCombinator after, RpcSendQueue q) => q.GetAndSend(after, m => m.Id);
     public PatternCombinator RpcReceive(PatternCombinator before, RpcReceiveQueue q) =>
         before.WithId(q.ReceiveAndGet<Guid, string>(before.Id, Guid.Parse));
@@ -597,7 +597,7 @@ public sealed class MultiDimensionContinuation(Guid id)
     public MultiDimensionContinuation WithId(Guid id) =>
         id == Id ? this : new(id);
 
-    public static MultiDimensionContinuation Instance { get; } = new(Guid.Empty);
+    public static MultiDimensionContinuation Instance { get; } = new(new Guid("1e5a0007-0000-4000-8000-000000000007"));
     public void RpcSend(MultiDimensionContinuation after, RpcSendQueue q) => q.GetAndSend(after, m => m.Id);
     public MultiDimensionContinuation RpcReceive(MultiDimensionContinuation before, RpcReceiveQueue q) =>
         before.WithId(q.ReceiveAndGet<Guid, string>(before.Id, Guid.Parse));

--- a/rewrite-csharp/csharp/OpenRewrite/Core/OmitBraces.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/OmitBraces.cs
@@ -29,7 +29,7 @@ public sealed class OmitBraces(Guid id) : Marker, IRpcCodec<OmitBraces>
     public OmitBraces WithId(Guid id) =>
         id == Id ? this : new(id);
 
-    public static OmitBraces Instance { get; } = new(Guid.Empty);
+    public static OmitBraces Instance { get; } = new(new Guid("1e5a0008-0000-4000-8000-000000000008"));
 
     public void RpcSend(OmitBraces after, RpcSendQueue q) => q.GetAndSend(after, m => m.Id);
     public OmitBraces RpcReceive(OmitBraces before, RpcReceiveQueue q) =>

--- a/rewrite-csharp/csharp/OpenRewrite/Core/PointerMemberAccess.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/PointerMemberAccess.cs
@@ -29,7 +29,7 @@ public sealed class PointerMemberAccess(Guid id) : Marker, IRpcCodec<PointerMemb
     public PointerMemberAccess WithId(Guid id) =>
         id == Id ? this : new(id);
 
-    public static PointerMemberAccess Instance { get; } = new(Guid.Empty);
+    public static PointerMemberAccess Instance { get; } = new(new Guid("1e5a0009-0000-4000-8000-000000000009"));
 
     public void RpcSend(PointerMemberAccess after, RpcSendQueue q) => q.GetAndSend(after, m => m.Id);
     public PointerMemberAccess RpcReceive(PointerMemberAccess before, RpcReceiveQueue q) =>

--- a/rewrite-csharp/csharp/OpenRewrite/Java/J.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/J.cs
@@ -64,7 +64,12 @@ public sealed class NullSafe : Marker, IRpcCodec<NullSafe>, IEquatable<NullSafe>
     public NullSafe WithDotPrefix(Space dotPrefix) =>
         ReferenceEquals(dotPrefix, DotPrefix) ? this : new(Id, dotPrefix);
 
-    public static NullSafe Instance { get; } = new(Guid.Empty);
+    // Distinct fixed UUID per singleton marker. A shared Guid.Empty collides across
+    // marker types in every UUID-keyed path of the V3 marker table (intern table,
+    // findById, multi-project extern resolveById) — resolving any zero-UUID marker
+    // returns whichever type was stored first, silently swapping e.g. NullSafe for
+    // NullCoalescing and dropping `?.`/`??` from printed C# so migration patches fail.
+    public static NullSafe Instance { get; } = new(new Guid("1e5a0001-0000-4000-8000-000000000001"));
 
     public void RpcSend(NullSafe after, RpcSendQueue q)
     {
@@ -95,7 +100,7 @@ public sealed class OmitParentheses(
     public OmitParentheses WithId(Guid id) =>
         id == Id ? this : new(id);
 
-    public static OmitParentheses Instance { get; } = new(Guid.Empty);
+    public static OmitParentheses Instance { get; } = new(new Guid("1e5a0002-0000-4000-8000-000000000002"));
     public void RpcSend(OmitParentheses after, RpcSendQueue q) => q.GetAndSend(after, m => m.Id);
     public OmitParentheses RpcReceive(OmitParentheses before, RpcReceiveQueue q) =>
         before.WithId(q.ReceiveAndGet<Guid, string>(before.Id, Guid.Parse));


### PR DESCRIPTION
The nine C# singleton markers (`NullSafe`, `OmitParentheses`, `OmitBraces`, `PointerMemberAccess`, `NullCoalescing`, `DelegateInvocation`, `MultiDimensionalArray`, `PatternCombinator`, `MultiDimensionContinuation`) all initialized their `.Instance` with `Guid.Empty`, which collided across types in every UUID-keyed path of the V3 marker table (intern table, `findById`, multi-project extern `resolveById`). Resolving any zero-UUID marker returned whichever type was stored first, silently swapping e.g. `NullSafe` for `NullCoalescing` and dropping `?.`/`??` from printed C# so .NET migration patches failed to apply. Each singleton now carries a distinct, non-empty fixed UUID, and a new `SingletonMarkerIdTests` guards non-emptiness and distinctness against regression.