### PR TITLE
C#: bump StreamJsonRpc to 2.25.29 to remediate CVE-2026-48109

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
@@ -39,7 +39,9 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="StreamJsonRpc" Version="2.20.20" />
+    <!-- 2.25.29 pulls in MessagePack 2.5.302, remediating CVE-2026-48109 (out-of-bounds read in the -->
+    <!-- LZ4 decompression path) that affected the MessagePack 2.5.187 carried by older StreamJsonRpc. -->
+    <PackageReference Include="StreamJsonRpc" Version="2.25.29" />
     <!-- xunit (assertion/fixture API only) is consumed by the public Test/ helpers (RewriteTest, RpcFixture, ...). -->
     <!-- The runner packages (Microsoft.NET.Test.Sdk, xunit.runner.visualstudio) live in the sibling OpenRewrite.Tests project. -->
     <PackageReference Include="xunit" Version="2.9.3" PrivateAssets="none" />

--- a/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
@@ -39,8 +39,6 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <!-- 2.25.29 pulls in MessagePack 2.5.302, remediating CVE-2026-48109 (out-of-bounds read in the -->
-    <!-- LZ4 decompression path) that affected the MessagePack 2.5.187 carried by older StreamJsonRpc. -->
     <PackageReference Include="StreamJsonRpc" Version="2.25.29" />
     <!-- xunit (assertion/fixture API only) is consumed by the public Test/ helpers (RewriteTest, RpcFixture, ...). -->
     <!-- The runner packages (Microsoft.NET.Test.Sdk, xunit.runner.visualstudio) live in the sibling OpenRewrite.Tests project. -->


### PR DESCRIPTION
## Background / problem

The vendored C# tool (`OpenRewrite.CSharp.Tool`) depended on `StreamJsonRpc` 2.20.20, which transitively pulls in `MessagePack` 2.5.187. That version of MessagePack is affected by [CVE-2026-48109](https://github.com/advisories/GHSA-hv8m-jj95-wg3x) (CVSS 8.2), an out-of-bounds read in the optional LZ4 decompression path (`Lz4Block`/`Lz4BlockArray`) that can trigger an `AccessViolationException` when deserializing untrusted input. The fix landed in MessagePack 2.5.301.

The vulnerable code path is not actually reachable here, since the RPC channel is configured with the System.Text.Json formatter rather than the MessagePack formatter, and the transport is a local pipe between cooperating processes. Even so, the affected DLL ships inside the published tool, so it surfaces as an active finding in dependency and container scanners that match on component coordinates.

## Solution

Bump `StreamJsonRpc` to 2.25.29, which references `MessagePack` 2.5.302 and floats the transitive away from the vulnerable 2.5.187. This stays on the dependency the project already declares rather than introducing a standalone MessagePack pin.

## Test plan

- [x] `dotnet build OpenRewrite.Tool -c Release` succeeds with 0 warnings, 0 errors (no source-breaking API changes across the bump)
- [x] `dotnet restore` resolves `StreamJsonRpc/2.25.29` and `MessagePack/2.5.302` (confirmed in `project.assets.json`)
- [x] Full C# suite green: `dotnet test OpenRewrite.Tests` — 1919 passed, 0 failed (includes the RPC roundtrip fixture tests that exercise the JSON-RPC wire protocol against a Java server)
- [x] Java-side integration tests green: `./gradlew :rewrite-csharp:integTest` (Java driving the C# tool over RPC)
