### PR TITLE
Avoid ClassCastException when a recipe rewrites the J.Return inside a K.Return

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -231,7 +231,14 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
         } else {
             r = (K.Return) temp2;
         }
-        r = r.withExpression(visitAndCast(r.getExpression(), p));
+        // A K.Return wraps a J.Return. A recipe may rewrite that inner J.Return into a
+        // different statement (e.g. unwrapping `return foo()` to `foo()`), so guard the
+        // cast rather than assuming the visited expression is still a J.Return.
+        J expression = visitAndCast(r.getExpression(), p);
+        if (!(expression instanceof J.Return)) {
+            return expression;
+        }
+        r = r.withExpression((J.Return) expression);
         return r.withLabel(visitAndCast(r.getLabel(), p));
     }
 

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinVisitorReturnTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinVisitorReturnTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class KotlinVisitorReturnTest implements RewriteTest {
+
+    /**
+     * A {@link org.openrewrite.kotlin.tree.K.Return} wraps a {@link J.Return}. A Java recipe (such as
+     * {@code TestMethodsShouldBeVoid}) may rewrite that inner {@code J.Return} into a different statement,
+     * e.g. unwrapping {@code return foo()} to {@code foo()}. {@code KotlinVisitor.visitReturn} previously
+     * cast the visited expression straight back to {@code J.Return}, throwing a {@link ClassCastException}.
+     */
+    @Test
+    void unwrapReturnIntoItsExpression() {
+        rewriteRun(
+          spec -> spec.recipe(new UnwrapReturn()),
+          kotlin(
+            """
+              fun test() {
+                  return bar()
+              }
+
+              fun bar() {
+              }
+              """,
+            """
+              fun test() {
+                  bar()
+              }
+
+              fun bar() {
+              }
+              """
+          )
+        );
+    }
+
+    static class UnwrapReturn extends Recipe {
+        @Override
+        public String getDisplayName() {
+            return "Unwrap a return into its expression";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Replaces `return foo()` with `foo()`, mimicking how Java cleanup recipes rewrite the inner return.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            return new JavaVisitor<ExecutionContext>() {
+                @Override
+                public J visitReturn(J.Return retrn, ExecutionContext ctx) {
+                    Expression expression = retrn.getExpression();
+                    if (expression != null) {
+                        return expression.withPrefix(retrn.getPrefix());
+                    }
+                    return super.visitReturn(retrn, ctx);
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## What's changed

`K.Return` wraps a `J.Return` (its `expression` field is typed `J.Return`). When a Java recipe rewrites that inner `J.Return` into a different statement, `KotlinVisitor.visitReturn` cast the visited expression straight back to `J.Return` and threw:

```
java.lang.ClassCastException: class org.openrewrite.java.tree.J$MethodInvocation cannot be cast to class org.openrewrite.java.tree.J$Return
    at org.openrewrite.kotlin.KotlinVisitor.visitReturn(KotlinVisitor.java:234)
```

This reproduces in the wild when running the `OpenRewriteRecipeBestPractices` composite over Kotlin sources: `TestMethodsShouldBeVoid` unwraps `return foo()` to `foo()`, turning the inner `J.Return` into a `J.MethodInvocation` and tripping the cast.

The fix guards the cast and returns the rewritten expression directly when it is no longer a `J.Return`, mirroring the existing defensive handling already present for `visitStatement` and `visitExpression` earlier in the same method.

## Anyone you would like to review specifically?

@timtebeek

## Checklist

- [x] I've added a unit test (`KotlinVisitorReturnTest`) that reproduces the `ClassCastException` without the fix and passes with it.