### PR TITLE
Go: fix received Block's RightPadded<Body>

### DIFF
--- a/rewrite-go/pkg/rpc/java_receiver.go
+++ b/rewrite-go/pkg/rpc/java_receiver.go
@@ -30,6 +30,32 @@ type Receiver interface {
 	Visit(t java.Tree, p any) java.Tree
 }
 
+// receiveBlockBody receives a `*Block` field that Java ships as a
+// RightPadded<Statement> (J.If.thenPart, J.ForLoop/ForEachLoop.body, ...).
+//
+// Passing the existing block as the receive baseline is essential. On a CHANGE
+// — e.g. a recipe edited a single nested statement — the unchanged siblings and
+// every whitespace/sub-field resolve to NO_CHANGE against this baseline. The
+// previous code passed nil, so q.Receive's CHANGE path materialized a fresh,
+// empty block (newObj) and every NO_CHANGE field then resolved to its zero
+// value: block prefix, statement prefixes and End space all collapsed (printed
+// `if cond{returnx}`), and nested NO_CHANGE nodes such as an inner If's
+// Condition came back nil — crashing the printer / coerceToStatementRP.
+func receiveBlockBody(r Receiver, q *ReceiveQueue, before *java.Block) *java.Block {
+	var baseline any
+	if before != nil {
+		baseline = java.RightPadded[java.Statement]{Element: before}
+	}
+	result := q.Receive(baseline, func(v any) any { return receiveRightPadded(r, q, v) })
+	if result == nil {
+		return before
+	}
+	if blk, ok := coerceToStatementRP(result).Element.(*java.Block); ok {
+		return blk
+	}
+	return before
+}
+
 // JavaReceiver deserializes J (shared Java-like) AST nodes via the
 // visitor pattern. Mirrors org.openrewrite.java.internal.rpc.JavaReceiver.
 //
@@ -447,12 +473,7 @@ func (r *JavaReceiver) VisitIf(i *java.If, p any) java.J {
 		i.Condition = cpResult.(*java.ControlParentheses)
 	}
 	// thenPart - Java sends RightPadded<Statement> wrapping the Block
-	if thenResult := q.Receive(nil, func(v any) any { return receiveRightPadded(r, q, v) }); thenResult != nil {
-		rp := coerceToStatementRP(thenResult)
-		if blk, ok := rp.Element.(*java.Block); ok {
-			i.Then = blk
-		}
-	}
+	i.Then = receiveBlockBody(r, q, i.Then)
 	// elsePart - Java sends Else node, convert to RightPadded
 	if elseResult := q.Receive(nil, func(v any) any { return r.Visit(v.(java.Tree), q) }); elseResult != nil {
 		el := elseResult.(*java.Else)
@@ -485,12 +506,7 @@ func (r *JavaReceiver) VisitForLoop(f *java.ForLoop, p any) java.J {
 		f.Control = *result.(*java.ForControl)
 	}
 	// body - Java sends RightPadded<Statement> wrapping the Block
-	if bodyResult := q.Receive(nil, func(v any) any { return receiveRightPadded(r, q, v) }); bodyResult != nil {
-		rp := coerceToStatementRP(bodyResult)
-		if blk, ok := rp.Element.(*java.Block); ok {
-			f.Body = blk
-		}
-	}
+	f.Body = receiveBlockBody(r, q, f.Body)
 	return f
 }
 
@@ -545,12 +561,7 @@ func (r *JavaReceiver) VisitForEachLoop(f *java.ForEachLoop, p any) java.J {
 		f.Control = *result.(*java.ForEachControl)
 	}
 	// body - Java sends RightPadded<Statement> wrapping the Block
-	if bodyResult := q.Receive(nil, func(v any) any { return receiveRightPadded(r, q, v) }); bodyResult != nil {
-		rp := coerceToStatementRP(bodyResult)
-		if blk, ok := rp.Element.(*java.Block); ok {
-			f.Body = blk
-		}
-	}
+	f.Body = receiveBlockBody(r, q, f.Body)
 	return f
 }
 

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/NestedReturnEditCorruptionTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/NestedReturnEditCorruptionTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.rpc;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static org.openrewrite.golang.Assertions.go;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+/**
+ * Regression test for the {@code receiveBlockBody} baseline fix in
+ * {@code rewrite-go/pkg/rpc/java_receiver.go}.
+ * <p>
+ * Editing a statement inside an {@code if} (or {@code for}) used to corrupt the
+ * enclosing block on RPC round-trip: the receiver passed a {@code nil} baseline
+ * when reconstructing {@code J.If.thenPart} and {@code ForLoop/ForEachLoop.body},
+ * so on a CHANGE every NO_CHANGE sibling field resolved to its zero value — the
+ * then-block's whitespace collapsed (printing {@code if ...; a != 0{returnb}})
+ * and, when wrapped in a {@code for}, the inner {@code if}'s {@code Condition}
+ * was dropped entirely.
+ * <p>
+ * A one-line {@code toRecipe} visitor that renames {@code a} to {@code b} is
+ * enough — the bug is structural, not recipe-specific.
+ */
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class NestedReturnEditCorruptionTest implements RewriteTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void before() {
+        Path binaryPath = Paths.get("build/rewrite-go-rpc").toAbsolutePath();
+        GoRewriteRpc.setFactory(GoRewriteRpc.builder()
+                .goBinaryPath(binaryPath)
+                .log(tempDir.resolve("go-rpc.log")));
+    }
+
+    @AfterEach
+    void after() {
+        GoRewriteRpc.shutdownCurrent();
+    }
+
+    @Override
+    public void defaults(org.openrewrite.test.RecipeSpec spec) {
+        spec.typeValidationOptions(TypeValidation.builder()
+                .allowNonWhitespaceInWhitespace(true)
+                .identifiers(false)
+                .methodInvocations(false)
+                .build());
+    }
+
+    /**
+     * Renames the identifier in any {@code return a} to {@code b} — the simplest
+     * possible edit to a statement. Used by every case below.
+     */
+    private static org.openrewrite.Recipe renameReturned() {
+        return toRecipe(() -> new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Return visitReturn(J.Return aReturn, ExecutionContext ctx) {
+                if (aReturn.getExpression() instanceof J.Identifier id && "a".equals(id.getSimpleName())) {
+                    return aReturn.withExpression(id.withSimpleName("b"));
+                }
+                return aReturn;
+            }
+        });
+    }
+
+    /** if-with-init, inside a for. */
+    @Test
+    void ifWithInitInsideFor() {
+        rewriteRun(
+                spec -> spec.recipe(renameReturned()),
+                go(
+                        """
+                        package main
+
+                        func f(items []int) int {
+                        \tfor _, item := range items {
+                        \t\tif a := g(item); a != 0 {
+                        \t\t\treturn a
+                        \t\t}
+                        \t}
+                        \treturn 0
+                        }
+                        """,
+                        """
+                        package main
+
+                        func f(items []int) int {
+                        \tfor _, item := range items {
+                        \t\tif a := g(item); a != 0 {
+                        \t\t\treturn b
+                        \t\t}
+                        \t}
+                        \treturn 0
+                        }
+                        """
+                )
+        );
+    }
+
+    /** plain if (no init), inside a for. */
+    @Test
+    void plainIfInsideFor() {
+        rewriteRun(
+                spec -> spec.recipe(renameReturned()),
+                go(
+                        """
+                        package main
+
+                        func f(items []int, a int) int {
+                        \tfor _, item := range items {
+                        \t\tif a != 0 {
+                        \t\t\treturn a
+                        \t\t}
+                        \t}
+                        \treturn 0
+                        }
+                        """,
+                        """
+                        package main
+
+                        func f(items []int, a int) int {
+                        \tfor _, item := range items {
+                        \t\tif a != 0 {
+                        \t\t\treturn b
+                        \t\t}
+                        \t}
+                        \treturn 0
+                        }
+                        """
+                )
+        );
+    }
+
+    /** if-with-init at top level (no enclosing for). */
+    @Test
+    void ifWithInitNoFor() {
+        rewriteRun(
+                spec -> spec.recipe(renameReturned()),
+                go(
+                        """
+                        package main
+
+                        func f(item int) int {
+                        \tif a := g(item); a != 0 {
+                        \t\treturn a
+                        \t}
+                        \treturn 0
+                        }
+                        """,
+                        """
+                        package main
+
+                        func f(item int) int {
+                        \tif a := g(item); a != 0 {
+                        \t\treturn b
+                        \t}
+                        \treturn 0
+                        }
+                        """
+                )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?

Fix Go's RPC logic for deserializing Block's and their bodies wrapped in `J.RightPadded`.

## What's your motivation?

They would fail and the RPC would desynchronize when executed in Moderne CLI.