### PR TITLE
Gradle 9: attach each subproject's own GradleProject in withToolingApi

### DIFF
--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
@@ -156,10 +156,14 @@ public class Assertions {
                         } else if (sourceFile.getSourcePath().endsWith("build.gradle") || sourceFile.getSourcePath().endsWith("build.gradle.kts")) {
                             OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(projectDir.toFile(), tempDirectory.resolve(sourceFile.getSourcePath()).toFile(), initScriptContents);
                             GradleProject gradleProject = model.getGradleProject();
+                            GradleProject projectForPath = model.getGradleProjectsByPath().get(gradlePathFor(tempDirectory, projectDir, sourceFile));
+                            if (projectForPath != null) {
+                                gradleProject = projectForPath;
+                            }
                             allRepositories.addAll(gradleProject.getMavenRepositories());
                             allBuildscriptRepositories.addAll(gradleProject.getBuildscript().getMavenRepositories());
                             sourceFiles.set(i, sourceFile.withMarkers(sourceFile.getMarkers().setByType(gradleProject)));
-                            gradleProjects.put(getDirectory(sourceFile), model.getGradleProject());
+                            gradleProjects.put(getDirectory(sourceFile), gradleProject);
                         } else if (sourceFile.getSourcePath().toString().endsWith(".gradle") || sourceFile.getSourcePath().toString().endsWith(".gradle.kts")) {
                             freestandingScriptFound = true;
                         }
@@ -231,5 +235,17 @@ public class Assertions {
             return parent.toString();
         }
         return "";
+    }
+
+    private static String gradlePathFor(Path tempDirectory, Path projectDir, SourceFile sourceFile) {
+        Path buildFileDir = tempDirectory.resolve(sourceFile.getSourcePath()).getParent();
+        if (buildFileDir == null) {
+            return ":";
+        }
+        String relative = projectDir.relativize(buildFileDir).toString();
+        if (relative.isEmpty()) {
+            return ":";
+        }
+        return ":" + relative.replace(File.separatorChar, ':').replace('/', ':');
     }
 }

--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModel.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModel.java
@@ -18,6 +18,7 @@ package org.openrewrite.gradle.toolingapi;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Value;
+import org.gradle.tooling.model.UnsupportedMethodException;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.RecipeSerializer;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
@@ -28,6 +29,7 @@ import org.openrewrite.internal.ListUtils;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -38,6 +40,12 @@ public class OpenRewriteModel {
 
     GradleProject gradleProject;
 
+    /**
+     * The {@link GradleProject} for every project in the build, keyed by its Gradle path (e.g. {@code ":"},
+     * {@code ":sub"}). Empty when produced by an older version of the tooling plugin that did not provide it.
+     */
+    Map<String, GradleProject> gradleProjectsByPath;
+
 
     org.openrewrite.gradle.marker. @Nullable GradleSettings gradleSettings;
 
@@ -46,7 +54,22 @@ public class OpenRewriteModel {
             GradleProject project = mapper.readValue(proxy.getGradleProjectBytes(), GradleProject.class);
             GradleSettings settings = proxy.getGradleSettingsBytes() == null ? null : mapper.readValue(proxy.getGradleSettingsBytes(), GradleSettings.class);
             deduplicate(project, settings);
-            return new OpenRewriteModel(project, settings);
+
+            Map<String, GradleProject> projectsByPath = new LinkedHashMap<>();
+            Map<String, byte[]> projectsByPathBytes;
+            try {
+                projectsByPathBytes = proxy.getGradleProjectsByPathBytes();
+            } catch (UnsupportedMethodException e) {
+                projectsByPathBytes = null;
+            }
+            if (projectsByPathBytes != null) {
+                for (Map.Entry<String, byte[]> entry : projectsByPathBytes.entrySet()) {
+                    GradleProject gp = mapper.readValue(entry.getValue(), GradleProject.class);
+                    deduplicate(gp, settings);
+                    projectsByPath.put(entry.getKey(), gp);
+                }
+            }
+            return new OpenRewriteModel(project, projectsByPath, settings);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         } catch (IOException e) {

--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelImpl.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelImpl.java
@@ -19,10 +19,13 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
+import java.util.Map;
 
 @Value
 public class OpenRewriteModelImpl implements OpenRewriteModelProxy, Serializable {
     byte[] gradleProjectBytes;
+
+    @Nullable Map<String, byte[]> gradleProjectsByPathBytes;
 
     byte @Nullable [] gradleSettingsBytes;
 }

--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelProxy.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelProxy.java
@@ -17,8 +17,18 @@ package org.openrewrite.gradle.toolingapi;
 
 import org.jspecify.annotations.Nullable;
 
+import java.util.Map;
+
 public interface OpenRewriteModelProxy {
     byte[] getGradleProjectBytes();
+
+    /**
+     * The serialized {@link org.openrewrite.gradle.marker.GradleProject} for every project in the build, keyed by
+     * its Gradle path (e.g. {@code ":"}, {@code ":sub"}). Allows consumers to attach the correct project model to a
+     * subproject build file now that Gradle 9 no longer supports targeting an individual build file.
+     * May be {@code null} when produced by an older version of the tooling plugin.
+     */
+    @Nullable Map<String, byte[]> getGradleProjectsByPathBytes();
 
     byte @Nullable [] getGradleSettingsBytes();
 }

--- a/rewrite-gradle-tooling-model/model/src/test/java/org/openrewrite/gradle/toolingapi/AssertionsTest.java
+++ b/rewrite-gradle-tooling-model/model/src/test/java/org/openrewrite/gradle/toolingapi/AssertionsTest.java
@@ -220,6 +220,57 @@ class AssertionsTest implements RewriteTest {
     }
 
     @Test
+    void multimoduleSubprojectGetsItsOwnGradleProjectOnGradle9() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(Assertions.withToolingApi(URI.create("https://downloads.gradle.org/distributions/gradle-9.5.1-bin.zip"))),
+          //language=groovy
+          settingsGradle(
+            """
+              rootProject.name = 'root'
+              include 'sub'
+              """
+          ),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              """,
+            spec -> spec
+              .path("build.gradle")
+              .afterRecipe(cu -> {
+                  Optional<GradleProject> gp = cu.getMarkers().findFirst(GradleProject.class);
+                  assertThat(gp).isPresent();
+                  assertThat(gp.get().getPath()).isEqualTo(":");
+              })
+          ),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation 'com.google.guava:guava:33.0.0-jre'
+              }
+              """,
+            spec -> spec
+              .path("sub/build.gradle")
+              .afterRecipe(cu -> {
+                  Optional<GradleProject> gp = cu.getMarkers().findFirst(GradleProject.class);
+                  assertThat(gp).isPresent();
+                  assertThat(gp.get().getPath()).isEqualTo(":sub");
+                  assertThat(gp.get().getConfiguration("compileClasspath"))
+                    .as("subproject's own configurations should be resolved")
+                    .isNotNull();
+              })
+          )
+        );
+    }
+
+    @Test
     void multimoduleResolvesAgainstBuildRoot() {
         rewriteRun(
           spec -> spec.beforeRecipe(Assertions.withToolingApi(URI.create("https://downloads.gradle.org/distributions/gradle-9.5.1-bin.zip"))),

--- a/rewrite-gradle-tooling-model/plugin/src/main/java/org/openrewrite/gradle/toolingapi/ToolingApiOpenRewriteModelPlugin.java
+++ b/rewrite-gradle-tooling-model/plugin/src/main/java/org/openrewrite/gradle/toolingapi/ToolingApiOpenRewriteModelPlugin.java
@@ -31,6 +31,8 @@ import org.openrewrite.maven.tree.MavenRepository;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @SuppressWarnings("unused")
 public class ToolingApiOpenRewriteModelPlugin implements Plugin<Project> {
@@ -60,6 +62,14 @@ public class ToolingApiOpenRewriteModelPlugin implements Plugin<Project> {
                 org.openrewrite.gradle.marker.GradleProject gradleProject = GradleProjectBuilder.gradleProject(project);
                 byte[] gradleProjectBytes = mapper.writeValueAsBytes(gradleProject);
 
+                Map<String, byte[]> gradleProjectsByPath = new LinkedHashMap<>();
+                gradleProjectsByPath.put(project.getPath(), gradleProjectBytes);
+                for (Project p : project.getRootProject().getAllprojects()) {
+                    if (!p.getPath().equals(project.getPath())) {
+                        gradleProjectsByPath.put(p.getPath(), mapper.writeValueAsBytes(GradleProjectBuilder.gradleProject(p)));
+                    }
+                }
+
                 byte[] gradleSettingsBytes = null;
                 if (GradleVersion.current().compareTo(GradleVersion.version("4.4")) >= 0 &&
                     (new File(project.getProjectDir(), "settings.gradle").exists() ||
@@ -67,7 +77,7 @@ public class ToolingApiOpenRewriteModelPlugin implements Plugin<Project> {
                     GradleSettings gradleSettings = GradleSettingsBuilder.gradleSettings(((DefaultGradle) project.getGradle()).getSettings());
                     gradleSettingsBytes = mapper.writeValueAsBytes(gradleSettings);
                 }
-                return new OpenRewriteModelImpl(gradleProjectBytes, gradleSettingsBytes);
+                return new OpenRewriteModelImpl(gradleProjectBytes, gradleProjectsByPath, gradleSettingsBytes);
             } catch (Exception e) {
                 throw new RuntimeException("Failed to serialize Gradle model to JSON", e);
             }


### PR DESCRIPTION
# Disclaimer: 

I did not have time to test the verification with cli/plugin against real repos. 
Perhaps good if @shanman190 or @sambsnyd also take a look here.

- Fixes #8080

## Problem

Gradle 9 removed the `-b`/`--build-file` argument that `Assertions.withToolingApi(...)` relied on to resolve a per-subproject `GradleProject`. On Gradle 9+, every subproject `build.gradle` in a multi-module build received the **root** project's `GradleProject` marker, so dependency-model recipes silently found nothing for a dependency declared only in a subproject (the subproject's configurations were never present). No error was thrown — recipes just made no change.

## Fix

- **Tooling plugin** (`ToolingApiOpenRewriteModelPlugin`): serialize the `GradleProject` for *every* project in the build, keyed by Gradle path (`":"`, `":sub"`). The already-built model for the requested project is reused rather than rebuilt, so its configuration-resolution state (and therefore its resolved transitive dependencies) is unchanged.
- **Model** (`OpenRewriteModelProxy` / `OpenRewriteModelImpl` / `OpenRewriteModel`): carry the per-path map. Models produced by older tooling plugins are handled gracefully via `UnsupportedMethodException`.
- **`Assertions.withToolingApi`**: prefer the project whose Gradle path matches each build file, falling back to the previous behavior when no match exists (e.g. `buildSrc`, included builds, or build files whose directory doesn't map to a configured project).

The per-build-file model building is intentionally retained, so Gradle 8 behavior is unchanged; the per-path map only *refines* the attached project when it contains a match — which is the Gradle 9 case.

## Test

`AssertionsTest#multimoduleSubprojectGetsItsOwnGradleProjectOnGradle9` declares a dependency in a subproject of a multi-module build on Gradle 9.5.1 and asserts the subproject's `build.gradle` carries its own `GradleProject` (`path == ":sub"`, with resolved configurations) rather than the root's.

- Before the fix: the subproject's marker had `path == ":"` (the root) — test fails.
- After the fix: `path == ":sub"` — test passes.

## Verification

Ran the new test plus the regression-sensitive consumer suites:
`AssertionsTest`, `DependencyInsightTest`, `RemoveDependencyTest`, `UpgradeDependencyVersionTest`, `UpgradeTransitiveDependencyVersionTest`, `AddDependencyTest`, `ChangeDependencyTest`, `AddSettingsPluginTest`, `FindGradleProjectTest`, `GradleProjectTest` — all green (default Gradle 8.14.5 and the Gradle 9 cases).
