### PR TITLE
Revert "Delete OWASP suppressions file when no suppressions remain"

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/security/RemoveOwaspSuppressions.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/security/RemoveOwaspSuppressions.java
@@ -49,18 +49,6 @@ public class RemoveOwaspSuppressions extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new IsOwaspSuppressionsFile(), new XmlIsoVisitor<ExecutionContext>() {
             @Override
-            public Xml.@Nullable Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-                Xml.Document doc = super.visitDocument(document, ctx);
-                Xml.Tag root = doc.getRoot();
-                if ("suppressions".equals(root.getName()) && root.getContent() != null &&
-                        root.getContent().stream().noneMatch(c -> c instanceof Xml.Tag && "suppress".equals(((Xml.Tag) c).getName()))) {
-                    // Remove the suppressions file altogether once no suppressions remain.
-                    return null;
-                }
-                return doc;
-            }
-
-            @Override
             public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
                 Xml.Tag t = super.visitTag(tag, ctx);
                 if (!new XPathMatcher("/suppressions").matches(getCursor()) || t.getContent() == null) {

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/security/RemoveOwaspSuppressionsTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/security/RemoveOwaspSuppressionsTest.java
@@ -44,8 +44,10 @@ class RemoveOwaspSuppressionsTest implements RewriteTest {
                       </notes>
                   </suppress>
               </suppressions>""",
-            // The file is removed altogether once no suppressions remain
-            (String) null,
+            """
+              <?xml version="1.0" encoding="UTF-8" ?>
+              <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+              </suppressions>""",
             spec -> spec.path("suppressions.xml"))
         );
     }
@@ -68,8 +70,10 @@ class RemoveOwaspSuppressionsTest implements RewriteTest {
                                     </suppress>
                                 </suppressions>"""
                                 .formatted(dayBeforeYesterdayString),
-                        // The file is removed altogether once no suppressions remain
-                        (String) null,
+                        """
+                                <?xml version="1.0" encoding="UTF-8" ?>
+                                <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+                                </suppressions>""",
                         spec -> spec.path("suppressions.xml"))
         );
     }
@@ -130,8 +134,10 @@ class RemoveOwaspSuppressionsTest implements RewriteTest {
                                     </suppress>
                                 </suppressions>""")
                                 .formatted(dayBeforeYesterdayString, dayBeforeYesterdayStringNoZ),
-                        // The file is removed altogether once no suppressions remain
-                        (String) null,
+                        """
+                                <?xml version="1.0" encoding="UTF-8" ?>
+                                <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+                                </suppressions>""",
                         spec -> spec.path("suppressions.xml"))
         );
     }
@@ -173,19 +179,6 @@ class RemoveOwaspSuppressionsTest implements RewriteTest {
                                     </suppress>
                                 </suppressions>""",
                         spec -> spec.path("suppressions.xml"))
-        );
-    }
-
-    @Test
-    void removesEmptySuppressionsFile() {
-        rewriteRun(
-          xml("""
-              <?xml version="1.0" encoding="UTF-8" ?>
-              <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-              </suppressions>""",
-            // An OWASP suppressions file without any suppressions is removed altogether
-            (String) null,
-            spec -> spec.path("suppressions.xml"))
         );
     }
 


### PR DESCRIPTION
- Reverts openrewrite/rewrite#7995
as it causes trouble in real-life.
At least the dependencyCheck Gradle plugin fails to operate with no `suppressions.xml` file:
```
[WARNING] Unable to read suppression file 'suppressions.xml'
[ERROR]   Exception occurred initializing CPE Analyzer.
...
InitializationException: Warn initializing the suppression analyzer:
  Failed to load suppressions.xml, caused by Unable to read suppression file.
    caused by SuppressionParseException: Failed to load suppressions.xml,
      caused by Unable to read suppression file.
```