### PR TITLE
Expose the major version of the JDK compiling the source code

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
@@ -233,6 +233,21 @@ public class Assertions {
         return sourceSpec;
     }
 
+    /**
+     * Attach a {@link JavaVersion} where the compiling JDK ({@code createdBy}) may differ from the
+     * {@code -source}/{@code --release} bytecode level, e.g. JDK 23 producing Java 8 bytecode.
+     */
+    public static SourceSpec<?> version(SourceSpec<?> sourceSpec, int createdByMajor, int sourceCompatibility, int targetCompatibility) {
+        return sourceSpec.markers(javaVersion(createdByMajor, sourceCompatibility, targetCompatibility));
+    }
+
+    public static SourceSpecs version(SourceSpecs sourceSpec, int createdByMajor, int sourceCompatibility, int targetCompatibility) {
+        for (SourceSpec<?> spec : sourceSpec) {
+            spec.markers(javaVersion(createdByMajor, sourceCompatibility, targetCompatibility));
+        }
+        return sourceSpec;
+    }
+
     public static SourceSpec<?> project(SourceSpec<?> sourceSpec, String projectName) {
         return sourceSpec.markers(javaProject(projectName));
     }
@@ -316,8 +331,18 @@ public class Assertions {
 
     public static JavaVersion javaVersion(int version) {
         return javaVersions.computeIfAbsent(version, v ->
-                new JavaVersion(Tree.randomId(), "openjdk", "adoptopenjdk",
+                new JavaVersion(Tree.randomId(), v + ".0.1", "adoptopenjdk",
                         Integer.toString(v), Integer.toString(v)));
+    }
+
+    /**
+     * @param createdByMajor       the major version of the compiling JDK ({@code createdBy})
+     * @param sourceCompatibility  the {@code -source} level
+     * @param targetCompatibility  the {@code --release}/target bytecode level
+     */
+    public static JavaVersion javaVersion(int createdByMajor, int sourceCompatibility, int targetCompatibility) {
+        return new JavaVersion(Tree.randomId(), createdByMajor + ".0.1", "adoptopenjdk",
+                Integer.toString(sourceCompatibility), Integer.toString(targetCompatibility));
     }
 
     private static JavaProject javaProject(String projectName) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaVersion.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaVersion.java
@@ -45,27 +45,42 @@ public class JavaVersion implements Marker {
         return majorVersionOf(targetCompatibility);
     }
 
+    /**
+     * The major version of the JDK that compiled the sources, parsed from {@link #createdBy}
+     * (typically the {@code java.runtime.version}). Unlike {@link #getMajorVersion()} and
+     * {@link #getMajorReleaseVersion()}, which reflect the {@code -source}/{@code --release}
+     * bytecode level, this reflects the JDK actually performing the compilation. Some features,
+     * such as Markdown documentation comments (JEP 467, JDK 23), are recognized based on the
+     * compiling JDK regardless of the targeted bytecode level.
+     *
+     * @return The major version of the compiling JDK, or -1 if it cannot be determined.
+     */
+    public int getMajorCreatedByVersion() {
+        return majorVersionOf(createdBy);
+    }
+
     private static int majorVersionOf(@Nullable String version) {
-        if (version == null || version.trim().isEmpty()) {
+        if (version == null) {
+            return -1;
+        }
+        String normalized = version.trim();
+        // Legacy "1.x" version scheme (e.g. "1.8.0_312") denotes major version x.
+        if (normalized.startsWith("1.")) {
+            normalized = normalized.substring(2);
+        }
+        // Take the leading run of digits, ignoring any ".minor", "+build" or "-suffix"
+        // (e.g. "21+35-2513", "23.0.1+11", "17.0.5").
+        int end = 0;
+        while (end < normalized.length() && Character.isDigit(normalized.charAt(end))) {
+            end++;
+        }
+        if (end == 0) {
             return -1;
         }
         try {
-            return Integer.parseInt(normalize(version));
+            return Integer.parseInt(normalized.substring(0, end));
         } catch (NumberFormatException e) {
             return -1;
-        }
-    }
-
-    private static String normalize(String version) {
-        if (!version.contains(".")) {
-            return version;
-        }
-
-        if (version.startsWith("1.")) {
-            String removePrefix = version.substring(version.indexOf(".") + 1);
-            return normalize(removePrefix);
-        } else {
-            return version.substring(0, version.indexOf("."));
         }
     }
 }

--- a/rewrite-java/src/test/java/org/openrewrite/java/marker/JavaVersionTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/marker/JavaVersionTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("DataFlowIssue")
 class JavaVersionTest {
 
     @Test
@@ -60,5 +61,24 @@ class JavaVersionTest {
         var javaVersion = new JavaVersion(UUID.randomUUID(), "", "", null, null);
         assertThat(javaVersion.getMajorVersion()).isEqualTo(-1);
         assertThat(javaVersion.getMajorReleaseVersion()).isEqualTo(-1);
+    }
+
+    @Test
+    void majorCreatedByVersionFromRuntimeVersionStrings() {
+        assertThat(createdBy("23.0.1+11").getMajorCreatedByVersion()).isEqualTo(23);
+        assertThat(createdBy("21+35-2513").getMajorCreatedByVersion()).isEqualTo(21);
+        assertThat(createdBy("17.0.5+8").getMajorCreatedByVersion()).isEqualTo(17);
+        assertThat(createdBy("1.8.0_312-b07").getMajorCreatedByVersion()).isEqualTo(8);
+    }
+
+    @Test
+    void majorCreatedByVersionUnparseableReturnsMinusOne() {
+        assertThat(createdBy("openjdk").getMajorCreatedByVersion()).isEqualTo(-1);
+        assertThat(createdBy("").getMajorCreatedByVersion()).isEqualTo(-1);
+        assertThat(new JavaVersion(UUID.randomUUID(), null, "", "", "").getMajorCreatedByVersion()).isEqualTo(-1);
+    }
+
+    private static JavaVersion createdBy(String runtimeVersion) {
+        return new JavaVersion(UUID.randomUUID(), runtimeVersion, "", "", "");
     }
 }


### PR DESCRIPTION
For most scenarios what matters is the bytecode level code is being compiled to target. But for some things, like supporting javadoc's markdown format, the only relevant thing is the version of the jdk doing the compiling.