### PR TITLE
Map all captured wildcards to `?` in the type mappers

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
@@ -183,7 +183,10 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
 
     private JavaType generic(Type.TypeVar type, String signature) {
         String name;
-        if (type instanceof Type.CapturedType && ((Type.CapturedType) type).wildcard.kind == BoundKind.UNBOUND) {
+        if (type instanceof Type.CapturedType) {
+            // A captured wildcard is javac's internal representation of the wildcard it was captured
+            // from; represent it as "?" (as the signature builder already does) rather than leaking
+            // javac's invalid-Java name "<captured wildcard>".
             name = "?";
         } else {
             name = type.tsym.name.toString();

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
@@ -183,7 +183,10 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
 
     private JavaType generic(Type.TypeVar type, String signature) {
         String name;
-        if (type instanceof Type.CapturedType && ((Type.CapturedType) type).wildcard.kind == BoundKind.UNBOUND) {
+        if (type instanceof Type.CapturedType) {
+            // A captured wildcard is javac's internal representation of the wildcard it was captured
+            // from; represent it as "?" (as the signature builder already does) rather than leaking
+            // javac's invalid-Java name "<captured wildcard>".
             name = "?";
         } else {
             name = type.tsym.name.toString();

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
@@ -182,7 +182,10 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
 
     private JavaType generic(Type.TypeVar type, String signature) {
         String name;
-        if (type instanceof Type.CapturedType && ((Type.CapturedType) type).wildcard.kind == BoundKind.UNBOUND) {
+        if (type instanceof Type.CapturedType) {
+            // A captured wildcard is javac's internal representation of the wildcard it was captured
+            // from; represent it as "?" (as the signature builder already does) rather than leaking
+            // javac's invalid-Java name "<captured wildcard>".
             name = "?";
         } else {
             name = type.tsym.name.toString();

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25TypeMapping.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25TypeMapping.java
@@ -183,7 +183,10 @@ class ReloadableJava25TypeMapping implements JavaTypeMapping<Tree> {
 
     private JavaType generic(Type.TypeVar type, String signature) {
         String name;
-        if (type instanceof Type.CapturedType && ((Type.CapturedType) type).wildcard.kind == BoundKind.UNBOUND) {
+        if (type instanceof Type.CapturedType) {
+            // A captured wildcard is javac's internal representation of the wildcard it was captured
+            // from; represent it as "?" (as the signature builder already does) rather than leaking
+            // javac's invalid-Java name "<captured wildcard>".
             name = "?";
         } else {
             name = type.tsym.name.toString();

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
@@ -184,7 +184,10 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
 
     private JavaType generic(Type.TypeVar type, String signature) {
         String name;
-        if (type instanceof Type.CapturedType && ((Type.CapturedType) type).wildcard.kind == BoundKind.UNBOUND) {
+        if (type instanceof Type.CapturedType) {
+            // A captured wildcard is javac's internal representation of the wildcard it was captured
+            // from; represent it as "?" (as the signature builder already does) rather than leaking
+            // javac's invalid-Java name "<captured wildcard>".
             name = "?";
         } else {
             name = type.tsym.name.toString();

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaParserTypeMappingTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaParserTypeMappingTest.java
@@ -142,6 +142,48 @@ class JavaParserTypeMappingTest implements JavaTypeMappingTest, RewriteTest {
         );
     }
 
+    @Test
+    void boundedCapturedWildcardMapsToQuestionMark() {
+        // Inferring `wrap`'s type variable from a bounded wildcard argument involves capture conversion
+        // (`List<CAP of (? extends Number)>`). javac names a captured wildcard "<captured wildcard>",
+        // which is not valid Java. Whether the capture reaches the type mapper depends on the JDK: modern
+        // javac upward-projects it back to a `?` wildcard, while older builders leave the capture in place,
+        // where the mapper must normalize it. Either way the LST must never surface "<captured wildcard>".
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+
+              class Test {
+                  static <T> List<T> wrap(List<T> list) {
+                      return list;
+                  }
+
+                  void test(List<? extends Number> list) {
+                      Object o = wrap(list);
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                AtomicReference<JavaType> wrapInvocationType = new AtomicReference<>();
+                new JavaIsoVisitor<Integer>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer p) {
+                        if ("wrap".equals(method.getSimpleName())) {
+                            wrapInvocationType.set(method.getType());
+                        }
+                        return super.visitMethodInvocation(method, p);
+                    }
+                }.visit(cu, 0);
+                Parameterized list = asParameterized(wrapInvocationType.get());
+                assertThat(list.getTypeParameters().get(0).toString())
+                  .isEqualTo("Generic{? extends java.lang.Number}")
+                  .doesNotContain("captured wildcard");
+            })
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/1762")
     @MinimumJava11
     @Test


### PR DESCRIPTION
The per-version `ReloadableJavaNTypeMapping` mappers only normalized an `UNBOUND` captured wildcard to the canonical wildcard name `?`. A *bounded* captured wildcard — javac's capture conversion of `? extends X` or `? super X` — fell through to `type.tsym.name.toString()`, which returns javac's internal symbol name `<captured wildcard>`. That is not a valid Java identifier, and it was being copied verbatim into `JavaType.GenericTypeVariable.name`.

When such a type is later rendered as source — most visibly when it is nested inside a parameterized type that `JavaTemplate` substitutes into a stub — the result is unparseable, e.g. `Set.of(__P__.<GenericCallback<<captured wildcard>>>p())`, which parses to zero statements and throws `Expected a template that would generate exactly one statement to replace one statement, but generated 0`. This was hit by `MigrateCollectionsSingletonSet` (rewrite-migrate-java) on an LST whose nested wildcard carried the un-normalized name.

The signature builders already canonicalize *every* `Type.CapturedType` to `?` (`generic instanceof Type.CapturedType ? "?" : ...`), so the mappers were inconsistent with the very signatures used as the type cache key. This aligns the mappers with the signature builders.

## Summary

- Normalize **all** captured wildcards (not just `UNBOUND`) to the name `?` in every `ReloadableJavaNTypeMapping` mapper (Java 8, 11, 17, 21, 25). The existing bound/variance handling then renders a bounded capture like an ordinary `? extends X` / `? super X` wildcard.
- Add a `JavaParserTypeMappingTest` case asserting the cross-version invariant that a captured wildcard surfaces as `Generic{? extends java.lang.Number}` and never as `<captured wildcard>`.

## Notes

- On JDK 17+ modern javac upward-projects captures back to plain `WildcardType` before they reach the mapper, so for those shapes this change is a no-op there; it earns its keep on older builders/paths that leave the capture in place. The test guards the invariant on every JDK the TCK runs against (verified on 8/11/17/21/25).
- This fixes the leak at the source: LSTs must be re-built (re-ingested) for the corrected attribution to take effect; already-serialized LSTs carrying the old name are not rewritten by this change.

## Test plan

- [x] New `JavaParserTypeMappingTest.boundedCapturedWildcardMapsToQuestionMark` passes on rewrite-java-8/11/17/21/25 (`compatibilityTest`).
- [x] Existing `JavaTemplate*` and `Substitutions` tests in rewrite-java-test still pass (no type-rendering regression).