### PR TITLE
Keep Javadoc reference parameter names out of whitespace

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -33,6 +33,7 @@ import com.sun.tools.javac.util.Context;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.marker.JavadocParameterName;
 import org.openrewrite.java.marker.LeadingBrace;
 import org.openrewrite.java.marker.Varargs;
 import org.openrewrite.java.tree.*;
@@ -649,8 +650,21 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                     for (int i = 0; i < paramTypes.size(); i++) {
                         JCTree param = paramTypes.get(i);
                         Expression paramExpr = (Expression) javaVisitor.scan(param, Space.build(whitespaceBeforeAsString(), emptyList()));
-                        Space rightFmt = Space.format(i == paramTypes.size() - 1 ?
-                                sourceBeforeAsString(")") : sourceBeforeAsString(","));
+                        // javac only records parameter types, so a non-standard parameter name such
+                        // as `str` in `#bar(String str)` is left in `afterParam`. Keep it out of the
+                        // whitespace-only Space by recording it on the parameter type expression; the
+                        // JavadocPrinter re-emits it verbatim.
+                        String afterParam = i == paramTypes.size() - 1 ?
+                                sourceBeforeAsString(")") : sourceBeforeAsString(",");
+                        int nameStart = 0;
+                        while (nameStart < afterParam.length() && Character.isWhitespace(afterParam.charAt(nameStart))) {
+                            nameStart++;
+                        }
+                        if (nameStart < afterParam.length()) {
+                            paramExpr = paramExpr.withMarkers(paramExpr.getMarkers().add(
+                                    new JavadocParameterName(randomId(), afterParam.substring(nameStart))));
+                        }
+                        Space rightFmt = Space.format(afterParam.substring(0, nameStart));
                         parameters.add(new JRightPadded<>(paramExpr, rightFmt, Markers.EMPTY));
                     }
                     paramContainer = JContainer.build(

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -35,6 +35,7 @@ import com.sun.tools.javac.util.Context;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.marker.JavadocParameterName;
 import org.openrewrite.java.marker.LeadingBrace;
 import org.openrewrite.java.marker.Varargs;
 import org.openrewrite.java.tree.*;
@@ -651,8 +652,21 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                     for (int i = 0; i < paramTypes.size(); i++) {
                         JCTree param = paramTypes.get(i);
                         Expression paramExpr = (Expression) javaVisitor.scan(param, Space.build(whitespaceBeforeAsString(), emptyList()));
-                        Space rightFmt = format(i == paramTypes.size() - 1 ?
-                                sourceBeforeAsString(")") : sourceBeforeAsString(","));
+                        // javac only records parameter types, so a non-standard parameter name such
+                        // as `str` in `#bar(String str)` is left in `afterParam`. Keep it out of the
+                        // whitespace-only Space by recording it on the parameter type expression; the
+                        // JavadocPrinter re-emits it verbatim.
+                        String afterParam = i == paramTypes.size() - 1 ?
+                                sourceBeforeAsString(")") : sourceBeforeAsString(",");
+                        int nameStart = 0;
+                        while (nameStart < afterParam.length() && Character.isWhitespace(afterParam.charAt(nameStart))) {
+                            nameStart++;
+                        }
+                        if (nameStart < afterParam.length()) {
+                            paramExpr = paramExpr.withMarkers(paramExpr.getMarkers().add(
+                                    new JavadocParameterName(randomId(), afterParam.substring(nameStart))));
+                        }
+                        Space rightFmt = format(afterParam.substring(0, nameStart));
                         parameters.add(new JRightPadded<>(paramExpr, rightFmt, Markers.EMPTY));
                     }
                     paramContainer = JContainer.build(

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
@@ -36,6 +36,7 @@ import com.sun.tools.javac.util.Context;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.marker.JavadocParameterName;
 import org.openrewrite.java.marker.LeadingBrace;
 import org.openrewrite.java.marker.Varargs;
 import org.openrewrite.java.tree.*;
@@ -652,8 +653,21 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                     for (int i = 0; i < paramTypes.size(); i++) {
                         JCTree param = paramTypes.get(i);
                         Expression paramExpr = (Expression) javaVisitor.scan(param, Space.build(whitespaceBeforeAsString(), emptyList()));
-                        Space rightFmt = Space.format(i == paramTypes.size() - 1 ?
-                                sourceBeforeAsString(")") : sourceBeforeAsString(","));
+                        // javac only records parameter types, so a non-standard parameter name such
+                        // as `str` in `#bar(String str)` is left in `afterParam`. Keep it out of the
+                        // whitespace-only Space by recording it on the parameter type expression; the
+                        // JavadocPrinter re-emits it verbatim.
+                        String afterParam = i == paramTypes.size() - 1 ?
+                                sourceBeforeAsString(")") : sourceBeforeAsString(",");
+                        int nameStart = 0;
+                        while (nameStart < afterParam.length() && Character.isWhitespace(afterParam.charAt(nameStart))) {
+                            nameStart++;
+                        }
+                        if (nameStart < afterParam.length()) {
+                            paramExpr = paramExpr.withMarkers(paramExpr.getMarkers().add(
+                                    new JavadocParameterName(randomId(), afterParam.substring(nameStart))));
+                        }
+                        Space rightFmt = Space.format(afterParam.substring(0, nameStart));
                         parameters.add(new JRightPadded<>(paramExpr, rightFmt, Markers.EMPTY));
                     }
                     paramContainer = JContainer.build(

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25JavadocVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25JavadocVisitor.java
@@ -38,6 +38,7 @@ import com.sun.tools.javac.util.Context;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.marker.JavadocParameterName;
 import org.openrewrite.java.marker.LeadingBrace;
 import org.openrewrite.java.marker.Varargs;
 import org.openrewrite.java.tree.*;
@@ -741,8 +742,21 @@ public class ReloadableJava25JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                     for (int i = 0; i < paramTypes.size(); i++) {
                         JCTree param = paramTypes.get(i);
                         Expression paramExpr = (Expression) javaVisitor.scan(param, Space.build(whitespaceBeforeAsString(), emptyList()));
-                        Space rightFmt = Space.format(i == paramTypes.size() - 1 ?
-                                sourceBeforeAsString(")") : sourceBeforeAsString(","));
+                        // javac only records parameter types, so a non-standard parameter name such
+                        // as `str` in `#bar(String str)` is left in `afterParam`. Keep it out of the
+                        // whitespace-only Space by recording it on the parameter type expression; the
+                        // JavadocPrinter re-emits it verbatim.
+                        String afterParam = i == paramTypes.size() - 1 ?
+                                sourceBeforeAsString(")") : sourceBeforeAsString(",");
+                        int nameStart = 0;
+                        while (nameStart < afterParam.length() && Character.isWhitespace(afterParam.charAt(nameStart))) {
+                            nameStart++;
+                        }
+                        if (nameStart < afterParam.length()) {
+                            paramExpr = paramExpr.withMarkers(paramExpr.getMarkers().add(
+                                    new JavadocParameterName(randomId(), afterParam.substring(nameStart))));
+                        }
+                        Space rightFmt = Space.format(afterParam.substring(0, nameStart));
                         parameters.add(new JRightPadded<>(paramExpr, rightFmt, Markers.EMPTY));
                     }
                     paramContainer = JContainer.build(

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -33,6 +33,7 @@ import com.sun.tools.javac.util.Context;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.marker.JavadocParameterName;
 import org.openrewrite.java.marker.LeadingBrace;
 import org.openrewrite.java.marker.Varargs;
 import org.openrewrite.java.tree.*;
@@ -609,8 +610,21 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
                     for (int i = 0; i < paramTypes.size(); i++) {
                         JCTree param = paramTypes.get(i);
                         Expression paramExpr = (Expression) javaVisitor.scan(param, Space.build(whitespaceBeforeAsString(), emptyList()));
-                        Space rightFmt = Space.format(i == paramTypes.size() - 1 ?
-                                sourceBeforeAsString(")") : sourceBeforeAsString(","));
+                        // javac only records parameter types, so a non-standard parameter name such
+                        // as `str` in `#bar(String str)` is left in `afterParam`. Keep it out of the
+                        // whitespace-only Space by recording it on the parameter type expression; the
+                        // JavadocPrinter re-emits it verbatim.
+                        String afterParam = i == paramTypes.size() - 1 ?
+                                sourceBeforeAsString(")") : sourceBeforeAsString(",");
+                        int nameStart = 0;
+                        while (nameStart < afterParam.length() && Character.isWhitespace(afterParam.charAt(nameStart))) {
+                            nameStart++;
+                        }
+                        if (nameStart < afterParam.length()) {
+                            paramExpr = paramExpr.withMarkers(paramExpr.getMarkers().add(
+                                    new JavadocParameterName(randomId(), afterParam.substring(nameStart))));
+                        }
+                        Space rightFmt = Space.format(afterParam.substring(0, nameStart));
                         parameters.add(new JRightPadded<>(paramExpr, rightFmt, Markers.EMPTY));
                     }
                     paramContainer = JContainer.build(

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
@@ -1096,6 +1096,7 @@ class JavadocTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/pull/8114")
     @Test
     void seeMethodReferenceWithNamedParameter() {
         rewriteRun(
@@ -1116,6 +1117,7 @@ class JavadocTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/pull/8114")
     @Test
     void seeMethodReferenceWithNamedParameters() {
         rewriteRun(
@@ -1136,6 +1138,7 @@ class JavadocTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/pull/8114")
     @Test
     void linkMethodReferenceWithNamedVarargsParameter() {
         rewriteRun(

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
@@ -1096,6 +1096,66 @@ class JavadocTest implements RewriteTest {
         );
     }
 
+    @Test
+    void seeMethodReferenceWithNamedParameter() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  /**
+                   * @see #bar(String str)
+                   */
+                  void foo() {
+                  }
+
+                  void bar(String str) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void seeMethodReferenceWithNamedParameters() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  /**
+                   * @see #bar(String str, int count)
+                   */
+                  void foo() {
+                  }
+
+                  void bar(String str, int count) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void linkMethodReferenceWithNamedVarargsParameter() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  /**
+                   * {@link #bar(String... strs)}
+                   */
+                  void foo() {
+                  }
+
+                  void bar(String... strs) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
     // see
     @Test
     void see() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavadocPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavadocPrinter.java
@@ -18,6 +18,7 @@ package org.openrewrite.java;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.java.marker.JavadocParameterName;
 import org.openrewrite.java.marker.LeadingBrace;
 import org.openrewrite.java.marker.LineComment;
 import org.openrewrite.java.marker.Varargs;
@@ -549,6 +550,11 @@ public class JavadocPrinter<P> extends JavadocVisitor<PrintOutputCapture<P>> {
                 JRightPadded<? extends J> node = nodes.get(i);
                 visit(node.getElement(), p);
                 visitSpace(node.getAfter(), location.getAfterLocation(), p);
+                // A non-standard parameter name following a parameter type in a Javadoc method
+                // reference (e.g. `str` in `#bar(String str)`) is kept out of the whitespace and
+                // re-emitted here verbatim.
+                node.getElement().getMarkers().findFirst(JavadocParameterName.class)
+                        .ifPresent(name -> p.append(name.getName()));
                 if (i < nodes.size() - 1) {
                     p.append(suffixBetween);
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavadocParameterName.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavadocParameterName.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.rpc.RpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.util.UUID;
+
+/**
+ * Records a parameter name that appears after a parameter type in a Javadoc method reference,
+ * e.g. the {@code str} in <code>{@literal @}see #bar(String str)</code>. Such names are not part
+ * of the Javadoc reference grammar (only parameter types are), so the compiler drops them and they
+ * are not modeled as part of the reference's {@link org.openrewrite.java.tree.J.MethodInvocation}
+ * arguments. This marker keeps the name out of the surrounding whitespace {@link
+ * org.openrewrite.java.tree.Space} (which must be whitespace-only) while still allowing the source
+ * to be printed back verbatim. The marker is attached to the parameter type expression and re-emitted
+ * by the Javadoc printer immediately after that expression.
+ */
+@Value
+@With
+public class JavadocParameterName implements Marker, RpcCodec<JavadocParameterName> {
+    UUID id;
+
+    /**
+     * The parameter name as it appeared in the source. Whitespace separating the name from the
+     * parameter type is retained in the parameter's trailing {@link
+     * org.openrewrite.java.tree.Space}, not here.
+     */
+    String name;
+
+    @Override
+    public void rpcSend(JavadocParameterName after, RpcSendQueue q) {
+        q.getAndSend(after, Marker::getId);
+        q.getAndSend(after, JavadocParameterName::getName);
+    }
+
+    @Override
+    public JavadocParameterName rpcReceive(JavadocParameterName before, RpcReceiveQueue q) {
+        return before
+                .withId(q.receiveAndGet(before.getId(), UUID::fromString))
+                .withName(q.receiveAndGet(before.getName(), (String s) -> s));
+    }
+}


### PR DESCRIPTION
## Problem
Scheduled CI in [openrewrite/rewrite-analysis](https://github.com/openrewrite/rewrite-analysis/actions/runs/28124014547) (and any repo parsing similar Javadoc) fails with:

```
java.lang.AssertionError: Source file was parsed into an LST that contains non-whitespace
characters in its whitespace. This is indicative of a bug in the parser.
     * @see #bar(String~~(non-whitespace)~~> str<~~)
```

## Root cause
A Javadoc method reference may include a non-standard **parameter name** after the parameter type, e.g. `@see #bar(String str)`. The compiler's `DCReference.paramTypes` only records the parameter *types*, so the trailing name (`str`) was consumed by `sourceBeforeAsString(")")`/`sourceBeforeAsString(",")` straight into the right-padding `Space` of the parameter type expression — i.e. non-whitespace ended up inside a `Space`.

- This has been latent for a long time; #8107 made `JavaWhitespaceValidationService` descend into Javadoc comments, which (correctly) now surfaces it.

## Fix
- Record the parameter name in a new `JavadocParameterName` marker attached to the parameter type expression, keeping the `Space` whitespace-only, and re-emit it verbatim in `JavadocPrinter` so the source still round-trips. The marker mirrors the `Varargs` marker added in #8107 (incl. `RpcCodec`). Applied to the Java 8/11/17/21/25 Javadoc visitors.

## Tests
Added to the TCK `JavadocTest` (run across all `rewrite-java-N` modules):
- `seeMethodReferenceWithNamedParameter` — `@see #bar(String str)` (the exact rewrite-analysis case)
- `seeMethodReferenceWithNamedParameters` — multiple named params
- `linkMethodReferenceWithNamedVarargsParameter` — `{@link #bar(String... strs)}` (named + varargs)

Verified green on `compatibilityTest` for java-8, -11, -17, -21, -25, plus the existing `JavadocTest`/`JavadocPrinterTest` suites.