### PR TITLE
Fix print idempotency when Lombok deletes a field annotation (@Delegate)

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -92,6 +92,9 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
     @SuppressWarnings("NotNullFieldNotInitialized")
     private DocCommentTable docCommentTable;
 
+    @Nullable
+    private JCCompilationUnit compilationUnit;
+
     private int cursor = 0;
 
     private static final Pattern whitespaceSuffixPattern = Pattern.compile("\\s*[^\\s]+(\\s*)");
@@ -502,6 +505,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
     @Override
     public J visitCompilationUnit(CompilationUnitTree node, Space fmt) {
         JCCompilationUnit cu = (JCCompilationUnit) node;
+        this.compilationUnit = cu;
 
         if (node.getTypeDecls().isEmpty() || cu.getPackageName() != null || !node.getImports().isEmpty()) {
             // if the package and imports are empty, allow the formatting to apply to the first class declaration.
@@ -2287,9 +2291,9 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
     /**
      * Reconstructs an annotation from the source text when no corresponding {@link JCAnnotation} is available,
      * which happens when Lombok deletes a user-written annotation (such as {@code @Delegate}) from the AST after
-     * handling it. The reconstructed annotation carries no type attribution because Lombok erased it, but it
-     * preserves the source so that the parse-to-print loop stays idempotent. Assumes the cursor is positioned at
-     * (optional) whitespace immediately preceding the {@code @}.
+     * handling it. The annotation type is resolved from the compilation unit's imports so the reconstructed
+     * annotation keeps its type attribution; only the (also erased) arguments are reproduced verbatim from source.
+     * Assumes the cursor is positioned at (optional) whitespace immediately preceding the {@code @}.
      */
     private J.Annotation sourceAnnotation() {
         Space prefix = sourceBefore("@");
@@ -2298,8 +2302,9 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                 (Character.isJavaIdentifierPart(source.charAt(cursor)) || source.charAt(cursor) == '.')) {
             cursor++;
         }
+        String annotationName = source.substring(nameStart, cursor);
         J.Identifier name = new J.Identifier(randomId(), EMPTY, Markers.EMPTY, emptyList(),
-                source.substring(nameStart, cursor), null, null);
+                annotationName, resolveErasedAnnotationType(annotationName), null);
 
         JContainer<Expression> args = null;
         int saveCursor = cursor;
@@ -2328,6 +2333,27 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
             cursor = saveCursor;
         }
         return new J.Annotation(randomId(), prefix, Markers.EMPTY, name, args);
+    }
+
+    /**
+     * Resolves the {@link JavaType} of an annotation that Lombok erased from the AST, using the still-resolved
+     * single-type imports of the compilation unit. Returns {@code null} when the type cannot be resolved (e.g. a
+     * wildcard import), in which case the reconstructed annotation simply has no type attribution.
+     */
+    private @Nullable JavaType resolveErasedAnnotationType(String annotationName) {
+        if (compilationUnit == null) {
+            return null;
+        }
+        String simpleName = annotationName.substring(annotationName.lastIndexOf('.') + 1);
+        for (ImportTree jcImport : compilationUnit.getImports()) {
+            if (jcImport.getQualifiedIdentifier() instanceof JCFieldAccess) {
+                JCFieldAccess qualid = (JCFieldAccess) jcImport.getQualifiedIdentifier();
+                if (qualid.sym instanceof Symbol.ClassSymbol && simpleName.equals(qualid.name.toString())) {
+                    return typeMapping.type(qualid.sym.type);
+                }
+            }
+        }
+        return null;
     }
 
     private J.Modifier mapModifier(Modifier mod, List<J.Annotation> annotations) {

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -2229,15 +2229,36 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                         noSpace = false;
                     }
                     if (!word.get().isEmpty()) {
+                        String keyword = word.get();
+                        // `@interface` is an annotation type declaration, not an annotation usage
+                        boolean isAnnotation = keyword.charAt(0) == '@' && !"@interface".equals(keyword);
                         Modifier matching = null;
-                        for (Modifier modifier : modifiers.getFlags()) {
-                            if (modifier.name().toLowerCase().equals(word.get())) {
-                                matching = modifier;
-                                break;
+                        if (!isAnnotation) {
+                            for (Modifier modifier : modifiers.getFlags()) {
+                                if (modifier.name().toLowerCase().equals(keyword)) {
+                                    matching = modifier;
+                                    break;
+                                }
                             }
                         }
 
-                        if (matching == null) {
+                        if (isAnnotation) {
+                            // An annotation that is present in the source but was removed from the AST by Lombok
+                            // (e.g. `@Delegate`, which Lombok deletes after generating the delegating methods).
+                            // Reconstruct it from the source so that printing remains idempotent rather than
+                            // letting the cursor desync and corrupt the following type expression. The cursor
+                            // already sits right after the previously converted modifier or annotation.
+                            J.Annotation annotation = sourceAnnotation();
+                            if (afterFirstModifier) {
+                                currentAnnotations.add(annotation);
+                            } else {
+                                leadingAnnotations.add(annotation);
+                            }
+                            word.set("");
+                            afterLastModifierPosition = cursor;
+                            lastAnnotationPosition = cursor;
+                            i = cursor - 1;
+                        } else if (matching == null) {
                             this.cursor = afterLastModifierPosition;
                             break;
                         } else {
@@ -2261,6 +2282,52 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                 leadingAnnotations.isEmpty() ? emptyList() : leadingAnnotations,
                 sortedModifiers.isEmpty() ? emptyList() : sortedModifiers
         );
+    }
+
+    /**
+     * Reconstructs an annotation from the source text when no corresponding {@link JCAnnotation} is available,
+     * which happens when Lombok deletes a user-written annotation (such as {@code @Delegate}) from the AST after
+     * handling it. The reconstructed annotation carries no type attribution because Lombok erased it, but it
+     * preserves the source so that the parse-to-print loop stays idempotent. Assumes the cursor is positioned at
+     * (optional) whitespace immediately preceding the {@code @}.
+     */
+    private J.Annotation sourceAnnotation() {
+        Space prefix = sourceBefore("@");
+        int nameStart = cursor;
+        while (cursor < source.length() &&
+                (Character.isJavaIdentifierPart(source.charAt(cursor)) || source.charAt(cursor) == '.')) {
+            cursor++;
+        }
+        J.Identifier name = new J.Identifier(randomId(), EMPTY, Markers.EMPTY, emptyList(),
+                source.substring(nameStart, cursor), null, null);
+
+        JContainer<Expression> args = null;
+        int saveCursor = cursor;
+        Space argsPrefix = whitespace();
+        if (cursor < source.length() && source.charAt(cursor) == '(') {
+            cursor++; // skip '('
+            int argsStart = cursor;
+            int depth = 1;
+            while (cursor < source.length() && depth > 0) {
+                char ch = source.charAt(cursor);
+                if (ch == '(') {
+                    depth++;
+                } else if (ch == ')') {
+                    if (--depth == 0) {
+                        break;
+                    }
+                }
+                cursor++;
+            }
+            String argsText = source.substring(argsStart, cursor);
+            Expression arg = argsText.isEmpty() ?
+                    new J.Empty(randomId(), EMPTY, Markers.EMPTY) :
+                    new J.Literal(randomId(), EMPTY, Markers.EMPTY, null, argsText, null, JavaType.Primitive.None);
+            args = JContainer.build(argsPrefix, singletonList(padRight(arg, sourceBefore(")"))), Markers.EMPTY);
+        } else {
+            cursor = saveCursor;
+        }
+        return new J.Annotation(randomId(), prefix, Markers.EMPTY, name, args);
     }
 
     private J.Modifier mapModifier(Modifier mod, List<J.Annotation> annotations) {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -2380,10 +2380,28 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                 // Check: char is whitespace OR next char is an `@` (which is an annotation preceded by modifier/annotation without space)
                 if (Character.isWhitespace(c) || (noSpace = (i + 1 < source.length() && source.charAt(i + 1) == '@'))) {
                     if (keywordStartIdx != -1) {
-                        Modifier matching = MODIFIER_BY_KEYWORD.get(source.substring(keywordStartIdx, noSpace ? i + 1 : i));
+                        String keyword = source.substring(keywordStartIdx, noSpace ? i + 1 : i);
+                        // `@interface` is an annotation type declaration, not an annotation usage
+                        boolean isAnnotation = keyword.charAt(0) == '@' && !"@interface".equals(keyword);
+                        Modifier matching = isAnnotation ? null : MODIFIER_BY_KEYWORD.get(keyword);
                         keywordStartIdx = -1;
 
-                        if (matching == null) {
+                        if (isAnnotation) {
+                            // An annotation that is present in the source but was removed from the AST by Lombok
+                            // (e.g. `@Delegate`, which Lombok deletes after generating the delegating methods).
+                            // Reconstruct it from the source so that printing remains idempotent rather than
+                            // letting the cursor desync and corrupt the following type expression. The cursor
+                            // already sits right after the previously converted modifier or annotation.
+                            J.Annotation annotation = sourceAnnotation();
+                            if (afterFirstModifier) {
+                                currentAnnotations.add(annotation);
+                            } else {
+                                leadingAnnotations.add(annotation);
+                            }
+                            afterLastModifierPosition = cursor;
+                            lastAnnotationPosition = cursor;
+                            i = cursor - 1;
+                        } else if (matching == null) {
                             this.cursor = afterLastModifierPosition;
                             break;
                         } else {
@@ -2406,6 +2424,52 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                 leadingAnnotations.isEmpty() ? emptyList() : leadingAnnotations,
                 sortedModifiers.isEmpty() ? emptyList() : sortedModifiers
         );
+    }
+
+    /**
+     * Reconstructs an annotation from the source text when no corresponding {@link JCAnnotation} is available,
+     * which happens when Lombok deletes a user-written annotation (such as {@code @Delegate}) from the AST after
+     * handling it. The reconstructed annotation carries no type attribution because Lombok erased it, but it
+     * preserves the source so that the parse-to-print loop stays idempotent. Assumes the cursor is positioned at
+     * (optional) whitespace immediately preceding the {@code @}.
+     */
+    private J.Annotation sourceAnnotation() {
+        Space prefix = sourceBefore("@");
+        int nameStart = cursor;
+        while (cursor < source.length() &&
+                (Character.isJavaIdentifierPart(source.charAt(cursor)) || source.charAt(cursor) == '.')) {
+            cursor++;
+        }
+        J.Identifier name = new J.Identifier(randomId(), EMPTY, Markers.EMPTY, emptyList(),
+                source.substring(nameStart, cursor), null, null);
+
+        JContainer<Expression> args = null;
+        int saveCursor = cursor;
+        Space argsPrefix = whitespace();
+        if (cursor < source.length() && source.charAt(cursor) == '(') {
+            cursor++; // skip '('
+            int argsStart = cursor;
+            int depth = 1;
+            while (cursor < source.length() && depth > 0) {
+                char ch = source.charAt(cursor);
+                if (ch == '(') {
+                    depth++;
+                } else if (ch == ')') {
+                    if (--depth == 0) {
+                        break;
+                    }
+                }
+                cursor++;
+            }
+            String argsText = source.substring(argsStart, cursor);
+            Expression arg = argsText.isEmpty() ?
+                    new J.Empty(randomId(), EMPTY, Markers.EMPTY) :
+                    new J.Literal(randomId(), EMPTY, Markers.EMPTY, null, argsText, null, JavaType.Primitive.None);
+            args = JContainer.build(argsPrefix, singletonList(padRight(arg, sourceBefore(")"))), Markers.EMPTY);
+        } else {
+            cursor = saveCursor;
+        }
+        return new J.Annotation(randomId(), prefix, Markers.EMPTY, name, args);
     }
 
     private J.Modifier mapModifier(Modifier mod, List<J.Annotation> annotations) {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -100,6 +100,9 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
     @SuppressWarnings("NotNullFieldNotInitialized")
     private DocCommentTable docCommentTable;
 
+    @Nullable
+    private JCCompilationUnit compilationUnit;
+
     private int cursor = 0;
 
     private static final Pattern whitespaceSuffixPattern = Pattern.compile("\\s*[^\\s]+(\\s*)");
@@ -608,6 +611,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
     @Override
     public J visitCompilationUnit(CompilationUnitTree node, Space fmt) {
         JCCompilationUnit cu = (JCCompilationUnit) node;
+        this.compilationUnit = cu;
 
         if (node.getTypeDecls().isEmpty() || cu.getPackageName() != null || !node.getImports().isEmpty()) {
             // if the package and imports are empty, allow the formatting to apply to the first class declaration.
@@ -2429,9 +2433,9 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
     /**
      * Reconstructs an annotation from the source text when no corresponding {@link JCAnnotation} is available,
      * which happens when Lombok deletes a user-written annotation (such as {@code @Delegate}) from the AST after
-     * handling it. The reconstructed annotation carries no type attribution because Lombok erased it, but it
-     * preserves the source so that the parse-to-print loop stays idempotent. Assumes the cursor is positioned at
-     * (optional) whitespace immediately preceding the {@code @}.
+     * handling it. The annotation type is resolved from the compilation unit's imports so the reconstructed
+     * annotation keeps its type attribution; only the (also erased) arguments are reproduced verbatim from source.
+     * Assumes the cursor is positioned at (optional) whitespace immediately preceding the {@code @}.
      */
     private J.Annotation sourceAnnotation() {
         Space prefix = sourceBefore("@");
@@ -2440,8 +2444,9 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                 (Character.isJavaIdentifierPart(source.charAt(cursor)) || source.charAt(cursor) == '.')) {
             cursor++;
         }
+        String annotationName = source.substring(nameStart, cursor);
         J.Identifier name = new J.Identifier(randomId(), EMPTY, Markers.EMPTY, emptyList(),
-                source.substring(nameStart, cursor), null, null);
+                annotationName, resolveErasedAnnotationType(annotationName), null);
 
         JContainer<Expression> args = null;
         int saveCursor = cursor;
@@ -2470,6 +2475,27 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
             cursor = saveCursor;
         }
         return new J.Annotation(randomId(), prefix, Markers.EMPTY, name, args);
+    }
+
+    /**
+     * Resolves the {@link JavaType} of an annotation that Lombok erased from the AST, using the still-resolved
+     * single-type imports of the compilation unit. Returns {@code null} when the type cannot be resolved (e.g. a
+     * wildcard import), in which case the reconstructed annotation simply has no type attribution.
+     */
+    private @Nullable JavaType resolveErasedAnnotationType(String annotationName) {
+        if (compilationUnit == null) {
+            return null;
+        }
+        String simpleName = annotationName.substring(annotationName.lastIndexOf('.') + 1);
+        for (ImportTree jcImport : compilationUnit.getImports()) {
+            if (jcImport.getQualifiedIdentifier() instanceof JCFieldAccess) {
+                JCFieldAccess qualid = (JCFieldAccess) jcImport.getQualifiedIdentifier();
+                if (qualid.sym instanceof Symbol.ClassSymbol && simpleName.equals(qualid.name.toString())) {
+                    return typeMapping.type(qualid.sym.type);
+                }
+            }
+        }
+        return null;
     }
 
     private J.Modifier mapModifier(Modifier mod, List<J.Annotation> annotations) {

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -102,6 +102,9 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
     @SuppressWarnings("NotNullFieldNotInitialized")
     private DocCommentTable docCommentTable;
 
+    @Nullable
+    private JCCompilationUnit compilationUnit;
+
     private int cursor = 0;
 
     private static final Pattern whitespaceSuffixPattern = Pattern.compile("\\s*[^\\s]+(\\s*)");
@@ -615,6 +618,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
     @Override
     public J visitCompilationUnit(CompilationUnitTree node, Space fmt) {
         JCCompilationUnit cu = (JCCompilationUnit) node;
+        this.compilationUnit = cu;
 
         if (node.getTypeDecls().isEmpty() || cu.getPackageName() != null || !node.getImports().isEmpty()) {
             // if the package and imports are empty, allow the formatting to apply to the first class declaration.
@@ -2467,9 +2471,9 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
     /**
      * Reconstructs an annotation from the source text when no corresponding {@link JCAnnotation} is available,
      * which happens when Lombok deletes a user-written annotation (such as {@code @Delegate}) from the AST after
-     * handling it. The reconstructed annotation carries no type attribution because Lombok erased it, but it
-     * preserves the source so that the parse-to-print loop stays idempotent. Assumes the cursor is positioned at
-     * (optional) whitespace immediately preceding the {@code @}.
+     * handling it. The annotation type is resolved from the compilation unit's imports so the reconstructed
+     * annotation keeps its type attribution; only the (also erased) arguments are reproduced verbatim from source.
+     * Assumes the cursor is positioned at (optional) whitespace immediately preceding the {@code @}.
      */
     private J.Annotation sourceAnnotation() {
         Space prefix = sourceBefore("@");
@@ -2478,8 +2482,9 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 (Character.isJavaIdentifierPart(source.charAt(cursor)) || source.charAt(cursor) == '.')) {
             cursor++;
         }
+        String annotationName = source.substring(nameStart, cursor);
         J.Identifier name = new J.Identifier(randomId(), EMPTY, Markers.EMPTY, emptyList(),
-                source.substring(nameStart, cursor), null, null);
+                annotationName, resolveErasedAnnotationType(annotationName), null);
 
         JContainer<Expression> args = null;
         int saveCursor = cursor;
@@ -2508,6 +2513,27 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
             cursor = saveCursor;
         }
         return new J.Annotation(randomId(), prefix, Markers.EMPTY, name, args);
+    }
+
+    /**
+     * Resolves the {@link JavaType} of an annotation that Lombok erased from the AST, using the still-resolved
+     * single-type imports of the compilation unit. Returns {@code null} when the type cannot be resolved (e.g. a
+     * wildcard import), in which case the reconstructed annotation simply has no type attribution.
+     */
+    private @Nullable JavaType resolveErasedAnnotationType(String annotationName) {
+        if (compilationUnit == null) {
+            return null;
+        }
+        String simpleName = annotationName.substring(annotationName.lastIndexOf('.') + 1);
+        for (ImportTree jcImport : compilationUnit.getImports()) {
+            if (jcImport.getQualifiedIdentifier() instanceof JCFieldAccess) {
+                JCFieldAccess qualid = (JCFieldAccess) jcImport.getQualifiedIdentifier();
+                if (qualid.sym instanceof Symbol.ClassSymbol && simpleName.equals(qualid.name.toString())) {
+                    return typeMapping.type(qualid.sym.type);
+                }
+            }
+        }
+        return null;
     }
 
     private J.Modifier mapModifier(Modifier mod, List<J.Annotation> annotations) {

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -2418,10 +2418,28 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 // Check: char is whitespace OR next char is an `@` (which is an annotation preceded by modifier/annotation without space)
                 if (Character.isWhitespace(c) || (noSpace = (i + 1 < source.length() && source.charAt(i + 1) == '@'))) {
                     if (keywordStartIdx != -1) {
-                        Modifier matching = MODIFIER_BY_KEYWORD.get(source.substring(keywordStartIdx, noSpace ? i + 1 : i));
+                        String keyword = source.substring(keywordStartIdx, noSpace ? i + 1 : i);
+                        // `@interface` is an annotation type declaration, not an annotation usage
+                        boolean isAnnotation = keyword.charAt(0) == '@' && !"@interface".equals(keyword);
+                        Modifier matching = isAnnotation ? null : MODIFIER_BY_KEYWORD.get(keyword);
                         keywordStartIdx = -1;
 
-                        if (matching == null) {
+                        if (isAnnotation) {
+                            // An annotation that is present in the source but was removed from the AST by Lombok
+                            // (e.g. `@Delegate`, which Lombok deletes after generating the delegating methods).
+                            // Reconstruct it from the source so that printing remains idempotent rather than
+                            // letting the cursor desync and corrupt the following type expression. The cursor
+                            // already sits right after the previously converted modifier or annotation.
+                            J.Annotation annotation = sourceAnnotation();
+                            if (afterFirstModifier) {
+                                currentAnnotations.add(annotation);
+                            } else {
+                                leadingAnnotations.add(annotation);
+                            }
+                            afterLastModifierPosition = cursor;
+                            lastAnnotationPosition = cursor;
+                            i = cursor - 1;
+                        } else if (matching == null) {
                             this.cursor = afterLastModifierPosition;
                             break;
                         } else {
@@ -2444,6 +2462,52 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 leadingAnnotations.isEmpty() ? emptyList() : leadingAnnotations,
                 sortedModifiers.isEmpty() ? emptyList() : sortedModifiers
         );
+    }
+
+    /**
+     * Reconstructs an annotation from the source text when no corresponding {@link JCAnnotation} is available,
+     * which happens when Lombok deletes a user-written annotation (such as {@code @Delegate}) from the AST after
+     * handling it. The reconstructed annotation carries no type attribution because Lombok erased it, but it
+     * preserves the source so that the parse-to-print loop stays idempotent. Assumes the cursor is positioned at
+     * (optional) whitespace immediately preceding the {@code @}.
+     */
+    private J.Annotation sourceAnnotation() {
+        Space prefix = sourceBefore("@");
+        int nameStart = cursor;
+        while (cursor < source.length() &&
+                (Character.isJavaIdentifierPart(source.charAt(cursor)) || source.charAt(cursor) == '.')) {
+            cursor++;
+        }
+        J.Identifier name = new J.Identifier(randomId(), EMPTY, Markers.EMPTY, emptyList(),
+                source.substring(nameStart, cursor), null, null);
+
+        JContainer<Expression> args = null;
+        int saveCursor = cursor;
+        Space argsPrefix = whitespace();
+        if (cursor < source.length() && source.charAt(cursor) == '(') {
+            cursor++; // skip '('
+            int argsStart = cursor;
+            int depth = 1;
+            while (cursor < source.length() && depth > 0) {
+                char ch = source.charAt(cursor);
+                if (ch == '(') {
+                    depth++;
+                } else if (ch == ')') {
+                    if (--depth == 0) {
+                        break;
+                    }
+                }
+                cursor++;
+            }
+            String argsText = source.substring(argsStart, cursor);
+            Expression arg = argsText.isEmpty() ?
+                    new J.Empty(randomId(), EMPTY, Markers.EMPTY) :
+                    new J.Literal(randomId(), EMPTY, Markers.EMPTY, null, argsText, null, JavaType.Primitive.None);
+            args = JContainer.build(argsPrefix, singletonList(padRight(arg, sourceBefore(")"))), Markers.EMPTY);
+        } else {
+            cursor = saveCursor;
+        }
+        return new J.Annotation(randomId(), prefix, Markers.EMPTY, name, args);
     }
 
     private J.Modifier mapModifier(Modifier mod, List<J.Annotation> annotations) {

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
@@ -2450,10 +2450,28 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
                 // Check: char is whitespace OR next char is an `@` (which is an annotation preceded by modifier/annotation without space)
                 if (Character.isWhitespace(c) || (noSpace = (i + 1 < source.length() && source.charAt(i + 1) == '@'))) {
                     if (keywordStartIdx != -1) {
-                        Modifier matching = MODIFIER_BY_KEYWORD.get(source.substring(keywordStartIdx, noSpace ? i + 1 : i));
+                        String keyword = source.substring(keywordStartIdx, noSpace ? i + 1 : i);
+                        // `@interface` is an annotation type declaration, not an annotation usage
+                        boolean isAnnotation = keyword.charAt(0) == '@' && !"@interface".equals(keyword);
+                        Modifier matching = isAnnotation ? null : MODIFIER_BY_KEYWORD.get(keyword);
                         keywordStartIdx = -1;
 
-                        if (matching == null) {
+                        if (isAnnotation) {
+                            // An annotation that is present in the source but was removed from the AST by Lombok
+                            // (e.g. `@Delegate`, which Lombok deletes after generating the delegating methods).
+                            // Reconstruct it from the source so that printing remains idempotent rather than
+                            // letting the cursor desync and corrupt the following type expression. The cursor
+                            // already sits right after the previously converted modifier or annotation.
+                            J.Annotation annotation = sourceAnnotation();
+                            if (afterFirstModifier) {
+                                currentAnnotations.add(annotation);
+                            } else {
+                                leadingAnnotations.add(annotation);
+                            }
+                            afterLastModifierPosition = cursor;
+                            lastAnnotationPosition = cursor;
+                            i = cursor - 1;
+                        } else if (matching == null) {
                             this.cursor = afterLastModifierPosition;
                             break;
                         } else {
@@ -2476,6 +2494,52 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
                 leadingAnnotations.isEmpty() ? emptyList() : leadingAnnotations,
                 sortedModifiers.isEmpty() ? emptyList() : sortedModifiers
         );
+    }
+
+    /**
+     * Reconstructs an annotation from the source text when no corresponding {@link JCAnnotation} is available,
+     * which happens when Lombok deletes a user-written annotation (such as {@code @Delegate}) from the AST after
+     * handling it. The reconstructed annotation carries no type attribution because Lombok erased it, but it
+     * preserves the source so that the parse-to-print loop stays idempotent. Assumes the cursor is positioned at
+     * (optional) whitespace immediately preceding the {@code @}.
+     */
+    private J.Annotation sourceAnnotation() {
+        Space prefix = sourceBefore("@");
+        int nameStart = cursor;
+        while (cursor < source.length() &&
+                (Character.isJavaIdentifierPart(source.charAt(cursor)) || source.charAt(cursor) == '.')) {
+            cursor++;
+        }
+        J.Identifier name = new J.Identifier(randomId(), EMPTY, Markers.EMPTY, emptyList(),
+                source.substring(nameStart, cursor), null, null);
+
+        JContainer<Expression> args = null;
+        int saveCursor = cursor;
+        Space argsPrefix = whitespace();
+        if (cursor < source.length() && source.charAt(cursor) == '(') {
+            cursor++; // skip '('
+            int argsStart = cursor;
+            int depth = 1;
+            while (cursor < source.length() && depth > 0) {
+                char ch = source.charAt(cursor);
+                if (ch == '(') {
+                    depth++;
+                } else if (ch == ')') {
+                    if (--depth == 0) {
+                        break;
+                    }
+                }
+                cursor++;
+            }
+            String argsText = source.substring(argsStart, cursor);
+            Expression arg = argsText.isEmpty() ?
+                    new J.Empty(randomId(), EMPTY, Markers.EMPTY) :
+                    new J.Literal(randomId(), EMPTY, Markers.EMPTY, null, argsText, null, JavaType.Primitive.None);
+            args = JContainer.build(argsPrefix, singletonList(padRight(arg, sourceBefore(")"))), Markers.EMPTY);
+        } else {
+            cursor = saveCursor;
+        }
+        return new J.Annotation(randomId(), prefix, Markers.EMPTY, name, args);
     }
 
     private J.Modifier mapModifier(Modifier mod, List<J.Annotation> annotations) {

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
@@ -103,6 +103,9 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
     @SuppressWarnings("NotNullFieldNotInitialized")
     private DocCommentTable docCommentTable;
 
+    @Nullable
+    private JCCompilationUnit compilationUnit;
+
     private int cursor = 0;
 
     private static final Pattern whitespaceSuffixPattern = Pattern.compile("\\s*[^\\s]+(\\s*)");
@@ -628,6 +631,7 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
     @Override
     public J visitCompilationUnit(CompilationUnitTree node, Space fmt) {
         JCCompilationUnit cu = (JCCompilationUnit) node;
+        this.compilationUnit = cu;
 
         if (node.getTypeDecls().isEmpty() || cu.getPackageName() != null || !node.getImports().isEmpty()) {
             // if the package and imports are empty, allow the formatting to apply to the first class declaration.
@@ -2499,9 +2503,9 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
     /**
      * Reconstructs an annotation from the source text when no corresponding {@link JCAnnotation} is available,
      * which happens when Lombok deletes a user-written annotation (such as {@code @Delegate}) from the AST after
-     * handling it. The reconstructed annotation carries no type attribution because Lombok erased it, but it
-     * preserves the source so that the parse-to-print loop stays idempotent. Assumes the cursor is positioned at
-     * (optional) whitespace immediately preceding the {@code @}.
+     * handling it. The annotation type is resolved from the compilation unit's imports so the reconstructed
+     * annotation keeps its type attribution; only the (also erased) arguments are reproduced verbatim from source.
+     * Assumes the cursor is positioned at (optional) whitespace immediately preceding the {@code @}.
      */
     private J.Annotation sourceAnnotation() {
         Space prefix = sourceBefore("@");
@@ -2510,8 +2514,9 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
                 (Character.isJavaIdentifierPart(source.charAt(cursor)) || source.charAt(cursor) == '.')) {
             cursor++;
         }
+        String annotationName = source.substring(nameStart, cursor);
         J.Identifier name = new J.Identifier(randomId(), EMPTY, Markers.EMPTY, emptyList(),
-                source.substring(nameStart, cursor), null, null);
+                annotationName, resolveErasedAnnotationType(annotationName), null);
 
         JContainer<Expression> args = null;
         int saveCursor = cursor;
@@ -2540,6 +2545,27 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
             cursor = saveCursor;
         }
         return new J.Annotation(randomId(), prefix, Markers.EMPTY, name, args);
+    }
+
+    /**
+     * Resolves the {@link JavaType} of an annotation that Lombok erased from the AST, using the still-resolved
+     * single-type imports of the compilation unit. Returns {@code null} when the type cannot be resolved (e.g. a
+     * wildcard import), in which case the reconstructed annotation simply has no type attribution.
+     */
+    private @Nullable JavaType resolveErasedAnnotationType(String annotationName) {
+        if (compilationUnit == null) {
+            return null;
+        }
+        String simpleName = annotationName.substring(annotationName.lastIndexOf('.') + 1);
+        for (ImportTree jcImport : compilationUnit.getImports()) {
+            if (jcImport.getQualifiedIdentifier() instanceof JCFieldAccess) {
+                JCFieldAccess qualid = (JCFieldAccess) jcImport.getQualifiedIdentifier();
+                if (qualid.sym instanceof Symbol.ClassSymbol && simpleName.equals(qualid.name.toString())) {
+                    return typeMapping.type(qualid.sym.type);
+                }
+            }
+        }
+        return null;
     }
 
     private J.Modifier mapModifier(Modifier mod, List<J.Annotation> annotations) {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -2213,15 +2213,36 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                         noSpace = false;
                     }
                     if (!word.get().isEmpty()) {
+                        String keyword = word.get();
+                        // `@interface` is an annotation type declaration, not an annotation usage
+                        boolean isAnnotation = keyword.charAt(0) == '@' && !"@interface".equals(keyword);
                         Modifier matching = null;
-                        for (Modifier modifier : modifiers.getFlags()) {
-                            if (modifier.name().toLowerCase().equals(word.get())) {
-                                matching = modifier;
-                                break;
+                        if (!isAnnotation) {
+                            for (Modifier modifier : modifiers.getFlags()) {
+                                if (modifier.name().toLowerCase().equals(keyword)) {
+                                    matching = modifier;
+                                    break;
+                                }
                             }
                         }
 
-                        if (matching == null) {
+                        if (isAnnotation) {
+                            // An annotation that is present in the source but was removed from the AST by Lombok
+                            // (e.g. `@Delegate`, which Lombok deletes after generating the delegating methods).
+                            // Reconstruct it from the source so that printing remains idempotent rather than
+                            // letting the cursor desync and corrupt the following type expression. The cursor
+                            // already sits right after the previously converted modifier or annotation.
+                            J.Annotation annotation = sourceAnnotation();
+                            if (afterFirstModifier) {
+                                currentAnnotations.add(annotation);
+                            } else {
+                                leadingAnnotations.add(annotation);
+                            }
+                            word.set("");
+                            afterLastModifierPosition = cursor;
+                            lastAnnotationPosition = cursor;
+                            i = cursor - 1;
+                        } else if (matching == null) {
                             this.cursor = afterLastModifierPosition;
                             break;
                         } else {
@@ -2245,6 +2266,52 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                 leadingAnnotations.isEmpty() ? emptyList() : leadingAnnotations,
                 sortedModifiers.isEmpty() ? emptyList() : sortedModifiers
         );
+    }
+
+    /**
+     * Reconstructs an annotation from the source text when no corresponding {@link JCAnnotation} is available,
+     * which happens when Lombok deletes a user-written annotation (such as {@code @Delegate}) from the AST after
+     * handling it. The reconstructed annotation carries no type attribution because Lombok erased it, but it
+     * preserves the source so that the parse-to-print loop stays idempotent. Assumes the cursor is positioned at
+     * (optional) whitespace immediately preceding the {@code @}.
+     */
+    private J.Annotation sourceAnnotation() {
+        Space prefix = sourceBefore("@");
+        int nameStart = cursor;
+        while (cursor < source.length() &&
+                (Character.isJavaIdentifierPart(source.charAt(cursor)) || source.charAt(cursor) == '.')) {
+            cursor++;
+        }
+        J.Identifier name = new J.Identifier(randomId(), EMPTY, Markers.EMPTY, emptyList(),
+                source.substring(nameStart, cursor), null, null);
+
+        JContainer<Expression> args = null;
+        int saveCursor = cursor;
+        Space argsPrefix = whitespace();
+        if (cursor < source.length() && source.charAt(cursor) == '(') {
+            cursor++; // skip '('
+            int argsStart = cursor;
+            int depth = 1;
+            while (cursor < source.length() && depth > 0) {
+                char ch = source.charAt(cursor);
+                if (ch == '(') {
+                    depth++;
+                } else if (ch == ')') {
+                    if (--depth == 0) {
+                        break;
+                    }
+                }
+                cursor++;
+            }
+            String argsText = source.substring(argsStart, cursor);
+            Expression arg = argsText.isEmpty() ?
+                    new J.Empty(randomId(), EMPTY, Markers.EMPTY) :
+                    new J.Literal(randomId(), EMPTY, Markers.EMPTY, null, argsText, null, JavaType.Primitive.None);
+            args = JContainer.build(argsPrefix, singletonList(padRight(arg, sourceBefore(")"))), Markers.EMPTY);
+        } else {
+            cursor = saveCursor;
+        }
+        return new J.Annotation(randomId(), prefix, Markers.EMPTY, name, args);
     }
 
     private J.Modifier mapModifier(Modifier mod, List<J.Annotation> annotations) {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -90,6 +90,9 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
     @SuppressWarnings("NotNullFieldNotInitialized")
     private DocCommentTable docCommentTable;
 
+    @Nullable
+    private JCCompilationUnit compilationUnit;
+
     private int cursor = 0;
 
     private static final Pattern whitespaceSuffixPattern = Pattern.compile("\\s*[^\\s]+(\\s*)");
@@ -501,6 +504,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
     @Override
     public J visitCompilationUnit(CompilationUnitTree node, Space fmt) {
         JCCompilationUnit cu = (JCCompilationUnit) node;
+        this.compilationUnit = cu;
 
         if (node.getTypeDecls().isEmpty() || cu.getPackageName() != null || !node.getImports().isEmpty()) {
             // if the package and imports are empty, allow the formatting to apply to the first class declaration.
@@ -2271,9 +2275,9 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
     /**
      * Reconstructs an annotation from the source text when no corresponding {@link JCAnnotation} is available,
      * which happens when Lombok deletes a user-written annotation (such as {@code @Delegate}) from the AST after
-     * handling it. The reconstructed annotation carries no type attribution because Lombok erased it, but it
-     * preserves the source so that the parse-to-print loop stays idempotent. Assumes the cursor is positioned at
-     * (optional) whitespace immediately preceding the {@code @}.
+     * handling it. The annotation type is resolved from the compilation unit's imports so the reconstructed
+     * annotation keeps its type attribution; only the (also erased) arguments are reproduced verbatim from source.
+     * Assumes the cursor is positioned at (optional) whitespace immediately preceding the {@code @}.
      */
     private J.Annotation sourceAnnotation() {
         Space prefix = sourceBefore("@");
@@ -2282,8 +2286,9 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                 (Character.isJavaIdentifierPart(source.charAt(cursor)) || source.charAt(cursor) == '.')) {
             cursor++;
         }
+        String annotationName = source.substring(nameStart, cursor);
         J.Identifier name = new J.Identifier(randomId(), EMPTY, Markers.EMPTY, emptyList(),
-                source.substring(nameStart, cursor), null, null);
+                annotationName, resolveErasedAnnotationType(annotationName), null);
 
         JContainer<Expression> args = null;
         int saveCursor = cursor;
@@ -2312,6 +2317,27 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
             cursor = saveCursor;
         }
         return new J.Annotation(randomId(), prefix, Markers.EMPTY, name, args);
+    }
+
+    /**
+     * Resolves the {@link JavaType} of an annotation that Lombok erased from the AST, using the still-resolved
+     * single-type imports of the compilation unit. Returns {@code null} when the type cannot be resolved (e.g. a
+     * wildcard import), in which case the reconstructed annotation simply has no type attribution.
+     */
+    private @Nullable JavaType resolveErasedAnnotationType(String annotationName) {
+        if (compilationUnit == null) {
+            return null;
+        }
+        String simpleName = annotationName.substring(annotationName.lastIndexOf('.') + 1);
+        for (ImportTree jcImport : compilationUnit.getImports()) {
+            if (jcImport.getQualifiedIdentifier() instanceof JCFieldAccess) {
+                JCFieldAccess qualid = (JCFieldAccess) jcImport.getQualifiedIdentifier();
+                if (qualid.sym instanceof Symbol.ClassSymbol && simpleName.equals(qualid.name.toString())) {
+                    return typeMapping.type(qualid.sym.type);
+                }
+            }
+        }
+        return null;
     }
 
     private J.Modifier mapModifier(Modifier mod, List<J.Annotation> annotations) {

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
@@ -33,6 +33,7 @@ import org.openrewrite.test.TypeValidation;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.CollectionAssert.assertThatCollection;
 import static org.openrewrite.java.Assertions.java;
 
@@ -953,7 +954,13 @@ class LombokTest implements RewriteTest {
                   @Delegate
                   private List<E> list = new ArrayList<>();
               }
-              """
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                J.VariableDeclarations field = (J.VariableDeclarations) cu.getClasses().get(0).getBody().getStatements().get(0);
+                J.Annotation delegate = field.getLeadingAnnotations().get(0);
+                // The erased annotation is reconstructed *with* its type attribution, not as a null stub
+                assertThat(TypeUtils.isOfClassType(delegate.getType(), "lombok.experimental.Delegate")).isTrue();
+            })
           )
         );
     }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
@@ -933,6 +933,85 @@ class LombokTest implements RewriteTest {
     }
 
     @Test
+    void delegateRemovedByLombokIsRecoveredFromSource() {
+        // When another Lombok annotation on the class triggers a full processing round, Lombok deletes the
+        // `@Delegate` annotation from the AST after generating the delegating methods, but leaves it in the source.
+        // The parser must reconstruct it from source so that printing remains idempotent.
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              import java.util.ArrayList;
+              import java.util.List;
+
+              import lombok.Getter;
+              import lombok.experimental.Delegate;
+
+              @Getter
+              public class ValidList<E> implements List<E> {
+
+                  @Delegate
+                  private List<E> list = new ArrayList<>();
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void delegateRemovedByLombokWithPrecedingAnnotation() {
+        // The annotation immediately preceding the Lombok-erased `@Delegate` must be preserved as-is while
+        // `@Delegate` is reconstructed from source.
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              import java.util.ArrayList;
+              import java.util.List;
+
+              import lombok.Getter;
+              import lombok.experimental.Delegate;
+
+              @Getter
+              public class ValidList<E> implements List<E> {
+
+                  @Deprecated
+                  @Delegate
+                  private List<E> list = new ArrayList<>();
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void delegateWithArgumentsRemovedByLombokIsRecoveredFromSource() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              import java.util.ArrayList;
+              import java.util.List;
+
+              import lombok.Getter;
+              import lombok.experimental.Delegate;
+
+              @Getter
+              public class ValidList<E> implements List<E> {
+
+                  private interface Simple {
+                      boolean add(Object o);
+                  }
+
+                  @Delegate(types = Simple.class)
+                  private List<E> list = new ArrayList<>();
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void utilityClass() {
         rewriteRun(
           java(


### PR DESCRIPTION
When a class-level Lombok annotation (e.g. `@Getter`) triggers a full processing round, Lombok erases a field's `@Delegate` annotation from the javac AST while leaving it in the source, after which `sortedModifiersAndAnnotations` treated the leftover `@Delegate` token as an unknown modifier, desynced the cursor, and corrupted the following type — printing `@Delegate` as `Listegate` and producing a non-idempotent `ParseError`.

All five Reloadable Java parser visitors (8/11/17/21/25) now detect a source `@`-token with no corresponding AST node and reconstruct it via a new `sourceAnnotation()` helper (handling arguments and a preceding real annotation) instead of bailing.

Added `LombokTest` coverage for the bare, with-arguments, and preceding-annotation cases; full TCK passes on every Java version.