### PR TITLE
Go: fail explicitly when the recipe implementation does not exist

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -90,6 +90,12 @@ type server struct {
 	// Prepared recipe instances keyed by unique ID
 	preparedRecipes map[string]recipe.Recipe
 
+	// Recipe name (fully qualified id) keyed by the same prepared recipe ID.
+	// Used to produce a meaningful error when an edit/scan run is attempted
+	// on a recipe that was registered descriptor-only (nil instance) — i.e.
+	// the workspace binary is stale or missing its implementation.
+	preparedRecipeNames map[string]string
+
 	// Bare editor cached at PrepareRecipe time when an editor was wrapped in
 	// preconditions.Check(...). Subsequent dispatch via instantiateVisitor
 	// returns the unwrapped editor — otherwise the precondition would also
@@ -203,6 +209,7 @@ func newServer(cfg serverConfig) *server {
 		reverseRemoteObjects:    make(map[string]any),
 		reverseRemoteRefs:       make(map[int]any),
 		preparedRecipes:         make(map[string]recipe.Recipe),
+		preparedRecipeNames:     make(map[string]string),
 		preparedEditorOverrides: make(map[string]recipe.TreeVisitor),
 		preparedAccumulators:    make(map[string]any),
 		preparedContexts:        make(map[string]*recipe.ExecutionContext),
@@ -1011,6 +1018,7 @@ func (s *server) handleReset() bool {
 	s.reverseRemoteObjects = make(map[string]any)
 	s.reverseRemoteRefs = make(map[int]any)
 	s.preparedRecipes = make(map[string]recipe.Recipe)
+	s.preparedRecipeNames = make(map[string]string)
 	s.preparedEditorOverrides = make(map[string]recipe.TreeVisitor)
 	s.preparedAccumulators = make(map[string]any)
 	s.preparedContexts = make(map[string]*recipe.ExecutionContext)
@@ -1415,6 +1423,7 @@ func (s *server) handlePrepareRecipe(params json.RawMessage) (any, *rpcError) {
 	// callers echo it back to identify the prepared instance.
 	recipeID := uuid.New().String()
 	s.preparedRecipes[recipeID] = instance
+	s.preparedRecipeNames[recipeID] = req.ID
 
 	resp := prepareRecipeResponse{
 		ID:                recipeID,
@@ -1531,8 +1540,21 @@ func (s *server) handleVisit(params json.RawMessage) (any, *rpcError) {
 		return nil, &rpcError{Code: -32602, Message: "Unknown recipe: " + recipeID}
 	}
 	if r == nil {
-		// Installer-loaded recipes have no implementation in Go
-		return &visitResponse{Modified: false}, nil
+		// The recipe was registered descriptor-only (nil instance) yet an
+		// edit/scan run is being dispatched against it. A descriptor-only
+		// registration exists purely so the recipe can be listed in the
+		// marketplace; the real implementation is supposed to overwrite it
+		// when the recipe binary is activated (see Registry.RegisterWithCategories).
+		// Reaching here means it never was — fail loudly rather than silently
+		// reporting "no changes", which masks a stale or missing workspace binary.
+		name := s.preparedRecipeNames[recipeID]
+		if name == "" {
+			name = recipeID
+		}
+		return nil, &rpcError{
+			Code:    -32603,
+			Message: fmt.Sprintf("recipe %q is registered as metadata only and has no executable implementation in this server build; the workspace binary is stale or missing", name),
+		}
 	}
 
 	// Get the tree from Java via bidirectional RPC

--- a/rewrite-go/cmd/rpc/prepare_recipe_test.go
+++ b/rewrite-go/cmd/rpc/prepare_recipe_test.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+)
+
+// prepareRecipe runs the PrepareRecipe handler and returns the per-instance id.
+func prepareRecipe(t *testing.T, s *server, id string) string {
+	t.Helper()
+	params, err := json.Marshal(prepareRecipeRequest{ID: id})
+	if err != nil {
+		t.Fatalf("marshal prepare request: %v", err)
+	}
+	resp, rpcErr := s.handlePrepareRecipe(params)
+	if rpcErr != nil {
+		t.Fatalf("handlePrepareRecipe returned error: %+v", rpcErr)
+	}
+	return resp.(prepareRecipeResponse).ID
+}
+
+// visit runs the Visit handler for the given "phase:recipeId" visitor.
+func visit(t *testing.T, s *server, visitor string) (any, *rpcError) {
+	t.Helper()
+	params, err := json.Marshal(visitRequest{Visitor: visitor, TreeID: "tree-1", SourceFileType: "Go"})
+	if err != nil {
+		t.Fatalf("marshal visit request: %v", err)
+	}
+	return s.handleVisit(params)
+}
+
+// A recipe registered descriptor-only (nil instance) — as the installer does
+// for marketplace listing — must NOT silently report "no changes" when an
+// edit/scan run is dispatched against it. Doing so masks a stale or missing
+// workspace binary. The Visit handler must instead return an rpcError naming
+// the recipe.
+func TestVisitMetadataOnlyRecipeFailsLoudly(t *testing.T) {
+	// given
+	s, _ := newTestServer(t)
+	const recipeName = "org.openrewrite.go.example.MetadataOnly"
+	s.registry.RegisterDescriptor(recipe.RecipeDescriptor{
+		Name:        recipeName,
+		DisplayName: "Metadata only",
+		Description: "Registered without an executable implementation.",
+	})
+	recipeID := prepareRecipe(t, s, recipeName)
+
+	// when
+	for _, phase := range []string{"edit", "scan"} {
+		resp, rpcErr := visit(t, s, phase+":"+recipeID)
+
+		// then
+		if rpcErr == nil {
+			t.Fatalf("%s: expected an rpcError, got success response %+v", phase, resp)
+		}
+		if !strings.Contains(rpcErr.Message, recipeName) {
+			t.Errorf("%s: error message %q does not name the recipe %q", phase, rpcErr.Message, recipeName)
+		}
+		if !strings.Contains(rpcErr.Message, "stale or missing") {
+			t.Errorf("%s: error message %q does not explain the stale/missing binary cause", phase, rpcErr.Message)
+		}
+	}
+}


### PR DESCRIPTION
## What's changed?

An amendment to Go RPC server logic.
If it has a metadata entry for a recipe, but it's implementation is not bundled, then fail explicitly.

## What's your motivation?

It has been observed in Moderne SaaS product that in some scenarios the recipes are missing (a different issue). But then the we should explicitly fail with a contextual error message. Otherwise the errors are hard to diagnose.