### PR TITLE
Fix RemoveExclusion#onlyIneffective for deep transitive exclusions

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -1019,6 +1019,11 @@ public class ResolvedPom {
                                                            MavenPomDownloader downloader, ExecutionContext ctx) throws MavenDownloadingExceptions {
         List<ResolvedDependency> dependencies = new ArrayList<>();
 
+        // Tracks the dependency that included each resolved dependency, so that an effective exclusion can be
+        // attributed to the dependency that declared it rather than to the deepest dependency whose direct child
+        // happened to match the exclusion glob (exclusions are propagated down the transitive chain).
+        Map<ResolvedDependency, ResolvedDependency> includedByMap = new IdentityHashMap<>();
+
         Map<GroupArtifact, DependencyAndDependent> rootDependencies = new LinkedHashMap<>();
         for (Dependency requestedDependency : getRequestedDependencies()) {
             Dependency d = getValues(requestedDependency, 0);
@@ -1142,6 +1147,7 @@ public class ResolvedPom {
                             includedBy.unsafeSetDependencies(new ArrayList<>());
                         }
                         includedBy.getDependencies().add(resolved);
+                        includedByMap.put(resolved, includedBy);
                     }
 
                     if (dd.getScope().transitiveOf(scope) == scope) {
@@ -1175,10 +1181,21 @@ public class ResolvedPom {
                             for (GroupArtifact exclusion : d.getExclusions()) {
                                 if (matchesGlob(getValue(d2.getGroupId()), getValue(exclusion.getGroupId())) &&
                                         matchesGlob(getValue(d2.getArtifactId()), getValue(exclusion.getArtifactId()))) {
-                                    if (resolved.getEffectiveExclusions().isEmpty()) {
-                                        resolved.unsafeSetEffectiveExclusions(new ArrayList<>());
+                                    // Exclusions are propagated down the transitive chain, so the dependency whose
+                                    // direct child matched the exclusion may be deeper than the dependency that
+                                    // actually declared it. Attribute the effective exclusion to the declaring
+                                    // dependency so callers can find it on the dependency that owns the exclusion.
+                                    ResolvedDependency declaredOn = resolved;
+                                    for (ResolvedDependency ancestor = includedByMap.get(resolved);
+                                         ancestor != null && ancestor.getRequested().getExclusions() != null &&
+                                                 ancestor.getRequested().getExclusions().contains(exclusion);
+                                         ancestor = includedByMap.get(ancestor)) {
+                                        declaredOn = ancestor;
                                     }
-                                    resolved.getEffectiveExclusions().add(d2.getGav().asGroupArtifact());
+                                    if (declaredOn.getEffectiveExclusions().isEmpty()) {
+                                        declaredOn.unsafeSetEffectiveExclusions(new ArrayList<>());
+                                    }
+                                    declaredOn.getEffectiveExclusions().add(d2.getGav().asGroupArtifact());
                                     continue nextDependency;
                                 }
                             }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveExclusionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveExclusionTest.java
@@ -186,6 +186,44 @@ class RemoveExclusionTest implements RewriteTest {
     }
 
     @Test
+    void keepsExclusionEffectiveOnlyOnDeeperTransitiveDependency() {
+        // spring-context -> spring-core -> spring-jcl, so excluding spring-jcl on spring-context is effective
+        // even though the excluded artifact is two levels deep in the transitive graph.
+        // https://github.com/openrewrite/rewrite/issues/8112
+        rewriteRun(
+          spec -> spec.recipe(new RemoveExclusion(
+            "*",
+            "*",
+            "*",
+            "*",
+            true
+          )),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                    <version>5.3.39</version>
+                    <exclusions>
+                      <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-jcl</artifactId>
+                      </exclusion>
+                    </exclusions>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     void removeUsedExclusions() {
         rewriteRun(
           spec -> spec.recipe(new RemoveExclusion(


### PR DESCRIPTION
## What's changed?

`RemoveExclusion` with `onlyIneffective: true` was removing exclusions that are actually effective when the excluded artifact is a transitive-of-transitive dependency (more than one level deep).

The recipe checks `ResolvedDependency#getEffectiveExclusions()` on the direct dependency that declares the exclusion. But during dependency resolution in `ResolvedPom#doResolveDependencies`, exclusions are propagated down the transitive chain, and the effective exclusion was recorded on the *deepest* dependency whose immediate child matched the exclusion glob — not on the dependency that declared it.

So given `third → second → first → log4j` with the `log4j` exclusion declared on `second` (in `third`'s POM), the effective exclusion was attributed to the `first` node rather than to the `second` node. `RemoveExclusion` looked up the direct `second` dependency, found no effective exclusion on it, and incorrectly removed it.

This change walks up the include chain when recording an effective exclusion and attributes it to the dependency that actually declared it.

## What's your motivation?

- Fixes #8112

## Anything in particular you'd like reviewers to focus on?

The attribution walks up the `includedBy` chain to the outermost ancestor that still carries the matched exclusion in its requested exclusions (exclusions are merged downward, so the chain from declarer to match point is contiguous). One-level exclusions are unaffected, since the declaring dependency is itself the match point's parent or the match point.

## Checklist

- [x] I've added unit tests to cover the change (`RemoveExclusionTest#keepsExclusionEffectiveOnlyOnDeeperTransitiveDependency`, which fails without the fix)