### PR TITLE
Fix Kotlin parse failure for annotation after modifier in primary constructor

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -969,16 +969,19 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
         }
 
         List<J.Annotation> leadingAnnotations = new ArrayList<>();
+        List<J.Annotation> lastAnnotations = new ArrayList<>();
         List<J.Modifier> modifiers = new ArrayList<>();
         Set<PsiElement> consumedSpaces = preConsumedInfix(constructor);
 
         if (constructor.getModifierList() != null) {
             KtModifierList ktModifierList = constructor.getModifierList();
-            modifiers.addAll(mapModifiers(ktModifierList, leadingAnnotations, emptyList(), data));
+            modifiers.addAll(mapModifiers(ktModifierList, leadingAnnotations, lastAnnotations, data));
         }
 
         if (constructor.getConstructorKeyword() != null) {
-            modifiers.add(mapModifier(constructor.getConstructorKeyword(), emptyList(), consumedSpaces));
+            // Annotations between the visibility modifier and the `constructor` keyword (e.g. `internal @Inject constructor`)
+            // are attached to the keyword modifier so they print in their original source position.
+            modifiers.add(mapModifier(constructor.getConstructorKeyword(), lastAnnotations, consumedSpaces));
         }
 
         JavaType.Method type = methodDeclarationType(constructor);

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -291,6 +291,18 @@ class ClassDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void primaryConstructorWithModifierBeforeAnnotation() {
+        rewriteRun(
+          kotlin(
+            """
+              annotation class Inject
+              class FooImpl internal @Inject constructor(provider: String)
+              """
+          )
+        );
+    }
+
+    @Test
     void implicitConstructorWithSuperType() {
         rewriteRun(
           kotlin(


### PR DESCRIPTION
## Motivation

Parsing a Kotlin primary constructor that places an annotation *after* a keyword modifier — for example `class FooImpl internal @Inject constructor(...)` — failed with an `UnsupportedOperationException`, causing the whole class to degrade to `J.Unknown`. This pattern appears in real code (e.g. Dagger's `RecursiveBindsTest.kt`).

The root cause: `KotlinTreeParserVisitor.visitPrimaryConstructor` passed an immutable `emptyList()` as the `lastAnnotations` argument to `mapModifiers`. That method collects "trailing" annotations — those appearing after a keyword modifier in the modifier list — and adds them to that list. For `internal @Inject`, `@Inject` follows the `internal` keyword, so it lands in `lastAnnotations`, and adding to the immutable list threw.

## Summary

- Pass a mutable `lastAnnotations` list to `mapModifiers` in `visitPrimaryConstructor`.
- Attach those trailing annotations to the `constructor` keyword modifier so they print back in their original source position (`internal @Inject constructor`), since `J.Modifier` already carries annotations and the printer emits them before the keyword.

## Test plan

- Added `ClassDeclarationTest.primaryConstructorWithModifierBeforeAnnotation`, which fails before the change (first with a `J.Unknown` assertion, then a print round-trip mismatch dropping `@Inject`) and passes after.
- The full `ClassDeclarationTest` suite passes, confirming no regression in the existing `internal constructor` / leading-annotation cases.
