### PR TITLE
Marking rewrite-csharp and rewrite-go explicitly as MSAL-licensed

### DIFF
--- a/gradle/msalLicenseHeaderGo.txt
+++ b/gradle/msalLicenseHeaderGo.txt
@@ -1,0 +1,13 @@
+Copyright ${year} the original author or authors.
+
+Licensed under the Moderne Source Available License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://docs.moderne.io/licensing/moderne-source-available-license
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/rewrite-csharp/LICENSE.md
+++ b/rewrite-csharp/LICENSE.md
@@ -1,0 +1,87 @@
+# Moderne Source Available License
+
+## Acceptance
+
+This Agreement sets forth the terms and conditions on which the Licensor makes the Software available. By installing, downloading, accessing, using, or distributing any part of the Software, you agree to all of the terms and conditions of this agreement.
+
+If you are receiving the Software on behalf of your company, you represent and warrant that you have the authority to agree to this agreement on behalf of such entity.
+
+The Licensor reserves the right to update this agreement from time to time.
+
+## Definitions
+
+**Agreement**: This Moderne Source Available License agreement.
+
+**Control**: Ownership, directly or indirectly, of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.
+
+**License**: The license as described in the License paragraph below.
+
+**Licensor**: The entity offering these terms, including Moderne, Inc., on behalf of itself and its subsidiaries and affiliates worldwide.
+
+**Modify**/**Modified**/**Modification**: Copying or adapting all or part of the work in a way that requires copyright permission, other than making an exact copy. The resulting work is called a _modified version_ of the original work.
+
+**Moderne**: The Moderne software as described in [moderne.ai](https://www.moderne.ai/).
+
+**Software**: Specific software components designed to work with Moderne and provided under this agreement.
+
+**Trademark**: Trademarks, service marks, and any other similar rights associated with the Licensor.
+
+**Use**: Any activity you perform with the Software that requires a license under this agreement.
+
+**You**: The recipient of the Software, whether an individual or an entity, on whose behalf this agreement is accepted.
+
+**Your Company**: Any legal entity, sole proprietorship, or organization that you work for, including all organizations that control, are controlled by, or are under common control with that organization.
+
+**Your Licenses**: All licenses granted to you for the Software under this agreement.
+
+## License
+
+The Licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensable, non-transferable license to use, copy, distribute, make available, and prepare derivative works of the Software, subject to the limitations and conditions below.
+
+## Limitations
+
+**You may not:**
+
+1. Make the functionality of the Software or a modified version available to third parties as a service.
+
+2. Distribute the Software or a modified version in a manner that makes its functionality available to third parties.
+
+**Prohibited actions include (but are not limited to):**
+
+* Enabling third parties to interact with the functionality of the Software or a modified version in distributed form or remotely through a computer network.
+
+* Offering products or services whose value derives from the Software or a modified version.
+
+* Providing a product or service that performs the functions of the Software or a modified version.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices provided by the Licensor. Any use of the Licensor’s trademarks is subject to applicable law.
+
+## Patents
+
+The Licensor grants you a license under any patent claims the Licensor owns or can license, to make, use, sell, offer for sale, import, and distribute the Software, subject to the limitations and conditions in this agreement.
+
+This license does not cover patent claims caused by your modifications or additions to the Software.
+
+If you or your company make any written claim that the Software infringes or contributes to the infringement of any patent, your patent license under this agreement terminates immediately.
+
+## Notices
+
+You must ensure that anyone who receives a copy of any part of the Software from you also receives a copy of this agreement.
+
+If you modify the Software, you must include prominent notices in any modified copies stating that you have modified the Software.
+
+## No Other Rights
+
+This agreement does not imply any licenses beyond those expressly granted.
+
+## Termination
+
+If you use the Software in violation of this agreement, such use is unlicensed, and your licenses will terminate automatically.
+
+If the Licensor notifies you of a violation and you cease all violations within 30 days, your licenses will be reinstated retroactively.
+
+However, subsequent violations will result in automatic and permanent termination of your licenses.
+
+## No Liability
+
+To the extent permitted by law, the Software is provided "as is," without warranties or conditions of any kind. The Licensor is not liable for any damages arising from this agreement or your use of the Software.

--- a/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
@@ -14,6 +14,7 @@
     <PackageProjectUrl>https://docs.openrewrite.org</PackageProjectUrl>
     <RepositoryUrl>https://github.com/openrewrite/rewrite</RepositoryUrl>
     <PackageTags>openrewrite;refactoring;csharp;dotnet</PackageTags>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <!-- VSTHRD200: RPC method names must match Java-side protocol (no Async suffix) -->
     <!-- VSTHRD002: Synchronous waits needed for RPC interop with Java peer -->
@@ -48,6 +49,11 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <!-- Moderne Source Available License, shipped at the nupkg root (see PackageLicenseFile). -->
+  <ItemGroup>
+    <None Include="../../LICENSE.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/rewrite-go/LICENSE.md
+++ b/rewrite-go/LICENSE.md
@@ -1,0 +1,87 @@
+# Moderne Source Available License
+
+## Acceptance
+
+This Agreement sets forth the terms and conditions on which the Licensor makes the Software available. By installing, downloading, accessing, using, or distributing any part of the Software, you agree to all of the terms and conditions of this agreement.
+
+If you are receiving the Software on behalf of your company, you represent and warrant that you have the authority to agree to this agreement on behalf of such entity.
+
+The Licensor reserves the right to update this agreement from time to time.
+
+## Definitions
+
+**Agreement**: This Moderne Source Available License agreement.
+
+**Control**: Ownership, directly or indirectly, of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.
+
+**License**: The license as described in the License paragraph below.
+
+**Licensor**: The entity offering these terms, including Moderne, Inc., on behalf of itself and its subsidiaries and affiliates worldwide.
+
+**Modify**/**Modified**/**Modification**: Copying or adapting all or part of the work in a way that requires copyright permission, other than making an exact copy. The resulting work is called a _modified version_ of the original work.
+
+**Moderne**: The Moderne software as described in [moderne.ai](https://www.moderne.ai/).
+
+**Software**: Specific software components designed to work with Moderne and provided under this agreement.
+
+**Trademark**: Trademarks, service marks, and any other similar rights associated with the Licensor.
+
+**Use**: Any activity you perform with the Software that requires a license under this agreement.
+
+**You**: The recipient of the Software, whether an individual or an entity, on whose behalf this agreement is accepted.
+
+**Your Company**: Any legal entity, sole proprietorship, or organization that you work for, including all organizations that control, are controlled by, or are under common control with that organization.
+
+**Your Licenses**: All licenses granted to you for the Software under this agreement.
+
+## License
+
+The Licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensable, non-transferable license to use, copy, distribute, make available, and prepare derivative works of the Software, subject to the limitations and conditions below.
+
+## Limitations
+
+**You may not:**
+
+1. Make the functionality of the Software or a modified version available to third parties as a service.
+
+2. Distribute the Software or a modified version in a manner that makes its functionality available to third parties.
+
+**Prohibited actions include (but are not limited to):**
+
+* Enabling third parties to interact with the functionality of the Software or a modified version in distributed form or remotely through a computer network.
+
+* Offering products or services whose value derives from the Software or a modified version.
+
+* Providing a product or service that performs the functions of the Software or a modified version.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices provided by the Licensor. Any use of the Licensor’s trademarks is subject to applicable law.
+
+## Patents
+
+The Licensor grants you a license under any patent claims the Licensor owns or can license, to make, use, sell, offer for sale, import, and distribute the Software, subject to the limitations and conditions in this agreement.
+
+This license does not cover patent claims caused by your modifications or additions to the Software.
+
+If you or your company make any written claim that the Software infringes or contributes to the infringement of any patent, your patent license under this agreement terminates immediately.
+
+## Notices
+
+You must ensure that anyone who receives a copy of any part of the Software from you also receives a copy of this agreement.
+
+If you modify the Software, you must include prominent notices in any modified copies stating that you have modified the Software.
+
+## No Other Rights
+
+This agreement does not imply any licenses beyond those expressly granted.
+
+## Termination
+
+If you use the Software in violation of this agreement, such use is unlicensed, and your licenses will terminate automatically.
+
+If the Licensor notifies you of a violation and you cease all violations within 30 days, your licenses will be reinstated retroactively.
+
+However, subsequent violations will result in automatic and permanent termination of your licenses.
+
+## No Liability
+
+To the extent permitted by law, the Software is provided "as is," without warranties or conditions of any kind. The Licensor is not liable for any damages arising from this agreement or your use of the Software.

--- a/rewrite-go/build.gradle.kts
+++ b/rewrite-go/build.gradle.kts
@@ -146,7 +146,10 @@ val prepareGoRpcSources = tasks.register<Sync>("prepareGoRpcSources") {
         exclude("**/*_test.go")
         exclude("**/testdata/**")
     }
-    from(rootProject.file("LICENSE"))
+    // rewrite-go is published under the Moderne Source Available License, so the
+    // packaged RPC source ships the module's MSAL LICENSE.md (not the repo-root
+    // Apache LICENSE).
+    from(file("LICENSE.md"))
 }
 
 sourceSets.named("main") {

--- a/rewrite-go/build.gradle.kts
+++ b/rewrite-go/build.gradle.kts
@@ -2,6 +2,10 @@
 
 import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports
 import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect
+import com.hierynomus.gradle.license.tasks.LicenseCheck
+import com.hierynomus.gradle.license.tasks.LicenseFormat
+import nl.javadude.gradle.plugins.license.License
+import java.util.Calendar
 
 plugins {
     id("org.openrewrite.build.language-library")
@@ -31,9 +35,12 @@ tasks.withType<Javadoc>().configureEach {
 }
 
 // Test fixtures for the GoMod conformance corpus are .gomod / .gosum / .json
-// files; none of these formats accept a leading license header. Go sources and
-// vendored third-party code are likewise excluded from the license header check
-// (.go files carry their own header management; vendor/ is third-party).
+// files; none of these formats accept a leading license header. The default
+// license task excludes all .go files (the vendored Go staged into main
+// resources must never be stamped); first-party Go sources are instead managed
+// by the dedicated licenseGo / licenseFormatGo tasks below, which scope precisely
+// to our own code. vendor/ (third-party) and testdata/ (sample user programs)
+// are never stamped.
 configure<nl.javadude.gradle.plugins.license.LicenseExtension> {
     excludePatterns.addAll(listOf(
         "**/*.gomod",
@@ -44,7 +51,54 @@ configure<nl.javadude.gradle.plugins.license.LicenseExtension> {
         "**/go.sum",
         "**/vendor/**",
     ))
+
+    // A /* */ header style for Go that tolerates leading build-constraint lines.
+    // Go requires `//go:build` (and legacy `// +build`) to precede the package
+    // clause and allows only line comments and blank lines before them, so a
+    // block-comment license header must come *after* the constraint. skipLinePattern
+    // keeps that leading line in place and applies/detects the header below it; for
+    // files without a constraint it behaves exactly like SLASHSTAR_STYLE.
+    headerDefinitions.create("go_slashstar_style") {
+        withFirstLine("/*")
+        withBeforeEachLine(" * ")
+        withEndLine(" */")
+        withSkipLinePattern("^//\\s*(go:build|\\+build).*\$")
+        withFirstLineDetectionDetectionPattern("(\\s|\\t)*/\\*.*\$")
+        withLastLineDetectionDetectionPattern(".*\\*/(\\s|\\t)*\$")
+        multiline()
+        withNoBlankLines()
+    }
 }
+
+// First-party Go sources use a blank-line header variant (not the <p> form used
+// by .java/.cs/.ts), so they get their own header template. The shared
+// LicenseExtension excludes **/*.go globally; that exclude is applied to every
+// License task via conventionMapping, i.e. only when the task does not set its
+// own excludes. These tasks therefore set excludes explicitly to override it and
+// actually scan our Go — while still skipping vendor/ and testdata/.
+val goLicenseHeader = file("${rootProject.projectDir}/gradle/msalLicenseHeaderGo.txt")
+val goLicenseExcludes = listOf("**/vendor/**", "**/testdata/**")
+fun License.configureForFirstPartyGo() {
+    group = "license"
+    source = fileTree(projectDir) { include("cmd/**/*.go", "pkg/**/*.go", "test/**/*.go", "*.go") }
+    setExcludes(goLicenseExcludes)
+    header = goLicenseHeader
+    mapping("go", "go_slashstar_style")
+    ext["year"] = Calendar.getInstance().get(Calendar.YEAR)
+}
+
+val licenseGo by tasks.registering(LicenseCheck::class) {
+    description = "Check license headers on first-party Go files"
+    configureForFirstPartyGo()
+}
+
+val licenseFormatGo by tasks.registering(LicenseFormat::class) {
+    description = "Apply license headers to first-party Go files"
+    configureForFirstPartyGo()
+}
+
+tasks.named("licenseMain") { dependsOn(licenseGo) }
+tasks.named("licenseFormatMain") { dependsOn(licenseFormatGo) }
 
 // ============================================
 // Go RPC Source Packaging

--- a/rewrite-go/pkg/preconditions/preconditions.go
+++ b/rewrite-go/pkg/preconditions/preconditions.go
@@ -1,11 +1,11 @@
 /*
  * Copyright 2026 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ * https://docs.moderne.io/licensing/moderne-source-available-license
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rewrite-go/pkg/preconditions/preconditions_test.go
+++ b/rewrite-go/pkg/preconditions/preconditions_test.go
@@ -1,11 +1,11 @@
 /*
  * Copyright 2026 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ * https://docs.moderne.io/licensing/moderne-source-available-license
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rewrite-go/pkg/preconditions/search.go
+++ b/rewrite-go/pkg/preconditions/search.go
@@ -1,11 +1,11 @@
 /*
  * Copyright 2026 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ * https://docs.moderne.io/licensing/moderne-source-available-license
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rewrite-go/test/visit_recipe_test.go
+++ b/rewrite-go/test/visit_recipe_test.go
@@ -1,5 +1,17 @@
 /*
  * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package test
 

--- a/rewrite-go/test/visit_recurse_test.go
+++ b/rewrite-go/test/visit_recurse_test.go
@@ -1,5 +1,17 @@
 /*
  * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package test
 


### PR DESCRIPTION
## What's changed?

Adding (more) explicit mentions of the MSAL (Moderne Source Available) License to rewrite-csharp and rewrite-go.
Fixing some license tagging which probably crept in by copy&paste.

## What's your motivation?

Avoid legal confusion.
