### PR TITLE
Scala: infix type notation

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -37,6 +37,7 @@ import org.openrewrite.scala.marker.BlockArgument;
 import org.openrewrite.scala.marker.DottedMatch;
 import org.openrewrite.scala.marker.Implicit;
 import org.openrewrite.scala.marker.IndentedSyntax;
+import org.openrewrite.scala.marker.InfixTypeNotation;
 import org.openrewrite.scala.marker.PackageBraces;
 import org.openrewrite.scala.marker.SObject;
 import org.openrewrite.scala.marker.Semicolon;
@@ -1363,11 +1364,28 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
     @Override
     public J visitParameterizedType(J.ParameterizedType type, PrintOutputCapture<P> p) {
         beforeSyntax(type, Space.Location.PARAMETERIZED_TYPE_PREFIX, p);
+
+        // Type-level infix operators (`A op B`) are modeled as `op[A, B]` flagged with
+        // InfixTypeNotation; re-emit them in source order as `left op right` rather than
+        // as a bracketed type application.
+        if (type.getMarkers().findFirst(InfixTypeNotation.class).isPresent() &&
+                type.getPadding().getTypeParameters() != null &&
+                type.getPadding().getTypeParameters().getPadding().getElements().size() == 2) {
+            List<JRightPadded<Expression>> operands = type.getPadding().getTypeParameters().getPadding().getElements();
+            JRightPadded<Expression> left = operands.get(0);
+            visit(left.getElement(), p);
+            visitSpace(left.getAfter(), Space.Location.LANGUAGE_EXTENSION, p);
+            visit(type.getClazz(), p);
+            visit(operands.get(1).getElement(), p);
+            afterSyntax(type, p);
+            return type;
+        }
+
         visit(type.getClazz(), p);
-        
+
         // Use Scala-style square brackets for type parameters
         visitContainer("[", type.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, ",", "]", p);
-        
+
         afterSyntax(type, p);
         return type;
     }

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/InfixTypeNotation.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/InfixTypeNotation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Marks a {@link org.openrewrite.java.tree.J.ParameterizedType} that uses Scala's
+ * type-level infix notation ({@code A op B}) rather than the desugared prefix form
+ * ({@code op[A, B]}). Scala parses a type-level infix operator such as
+ * {@code AsyncDb @@ InsightDb} as {@code @@[AsyncDb, InsightDb]}; this marker tells
+ * the printer to re-emit the operator between its two operands instead of as a
+ * bracketed type application. The {@code clazz} of the parameterized type holds the
+ * operator identifier and the two type parameters hold the left and right operands.
+ */
+@Value
+@With
+public class InfixTypeNotation implements Marker {
+    UUID id;
+
+    public static InfixTypeNotation create() {
+        return new InfixTypeNotation(Tree.randomId());
+    }
+}

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -29,6 +29,7 @@ import org.openrewrite.scala.marker.AmpersandIntersection
 import org.openrewrite.scala.marker.DottedMatch
 import org.openrewrite.scala.marker.ExtraConstructorParamLists
 import org.openrewrite.scala.marker.Implicit
+import org.openrewrite.scala.marker.InfixTypeNotation
 import org.openrewrite.scala.marker.LambdaParameter
 import org.openrewrite.scala.marker.IndentedSyntax
 import org.openrewrite.scala.marker.OmitBraces
@@ -8148,8 +8149,7 @@ class ScalaTreeVisitor(
       visitRepeatedType(po)
     case tuple: untpd.Tuple => visitTupleType(tuple)
     case parens: untpd.Parens => visitParenthesizedType(parens)
-    case infix: untpd.InfixOp if infix.op != null &&
-        (infix.op.name.toString == "|" || infix.op.name.toString == "&") =>
+    case infix: untpd.InfixOp if infix.op != null =>
       visitTypeOperatorInfix(infix)
     case _ =>
       visitTree(tpt) match {
@@ -8160,16 +8160,52 @@ class ScalaTreeVisitor(
   }
 
   /**
-   * Scala 3 operator-form intersection (`A & B`) and union (`A | B`) types are parsed as an
-   * `untpd.InfixOp`. They are modeled structurally — `&` as a `J.IntersectionType` (flagged
-   * with `AmpersandIntersection` so the printer emits `&` rather than `with`) and `|` as an
-   * `S.UnionType` — rather than crammed whole into a single `J.Identifier`. This fixes every
-   * type-annotation position at once (params, return types, ascriptions, bounds, tuple and
-   * function components, ...).
+   * Type-level infix operators are parsed as an `untpd.InfixOp`. They are modeled
+   * structurally rather than crammed whole into a single `J.Identifier`:
+   *   - `&` as a `J.IntersectionType` (flagged with `AmpersandIntersection` so the
+   *     printer emits `&` rather than `with`),
+   *   - `|` as an `S.UnionType`,
+   *   - any other operator (`A @@ B`, `A =:= B`, ...) as a `J.ParameterizedType`
+   *     (since Scala desugars `A op B` to `op[A, B]`) flagged with `InfixTypeNotation`
+   *     so the printer re-emits the infix form.
+   * This fixes every type-annotation position at once (params, return types,
+   * ascriptions, bounds, tuple and function components, ...).
    */
   private def visitTypeOperatorInfix(infix: untpd.InfixOp): TypeTree =
-    if (infix.op.name.toString == "&") visitIntersectionInfixType(infix)
-    else visitUnionInfixType(infix)
+    infix.op.name.toString match {
+      case "&" => visitIntersectionInfixType(infix)
+      case "|" => visitUnionInfixType(infix)
+      case _ => visitGeneralInfixType(infix)
+    }
+
+  /**
+   * Model a general type-level infix operator `A op B` as `op[A, B]` (a
+   * `J.ParameterizedType` whose `clazz` is the operator identifier and whose two type
+   * parameters are the left and right operands), flagged with `InfixTypeNotation` so the
+   * printer re-emits the source `A op B` form. The space before the operator is stored as
+   * the left operand's right-padding; the space before the right operand is its own prefix.
+   */
+  private def visitGeneralInfixType(infix: untpd.InfixOp): TypeTree = {
+    val opName = infix.op.name.toString
+    val prefix = extractPrefix(infix.span)
+    val left = asExpression(visitTypeTree(infix.left))
+    if (left == null) return ident(extractSource(infix.span), prefix)
+    val beforeOp = sourceBefore(opName)
+    val right = asExpression(visitTypeTree(infix.right))
+    if (right == null) return ident(extractSource(infix.span), prefix)
+    updateCursor(infix.span.end)
+    val elements = new util.ArrayList[JRightPadded[Expression]](2)
+    elements.add(new JRightPadded[Expression](left, beforeOp, Markers.EMPTY))
+    elements.add(new JRightPadded[Expression](right, Space.EMPTY, Markers.EMPTY))
+    new J.ParameterizedType(
+      Tree.randomId(),
+      prefix,
+      Markers.EMPTY.add(InfixTypeNotation.create()),
+      ident(opName),
+      JContainer.build(Space.EMPTY, elements, Markers.EMPTY),
+      typeOfTree(infix)
+    )
+  }
 
   /**
    * Flatten a (possibly chained) type-level infix `A op B op C` into its leaf operands in

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -937,4 +937,18 @@ class MethodDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void parameterWithInfixType() {
+        rewriteRun(
+          scala(
+            """
+            class AsyncDb
+            class InsightDb
+            type @@[A, B] = A
+            def f(x: AsyncDb @@ InsightDb) = x
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's your motivation?

In Scala you can have types which use infix-syntax and what looks like a custom operator, e.g. `@@`.

## What's changed?

Fixing parsing of these with a special marker to denote the infix syntax.


