### PR TITLE
Scala: fix parsing of two consecutive extension methods

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -7626,11 +7626,21 @@ class ScalaTreeVisitor(
 
   private def visitExtMethods(ext: untpd.ExtMethods): S.ExtensionMethods = {
     // Scala 3 extension method block: `extension (x: T) { def ... }`
+    // The dotty span of an ExtMethods begins at the parameter/method region, not at
+    // the `extension` keyword, so we search backwards for the keyword. Floor that
+    // search at the previous statement's end (the cursor before the prefix) — otherwise
+    // a `(` in a preceding extension's method body (e.g. `def a = foo()`) is mistaken
+    // for this extension's parameter clause, rewinding the cursor into the previous
+    // block and duplicating it on print.
+    val keywordFloor = cursor
     val prefix = extractPrefix(ext.span)
     val adjustedStart = Math.max(0, ext.span.start - offsetAdjustment)
-    val searchStart = Math.max(0, Math.min(cursor, adjustedStart) - "extension".length)
+    val searchStart = Math.max(keywordFloor, Math.min(cursor, adjustedStart) - "extension".length)
     val firstParenIdx = positionOfNext("(", searchStart)
-    val extKwIdx = if (firstParenIdx >= 0) source.lastIndexOf("extension", firstParenIdx) else positionOfNext("extension", cursor)
+    val extKwIdx = if (firstParenIdx >= 0) {
+      val idx = source.lastIndexOf("extension", firstParenIdx)
+      if (idx >= keywordFloor) idx else -1
+    } else positionOfNext("extension", cursor)
     val keywordEnd = if (extKwIdx >= 0) extKwIdx + "extension".length else cursor
     cursor = keywordEnd
 

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -633,6 +633,23 @@ class MethodDeclarationTest implements RewriteTest {
         }
 
         @Test
+        void consecutiveBracelessExtensionsWithMethodCallBody() {
+            // Two consecutive braceless extensions where the first's method body is a
+            // method invocation used to duplicate the first extension on print.
+            rewriteRun(
+                scala(
+                    """
+                    extension (pk: Int)
+                      def a: Int = foo()
+
+                    extension (v: Int)
+                      def c: Int = v
+                    """
+                )
+            );
+        }
+
+        @Test
         void bracelessExtensionWithBraceBlockMethodBody() {
             // A `{` inside a method body must not be mistaken for the extension's
             // opening brace, which would make the parser treat this braceless


### PR DESCRIPTION
## What's changed?

Fix Scala parser handling of two consecutive extension methods.

## What's your motivation?

They suffer from idempotency issues.