### PR TITLE
Scala: fix parsing of trailing comments after method header

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5183,7 +5183,8 @@ class ScalaTreeVisitor(
               val afterCursor = source.substring(cursor, classEnd)
               val braceIndex = positionOfNextIn(afterCursor, "{", 0)
               // For Scala 3 braceless: look for `:` at end of line (not `: Type` annotation).
-              // A braceless body colon is followed by a newline, not by a type name.
+              // A braceless body colon is followed by a newline (or a trailing comment),
+              // not by a type name.
               val colonIndex = {
                 var result = -1
                 var idx = positionOfNextIn(afterCursor, ":", 0)
@@ -5193,8 +5194,12 @@ class ScalaTreeVisitor(
                   } else {
                     val afterColon = afterCursor.substring(idx + 1)
                     val nextNonSpace = afterColon.indexWhere(c => c != ' ' && c != '\t')
-                    if (nextNonSpace < 0 || afterColon.charAt(nextNonSpace) == '\n' || afterColon.charAt(nextNonSpace) == '\r') {
-                      result = idx // `:` followed by newline = braceless body
+                    val startsComment = nextNonSpace >= 0 && nextNonSpace + 1 < afterColon.length &&
+                      afterColon.charAt(nextNonSpace) == '/' &&
+                      (afterColon.charAt(nextNonSpace + 1) == '/' || afterColon.charAt(nextNonSpace + 1) == '*')
+                    if (nextNonSpace < 0 || afterColon.charAt(nextNonSpace) == '\n' ||
+                        afterColon.charAt(nextNonSpace) == '\r' || startsComment) {
+                      result = idx // `:` followed by newline or trailing comment = braceless body
                     }
                   }
                   if (result < 0) idx = positionOfNextIn(afterCursor, ":", idx + 1)

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
@@ -521,4 +521,16 @@ class ClassDeclarationTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void colonBodyWithTrailingCommentAfterColon() {
+        rewriteRun(
+            scala(
+                """
+                case class Matchup(users: Users): // score is x10
+                  def nonEmpty = true
+                """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fix parsing of Scala trailing comments after method header.

## What's your motivation?

When the actual code ends with `:` the subsequent comment shouldn't be confused with return type declaration.
