### PR TITLE
JavaScript: isolate integration tests better, reset RPC process manager

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcessManager.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcessManager.java
@@ -49,6 +49,11 @@ public class RewriteRpcProcessManager<R extends RewriteRpc> {
         this.factory.set(factory);
     }
 
+    // Needed by tests for isolation
+    public void resetFactory() {
+        this.factory.remove();
+    }
+
     public void reset() {
         R current = rpc.get();
         //noinspection ConstantValue

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
@@ -85,6 +85,10 @@ class JavaScriptRewriteRpcTest implements RewriteTest {
         if (Files.exists(tempDir.resolve("rpc.log"))) {
             System.out.println(Files.readString(tempDir.resolve("rpc.log")));
         }
+        // Restore the default factory so this test's per-test @TempDir-backed
+        // factory does not leak into later test classes that lazily (re)start
+        // the RPC process on the same thread.
+        JavaScriptRewriteRpc.resetFactory();
     }
 
     @Override
@@ -116,6 +120,30 @@ class JavaScriptRewriteRpcTest implements RewriteTest {
             spec -> spec.path("package.json")
           )
         );
+    }
+
+    @Test
+    void startsWhenLogParentDirectoryIsMissing() {
+        // given a log path whose parent directory does not exist yet (mimics a
+        // torn-down @TempDir that a stale factory still references)
+        Path missingParent = tempDir.resolve("does-not-exist-yet");
+        Path log = missingParent.resolve("rpc.log");
+        assertThat(Files.exists(missingParent)).isFalse();
+
+        // when starting the RPC process configured to log there
+        JavaScriptRewriteRpc rpc = JavaScriptRewriteRpc.builder()
+          .recipeInstallDir(tempDir)
+          .log(log)
+          .get();
+
+        // then the process starts and the log (with its parent) is created
+        // rather than failing with NoSuchFileException
+        try {
+            assertThat(rpc).isNotNull();
+            assertThat(Files.exists(log)).isTrue();
+        } finally {
+            rpc.shutdown();
+        }
     }
 
     @Test

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -37,6 +37,7 @@ import org.openrewrite.tree.ParsingExecutionContextView;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -82,6 +83,10 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
 
     public static void setFactory(Builder builder) {
         MANAGER.setFactory(builder);
+    }
+
+    public static void resetFactory() {
+        MANAGER.resetFactory();
     }
 
     @Override
@@ -460,10 +465,21 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
                         String.join(" ", cmdArr), process.environment())
                         .livenessCheck(process::getLivenessCheck)
                         .timeout(timeout)
-                        .log(log == null ? null : new PrintStream(Files.newOutputStream(log, StandardOpenOption.APPEND, StandardOpenOption.CREATE)));
+                        .log(log == null ? null : new PrintStream(openLog(log)));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+        }
+
+        private static OutputStream openLog(Path log) throws IOException {
+            // The parent directory may not exist yet (e.g. a previously configured
+            // temp directory that has since been deleted), so create it defensively
+            // rather than failing the (re)start of the RPC process.
+            Path parent = log.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            return Files.newOutputStream(log, StandardOpenOption.APPEND, StandardOpenOption.CREATE);
         }
     }
 }


### PR DESCRIPTION
## What's changed?

Isolate the test cases in `JavaScriptRewriteRpcTest` when it comes to temporary directories. Each test case to have its own directories.

## What's your motivation?

Addressing recurring IO failures in JavaScript integration tests.