### PR TITLE
Index used/declared method types for prefix-based matching

### DIFF
--- a/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/java/HasMethodUseBenchmark.java
+++ b/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/java/HasMethodUseBenchmark.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.java;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.internal.TypesInUse;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.JavaType;
+
+import java.lang.reflect.Field;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.newSetFromMap;
+import static org.openrewrite.java.tree.JavaType.ShallowClass.build;
+
+/**
+ * Isolates {@link TypesInUse#hasMethodUse(MethodMatcher)} against a synthetic used-method set whose size
+ * varies with {@code methodCount}. The indexed path binary-searches a per-set array sorted by canonical
+ * declaring-type FQN to the matcher's literal declaring-type prefix; the {@code scan} baseline replicates the
+ * pre-change behavior of testing every method in the set. {@code indexedCold} additionally pays the one-time
+ * O(n log n) sort, the worst case for the indexed path.
+ */
+@Fork(1)
+@Warmup(iterations = 2, time = 3)
+@Measurement(iterations = 3, time = 3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Threads(1)
+@State(Scope.Benchmark)
+public class HasMethodUseBenchmark {
+
+    @State(Scope.Benchmark)
+    public static class MethodSet {
+        @Param({"100", "1000", "5000"})
+        int methodCount;
+
+        JavaSourceFile cu;
+        TypesInUse typesInUse;
+        MethodMatcher matcher;
+        Field usedMethodIndex;
+
+        @Setup(Level.Trial)
+        public void setup() throws NoSuchFieldException {
+            List<SourceFile> parsed = JavaParser.fromJavaVersion()
+                    .build()
+                    .parse(new InMemoryExecutionContext(), "class A {}")
+                    .toList();
+            cu = (JavaSourceFile) parsed.get(0);
+
+            Set<JavaType.Method> usedMethods = newSetFromMap(new IdentityHashMap<>());
+            for (int i = 0; i < methodCount; i++) {
+                usedMethods.add(newMethodType("com.example.svc" + i + ".Service" + i, "find", "long"));
+            }
+            typesInUse = TypesInUse.of(cu, emptySet(), emptySet(), usedMethods, emptySet());
+
+            // A literal-prefix pattern targeting the middle declaring type, so the indexed path narrows
+            // to a single candidate while the scan must walk the whole set on a negative-leaning query.
+            int mid = methodCount / 2;
+            matcher = new MethodMatcher("com.example.svc" + mid + ".Service" + mid + " find(..)");
+
+            usedMethodIndex = TypesInUse.class.getDeclaredField("usedMethodIndex");
+            usedMethodIndex.setAccessible(true);
+
+            // Build and cache the index once so indexedHot measures only the binary search.
+            typesInUse.hasMethodUse(matcher);
+        }
+    }
+
+    /** Index already built; measures the steady-state binary-search-and-confirm cost. */
+    @Benchmark
+    public void indexedHot(MethodSet state, Blackhole bh) {
+        bh.consume(state.typesInUse.hasMethodUse(state.matcher));
+    }
+
+    /** Index cleared before each invocation; measures the one-time sort plus a single query. */
+    @Benchmark
+    public void indexedCold(MethodSet state, Blackhole bh) throws IllegalAccessException {
+        state.usedMethodIndex.set(state.typesInUse, null);
+        bh.consume(state.typesInUse.hasMethodUse(state.matcher));
+    }
+
+    /** Replicates the pre-change behavior: scan every used method calling {@link MethodMatcher#matches}. */
+    @Benchmark
+    public void scan(MethodSet state, Blackhole bh) {
+        boolean found = false;
+        for (JavaType.Method m : state.typesInUse.getUsedMethods()) {
+            if (state.matcher.matches(m)) {
+                found = true;
+                break;
+            }
+        }
+        bh.consume(found);
+    }
+
+    private static JavaType.Method newMethodType(String type, String method, String... parameterTypes) {
+        List<JavaType> parameterTypeList = new java.util.ArrayList<>(parameterTypes.length);
+        for (String name : parameterTypes) {
+            JavaType.Primitive primitive = JavaType.Primitive.fromKeyword(name);
+            parameterTypeList.add(primitive != null ? primitive : JavaType.ShallowClass.build(name));
+        }
+        return new JavaType.Method(
+                null,
+                1L,
+                build(type),
+                method,
+                null,
+                null,
+                parameterTypeList,
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                null
+        );
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(HasMethodUseBenchmark.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/MethodMatcherTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/MethodMatcherTest.java
@@ -42,6 +42,19 @@ import static org.openrewrite.java.tree.JavaType.ShallowClass.build;
 class MethodMatcherTest implements RewriteTest {
 
     @Test
+    void declaringTypeMatchPrefix() {
+        // The literal prefix is everything in the declaring-type pattern up to the first wildcard.
+        assertThat(new MethodMatcher("java.util.List add(..)").getDeclaringTypeMatchPrefix()).isEqualTo("java.util.List");
+        assertThat(new MethodMatcher("java.util.List *(..)").getDeclaringTypeMatchPrefix()).isEqualTo("java.util.List");
+        // The package separator before the `..` wildcard is retained, since every match's FQN has it.
+        assertThat(new MethodMatcher("java.util..* *(..)").getDeclaringTypeMatchPrefix()).isEqualTo("java.util.");
+        assertThat(new MethodMatcher("com.*.Bar foo(..)").getDeclaringTypeMatchPrefix()).isEqualTo("com.");
+        // A leading wildcard yields no usable prefix.
+        assertThat(new MethodMatcher("* *(..)").getDeclaringTypeMatchPrefix()).isNull();
+        assertThat(new MethodMatcher("*..* *(..)").getDeclaringTypeMatchPrefix()).isNull();
+    }
+
+    @Test
     void invalidMethodMatcher() {
         Validated<String> validate = MethodMatcher.validate("com.google.common.collect.*");
         assertThat(validate.isValid()).isFalse();

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/internal/TypesInUseTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/internal/TypesInUseTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.internal;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
+import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.test.RewriteTest;
@@ -96,6 +97,57 @@ class TypesInUseTest implements RewriteTest {
                 assertThat(tiu.hasDocReferenceInPackage("org.openrewrite", false)).isFalse();
                 assertThat(tiu.hasDocReferenceInPackage("org.openrewrite", true)).isTrue();
                 assertThat(tiu.hasDocReferenceInPackage("com.other", true)).isFalse();
+            })
+          )
+        );
+    }
+
+    @Test
+    void methodMatchingAcrossPatternShapes() {
+        rewriteRun(
+          java(
+            """
+              import java.util.Collections;
+              import java.util.List;
+              class A {
+                  void f(List<String> l) {
+                      l.add("x");
+                      l.get(0);
+                      Collections.emptyList();
+                      "a".concat("b");
+                  }
+                  int g() {
+                      return 1;
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                TypesInUse tiu = cu.getTypesInUse();
+
+                // Exact method name on a concrete type.
+                assertThat(tiu.hasMethodUse(new MethodMatcher("java.util.List add(..)"))).isTrue();
+                // Wildcard method name on a concrete type — the case the declaring-type prefix index must cover.
+                assertThat(tiu.hasMethodUse(new MethodMatcher("java.util.List *(..)"))).isTrue();
+                // Subpackage prefix matches both List and Collections.
+                assertThat(tiu.hasMethodUse(new MethodMatcher("java.util..* *(..)"))).isTrue();
+                // Mid-string type wildcard yields the weak "java." prefix but still matches.
+                assertThat(tiu.hasMethodUse(new MethodMatcher("java.*.List add(..)"))).isTrue();
+                // Full type wildcard with a pinned name falls back to a full scan.
+                assertThat(tiu.hasMethodUse(new MethodMatcher("*..* concat(..)"))).isTrue();
+
+                // Negative: declaring type is referenced, but the method is not used.
+                assertThat(tiu.hasMethodUse(new MethodMatcher("java.util.List remove(..)"))).isFalse();
+                // Negative: declaring type is not referenced at all (sorts past every key).
+                assertThat(tiu.hasMethodUse(new MethodMatcher("java.util.Map put(..)"))).isFalse();
+
+                // matchOverrides bypasses the prefix index: List.add matches the Collection#add supertype pattern.
+                assertThat(tiu.hasMethodUse(new MethodMatcher("java.util.Collection add(..)", true))).isTrue();
+                assertThat(tiu.hasMethodUse(new MethodMatcher("java.util.Collection add(..)", false))).isFalse();
+
+                // Declared methods go through the same path.
+                assertThat(tiu.declaresMethod(new MethodMatcher("A g()"))).isTrue();
+                assertThat(tiu.declaresMethod(new MethodMatcher("A *(..)"))).isTrue();
+                assertThat(tiu.declaresMethod(new MethodMatcher("A nonexistent()"))).isFalse();
             })
           )
         );

--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
@@ -82,6 +82,7 @@ public class MethodMatcher {
     private MethodNameMatcher methodNameMatcher;
     private List<ArgumentMatcher> argumentMatchers;
     private int varArgsPosition = -1;
+    private @Nullable String declaringTypeMatchPrefix;
 
     /**
      * Whether to match overridden forms of the method on subclasses of {@link #typeMatcher}.
@@ -137,6 +138,50 @@ public class MethodMatcher {
         this.methodNameMatcher = parser.methodNameMatcher;
         this.argumentMatchers = parser.argumentMatchers;
         this.varArgsPosition = parser.varArgsPosition;
+        this.declaringTypeMatchPrefix = parser.declaringTypeMatchPrefix;
+    }
+
+    /**
+     * The literal prefix that the declaring-type pattern requires of any matching type's fully qualified name:
+     * everything in the type pattern up to the first wildcard metacharacter ({@code *} or {@code ..}), with
+     * {@code $} canonicalized to {@code .}. A {@code ..} subpackage wildcard keeps the package separator that
+     * precedes it, since every type it matches has that separator in its FQN ({@code java.util..*} yields
+     * {@code java.util.}). Returns {@code null} when the pattern starts with a wildcard, i.e. no prefix can be
+     * required.
+     * <p>
+     * Because the type portion of a method pattern is matched verbatim against the declaring type's name (ignoring
+     * {@code matchOverrides}), this prefix is a <em>necessary</em> prefix of any non-override match. Callers holding
+     * a collection of methods sorted by canonical declaring-type FQN can therefore binary-search to this prefix and
+     * scan only the {@code startsWith(prefix)} window, confirming each candidate with {@link #matches(JavaType.Method)}.
+     */
+    public @Nullable String getDeclaringTypeMatchPrefix() {
+        return declaringTypeMatchPrefix;
+    }
+
+    /**
+     * The literal prefix of a declaring-type pattern: characters preceding the first {@code *} or {@code ..}, with
+     * {@code $} canonicalized to {@code .}. The package separator before a {@code ..} wildcard is retained
+     * ({@code java.util..*} -> {@code java.util.}) because every match has it; a separator before {@code *} is
+     * naturally retained too ({@code com.*.Bar} -> {@code com.}). {@code null} when empty.
+     */
+    private static @Nullable String literalTypePrefix(String typePattern) {
+        int end = typePattern.length();
+        for (int i = 0; i < typePattern.length(); i++) {
+            char c = typePattern.charAt(i);
+            if (c == '.' && i + 1 < typePattern.length() && typePattern.charAt(i + 1) == '.') {
+                end = i == 0 ? 0 : i + 1;
+                break;
+            }
+            if (c == '*') {
+                end = i;
+                break;
+            }
+        }
+        if (end == 0) {
+            return null;
+        }
+        String prefix = typePattern.substring(0, end);
+        return prefix.indexOf('$') < 0 ? prefix : prefix.replace('$', '.');
     }
 
     public static Validated<String> validate(@Nullable String signature) {
@@ -867,6 +912,7 @@ public class MethodMatcher {
         private MethodMatcher.MethodNameMatcher methodNameMatcher;
         private List<MethodMatcher.ArgumentMatcher> argumentMatchers;
         private int varArgsPosition = -1;
+        private @Nullable String declaringTypeMatchPrefix;
         private boolean hasWildcardVarArgs = false;  // Track if we've seen .. wildcard
 
         void parse() {
@@ -895,6 +941,7 @@ public class MethodMatcher {
                 throw new IllegalArgumentException("Invalid method pattern - empty type pattern: " + pattern);
             }
             typeMatcher = parseTypeMatcher(typePattern);
+            declaringTypeMatchPrefix = literalTypePrefix(typePattern);
 
             // Parse method name pattern
             String methodName = pattern.substring(separator + 1, openParen).trim();

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/TypesInUse.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/TypesInUse.java
@@ -31,6 +31,7 @@ import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
@@ -92,6 +93,16 @@ public class TypesInUse {
      */
     @Nullable
     private volatile Map<String, Boolean> typeMatchingCache;
+
+    /**
+     * {@link #usedMethods} / {@link #declaredMethods} sorted by canonical declaring-type FQN, so a
+     * {@link MethodMatcher} carrying a literal declaring-type prefix can binary-search to its window instead of
+     * scanning the whole set. Lazily built on first matchable query and cached, mirroring {@link #trie}.
+     */
+    @Nullable
+    private volatile MethodEntry[] usedMethodIndex;
+    @Nullable
+    private volatile MethodEntry[] declaredMethodIndex;
 
     public static TypesInUse build(JavaSourceFile cu) {
         FindTypesInUse findTypesInUse = new FindTypesInUse();
@@ -190,18 +201,43 @@ public class TypesInUse {
      * Whether this compilation unit invokes any method matching {@code matcher}.
      */
     public boolean hasMethodUse(MethodMatcher matcher) {
-        for (JavaType.Method m : usedMethods) {
-            if (matcher.matches(m)) {
-                return true;
-            }
-        }
-        return false;
+        return anyMethodMatches(matcher, true);
     }
 
     /** Whether this compilation unit declares any method matching {@code matcher}. */
     public boolean declaresMethod(MethodMatcher matcher) {
-        for (JavaType.Method m : declaredMethods) {
-            if (matcher.matches(m)) {
+        return anyMethodMatches(matcher, false);
+    }
+
+    /**
+     * When the matcher pins a literal declaring-type prefix and does not need override resolution, binary-search the
+     * sorted index to the prefix window and confirm candidates with {@link MethodMatcher#matches(JavaType.Method)};
+     * otherwise (leading-wildcard type, or {@code matchOverrides} where the match may live under a subtype key) fall
+     * back to a full scan.
+     */
+    private boolean anyMethodMatches(MethodMatcher matcher, boolean used) {
+        Set<JavaType.Method> methods = used ? usedMethods : declaredMethods;
+        String prefix = matcher.getDeclaringTypeMatchPrefix();
+        if (prefix == null || matcher.isMatchOverrides()) {
+            for (JavaType.Method m : methods) {
+                if (matcher.matches(m)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        MethodEntry[] index = used ? usedMethodIndex : declaredMethodIndex;
+        if (index == null) {
+            index = MethodEntry.index(methods);
+            if (used) {
+                usedMethodIndex = index;
+            } else {
+                declaredMethodIndex = index;
+            }
+        }
+        for (int i = MethodEntry.lowerBound(index, prefix); i < index.length && index[i].key.startsWith(prefix); i++) {
+            if (matcher.matches(index[i].method)) {
                 return true;
             }
         }
@@ -534,6 +570,49 @@ public class TypesInUse {
                 childCount++;
                 return child;
             }
+        }
+    }
+
+    /**
+     * A method paired with its canonical declaring-type FQN ({@code $} replaced with {@code .}), used as the sort key
+     * so that {@link MethodMatcher#getDeclaringTypeMatchPrefix() declaring-type prefixes} — exact FQNs, package
+     * prefixes from {@code ..*} patterns, and the shorter prefixes of mid-string wildcards alike — all resolve to a
+     * contiguous {@code startsWith} window. Canonicalizing here lets inner-class FQNs match either {@code .} or
+     * {@code $} prefix form, consistent with {@link TypeUtils#fullyQualifiedNamesAreEqual}.
+     */
+    private static final class MethodEntry {
+        private final String key;
+        private final JavaType.Method method;
+
+        private MethodEntry(String key, JavaType.Method method) {
+            this.key = key;
+            this.method = method;
+        }
+
+        static MethodEntry[] index(Set<JavaType.Method> methods) {
+            MethodEntry[] entries = new MethodEntry[methods.size()];
+            int i = 0;
+            for (JavaType.Method m : methods) {
+                String fqn = m.getDeclaringType().getFullyQualifiedName();
+                entries[i++] = new MethodEntry(fqn.indexOf('$') < 0 ? fqn : fqn.replace('$', '.'), m);
+            }
+            Arrays.sort(entries, Comparator.comparing(e -> e.key));
+            return entries;
+        }
+
+        /** First index whose key is {@code >= prefix} — the start of the {@code startsWith(prefix)} run. */
+        static int lowerBound(MethodEntry[] index, String prefix) {
+            int lo = 0;
+            int hi = index.length;
+            while (lo < hi) {
+                int mid = (lo + hi) >>> 1;
+                if (index[mid].key.compareTo(prefix) < 0) {
+                    lo = mid + 1;
+                } else {
+                    hi = mid;
+                }
+            }
+            return lo;
         }
     }
 


### PR DESCRIPTION
## Motivation

`TypesInUse.hasMethodUse` and `declaresMethod` back the preconditions of method-oriented searches and recipes (`UsesMethod`, `DeclaresMethod`, `FindMethods`, and anything composed on top of them). Until now each query scanned the compilation unit's entire used- or declared-method set, calling `MethodMatcher.matches` on every entry. A single `TypesInUse` instance is cached on the source file and queried by the preconditions of many recipes between edits, so a file with a large used-method set paid that full scan once per recipe per cycle — linear in method count, every time.

The key observation is that the type portion of a method pattern is matched verbatim against the declaring type's fully qualified name (it does not participate in `matchOverrides`). So the literal characters before the first wildcard are a *necessary* prefix of any non-override match, which means a set sorted by declaring-type FQN can be binary-searched straight to the only window that could possibly match.

## Examples

`MethodMatcher` now exposes that necessary prefix:

```java
new MethodMatcher("java.util.List add(..)").getDeclaringTypeMatchPrefix(); // "java.util.List"
new MethodMatcher("java.util..* *(..)").getDeclaringTypeMatchPrefix();     // "java.util." (subpackage prefix, separator kept)
new MethodMatcher("com.*.Bar foo(..)").getDeclaringTypeMatchPrefix();      // "com."       (mid-string wildcard)
new MethodMatcher("*..* *(..)").getDeclaringTypeMatchPrefix();             // null         (leading wildcard)
```

`TypesInUse.hasMethodUse` / `declaresMethod` use it transparently — the API and results are unchanged, only the lookup is faster:

```java
TypesInUse tiu = cu.getTypesInUse();
tiu.hasMethodUse(new MethodMatcher("java.util.List add(..)")); // binary-searches the "java.util.List" window
tiu.hasMethodUse(new MethodMatcher("*..* concat(..)"));        // leading wildcard -> falls back to a full scan
```

## Summary

- Added `MethodMatcher.getDeclaringTypeMatchPrefix()`: everything in the declaring-type pattern up to the first `*` or `..`, with `$` canonicalized to `.`. It returns an exact FQN (`java.util.List`), a subpackage prefix that keeps the package separator (`java.util.` from `java.util..*`), the shorter prefix of a mid-string wildcard (`com.` from `com.*.Bar`), or `null` when the pattern starts with a wildcard. The prefix is computed once during pattern parsing.
- `TypesInUse` lazily builds, on the first matchable query, a `MethodEntry[]` per set (used and declared) sorted by canonical declaring-type FQN, and caches it on the instance (mirroring the existing lazy `trie` for `hasType`). A matching query lower-bound binary-searches to the prefix window and confirms each candidate in the `startsWith(prefix)` run with `MethodMatcher.matches`.
- Leading-wildcard declaring types (no usable prefix) and `matchOverrides` queries — where a match may live under a subtype key rather than the literal one — fall back to the original linear scan, so behavior is identical across every pattern shape.
- The sort is lazy (not in `TypesInUse.build`), cached on the instance, and is ~O(n log n) over the distinct declaring types. Rough break-even versus scanning is ~12 matching queries per `TypesInUse` instance — easily crossed, since a cached instance is queried by many recipes' preconditions between edits.
- Added a `HasMethodUseBenchmark` (JMH) isolating the indexed path against the prior scan across used-method-set sizes and the one-time index sort cost. The indexed query stays roughly constant-time as the set grows while the scan degrades linearly.

## Test plan

- [x] `MethodMatcherTest.declaringTypeMatchPrefix` covers exact, wildcard-name, subpackage, mid-string-wildcard, and leading-wildcard pattern shapes.
- [x] `TypesInUseTest.methodMatchingAcrossPatternShapes` exercises `hasMethodUse`/`declaresMethod` across all those shapes plus the `matchOverrides` and leading-wildcard fallbacks, with positive and negative cases (including a declaring type that sorts past every key).
- [x] `./gradlew :rewrite-java-test:test --tests "org.openrewrite.java.search.*" --tests "org.openrewrite.java.MethodMatcherTest" --tests "org.openrewrite.java.internal.TypesInUseTest"` — green (covers `UsesMethod`/`DeclaresMethod`/`FindMethods` plus the two new tests).
- [x] `HasMethodUseBenchmark` runs and shows the indexed path roughly constant-time versus a linearly degrading scan.
