### PR TITLE
JavaScript: synchronize artifact versions for snapshots of rewrite-javascript between Maven and NPM

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -39,6 +39,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      actions: read  # download the published-snapshot-version artifact from the triggering `ci` run
     steps:
       - uses: actions/checkout@v7
         with:
@@ -63,22 +64,45 @@ jobs:
       - shell: bash
         run: sudo npm install -g npm@latest
 
+      # The `ci` run records the exact Maven snapshot version it deployed for
+      # rewrite-javascript and uploads it as the `published-snapshot-version` artifact.
+      # Download it so the npm package can mirror that version 1:1. Best-effort: absent
+      # on the `publish` tag path (and on older `ci` runs), in which case the step below
+      # falls back to Gradle's own snapshot-version derivation.
+      - if: github.event.workflow_run.name == 'ci'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: published-snapshot-version
+          path: .published-version
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
       # For a tag-triggered upstream `publish` run, `head_branch` is the tag name
       # (e.g. `v8.83.0`). Strip the leading `v` and publish to dist-tag `latest`.
-      # Otherwise this is the `ci`-triggered snapshot path: let Gradle derive the
-      # dated snapshot version and publish to dist-tag `next`.
+      # Otherwise this is the `ci`-triggered snapshot path: mirror the exact Maven
+      # snapshot version handed off above (so every Maven snapshot gets a 1:1 npm
+      # counterpart), and publish to dist-tag `next`.
       - id: ver
         shell: bash
         env:
           TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
           if [[ '${{ github.event.workflow_run.name }}' == 'publish' ]]; then
-            echo "version=${TAG#v}"   >> "$GITHUB_OUTPUT"
-            echo "dist_tag=latest"    >> "$GITHUB_OUTPUT"
-          else
-            echo "version="           >> "$GITHUB_OUTPUT"
-            echo "dist_tag=next"      >> "$GITHUB_OUTPUT"
+            echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+            echo "dist_tag=latest"  >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          V=''
+          F=$(find .published-version -name publishedVersion.txt 2>/dev/null | head -1)
+          if [[ -n "$F" ]]; then
+            V=$(tr -d '[:space:]' < "$F")
+            echo "Mirroring Maven snapshot version handed off from the ci run: $V"
+          else
+            echo "No handed-off version found; falling back to Gradle-derived snapshot version"
+          fi
+          echo "version=$V"     >> "$GITHUB_OUTPUT"
+          echo "dist_tag=next"  >> "$GITHUB_OUTPUT"
 
       - shell: bash
         run: |
@@ -89,9 +113,10 @@ jobs:
           ./gradlew --no-daemon --console=plain --info --stacktrace \
             :rewrite-javascript:npmPack "${ARGS[@]}"
 
-      # npm has no `--skip-duplicate`. The daily scheduled snapshot publish would
-      # otherwise 403 whenever no new commit had landed since the previous run
-      # (the snapshot version is derived from the latest commit timestamp).
+      # npm has no `--skip-duplicate`. Guards against a re-run of the same upstream
+      # event (which resolves to the identical version) 403-ing. A genuine new Maven
+      # snapshot always carries a fresh build number, so this never suppresses a
+      # legitimate publish — including the daily schedule, even with no new commit.
       - shell: bash
         env:
           CI: 'true'

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -246,6 +246,42 @@ testing {
 // `next`), and the duplicate-publish guard. The dedicated workflow filename is also what the
 // package's npm Trusted Publisher (OIDC) record matches against. CI/release workflows still
 // publish to Sonatype, PyPI, NuGet as before.
+//
+// npm publishing is decoupled from the Maven snapshot publish (it runs in a separate
+// `workflow_run` triggered by `ci`, because npm Trusted Publisher binds to a single workflow
+// filename). To still give every Maven snapshot a 1:1 npm counterpart carrying the identical
+// version reference, this task records the exact unique snapshot version that Gradle assigned to
+// `org.openrewrite:rewrite-javascript` (e.g. `8.86.0-20260625.164513-55`). Gradle's maven-publish
+// computes that version client-side and stages the very `maven-metadata.xml` it uploads under
+// `build/tmp/publish<Pub>PublicationTo<Repo>Repository/snapshot-maven-metadata.xml`; we read the
+// `<value>` straight from that local file — no network read-back. The `ci` run uploads the
+// recorded version as an artifact and `npm-publish.yml` pins the npm version to it.
+val recordPublishedSnapshotVersion = tasks.register("recordPublishedSnapshotVersion") {
+    description = "Records the unique Sonatype snapshot version of rewrite-javascript for npm-publish to mirror."
+    val baseVersion = project.version.toString()
+    val buildDirectory = layout.buildDirectory
+    val versionFile = buildDirectory.file("npm/publishedVersion.txt")
+    onlyIf { baseVersion.endsWith("-SNAPSHOT") }
+    doLast {
+        val staged = buildDirectory.dir("tmp").get().asFile.walkTopDown()
+            .firstOrNull { it.name == "snapshot-maven-metadata.xml" }
+        val resolved = staged?.readText()
+            ?.let { Regex("<value>([^<]+)</value>").find(it)?.groupValues?.get(1) }
+        if (resolved == null) {
+            logger.warn("Could not find the staged snapshot metadata under build/tmp; " +
+                    "npm-publish will fall back to its default version derivation.")
+            return@doLast
+        }
+        val out = versionFile.get().asFile
+        out.parentFile.mkdirs()
+        out.writeText(resolved)
+        logger.lifecycle("Recorded published snapshot version for npm: $resolved")
+    }
+}
+
+tasks.named("publish") {
+    finalizedBy(recordPublishedSnapshotVersion)
+}
 
 // ============================================
 // JavaScript Test Support Tasks


### PR DESCRIPTION
## What's changed?

- Publish the NPM version string as an GHA artifact of the build. To be picked up by https://github.com/openrewrite/gh-automation/pull/97.
- Use that version string in `npm-publish` which runs after CI. 

## What's your motivation?

As one of the steps towards synchronizing the version numbering between rewrite-javascript Maven artifact and NPM artifact.
Currently it's not in sync at times for **snapshots** (proper release versions are fine)