### PR TITLE
Add `UsesType`/`UsesMethod` preconditions to type/method-targeted recipes

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/ChangePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/ChangePluginVersion.java
@@ -29,6 +29,7 @@ import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -161,6 +162,11 @@ public class ChangePluginVersion extends Recipe {
                 }
             }
         };
-        return Preconditions.or(Preconditions.check(Preconditions.or(new IsBuildGradle<>(), new IsSettingsGradle<>()), groovyVisitor));
+        // Also require the plugin `version(..)` method to be used so the recipe only runs on
+        // build/settings scripts that reference it.
+        return Preconditions.check(
+                Preconditions.and(new UsesMethod<>(versionMatcher),
+                        Preconditions.or(new IsBuildGradle<>(), new IsSettingsGradle<>())),
+                groovyVisitor);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/AnnotationMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AnnotationMatcher.java
@@ -79,6 +79,15 @@ public class AnnotationMatcher {
         this(signature, false);
     }
 
+    /**
+     * @return The annotation type pattern this matcher was constructed with, without the leading
+     * {@code @} or any parameter constraints (e.g. {@code java.lang.SuppressWarnings}). Suitable for
+     * use as a {@link org.openrewrite.java.search.UsesType} pattern.
+     */
+    public String getAnnotationName() {
+        return match.annotationName().getText();
+    }
+
     public boolean matches(J.Annotation annotation) {
         return matchesAnnotationName(annotation) &&
                matchesSingleParameter(annotation) &&

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodInvocationReturnType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodInvocationReturnType.java
@@ -20,6 +20,7 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -53,8 +54,8 @@ public class ChangeMethodInvocationReturnType extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new JavaIsoVisitor<ExecutionContext>() {
-            private final MethodMatcher methodMatcher = new MethodMatcher(methodPattern, false);
+        MethodMatcher methodMatcher = new MethodMatcher(methodPattern, false);
+        return Preconditions.check(new UsesMethod<>(methodMatcher), new JavaIsoVisitor<ExecutionContext>() {
 
             private boolean methodUpdated;
 
@@ -136,6 +137,6 @@ public class ChangeMethodInvocationReturnType extends Recipe {
                 }
                 return false;
             }
-        };
+        });
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotation.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotation.java
@@ -17,8 +17,12 @@ package org.openrewrite.java;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.search.UsesType;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
@@ -33,7 +37,12 @@ public class RemoveAnnotation extends Recipe {
     String description = "Remove matching annotations wherever they occur.";
 
     @Override
-    public RemoveAnnotationVisitor  getVisitor() {
-        return new RemoveAnnotationVisitor(new AnnotationMatcher(annotationPattern));
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        AnnotationMatcher annotationMatcher = new AnnotationMatcher(annotationPattern);
+        // Only run on source files that reference the annotation type. The visitor is reachable
+        // directly (e.g. via `getVisitor().visitNonNull(...)` on a non-source-file node), where the
+        // precondition is bypassed, so this only filters whole-file traversals.
+        return Preconditions.check(new UsesType<>(annotationMatcher.getAnnotationName(), true),
+                new RemoveAnnotationVisitor(annotationMatcher));
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveImplements.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveImplements.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -54,7 +55,9 @@ public class RemoveImplements extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new JavaIsoVisitor<ExecutionContext>() {
+        // Also require the interface type to be used so the recipe only runs on source files
+        // that reference it.
+        return Preconditions.check(Preconditions.and(new UsesType<>(interfaceType, true), new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDeclaration, ExecutionContext ctx) {
                 if (!(classDeclaration.getType() instanceof JavaType.Class) || classDeclaration.getImplements() == null) {
@@ -66,7 +69,7 @@ public class RemoveImplements extends Recipe {
                 }
                 return super.visitClassDeclaration(classDeclaration, ctx);
             }
-        }, new JavaIsoVisitor<ExecutionContext>() {
+        }), new JavaIsoVisitor<ExecutionContext>() {
             @Nullable
             AnnotationService annotationService;
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodThrows.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodThrows.java
@@ -20,7 +20,9 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.search.DeclaresMethod;
+import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -66,7 +68,14 @@ public class RemoveMethodThrows extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         MethodMatcher methodMatcher = new MethodMatcher(methodPattern, matchOverrides != null ? matchOverrides : true);
         TypeMatcher typeMatcher = new TypeMatcher(exceptionTypePattern, true);
-        return Preconditions.check(new DeclaresMethod<>(methodMatcher), new JavaIsoVisitor<ExecutionContext>() {
+        TreeVisitor<?, ExecutionContext> precondition = new DeclaresMethod<>(methodMatcher);
+        // An exception can only be removed if it appears in a `throws` clause (or `@Throws`), so also
+        // require its type to be used — unless the pattern matches all exceptions, where no single
+        // type applies.
+        if (!StringUtils.isBlank(exceptionTypePattern) && !"*".equals(exceptionTypePattern)) {
+            precondition = Preconditions.and(new UsesType<>(exceptionTypePattern, true), precondition);
+        }
+        return Preconditions.check(precondition, new JavaIsoVisitor<ExecutionContext>() {
                     @Override
                     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                         J.ClassDeclaration enclosingClass = getCursor().firstEnclosing(J.ClassDeclaration.class);

--- a/rewrite-java/src/main/java/org/openrewrite/java/ReplaceAnnotation.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ReplaceAnnotation.java
@@ -20,8 +20,10 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.service.ImportService;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
@@ -66,7 +68,7 @@ public class ReplaceAnnotation extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         AnnotationMatcher matcher = new AnnotationMatcher(annotationPatternToReplace);
-        return new JavaIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(new UsesType<>(matcher.getAnnotationName(), true), new JavaIsoVisitor<ExecutionContext>() {
 
             @Override
             public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
@@ -141,6 +143,6 @@ public class ReplaceAnnotation extends Recipe {
                     }
                 }
             }
-        };
+        });
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindAnnotations.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindAnnotations.java
@@ -58,20 +58,27 @@ public class FindAnnotations extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         AnnotationMatcher annotationMatcher = new AnnotationMatcher(annotationPattern, matchMetaAnnotations);
-        return Preconditions.check(
-                new JavaIsoVisitor<ExecutionContext>() {
-                    @Override
-                    public J preVisit(J tree, ExecutionContext ctx) {
-                        stopAfterPreVisit();
-                        JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
-                        for (JavaType type : cu.getTypesInUse().getTypesInUse()) {
-                            if (annotationMatcher.matchesAnnotationOrMetaAnnotation(TypeUtils.asFullyQualified(type))) {
-                                return SearchResult.found(cu);
-                            }
-                        }
-                        return tree;
+        TreeVisitor<?, ExecutionContext> precondition = new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J preVisit(J tree, ExecutionContext ctx) {
+                stopAfterPreVisit();
+                JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
+                for (JavaType type : cu.getTypesInUse().getTypesInUse()) {
+                    if (annotationMatcher.matchesAnnotationOrMetaAnnotation(TypeUtils.asFullyQualified(type))) {
+                        return SearchResult.found(cu);
                     }
-                },
+                }
+                return tree;
+            }
+        };
+
+        // In meta-annotation mode the matched type need not literally appear in a file (it can be
+        // reached transitively), so only require the annotation type's use when matching directly.
+        if (!Boolean.TRUE.equals(matchMetaAnnotations)) {
+            precondition = Preconditions.and(new UsesType<>(annotationMatcher.getAnnotationName(), true), precondition);
+        }
+
+        return Preconditions.check(precondition,
                 new JavaIsoVisitor<ExecutionContext>() {
                     @Override
                     public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedClasses.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedClasses.java
@@ -73,7 +73,7 @@ public class FindDeprecatedClasses extends Recipe {
         TypeMatcher typeMatcher = typePattern == null ? null : new TypeMatcher(typePattern,
                 Boolean.TRUE.equals(matchInherited));
 
-        return Preconditions.check(new JavaIsoVisitor<ExecutionContext>() {
+        TreeVisitor<?, ExecutionContext> precondition = new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
                 for (JavaType javaType : cu.getTypesInUse().getTypesInUse()) {
@@ -88,7 +88,15 @@ public class FindDeprecatedClasses extends Recipe {
                 }
                 return cu;
             }
-        }, new JavaIsoVisitor<ExecutionContext>() {
+        };
+
+        // When a type pattern is provided, also require a matching type use so the recipe
+        // only runs on source files that reference it.
+        if (typeMatcher != null) {
+            precondition = Preconditions.and(new UsesType<>(typePattern, true), precondition);
+        }
+
+        return Preconditions.check(precondition, new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public <N extends NameTree> N visitTypeName(N nameTree, ExecutionContext ctx) {
                 if (getCursor().firstEnclosing(J.Import.class) == null) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
@@ -81,7 +81,7 @@ public class FindDeprecatedMethods extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         MethodMatcher methodMatcher = methodPattern == null || methodPattern.isEmpty() ? null : new MethodMatcher(methodPattern, true);
 
-        return Preconditions.check(new JavaIsoVisitor<ExecutionContext>() {
+        TreeVisitor<?, ExecutionContext> precondition = new JavaIsoVisitor<ExecutionContext>() {
             @SuppressWarnings("NullableProblems")
             @Override
             public J visit(Tree tree, ExecutionContext ctx) {
@@ -99,7 +99,15 @@ public class FindDeprecatedMethods extends Recipe {
                 }
                 return (J) tree;
             }
-        }, new JavaIsoVisitor<ExecutionContext>() {
+        };
+
+        // When a method pattern is provided, also require a matching method use so the recipe
+        // only runs on source files that reference it.
+        if (methodMatcher != null) {
+            precondition = Preconditions.and(new UsesMethod<>(methodMatcher), precondition);
+        }
+
+        return Preconditions.check(precondition, new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/ResultOfMethodCallIgnored.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/ResultOfMethodCallIgnored.java
@@ -60,7 +60,7 @@ public class ResultOfMethodCallIgnored extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         MethodMatcher methodMatcher = new MethodMatcher(methodPattern, matchOverrides);
-        return new JavaIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(new UsesMethod<>(methodMatcher), new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
@@ -71,6 +71,6 @@ public class ResultOfMethodCallIgnored extends Recipe {
                 }
                 return m;
             }
-        };
+        });
     }
 }

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/RenameTypeAlias.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/RenameTypeAlias.java
@@ -18,6 +18,7 @@ package org.openrewrite.kotlin;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
+import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.kotlin.tree.K;
@@ -48,7 +49,7 @@ public class RenameTypeAlias extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new KotlinIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(new UsesType<>(fullyQualifiedAliasedType, true), new KotlinIsoVisitor<ExecutionContext>() {
             @Override
             public K.TypeAlias visitTypeAlias(K.TypeAlias typeAlias, ExecutionContext ctx) {
                 if (!aliasName.equals(typeAlias.getSimpleName()) || !TypeUtils.isOfClassType(typeAlias.getType(), fullyQualifiedAliasedType)) {
@@ -68,7 +69,7 @@ public class RenameTypeAlias extends Recipe {
                 }
                 return i;
             }
-        };
+        });
     }
 
     private boolean isVariableName(Cursor cursor, J.Identifier ident) {

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/cleanup/EqualsMethodUsage.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/cleanup/EqualsMethodUsage.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
@@ -58,7 +59,8 @@ public class EqualsMethodUsage extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new KotlinVisitor<ExecutionContext>() {
+        // `equals` can be a non-override overload on any type, so match it on any receiver.
+        return Preconditions.check(new UsesMethod<>("*..* equals(..)"), new KotlinVisitor<ExecutionContext>() {
             @Override
             public J visitUnary(J.Unary unary, ExecutionContext ctx) {
                 unary = (J.Unary) super.visitUnary(unary, ctx);
@@ -106,7 +108,7 @@ public class EqualsMethodUsage extends Recipe {
                 }
                 return method;
             }
-        };
+        });
     }
 
     @SuppressWarnings("all")

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/cleanup/ReplaceCharToIntWithCode.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/cleanup/ReplaceCharToIntWithCode.java
@@ -18,9 +18,11 @@ package org.openrewrite.kotlin.cleanup;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.KotlinVisitor;
@@ -39,7 +41,7 @@ public class ReplaceCharToIntWithCode extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new KotlinVisitor<ExecutionContext>() {
+        return Preconditions.check(new UsesMethod<>(CHAR_TO_INT_METHOD_MATCHER), new KotlinVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 if (CHAR_TO_INT_METHOD_MATCHER.matches(method) && method.getSelect() != null) {
@@ -52,7 +54,7 @@ public class ReplaceCharToIntWithCode extends Recipe {
                 }
                 return super.visitMethodInvocation(method, ctx);
             }
-        };
+        });
     }
 
 }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/RemoveAnnotationKotlinTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/RemoveAnnotationKotlinTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.RemoveAnnotation;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class RemoveAnnotationKotlinTest implements RewriteTest {
+
+    /**
+     * {@code RemoveAnnotation} gates its visitor behind a {@code UsesType} precondition. File-scope
+     * annotations live on {@code K.CompilationUnit.annotations}, so this verifies the precondition
+     * still considers their type "used" and does not skip the file before the Kotlin removal path
+     * (see {@link RemoveAnnotationKotlinMixin}) runs.
+     */
+    @Test
+    void removesFileScopeAnnotation() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveAnnotation("@kotlin.Suppress")),
+          kotlin(
+            """
+              @file:Suppress("unused")
+
+              class A
+              """,
+            """
+              class A
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What

Several recipes can only change source files that already reference a specific type or method. This PR gates each on a `UsesType`/`UsesMethod` precondition — either as the sole precondition, or `and`-ed alongside an existing one — so files that cannot match are filtered out before the recipe's visitor runs.

The set of files ultimately transformed is **unchanged**: each precondition keys on a type/method that must already be present for the recipe to do anything (the "from"/old side), so it selects a strict superset of changeable files. Where an existing custom precondition already exists, the new arm is `and`-ed in and the custom arm continues to narrow further.

### rewrite-java
| Recipe | Shape | Precondition |
|---|---|---|
| `FindDeprecatedMethods` | and | `UsesMethod` (when a method pattern is set) |
| `FindDeprecatedClasses` | and | `UsesType` (when a type pattern is set) |
| `ChangeMethodInvocationReturnType` | sole | `UsesMethod` |
| `ResultOfMethodCallIgnored` | sole | `UsesMethod` |
| `RemoveImplements` | and | `UsesType` on the interface |
| `ReplaceAnnotation` | sole | `UsesType` on the annotation |
| `RemoveAnnotation` | sole | `UsesType` on the annotation |
| `FindAnnotations` | and | `UsesType` (skipped in match-meta-annotations mode) |
| `RemoveMethodThrows` | and | `UsesType` on the exception (skipped for `*`) |

### rewrite-kotlin
| Recipe | Shape | Precondition |
|---|---|---|
| `ReplaceCharToIntWithCode` | sole | `UsesMethod` |
| `EqualsMethodUsage` | sole | `UsesMethod` (`*..* equals(..)`) |
| `RenameTypeAlias` | sole | `UsesType` on the aliased type |

### rewrite-gradle
| Recipe | Shape | Precondition |
|---|---|---|
| `ChangePluginVersion` | and | `UsesMethod` on the plugin `version(..)` call (also drops a redundant single-arg `or`) |

## Supporting changes
- Adds a shared `AnnotationMatcher#getAnnotationName()` accessor (returns the annotation type pattern without the leading `@` or parameters), used by the annotation recipes to build the `UsesType` precondition.
- `RemoveAnnotation#getVisitor()` return type widened from `RemoveAnnotationVisitor` to `TreeVisitor<?, ExecutionContext>` (the only caller, `RemoveImplements`, uses it via `visitNonNull`, which `Preconditions.Check` passes straight through for non-source-file nodes).
- New `RemoveAnnotationKotlinTest` confirms the precondition does not skip Kotlin file-scope (`@file:`) annotations.

## Safety note
A `UsesType`/`UsesMethod` precondition is only behavior-preserving when the recipe's own matching is no more permissive than strict, attributed matching. `FindRepository` was evaluated and **deliberately left unchanged**: its visitor matches with the relaxed `MethodMatcher.matches(m, true)` overload, which fires on under-attributed `.gradle.kts` scripts that a strict `UsesMethod` precondition would skip.

All affected recipe tests pass across rewrite-java, rewrite-kotlin, and rewrite-gradle (including `.gradle.kts` and Kotlin cases).