### PR TITLE
Fix C# recipe over-attribution when multiple packages share a dependency

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.VisibleForTesting;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
-import org.openrewrite.config.OptionDescriptor;
 import org.openrewrite.internal.RecipeLoader;
 import org.openrewrite.marketplace.RecipeBundle;
 import org.openrewrite.marketplace.RecipeBundleResolver;
@@ -376,8 +375,14 @@ public class RewriteRpc {
     }
 
     public Recipe prepareRecipe(String id, Map<String, Object> options) {
+        // Required-option validation is enforced server-side: PrepareRecipe instantiates the whole
+        // tree there and validates each recipe's option values (root and children alike), which a
+        // host-side check on the root descriptor alone cannot cover.
         PrepareRecipeResponse r = send("PrepareRecipe", new PrepareRecipe(id, options), PrepareRecipeResponse.class);
+        return recipeFromPrepareResponse(r);
+    }
 
+    Recipe recipeFromPrepareResponse(PrepareRecipeResponse r) {
         if (r.getDelegatesTo() != null) {
             PrepareRecipeResponse.DelegatesTo d = r.getDelegatesTo();
             RecipeListing listing = marketplace.findRecipe(d.getRecipeName());
@@ -388,16 +393,9 @@ public class RewriteRpc {
             }
             return listing.prepare(resolvers, d.getOptions());
         }
-
-        // FIXME do this validation on the server side instead
-        for (OptionDescriptor option : r.getDescriptor().getOptions()) {
-            if (option.isRequired() && !options.containsKey(option.getName())) {
-                throw new IllegalArgumentException("Missing required option `" + option.getName() + "` for recipe `" + id + "`.");
-            }
-        }
-
         return new RpcRecipe(this, r.getId(), r.getDescriptor(), r.getEditVisitor(),
-                matchAll(r.getEditPreconditions()), r.getScanVisitor(), matchAll(r.getScanPreconditions()));
+                matchAll(r.getEditPreconditions()), r.getScanVisitor(), matchAll(r.getScanPreconditions()),
+                r.getRecipeList());
     }
 
     private @Nullable TreeVisitor<?, ExecutionContext> matchAll(List<PrepareRecipeResponse.Precondition> preconditions) {

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcRecipe.java
@@ -22,6 +22,7 @@ import org.openrewrite.*;
 import org.openrewrite.config.OptionDescriptor;
 import org.openrewrite.config.RecipeDescriptor;
 import org.openrewrite.config.RecipeExample;
+import org.openrewrite.rpc.request.PrepareRecipeResponse;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -61,6 +62,13 @@ public class RpcRecipe extends ScanningRecipe<Integer> {
     private final @Nullable String scanVisitor;
     @Getter
     private final @Nullable TreeVisitor<?, ExecutionContext> scanPreconditionVisitor;
+
+    /**
+     * The prepared child recipe responses returned by the server as part of the whole-tree
+     * prepare response. When non-null and non-empty, {@link #getRecipeList()} builds children
+     * locally from these nodes instead of making individual PrepareRecipe RPC calls.
+     */
+    private final @Nullable List<PrepareRecipeResponse> childResponses;
 
     @Override
     public String getName() {
@@ -126,11 +134,22 @@ public class RpcRecipe extends ScanningRecipe<Integer> {
     @Override
     public synchronized List<Recipe> getRecipeList() {
         if (recipeList == null) {
-            recipeList = descriptor.getRecipeList().stream()
-                    .map(r -> rpc.prepareRecipe(r.getName(), r.getOptions().stream()
-                            .filter(opt -> opt.getValue() != null)
-                            .collect(toMap(OptionDescriptor::getName, OptionDescriptor::getValue))))
-                    .collect(toList());
+            if (childResponses != null) {
+                // Whole-tree: children were prepared in the parent's response; build locally, no RPC.
+                recipeList = childResponses.stream()
+                        .map(rpc::recipeFromPrepareResponse)
+                        .collect(toList());
+            } else {
+                // Fallback: peers whose servers don't yet return a prepared child tree
+                // (Python/JS/Go until updated). This is the pre-existing by-name path, unchanged.
+                // TODO(remove-fallback): delete this branch once every RPC server populates
+                // `recipeList`. The C# server (this change) always takes the branch above.
+                recipeList = descriptor.getRecipeList().stream()
+                        .map(r -> rpc.prepareRecipe(r.getName(), r.getOptions().stream()
+                                .filter(opt -> opt.getValue() != null)
+                                .collect(toMap(OptionDescriptor::getName, OptionDescriptor::getValue))))
+                        .collect(toList());
+            }
         }
         return recipeList;
     }

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/GetMarketplaceResponse.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/GetMarketplaceResponse.java
@@ -16,6 +16,7 @@
 package org.openrewrite.rpc.request;
 
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.config.CategoryDescriptor;
 import org.openrewrite.config.RecipeDescriptor;
 import org.openrewrite.marketplace.RecipeBundle;
@@ -35,11 +36,27 @@ public class GetMarketplaceResponse extends ArrayList<GetMarketplaceResponse.Row
     public static class Row {
         RecipeDescriptor descriptor;
         List<List<CategoryDescriptor>> categoryPaths;
+
+        /**
+         * The package this recipe was contributed by, as reported by the RPC server. Lets the host
+         * attribute each row to its true bundle instead of force-tagging every row with the one
+         * requested bundle. Null when the server does not report origin (e.g. ecosystems not yet
+         * emitting it, or built-in recipes) — such rows fall back to the requested bundle.
+         */
+        @Nullable String packageName;
     }
 
     public RecipeMarketplace toMarketplace(RecipeBundle bundle) {
         RecipeMarketplace marketplace = new RecipeMarketplace();
         for (Row recipe : this) {
+            // A row carrying a different package's origin belongs to that bundle's own reader, not this
+            // one — skip it so each reader contributes only its own recipes (and a later install of one
+            // bundle can't resurrect another the host has uninstalled). A null origin (ecosystems not yet
+            // emitting it, or built-in recipes) falls back to the requested bundle.
+            if (recipe.getPackageName() != null &&
+                    !recipe.getPackageName().equals(bundle.getPackageName())) {
+                continue;
+            }
             for (List<CategoryDescriptor> categoryPath : recipe.getCategoryPaths()) {
                 marketplace.install(RecipeListing.fromDescriptor(recipe.getDescriptor(), bundle), categoryPath);
             }
@@ -66,7 +83,8 @@ public class GetMarketplaceResponse extends ArrayList<GetMarketplaceResponse.Row
                 category.getDescription(), emptySet(), false, 0, false));
         for (RecipeListing recipe : category.getRecipes()) {
             rowByRecipeId.computeIfAbsent(recipe.getName(), recipeId ->
-                    new Row(recipe.describe(resolvers), new ArrayList<>())).categoryPaths.add(categoryPath);
+                    new Row(recipe.describe(resolvers), new ArrayList<>(),
+                            recipe.getBundle().getPackageName())).categoryPaths.add(categoryPath);
         }
         for (RecipeMarketplace.Category child : category.getCategories()) {
             fromCategory(resolvers, rowByRecipeId, child, categoryPath);

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipe.java
@@ -23,6 +23,8 @@ import org.openrewrite.Recipe;
 import org.openrewrite.ScanningRecipe;
 import org.openrewrite.rpc.internal.PreparedRecipeCache;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
@@ -44,8 +46,16 @@ public class PrepareRecipe implements RpcRequest {
         @Override
         protected Object handle(PrepareRecipe request) throws Exception {
             Recipe recipe = recipeLoader.load(request.id, request.getOptions());
+            return prepareTree(recipe, preparedRecipes);
+        }
+
+        static PrepareRecipeResponse prepareTree(Recipe recipe, PreparedRecipeCache preparedRecipes) {
             String instanceId = SnowflakeId.generateId();
             preparedRecipes.getInstantiated().put(instanceId, recipe);
+            List<PrepareRecipeResponse> children = new ArrayList<>();
+            for (Recipe child : recipe.getRecipeList()) {
+                children.add(prepareTree(child, preparedRecipes));
+            }
             return new PrepareRecipeResponse(
                     instanceId,
                     recipe.getDescriptor(),
@@ -56,8 +66,8 @@ public class PrepareRecipe implements RpcRequest {
                     emptyList(),
                     recipe instanceof ScanningRecipe ? "scan:" + instanceId : null,
                     emptyList(),
-                    null
-            );
+                    null,
+                    children);
         }
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipeResponse.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipeResponse.java
@@ -47,6 +47,15 @@ public class PrepareRecipeResponse {
     @Nullable
     DelegatesTo delegatesTo;
 
+    /**
+     * The fully-prepared child recipe responses returned by the server as part of the
+     * whole-tree prepare response. When non-null and non-empty, the host builds
+     * {@link org.openrewrite.rpc.RpcRecipe} children locally from these nodes instead
+     * of making individual PrepareRecipe RPC calls.
+     */
+    @Nullable
+    List<PrepareRecipeResponse> recipeList;
+
     @Value
     public static class DelegatesTo {
         String recipeName;

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/GetMarketplaceResponseTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/GetMarketplaceResponseTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.CategoryDescriptor;
+import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.marketplace.RecipeBundle;
+import org.openrewrite.marketplace.RecipeListing;
+import org.openrewrite.marketplace.RecipeMarketplace;
+import org.openrewrite.rpc.request.GetMarketplaceResponse;
+
+import java.net.URI;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GetMarketplaceResponseTest {
+
+    private static RecipeDescriptor descriptor(String name) {
+        return new RecipeDescriptor(name, name, name, name, emptySet(), null,
+                emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), URI.create("https://example.com"));
+    }
+
+    @Test
+    void filtersForeignOriginAndAttributesTheRestToRequestedBundle() {
+        GetMarketplaceResponse response = new GetMarketplaceResponse();
+        // Row from a different package than the one requested: it belongs to that bundle's own reader,
+        // so this read must filter it out.
+        response.add(new GetMarketplaceResponse.Row(descriptor("recipe.FromCore"),
+                List.of(List.of(new CategoryDescriptor("Cat", "", "", emptySet(), false, 0, false))),
+                "Core"));
+        // Row with no origin: must fall back to the requested bundle.
+        response.add(new GetMarketplaceResponse.Row(descriptor("recipe.Unattributed"),
+                List.of(List.of(new CategoryDescriptor("Cat", "", "", emptySet(), false, 0, false))),
+                null));
+        // Row whose origin equals the requested bundle's packageName: attributed to the requested
+        // bundle (with its version preserved).
+        response.add(new GetMarketplaceResponse.Row(descriptor("recipe.OwnPinned"),
+                List.of(List.of(new CategoryDescriptor("Cat", "", "", emptySet(), false, 0, false))),
+                "Migration"));
+
+        RecipeBundle requested = new RecipeBundle("nuget", "Migration", null, "1.0.0", null);
+        RecipeMarketplace marketplace = response.toMarketplace(requested);
+
+        // Foreign-origin row is excluded — its own bundle's reader contributes it instead.
+        assertThat(marketplace.findRecipe("recipe.FromCore")).isNull();
+
+        // Null-origin row falls back to the requested bundle.
+        RecipeListing unattributed = marketplace.findRecipe("recipe.Unattributed");
+        assertThat(unattributed).isNotNull();
+        assertThat(unattributed.getBundle().getPackageName()).isEqualTo("Migration");
+
+        // Own-origin row is attributed to the requested bundle, preserving its version.
+        RecipeListing ownPinned = marketplace.findRecipe("recipe.OwnPinned");
+        assertThat(ownPinned).isNotNull();
+        assertThat(ownPinned.getBundle().getPackageName()).isEqualTo("Migration");
+        assertThat(ownPinned.getBundle().getVersion()).isEqualTo("1.0.0");
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/InstallRecipesDependencyActivationTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/InstallRecipesDependencyActivationTest.cs
@@ -20,17 +20,10 @@ using OpenRewrite.CSharp.Rpc;
 namespace OpenRewrite.Tests.Rpc;
 
 /// <summary>
-/// Regression test for cross-package composite recipe resolution when a recipe package is
-/// registered as a loose DLL (file path) rather than a NuGet package.
-///
-/// A composite recipe in one package (here: PrimaryPlugin) commonly lists a recipe defined in a
-/// *referenced* package (here: DepPlugin) inside its <c>GetRecipeList()</c>. When installed via
-/// <c>InstallRecipes</c> from a loose DLL, only the primary assembly used to be activated; the
-/// dependency assembly's types loaded on demand but its <see cref="IRecipeActivator"/> never ran,
-/// so its recipes were missing from the marketplace and <c>PrepareRecipe</c> failed with
-/// "Recipe not found" (e.g. Migration.Dotnet's UpgradeToDotNet10 -> Core's
-/// ChangeDotNetTargetFramework). <c>InstallRecipes</c> now walks the primary's reference graph and
-/// activates plugin-private recipe assemblies too.
+/// Verifies strict isolation when a recipe package is installed as a loose DLL: only the
+/// primary assembly's own recipes are registered into the marketplace. Referenced dependency
+/// assemblies are NOT activated at install time; cross-package composition is resolved by binary
+/// integration at recipe-tree preparation time instead.
 /// </summary>
 public class InstallRecipesDependencyActivationTest : IDisposable
 {
@@ -138,7 +131,7 @@ public class InstallRecipesDependencyActivationTest : IDisposable
     }
 
     [Fact]
-    public void InstallRecipes_FromLooseDll_ActivatesReferencedRecipePackages()
+    public void InstallRecipes_FromLooseDll_RegistersOnlyPrimaryAssemblyRecipes()
     {
         var primaryDll = Path.Combine(_publishDir, "PrimaryPlugin.dll");
         Assert.True(File.Exists(primaryDll), $"Primary plugin DLL not found at {primaryDll}");
@@ -153,11 +146,12 @@ public class InstallRecipesDependencyActivationTest : IDisposable
 
         var names = marketplace.AllRecipes().Select(r => r.Name).ToHashSet();
 
+        // The installed artifact contributes only its own recipe.
         Assert.Contains("PrimaryPlugin.PrimaryRecipe", names);
-        // The fix: the referenced package's recipe is registered even though only the primary
-        // DLL was installed by path. Without dependency activation this is absent and a
-        // composite run fails with "Recipe not found: DepPlugin.DepRecipe".
-        Assert.Contains("DepPlugin.DepRecipe", names);
+        // Strict isolation: the referenced package's recipe is NOT registered into the
+        // marketplace by installing the dependent. It is resolved by binary integration
+        // at composition time instead (see PrepareRecipeTreeTest).
+        Assert.DoesNotContain("DepPlugin.DepRecipe", names);
     }
 
     private static void RunDotnet(string arguments)

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/MarketplaceOriginAttributionTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/MarketplaceOriginAttributionTest.cs
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Diagnostics;
+using System.Text.Json;
+using OpenRewrite.Core;
+using OpenRewrite.CSharp.Rpc;
+
+namespace OpenRewrite.Tests.Rpc;
+
+/// <summary>
+/// Verifies the RPC server attributes each marketplace row to the package that contributed it,
+/// so the host can correctly bind recipes to their bundle instead of over-tagging.
+/// </summary>
+public class MarketplaceOriginAttributionTest : IDisposable
+{
+    private readonly string _root;
+    private readonly string _alphaDll;
+    private readonly string _betaDll;
+
+    public MarketplaceOriginAttributionTest()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "rewrite-origin-attr-test",
+            Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_root);
+        var hostDll = typeof(IRecipeActivator).Assembly.Location;
+        _alphaDll = BuildPackage("Alpha", hostDll);
+        _betaDll = BuildPackage("Beta", hostDll);
+    }
+
+    private string BuildPackage(string id, string hostDll)
+    {
+        var dir = Path.Combine(_root, id);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, $"{id}.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
+              <ItemGroup>
+                <Reference Include="OpenRewrite"><HintPath>{hostDll}</HintPath><Private>false</Private></Reference>
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(dir, "Recipe.cs"), $$"""
+            using OpenRewrite.Core;
+            using OpenRewrite.CSharp;
+            using OpenRewrite.Java;
+            namespace {{id}}Plugin;
+            public class {{id}}Activator : IRecipeActivator
+            {
+                public void Activate(RecipeMarketplace marketplace) =>
+                    marketplace.Install(new {{id}}Recipe(), new CategoryDescriptor("{{id}}"));
+            }
+            public class {{id}}Recipe : Recipe
+            {
+                public override string DisplayName => "{{id}} recipe";
+                public override string Description => "Recipe from {{id}}.";
+                public override JavaVisitor<ExecutionContext> GetVisitor() => new CSharpVisitor<ExecutionContext>();
+            }
+            """);
+        var publish = Path.Combine(dir, "publish");
+        RunDotnet($"publish \"{Path.Combine(dir, $"{id}.csproj")}\" -c Release -o \"{publish}\"");
+        return Path.Combine(publish, $"{id}.dll");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, true); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public void GetMarketplace_AttributesEachRecipeToItsOwnPackage()
+    {
+        var marketplace = new RecipeMarketplace();
+        var server = new RewriteRpcServer(marketplace);
+
+        // Install via the object form so the server sees a packageName for each.
+        // Serialize to JsonElement so the server's JsonValueKind.Object branch is reached
+        // (in-process anonymous objects don't deserialize to JsonElement automatically).
+        server.InstallRecipes(new InstallRecipesRequest
+            {
+                Recipes = JsonSerializer.SerializeToElement(new { packageName = _alphaDll, version = (string?)null })
+            })
+            .GetAwaiter().GetResult();
+        server.InstallRecipes(new InstallRecipesRequest
+            {
+                Recipes = JsonSerializer.SerializeToElement(new { packageName = _betaDll, version = (string?)null })
+            })
+            .GetAwaiter().GetResult();
+
+        var rows = server.GetMarketplace().GetAwaiter().GetResult();
+
+        var alpha = rows.Single(r => r.Descriptor.Name == "AlphaPlugin.AlphaRecipe");
+        var beta = rows.Single(r => r.Descriptor.Name == "BetaPlugin.BetaRecipe");
+
+        Assert.Equal(_alphaDll, alpha.PackageName);
+        Assert.Equal(_betaDll, beta.PackageName);
+    }
+
+    private static void RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true
+        };
+        using var process = Process.Start(psi)
+                            ?? throw new InvalidOperationException("Failed to start dotnet process");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"dotnet {arguments} failed ({process.ExitCode}):\n{stderr}\n{stdout}");
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/OwnAssemblyNamesTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/OwnAssemblyNamesTest.cs
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.CSharp.Rpc;
+
+namespace OpenRewrite.Tests.Rpc;
+
+/// <summary>
+/// Verifies that <c>OwnAssemblyNames</c> returns only the direct package's
+/// own assemblies from its <c>lib/&lt;tfm&gt;</c> folder in the global packages
+/// cache — not transitive dependency DLLs.
+/// </summary>
+public class OwnAssemblyNamesTest
+{
+    [Fact]
+    public void OwnAssemblyNames_ReturnsOnlyTheDirectPackagesOwnAssemblies()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "own-asm-test", Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            // direct package: my.package 1.0.0 -> lib/net10.0/Primary.dll
+            Directory.CreateDirectory(Path.Combine(root, "my.package", "1.0.0", "lib", "net10.0"));
+            File.WriteAllText(Path.Combine(root, "my.package", "1.0.0", "lib", "net10.0", "Primary.dll"), "");
+            // a transitive dependency that must NOT be reported
+            Directory.CreateDirectory(Path.Combine(root, "dep.package", "2.0.0", "lib", "net10.0"));
+            File.WriteAllText(Path.Combine(root, "dep.package", "2.0.0", "lib", "net10.0", "DepLib.dll"), "");
+
+            var own = RewriteRpcServer.OwnAssemblyNamesForTest("My.Package", "1.0.0", root);
+
+            Assert.Contains("Primary", own);
+            Assert.DoesNotContain("DepLib", own);
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/PrepareRecipeTreeTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/PrepareRecipeTreeTest.cs
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * Licensed under the Moderne Source Available License (the "License");
+ * See https://docs.moderne.io/licensing/moderne-source-available-license
+ */
+using OpenRewrite.CSharp;
+using OpenRewrite.CSharp.Rpc;
+using OpenRewrite.Java;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Tests.Rpc;
+
+public class PrepareRecipeTreeTest
+{
+    private sealed class ChildRecipe : global::OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Child";
+        public override string Description => "Child recipe.";
+        public override JavaVisitor<ExecutionContext> GetVisitor() => new CSharpVisitor<ExecutionContext>();
+    }
+
+    private sealed class ParentRecipe : global::OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Parent";
+        public override string Description => "Parent composite recipe.";
+        public override List<global::OpenRewrite.Core.Recipe> GetRecipeList() => [new ChildRecipe()];
+    }
+
+    [Fact]
+    public void PrepareRecipe_ReturnsConfiguredChildTree()
+    {
+        var marketplace = new global::OpenRewrite.Core.RecipeMarketplace();
+        marketplace.Install(new ParentRecipe(), new global::OpenRewrite.Core.CategoryDescriptor("Test"));
+        var server = new RewriteRpcServer(marketplace);
+
+        var parent = server.PrepareRecipe(new PrepareRecipeRequest
+        {
+            Id = typeof(ParentRecipe).FullName!
+        }).GetAwaiter().GetResult();
+
+        Assert.Single(parent.RecipeList);
+        var child = parent.RecipeList[0];
+        Assert.Equal(typeof(ChildRecipe).FullName, child.Descriptor.Name);
+        Assert.NotEqual(parent.Id, child.Id);
+        Assert.False(string.IsNullOrEmpty(child.EditVisitor));
+    }
+
+    private sealed class ChildWithRequiredOption : global::OpenRewrite.Core.Recipe
+    {
+        [global::OpenRewrite.Core.Option(DisplayName = "Required thing", Description = "A required option.")]
+        public string? RequiredThing { get; set; }
+
+        public override string DisplayName => "Child with required option";
+        public override string Description => "Child recipe with a required option.";
+        public override JavaVisitor<ExecutionContext> GetVisitor() => new CSharpVisitor<ExecutionContext>();
+    }
+
+    private sealed class ParentMissingChildOption : global::OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Parent missing child option";
+        public override string Description => "Composite whose child is missing a required option.";
+        public override List<global::OpenRewrite.Core.Recipe> GetRecipeList() => [new ChildWithRequiredOption()];
+    }
+
+    [Fact]
+    public void PrepareRecipe_ThrowsWhenAChildIsMissingARequiredOption()
+    {
+        var marketplace = new global::OpenRewrite.Core.RecipeMarketplace();
+        marketplace.Install(new ParentMissingChildOption(), new global::OpenRewrite.Core.CategoryDescriptor("Test"));
+        var server = new RewriteRpcServer(marketplace);
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            server.PrepareRecipe(new PrepareRecipeRequest { Id = typeof(ParentMissingChildOption).FullName! })
+                .GetAwaiter().GetResult());
+
+        Assert.Contains("RequiredThing", ex.Message);
+        Assert.Contains("Missing required option", ex.Message);
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/TwoBundleVersionIsolationTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/TwoBundleVersionIsolationTest.cs
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Diagnostics;
+using OpenRewrite.Core;
+using OpenRewrite.CSharp.Rpc;
+
+namespace OpenRewrite.Tests.Rpc;
+
+/// <summary>
+/// Verifies that two installed artifacts each resolve their composite child recipe against
+/// their OWN bundled dependency version. When artifact A bundles DepPlugin v1 and artifact B
+/// bundles DepPlugin v2 — both loaded in the same process — A's composite must see "child-v1"
+/// and B's must see "child-v2" even though DepPlugin.ChildRecipe is the same FQN in both.
+/// This proves the per-bundle AssemblyLoadContext isolation that whole-tree preparation relies on.
+/// </summary>
+public class TwoBundleVersionIsolationTest : IDisposable
+{
+    private readonly string _root;
+    private readonly string _publishDirA;
+    private readonly string _publishDirB;
+
+    public TwoBundleVersionIsolationTest()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "rewrite-two-bundle-test",
+            Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_root);
+
+        // The host DLL (OpenRewrite.dll) is referenced by plugin projects with Private=false so
+        // it is not copied into each publish dir — the PluginLoadContext picks it up from the
+        // Default ALC, preserving type identity for Recipe, IRecipeActivator, etc.
+        var hostDll = typeof(IRecipeActivator).Assembly.Location;
+
+        // --- Dep v1: DepPlugin assembly whose ChildRecipe.DisplayName is "child-v1" ----------
+        var depV1Dir = Path.Combine(_root, "DepV1");
+        Directory.CreateDirectory(depV1Dir);
+        File.WriteAllText(Path.Combine(depV1Dir, "DepV1.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <AssemblyName>DepPlugin</AssemblyName>
+              </PropertyGroup>
+              <ItemGroup>
+                <Reference Include="OpenRewrite">
+                  <HintPath>{hostDll}</HintPath>
+                  <Private>false</Private>
+                </Reference>
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(depV1Dir, "Dep.cs"), """
+            using OpenRewrite.Core;
+            using OpenRewrite.CSharp;
+            using OpenRewrite.Java;
+
+            namespace DepPlugin;
+
+            public class ChildRecipe : Recipe
+            {
+                public override string DisplayName => "child-v1";
+                public override string Description => "Child recipe from dep v1.";
+                public override JavaVisitor<ExecutionContext> GetVisitor() =>
+                    new CSharpVisitor<ExecutionContext>();
+            }
+            """);
+
+        // --- Dep v2: identical FQN (DepPlugin.ChildRecipe), different DisplayName -------------
+        var depV2Dir = Path.Combine(_root, "DepV2");
+        Directory.CreateDirectory(depV2Dir);
+        File.WriteAllText(Path.Combine(depV2Dir, "DepV2.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <AssemblyName>DepPlugin</AssemblyName>
+              </PropertyGroup>
+              <ItemGroup>
+                <Reference Include="OpenRewrite">
+                  <HintPath>{hostDll}</HintPath>
+                  <Private>false</Private>
+                </Reference>
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(depV2Dir, "Dep.cs"), """
+            using OpenRewrite.Core;
+            using OpenRewrite.CSharp;
+            using OpenRewrite.Java;
+
+            namespace DepPlugin;
+
+            public class ChildRecipe : Recipe
+            {
+                public override string DisplayName => "child-v2";
+                public override string Description => "Child recipe from dep v2.";
+                public override JavaVisitor<ExecutionContext> GetVisitor() =>
+                    new CSharpVisitor<ExecutionContext>();
+            }
+            """);
+
+        // --- Primary A: distinct FQN PrimaryA.PrimaryRecipeA, composes DepPlugin v1 ----------
+        var primaryADir = Path.Combine(_root, "PrimaryA");
+        Directory.CreateDirectory(primaryADir);
+        File.WriteAllText(Path.Combine(primaryADir, "PrimaryA.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <Reference Include="OpenRewrite">
+                  <HintPath>{hostDll}</HintPath>
+                  <Private>false</Private>
+                </Reference>
+                <ProjectReference Include="../DepV1/DepV1.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(primaryADir, "PrimaryA.cs"), """
+            using System.Collections.Generic;
+            using DepPlugin;
+            using OpenRewrite.Core;
+            using OpenRewrite.CSharp;
+            using OpenRewrite.Java;
+
+            namespace PrimaryA;
+
+            public class PrimaryActivatorA : IRecipeActivator
+            {
+                public void Activate(RecipeMarketplace marketplace) =>
+                    marketplace.Install(new PrimaryRecipeA(), new CategoryDescriptor("PrimaryA"));
+            }
+
+            public class PrimaryRecipeA : Recipe
+            {
+                public override string DisplayName => "Primary A";
+                public override string Description => "Composite that bundles dep v1.";
+                public override List<Recipe> GetRecipeList() => [new ChildRecipe()];
+            }
+            """);
+
+        // --- Primary B: distinct FQN PrimaryB.PrimaryRecipeB, composes DepPlugin v2 ----------
+        var primaryBDir = Path.Combine(_root, "PrimaryB");
+        Directory.CreateDirectory(primaryBDir);
+        File.WriteAllText(Path.Combine(primaryBDir, "PrimaryB.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <Reference Include="OpenRewrite">
+                  <HintPath>{hostDll}</HintPath>
+                  <Private>false</Private>
+                </Reference>
+                <ProjectReference Include="../DepV2/DepV2.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(primaryBDir, "PrimaryB.cs"), """
+            using System.Collections.Generic;
+            using DepPlugin;
+            using OpenRewrite.Core;
+            using OpenRewrite.CSharp;
+            using OpenRewrite.Java;
+
+            namespace PrimaryB;
+
+            public class PrimaryActivatorB : IRecipeActivator
+            {
+                public void Activate(RecipeMarketplace marketplace) =>
+                    marketplace.Install(new PrimaryRecipeB(), new CategoryDescriptor("PrimaryB"));
+            }
+
+            public class PrimaryRecipeB : Recipe
+            {
+                public override string DisplayName => "Primary B";
+                public override string Description => "Composite that bundles dep v2.";
+                public override List<Recipe> GetRecipeList() => [new ChildRecipe()];
+            }
+            """);
+
+        // Publish each primary to its own flat directory. Each publish dir contains the primary
+        // DLL + the dep DLL (DepPlugin.dll) from the corresponding dep version. The two
+        // DepPlugin.dll files are identical in name/FQN but differ in content — that's the point.
+        _publishDirA = Path.Combine(_root, "publishA");
+        RunDotnet($"publish \"{Path.Combine(primaryADir, "PrimaryA.csproj")}\" " +
+                  $"-c Release -o \"{_publishDirA}\"");
+
+        _publishDirB = Path.Combine(_root, "publishB");
+        RunDotnet($"publish \"{Path.Combine(primaryBDir, "PrimaryB.csproj")}\" " +
+                  $"-c Release -o \"{_publishDirB}\"");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, true); }
+        catch { /* best-effort cleanup */ }
+    }
+
+    [Fact]
+    public void TwoBundles_ResolveTheirOwnDependencyVersion()
+    {
+        var primaryADll = Path.Combine(_publishDirA, "PrimaryA.dll");
+        var primaryBDll = Path.Combine(_publishDirB, "PrimaryB.dll");
+
+        Assert.True(File.Exists(primaryADll), $"PrimaryA DLL not found at {primaryADll}");
+        Assert.True(File.Exists(primaryBDll), $"PrimaryB DLL not found at {primaryBDll}");
+        Assert.True(File.Exists(Path.Combine(_publishDirA, "DepPlugin.dll")),
+            "DepPlugin.dll (v1) must be published alongside PrimaryA");
+        Assert.True(File.Exists(Path.Combine(_publishDirB, "DepPlugin.dll")),
+            "DepPlugin.dll (v2) must be published alongside PrimaryB");
+
+        var marketplace = new RecipeMarketplace();
+        var server = new RewriteRpcServer(marketplace);
+
+        // Install both primaries into the same server / marketplace.
+        // Each is loaded into its own PluginLoadContext (ALC), so each primary's
+        // ALC holds its own copy of DepPlugin.dll.
+        server.InstallRecipes(new InstallRecipesRequest { Recipes = primaryADll })
+            .GetAwaiter().GetResult();
+        server.InstallRecipes(new InstallRecipesRequest { Recipes = primaryBDll })
+            .GetAwaiter().GetResult();
+
+        // Whole-tree preparation: PrepareInstance calls recipe.GetRecipeList() on the live
+        // instance stored in the marketplace. Because PrimaryRecipeA was created inside ALC-A,
+        // its GetRecipeList() returns a DepPlugin.ChildRecipe instance from ALC-A's DepPlugin
+        // (v1), not from ALC-B's DepPlugin (v2) — and vice versa for PrimaryRecipeB.
+        var a = server.PrepareRecipe(new PrepareRecipeRequest { Id = "PrimaryA.PrimaryRecipeA" })
+            .GetAwaiter().GetResult();
+        var b = server.PrepareRecipe(new PrepareRecipeRequest { Id = "PrimaryB.PrimaryRecipeB" })
+            .GetAwaiter().GetResult();
+
+        // Each parent's composite child must reflect ITS OWN bundled DepPlugin version.
+        // Same FQN (DepPlugin.ChildRecipe), different DisplayName proves per-ALC isolation:
+        // no shared/global instance per recipe FQN bleeds across bundle boundaries.
+        Assert.Single(a.RecipeList);
+        Assert.Single(b.RecipeList);
+        Assert.Equal("child-v1", a.RecipeList[0].Descriptor.DisplayName);
+        Assert.Equal("child-v2", b.RecipeList[0].Descriptor.DisplayName);
+    }
+
+    private static void RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi)
+                            ?? throw new InvalidOperationException("Failed to start dotnet process");
+
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"dotnet {arguments} failed (exit code {process.ExitCode}):\n{stderr}\n{stdout}");
+        }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/PluginLoadContext.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/PluginLoadContext.cs
@@ -36,15 +36,6 @@ public class PluginLoadContext : AssemblyLoadContext
         _resolver = new AssemblyDependencyResolver(pluginMainDllPath);
     }
 
-    /// <summary>
-    /// Returns the plugin-private path for <paramref name="assemblyName"/> as declared by the
-    /// plugin's <c>.deps.json</c>, or <c>null</c> when the assembly is not part of the plugin's
-    /// private dependency graph (host/framework assemblies resolve to <c>null</c>). Lets callers
-    /// distinguish a plugin-bundled dependency from a shared host assembly without loading it.
-    /// </summary>
-    public string? ResolvePluginPath(AssemblyName assemblyName) =>
-        _resolver.ResolveAssemblyToPath(assemblyName);
-
     protected override Assembly? Load(AssemblyName assemblyName)
     {
         // If the assembly is already loaded in the Default ALC, return it directly.

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -48,6 +48,11 @@ public class RewriteRpcServer
     public static void SetCurrent(RewriteRpcServer? server) => _current = server;
 
     private readonly RecipeMarketplace _marketplace;
+
+    // Recipe name -> the package that contributed it, recorded at install time and persisted for the
+    // process lifetime so GetMarketplace can attribute each row even when a later install is a no-op.
+    private readonly ConcurrentDictionary<string, string> _recipeOrigin = new();
+
     private readonly ConcurrentDictionary<string, Recipe> _preparedRecipes = new();
     private readonly ConcurrentDictionary<string, object?> _recipeAccumulators = new();
     private readonly ConcurrentDictionary<string, ExecutionContext> _executionContexts = new();
@@ -517,7 +522,7 @@ public class RewriteRpcServer
         return Task.FromResult(rowByRecipeId.Values.ToList());
     }
 
-    private static void CollectRecipes(
+    private void CollectRecipes(
         Dictionary<string, GetMarketplaceResponseRow> rowByRecipeId,
         RecipeMarketplace.Category category,
         List<CategoryDescriptorDto> parentPath)
@@ -534,7 +539,8 @@ public class RewriteRpcServer
                 row = new GetMarketplaceResponseRow
                 {
                     Descriptor = RecipeDescriptorDto.FromDescriptor(descriptor),
-                    CategoryPaths = []
+                    CategoryPaths = [],
+                    PackageName = _recipeOrigin.GetValueOrDefault(descriptor.Name)
                 };
                 rowByRecipeId[descriptor.Name] = row;
             }
@@ -551,7 +557,8 @@ public class RewriteRpcServer
     public Task<InstallRecipesResponse> InstallRecipes(InstallRecipesRequest request)
     {
         var beforeCount = _marketplace.AllRecipes().Count;
-        string? version = null;
+        string? version = null;          // requested version, as supplied by the caller (never mutated)
+        string? resolvedVersion = null;  // concrete version NuGet resolved it to (null off the NuGet path)
 
         // SystemTextJsonFormatter deserializes the object-typed Recipes payload to a JsonElement:
         // a JSON string is a local assembly path; a JSON object describes a NuGet package.
@@ -572,8 +579,7 @@ public class RewriteRpcServer
             var context = new PluginLoadContext(absolutePath);
             var assembly = context.LoadFromAssemblyPath(absolutePath);
             CheckVersionCompatibility(assembly);
-            ActivateAssembly(assembly);
-            ActivateDependencyRecipeAssemblies(assembly, context);
+            ActivateAssembly(assembly, recipesString);
         }
         else if (recipesObject is { } packageObj)
         {
@@ -587,29 +593,30 @@ public class RewriteRpcServer
                 var context = new PluginLoadContext(absolutePath);
                 var assembly = context.LoadFromAssemblyPath(absolutePath);
                 CheckVersionCompatibility(assembly);
-                ActivateAssembly(assembly);
-                ActivateDependencyRecipeAssemblies(assembly, context);
+                ActivateAssembly(assembly, packageName);
             }
             else
             {
-                // NuGet package download via dotnet CLI
-                var csprojPath = EnsureRecipesProject();
-                var args = $"add \"{csprojPath}\" package {packageName}";
-                if (version != null)
-                    args += $" --version {version}";
-                RunDotnet(args);
-
-                // dotnet add package preserves the user-supplied version constraint
-                // verbatim in the csproj's PackageReference, so wildcards like "*" survive
-                // there. The resolved concrete version lives in obj/project.assets.json.
-                version = MSBuildProjectHelper.GetResolvedPackageVersion(
-                    Path.GetDirectoryName(csprojPath)!, packageName);
-
-                var assemblies = PublishAndLoadPlugin(csprojPath, packageName);
+                // NuGet install reads as a three-stage pipeline: restore the bundle (which also
+                // resolves the concrete version), publish it into the resolved-version dir, then
+                // load the plugin assemblies. The requested version may be a concrete pin or a
+                // floating/unspecified spec — restore resolves either uniformly.
+                var (stagingCsproj, resolved) = RestoreBundle(packageName, version);
+                resolvedVersion = resolved;
+                var publishDir = PublishBundle(stagingCsproj, resolved);
+                var assemblies = LoadPlugin(publishDir);
+                var ownAssemblyNames = OwnAssemblyNames(packageName, resolved);
+                if (ownAssemblyNames.Count == 0)
+                {
+                    Log.Warning("No own assemblies found for {Package} {Version} (lib folder missing/empty); no recipes activated", packageName, resolved);
+                }
                 foreach (var assembly in assemblies)
                 {
                     CheckVersionCompatibility(assembly);
-                    ActivateAssembly(assembly);
+                    if (ownAssemblyNames.Contains(assembly.GetName().Name))
+                    {
+                        ActivateAssembly(assembly, packageName);
+                    }
                 }
             }
         }
@@ -618,16 +625,18 @@ public class RewriteRpcServer
             throw new ArgumentException($"Unexpected recipes type: {request.Recipes?.GetType().Name ?? "null"}");
         }
 
-        var afterCount = _marketplace.AllRecipes().Count;
         return Task.FromResult(new InstallRecipesResponse
         {
-            RecipesInstalled = afterCount - beforeCount,
-            Version = version
+            RecipesInstalled = _marketplace.AllRecipes().Count - beforeCount,
+            Version = resolvedVersion ?? version
         });
     }
 
-    private void ActivateAssembly(Assembly assembly)
+    private void ActivateAssembly(Assembly assembly, string? packageName = null)
     {
+        var before = packageName == null ? null
+            : new HashSet<string>(_marketplace.AllRecipes().Select(r => r.Name));
+
         Type[] exportedTypes;
         try
         {
@@ -651,82 +660,45 @@ public class RewriteRpcServer
                 activator.Activate(_marketplace);
             }
         }
-    }
 
-    /// <summary>
-    /// Activates the recipe-bearing dependency assemblies of a plugin loaded from a loose DLL.
-    /// </summary>
-    /// <remarks>
-    /// The NuGet install path runs <c>dotnet publish</c>, which surfaces every dependency
-    /// assembly so each gets <see cref="ActivateAssembly"/>'d. A loose DLL registered by file
-    /// path has no such enumeration: the ALC loads a referenced recipe package's types on demand
-    /// (to satisfy a <c>new SomeOtherRecipe()</c> reference) but never runs that package's
-    /// <see cref="IRecipeActivator"/>, so its recipes stay absent from the marketplace. A composite
-    /// recipe that lists a recipe from a referenced package then fails <c>PrepareRecipe</c> with
-    /// "Recipe not found" (e.g. Migration.Dotnet's UpgradeToDotNet10 -> Core's
-    /// ChangeDotNetTargetFramework). Walk the reference graph and activate any plugin-private
-    /// assembly that exposes an activator; host/framework assemblies (including the SDK, already
-    /// activated at startup) resolve to no plugin path and are skipped.
-    /// </remarks>
-    private void ActivateDependencyRecipeAssemblies(Assembly primary, PluginLoadContext context)
-    {
-        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        if (packageName != null)
         {
-            // The SDK assembly is activated once at startup; the primary plugin just above.
-            Assembly.GetExecutingAssembly().GetName().Name!,
-            primary.GetName().Name!,
-        };
-
-        var queue = new Queue<Assembly>();
-        queue.Enqueue(primary);
-        while (queue.Count > 0)
-        {
-            foreach (var reference in queue.Dequeue().GetReferencedAssemblies())
+            foreach (var name in _marketplace.AllRecipes().Select(r => r.Name))
             {
-                if (reference.Name == null || !visited.Add(reference.Name))
-                    continue;
-
-                // Only follow plugin-private dependencies (those listed in the plugin's
-                // .deps.json). Shared host/framework assemblies resolve to null here, so the
-                // SDK's activator is never re-run and core recipes are not double-registered.
-                if (context.ResolvePluginPath(reference) == null)
-                    continue;
-
-                Assembly dependency;
-                try
+                if (!before!.Contains(name))
                 {
-                    dependency = context.LoadFromAssemblyName(reference);
+                    _recipeOrigin[name] = packageName;
                 }
-                catch (Exception ex)
-                {
-                    Log.Warning("Could not load dependency {Assembly} for recipe activation: {Error}",
-                        reference.Name, ex.Message);
-                    continue;
-                }
-
-                ActivateAssembly(dependency);
-                queue.Enqueue(dependency);
             }
         }
     }
 
-    private string EnsureRecipesProject()
+    // Sanitize a path segment (package id or version) for use as a directory name.
+    private static string Sanitize(string s) => string.Join("_", s.Split(Path.GetInvalidFileNameChars()));
+
+    private string EnsureRecipesProject(string packageName, string? version)
     {
-        if (_recipesProjectDir != null)
+        // Use the caller-supplied recipe install directory when provided (so a co-located
+        // NuGet.config is found by dotnet's project-directory config walk); otherwise fall
+        // back to a temp directory.
+        var root = _recipeInstallDir
+            ?? Path.Combine(Path.GetTempPath(), "rewrite-recipes");
+        // Mirror NuGet's global-packages layout: <root>/<id>/<version>/, versions as
+        // immutable siblings. Never deleted — old versions accumulate (no cleanup),
+        // matching ~/.nuget and existing Moderne/OpenRewrite practice.
+        var bundleDir = Path.Combine(root, Sanitize(packageName), Sanitize(version ?? "unversioned"));
+        var csprojPath = Path.Combine(bundleDir, "Recipes.csproj");
+        _recipesProjectDir = bundleDir;
+
+        // Reuse an already-published version dir (idempotent, like NuGet reusing an
+        // already-extracted package). Snapshots carry timestamps in their version string,
+        // so each publish lands in a fresh dir.
+        if (File.Exists(csprojPath))
         {
-            var existing = Path.Combine(_recipesProjectDir, "Recipes.csproj");
-            if (File.Exists(existing))
-                return existing;
+            return csprojPath;
         }
+        Directory.CreateDirectory(bundleDir);
 
-        // Use the caller-supplied recipe install directory when provided (so a
-        // co-located NuGet.config is found by dotnet's project-directory config
-        // walk); otherwise fall back to a unique temp directory.
-        _recipesProjectDir = _recipeInstallDir
-            ?? Path.Combine(Path.GetTempPath(), "rewrite-recipes", Guid.NewGuid().ToString("N")[..8]);
-        Directory.CreateDirectory(_recipesProjectDir);
-
-        var csprojPath = Path.Combine(_recipesProjectDir, "Recipes.csproj");
         File.WriteAllText(csprojPath, """
             <Project Sdk="Microsoft.NET.Sdk">
               <PropertyGroup>
@@ -748,13 +720,43 @@ public class RewriteRpcServer
             ".nuget", "local-feed");
         if (Directory.Exists(localFeed))
         {
-            var nugetConfig = Path.Combine(_recipesProjectDir, "nuget.config");
+            var nugetConfig = Path.Combine(bundleDir, "nuget.config");
             var existing = File.Exists(nugetConfig) ? File.ReadAllText(nugetConfig) : null;
             File.WriteAllText(nugetConfig, BuildRecipesNuGetConfig(existing, localFeed));
         }
 
         return csprojPath;
     }
+
+    private static HashSet<string> OwnAssemblyNames(string packageName, string? version, string? packagesRoot = null)
+    {
+        // The package's own runtime assemblies are those shipped in its lib/<tfm> folder
+        // in the global packages cache (the directly-contributed boundary). All other
+        // published DLLs are transitive dependencies and must not be activated.
+        packagesRoot ??= Environment.GetEnvironmentVariable("NUGET_PACKAGES")
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+        // NuGet's v3 global-packages layout lowercases both the package id and the (normalized)
+        // version in the folder path, so match that or the lib dir won't be found on a
+        // case-sensitive filesystem (Linux).
+        var libDir = Path.Combine(packagesRoot, packageName.ToLowerInvariant(), (version ?? "").ToLowerInvariant(), "lib");
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (Directory.Exists(libDir))
+        {
+            foreach (var dll in Directory.GetFiles(libDir, "*.dll", SearchOption.AllDirectories))
+            {
+                names.Add(Path.GetFileNameWithoutExtension(dll));
+            }
+        }
+        return names;
+    }
+
+    /// <summary>
+    /// Test seam for <see cref="OwnAssemblyNames"/>: exposes the private helper
+    /// with an explicit packages root so unit tests can use a synthetic temp directory
+    /// without a real NuGet install.
+    /// </summary>
+    internal static HashSet<string> OwnAssemblyNamesForTest(string packageName, string? version, string packagesRoot)
+        => OwnAssemblyNames(packageName, version, packagesRoot);
 
     /// <summary>
     /// Produces the recipe project's <c>nuget.config</c> with the local development
@@ -828,27 +830,59 @@ public class RewriteRpcServer
     }
 
     /// <summary>
-    /// Publish the temp recipes project to produce a flat output directory with all transitive
-    /// dependencies and a .deps.json, then load plugin assemblies in an isolated
-    /// <see cref="PluginLoadContext"/>. Because the NuGet package name may not match the assembly
-    /// name, we scan all non-host DLLs in the publish output for <see cref="IRecipeActivator"/>
-    /// implementations.
+    /// Restore stage: restore a NuGet recipe bundle in a staging project under the install root
+    /// (so the caller's nuget.config is found by dotnet's upward project-directory config walk),
+    /// and return the staging project plus the resolved concrete version.
     /// </summary>
-    private List<Assembly> PublishAndLoadPlugin(string csprojPath, string packageName)
+    private (string Csproj, string ResolvedVersion) RestoreBundle(string packageName, string? requestedVersion)
     {
-        var projectDir = Path.GetDirectoryName(csprojPath)!;
-        var publishDir = Path.Combine(projectDir, "publish");
+        var stagingCsproj = EnsureRecipesProject(packageName, ".staging");
+        var addArgs = $"add \"{stagingCsproj}\" package {packageName}";
+        if (requestedVersion != null)
+            addArgs += $" --version {requestedVersion}";
+        RunDotnet(addArgs);
 
-        RunDotnet($"publish \"{csprojPath}\" -c Release -o \"{publishDir}\"");
+        // dotnet add package preserves the requested constraint verbatim in the csproj;
+        // the resolved concrete version lives in obj/project.assets.json.
+        var resolvedVersion = MSBuildProjectHelper.GetResolvedPackageVersion(
+            Path.GetDirectoryName(stagingCsproj)!, packageName);
+        return (stagingCsproj, resolvedVersion);
+    }
 
-        // Use the Recipes.deps.json (from the temp project) for the dependency resolver
+    /// <summary>
+    /// Publish stage: publish a restored staging project into its permanent, resolved-version-keyed
+    /// sibling dir (<c>&lt;root&gt;/&lt;id&gt;/&lt;resolvedVersion&gt;</c>), reusing it if already
+    /// present. Returns the publish output directory.
+    /// </summary>
+    private static string PublishBundle(string stagingCsproj, string resolvedVersion)
+    {
+        var bundleRoot = Directory.GetParent(Path.GetDirectoryName(stagingCsproj)!)!.FullName; // <root>/<id>
+        var publishDir = Path.Combine(bundleRoot, Sanitize(resolvedVersion));
+        // The publish output is an immutable sibling: publish only when this resolved version
+        // isn't there yet. --no-restore reuses the staging project's restore.
+        if (!File.Exists(Path.Combine(publishDir, "Recipes.dll")))
+        {
+            RunDotnet($"publish \"{stagingCsproj}\" --no-restore -c Release -o \"{publishDir}\"");
+        }
+        return publishDir;
+    }
+
+    /// <summary>
+    /// Load stage: load the recipe-bearing assemblies from a publish output directory into an
+    /// isolated <see cref="PluginLoadContext"/>. Because the NuGet package name may not match the
+    /// assembly name, we scan all non-host DLLs in the publish output for
+    /// <see cref="IRecipeActivator"/> implementations.
+    /// </summary>
+    private List<Assembly> LoadPlugin(string publishDir)
+    {
+        // Use the Recipes.deps.json (from the staging project) for the dependency resolver
         var depsJson = Path.Combine(publishDir, "Recipes.deps.json");
         if (!File.Exists(depsJson))
         {
             Log.Warning("No .deps.json found in publish output at {PublishDir}", publishDir);
         }
 
-        // The temp project's main DLL is the anchor for AssemblyDependencyResolver
+        // The staging project's main DLL is the anchor for AssemblyDependencyResolver
         var anchorDll = Path.Combine(publishDir, "Recipes.dll");
         if (!File.Exists(anchorDll))
         {
@@ -1019,10 +1053,40 @@ public class RewriteRpcServer
             throw new InvalidOperationException($"Recipe {request.Id} has no live instance (installed without constructor)");
         }
 
-        // If options are provided, create a new instance with options applied
-        if (request.Options is { Count: > 0 })
+        return Task.FromResult(PrepareInstance(recipe, request.Options));
+    }
+
+    /// <summary>
+    /// Prepares a single recipe instance (optionally applying options) and recursively
+    /// prepares the full child tree, storing every node in <see cref="_preparedRecipes"/>.
+    /// A child that is <see cref="IDelegatesTo"/> carries only <c>DelegatesTo</c> and
+    /// no children; all other children have their own <c>RecipeList</c> populated.
+    /// </summary>
+    private PrepareRecipeResponse PrepareInstance(Recipe recipe, Dictionary<string, object?>? options)
+    {
+        // If options are provided, create a new instance with options applied.
+        if (options is { Count: > 0 })
         {
-            recipe = InstantiateWithOptions(recipe.GetType(), request.Options);
+            recipe = InstantiateWithOptions(recipe.GetType(), options);
+        }
+
+        // Validate required options on the instantiated recipe — the root against the caller's
+        // options, and every child against the values its parent set in GetRecipeList(). Because
+        // PrepareInstance recurses, this covers the whole tree, and it's the only place the C# tree
+        // gets validated: declarative recipes bundled in an artifact often ship without a test that
+        // runs validateAll, so this is the safety net against executing a broken recipe. Delegating
+        // recipes forward to a Java recipe that validates its own options, so they are skipped here.
+        if (recipe is not IDelegatesTo)
+        {
+            var descriptor = recipe.GetDescriptor();
+            foreach (var option in descriptor.Options)
+            {
+                if (option.Required && option.Value is null)
+                {
+                    throw new ArgumentException(
+                        $"Missing required option `{option.Name}` for recipe `{descriptor.Name}`.");
+                }
+            }
         }
 
         var id = Guid.NewGuid().ToString();
@@ -1038,6 +1102,7 @@ public class RewriteRpcServer
 
         if (recipe is IDelegatesTo del)
         {
+            // Cross-ecosystem child: host resolves locally; no C# child tree.
             response.DelegatesTo = new DelegatesTo
             {
                 RecipeName = del.JavaRecipeName,
@@ -1047,9 +1112,13 @@ public class RewriteRpcServer
         else
         {
             OptimizePreconditions(recipe, response);
+            // Whole-tree preparation: children are real instances in this recipe's own ALC.
+            response.RecipeList = recipe.GetRecipeList()
+                .Select(child => PrepareInstance(child, null))
+                .ToList();
         }
 
-        return Task.FromResult(response);
+        return response;
     }
 
     /// <summary>
@@ -1684,6 +1753,7 @@ public class GetMarketplaceResponseRow
 {
     public RecipeDescriptorDto Descriptor { get; set; } = null!;
     public List<List<CategoryDescriptorDto>> CategoryPaths { get; set; } = [];
+    public string? PackageName { get; set; }
 }
 
 public class CategoryDescriptorDto
@@ -1818,6 +1888,7 @@ public class PrepareRecipeResponse
     public string? ScanVisitor { get; set; }
     public List<Precondition> ScanPreconditions { get; set; } = [];
     public DelegatesTo? DelegatesTo { get; set; }
+    public List<PrepareRecipeResponse> RecipeList { get; set; } = [];
 }
 
 public class DelegatesTo

--- a/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpRecipeArtifactIsolationTest.java
+++ b/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpRecipeArtifactIsolationTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.rpc;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.openrewrite.Recipe;
+import org.openrewrite.csharp.marketplace.NuGetRecipeBundleResolver;
+import org.openrewrite.marketplace.RecipeBundle;
+import org.openrewrite.marketplace.RecipeBundleReader;
+import org.openrewrite.marketplace.RecipeListing;
+import org.openrewrite.marketplace.RecipeMarketplace;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end regression test for the recipe artifact isolation fix.
+ * <p>
+ * Verifies that installing {@code OpenRewrite.Recipes.CSharp.Migration.Dotnet}
+ * (which depends on {@code OpenRewrite.Recipes.CSharp.Core} as a transitive NuGet
+ * dependency) does not "steal" Core's recipes: after all three bundles are installed,
+ * {@code ChangeDotNetTargetFramework} must remain attributed to the Core bundle, must
+ * not appear in the Migration bundle's listing, and Migration's composite
+ * {@code UpgradeToDotNet10} recipe must still resolve Core's recipe as a child via
+ * PrepareRecipe.
+ */
+@Tag("slow")
+@Timeout(value = 300, unit = TimeUnit.SECONDS)
+class CSharpRecipeArtifactIsolationTest {
+
+    @BeforeAll
+    static void setUpFactory() {
+        Path basePath = Paths.get(System.getProperty("user.dir"));
+        Path[] searchPaths = {
+          basePath.resolve("csharp"),
+          basePath.resolve("rewrite-csharp/csharp"),
+        };
+        for (Path searchPath : searchPaths) {
+            Path csproj = searchPath.resolve("OpenRewrite.Tool/OpenRewrite.Tool.csproj");
+            if (csproj.toFile().exists()) {
+                CSharpRewriteRpc.setFactory(
+                  CSharpRewriteRpc.builder()
+                    .csharpServerEntry(csproj.toAbsolutePath().normalize())
+                    .log(Paths.get(System.getProperty("java.io.tmpdir"), "csharp-rpc-isolation.log"))
+                );
+                return;
+            }
+        }
+        throw new IllegalStateException("Could not find C# Rewrite project");
+    }
+
+    @AfterAll
+    static void tearDown() {
+        CSharpRewriteRpc.shutdownCurrent();
+    }
+
+    /**
+     * The earliest snapshot version that introduced the explicit Core dependency in
+     * Migration.Dotnet (0.3.0 generation).  Core has never had a stable release, so
+     * an explicit version is required to bypass dotnet's "no stable version" guard.
+     * All three packages must be at the same generation so their inter-package
+     * version constraints are satisfied.
+     */
+    private static final String PACKAGE_VERSION = "0.3.0-snapshot.20260627172857";
+
+    @Test
+    void recipeIsolation_coreNotStolenByMigration() {
+        CSharpRewriteRpc rpc = CSharpRewriteRpc.getOrStart();
+        NuGetRecipeBundleResolver resolver = new NuGetRecipeBundleResolver(rpc);
+        RecipeMarketplace marketplace = new RecipeMarketplace();
+
+        // Install all three bundles in dependency order.
+        // Migration.Dotnet depends on Core, so installing Migration would previously
+        // pull Core's assemblies into Migration's scan dir and steal its recipes.
+        install(marketplace, resolver, "OpenRewrite.Recipes.CSharp.Core", PACKAGE_VERSION);
+        install(marketplace, resolver, "OpenRewrite.Recipes.CSharp.CodeQuality", PACKAGE_VERSION);
+        install(marketplace, resolver, "OpenRewrite.Recipes.CSharp.Migration.Dotnet", PACKAGE_VERSION);
+
+        Set<String> coreBundleRecipes = recipesOfBundle(marketplace, "OpenRewrite.Recipes.CSharp.Core");
+        Set<String> migrationBundleRecipes = recipesOfBundle(marketplace, "OpenRewrite.Recipes.CSharp.Migration.Dotnet");
+
+        // (a) Core still owns its recipes — they did not disappear from the deployment list.
+        assertThat(coreBundleRecipes)
+          .as("Core bundle must contain ChangeDotNetTargetFramework")
+          .contains("OpenRewrite.CSharp.Recipes.ChangeDotNetTargetFramework");
+
+        // (b) Core's recipe is NOT attributed to the Migration bundle.
+        assertThat(migrationBundleRecipes)
+          .as("Migration bundle must not steal ChangeDotNetTargetFramework from Core")
+          .doesNotContain("OpenRewrite.CSharp.Recipes.ChangeDotNetTargetFramework");
+
+        // (c) Migration lists its own composite recipe.
+        assertThat(migrationBundleRecipes)
+          .as("Migration bundle must contain an UpgradeToDotNet10 recipe")
+          .anyMatch(name -> name.endsWith(".UpgradeToDotNet10"));
+
+        // (d) Migration's composite still resolves Core's child recipe via PrepareRecipe.
+        String upgradeName = migrationBundleRecipes.stream()
+          .filter(n -> n.endsWith(".UpgradeToDotNet10"))
+          .findFirst()
+          .orElseThrow(() -> new AssertionError("No UpgradeToDotNet10 recipe in Migration bundle"));
+        RecipeListing upgrade = marketplace.findRecipe(upgradeName);
+        assertThat(upgrade).as("Could not find listing for " + upgradeName).isNotNull();
+        Recipe prepared = upgrade.prepare(List.of(resolver), Map.of());
+        assertThat(prepared.getRecipeList())
+          .as("UpgradeToDotNet10 must resolve ChangeDotNetTargetFramework as a child recipe")
+          .anyMatch(r -> r.getName().equals("OpenRewrite.CSharp.Recipes.ChangeDotNetTargetFramework"));
+    }
+
+    /**
+     * Installs the NuGet bundle for {@code packageName} at {@code version}
+     * into the given marketplace.
+     */
+    private static void install(RecipeMarketplace marketplace, NuGetRecipeBundleResolver resolver,
+                                String packageName, String version) {
+        RecipeBundle bundle = new RecipeBundle("nuget", packageName, version, null, null);
+        RecipeBundleReader reader = resolver.resolve(bundle);
+        marketplace.install(reader);
+    }
+
+    /**
+     * Returns the names of all recipes in the marketplace that are attributed to
+     * the bundle with the given package name.
+     */
+    private static Set<String> recipesOfBundle(RecipeMarketplace marketplace, String packageName) {
+        return marketplace.getAllRecipes().stream()
+          .filter(listing -> packageName.equals(listing.getBundle().getPackageName()))
+          .map(RecipeListing::getName)
+          .collect(Collectors.toSet());
+    }
+}

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleResolver.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleResolver.java
@@ -40,7 +40,13 @@ public class NuGetRecipeBundleResolver implements RecipeBundleResolver {
         Path pkgPath = Paths.get(bundle.getPackageName());
         InstallRecipesResponse response;
         if (Files.exists(pkgPath)) {
-            response = rpc.installRecipes(pkgPath.toFile());
+            // Local file: send (and record on the bundle) the absolute path. The server's working
+            // directory may differ from ours, so it needs the absolute form to load the assembly —
+            // and aligning the bundle's packageName with it keeps the install origin the server
+            // records and the marketplace filter key (the bundle's packageName) the same value.
+            String absolutePath = pkgPath.toAbsolutePath().toString();
+            bundle.setPackageName(absolutePath);
+            response = rpc.installRecipes(absolutePath, bundle.getVersion());
         } else {
             response = rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
         }


### PR DESCRIPTION
## Problem

Installing several .NET recipe packages that share a transitive dependency —
e.g. `Core`, `CodeQuality`, and `Migration.DotNet` (which depends on `Core`) —
caused `Core`'s recipes to disappear from the deployment list. A dependent
package was effectively "stealing" the recipes its dependency contributed.

Two independent root causes:

1. **Cross-ALC name reflection during composition.** C# composite recipes
   resolved their children by *name* across sibling `AssemblyLoadContext`
   instances, which pulled dependency recipes into the shared marketplace and
   mis-attributed them.
2. **Origin-blind marketplace rows.** `GetMarketplace` rows carried no origin,
   so the host's `toMarketplace(bundle)` tagged *every* recipe with the single
   requested bundle — over-attributing recipes contributed by other packages.

## Fix

### Composition isolation (whole-tree `PrepareRecipe`)
- `PrepareRecipe` returns the entire prepared child tree in one response, so a
  composite resolves its children by binary integration **within its own ALC**
  instead of reflecting across sibling contexts. `RpcRecipe` builds children
  locally from that tree.
- A guarded by-name fallback remains for RPC peers (Python/JS/Go) that don't yet
  return a prepared tree — they keep working unchanged until they adopt it.
- Each NuGet bundle installs into its own per-`(package, version)` directory and
  activates only its own `lib/<tfm>` assemblies; transitive dependency DLLs load
  (for composition) but are not activated into the marketplace.

### Origin attribution (marketplace)
- The C# server records each recipe's origin package at activation and emits it
  as `packageName` on each `GetMarketplace` row.
- `toMarketplace` attributes each row to its own bundle and **filters out
  foreign-origin rows**, so each bundle reader contributes only its own recipes.
  A `null` origin falls back to the requested bundle, so ecosystems not yet
  emitting origin (npm/Go/Python) behave exactly as before.

## Testing

- New end-to-end regression test `CSharpRecipeArtifactIsolationTest` installs the
  three real NuGet packages and asserts `Core` keeps `ChangeDotNetTargetFramework`,
  `Migration.DotNet` doesn't steal it, and `Migration.DotNet`'s composite still
  resolves `Core`'s recipe as a child via `PrepareRecipe`.
- Unit coverage for the per-row `toMarketplace` filter, server-side origin
  attribution, own-assembly scoping, whole-tree prepare, and per-bundle version
  isolation.
