### PR TITLE
Allow the recipe-run host to configure data table stores for RPC-language recipes

### DIFF
--- a/doc/adr/0008-rpc-data-table-stores.md
+++ b/doc/adr/0008-rpc-data-table-stores.md
@@ -1,0 +1,132 @@
+# 8. Data table stores across the Rewrite RPC boundary
+
+Date: 2026-06-26
+
+## Status
+
+Accepted
+
+## Context
+
+Recipes emit rows into [data tables](../../rewrite-core/src/main/java/org/openrewrite/DataTable.java)
+during a run. Where those rows go is decided by the [`DataTableStore`](../../rewrite-core/src/main/java/org/openrewrite/DataTableStore.java)
+installed on the `ExecutionContext`. In-process this is an *open* abstraction: any
+implementation works — `InMemoryDataTableStore` (default), `CsvDataTableStore`
+(writes `.csv`/`.csv.gz` directly), `NoOpDataTableStore`, or an arbitrary custom store
+supplied by an embedding tool.
+
+Recipes are increasingly written in non-Java languages (TypeScript/JavaScript, Python,
+Go, C#) and executed over Rewrite RPC. Each of those runtimes has already independently
+ported the data table abstraction — a `DataTable` with `insertRow`, plus `InMemory`,
+`Csv` and `NoOp` store implementations — but there is **no way for the process that
+controls a recipe run (almost always Java) to tell a language runtime where to put its
+rows.** As a result, rows emitted by a recipe written in TypeScript or Python are dropped
+into a default in-memory store on the remote side and never surface to the host.
+
+We deliberately do **not** want individual data table rows to cross the RPC boundary:
+column definitions are arbitrary recipe-defined data, and serializing rows back to the
+host so that the host's store handles them is both risky and contrary to the streaming,
+write-as-you-go design of `CsvDataTableStore`. The host should configure *where* rows
+go; each runtime should write its own rows locally.
+
+The open question this ADR settles is: **how does the host configure an arbitrary
+`DataTableStore` implementation on a remote runtime that cannot run the host's code?**
+
+## Decision
+
+### The RPC boundary supports a *closed, mirrored* set of stores
+
+`DataTableStore` remains an open interface in-process. Across RPC it necessarily
+collapses to a closed set of implementations that are *mirrored* in every runtime —
+exactly the situation that already exists for `PrintOutputCapture.MarkerPrinter`, whose
+RPC form is the closed enum [`Print.MarkerPrinter`](../../rewrite-core/src/main/java/org/openrewrite/rpc/request/Print.java)
+(`DEFAULT`, `SEARCH_MARKERS_ONLY`, `FENCED`, `SANITIZED`). A remote runtime can only
+reproduce behavior it has code for. We do not introduce a parallel "descriptor"
+taxonomy; the abstraction is still `DataTableStore`.
+
+The conveyable set is:
+
+* **`Csv`** — the production path. Carries the minimal serializable configuration needed
+  to reconstruct the runtime's own `CsvDataTableStore`: output directory and the ordered
+  static prefix/suffix columns. The runtime always writes raw `.csv`; any compression or
+  finalization of the files is the host's concern (see below), so no encoding is
+  conveyed. (`CsvDataTableStore` already exists in every runtime.)
+* **`NoOp`** — explicitly disable data table output on the remote side.
+
+`InMemoryDataTableStore` is intentionally *not* conveyable: its rows would be trapped in
+the remote process and never reach the host, which is meaningless across RPC.
+
+### Mechanism: a `Print.MarkerPrinter`-style mapping
+
+A new `SetDataTableStore` RPC request mirrors the marker-printer pattern:
+
+* `SetDataTableStore.from(DataTableStore)` maps a host-side store to its wire form, or
+  returns `null` when the store is not RPC-conveyable.
+* `SetDataTableStore.toDataTableStore()` reconstructs the runtime's mirror implementation
+  on the receiving side.
+
+The host (`RewriteRpc`) exposes `dataTableStore(DataTableStore)` and lazily sends the
+wire form before the first `Visit`/`BatchVisit`/`Generate`. Each runtime's handler
+installs the reconstructed store on the per-run `ExecutionContext`
+(`DataTableExecutionContextView`). Rows never cross the wire — only the store's
+configuration does, and that configuration is host-known static metadata, never
+arbitrary recipe row data.
+
+### A truly arbitrary store is not RPC-conveyable — by the same logic as markers
+
+If the host configures a custom Java-only store, `from()` returns `null`. There are then
+exactly three outcomes, and the choice is the host's:
+
+1. It is a mirrored kind (`Csv`, `NoOp`) → honored natively by the runtime.
+2. The host accepts that remote recipes' rows are not captured by the custom store →
+   the runtime keeps its default (in-memory/no-op). Graceful, lossy-by-design.
+3. The host wants remote rows captured by the custom store anyway → the only mechanism
+   is shipping rows back over the wire, which we have rejected as the default. If ever
+   needed it would be an explicit, opt-in escape hatch, not the norm.
+
+### One shared file per table
+
+The Java host and the RPC processes write to **one shared file per data table**
+(computed identically everywhere from `outputDir` + `fileKey` + `.csv`), including,
+occasionally, the same logically-named table. This is safe because of two properties of
+the runtime:
+
+* **Recipe execution is sequential** by recipe and source file, so no two writers write
+  at the same instant. (`RecipeScheduler` iterates files in plain loops; there is no
+  parallel file visiting.)
+* **RPC processes are per-thread** — `RewriteRpcProcessManager` keys the process by
+  `ThreadLocal`. A host that runs independent units of work on separate threads gets a
+  separate process, and a separate output directory, per unit, so a process-global
+  output directory is correct and two units never share a file.
+
+Writers append **raw CSV** with the file handle held open, flushing complete lines
+before yielding control. Raw CSV has no cross-record state, so complete-line appends
+from sequential writers interleave into one valid file regardless of order. The first
+writer to create a file writes the `#`-comments and header (decided by file existence,
+so it happens exactly once across processes); a fail-loud guard rejects an append whose
+column layout differs from the existing header, so a shared file can never silently
+misalign. Any compression or post-processing of the completed files is the host's
+concern, performed after the writers have finished.
+
+We deliberately do **not** stream a compressed format (such as `.csv.gz`) per writer:
+per-member gzip framing allocates and frees a `Deflater` per member, destroys
+compression (each row a fresh deflate window — 3-5x bloat at 100k rows), and two writers
+cannot safely hold a compression stream open on the same file. Writing raw CSV and
+leaving any compression to a single post-run pass avoids all of this. Because every
+writer shares the one file, the static prefix/suffix columns are conveyed to each
+runtime and written on every row (all writers must agree on the column order — enforced
+by the header guard).
+
+## Consequences
+
+* The host can uniformly configure CSV (or no-op) data table output for Java and every
+  RPC language through one builder method, `XXXRewriteRpc.Builder.dataTableStore(..)`.
+* No row data crosses the RPC boundary; only host-known store configuration does.
+* Adding a new conveyable store kind requires implementing it in core *and* mirroring it
+  in every runtime — the same cost the marker printers already pay. This is the price of
+  the closed set and is accepted deliberately.
+* Custom Java-only stores are not honored for remote recipes unless rows are shipped
+  back (an opt-in we do not build now).
+* Existing ad hoc wiring (Go's `--data-tables-csv-dir` launch flag, Python's
+  `dataTableOutputDir` `PrepareRecipe` parameter) is superseded by the unified
+  `SetDataTableStore` handshake and should be retired as each runtime is migrated.

--- a/rewrite-core/src/main/java/org/openrewrite/CsvDataTableStore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/CsvDataTableStore.java
@@ -108,6 +108,16 @@ public class CsvDataTableStore implements DataTableStore, AutoCloseable {
     }
 
     /**
+     * Raw CSV has no cross-record state, so several writers can safely append to one shared file.
+     */
+    public CsvDataTableStore(Path outputDir,
+                             Map<String, String> prefixColumns,
+                             Map<String, String> suffixColumns) {
+        this(outputDir, CsvDataTableStore::defaultOutputStream, CsvDataTableStore::defaultInputStream,
+                ".csv", prefixColumns, suffixColumns);
+    }
+
+    /**
      * Create a store with control over output stream creation, file extension,
      * and additional static columns prepended/appended to each row.
      * <p>
@@ -164,6 +174,22 @@ public class CsvDataTableStore implements DataTableStore, AutoCloseable {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    public Path getOutputDir() {
+        return outputDir;
+    }
+
+    public String getFileExtension() {
+        return fileExtension;
+    }
+
+    public Map<String, String> getPrefixColumns() {
+        return prefixColumns;
+    }
+
+    public Map<String, String> getSuffixColumns() {
+        return suffixColumns;
     }
 
     private static OutputStream defaultOutputStream(Path path) {
@@ -318,6 +344,11 @@ public class CsvDataTableStore implements DataTableStore, AutoCloseable {
         }
         headers.addAll(suffixColumns.keySet());
 
+        // Writers sharing one file must agree on column order; fail loud rather than misalign rows.
+        if (append) {
+            validateExistingHeader(path, headers);
+        }
+
         OutputStream os = outputStreamFactory.apply(path);
         try {
             CsvWriterSettings settings = new CsvWriterSettings();
@@ -340,6 +371,26 @@ public class CsvDataTableStore implements DataTableStore, AutoCloseable {
             } catch (IOException ignored) {
             }
             throw e;
+        }
+    }
+
+    private void validateExistingHeader(Path path, List<String> expectedHeaders) {
+        try (InputStream is = inputStreamFactory.apply(path)) {
+            CsvParserSettings settings = new CsvParserSettings();
+            settings.setMaxCharsPerColumn(-1);
+            settings.getFormat().setComment('#');
+            CsvParser parser = new CsvParser(settings);
+            parser.beginParsing(new InputStreamReader(is, StandardCharsets.UTF_8));
+            String[] existing = parser.parseNext();
+            parser.stopParsing();
+            if (existing != null && !Arrays.asList(existing).equals(expectedHeaders)) {
+                throw new IllegalStateException(
+                        "Data table file " + path.getFileName() + " has header " + Arrays.toString(existing) +
+                        " but a writer expected " + expectedHeaders + ". Writers sharing a data table file " +
+                        "must agree on column order.");
+            }
+        } catch (IOException e) {
+            // Existing file is unreadable here (e.g. not yet flushed); skip the guard and proceed.
         }
     }
 
@@ -388,6 +439,8 @@ public class CsvDataTableStore implements DataTableStore, AutoCloseable {
             }
 
             csvWriter.writeRow((Object[]) values);
+            // Flush per row so a shared file always ends at a complete line.
+            csvWriter.flush();
         }
 
         void close() {

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -92,6 +93,11 @@ public class RewriteRpc {
     final IdentityHashMap<Object, Integer> localRefs = new IdentityHashMap<>();
 
     private @Nullable List<String> remoteLanguages;
+
+    private volatile @Nullable DataTableStore configuredDataTableStore;
+
+    private @Nullable SetDataTableStore pendingDataTableStore;
+    private boolean dataTableStoreSent;
 
     /**
      * Creates a new RPC interface that can be used to communicate with a remote.
@@ -150,12 +156,21 @@ public class RewriteRpc {
         this.marketplace = marketplace;
         this.resolvers.addAll(resolvers);
 
+        // Install the configured store on each reconstructed ExecutionContext, keeping that out of the handlers.
+        BiFunction<String, @Nullable String, ?> getRecipeObject = (id, sourceFileType) -> {
+            Object o = getObject(id, sourceFileType);
+            DataTableStore store = configuredDataTableStore;
+            if (store != null && o instanceof ExecutionContext) {
+                DataTableExecutionContextView.view((ExecutionContext) o).setDataTableStore(store);
+            }
+            return o;
+        };
         jsonRpc.rpc("Visit", new Visit.Handler(localObjects, preparedRecipes,
-                this::getObject, this::getCursor));
+                getRecipeObject, this::getCursor));
         jsonRpc.rpc("BatchVisit", new BatchVisit.Handler(localObjects, preparedRecipes,
-                this::getObject, this::getCursor));
+                getRecipeObject, this::getCursor));
         jsonRpc.rpc("Generate", new Generate.Handler(localObjects, preparedRecipes,
-                this::getObject));
+                getRecipeObject));
         jsonRpc.rpc("GetObject", new GetObject.Handler(batchSize, remoteObjects, localObjects,
                 localRefs, log, () -> traceGetObject.get().isSend()));
         jsonRpc.rpc("GetMarketplace", new JsonRpcMethod<Void>() {
@@ -219,6 +234,8 @@ public class RewriteRpc {
         }));
         jsonRpc.rpc("Parse", new Parse.Handler(localObjects, () -> parsers));
         jsonRpc.rpc("Print", new Print.Handler(this::getObject));
+        jsonRpc.rpc("SetDataTableStore", new SetDataTableStore.Handler(
+                store -> configuredDataTableStore = store));
         jsonRpc.rpc("Reset", new JsonRpcMethod<Void>() {
             @Override
             protected Boolean handle(Void noParams) {
@@ -256,6 +273,31 @@ public class RewriteRpc {
         return this;
     }
 
+    /**
+     * Configure where recipes in the remote runtime write data table rows. Only the store's
+     * configuration crosses the boundary (lazily, before the first visit/generate), never rows.
+     * A {@code null} or non-conveyable store leaves the remote on its own default.
+     *
+     * @see SetDataTableStore
+     */
+    public RewriteRpc dataTableStore(@Nullable DataTableStore store) {
+        this.pendingDataTableStore = SetDataTableStore.from(store);
+        this.dataTableStoreSent = false;
+        return this;
+    }
+
+    private void ensureDataTableStoreSent() {
+        if (pendingDataTableStore != null && !dataTableStoreSent) {
+            send("SetDataTableStore", pendingDataTableStore, Boolean.class);
+            dataTableStoreSent = true;
+        }
+    }
+
+    @VisibleForTesting
+    public @Nullable DataTableStore getConfiguredDataTableStore() {
+        return configuredDataTableStore;
+    }
+
     public void shutdown() {
         PrintStream logOut = log.get();
         if (logOut != null) {
@@ -287,6 +329,7 @@ public class RewriteRpc {
     }
 
     public <P> @Nullable Tree visit(Tree tree, String visitorName, P p, @Nullable Cursor cursor) {
+        ensureDataTableStoreSent();
         // Set the local state of this tree, so that when the remote asks for it, we know what to send.
         localObjects.put(tree.getId().toString(), tree);
 
@@ -307,6 +350,7 @@ public class RewriteRpc {
 
     public <P> BatchVisitResponse batchVisit(Tree tree, P p, @Nullable Cursor cursor,
                                              List<BatchVisit.BatchVisitItem> visitors) {
+        ensureDataTableStoreSent();
         String treeId = tree.getId().toString();
         localObjects.put(treeId, tree);
 
@@ -324,6 +368,7 @@ public class RewriteRpc {
     }
 
     public Collection<? extends SourceFile> generate(String remoteRecipeId, ExecutionContext ctx) {
+        ensureDataTableStoreSent();
         String ctxId = maybeUnwrapExecutionContext(ctx);
         GenerateResponse response = RewriteRpcExecutionContextView.view(ctx).withInFlightSlot(() ->
                 send("Generate", new Generate(remoteRecipeId, ctxId), GenerateResponse.class));

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/SetDataTableStore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/SetDataTableStore.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc.request;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.moderne.jsonrpc.JsonRpcMethod;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.CsvDataTableStore;
+import org.openrewrite.DataTableStore;
+
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * Conveys a {@link DataTableStore}'s configuration to a remote runtime so recipes there
+ * write data table rows where the host wants. Like {@link Print.MarkerPrinter}, only a
+ * closed set of mirrored implementations crosses the wire; rows never do.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = SetDataTableStore.Csv.class, name = "CSV"),
+        @JsonSubTypes.Type(value = SetDataTableStore.NoOp.class, name = "NOOP")
+})
+public interface SetDataTableStore extends RpcRequest {
+
+    DataTableStore toDataTableStore();
+
+    /**
+     * @return the wire form, or {@code null} when {@code store} is not RPC-conveyable
+     * (the remote then keeps its own default store).
+     */
+    static @Nullable SetDataTableStore from(@Nullable DataTableStore store) {
+        if (store == null) {
+            return null;
+        }
+        if (store == DataTableStore.noop()) {
+            return new NoOp();
+        }
+        if (store instanceof CsvDataTableStore) {
+            CsvDataTableStore csv = (CsvDataTableStore) store;
+            return new Csv(
+                    csv.getOutputDir().toAbsolutePath().normalize().toString(),
+                    new LinkedHashMap<>(csv.getPrefixColumns()),
+                    new LinkedHashMap<>(csv.getSuffixColumns()));
+        }
+        return null;
+    }
+
+    @Value
+    class Csv implements SetDataTableStore {
+        String outputDir;
+
+        @Nullable
+        Map<String, String> prefixColumns;
+
+        @Nullable
+        Map<String, String> suffixColumns;
+
+        @Override
+        public DataTableStore toDataTableStore() {
+            Map<String, String> prefix = prefixColumns != null ? prefixColumns : emptyMap();
+            Map<String, String> suffix = suffixColumns != null ? suffixColumns : emptyMap();
+            return new CsvDataTableStore(Paths.get(outputDir), prefix, suffix);
+        }
+    }
+
+    @Value
+    class NoOp implements SetDataTableStore {
+        @Override
+        public DataTableStore toDataTableStore() {
+            return DataTableStore.noop();
+        }
+    }
+
+    @RequiredArgsConstructor
+    class Handler extends JsonRpcMethod<SetDataTableStore> {
+        private final Consumer<DataTableStore> installStore;
+
+        @Override
+        protected Object handle(SetDataTableStore request) {
+            installStore.accept(request.toDataTableStore());
+            return true;
+        }
+    }
+}

--- a/rewrite-core/src/test/java/org/openrewrite/DataTableStoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/DataTableStoreTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +36,7 @@ import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("DataFlowIssue")
 class DataTableStoreTest {
@@ -568,5 +570,44 @@ class DataTableStoreTest {
         PlainText after = (PlainText) run.getChangeset().getAllResults().getFirst().getAfter();
         assertThat(after).isNotNull();
         assertThat(after.getText()).isEqualTo("hello-scanned-read:hello");
+    }
+
+    @Test
+    void multipleWritersShareOneFileWithSingleHeader(@TempDir Path tempDir) throws IOException {
+        Map<String, String> prefix = new LinkedHashMap<>();
+        prefix.put("repositoryOrigin", "github.com/acme/x");
+        TestTable table = new TestTable(Recipe.noop());
+
+        try (CsvDataTableStore a = new CsvDataTableStore(tempDir, prefix, Collections.emptyMap());
+             CsvDataTableStore b = new CsvDataTableStore(tempDir, prefix, Collections.emptyMap())) {
+            a.insertRow(table, ctx(), new TestTable.Row("alice"));
+            b.insertRow(table, ctx(), new TestTable.Row("bob"));
+            a.insertRow(table, ctx(), new TestTable.Row("carol"));
+        }
+
+        Path csv = tempDir.resolve(table.getName() + ".csv");
+        List<String> lines = Files.readAllLines(csv);
+        long headerLines = lines.stream().filter(l -> l.startsWith("repositoryOrigin,")).count();
+        assertThat(headerLines).as("exactly one header across both writers").isEqualTo(1);
+        String content = String.join("\n", lines);
+        assertThat(content).contains("alice").contains("bob").contains("carol");
+    }
+
+    @Test
+    void appendingWithMismatchedColumnsThrows(@TempDir Path tempDir) {
+        TestTable table = new TestTable(Recipe.noop());
+        Map<String, String> originPrefix = new LinkedHashMap<>();
+        originPrefix.put("repositoryOrigin", "github.com/acme/x");
+        try (CsvDataTableStore a = new CsvDataTableStore(tempDir, originPrefix, Collections.emptyMap())) {
+            a.insertRow(table, ctx(), new TestTable.Row("alice"));
+        }
+
+        Map<String, String> branchPrefix = new LinkedHashMap<>();
+        branchPrefix.put("repositoryBranch", "main");
+        try (CsvDataTableStore b = new CsvDataTableStore(tempDir, branchPrefix, Collections.emptyMap())) {
+            assertThatThrownBy(() -> b.insertRow(table, ctx(), new TestTable.Row("bob")))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("must agree on column order");
+        }
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.*;
 import org.openrewrite.internal.InMemoryLargeSourceSet;
 import org.openrewrite.marker.Markup;
@@ -241,6 +242,33 @@ class RewriteRpcTest implements RewriteTest {
         Recipe recipe = client.prepareRecipe("org.openrewrite.text.Find",
           Map.of("find", "hello"));
         assertThat(recipe.getDescriptor().getDisplayName()).isEqualTo("Find text");
+    }
+
+    @Test
+    void dataTableStoreConfigurationCrossesRpc(@TempDir Path tmp) {
+        client.dataTableStore(new CsvDataTableStore(tmp,
+          java.util.Collections.singletonMap("repositoryOrigin", "github.com/acme/example"),
+          java.util.Collections.emptyMap()));
+
+        // A trivial remote visit triggers the lazy SetDataTableStore handshake.
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new TreeVisitor<>() {
+              @Override
+              @SneakyThrows
+              public Tree preVisit(Tree tree, ExecutionContext ctx) {
+                  client.visit((SourceFile) tree, PlainTextVisitor.class.getName(), 0);
+                  stopAfterPreVisit();
+                  return tree;
+              }
+          })),
+          text("hello world")
+        );
+
+        DataTableStore remote = server.getConfiguredDataTableStore();
+        assertThat(remote).isInstanceOf(CsvDataTableStore.class);
+        CsvDataTableStore csv = (CsvDataTableStore) remote;
+        assertThat(csv.getOutputDir()).isEqualTo(tmp.toAbsolutePath().normalize());
+        assertThat(csv.getPrefixColumns()).containsEntry("repositoryOrigin", "github.com/acme/example");
     }
 
     @Disabled("Disabled until https://github.com/openrewrite/rewrite/pull/5260 is complete")

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/request/SetDataTableStoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/request/SetDataTableStoreTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc.request;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.*;
+import org.openrewrite.table.TextMatches;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SetDataTableStoreTest {
+
+    @Test
+    void onlyCsvAndNoopAreConveyable() {
+        assertThat(SetDataTableStore.from(null)).isNull();
+
+        assertThat(SetDataTableStore.from(DataTableStore.noop()))
+          .isInstanceOf(SetDataTableStore.NoOp.class);
+
+        DataTableStore custom = new DataTableStore() {
+            @Override
+            public <Row> void insertRow(DataTable<Row> dataTable, ExecutionContext ctx, Row row) {
+            }
+
+            @Override
+            public java.util.stream.Stream<?> getRows(String dataTableName, String group) {
+                return java.util.stream.Stream.empty();
+            }
+
+            @Override
+            public java.util.Collection<DataTable<?>> getDataTables() {
+                return Collections.emptyList();
+            }
+        };
+        assertThat(SetDataTableStore.from(custom)).isNull();
+    }
+
+    @Test
+    void csvConfigRoundTripsThroughWireFormAndWritesRows(@TempDir Path tmp) throws IOException {
+        Map<String, String> prefix = new LinkedHashMap<>();
+        prefix.put("repositoryOrigin", "github.com/acme/example");
+
+        CsvDataTableStore original = new CsvDataTableStore(tmp, prefix, Collections.emptyMap());
+
+        SetDataTableStore wire = SetDataTableStore.from(original);
+        assertThat(wire).isInstanceOf(SetDataTableStore.Csv.class);
+        SetDataTableStore.Csv csvWire = (SetDataTableStore.Csv) wire;
+        assertThat(csvWire.getPrefixColumns()).containsEntry("repositoryOrigin", "github.com/acme/example");
+        assertThat(Paths.get(csvWire.getOutputDir())).isEqualTo(tmp.toAbsolutePath().normalize());
+
+        DataTableStore rebuilt = wire.toDataTableStore();
+        assertThat(rebuilt).isInstanceOf(CsvDataTableStore.class);
+
+        TextMatches table = new TextMatches(Recipe.noop());
+        rebuilt.insertRow(table, new InMemoryExecutionContext(), new TextMatches.Row("a.txt", "ctx"));
+        ((CsvDataTableStore) rebuilt).close();
+
+        Path csv = tmp.resolve(table.getName() + ".csv");
+        assertThat(csv).exists();
+        String content = new String(Files.readAllBytes(csv), StandardCharsets.UTF_8);
+        assertThat(content)
+          .as("prefix column header + value and the data row are present")
+          .contains("repositoryOrigin")
+          .contains("github.com/acme/example")
+          .contains("a.txt");
+    }
+
+    @Test
+    void noopWireFormReconstructsNoop() {
+        SetDataTableStore wire = SetDataTableStore.from(DataTableStore.noop());
+        assertThat(wire).isInstanceOf(SetDataTableStore.NoOp.class);
+        assertThat(wire.toDataTableStore()).isSameAs(DataTableStore.noop());
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Core/DataTableTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Core/DataTableTests.cs
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+using System.Text.Json;
 using OpenRewrite.Core;
+using OpenRewrite.Core.Rpc;
+using OpenRewrite.CSharp.Rpc;
 
 namespace OpenRewrite.Tests.Core;
 
@@ -119,7 +122,8 @@ public class CsvDataTableStoreTests
             Assert.StartsWith("# @name", lines[0]);
             Assert.StartsWith("# @instanceName", lines[1]);
             Assert.StartsWith("# @group", lines[2]);
-            Assert.Equal("Source Path,Line Number,Match", lines[3]);
+            // Header uses field names (matches the Java writer for shared files).
+            Assert.Equal("SourcePath,LineNumber,Match", lines[3]);
             Assert.Equal("Foo.cs,42,hello", lines[4]);
             Assert.Equal("Bar.cs,7,world", lines[5]);
         }
@@ -207,6 +211,131 @@ public class CsvDataTableStoreTests
             if (Directory.Exists(outputDir)) Directory.Delete(outputDir, true);
         }
     }
+
+    [Fact]
+    public void WritesPrefixAndSuffixColumns()
+    {
+        var outputDir = Path.Combine(Path.GetTempPath(), "datatable-test-" + Guid.NewGuid());
+        try
+        {
+            var store = new CsvDataTableStore(outputDir,
+                new Dictionary<string, string> { ["repositoryOrigin"] = "github.com/acme/widgets" },
+                new Dictionary<string, string> { ["organization"] = "Acme" });
+            var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+                "Matches found by a text search.");
+            var ctx = new OpenRewrite.Core.ExecutionContext();
+
+            store.InsertRow(table, ctx, new TextMatch { SourcePath = "Foo.cs", LineNumber = 42, Match = "hello" });
+
+            var fileKey = CsvDataTableStore.FileKey(table);
+            var lines = File.ReadAllLines(Path.Combine(outputDir, fileKey + ".csv"));
+            Assert.Equal("repositoryOrigin,SourcePath,LineNumber,Match,organization", lines[3]);
+            Assert.Equal("github.com/acme/widgets,Foo.cs,42,hello,Acme", lines[4]);
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir)) Directory.Delete(outputDir, true);
+        }
+    }
+
+    [Fact]
+    public void DecidesHeaderByFileExistenceAcrossStores()
+    {
+        var outputDir = Path.Combine(Path.GetTempPath(), "datatable-test-" + Guid.NewGuid());
+        try
+        {
+            var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+                "Matches found by a text search.");
+            var ctx = new OpenRewrite.Core.ExecutionContext();
+
+            // Two store instances on one dir simulate the Java host + an RPC runtime sharing one file.
+            new CsvDataTableStore(outputDir)
+                .InsertRow(table, ctx, new TextMatch { SourcePath = "A.cs", LineNumber = 1, Match = "a" });
+            new CsvDataTableStore(outputDir)
+                .InsertRow(table, ctx, new TextMatch { SourcePath = "B.cs", LineNumber = 2, Match = "b" });
+
+            var fileKey = CsvDataTableStore.FileKey(table);
+            var lines = File.ReadAllLines(Path.Combine(outputDir, fileKey + ".csv"));
+            // 3 comment lines + 1 header + 2 data rows
+            Assert.Equal(6, lines.Length);
+            Assert.Equal("SourcePath,LineNumber,Match", lines[3]);
+            Assert.Equal("A.cs,1,a", lines[4]);
+            Assert.Equal("B.cs,2,b", lines[5]);
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir)) Directory.Delete(outputDir, true);
+        }
+    }
+}
+
+public class SetDataTableStoreTests
+{
+    [Fact]
+    public void CsvReconstructsRawCsvStoreAtOutputDir()
+    {
+        var outputDir = Path.Combine(Path.GetTempPath(), "datatable-test-" + Guid.NewGuid());
+        try
+        {
+            var store = new SetDataTableStoreRequest.Csv
+            {
+                OutputDir = outputDir,
+                PrefixColumns = new Dictionary<string, string> { ["repositoryOrigin"] = "acme" },
+                SuffixColumns = new Dictionary<string, string> { ["organization"] = "Acme" }
+            }.ToDataTableStore();
+
+            var csv = Assert.IsType<CsvDataTableStore>(store);
+            Assert.Equal("acme", csv.PrefixColumns["repositoryOrigin"]);
+            Assert.Equal("Acme", csv.SuffixColumns["organization"]);
+
+            var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text Matches",
+                "Matches found by a text search.");
+            csv.InsertRow(table, new OpenRewrite.Core.ExecutionContext(),
+                new TextMatch { SourcePath = "Foo.cs", LineNumber = 1, Match = "x" });
+
+            var fileKey = CsvDataTableStore.FileKey(table);
+            var lines = File.ReadAllLines(Path.Combine(outputDir, fileKey + ".csv"));
+            Assert.Equal("repositoryOrigin,SourcePath,LineNumber,Match,organization", lines[3]);
+            Assert.Equal("acme,Foo.cs,1,x,Acme", lines[4]);
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir)) Directory.Delete(outputDir, true);
+        }
+    }
+
+    [Fact]
+    public void NoopKeepsRowsInMemory()
+    {
+        var store = new SetDataTableStoreRequest.NoOp().ToDataTableStore();
+        Assert.IsType<InMemoryDataTableStore>(store);
+    }
+
+    [Fact]
+    public void UnderSpecifiedCsvFallsBackToInMemory()
+    {
+        var store = new SetDataTableStoreRequest.Csv().ToDataTableStore();
+        Assert.IsType<InMemoryDataTableStore>(store);
+    }
+
+    [Fact]
+    public void DeserializesCsvWireFormByKindDiscriminator()
+    {
+        const string json =
+            """{"kind":"CSV","outputDir":"/tmp/dt","prefixColumns":{"repositoryOrigin":"acme"},"suffixColumns":{}}""";
+        var request = JsonSerializer.Deserialize<SetDataTableStoreRequest>(json, RpcJson.Options);
+        var csv = Assert.IsType<SetDataTableStoreRequest.Csv>(request);
+        Assert.Equal("/tmp/dt", csv.OutputDir);
+        Assert.Equal("acme", csv.PrefixColumns!["repositoryOrigin"]);
+    }
+
+    [Fact]
+    public void DeserializesNoOpWireForm()
+    {
+        var request = JsonSerializer.Deserialize<SetDataTableStoreRequest>(
+            """{"kind":"NOOP"}""", RpcJson.Options);
+        Assert.IsType<SetDataTableStoreRequest.NoOp>(request);
+    }
 }
 
 public class DataTableTests
@@ -271,5 +400,42 @@ public class DataTableTests
         Assert.Equal("SourcePath", descriptor.Columns[0].Name);
         Assert.Equal("Source Path", descriptor.Columns[0].DisplayName);
         Assert.Equal("The path of the source file", descriptor.Columns[0].Description);
+    }
+}
+
+public class FileKeyMatchesJavaTests
+{
+    // fileKey must match the Java host's exactly (incl. the sha256[..4] suffix), or a shared table resolves to two files.
+
+    [Fact]
+    public void DefaultTableUsesBareFullyQualifiedName()
+    {
+        var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text matches",
+            "Lines matching a text search.");
+        Assert.Equal("org.openrewrite.table.TextMatches", CsvDataTableStore.FileKey(table));
+    }
+
+    [Fact]
+    public void CustomInstanceNameAppendsSanitizedSuffix()
+    {
+        var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text matches",
+            "Lines matching a text search.") { InstanceName = "Custom run" };
+        Assert.Equal("org.openrewrite.table.TextMatches--custom-run-6251", CsvDataTableStore.FileKey(table));
+    }
+
+    [Fact]
+    public void GroupTakesPrecedenceAndIsSanitized()
+    {
+        var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text matches",
+            "Lines matching a text search.") { InstanceName = "Custom run", Group = "team-alpha" };
+        Assert.Equal("org.openrewrite.table.TextMatches--team-alpha-29c4", CsvDataTableStore.FileKey(table));
+    }
+
+    [Fact]
+    public void GroupEqualToNameUsesBareName()
+    {
+        var table = new DataTable<TextMatch>("org.openrewrite.table.TextMatches", "Text matches",
+            "Lines matching a text search.") { Group = "org.openrewrite.table.TextMatches" };
+        Assert.Equal("org.openrewrite.table.TextMatches", CsvDataTableStore.FileKey(table));
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -51,6 +51,9 @@ public class RewriteRpcServer
     private readonly ConcurrentDictionary<string, Recipe> _preparedRecipes = new();
     private readonly ConcurrentDictionary<string, object?> _recipeAccumulators = new();
     private readonly ConcurrentDictionary<string, ExecutionContext> _executionContexts = new();
+
+    private volatile IDataTableStore? _configuredDataTableStore;
+
     private string? _recipesProjectDir;
     private readonly string? _recipeInstallDir;
     private JsonRpc? _jsonRpc;
@@ -1509,6 +1512,13 @@ public class RewriteRpcServer
         return (Tree)_localObjects[treeId]!;
     }
 
+    [JsonRpcMethod("SetDataTableStore", UseSingleObjectParameterDeserialization = true)]
+    public Task<bool> SetDataTableStore(SetDataTableStoreRequest request)
+    {
+        _configuredDataTableStore = request.ToDataTableStore();
+        return Task.FromResult(true);
+    }
+
     /// <summary>
     /// JSON-RPC handler and public API for resetting all cached state.
     /// When called via JSON-RPC from the remote process, clears local caches.
@@ -1559,12 +1569,16 @@ public class RewriteRpcServer
     private ExecutionContext GetOrCreateExecutionContext(string? pId)
     {
         if (pId != null && _executionContexts.TryGetValue(pId, out var existing))
+        {
+            InstallDataTableStore(existing);
             return existing;
+        }
 
         var ctx = new ExecutionContext();
         // Inject the build context captured during ParseSolution so that
         // reattestation (MSBuildProjectHelper) can materialize build files
         _buildContext?.StoreIn(ctx);
+        InstallDataTableStore(ctx);
 
         if (pId != null)
         {
@@ -1572,6 +1586,15 @@ public class RewriteRpcServer
             _localObjects[pId] = ctx;
         }
         return ctx;
+    }
+
+    private void InstallDataTableStore(ExecutionContext ctx)
+    {
+        var store = _configuredDataTableStore;
+        if (store != null)
+        {
+            ctx.PutMessage(DataTable<object>.DataTableStoreKey, store);
+        }
     }
 
     /// <summary>
@@ -1658,6 +1681,34 @@ public class GetObjectRequest
 {
     public string Id { get; set; } = "";
     public string? SourceFileType { get; set; }
+}
+
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(Csv), "CSV")]
+[JsonDerivedType(typeof(NoOp), "NOOP")]
+public abstract class SetDataTableStoreRequest
+{
+    public abstract IDataTableStore ToDataTableStore();
+
+    public sealed class Csv : SetDataTableStoreRequest
+    {
+        public string? OutputDir { get; set; }
+        public Dictionary<string, string>? PrefixColumns { get; set; }
+        public Dictionary<string, string>? SuffixColumns { get; set; }
+
+        public override IDataTableStore ToDataTableStore() =>
+            string.IsNullOrEmpty(OutputDir)
+                ? new InMemoryDataTableStore()
+                : new CsvDataTableStore(
+                    OutputDir,
+                    PrefixColumns ?? new Dictionary<string, string>(),
+                    SuffixColumns ?? new Dictionary<string, string>());
+    }
+
+    public sealed class NoOp : SetDataTableStoreRequest
+    {
+        public override IDataTableStore ToDataTableStore() => new InMemoryDataTableStore();
+    }
 }
 
 public class ParseRequest

--- a/rewrite-csharp/csharp/OpenRewrite/Core/CsvDataTableStore.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/CsvDataTableStore.cs
@@ -26,37 +26,66 @@ namespace OpenRewrite.Core;
 public class CsvDataTableStore : IDataTableStore
 {
     private readonly string _outputDir;
-    private readonly HashSet<string> _initializedTables = [];
+    private readonly IReadOnlyDictionary<string, string> _prefixColumns;
+    private readonly IReadOnlyDictionary<string, string> _suffixColumns;
     private readonly Dictionary<string, int> _rowCounts = new();
     private readonly Dictionary<string, object> _dataTables = new();
     private readonly Dictionary<Type, PropertyInfo[]> _propertyCache = new();
+    private readonly object _lock = new();
 
     public CsvDataTableStore(string outputDir)
+        : this(outputDir, new Dictionary<string, string>(), new Dictionary<string, string>())
+    {
+    }
+
+    /// <summary>
+    /// Raw (uncompressed) CSV so complete-line appends from multiple writers sharing one
+    /// file per table interleave into one valid file.
+    /// </summary>
+    public CsvDataTableStore(string outputDir,
+        IReadOnlyDictionary<string, string> prefixColumns,
+        IReadOnlyDictionary<string, string> suffixColumns)
     {
         _outputDir = outputDir;
+        _prefixColumns = prefixColumns;
+        _suffixColumns = suffixColumns;
         Directory.CreateDirectory(outputDir);
     }
+
+    public IReadOnlyDictionary<string, string> PrefixColumns => _prefixColumns;
+
+    public IReadOnlyDictionary<string, string> SuffixColumns => _suffixColumns;
 
     public void InsertRow<TRow>(DataTable<TRow> dataTable, ExecutionContext ctx, TRow row) where TRow : notnull
     {
         var fileKey = FileKey(dataTable);
         var csvPath = Path.Combine(_outputDir, fileKey + ".csv");
 
-        if (!_initializedTables.Contains(fileKey))
+        lock (_lock)
         {
-            _initializedTables.Add(fileKey);
-            _rowCounts[fileKey] = 0;
             _dataTables[fileKey] = dataTable;
+            var properties = GetCachedProperties(typeof(TRow), dataTable.Descriptor);
 
-            var headers = dataTable.Descriptor.Columns.Select(c => EscapeCsv(c.DisplayName));
-            var comments = $"# @name {dataTable.Name}\n# @instanceName {dataTable.InstanceName}\n# @group {dataTable.Group ?? ""}\n";
-            File.WriteAllText(csvPath, comments + string.Join(",", headers) + "\n");
+            // Header decided by file existence (not in-memory state) and keyed on field NAMES,
+            // so writers sharing one file with the Java host write it once and stay aligned.
+            if (!File.Exists(csvPath))
+            {
+                var headers = _prefixColumns.Keys
+                    .Concat(dataTable.Descriptor.Columns.Select(c => c.Name))
+                    .Concat(_suffixColumns.Keys)
+                    .Select(EscapeCsv);
+                var comments = $"# @name {dataTable.Name}\n# @instanceName {dataTable.InstanceName}\n# @group {dataTable.Group ?? ""}\n";
+                File.WriteAllText(csvPath, comments + string.Join(",", headers) + "\n");
+            }
+
+            var values = _prefixColumns.Values
+                .Select(v => (object?)v)
+                .Concat(properties.Select(p => p.GetValue(row)))
+                .Concat(_suffixColumns.Values.Select(v => (object?)v))
+                .Select(EscapeCsv);
+            File.AppendAllText(csvPath, string.Join(",", values) + "\n");
+            _rowCounts[fileKey] = _rowCounts.GetValueOrDefault(fileKey) + 1;
         }
-
-        var properties = GetCachedProperties(typeof(TRow), dataTable.Descriptor);
-        var values = properties.Select(p => EscapeCsv(p.GetValue(row)));
-        File.AppendAllText(csvPath, string.Join(",", values) + "\n");
-        _rowCounts[fileKey]++;
     }
 
     public IEnumerable<object> GetRows(string dataTableName, string? group)
@@ -67,18 +96,39 @@ public class CsvDataTableStore : IDataTableStore
 
     public IReadOnlyList<object> GetDataTables()
     {
-        return _dataTables.Values.ToList();
+        lock (_lock)
+        {
+            return _dataTables.Values.ToList();
+        }
     }
 
     /// <summary>
     /// Number of rows written for each data table.
     /// </summary>
-    public IReadOnlyDictionary<string, int> RowCounts => _rowCounts;
+    public IReadOnlyDictionary<string, int> RowCounts
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return new Dictionary<string, int>(_rowCounts);
+            }
+        }
+    }
 
     /// <summary>
     /// File-safe keys of all data tables that have been written to.
     /// </summary>
-    public IReadOnlyList<string> TableKeys => _initializedTables.ToList();
+    public IReadOnlyList<string> TableKeys
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _dataTables.Keys.ToList();
+            }
+        }
+    }
 
     private PropertyInfo[] GetCachedProperties(Type rowType, DataTableDescriptor descriptor)
     {
@@ -104,8 +154,15 @@ public class CsvDataTableStore : IDataTableStore
 
     public static string FileKey<TRow>(DataTable<TRow> dataTable) where TRow : notnull
     {
-        var suffix = dataTable.Group ?? dataTable.InstanceName;
-        return suffix == dataTable.Name ? dataTable.Name : $"{dataTable.Name}--{Sanitize(suffix)}";
+        // Must mirror the Java host's fileKey exactly, or a table shared by a Java and a C# recipe resolves to two files.
+        var group = dataTable.Group;
+        if (group != null)
+        {
+            return group == dataTable.Name ? dataTable.Name : $"{dataTable.Name}--{Sanitize(group)}";
+        }
+        return dataTable.InstanceName == dataTable.Descriptor.DisplayName
+            ? dataTable.Name
+            : $"{dataTable.Name}--{Sanitize(dataTable.InstanceName)}";
     }
 
     public static string Sanitize(string value)

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Recipe.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Recipe.cs
@@ -42,6 +42,8 @@ public abstract class Recipe
 
     public virtual TimeSpan? EstimatedEffortPerOccurrence => TimeSpan.FromMinutes(5);
 
+    public virtual IReadOnlyList<DataTableDescriptor> DataTables => [];
+
     public virtual List<Recipe> GetRecipeList() => [];
 
     public virtual ITreeVisitor<ExecutionContext> GetVisitor() => ITreeVisitor<ExecutionContext>.Noop();
@@ -61,7 +63,7 @@ public abstract class Recipe
         return new RecipeDescriptor(
             Name, DisplayName, Description,
             Tags, EstimatedEffortPerOccurrence,
-            options, recipeList
+            options, recipeList, DataTables
         );
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipeDescriptor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipeDescriptor.cs
@@ -28,5 +28,6 @@ public record RecipeDescriptor(
     IReadOnlySet<string> Tags,
     TimeSpan? EstimatedEffortPerOccurrence,
     IReadOnlyList<OptionDescriptor> Options,
-    IReadOnlyList<RecipeDescriptor> RecipeList
+    IReadOnlyList<RecipeDescriptor> RecipeList,
+    IReadOnlyList<DataTableDescriptor> DataTables
 );

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -18,6 +18,7 @@ package org.openrewrite.csharp.rpc;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.DataTableStore;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
@@ -208,6 +209,7 @@ public class CSharpRewriteRpc extends RewriteRpc {
         private @Nullable Path workingDirectory;
         private @Nullable Path recipeInstallDir;
         private @Nullable Path profileOutputPath;
+        private @Nullable DataTableStore dataTableStore;
 
         public Builder marketplace(RecipeMarketplace marketplace) {
             this.marketplace = marketplace;
@@ -266,6 +268,11 @@ public class CSharpRewriteRpc extends RewriteRpc {
 
         public Builder log(@Nullable Path log) {
             this.log = log;
+            return this;
+        }
+
+        public Builder dataTableStore(@Nullable DataTableStore dataTableStore) {
+            this.dataTableStore = dataTableStore;
             return this;
         }
 
@@ -418,6 +425,7 @@ public class CSharpRewriteRpc extends RewriteRpc {
                         String.join(" ", cmdArr), process.environment())
                         .livenessCheck(process::getLivenessCheck)
                         .timeout(timeout)
+                        .dataTableStore(dataTableStore)
                         .log(log == null ? null : new PrintStream(Files.newOutputStream(log, StandardOpenOption.APPEND, StandardOpenOption.CREATE)));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/csv"
 	"encoding/json"
 	"flag"
@@ -117,8 +118,9 @@ type server struct {
 	traceSend    bool
 
 	// Server configuration from CLI flags (see serverConfig)
-	metricsCsv       string
-	dataTablesCsvDir string
+	metricsCsv string
+
+	configuredDataTableStore recipe.DataTableStore
 
 	// Per-RPC metrics writer. Lazily opened in newServer when metricsCsv
 	// is set. Writes are guarded by metricsMu so concurrent dispatch
@@ -145,7 +147,6 @@ type serverConfig struct {
 	traceRpcMessages bool
 	metricsCsv       string
 	recipeInstallDir string
-	dataTablesCsvDir string
 }
 
 func newServer(cfg serverConfig) *server {
@@ -217,7 +218,6 @@ func newServer(cfg serverConfig) *server {
 		traceReceive:            cfg.traceRpcMessages,
 		traceSend:               cfg.traceRpcMessages,
 		metricsCsv:              cfg.metricsCsv,
-		dataTablesCsvDir:        cfg.dataTablesCsvDir,
 		reader:                  bufio.NewReader(os.Stdin),
 		writer:                  os.Stdout,
 		logger:                  logger,
@@ -292,7 +292,6 @@ func parseFlags() serverConfig {
 	flag.BoolVar(&cfg.traceRpcMessages, "trace-rpc-messages", false, "log every GetObject batch send/receive")
 	flag.StringVar(&cfg.metricsCsv, "metrics-csv", "", "path to write per-RPC metrics as CSV")
 	flag.StringVar(&cfg.recipeInstallDir, "recipe-install-dir", "", "directory used as the recipe installer workspace; if empty, a temporary directory is created and cleaned up on shutdown")
-	flag.StringVar(&cfg.dataTablesCsvDir, "data-tables-csv-dir", "", "directory where DataTable rows are written as CSV; empty = in-memory only")
 	flag.Parse()
 	return cfg
 }
@@ -450,6 +449,8 @@ func (s *server) handleRequest(req *jsonRPCRequest) *jsonRPCResponse {
 		result, rpcErr = s.handleBatchVisit(req.Params)
 	case "Generate":
 		result, rpcErr = s.handleGenerate(req.Params)
+	case "SetDataTableStore":
+		result, rpcErr = s.handleSetDataTableStore(req.Params)
 	case "TraceGetObject":
 		result, rpcErr = s.handleTraceGetObject(req.Params)
 	case "ParseProject":
@@ -1030,10 +1031,7 @@ func (s *server) handleReset() bool {
 // returned. Otherwise the ctx is fetched from Java once (via the empty-body
 // codec) and cached under the pid for subsequent calls in the same recipe run.
 //
-// When --data-tables-csv-dir is set, a CsvDataTableStore is installed into
-// the ctx so any recipe that emits data-table rows writes them to that
-// directory. Otherwise an InMemoryDataTableStore is created lazily on first
-// InsertRow.
+// It then installs the host-configured DataTableStore (see installDataTableStore).
 func (s *server) resolveExecutionContext(pid *string) *recipe.ExecutionContext {
 	var ctx *recipe.ExecutionContext
 	if pid == nil || *pid == "" {
@@ -1091,22 +1089,112 @@ func (s *server) seedCursor(v recipe.TreeVisitor, ids []string) {
 	}
 }
 
-// installDataTableStore puts a DataTableStore into the ctx if one isn't
-// already present. Choice driven by --data-tables-csv-dir.
+// installDataTableStore installs the host-configured store onto the ctx. When
+// none was configured, the ctx is left untouched so an InMemoryDataTableStore
+// is created lazily on the first InsertRow.
 func (s *server) installDataTableStore(ctx *recipe.ExecutionContext) {
-	if _, ok := ctx.GetMessage(recipe.DataTableStoreKey); ok {
-		return
+	if s.configuredDataTableStore != nil {
+		ctx.PutMessage(recipe.DataTableStoreKey, s.configuredDataTableStore)
 	}
-	if s.dataTablesCsvDir != "" {
-		store, err := recipe.NewCsvDataTableStore(s.dataTablesCsvDir)
-		if err != nil {
-			s.logger.Printf("CsvDataTableStore unavailable, falling back to in-memory: %v", err)
-		} else {
-			ctx.PutMessage(recipe.DataTableStoreKey, store)
-			return
+}
+
+// setDataTableStore is the wire form of the data table store configuration,
+// mirroring org.openrewrite.rpc.request.SetDataTableStore.
+type setDataTableStore interface {
+	toDataTableStore() (recipe.DataTableStore, error)
+}
+
+type csvDataTableStore struct {
+	OutputDir string `json:"outputDir"`
+	// Raw JSON to preserve the host's key order; Go maps are unordered.
+	PrefixColumns json.RawMessage `json:"prefixColumns"`
+	SuffixColumns json.RawMessage `json:"suffixColumns"`
+}
+
+func (c *csvDataTableStore) toDataTableStore() (recipe.DataTableStore, error) {
+	if c.OutputDir == "" {
+		return recipe.NewInMemoryDataTableStore(), nil
+	}
+	prefix, err := parseOrderedColumns(c.PrefixColumns)
+	if err != nil {
+		return nil, fmt.Errorf("prefixColumns: %w", err)
+	}
+	suffix, err := parseOrderedColumns(c.SuffixColumns)
+	if err != nil {
+		return nil, fmt.Errorf("suffixColumns: %w", err)
+	}
+	return recipe.NewCsvDataTableStoreWithColumns(c.OutputDir, prefix, suffix)
+}
+
+type noOpDataTableStore struct{}
+
+func (noOpDataTableStore) toDataTableStore() (recipe.DataTableStore, error) {
+	return recipe.NewInMemoryDataTableStore(), nil
+}
+
+func parseSetDataTableStore(params json.RawMessage) (setDataTableStore, error) {
+	var tag struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(params, &tag); err != nil {
+		return nil, err
+	}
+	if tag.Kind == "CSV" {
+		var c csvDataTableStore
+		if err := json.Unmarshal(params, &c); err != nil {
+			return nil, err
 		}
+		return &c, nil
 	}
-	ctx.PutMessage(recipe.DataTableStoreKey, recipe.NewInMemoryDataTableStore())
+	return noOpDataTableStore{}, nil
+}
+
+// handleSetDataTableStore remembers the reconstructed store as the configured
+// store. Mirrors the JS SetDataTableStore.handle.
+func (s *server) handleSetDataTableStore(params json.RawMessage) (any, *rpcError) {
+	cfg, err := parseSetDataTableStore(params)
+	if err != nil {
+		return nil, &rpcError{Code: -32602, Message: fmt.Sprintf("Invalid params: %v", err)}
+	}
+	store, err := cfg.toDataTableStore()
+	if err != nil {
+		return nil, &rpcError{Code: -32603, Message: fmt.Sprintf("Cannot reconstruct data table store: %v", err)}
+	}
+	s.configuredDataTableStore = store
+	return true, nil
+}
+
+// parseOrderedColumns decodes a JSON object into ordered (name, value) pairs;
+// key order must be preserved, so a plain (unordered) map won't do.
+func parseOrderedColumns(raw json.RawMessage) ([]recipe.ColumnValue, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return nil, fmt.Errorf("expected JSON object, got %v", tok)
+	}
+	var cols []recipe.ColumnValue
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected string key, got %v", keyTok)
+		}
+		var val string
+		if err := dec.Decode(&val); err != nil {
+			return nil, err
+		}
+		cols = append(cols, recipe.ColumnValue{Name: key, Value: val})
+	}
+	return cols, nil
 }
 
 // marketplaceRow matches Java's GetMarketplaceResponse.Row.

--- a/rewrite-go/cmd/rpc/set_data_table_store_test.go
+++ b/rewrite-go/cmd/rpc/set_data_table_store_test.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+)
+
+func TestParseOrderedColumnsPreservesOrder(t *testing.T) {
+	raw := json.RawMessage(`{"zeta":"1","alpha":"2","mike":"3"}`)
+	cols, err := parseOrderedColumns(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []recipe.ColumnValue{
+		{Name: "zeta", Value: "1"},
+		{Name: "alpha", Value: "2"},
+		{Name: "mike", Value: "3"},
+	}
+	if len(cols) != len(want) {
+		t.Fatalf("expected %d columns, got %d: %+v", len(want), len(cols), cols)
+	}
+	for i := range want {
+		if cols[i] != want[i] {
+			t.Errorf("column %d = %+v, want %+v", i, cols[i], want[i])
+		}
+	}
+}
+
+func TestParseOrderedColumnsEmptyAndNull(t *testing.T) {
+	for _, raw := range []json.RawMessage{nil, json.RawMessage("null"), json.RawMessage("{}")} {
+		cols, err := parseOrderedColumns(raw)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", string(raw), err)
+		}
+		if len(cols) != 0 {
+			t.Errorf("expected no columns for %q, got %+v", string(raw), cols)
+		}
+	}
+}
+
+func TestToDataTableStoreKinds(t *testing.T) {
+	dir := t.TempDir()
+
+	csv := &csvDataTableStore{
+		OutputDir:     dir,
+		PrefixColumns: json.RawMessage(`{"repositoryPath":"acme/widgets"}`),
+		SuffixColumns: json.RawMessage(`{"organization":"acme"}`),
+	}
+	store, err := csv.toDataTableStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := store.(*recipe.CsvDataTableStore); !ok {
+		t.Fatalf("CSV kind: expected *CsvDataTableStore, got %T", store)
+	}
+
+	store, err = (noOpDataTableStore{}).toDataTableStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := store.(*recipe.InMemoryDataTableStore); !ok {
+		t.Fatalf("NOOP kind: expected *InMemoryDataTableStore, got %T", store)
+	}
+
+	store, err = (&csvDataTableStore{}).toDataTableStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := store.(*recipe.InMemoryDataTableStore); !ok {
+		t.Fatalf("under-specified CSV: expected *InMemoryDataTableStore, got %T", store)
+	}
+}
+
+func TestParseSetDataTableStoreSelectsVariantByKind(t *testing.T) {
+	csv, err := parseSetDataTableStore(json.RawMessage(
+		`{"kind":"CSV","outputDir":"/tmp/dt","prefixColumns":{"repositoryOrigin":"acme"}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, ok := csv.(*csvDataTableStore)
+	if !ok {
+		t.Fatalf("CSV: expected *csvDataTableStore, got %T", csv)
+	}
+	if c.OutputDir != "/tmp/dt" {
+		t.Errorf("OutputDir = %q, want /tmp/dt", c.OutputDir)
+	}
+
+	noop, err := parseSetDataTableStore(json.RawMessage(`{"kind":"NOOP"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := noop.(noOpDataTableStore); !ok {
+		t.Fatalf("NOOP: expected noOpDataTableStore, got %T", noop)
+	}
+}
+
+func TestHandleSetDataTableStoreInstallsConfiguredStore(t *testing.T) {
+	dir := t.TempDir()
+	s := &server{}
+
+	params, _ := json.Marshal(map[string]string{"kind": "CSV", "outputDir": dir})
+	result, rpcErr := s.handleSetDataTableStore(params)
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	if result != true {
+		t.Errorf("expected result true, got %v", result)
+	}
+	if _, ok := s.configuredDataTableStore.(*recipe.CsvDataTableStore); !ok {
+		t.Fatalf("expected configured *CsvDataTableStore, got %T", s.configuredDataTableStore)
+	}
+
+	ctx := recipe.NewExecutionContext()
+	s.installDataTableStore(ctx)
+	installed, ok := ctx.GetMessage(recipe.DataTableStoreKey)
+	if !ok {
+		t.Fatal("expected a store installed on the ctx")
+	}
+	if installed != s.configuredDataTableStore {
+		t.Errorf("installed store %p != configured store %p", installed, s.configuredDataTableStore)
+	}
+}
+
+func TestInstallDataTableStoreNoopWhenUnconfigured(t *testing.T) {
+	s := &server{}
+	ctx := recipe.NewExecutionContext()
+	s.installDataTableStore(ctx)
+	if _, ok := ctx.GetMessage(recipe.DataTableStoreKey); ok {
+		t.Error("expected no store installed when host configured none")
+	}
+}

--- a/rewrite-go/pkg/recipe/data_table.go
+++ b/rewrite-go/pkg/recipe/data_table.go
@@ -169,8 +169,7 @@ var dashRun = regexp.MustCompile(`-+`)
 var leadingTrailingDash = regexp.MustCompile(`^-|-$`)
 
 // SanitizeScope produces a filesystem-safe identifier from a scope string,
-// matching JS data-table.ts:85-103. Lowercase, non-alnum→dash, collapse
-// dashes, truncate to 30 at a word boundary, suffix with a 4-char sha256.
+// byte-identical to Java's CsvDataTableStore.sanitize for ASCII input.
 func SanitizeScope(scope string) string {
 	s := strings.ToLower(scope)
 	s = nonAlnum.ReplaceAllString(s, "-")
@@ -186,43 +185,57 @@ func SanitizeScope(scope string) string {
 	return s + "-" + hex.EncodeToString(sum[:2])
 }
 
-// CsvDataTableStore writes rows directly to CSV files as they are inserted.
-// One file per (recipe, dataTable, group) tuple, opened append-mode and
-// kept open for the store's lifetime.
+// ColumnValue is a static prefix/suffix column. Order matters: all writers
+// sharing one CSV file must agree on the column order.
+type ColumnValue struct {
+	Name  string
+	Value string
+}
+
+// CsvDataTableStore writes rows directly to raw .csv files, one per (recipe, dataTable, group).
 type CsvDataTableStore struct {
-	outputDir  string
-	mu         sync.Mutex
-	files      map[string]*os.File
-	dataTables map[string]DataTableLike
+	outputDir     string
+	prefixColumns []ColumnValue
+	suffixColumns []ColumnValue
+	mu            sync.Mutex
+	dataTables    map[string]DataTableLike
 }
 
 func NewCsvDataTableStore(outputDir string) (*CsvDataTableStore, error) {
+	return NewCsvDataTableStoreWithColumns(outputDir, nil, nil)
+}
+
+func NewCsvDataTableStoreWithColumns(outputDir string, prefix, suffix []ColumnValue) (*CsvDataTableStore, error) {
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return nil, fmt.Errorf("create dataTables output dir: %w", err)
 	}
 	return &CsvDataTableStore{
-		outputDir:  outputDir,
-		files:      map[string]*os.File{},
-		dataTables: map[string]DataTableLike{},
+		outputDir:     outputDir,
+		prefixColumns: prefix,
+		suffixColumns: suffix,
+		dataTables:    map[string]DataTableLike{},
 	}, nil
 }
 
-// Close flushes and closes all CSV files. Call on server Reset / shutdown.
-func (s *CsvDataTableStore) Close() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for _, f := range s.files {
-		_ = f.Close()
-	}
-	s.files = map[string]*os.File{}
-}
+// Close is a no-op: each row is written with its own short-lived append handle.
+func (s *CsvDataTableStore) Close() {}
 
+// fileKey mirrors Java's CsvDataTableStore.fileKey exactly so a table shared by
+// a Java and a Go recipe resolves to the same filename; a DEFAULT table returns
+// the bare FQN because that is what the Java host writes it under.
 func fileKey(dt DataTableLike) string {
-	scope := dt.InstanceName()
-	if dt.Group() != "" {
-		scope = scope + "-" + dt.Group()
+	desc := dt.Descriptor()
+	name := desc.Name
+	if group := dt.Group(); group != "" {
+		if group == name {
+			return name
+		}
+		return name + "--" + SanitizeScope(group)
 	}
-	return SanitizeScope(dt.Descriptor().Name + "-" + scope)
+	if instanceName := dt.InstanceName(); instanceName != desc.DisplayName {
+		return name + "--" + SanitizeScope(instanceName)
+	}
+	return name
 }
 
 func (s *CsvDataTableStore) InsertRow(dt DataTableLike, _ *ExecutionContext, row any) {
@@ -230,31 +243,45 @@ func (s *CsvDataTableStore) InsertRow(dt DataTableLike, _ *ExecutionContext, row
 	defer s.mu.Unlock()
 
 	key := fileKey(dt)
-	f, ok := s.files[key]
-	if !ok {
-		csvPath := filepath.Join(s.outputDir, key+".csv")
-		newFile, err := os.OpenFile(csvPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-		if err != nil {
-			return // best-effort; fail silently rather than crash a recipe
-		}
-		// Header preamble + column header row, written once when the file is created.
-		desc := dt.Descriptor()
+	csvPath := filepath.Join(s.outputDir, key+".csv")
+	s.dataTables[key] = dt
+	desc := dt.Descriptor()
+
+	// Decide the header by file existence so writers sharing one file write it
+	// exactly once; column NAMES (not display names) match the Java writer.
+	_, statErr := os.Stat(csvPath)
+	fileExists := statErr == nil
+
+	// Short-lived O_APPEND handle per row so a concurrent appender (the Java
+	// host sharing this file) isn't clobbered.
+	f, err := os.OpenFile(csvPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return // best-effort; fail silently rather than crash a recipe
+	}
+	defer func() { _ = f.Close() }()
+
+	if !fileExists {
 		preamble := fmt.Sprintf("# @name %s\n# @instanceName %s\n# @group %s\n",
 			desc.Name, dt.InstanceName(), dt.Group())
-		header := make([]string, 0, len(desc.Columns))
-		for _, c := range desc.Columns {
-			header = append(header, csvEscape(c.DisplayName))
+		header := make([]string, 0, len(s.prefixColumns)+len(desc.Columns)+len(s.suffixColumns))
+		for _, c := range s.prefixColumns {
+			header = append(header, csvEscape(c.Name))
 		}
-		_, _ = newFile.WriteString(preamble + strings.Join(header, ",") + "\n")
-		f = newFile
-		s.files[key] = f
-		s.dataTables[key] = dt
+		for _, c := range desc.Columns {
+			header = append(header, csvEscape(c.Name))
+		}
+		for _, c := range s.suffixColumns {
+			header = append(header, csvEscape(c.Name))
+		}
+		_, _ = f.WriteString(preamble + strings.Join(header, ",") + "\n")
 	}
 
-	// Reflect the row by column name. Rows are typically structs with field
-	// names matching column names (case-insensitive).
-	desc := dt.Descriptor()
-	values := make([]string, 0, len(desc.Columns))
+	// Reflect the row by column name; rows are typically structs with field
+	// names matching column names (case-insensitive), or maps keyed by column name.
+	values := make([]string, 0, len(s.prefixColumns)+len(desc.Columns)+len(s.suffixColumns))
+	for _, c := range s.prefixColumns {
+		values = append(values, csvEscape(c.Value))
+	}
 	rv := reflect.ValueOf(row)
 	if rv.Kind() == reflect.Ptr {
 		rv = rv.Elem()
@@ -275,6 +302,9 @@ func (s *CsvDataTableStore) InsertRow(dt DataTableLike, _ *ExecutionContext, row
 			}
 		}
 		values = append(values, csvEscape(v))
+	}
+	for _, c := range s.suffixColumns {
+		values = append(values, csvEscape(c.Value))
 	}
 	_, _ = f.WriteString(strings.Join(values, ",") + "\n")
 }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
@@ -17,6 +17,7 @@ package org.openrewrite.golang.rpc;
 
 import lombok.Getter;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.DataTableStore;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
@@ -318,7 +319,7 @@ public class GoRewriteRpc extends RewriteRpc {
         private @Nullable Path log;
         private @Nullable Path metricsCsv;
         private @Nullable Path recipeInstallDir;
-        private @Nullable Path dataTablesCsvDir;
+        private @Nullable DataTableStore dataTableStore;
         private @Nullable Path workingDirectory;
         private boolean traceRpcMessages;
 
@@ -370,8 +371,8 @@ public class GoRewriteRpc extends RewriteRpc {
             return this;
         }
 
-        public Builder dataTablesCsvDir(@Nullable Path dataTablesCsvDir) {
-            this.dataTablesCsvDir = dataTablesCsvDir;
+        public Builder dataTableStore(@Nullable DataTableStore dataTableStore) {
+            this.dataTableStore = dataTableStore;
             return this;
         }
 
@@ -415,7 +416,6 @@ public class GoRewriteRpc extends RewriteRpc {
                     log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
                     metricsCsv == null ? null : "--metrics-csv=" + metricsCsv.toAbsolutePath().normalize(),
                     recipeInstallDir == null ? null : "--recipe-install-dir=" + recipeInstallDir.toAbsolutePath().normalize(),
-                    dataTablesCsvDir == null ? null : "--data-tables-csv-dir=" + dataTablesCsvDir.toAbsolutePath().normalize(),
                     traceRpcMessages ? "--trace-rpc-messages" : null
             );
 
@@ -434,6 +434,7 @@ public class GoRewriteRpc extends RewriteRpc {
                         String.join(" ", cmdArr), process.environment())
                         .livenessCheck(process::getLivenessCheck)
                         .timeout(timeout)
+                        .dataTableStore(dataTableStore)
                         .log(log == null ? null : new PrintStream(Files.newOutputStream(log, StandardOpenOption.APPEND, StandardOpenOption.CREATE)));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/rewrite-go/test/data_table_test.go
+++ b/rewrite-go/test/data_table_test.go
@@ -115,10 +115,177 @@ func TestCsvDataTableStoreWritesFile(t *testing.T) {
 	}
 }
 
+func TestCsvDataTableStoreWritesPrefixAndSuffixColumns(t *testing.T) {
+	dir := t.TempDir()
+	store, err := recipe.NewCsvDataTableStoreWithColumns(dir,
+		[]recipe.ColumnValue{{Name: "repositoryPath", Value: "acme/widgets"}},
+		[]recipe.ColumnValue{{Name: "organization", Value: "acme"}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	ctx := recipe.NewExecutionContext()
+	ctx.PutMessage(recipe.DataTableStoreKey, store)
+
+	findings.InsertRow(ctx, findingsRow{File: "x.go", Count: 5})
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 CSV file, got %d", len(entries))
+	}
+	data, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		"repositoryPath,File,Count,organization",
+		"acme/widgets,x.go,5,acme",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("CSV missing expected line %q; got:\n%s", want, got)
+		}
+	}
+}
+
+func TestCsvDataTableStoresShareOneFileWithSingleHeader(t *testing.T) {
+	dir := t.TempDir()
+	prefix := []recipe.ColumnValue{{Name: "repositoryPath", Value: "acme/widgets"}}
+
+	// Two stores model the Java host and an RPC runtime sharing one file.
+	store1, err := recipe.NewCsvDataTableStoreWithColumns(dir, prefix, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store2, err := recipe.NewCsvDataTableStoreWithColumns(dir, prefix, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx1 := recipe.NewExecutionContext()
+	ctx1.PutMessage(recipe.DataTableStoreKey, store1)
+	findings.InsertRow(ctx1, findingsRow{File: "a.go", Count: 1})
+
+	ctx2 := recipe.NewExecutionContext()
+	ctx2.PutMessage(recipe.DataTableStoreKey, store2)
+	findings.InsertRow(ctx2, findingsRow{File: "b.go", Count: 2})
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected the two stores to share 1 CSV file, got %d", len(entries))
+	}
+	data, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if n := strings.Count(got, "# @name "); n != 1 {
+		t.Errorf("expected exactly 1 comment preamble, got %d; content:\n%s", n, got)
+	}
+	if n := strings.Count(got, "repositoryPath,File,Count"); n != 1 {
+		t.Errorf("expected exactly 1 header row, got %d; content:\n%s", n, got)
+	}
+	for _, want := range []string{"acme/widgets,a.go,1", "acme/widgets,b.go,2"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("CSV missing expected row %q; got:\n%s", want, got)
+		}
+	}
+}
+
 func TestSanitizeScope(t *testing.T) {
 	got := recipe.SanitizeScope("org.openrewrite.Foo$Bar")
 	// lowercase + non-alnum→dash + 4-char hash suffix (matching JS spec)
 	if !strings.HasPrefix(got, "org-openrewrite-foo-bar-") {
 		t.Errorf("unexpected sanitized value: %s", got)
 	}
+	// Byte-identical to Java's CsvDataTableStore.sanitize; verified with `shasum -a 256`.
+	if want := "org-openrewrite-foo-bar-fa3f"; got != want {
+		t.Errorf("SanitizeScope cross-language mismatch: got %q, want %q", got, want)
+	}
+}
+
+// fileKeyOf returns the on-disk file name (minus ".csv") produced for dt — the
+// only way to exercise the unexported fileKey end-to-end.
+func fileKeyOf(t *testing.T, dt *recipe.DataTable[findingsRow]) string {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := recipe.NewCsvDataTableStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := recipe.NewExecutionContext()
+	ctx.PutMessage(recipe.DataTableStoreKey, store)
+	dt.InsertRow(ctx, findingsRow{File: "a.go", Count: 1})
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 CSV file, got %d", len(entries))
+	}
+	return strings.TrimSuffix(entries[0].Name(), ".csv")
+}
+
+// TestFileKeyMatchesJavaScheme verifies a table shared by a Java and a Go
+// recipe resolves to the same on-disk file name (expected strings = what
+// Java's CsvDataTableStore.fileKey produces).
+func TestFileKeyMatchesJavaScheme(t *testing.T) {
+	const name = "org.openrewrite.table.TextMatches"
+	const displayName = "Text matches"
+	cols := []recipe.ColumnDescriptor{{Name: "File", DisplayName: "File", Description: "The file"}}
+	newTable := func() *recipe.DataTable[findingsRow] {
+		return recipe.NewDataTable[findingsRow](name, displayName, "desc", cols)
+	}
+
+	// A DEFAULT table must yield the bare FQN — the Java host writes it there.
+	t.Run("default table -> bare FQN", func(t *testing.T) {
+		got := fileKeyOf(t, newTable())
+		if got != name {
+			t.Errorf("default table fileKey = %q, want bare FQN %q", got, name)
+		}
+	})
+
+	t.Run("custom instance name -> name--sanitize(instanceName)", func(t *testing.T) {
+		dt := newTable()
+		dt.SetInstanceName("Custom run")
+		got := fileKeyOf(t, dt)
+		want := name + "--custom-run-6251"
+		if want != name+"--"+recipe.SanitizeScope("Custom run") {
+			t.Fatalf("test setup: literal want %q out of sync with SanitizeScope", want)
+		}
+		if got != want {
+			t.Errorf("custom-instance fileKey = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("grouped table -> name--sanitize(group)", func(t *testing.T) {
+		dt := newTable()
+		dt.SetGroup("team-alpha")
+		got := fileKeyOf(t, dt)
+		want := name + "--team-alpha-29c4"
+		if want != name+"--"+recipe.SanitizeScope("team-alpha") {
+			t.Fatalf("test setup: literal want %q out of sync with SanitizeScope", want)
+		}
+		if got != want {
+			t.Errorf("grouped fileKey = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("group == name -> bare FQN", func(t *testing.T) {
+		dt := newTable()
+		dt.SetGroup(name)
+		got := fileKeyOf(t, dt)
+		if got != name {
+			t.Errorf("group==name fileKey = %q, want bare FQN %q", got, name)
+		}
+	})
 }

--- a/rewrite-javascript/rewrite/src/data-table.ts
+++ b/rewrite-javascript/rewrite/src/data-table.ts
@@ -82,14 +82,16 @@ function sha256Prefix(input: string, hexChars: number): string {
     return hash.substring(0, hexChars);
 }
 
+/**
+ * Sanitize a value for a filename, byte-identical to the Java host's
+ * {@code CsvDataTableStore.sanitize} so a shared data table resolves to the same file.
+ */
 export function sanitizeScope(scope: string): string {
     // 1. lowercase
     let s = scope.toLowerCase();
-    // 2. replace non-alphanumeric with '-'
-    s = s.replace(/[^a-z0-9]/g, '-');
-    // 3. collapse consecutive '-', trim leading/trailing
+    // \p{L}\p{Nd} mirrors Java's Character.isLetterOrDigit, for cross-runtime parity
+    s = s.replace(/[^\p{L}\p{Nd}]/gu, '-');
     s = s.replace(/-+/g, '-').replace(/^-|-$/g, '');
-    // 4. truncate to ~30 chars at word boundary
     if (s.length > 30) {
         s = s.substring(0, 30);
         const lastDash = s.lastIndexOf('-');
@@ -97,7 +99,6 @@ export function sanitizeScope(scope: string): string {
             s = s.substring(0, lastDash);
         }
     }
-    // 5. append 4-char hash
     const hash = sha256Prefix(scope, 4);
     return `${s}-${hash}`;
 }
@@ -182,41 +183,45 @@ function escapeCsv(value: unknown): string {
  * Uses the data table's file-safe key for filenames.
  */
 export class CsvDataTableStore implements DataTableStore {
-    private readonly _initializedTables = new Set<string>();
     private readonly _rowCounts: { [key: string]: number } = {};
     private readonly _dataTables = new Map<string, DataTable<any>>();
 
-    constructor(private readonly outputDir: string) {
+    constructor(private readonly outputDir: string,
+                private readonly prefixColumns: { [key: string]: string } = {},
+                private readonly suffixColumns: { [key: string]: string } = {}) {
         fs.mkdirSync(outputDir, {recursive: true});
     }
 
     insertRow<Row>(dataTable: DataTable<Row>, _ctx: ExecutionContext, row: Row): void {
         const fileKey = CsvDataTableStore.fileKey(dataTable);
         const csvPath = path.join(this.outputDir, fileKey + '.csv');
+        this._dataTables.set(fileKey, dataTable);
 
-        if (!this._initializedTables.has(fileKey)) {
-            this._initializedTables.add(fileKey);
-            this._rowCounts[fileKey] = 0;
-            this._dataTables.set(fileKey, dataTable);
+        const columns = dataTable.descriptor.columns;
 
-            const columns = dataTable.descriptor.columns;
-            const headerRow = columns.map(col => escapeCsv(col.displayName)).join(',');
-            // Write metadata comments + header
+        // Key the header on file existence, not in-memory state, so writers sharing one file
+        // (Java host + RPC runtimes) emit it once; column names (not display names) match the Java writer.
+        if (!fs.existsSync(csvPath)) {
+            const header = [
+                ...Object.keys(this.prefixColumns),
+                ...columns.map(col => col.name),
+                ...Object.keys(this.suffixColumns),
+            ].map(escapeCsv).join(',');
             const comments = [
                 `# @name ${dataTable.descriptor.name}`,
                 `# @instanceName ${dataTable.instanceName}`,
                 `# @group ${dataTable.group ?? ''}`,
             ].join('\n');
-            fs.writeFileSync(csvPath, comments + '\n' + headerRow + '\n');
+            fs.writeFileSync(csvPath, comments + '\n' + header + '\n');
         }
 
-        const columns = dataTable.descriptor.columns;
-        const rowValues = columns.map(col => {
-            const value = (row as any)[col.name];
-            return escapeCsv(value);
-        });
+        const rowValues = [
+            ...Object.values(this.prefixColumns),
+            ...columns.map(col => (row as any)[col.name]),
+            ...Object.values(this.suffixColumns),
+        ].map(escapeCsv);
         fs.appendFileSync(csvPath, rowValues.join(',') + '\n');
-        this._rowCounts[fileKey]++;
+        this._rowCounts[fileKey] = (this._rowCounts[fileKey] ?? 0) + 1;
     }
 
     getRows(_dataTableName: string, _group?: string): any[] {
@@ -233,14 +238,27 @@ export class CsvDataTableStore implements DataTableStore {
     }
 
     get tableKeys(): string[] {
-        return [...this._initializedTables];
+        return Array.from(this._dataTables.keys());
     }
 
+    /**
+     * Filesystem-safe key for a data table; mirrors the Java host's
+     * {@code CsvDataTableStore.fileKey} so a shared table resolves to the same filename.
+     */
     static fileKey(dataTable: DataTable<any>): string {
-        const suffix = dataTable.group ?? dataTable.instanceName;
-        if (suffix === dataTable.descriptor.name) {
-            return dataTable.descriptor.name;
+        const name = dataTable.descriptor.name;
+        const group = dataTable.group;
+        if (group != null) {
+            if (group === name) {
+                return name;
+            }
+            return `${name}--${sanitizeScope(group)}`;
         }
-        return `${dataTable.descriptor.name}--${sanitizeScope(suffix)}`;
+        // Suffix only when instanceName was customized (differs from the display name).
+        const instanceName = dataTable.instanceName;
+        if (instanceName === dataTable.descriptor.displayName) {
+            return name;
+        }
+        return `${name}--${sanitizeScope(instanceName)}`;
     }
 }

--- a/rewrite-javascript/rewrite/src/rpc/request/batch-visit.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/batch-visit.ts
@@ -19,6 +19,8 @@ import {Cursor, Tree} from "../../tree";
 import {TreeVisitor} from "../../visitor";
 import {MarkersKind, SearchResult} from "../../markers";
 import {Visit} from "./visit";
+import {ExecutionContext} from "../../execution";
+import {DATA_TABLE_STORE, DataTableStore} from "../../data-table";
 import {withMetrics} from "./metrics";
 
 export interface BatchVisitItem {
@@ -67,6 +69,7 @@ export class BatchVisit {
                   recipeCursors: WeakMap<Recipe, Cursor>,
                   getObject: (id: string, sourceFileType?: string) => any,
                   getCursor: (cursorIds: string[] | undefined, sourceFileType?: string) => Promise<Cursor>,
+                  dataTableStore: () => DataTableStore | undefined,
                   metricsCsv?: string): void {
         connection.onRequest(
             new rpc.RequestType<BatchVisitRequest, BatchVisitResponse, Error>("BatchVisit"),
@@ -75,6 +78,10 @@ export class BatchVisit {
                 metricsCsv,
                 (_context) => async (request) => {
                     const p = await getObject(request.p, undefined);
+                    const store = dataTableStore();
+                    if (store && p instanceof ExecutionContext) {
+                        p.messages[DATA_TABLE_STORE] = store;
+                    }
                     let tree: Tree = await getObject(request.treeId, request.sourceFileType);
                     const cursor = await getCursor(request.cursor, request.sourceFileType);
 

--- a/rewrite-javascript/rewrite/src/rpc/request/generate.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/generate.ts
@@ -17,6 +17,7 @@ import * as rpc from "vscode-jsonrpc/node";
 import {Recipe, ScanningRecipe} from "../../recipe";
 import {Cursor, rootCursor} from "../../tree";
 import {ExecutionContext} from "../../execution";
+import {DATA_TABLE_STORE, DataTableStore} from "../../data-table";
 import {withMetrics} from "./metrics";
 
 export interface GenerateResponse {
@@ -33,6 +34,7 @@ export class Generate {
                   preparedRecipes: Map<String, Recipe>,
                   recipeCursors: WeakMap<Recipe, Cursor>,
                   getObject: (id: string) => any,
+                  dataTableStore: () => DataTableStore | undefined,
                   metricsCsv?: string): void {
         connection.onRequest(
             new rpc.RequestType<Generate, GenerateResponse, Error>("Generate"),
@@ -54,6 +56,10 @@ export class Generate {
                             recipeCursors.set(recipe, cursor);
                         }
                         const ctx = await getObject(request.p) as ExecutionContext;
+                        const store = dataTableStore();
+                        if (store) {
+                            ctx.messages[DATA_TABLE_STORE] = store;
+                        }
                         const acc = recipe.accumulator(cursor, ctx);
                         const generated = await recipe.generate(acc, ctx)
 

--- a/rewrite-javascript/rewrite/src/rpc/request/index.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/index.ts
@@ -23,3 +23,4 @@ export * from "./print";
 export * from "./visit";
 export * from "./batch-visit";
 export * from "./trace-get-object";
+export * from "./set-data-table-store";

--- a/rewrite-javascript/rewrite/src/rpc/request/set-data-table-store.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/set-data-table-store.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as rpc from "vscode-jsonrpc/node";
+import {CsvDataTableStore, DataTableStore, InMemoryDataTableStore} from "../../data-table";
+import {withMetrics} from "./metrics";
+
+/**
+ * Conveys a data table store's configuration from the host; rows never cross the wire.
+ * Mirrors Java's {@code SetDataTableStore}.
+ */
+export type SetDataTableStore = SetDataTableStore.NoOp | SetDataTableStore.Csv;
+
+export namespace SetDataTableStore {
+    export interface NoOp {
+        readonly kind: "NOOP";
+    }
+
+    export interface Csv {
+        readonly kind: "CSV";
+        readonly outputDir: string;
+        readonly prefixColumns?: { [key: string]: string };
+        readonly suffixColumns?: { [key: string]: string };
+    }
+
+    export function toDataTableStore(request: SetDataTableStore): DataTableStore {
+        if (request.kind === "CSV" && request.outputDir) {
+            return new CsvDataTableStore(
+                request.outputDir,
+                request.prefixColumns ?? {},
+                request.suffixColumns ?? {});
+        }
+        return new InMemoryDataTableStore();
+    }
+
+    export function handle(connection: rpc.MessageConnection,
+                           install: (store: DataTableStore) => void,
+                           metricsCsv?: string): void {
+        connection.onRequest(
+            new rpc.RequestType<SetDataTableStore, boolean, Error>("SetDataTableStore"),
+            withMetrics<SetDataTableStore, boolean>(
+                "SetDataTableStore",
+                metricsCsv,
+                (_context) => async (request) => {
+                    install(toDataTableStore(request));
+                    return true;
+                }
+            )
+        );
+    }
+}

--- a/rewrite-javascript/rewrite/src/rpc/request/visit.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/visit.ts
@@ -18,6 +18,7 @@ import {Recipe, ScanningRecipe} from "../../recipe";
 import {Cursor, rootCursor, SourceFile, Tree} from "../../tree";
 import {TreeVisitor} from "../../visitor";
 import {ExecutionContext} from "../../execution";
+import {DATA_TABLE_STORE, DataTableStore} from "../../data-table";
 import {withMetrics, extractSourcePath} from "./metrics";
 
 export interface VisitResponse {
@@ -43,6 +44,7 @@ export class Visit {
                   recipeCursors: WeakMap<Recipe, Cursor>,
                   getObject: (id: string, sourceFileType?: string) => any,
                   getCursor: (cursorIds: string[] | undefined, sourceFileType?: string) => Promise<Cursor>,
+                  dataTableStore: () => DataTableStore | undefined,
                   metricsCsv?: string): void {
         connection.onRequest(
             new rpc.RequestType<Visit, VisitResponse, Error>("Visit"),
@@ -51,6 +53,10 @@ export class Visit {
                 metricsCsv,
                 (context) => async (request) => {
                     const p = await getObject(request.p, undefined);
+                    const store = dataTableStore();
+                    if (store && p instanceof ExecutionContext) {
+                        p.messages[DATA_TABLE_STORE] = store;
+                    }
                     const before: Tree = await getObject(request.treeId, request.sourceFileType);
                     const cursor = await getCursor(request.cursor, request.sourceFileType);
                     context.target = extractSourcePath(before, cursor);

--- a/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
+++ b/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
@@ -33,8 +33,10 @@ import {
     TraceGetObject,
     Visit,
     VisitResponse,
-    BatchVisit
+    BatchVisit,
+    SetDataTableStore
 } from "./request";
+import {DataTableStore} from "../data-table";
 import {RecipeMarketplace} from "../marketplace";
 import {initializeMetricsCsv} from "./request/metrics";
 import {RpcObjectData, RpcObjectState, RpcReceiveQueue} from "./queue";
@@ -76,6 +78,8 @@ export class RewriteRpc {
     private readonly logger?: rpc.Logger;
     private traceGetObject: TraceGetObject = {receive: false, send: false};
 
+    private configuredDataTableStore?: DataTableStore;
+
     constructor(readonly connection: MessageConnection = rpc.createMessageConnection(
                     new rpc.StreamMessageReader(process.stdin),
                     new rpc.StreamMessageWriter(process.stdout),
@@ -98,12 +102,14 @@ export class RewriteRpc {
         const getObject = (id: string, sourceFileType?: string) => this.getObject(id, sourceFileType);
         const getCursor = (cursorIds: string[] | undefined, sourceFileType?: string) => this.getCursor(cursorIds, sourceFileType);
         const traceGetObject = () => this.traceGetObject.send;
+        const dataTableStore = () => this.configuredDataTableStore;
 
         const marketplace = options.marketplace || new RecipeMarketplace();
 
-        Visit.handle(this.connection, this.localObjects, preparedRecipes, recipeCursors, getObject, getCursor, options.metricsCsv);
-        BatchVisit.handle(this.connection, this.localObjects, preparedRecipes, recipeCursors, getObject, getCursor, options.metricsCsv);
-        Generate.handle(this.connection, this.localObjects, preparedRecipes, recipeCursors, getObject, options.metricsCsv);
+        Visit.handle(this.connection, this.localObjects, preparedRecipes, recipeCursors, getObject, getCursor, dataTableStore, options.metricsCsv);
+        BatchVisit.handle(this.connection, this.localObjects, preparedRecipes, recipeCursors, getObject, getCursor, dataTableStore, options.metricsCsv);
+        Generate.handle(this.connection, this.localObjects, preparedRecipes, recipeCursors, getObject, dataTableStore, options.metricsCsv);
+        SetDataTableStore.handle(this.connection, store => this.configuredDataTableStore = store, options.metricsCsv);
         GetObject.handle(this.connection, this.remoteObjects, this.localObjects,
             this.localRefs, options?.batchSize || 1000, traceGetObject, options.metricsCsv);
         GetMarketplace.handle(this.connection, marketplace, options.metricsCsv);

--- a/rewrite-javascript/rewrite/test/data-table.test.ts
+++ b/rewrite-javascript/rewrite/test/data-table.test.ts
@@ -18,7 +18,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import {ReplacedText} from "../fixtures/replaced-text";
-import {CsvDataTableStore, DATA_TABLE_STORE, ExecutionContext} from "../src";
+import {CsvDataTableStore, DataTable, DATA_TABLE_STORE, ExecutionContext, sanitizeScope} from "../src";
+import {SetDataTableStore} from "../src/rpc/request/set-data-table-store";
 
 describe("data tables", () => {
 
@@ -61,8 +62,8 @@ describe("data tables", () => {
         expect(lines[0]).toMatch(/^# @name /);
         expect(lines[1]).toMatch(/^# @instanceName /);
         expect(lines[2]).toMatch(/^# @group/);
-        // Header row
-        expect(lines[3]).toBe('Source Path,Text');
+        // Header row uses column names (matches the Java writer)
+        expect(lines[3]).toBe('sourcePath,text');
         // Data rows
         expect(lines[4]).toBe('src/foo.ts,old text');
         expect(lines[5]).toBe('src/bar.ts,another');
@@ -145,5 +146,96 @@ describe("data tables", () => {
 
         const store = new CsvDataTableStore(nestedDir);
         expect(fs.existsSync(nestedDir)).toBe(true);
+    });
+
+    test("SetDataTableStore reconstructs a CSV store that writes prefix columns", () => {
+        const store = SetDataTableStore.toDataTableStore({
+            kind: "CSV",
+            outputDir: tmpDir,
+            prefixColumns: {repositoryOrigin: "github.com/acme/example"},
+            suffixColumns: {},
+        });
+        expect(store).toBeInstanceOf(CsvDataTableStore);
+
+        const ctx = new ExecutionContext();
+        ctx.messages[DATA_TABLE_STORE] = store;
+        ReplacedText.dataTable.insertRow(ctx, new ReplacedText("src/foo.ts", "written"));
+
+        const fileKey = CsvDataTableStore.fileKey(ReplacedText.dataTable);
+        const csvPath = path.join(tmpDir, fileKey + ".csv");
+        expect(fs.existsSync(csvPath)).toBe(true);
+        const content = fs.readFileSync(csvPath, 'utf8');
+        expect(content).toContain('repositoryOrigin');
+        expect(content).toContain('github.com/acme/example,src/foo.ts,written');
+    });
+
+    test("SetDataTableStore NOOP does not write to disk", () => {
+        const store = SetDataTableStore.toDataTableStore({kind: "NOOP"});
+        expect(store).not.toBeInstanceOf(CsvDataTableStore);
+
+        const ctx = new ExecutionContext();
+        ctx.messages[DATA_TABLE_STORE] = store;
+        ReplacedText.dataTable.insertRow(ctx, new ReplacedText("src/foo.ts", "dropped"));
+
+        expect(fs.readdirSync(tmpDir).filter(f => f.endsWith(".csv"))).toHaveLength(0);
+    });
+
+    test("two stores share one file with a single header", () => {
+        const a = new CsvDataTableStore(tmpDir, {repositoryOrigin: "github.com/acme/x"});
+        const b = new CsvDataTableStore(tmpDir, {repositoryOrigin: "github.com/acme/x"});
+        const ctxA = new ExecutionContext(); ctxA.messages[DATA_TABLE_STORE] = a;
+        const ctxB = new ExecutionContext(); ctxB.messages[DATA_TABLE_STORE] = b;
+
+        ReplacedText.dataTable.insertRow(ctxA, new ReplacedText("a.ts", "A"));
+        ReplacedText.dataTable.insertRow(ctxB, new ReplacedText("b.ts", "B"));
+
+        const fileKey = CsvDataTableStore.fileKey(ReplacedText.dataTable);
+        const content = fs.readFileSync(path.join(tmpDir, fileKey + ".csv"), 'utf8');
+        const headerLines = content.split('\n').filter(l => l.startsWith('repositoryOrigin,'));
+        expect(headerLines).toHaveLength(1);
+        expect(content).toContain('a.ts');
+        expect(content).toContain('b.ts');
+    });
+
+    // fileKey must match the Java host byte-for-byte, or a shared table resolves to two files.
+    describe("fileKey matches the Java host", () => {
+
+        test("default table (no group, instanceName == displayName) -> bare FQN", () => {
+            const dt = new DataTable("org.openrewrite.table.TextMatches", "Text matches", "Text matches.", {});
+            expect(CsvDataTableStore.fileKey(dt)).toBe("org.openrewrite.table.TextMatches");
+        });
+
+        test("the ReplacedText default table -> bare FQN (no '--' suffix)", () => {
+            const key = CsvDataTableStore.fileKey(ReplacedText.dataTable);
+            expect(key).toBe("org.openrewrite.text.replaced-text");
+            expect(key).not.toContain("--");
+        });
+
+        test("custom instanceName -> <name>--<sanitize(instanceName)>", () => {
+            const dt = new DataTable("org.openrewrite.table.TextMatches", "Text matches", "Text matches.", {});
+            dt.instanceName = "My custom instance";
+            expect(CsvDataTableStore.fileKey(dt)).toBe("org.openrewrite.table.TextMatches--my-custom-instance-36f3");
+            expect(CsvDataTableStore.fileKey(dt))
+                .toBe(`org.openrewrite.table.TextMatches--${sanitizeScope("My custom instance")}`);
+        });
+
+        test("group -> <name>--<sanitize(group)>", () => {
+            const dt = new DataTable("org.openrewrite.table.TextMatches", "Text matches", "Text matches.", {});
+            dt.group = "acme.shared";
+            expect(CsvDataTableStore.fileKey(dt)).toBe("org.openrewrite.table.TextMatches--acme-shared-eb95");
+        });
+
+        test("group equal to the name -> bare FQN", () => {
+            const dt = new DataTable("org.openrewrite.table.TextMatches", "Text matches", "Text matches.", {});
+            dt.group = "org.openrewrite.table.TextMatches";
+            expect(CsvDataTableStore.fileKey(dt)).toBe("org.openrewrite.table.TextMatches");
+        });
+
+        test("long group -> truncated at last dash + hash", () => {
+            const dt = new DataTable("org.openrewrite.table.TextMatches", "Text matches", "Text matches.", {});
+            dt.group = "Group with a really really long descriptive name here";
+            expect(CsvDataTableStore.fileKey(dt))
+                .toBe("org.openrewrite.table.TextMatches--group-with-a-really-really-e49b");
+        });
     });
 });

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -271,6 +271,8 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
 
         private @Nullable Path workingDirectory;
 
+        private @Nullable DataTableStore dataTableStore;
+
         public Builder marketplace(RecipeMarketplace marketplace) {
             this.marketplace = marketplace;
             return this;
@@ -399,6 +401,15 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
             return this;
         }
 
+        /**
+         * Where recipes in the JavaScript runtime write data table rows, conveyed via the
+         * {@link org.openrewrite.rpc.request.SetDataTableStore} handshake.
+         */
+        public Builder dataTableStore(@Nullable DataTableStore dataTableStore) {
+            this.dataTableStore = dataTableStore;
+            return this;
+        }
+
         @Override
         public JavaScriptRewriteRpc get() {
             Path npxPath = npxPathSupplier.get();
@@ -465,6 +476,7 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
                         String.join(" ", cmdArr), process.environment())
                         .livenessCheck(process::getLivenessCheck)
                         .timeout(timeout)
+                        .dataTableStore(dataTableStore)
                         .log(log == null ? null : new PrintStream(openLog(log)));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/rewrite-python/rewrite/src/rewrite/data_table.py
+++ b/rewrite-python/rewrite/src/rewrite/data_table.py
@@ -155,15 +155,19 @@ class _Bucket:
 
 class CsvDataTableStore(DataTableStore):
     """
-    Writes data table rows directly to CSV files (RFC 4180 format).
-
-    Each data table bucket is written to a separate CSV file named using
-    the data table's file-safe key.
+    Writes data table rows to raw CSV files (RFC 4180), one per file-safe key.
+    Prefix/suffix columns are static columns the host conveys so writers sharing a file agree on them.
     """
 
-    def __init__(self, output_dir: str):
+    def __init__(
+        self,
+        output_dir: str,
+        prefix_columns: Optional[Dict[str, str]] = None,
+        suffix_columns: Optional[Dict[str, str]] = None,
+    ):
         self._output_dir = output_dir
-        self._initialized_tables: set[str] = set()
+        self._prefix_columns: Dict[str, str] = dict(prefix_columns or {})
+        self._suffix_columns: Dict[str, str] = dict(suffix_columns or {})
         self._row_counts: Dict[str, int] = {}
         self._data_tables: Dict[str, DataTable] = {}
         os.makedirs(output_dir, exist_ok=True)
@@ -173,27 +177,33 @@ class CsvDataTableStore(DataTableStore):
     ) -> None:
         file_key = self._file_key(data_table)
         csv_path = os.path.join(self._output_dir, f"{file_key}.csv")
+        self._data_tables[file_key] = data_table
 
-        # Write metadata comments and header on first row
-        if file_key not in self._initialized_tables:
-            self._initialized_tables.add(file_key)
-            self._row_counts[file_key] = 0
-            self._data_tables[file_key] = data_table
-            descriptor = data_table.descriptor()
-            headers = [
-                self._escape_csv(col["displayName"]) for col in descriptor["columns"]
+        descriptor = data_table.descriptor()
+        columns = descriptor["columns"]
+
+        # Key the header on file existence (not in-memory state) so writers sharing a
+        # file emit it once; use column NAMES, not display names, to match the Java writer.
+        if not os.path.exists(csv_path):
+            header = [
+                self._escape_csv(name) for name in self._prefix_columns.keys()
+            ] + [
+                self._escape_csv(col["name"]) for col in columns
+            ] + [
+                self._escape_csv(name) for name in self._suffix_columns.keys()
             ]
             with open(csv_path, "w") as f:
                 f.write(f"# @name {data_table.name}\n")
                 f.write(f"# @instanceName {data_table.instance_name}\n")
                 f.write(f"# @group {data_table.group or ''}\n")
-                f.write(",".join(headers) + "\n")
+                f.write(",".join(header) + "\n")
 
-        # Write data row
-        descriptor = data_table.descriptor()
-        columns = descriptor["columns"]
         values = [
+            self._escape_csv(value) for value in self._prefix_columns.values()
+        ] + [
             self._escape_csv(getattr(row, col["name"], "")) for col in columns
+        ] + [
+            self._escape_csv(value) for value in self._suffix_columns.values()
         ]
         with open(csv_path, "a") as f:
             f.write(",".join(values) + "\n")
@@ -214,14 +224,21 @@ class CsvDataTableStore(DataTableStore):
     @property
     def table_names(self) -> List[str]:
         """Get the file-safe keys of all data tables that have been written to."""
-        return list(self._initialized_tables)
+        return list(self._data_tables.keys())
 
     @staticmethod
     def _file_key(data_table: DataTable) -> str:
-        suffix = data_table.group if data_table.group else data_table.instance_name
-        if suffix == data_table.name:
+        # Mirror org.openrewrite.CsvDataTableStore#fileKey exactly so a table shared
+        # by Java and Python recipes resolves to the same filename.
+        group = data_table.group
+        if group is not None:
+            if group == data_table.name:
+                return data_table.name
+            return f"{data_table.name}--{sanitize_scope(group)}"
+        instance_name = data_table.instance_name
+        if instance_name == data_table.display_name:
             return data_table.name
-        return f"{data_table.name}--{sanitize_scope(suffix)}"
+        return f"{data_table.name}--{sanitize_scope(instance_name)}"
 
     @staticmethod
     def _escape_csv(value: Any) -> str:

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1212,8 +1212,8 @@ _execution_contexts: Dict[str, Any] = {}
 _recipe_accumulators: Dict[str, Any] = {}
 # Phase tracking for recipes - maps recipe IDs to 'scan' or 'edit'
 _recipe_phases: Dict[str, str] = {}
-# Data table output directory - if set, data tables will be written to CSV files
-_data_table_output_dir: Optional[str] = None
+# Host-configured store (via SetDataTableStore); None means per-context in-memory default.
+_configured_data_table_store: Optional[Any] = None
 
 # Registry mapping fully-qualified visitor names to visitor classes.
 # Used to instantiate visitors by name when dispatched via RPC (e.g., auto-format).
@@ -1260,22 +1260,15 @@ def handle_prepare_recipe(params: dict) -> dict:
     4. Returning the descriptor and visitor info
 
     Args:
-        params: dict with 'id' (recipe name), optional 'options', and optional 'dataTableOutputDir'
+        params: dict with 'id' (recipe name) and optional 'options'
 
     Returns:
         dict with 'id', 'descriptor', 'editVisitor', and precondition info
     """
-    global _data_table_output_dir
-
     recipe_name = params.get('id')
     if recipe_name is None:
         raise ValueError("Recipe 'id' is required")
     options = params.get('options', {})
-
-    # Set up data table output directory if specified
-    if 'dataTableOutputDir' in params:
-        _data_table_output_dir = params['dataTableOutputDir']
-        logger.info(f"Data table output directory set to: {_data_table_output_dir}")
 
     logger.debug(f"PrepareRecipe: id={recipe_name}, options={options}")
 
@@ -1511,6 +1504,34 @@ def _find_prepared_id(recipe) -> Optional[str]:
     return None
 
 
+def handle_set_data_table_store(params: dict) -> bool:
+    """Install the host-configured store: ``CSV`` writes raw CSV at ``outputDir``, else in-memory."""
+    global _configured_data_table_store
+
+    from rewrite.data_table import CsvDataTableStore, InMemoryDataTableStore
+
+    kind = params.get('kind')
+    output_dir = params.get('outputDir')
+    if kind == 'CSV' and output_dir:
+        prefix_columns = params.get('prefixColumns') or {}
+        suffix_columns = params.get('suffixColumns') or {}
+        _configured_data_table_store = CsvDataTableStore(
+            output_dir, prefix_columns, suffix_columns)
+        logger.info(f"SetDataTableStore: CSV store at {output_dir}")
+    else:
+        _configured_data_table_store = InMemoryDataTableStore()
+        logger.info("SetDataTableStore: in-memory (NOOP) store")
+
+    return True
+
+
+def _install_data_table_store(ctx) -> None:
+    """Install the host-configured store on a recipe-run context (no-op when unconfigured)."""
+    if _configured_data_table_store is not None:
+        from rewrite.data_table import DATA_TABLE_STORE
+        ctx.put_message(DATA_TABLE_STORE, _configured_data_table_store)
+
+
 def handle_visit(params: dict) -> dict:
     """Handle a Visit RPC request.
 
@@ -1541,15 +1562,11 @@ def handle_visit(params: dict) -> dict:
     else:
         from rewrite import InMemoryExecutionContext
         ctx = InMemoryExecutionContext()
-        # Set up data table store if output directory is configured
-        if _data_table_output_dir:
-            from rewrite.data_table import CsvDataTableStore, DATA_TABLE_STORE
-            store = CsvDataTableStore(_data_table_output_dir)
-            store.accept_rows(True)
-            ctx.put_message(DATA_TABLE_STORE, store)
         if p_id:
             _execution_contexts[p_id] = ctx
             local_objects[p_id] = ctx
+
+    _install_data_table_store(ctx)
 
     # Always fetch the tree from Java to ensure we have the latest version.
     # Java may have modified the tree (e.g., via a Java-side recipe) since our last sync.
@@ -1619,14 +1636,11 @@ def handle_batch_visit(params: dict) -> dict:
     else:
         from rewrite import InMemoryExecutionContext
         ctx = InMemoryExecutionContext()
-        if _data_table_output_dir:
-            from rewrite.data_table import CsvDataTableStore, DATA_TABLE_STORE
-            store = CsvDataTableStore(_data_table_output_dir)
-            store.accept_rows(True)
-            ctx.put_message(DATA_TABLE_STORE, store)
         if p_id:
             _execution_contexts[p_id] = ctx
             local_objects[p_id] = ctx
+
+    _install_data_table_store(ctx)
 
     # Fetch tree once from Java
     tree = get_object_from_java(tree_id, source_file_type)
@@ -1811,15 +1825,11 @@ def handle_generate(params: dict) -> dict:
     else:
         from rewrite import InMemoryExecutionContext
         ctx = InMemoryExecutionContext()
-        # Set up data table store if output directory is configured
-        if _data_table_output_dir:
-            from rewrite.data_table import CsvDataTableStore, DATA_TABLE_STORE
-            store = CsvDataTableStore(_data_table_output_dir)
-            store.accept_rows(True)
-            ctx.put_message(DATA_TABLE_STORE, store)
         if p_id:
             _execution_contexts[p_id] = ctx
             local_objects[p_id] = ctx
+
+    _install_data_table_store(ctx)
 
     # Only scanning recipes can generate files
     from rewrite.recipe import ScanningRecipe
@@ -1859,6 +1869,7 @@ def handle_request(method: str, params: dict) -> Any:
         'InstallRecipes': handle_install_recipes,
         'GetMarketplace': handle_get_marketplace,
         'PrepareRecipe': handle_prepare_recipe,
+        'SetDataTableStore': handle_set_data_table_store,
         'Visit': handle_visit,
         'BatchVisit': handle_batch_visit,
         'Generate': handle_generate,

--- a/rewrite-python/rewrite/tests/test_data_table.py
+++ b/rewrite-python/rewrite/tests/test_data_table.py
@@ -27,6 +27,7 @@ from rewrite.data_table import (
     InMemoryDataTableStore,
     CsvDataTableStore,
     DATA_TABLE_STORE,
+    sanitize_scope,
 )
 
 
@@ -166,7 +167,8 @@ class TestCsvDataTableStore:
             assert lines[0].startswith("# @name ")
             assert lines[1].startswith("# @instanceName ")
             assert lines[2].startswith("# @group")
-            assert lines[3] == "Source Path,Text"
+            # Column NAMES, not display names (matches the Java writer).
+            assert lines[3] == "source_path,text"
             assert lines[4] == "src/foo.py,hello"
             assert lines[5] == "src/bar.py,world"
 
@@ -211,3 +213,181 @@ class TestCsvDataTableStore:
             file_key = store._file_key(table)
             assert store.row_counts[file_key] == 2
             assert file_key in store.table_names
+
+    def test_writes_prefix_and_suffix_columns(self):
+        """Prefix/suffix columns appear in the header and on every row."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = CsvDataTableStore(
+                tmpdir,
+                {"repositoryOrigin": "github.com/acme/example"},
+                {"organization": "acme"},
+            )
+            table = DataTable[SampleRow](
+                "org.openrewrite.test.TestTable",
+                "Test Table",
+                "A test data table.",
+                SampleRow,
+            )
+            ctx = InMemoryExecutionContext()
+
+            store.insert_row(table, ctx, SampleRow("src/foo.py", "written"))
+
+            file_key = store._file_key(table)
+            with open(os.path.join(tmpdir, file_key + ".csv")) as f:
+                content = f.read()
+
+            lines = content.strip().split("\n")
+            assert lines[3] == "repositoryOrigin,source_path,text,organization"
+            assert lines[4] == "github.com/acme/example,src/foo.py,written,acme"
+
+    def test_two_stores_share_one_file_with_single_header(self):
+        """Two writers share one file; the header is written once (keyed on file existence)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            a = CsvDataTableStore(tmpdir, {"repositoryOrigin": "github.com/acme/x"})
+            b = CsvDataTableStore(tmpdir, {"repositoryOrigin": "github.com/acme/x"})
+            table = DataTable[SampleRow](
+                "org.openrewrite.test.TestTable",
+                "Test Table",
+                "A test data table.",
+                SampleRow,
+            )
+            ctx = InMemoryExecutionContext()
+
+            a.insert_row(table, ctx, SampleRow("a.py", "A"))
+            b.insert_row(table, ctx, SampleRow("b.py", "B"))
+
+            file_key = a._file_key(table)
+            with open(os.path.join(tmpdir, file_key + ".csv")) as f:
+                content = f.read()
+
+            header_lines = [
+                line for line in content.split("\n")
+                if line.startswith("repositoryOrigin,")
+            ]
+            assert len(header_lines) == 1
+            assert "a.py" in content
+            assert "b.py" in content
+
+
+class TestFileKeyMatchesJava:
+    """File key must mirror org.openrewrite.CsvDataTableStore#fileKey so Java and Python recipes share a filename."""
+
+    def test_default_table_uses_bare_fully_qualified_name(self):
+        """A default table (instance_name == display_name) resolves to the bare FQN, not '<name>--<suffix>'."""
+        table = DataTable[SampleRow](
+            "org.openrewrite.table.TextMatches",
+            "Text matches",
+            "Text matches.",
+            SampleRow,
+        )
+        assert table.instance_name == table.display_name
+        assert CsvDataTableStore._file_key(table) == "org.openrewrite.table.TextMatches"
+
+    def test_custom_instance_name_appends_sanitized_suffix(self):
+        """A customized instance name gets a '--<sanitize(instanceName)>' suffix."""
+        table = DataTable[SampleRow](
+            "org.openrewrite.test.TestTable",
+            "Test Table",
+            "A test data table.",
+            SampleRow,
+        )
+        table.instance_name = "Custom Name"
+        # 'Custom Name' -> 'custom-name' + '-' + first 4 hex of sha256('Custom Name')
+        assert (
+            CsvDataTableStore._file_key(table)
+            == "org.openrewrite.test.TestTable--custom-name-3ee9"
+        )
+
+    def test_grouped_table_appends_sanitized_group(self):
+        """A grouped table keys off the group, which takes precedence over the instance name."""
+        table = DataTable[SampleRow](
+            "org.openrewrite.test.TestTable",
+            "Test Table",
+            "A test data table.",
+            SampleRow,
+        )
+        table.group = "org.openrewrite.table.SharedDeprecations"
+        table.instance_name = "Custom Name"
+        assert (
+            CsvDataTableStore._file_key(table)
+            == "org.openrewrite.test.TestTable--org-openrewrite-table-dca0"
+        )
+
+    def test_group_equal_to_name_uses_bare_name(self):
+        """When the group equals the table's own name, the bare name is returned (no suffix)."""
+        table = DataTable[SampleRow](
+            "org.openrewrite.test.TestTable",
+            "Test Table",
+            "A test data table.",
+            SampleRow,
+        )
+        table.group = "org.openrewrite.test.TestTable"
+        assert CsvDataTableStore._file_key(table) == "org.openrewrite.test.TestTable"
+
+    def test_sanitize_scope_is_byte_identical_to_java(self):
+        """sanitize() must be byte-identical to Java: truncate-to-30-at-last-dash + 4-hex sha256 of the original value."""
+        assert sanitize_scope("Custom Name") == "custom-name-3ee9"
+        assert (
+            sanitize_scope("org.openrewrite.table.SharedDeprecations")
+            == "org-openrewrite-table-dca0"
+        )
+        assert (
+            sanitize_scope(
+                "A very long custom instance name that exceeds thirty characters"
+            )
+            == "a-very-long-custom-instance-321f"
+        )
+
+
+class TestSetDataTableStoreHandler:
+    """Tests for the SetDataTableStore RPC handshake (only configuration is conveyed, not rows)."""
+
+    def test_reconstructs_csv_store_that_writes_prefix_columns(self):
+        from rewrite.rpc import server
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assert server.handle_set_data_table_store({
+                "kind": "CSV",
+                "outputDir": tmpdir,
+                "prefixColumns": {"repositoryOrigin": "github.com/acme/example"},
+                "suffixColumns": {},
+            }) is True
+
+            store = server._configured_data_table_store
+            assert isinstance(store, CsvDataTableStore)
+
+            table = DataTable[SampleRow](
+                "org.openrewrite.test.TestTable",
+                "Test Table",
+                "A test data table.",
+                SampleRow,
+            )
+            ctx = InMemoryExecutionContext()
+            store.insert_row(table, ctx, SampleRow("src/foo.py", "written"))
+
+            file_key = store._file_key(table)
+            with open(os.path.join(tmpdir, file_key + ".csv")) as f:
+                content = f.read()
+
+            assert "repositoryOrigin" in content
+            assert "github.com/acme/example,src/foo.py,written" in content
+
+    def test_noop_does_not_write_to_disk(self):
+        from rewrite.rpc import server
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assert server.handle_set_data_table_store({"kind": "NOOP"}) is True
+
+            store = server._configured_data_table_store
+            assert isinstance(store, InMemoryDataTableStore)
+
+            table = DataTable[SampleRow](
+                "org.openrewrite.test.TestTable",
+                "Test Table",
+                "A test data table.",
+                SampleRow,
+            )
+            ctx = InMemoryExecutionContext()
+            store.insert_row(table, ctx, SampleRow("src/foo.py", "dropped"))
+
+            assert [f for f in os.listdir(tmpdir) if f.endswith(".csv")] == []

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -444,6 +444,8 @@ public class PythonRewriteRpc extends RewriteRpc {
          */
         private String pythonVersion = "3";
 
+        private @Nullable DataTableStore dataTableStore;
+
         public Builder marketplace(RecipeMarketplace marketplace) {
             this.marketplace = marketplace;
             return this;
@@ -606,6 +608,15 @@ public class PythonRewriteRpc extends RewriteRpc {
             return this;
         }
 
+        /**
+         * Configures where recipes in the Python runtime write data table rows, conveyed via
+         * the {@link org.openrewrite.rpc.request.SetDataTableStore} handshake.
+         */
+        public Builder dataTableStore(@Nullable DataTableStore dataTableStore) {
+            this.dataTableStore = dataTableStore;
+            return this;
+        }
+
         @Override
         public PythonRewriteRpc get() {
             Path pythonPath = pythonPathSupplier.get();
@@ -735,6 +746,7 @@ public class PythonRewriteRpc extends RewriteRpc {
                         String.join(" ", cmdArr), process.environment())
                         .livenessCheck(process::getLivenessCheck)
                         .timeout(timeout)
+                        .dataTableStore(dataTableStore)
                         .log(log == null ? null : new PrintStream(Files.newOutputStream(log, StandardOpenOption.APPEND, StandardOpenOption.CREATE)));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);


### PR DESCRIPTION
## What

Lets the process that controls a recipe run (typically Java) decide **where recipes written in RPC languages — TypeScript, Python, Go, C# — write their data table rows**, via a new `SetDataTableStore` RPC handshake.

Only the data table store's *configuration* crosses the boundary; **individual rows never do**. The conveyable set is closed and mirrored in every runtime (`Csv` / `NoOp`), exactly the way `Print.MarkerPrinter` already works — a store that isn't conveyable simply leaves the remote on its per-context default. See [ADR 0008](doc/adr/0008-rpc-data-table-stores.md) for the rationale.

## How

- **`org.openrewrite.rpc.request.SetDataTableStore`** — a polymorphic wire form (`Csv` / `NoOp`, each carrying only the configuration it needs) plus a `from(DataTableStore)` / `toDataTableStore()` mapping that mirrors `Print.MarkerPrinter`. `RewriteRpc.dataTableStore(..)` sends it lazily before the first visit/generate; the server-side handler installs the reconstructed store on the per-run `ExecutionContext` as it is materialized for the recipe-running handlers (`Visit` / `BatchVisit` / `Generate`), so that concern stays inside `RewriteRpc` rather than leaking into the handlers.
- Each runtime reconstructs its own `CsvDataTableStore` and **appends raw CSV to one file per data table**, so a table written by *both* a Java recipe and an RPC recipe merges into a single file. Any compression or finalization of those files is the host's concern.
- **`fileKey()` aligned across all four runtimes** to match the Java host's scheme (bare fully-qualified name for a default table; `name--sanitize(group/instanceName)` otherwise, sanitize byte-identical incl. the sha256 suffix). The prior per-runtime divergence silently wrote *two separate files* for a shared table; a regression test was added in each runtime (the existing tests missed it because they used same-language stores with identical display names).
- C#: `Recipe`/`RecipeDescriptor` gained the missing `DataTables` declaration.

## Testing

Unit tests in every runtime (rewrite-core, JS/TS, Python, Go, C#) plus an in-process Java↔Java loopback test for the handshake. Verified **live end-to-end through a controlling host** for all four RPC languages, both cases:
- **shared** — a runtime recipe and Java `org.openrewrite.text.Find` both write `org.openrewrite.table.TextMatches` → one shared file, a single header, rows from both sides;
- **unique** — each runtime writes its own table → a bare-FQN file (confirming the fileKey fix live).

Framework data tables (`SourcesFileResults`, `RecipeRunStats`, …) remain host-only and correct.

## Note

The host-side wiring that configures these stores (output directory and any finalization of the written files) lives in the controlling host and ships separately.
