### PR TITLE
npm: per-bundle recipe attribution and whole-tree PrepareRecipe

### DIFF
--- a/rewrite-javascript/rewrite/fixtures/composite-with-invalid-child.ts
+++ b/rewrite-javascript/rewrite/fixtures/composite-with-invalid-child.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Recipe} from "@openrewrite/rewrite";
+import {ChangeText} from "./change-text";
+
+/**
+ * A composite whose recipeList contains a child left without its required `text` option. Used to
+ * verify that PrepareRecipe validates required options recursively through the whole tree, so a
+ * broken child is rejected rather than silently prepared.
+ */
+export class CompositeWithInvalidChild extends Recipe {
+    name = "org.openrewrite.example.text.composite-with-invalid-child";
+    displayName = "Composite with an invalid child";
+    description = "A composite whose child is missing a required option.";
+
+    async recipeList(): Promise<Recipe[]> {
+        return [new ChangeText({} as { text: string })];
+    }
+}

--- a/rewrite-javascript/rewrite/fixtures/example-recipe.ts
+++ b/rewrite-javascript/rewrite/fixtures/example-recipe.ts
@@ -30,6 +30,7 @@ import {ScanningEditor} from "./scanning-editor";
 import {ReplaceAssignment} from "./replace-assignment";
 import {JavaChangeMethodName} from "./java-change-method-name";
 import {CrossModuleRecipeList} from "./cross-module-recipe-list";
+import {CompositeWithInvalidChild} from "./composite-with-invalid-child";
 
 export async function activate(marketplace: RecipeMarketplace): Promise<void> {
     await marketplace.install(ChangeText, JavaScript);
@@ -48,4 +49,5 @@ export async function activate(marketplace: RecipeMarketplace): Promise<void> {
     await marketplace.install(ReplaceAssignment, JavaScript);
     await marketplace.install(JavaChangeMethodName, JavaScript);
     await marketplace.install(CrossModuleRecipeList, JavaScript);
+    await marketplace.install(CompositeWithInvalidChild, JavaScript);
 }

--- a/rewrite-javascript/rewrite/src/rpc/request/get-marketplace.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/get-marketplace.ts
@@ -21,6 +21,12 @@ import {RecipeDescriptor} from "../../recipe";
 export interface GetMarketplaceResponseRow {
     readonly descriptor: RecipeDescriptor
     readonly categoryPaths: CategoryDescriptor[][]
+    /**
+     * The package this recipe was contributed by, recorded at install time. Lets the host attribute
+     * each row to its own bundle instead of force-tagging every row with the one requested bundle.
+     * Undefined for recipes installed from a local path (no package identity).
+     */
+    readonly packageName?: string
 }
 
 /**
@@ -38,7 +44,8 @@ export async function toMarketplace(rows: GetMarketplaceResponseRow[]): Promise<
 }
 
 export class GetMarketplace {
-    static handle(connection: rpc.MessageConnection, marketplace: RecipeMarketplace, metricsCsv?: string): void {
+    static handle(connection: rpc.MessageConnection, marketplace: RecipeMarketplace,
+                  recipeOrigin: Map<string, string>, metricsCsv?: string): void {
         connection.onRequest(
             new rpc.RequestType0<GetMarketplaceResponseRow[], Error>("GetMarketplace"),
             withMetrics0<GetMarketplaceResponseRow[]>(
@@ -46,7 +53,7 @@ export class GetMarketplace {
                 metricsCsv,
                 (context) => async () => {
                     // Group recipes by name, collecting all category paths for each
-                    const rowByRecipeId = new Map<string, { descriptor: RecipeDescriptor, categoryPaths: CategoryDescriptor[][] }>();
+                    const rowByRecipeId = new Map<string, { descriptor: RecipeDescriptor, categoryPaths: CategoryDescriptor[][], packageName?: string }>();
 
                     function collectRecipes(category: RecipeMarketplace.Category, categoryPath: CategoryDescriptor[]): void {
                         const currentPath = [...categoryPath, category.descriptor];
@@ -59,7 +66,8 @@ export class GetMarketplace {
                             } else {
                                 rowByRecipeId.set(recipe.name, {
                                     descriptor: recipe,
-                                    categoryPaths: [currentPath]
+                                    categoryPaths: [currentPath],
+                                    packageName: recipeOrigin.get(recipe.name)
                                 });
                             }
                         }

--- a/rewrite-javascript/rewrite/src/rpc/request/install-recipes.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/install-recipes.ts
@@ -72,7 +72,7 @@ export class InstallRecipes {
     }
 
     static handle(connection: rpc.MessageConnection, installDir: string, marketplace: RecipeMarketplace,
-                  logger?: rpc.Logger, metricsCsv?: string): void {
+                  recipeOrigin: Map<string, string>, logger?: rpc.Logger, metricsCsv?: string): void {
         connection.onRequest(
             new rpc.RequestType<InstallRecipes, InstallRecipesResponse, Error>("InstallRecipes"),
             withMetrics<InstallRecipes, InstallRecipesResponse>(
@@ -80,7 +80,7 @@ export class InstallRecipes {
                 metricsCsv,
                 (context) => async (request) => {
                     context.target = typeof request.recipes === "object" ? request.recipes.packageName : request.recipes;
-                    const beforeInstall = marketplace.allRecipes().length;
+                    const beforeNames = new Set(marketplace.allRecipes().map(r => r.name));
                     let resolvedPath;
                     let recipesName = request.recipes;
 
@@ -150,8 +150,21 @@ export class InstallRecipes {
                         throw new Error(`${recipesName} does not export an 'activate' function`);
                     }
 
+                    // Attribute the recipes this install contributed to their package, so GetMarketplace
+                    // can tag each row with its origin and the host can bind it to the right bundle.
+                    // Local-path installs have no package identity, so they stay unattributed and fall
+                    // back to the requested bundle on the host.
+                    if (typeof request.recipes === "object") {
+                        const packageName = request.recipes.packageName;
+                        for (const recipe of marketplace.allRecipes()) {
+                            if (!beforeNames.has(recipe.name)) {
+                                recipeOrigin.set(recipe.name, packageName);
+                            }
+                        }
+                    }
+
                     return {
-                        recipesInstalled: marketplace.allRecipes().length - beforeInstall,
+                        recipesInstalled: marketplace.allRecipes().length - beforeNames.size,
                         version: installedVersion
                     };
                 }

--- a/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
@@ -40,18 +40,13 @@ export class PrepareRecipe {
                 metricsCsv,
                 (context) => async (request) => {
                     context.target = request.id;
-                    const id = snowflake.generate();
                     const recipeCtor = marketplace.findRecipe(request.id);
                     if (!recipeCtor) {
-                        // The host re-prepares every sub-recipe of a composite by id while
-                        // building RpcRecipe.getRecipeList(). A sub-recipe that delegates to a
-                        // Java recipe (e.g. org.openrewrite.javascript.UpgradeDependencyVersion,
-                        // produced by upgradeDependencyVersion() -> prepareJavaRecipe) is an
-                        // RpcRecipe that installSubRecipes deliberately did not register here: it
-                        // has no no-arg constructor and is hosted on the peer. A miss therefore
-                        // means the host owns this recipe, so tell it to resolve the id locally
-                        // (the Java recipe is on the host's classpath) via delegatesTo, rather
-                        // than failing with "Could not find recipe with id ...".
+                        // A miss means the host owns this recipe (e.g. a sub-recipe that delegates to
+                        // a Java recipe, produced by prepareJavaRecipe — an RpcRecipe hosted on the peer
+                        // with no no-arg constructor to register here). Tell the host to resolve the id
+                        // locally via delegatesTo rather than failing with "Could not find recipe ...".
+                        const id = snowflake.generate();
                         return {
                             id: id,
                             descriptor: PrepareRecipe.delegateDescriptor(request.id),
@@ -67,35 +62,8 @@ export class PrepareRecipe {
                     if (!recipeCtor[1]) {
                         throw new Error(`Recipe ${request.id} was installed without a constructor`);
                     }
-                    let recipe = new recipeCtor[1](request.options);
-
-                    const editPreconditions: Precondition[] = [];
-                    recipe = await this.optimizePreconditions(recipe, "edit", editPreconditions);
-
-                    const scanPreconditions: Precondition[] = [];
-                    recipe = await this.optimizePreconditions(recipe, "scan", scanPreconditions);
-
-                    preparedRecipes.set(id, recipe);
-
-                    await this.installSubRecipes(recipe, marketplace);
-
-                    const result: PrepareRecipeResponse = {
-                        id: id,
-                        descriptor: await recipe.descriptor(),
-                        editVisitor: `edit:${id}`,
-                        editPreconditions: editPreconditions,
-                        scanVisitor: recipe instanceof ScanningRecipe ? `scan:${id}` : undefined,
-                        scanPreconditions: scanPreconditions
-                    };
-
-                    if ('javaRecipeName' in recipe) {
-                        result.delegatesTo = {
-                            recipeName: (recipe as any).javaRecipeName,
-                            options: (recipe as any).delegatesToOptions ?? {}
-                        };
-                    }
-
-                    return result;
+                    return await PrepareRecipe.prepareInstance(new recipeCtor[1](request.options),
+                        snowflake, preparedRecipes, marketplace);
                 }
             )
         );
@@ -124,19 +92,91 @@ export class PrepareRecipe {
         };
     }
 
-    private static async installSubRecipes(recipe: Recipe, marketplace: RecipeMarketplace) {
-        for (const subRecipe of await recipe.recipeList()) {
-            // An RpcRecipe is a proxy for a recipe already prepared on a remote
-            // peer; it has no no-arg constructor to install and its sub-recipes
-            // live remotely, so there is nothing to register locally.
-            if (subRecipe instanceof RpcRecipe) {
-                continue;
-            }
-            if (!marketplace.findRecipe(subRecipe.name)) {
-                await marketplace.install(subRecipe.constructor as any, []);
-                await this.installSubRecipes(subRecipe, marketplace);
+    /**
+     * Prepares a recipe instance and recursively its whole child tree, registering every node in
+     * {@code preparedRecipes} and returning the prepared response with {@code recipeList} populated,
+     * so the host builds the tree locally instead of a PrepareRecipe round-trip per child.
+     *
+     * Mirrors the C# server's PrepareInstance. Required options are validated as each node is
+     * prepared (covering the whole tree). A child hosted on the peer (an {@link RpcRecipe}, e.g. from
+     * prepareJavaRecipe) carries only {@code delegatesTo} for the host to resolve locally; every other
+     * child carries its own {@code recipeList}. Delegating recipes forward validation to the recipe
+     * they delegate to, so they are not validated here.
+     */
+    private static async prepareInstance(recipe: Recipe,
+                                         snowflake: ReturnType<typeof SnowflakeId>,
+                                         preparedRecipes: Map<String, Recipe>,
+                                         marketplace: RecipeMarketplace): Promise<PrepareRecipeResponse> {
+        const id = snowflake.generate();
+
+        const editPreconditions: Precondition[] = [];
+        recipe = await PrepareRecipe.optimizePreconditions(recipe, "edit", editPreconditions);
+        const scanPreconditions: Precondition[] = [];
+        recipe = await PrepareRecipe.optimizePreconditions(recipe, "scan", scanPreconditions);
+
+        preparedRecipes.set(id, recipe);
+
+        const descriptor = await recipe.descriptor();
+        const isDelegating = 'javaRecipeName' in recipe;
+
+        if (!isDelegating) {
+            for (const option of descriptor.options) {
+                if ((option.required ?? true) && option.value == null) {
+                    throw new Error(`Missing required option \`${option.name}\` for recipe \`${descriptor.name}\`.`);
+                }
             }
         }
+
+        const response: PrepareRecipeResponse = {
+            id: id,
+            descriptor: descriptor,
+            editVisitor: `edit:${id}`,
+            editPreconditions: editPreconditions,
+            scanVisitor: recipe instanceof ScanningRecipe ? `scan:${id}` : undefined,
+            scanPreconditions: scanPreconditions
+        };
+
+        if (isDelegating) {
+            response.delegatesTo = {
+                recipeName: (recipe as any).javaRecipeName,
+                options: (recipe as any).delegatesToOptions ?? {}
+            };
+            return response;
+        }
+
+        const childResponses: PrepareRecipeResponse[] = [];
+        for (const child of await recipe.recipeList()) {
+            if (child instanceof RpcRecipe) {
+                // Hosted on the peer: emit delegatesTo (its name + the options its parent set) so the
+                // host resolves it locally, matching how the by-name fallback used to resolve it.
+                const childId = snowflake.generate();
+                const childDescriptor = await child.descriptor();
+                const options: Record<string, any> = {};
+                for (const option of childDescriptor.options) {
+                    if (option.value != null) {
+                        options[option.name] = option.value;
+                    }
+                }
+                childResponses.push({
+                    id: childId,
+                    descriptor: PrepareRecipe.delegateDescriptor(child.name),
+                    editVisitor: `edit:${childId}`,
+                    editPreconditions: [],
+                    scanPreconditions: [],
+                    delegatesTo: {recipeName: child.name, options}
+                });
+            } else {
+                // Register a child that was instantiated in recipeList() but never installed, so a peer
+                // that re-prepares children by name (rather than consuming recipeList) can still find it.
+                if (!marketplace.findRecipe(child.name)) {
+                    await marketplace.install(child.constructor as any, []);
+                }
+                childResponses.push(await PrepareRecipe.prepareInstance(child, snowflake, preparedRecipes, marketplace));
+            }
+        }
+        response.recipeList = childResponses;
+
+        return response;
     }
 
     /**
@@ -266,6 +306,11 @@ export interface PrepareRecipeResponse {
     scanVisitor?: string
     scanPreconditions: Precondition[]
     delegatesTo?: DelegatesTo
+    /**
+     * The prepared child recipes of a composite. When present, the host builds the recipe tree
+     * locally from these instead of re-preparing each child by name (the whole-tree optimization).
+     */
+    recipeList?: PrepareRecipeResponse[]
 }
 
 /**

--- a/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
+++ b/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
@@ -105,6 +105,9 @@ export class RewriteRpc {
         const dataTableStore = () => this.configuredDataTableStore;
 
         const marketplace = options.marketplace || new RecipeMarketplace();
+        // Recipe name -> the package that contributed it, recorded during InstallRecipes and read when
+        // GetMarketplace builds rows so the host can attribute each recipe to its own bundle.
+        const recipeOrigin: Map<string, string> = new Map();
 
         Visit.handle(this.connection, this.localObjects, preparedRecipes, recipeCursors, getObject, getCursor, dataTableStore, options.metricsCsv);
         BatchVisit.handle(this.connection, this.localObjects, preparedRecipes, recipeCursors, getObject, getCursor, dataTableStore, options.metricsCsv);
@@ -112,13 +115,13 @@ export class RewriteRpc {
         SetDataTableStore.handle(this.connection, store => this.configuredDataTableStore = store, options.metricsCsv);
         GetObject.handle(this.connection, this.remoteObjects, this.localObjects,
             this.localRefs, options?.batchSize || 1000, traceGetObject, options.metricsCsv);
-        GetMarketplace.handle(this.connection, marketplace, options.metricsCsv);
+        GetMarketplace.handle(this.connection, marketplace, recipeOrigin, options.metricsCsv);
         GetLanguages.handle(this.connection, options.metricsCsv);
         PrepareRecipe.handle(this.connection, marketplace, preparedRecipes, options.metricsCsv);
         Parse.handle(this.connection, this.localObjects, options.metricsCsv);
         ParseProject.handle(this.connection, this.localObjects, options.metricsCsv);
         Print.handle(this.connection, getObject, options.logger, options.metricsCsv);
-        InstallRecipes.handle(this.connection, options.recipeInstallDir ?? ".rewrite", marketplace, options.logger, options.metricsCsv);
+        InstallRecipes.handle(this.connection, options.recipeInstallDir ?? ".rewrite", marketplace, recipeOrigin, options.logger, options.metricsCsv);
 
         this.connection.onRequest(
             new rpc.RequestType<TraceGetObject, boolean, Error>("TraceGetObject"),

--- a/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
@@ -18,12 +18,14 @@ import * as fs from "fs";
 import * as path from "path";
 import {RecipeMarketplace} from "../../src";
 import {InstallRecipes, InstallRecipesResponse} from "../../src/rpc/request/install-recipes";
+import {GetMarketplace, GetMarketplaceResponseRow} from "../../src/rpc/request/get-marketplace";
 
 describe("InstallRecipes", () => {
 
     type RequestHandler = (request: InstallRecipes) => Promise<InstallRecipesResponse>;
 
-    function captureHandler(installDir: string, marketplace: RecipeMarketplace): RequestHandler {
+    function captureHandler(installDir: string, marketplace: RecipeMarketplace,
+                            recipeOrigin: Map<string, string> = new Map()): RequestHandler {
         let capturedHandler: RequestHandler | undefined;
 
         const dummyConnection = {
@@ -32,13 +34,32 @@ describe("InstallRecipes", () => {
             }
         } as any;
 
-        InstallRecipes.handle(dummyConnection, installDir, marketplace);
+        InstallRecipes.handle(dummyConnection, installDir, marketplace, recipeOrigin);
 
         if (!capturedHandler) {
             throw new Error("Handler was not registered");
         }
 
         return capturedHandler;
+    }
+
+    function captureGetMarketplace(marketplace: RecipeMarketplace,
+                                   recipeOrigin: Map<string, string>): () => Promise<GetMarketplaceResponseRow[]> {
+        let capturedHandler: ((token?: any) => Promise<GetMarketplaceResponseRow[]>) | undefined;
+
+        const dummyConnection = {
+            onRequest: (_requestType: any, handler: any) => {
+                capturedHandler = handler;
+            }
+        } as any;
+
+        GetMarketplace.handle(dummyConnection, marketplace, recipeOrigin);
+
+        if (!capturedHandler) {
+            throw new Error("GetMarketplace handler was not registered");
+        }
+
+        return () => capturedHandler!();
     }
 
     describe("local file path installation", () => {
@@ -284,6 +305,93 @@ describe("InstallRecipes", () => {
                 expect(match).not.toBeNull();
                 const minorVersion = parseInt(match![2], 10);
                 expect(minorVersion).toBeGreaterThan(36);
+            }, {unsafeCleanup: true});
+        }, 120000);
+    });
+
+    describe("recipe attribution", () => {
+
+        test("does not attribute recipes installed from a local path", async () => {
+            await withDir(async (dir) => {
+                const recipeModulePath = path.join(dir.path, "local-recipe.js");
+                fs.writeFileSync(recipeModulePath, `
+                    module.exports = {
+                        activate: async function(marketplace) {
+                            await marketplace.install(
+                                class LocalRecipe {
+                                    async descriptor() {
+                                        return { name: "local.recipe", displayName: "Local", description: "" };
+                                    }
+                                },
+                                [{displayName: "Local"}]
+                            );
+                        }
+                    };
+                `);
+
+                const installDir = path.join(dir.path, "recipes");
+                const marketplace = new RecipeMarketplace();
+                const recipeOrigin = new Map<string, string>();
+                const handler = captureHandler(installDir, marketplace, recipeOrigin);
+
+                await handler({recipes: recipeModulePath} as any);
+
+                expect(marketplace.allRecipes().length).toBe(1);
+                // A local-path install has no package identity, so it stays unattributed and falls
+                // back to the requested bundle on the host.
+                expect(recipeOrigin.size).toBe(0);
+            }, {unsafeCleanup: true});
+        });
+
+        test("GetMarketplace tags each row with its recipe's origin package", async () => {
+            await withDir(async (dir) => {
+                const recipeModulePath = path.join(dir.path, "row-recipe.js");
+                fs.writeFileSync(recipeModulePath, `
+                    module.exports = {
+                        activate: async function(marketplace) {
+                            await marketplace.install(
+                                class RowRecipe {
+                                    async descriptor() {
+                                        return { name: "row.recipe", displayName: "Row", description: "" };
+                                    }
+                                },
+                                [{displayName: "Row"}]
+                            );
+                        }
+                    };
+                `);
+
+                const installDir = path.join(dir.path, "recipes");
+                const marketplace = new RecipeMarketplace();
+                const recipeOrigin = new Map<string, string>();
+                const install = captureHandler(installDir, marketplace, recipeOrigin);
+                await install({recipes: recipeModulePath} as any);
+
+                // Stand in for the attribution InstallRecipes records for a package install.
+                recipeOrigin.set("row.recipe", "@example/recipes");
+
+                const getMarketplace = captureGetMarketplace(marketplace, recipeOrigin);
+                const rows = await getMarketplace();
+
+                const row = rows.find(r => r.descriptor.name === "row.recipe");
+                expect(row).toBeDefined();
+                expect(row!.packageName).toBe("@example/recipes");
+            }, {unsafeCleanup: true});
+        });
+
+        test("attributes npm-installed recipes to their package", async () => {
+            await withDir(async (dir) => {
+                const installDir = path.join(dir.path, "recipes");
+                const marketplace = new RecipeMarketplace();
+                const recipeOrigin = new Map<string, string>();
+                const handler = captureHandler(installDir, marketplace, recipeOrigin);
+
+                await handler({recipes: {packageName: "@openrewrite/recipes-nodejs"}} as any);
+
+                expect(recipeOrigin.size).toBeGreaterThan(0);
+                for (const recipe of marketplace.allRecipes()) {
+                    expect(recipeOrigin.get(recipe.name)).toBe("@openrewrite/recipes-nodejs");
+                }
             }, {unsafeCleanup: true});
         }, 120000);
     });

--- a/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
@@ -140,6 +140,20 @@ describe("Rewrite RPC", () => {
         expect(recipe.instanceName()).toEqual("Change text to 'hello'");
     });
 
+    test("prepareRecipe rejects a missing required option", async () => {
+        // The server validates required options when preparing a recipe. `text` is required, so
+        // omitting it must fail rather than silently preparing a broken recipe.
+        await expect(client.prepareRecipe("org.openrewrite.example.text.change-text", {}))
+            .rejects.toThrow("Missing required option `text`");
+    });
+
+    test("prepareRecipe validates required options of child recipes", async () => {
+        // The composite's child ChangeText is missing its required `text`. Validation recurses through
+        // the whole prepared tree (like the C# server), so preparing the composite must fail.
+        await expect(client.prepareRecipe("org.openrewrite.example.text.composite-with-invalid-child"))
+            .rejects.toThrow("Missing required option `text`");
+    });
+
     // TODO: Re-enable once @openrewrite/recipes-npm is updated to use RecipeMarketplace API
     test.skip("installRecipes", async () => {
         const installed = await client.installRecipes(


### PR DESCRIPTION
## What

Brings the npm (JavaScript) RPC recipe server to parity with the C# server on two fronts.

### Per-bundle recipe attribution (GetMarketplace)

The JS server returned origin-less `GetMarketplace` rows, so the host's `toMarketplace` tagged every recipe with the single requested bundle — over-attributing recipes contributed by other packages. `InstallRecipes` now records each recipe's origin package (the recipes a package's `activate` adds, via a before/after delta) and `GetMarketplace` emits it as `packageName` on each row, so the host attributes each recipe to its own bundle. Local-path installs have no package identity and stay unattributed (the host falls back to the requested bundle). The shared `Row.packageName` field and `toMarketplace` filter already exist on the host, so there is no host change.

### Whole-tree (one-shot) PrepareRecipe + recursive validation

`PrepareRecipe` now prepares the whole recipe tree in one call and returns it as `recipeList` (the child prepared responses), mirroring the C# server, so the host builds the tree locally instead of a `PrepareRecipe` round-trip per child. Required-option validation lives in that recursion, so it covers the whole tree — each node is validated against the values its parent set, not just the root. A cross-ecosystem child (an `RpcRecipe`, e.g. from `prepareJavaRecipe`) is emitted as `delegatesTo` for the host to resolve locally; the rest are prepared and validated recursively.

## Testing

- `rewrite-rpc.test.ts`: full prepare/run suite green — composites, cross-ecosystem (`composite-with-java-delegate`), cross-module recipe lists, and a new `composite-with-invalid-child` asserting a child's missing required option is rejected.
- `install-recipes.test.ts`: new attribution tests — real npm-package capture, local-path no-attribution, and the GetMarketplace `packageName` emit.
- `npm run typecheck` clean.
