### PR TITLE
python: per-bundle recipe attribution and whole-tree PrepareRecipe

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/discovery.py
+++ b/rewrite-python/rewrite/src/rewrite/discovery.py
@@ -51,6 +51,10 @@ class RecipeAttribution:
 
     def __init__(self) -> None:
         self._by_package: Dict[NormalizedDistName, Set[RecipeName]] = {}
+        # recipe name -> the distribution name as recorded (first attribution wins).
+        # Kept un-normalized so a GetMarketplace row carries the package spelling the
+        # host installed, which is what its bundle filter matches against.
+        self._by_recipe: Dict[RecipeName, str] = {}
 
     def record(self, distribution_name: str, recipe_names: Set[RecipeName]) -> None:
         """Attribute ``recipe_names`` to ``distribution_name``.
@@ -62,6 +66,8 @@ class RecipeAttribution:
             return
         key = _normalize_package_name(distribution_name)
         self._by_package.setdefault(key, set()).update(recipe_names)
+        for recipe_name in recipe_names:
+            self._by_recipe.setdefault(recipe_name, distribution_name)
 
     def recipes_for(self, distribution_name: str) -> Set[RecipeName]:
         """Return the (possibly empty) set of recipe names attributed to a
@@ -69,6 +75,13 @@ class RecipeAttribution:
         change the attribution.
         """
         return set(self._by_package.get(_normalize_package_name(distribution_name), ()))
+
+    def package_for(self, recipe_name: RecipeName) -> Optional[str]:
+        """Return the distribution that contributed ``recipe_name`` (the spelling
+        it was recorded with), or None if the recipe wasn't attributed. Used to tag
+        each GetMarketplace row with its origin so the host attributes it to the
+        right bundle instead of the single requested one."""
+        return self._by_recipe.get(recipe_name)
 
 
 def discover_recipes(

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -874,23 +874,10 @@ def handle_install_recipes(params: dict) -> dict:
     else:
         raise ValueError(f"Invalid recipes parameter: {recipes}")
 
-    package_rows: List[dict] = []
-    if package_name:
-        # recipes_for returns an empty set (not None) when the package activated
-        # nothing, so the filter scopes the result to "this package's recipes"
-        # (zero of them) instead of falling back to "no filter" and returning
-        # everything.
-        package_rows = _collect_marketplace_rows(
-            marketplace, recipe_filter=_attribution.recipes_for(package_name)
-        )
-
-    logger.info(
-        f"InstallRecipes: {recipes_added} new, {len(package_rows)} cumulative for {package_name}"
-    )
+    logger.info(f"InstallRecipes: {recipes_added} new for {package_name}")
     return {
         'recipesInstalled': recipes_added,
         'version': installed_version,
-        'recipes': package_rows,
     }
 
 
@@ -1101,7 +1088,8 @@ def _collect_marketplace_rows(
             else:
                 rows.append({
                     'descriptor': _recipe_descriptor_to_dict(recipe_desc),
-                    'categoryPaths': [current_path]
+                    'categoryPaths': [current_path],
+                    'packageName': _attribution.package_for(recipe_desc.name),
                 })
 
         for subcategory in category.categories:

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1219,23 +1219,99 @@ def _get_visitor_registry() -> Dict[str, type]:
     return _VISITOR_REGISTRY
 
 
-def _install_sub_recipes(recipe, marketplace) -> None:
-    """Ensure sub-recipes from recipe_list() are registered in the marketplace."""
+def _prepare_instance(recipe, marketplace) -> dict:
+    """Prepare a recipe instance and, recursively, its whole child tree — storing every node in
+    _prepared_recipes and returning the response with ``recipeList`` populated, so the host builds
+    the tree locally instead of a PrepareRecipe round trip per child.
+
+    Mirrors the C# and JS servers. Required options are validated as each node is prepared, which
+    covers the whole tree (the root against the caller's options and each child against the values
+    its parent set). A child hosted on the peer (an RpcRecipe) carries only ``delegatesTo`` for the
+    host to resolve; every other child carries its own ``recipeList``. Delegating recipes forward
+    validation to the recipe they delegate to, so they are not validated here.
+    """
+    from rewrite.recipe import ScanningRecipe
     from rewrite.rpc.rpc_recipe import RpcRecipe
 
-    for sub_recipe in recipe.recipe_list():
-        if isinstance(sub_recipe, RpcRecipe):
-            # An RpcRecipe is a reference to a recipe on another peer, with no
-            # Python implementation and no no-arg constructor, so it can't be
-            # installed in the marketplace. Register it so a later PrepareRecipe
-            # round-trip for its id resolves to it (and answers with
-            # delegatesTo). It has no sub-recipes of its own, so there is nothing
-            # to recurse into.
-            _delegating_recipes[sub_recipe.java_recipe_name] = sub_recipe
-            continue
-        if not marketplace.find_recipe(sub_recipe.name):
-            marketplace.install(type(sub_recipe), [])
-            _install_sub_recipes(sub_recipe, marketplace)
+    prepared_id = generate_id()
+    _prepared_recipes[prepared_id] = recipe
+
+    descriptor = recipe.descriptor()
+    is_delegating = hasattr(recipe, 'java_recipe_name')
+
+    if not is_delegating:
+        for name, value, opt in descriptor.options:
+            if opt.required and value is None:
+                raise ValueError(
+                    f"Missing required option `{name}` for recipe `{descriptor.name}`."
+                )
+
+    is_scanning = isinstance(recipe, ScanningRecipe)
+
+    # Introspect recipe.editor() once at prepare time. If the recipe wrapped its editor in
+    # Preconditions.check(...), we extract the precondition's wire identity (so the Java host can
+    # evaluate it locally and skip the visit RPC for non-matching files) and cache the bare editor
+    # (so a subsequent dispatch via _instantiate_visitor returns the unwrapped editor — otherwise
+    # the precondition would also run Python-side and double the cost).
+    edit_preconditions: List[Dict[str, Any]] = list(_get_preconditions(recipe, 'edit'))
+    if not is_scanning:
+        try:
+            editor_visitor = recipe.editor()
+        except Exception:
+            editor_visitor = None
+        if editor_visitor is not None:
+            extracted = _extract_preconditions_from_editor(editor_visitor)
+            if extracted is not None:
+                bare_editor, wire_entries = extracted
+                _prepared_editor_overrides[prepared_id] = bare_editor
+                edit_preconditions.extend(wire_entries)
+    _prepared_edit_preconditions[prepared_id] = edit_preconditions
+
+    response = {
+        'id': prepared_id,
+        'descriptor': _recipe_descriptor_to_dict(descriptor),
+        'editVisitor': f'edit:{prepared_id}',
+        'editPreconditions': edit_preconditions,
+        'scanVisitor': f'scan:{prepared_id}' if is_scanning else None,
+        'scanPreconditions': _get_preconditions(recipe, 'scan') if is_scanning else [],
+    }
+
+    if is_delegating:
+        response['delegatesTo'] = {
+            'recipeName': recipe.java_recipe_name,
+            'options': getattr(recipe, 'delegates_to_options', {}),
+        }
+        return response
+
+    # Whole-tree: prepare each child here so the host builds the tree locally. A child hosted on
+    # the peer (an RpcRecipe) is emitted as delegatesTo for the host to resolve; the rest are
+    # prepared recursively. Children are also registered (in the marketplace, or _delegating_recipes
+    # for an RpcRecipe) so a peer that re-prepares children by name — rather than consuming
+    # recipeList — can still resolve them.
+    child_responses: List[dict] = []
+    for child in recipe.recipe_list():
+        if isinstance(child, RpcRecipe):
+            _delegating_recipes[child.java_recipe_name] = child
+            child_id = generate_id()
+            child_responses.append({
+                'id': child_id,
+                'descriptor': _delegate_descriptor(child.java_recipe_name),
+                'editVisitor': f'edit:{child_id}',
+                'editPreconditions': [],
+                'scanVisitor': None,
+                'scanPreconditions': [],
+                'delegatesTo': {
+                    'recipeName': child.java_recipe_name,
+                    'options': getattr(child, 'delegates_to_options', {}),
+                },
+            })
+        else:
+            if not marketplace.find_recipe(child.name):
+                marketplace.install(type(child), [])
+            child_responses.append(_prepare_instance(child, marketplace))
+    response['recipeList'] = child_responses
+
+    return response
 
 
 def handle_prepare_recipe(params: dict) -> dict:
@@ -1309,62 +1385,10 @@ def handle_prepare_recipe(params: dict) -> dict:
     if recipe_class is None:
         raise ValueError(f"Recipe class not found for: {recipe_name}")
 
-    # Instantiate the recipe with options
-    if options:
-        recipe = recipe_class(**options)
-    else:
-        recipe = recipe_class()
+    # Instantiate the recipe with options, then prepare it and its whole child tree.
+    recipe = recipe_class(**options) if options else recipe_class()
 
-    # Generate a unique ID for this prepared recipe
-    prepared_id = generate_id()
-    _prepared_recipes[prepared_id] = recipe
-
-    _install_sub_recipes(recipe, marketplace)
-
-    # Build the response
-    descriptor = recipe.descriptor()
-
-    # Determine if this is a scanning recipe
-    from rewrite.recipe import ScanningRecipe
-    is_scanning = isinstance(recipe, ScanningRecipe)
-
-    # Introspect recipe.editor() once at prepare time. If the recipe wrapped
-    # its editor in Preconditions.check(...), we extract the precondition's
-    # wire identity (so the Java host can evaluate it locally and skip the
-    # visit RPC for non-matching files) and cache the bare editor (so a
-    # subsequent dispatch via _instantiate_visitor returns the unwrapped
-    # editor — otherwise the precondition would also run Python-side and
-    # double the cost).
-    edit_preconditions: List[Dict[str, Any]] = list(_get_preconditions(recipe, 'edit'))
-    if not is_scanning:
-        try:
-            editor_visitor = recipe.editor()
-        except Exception:
-            editor_visitor = None
-        if editor_visitor is not None:
-            extracted = _extract_preconditions_from_editor(editor_visitor)
-            if extracted is not None:
-                bare_editor, wire_entries = extracted
-                _prepared_editor_overrides[prepared_id] = bare_editor
-                edit_preconditions.extend(wire_entries)
-    _prepared_edit_preconditions[prepared_id] = edit_preconditions
-
-    response = {
-        'id': prepared_id,
-        'descriptor': _recipe_descriptor_to_dict(descriptor),
-        'editVisitor': f'edit:{prepared_id}',
-        'editPreconditions': edit_preconditions,
-        'scanVisitor': f'scan:{prepared_id}' if is_scanning else None,
-        'scanPreconditions': _get_preconditions(recipe, 'scan') if is_scanning else [],
-    }
-
-    # If the recipe declares delegation to a Java recipe, include it in the response
-    if hasattr(recipe, 'java_recipe_name'):
-        response['delegatesTo'] = {
-            'recipeName': recipe.java_recipe_name,
-            'options': getattr(recipe, 'delegates_to_options', {}),
-        }
-
+    response = _prepare_instance(recipe, marketplace)
     logger.debug(f"PrepareRecipe response: {response}")
     return response
 

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -241,3 +241,56 @@ def test_recipe_descriptor_to_dict_emits_all_collection_keys():
                 "dataTables", "maintainers", "contributors", "examples"):
         assert key in result, f"missing key: {key}"
         assert result[key] == [], f"{key} should be empty list, got {result[key]!r}"
+
+
+def test_get_marketplace_row_carries_package_name(monkeypatch):
+    """A GetMarketplace row is tagged with the package that contributed the recipe,
+    so the host attributes it to its own bundle instead of the requested one."""
+    import rewrite.rpc.server as server
+    from rewrite.discovery import RecipeAttribution
+    from rewrite import CategoryDescriptor, RecipeMarketplace, Recipe
+
+    class _MyRecipe(Recipe):
+        @property
+        def name(self): return "org.example.MyRecipe"
+        @property
+        def display_name(self): return "My Recipe"
+        @property
+        def description(self): return "A recipe."
+
+    marketplace = RecipeMarketplace()
+    marketplace.install(_MyRecipe, [CategoryDescriptor(display_name="Test")])
+
+    attribution = RecipeAttribution()
+    attribution.record("my-recipes-package", {"org.example.MyRecipe"})
+    monkeypatch.setattr(server, "_attribution", attribution)
+
+    rows = server._collect_marketplace_rows(marketplace)
+
+    row = next(r for r in rows if r["descriptor"]["name"] == "org.example.MyRecipe")
+    assert row["packageName"] == "my-recipes-package"
+
+
+def test_get_marketplace_row_unattributed_has_none_package_name(monkeypatch):
+    """An unattributed recipe (e.g. a local-path install with no package identity)
+    leaves packageName None so the host falls back to the requested bundle."""
+    import rewrite.rpc.server as server
+    from rewrite.discovery import RecipeAttribution
+    from rewrite import CategoryDescriptor, RecipeMarketplace, Recipe
+
+    class _Unattributed(Recipe):
+        @property
+        def name(self): return "org.example.Unattributed"
+        @property
+        def display_name(self): return "Unattributed"
+        @property
+        def description(self): return "A recipe."
+
+    marketplace = RecipeMarketplace()
+    marketplace.install(_Unattributed, [CategoryDescriptor(display_name="Test")])
+    monkeypatch.setattr(server, "_attribution", RecipeAttribution())
+
+    rows = server._collect_marketplace_rows(marketplace)
+
+    row = next(r for r in rows if r["descriptor"]["name"] == "org.example.Unattributed")
+    assert row["packageName"] is None

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -294,3 +294,114 @@ def test_get_marketplace_row_unattributed_has_none_package_name(monkeypatch):
 
     row = next(r for r in rows if r["descriptor"]["name"] == "org.example.Unattributed")
     assert row["packageName"] is None
+
+
+def test_prepare_recipe_rejects_missing_required_option(monkeypatch):
+    """The server validates required options when preparing a recipe, rather than silently
+    preparing a broken recipe."""
+    import rewrite.rpc.server as server
+    from rewrite.marketplace import RecipeMarketplace
+    from rewrite import Recipe, CategoryDescriptor
+    from rewrite.recipe import option
+    from dataclasses import dataclass, field
+
+    @dataclass
+    class _RequiresText(Recipe):
+        text: str = field(default=None, metadata=option(
+            display_name="Text", description="Required text."))
+
+        @property
+        def name(self): return "org.example.RequiresText"
+        @property
+        def display_name(self): return "Requires text"
+        @property
+        def description(self): return "A recipe with a required option."
+
+    marketplace = RecipeMarketplace()
+    marketplace.install(_RequiresText, [CategoryDescriptor(display_name="Test")])
+    monkeypatch.setattr(server, "_marketplace", marketplace)
+
+    try:
+        server.handle_prepare_recipe({"id": "org.example.RequiresText"})
+        assert False, "expected a missing-required-option error"
+    except ValueError as e:
+        assert "Missing required option `text`" in str(e)
+
+
+def test_prepare_recipe_validates_required_options_of_children(monkeypatch):
+    """Validation recurses through the whole prepared tree (like the C# and JS servers), so a
+    composite whose child is missing a required option is rejected."""
+    import rewrite.rpc.server as server
+    from rewrite.marketplace import RecipeMarketplace
+    from rewrite import Recipe, CategoryDescriptor
+    from rewrite.recipe import option
+    from dataclasses import dataclass, field
+
+    @dataclass
+    class _RequiresText(Recipe):
+        text: str = field(default=None, metadata=option(
+            display_name="Text", description="Required text."))
+
+        @property
+        def name(self): return "org.example.ChildRequiresText"
+        @property
+        def display_name(self): return "Child requires text"
+        @property
+        def description(self): return "A child recipe with a required option."
+
+    class _CompositeWithInvalidChild(Recipe):
+        @property
+        def name(self): return "org.example.CompositeWithInvalidChild"
+        @property
+        def display_name(self): return "Composite with an invalid child"
+        @property
+        def description(self): return "A composite whose child lacks a required option."
+
+        def recipe_list(self):
+            return [_RequiresText()]
+
+    marketplace = RecipeMarketplace()
+    marketplace.install(_CompositeWithInvalidChild, [CategoryDescriptor(display_name="Test")])
+    monkeypatch.setattr(server, "_marketplace", marketplace)
+
+    try:
+        server.handle_prepare_recipe({"id": "org.example.CompositeWithInvalidChild"})
+        assert False, "expected a missing-required-option error for the child"
+    except ValueError as e:
+        assert "Missing required option `text`" in str(e)
+
+
+def test_prepare_recipe_returns_whole_child_tree(monkeypatch):
+    """PrepareRecipe prepares and returns the whole tree (recipeList), so the host builds it
+    locally instead of a round trip per child."""
+    import rewrite.rpc.server as server
+    from rewrite.marketplace import RecipeMarketplace
+    from rewrite import Recipe, CategoryDescriptor
+
+    class _Leaf(Recipe):
+        @property
+        def name(self): return "org.example.Leaf"
+        @property
+        def display_name(self): return "Leaf"
+        @property
+        def description(self): return "A leaf recipe."
+
+    class _Composite(Recipe):
+        @property
+        def name(self): return "org.example.Composite"
+        @property
+        def display_name(self): return "Composite"
+        @property
+        def description(self): return "A composite recipe."
+
+        def recipe_list(self):
+            return [_Leaf()]
+
+    marketplace = RecipeMarketplace()
+    marketplace.install(_Composite, [CategoryDescriptor(display_name="Test")])
+    monkeypatch.setattr(server, "_marketplace", marketplace)
+
+    response = server.handle_prepare_recipe({"id": "org.example.Composite"})
+
+    assert "recipeList" in response
+    assert [c["descriptor"]["name"] for c in response["recipeList"]] == ["org.example.Leaf"]

--- a/rewrite-python/rewrite/tests/test_marketplace.py
+++ b/rewrite-python/rewrite/tests/test_marketplace.py
@@ -262,8 +262,8 @@ class TestPerPackageAttribution:
         server._marketplace = self._saved_marketplace
         server._attribution = self._saved_attribution
 
-    def test_install_response_returns_only_packages_own_recipes(self, monkeypatch):
-        """Installing pkg-a then pkg-b: each response carries only its own recipe."""
+    def test_get_marketplace_attributes_each_recipe_to_its_package(self, monkeypatch):
+        """Installing pkg-a then pkg-b: each GetMarketplace row carries its own package."""
         import rewrite.rpc.server as server
 
         def fake_import_and_activate(name, marketplace, local_path=None):
@@ -275,21 +275,22 @@ class TestPerPackageAttribution:
 
         monkeypatch.setattr(server, "_import_and_activate_package", fake_import_and_activate)
 
-        a_response = server.handle_install_recipes({"recipes": {"packageName": "pkg-a"}})
-        b_response = server.handle_install_recipes({"recipes": {"packageName": "pkg-b"}})
+        server.handle_install_recipes({"recipes": {"packageName": "pkg-a"}})
+        server.handle_install_recipes({"recipes": {"packageName": "pkg-b"}})
 
-        a_names = {r["descriptor"]["name"] for r in a_response["recipes"]}
-        b_names = {r["descriptor"]["name"] for r in b_response["recipes"]}
+        # Each row carries its origin packageName, so the host attributes each recipe to the
+        # package that actually contributed it instead of the single requested bundle.
+        package_of = {r["descriptor"]["name"]: r["packageName"]
+                      for r in server.handle_get_marketplace({})}
 
-        assert a_names == {"org.openrewrite.test.pkga.RecipeA"}
-        assert b_names == {"org.openrewrite.test.pkgb.RecipeB"}
+        assert package_of["org.openrewrite.test.pkga.RecipeA"] == "pkg-a"
+        assert package_of["org.openrewrite.test.pkgb.RecipeB"] == "pkg-b"
 
-    def test_install_response_for_package_with_no_recipes_is_empty(self, monkeypatch):
-        """Visualization-only pip packages (no recipes) must not be assigned others' recipes.
+    def test_noop_install_does_not_inherit_other_packages_recipes(self, monkeypatch):
+        """A visualization-only pip package (no recipes) must not be assigned others' recipes.
 
-        Reproduces the moderne-visualizations-misc case: pkg-a contributed
-        recipes earlier; pkg-b is a no-op (no openrewrite.recipes entry point).
-        Installing pkg-b must NOT inherit pkg-a's recipes.
+        pkg-a contributed recipes earlier; pkg-b is a no-op (no openrewrite.recipes entry
+        point). Installing pkg-b must NOT inherit pkg-a's recipes.
         """
         import rewrite.rpc.server as server
 
@@ -303,8 +304,13 @@ class TestPerPackageAttribution:
         server.handle_install_recipes({"recipes": {"packageName": "pkg-a"}})
         b_response = server.handle_install_recipes({"recipes": {"packageName": "pkg-b"}})
 
-        assert b_response["recipes"] == []
+        # pkg-b contributed nothing, so no GetMarketplace row is attributed to it, and pkg-a's
+        # recipe keeps its own attribution.
         assert b_response["recipesInstalled"] == 0
+        package_of = {r["descriptor"]["name"]: r["packageName"]
+                      for r in server.handle_get_marketplace({})}
+        assert package_of["org.openrewrite.test.pkga.RecipeA"] == "pkg-a"
+        assert "pkg-b" not in package_of.values()
 
     def test_get_marketplace_filters_by_package_name(self, monkeypatch):
         """GetMarketplace with packageName returns only that package's recipes."""

--- a/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleReader.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleReader.java
@@ -34,9 +34,6 @@ public class PipRecipeBundleReader implements RecipeBundleReader {
 
     @Override
     public RecipeMarketplace read() {
-        // GetMarketplace rows now carry each recipe's origin packageName, so toMarketplace keeps
-        // only this bundle's recipes — the round trip that used to over-attribute the whole
-        // singleton marketplace to this bundle is now safe.
         return rpc.getMarketplace(bundle);
     }
 

--- a/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleReader.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleReader.java
@@ -19,13 +19,11 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.openrewrite.Recipe;
 import org.openrewrite.config.RecipeDescriptor;
-import org.openrewrite.python.rpc.InstallRecipesResponse;
 import org.openrewrite.python.rpc.PythonRewriteRpc;
 import org.openrewrite.marketplace.RecipeBundle;
 import org.openrewrite.marketplace.RecipeBundleReader;
 import org.openrewrite.marketplace.RecipeListing;
 import org.openrewrite.marketplace.RecipeMarketplace;
-import org.openrewrite.rpc.request.GetMarketplaceResponse;
 
 import java.util.Map;
 
@@ -33,19 +31,13 @@ import java.util.Map;
 public class PipRecipeBundleReader implements RecipeBundleReader {
     private final @Getter RecipeBundle bundle;
     private final PythonRewriteRpc rpc;
-    /**
-     * The response from the install call that produced this reader. Carrying the
-     * row list directly lets {@link #read()} skip the GetMarketplace round trip
-     * (which returns the singleton marketplace's full contents and would
-     * over-attribute every recipe in the process to {@link #bundle}).
-     */
-    private final InstallRecipesResponse installResponse;
 
     @Override
     public RecipeMarketplace read() {
-        GetMarketplaceResponse response = new GetMarketplaceResponse();
-        response.addAll(installResponse.recipesOrEmpty());
-        return response.toMarketplace(bundle);
+        // GetMarketplace rows now carry each recipe's origin packageName, so toMarketplace keeps
+        // only this bundle's recipes — the round trip that used to over-attribute the whole
+        // singleton marketplace to this bundle is now safe.
+        return rpc.getMarketplace(bundle);
     }
 
     @Override

--- a/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
@@ -47,6 +47,6 @@ public class PipRecipeBundleResolver implements RecipeBundleResolver {
         if (response.getVersion() != null) {
             bundle.setVersion(response.getVersion());
         }
-        return new PipRecipeBundleReader(bundle, rpc, response);
+        return new PipRecipeBundleReader(bundle, rpc);
     }
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/InstallRecipesResponse.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/InstallRecipesResponse.java
@@ -17,31 +17,15 @@ package org.openrewrite.python.rpc;
 
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.rpc.request.GetMarketplaceResponse;
-
-import java.util.Collections;
-import java.util.List;
 
 /**
- * Response to an {@code InstallRecipes} RPC request.
- * <p>
- * {@code recipes} carries the descriptor rows for recipes attributed to the
- * just-installed distribution, so the caller can construct a
- * {@link org.openrewrite.marketplace.RecipeMarketplace} bound to the bundle
- * without a follow-up {@code GetMarketplace} round trip. The follow-up call
- * was the source of the prior over-attribution bug — it returned the entire
- * singleton marketplace, which on a Python RPC server includes built-in
- * {@code openrewrite} recipes plus any recipes from previously-installed
- * sibling packages, all of which were then incorrectly tagged with the
- * just-requested bundle.
+ * Response to an {@code InstallRecipes} RPC request. The reader gets the bundle's recipes from a
+ * follow-up {@code GetMarketplace} call, whose rows now carry each recipe's origin
+ * {@code packageName} so the host attributes each to its own bundle — so this response only needs
+ * to report how many recipes were installed and the resolved version.
  */
 @Value
 public class InstallRecipesResponse {
     int recipesInstalled;
     @Nullable String version;
-    @Nullable List<GetMarketplaceResponse.Row> recipes;
-
-    public List<GetMarketplaceResponse.Row> recipesOrEmpty() {
-        return recipes == null ? Collections.emptyList() : recipes;
-    }
 }


### PR DESCRIPTION
## What

Brings the Python (pip) RPC recipe server to parity with the C#, JS, and Go servers across three features.

### Per-bundle recipe attribution (GetMarketplace)

The Python server emitted origin-less `GetMarketplace` rows, so the host worked around the resulting over-attribution by reading the bundle's recipes from the `InstallRecipes` response instead (a bolt-on). `GetMarketplace` rows now carry each recipe's origin `packageName` — recorded per-distribution during discovery/install and looked up via `RecipeAttribution.package_for` — so the host's `toMarketplace` attributes each recipe to its own bundle. The reader (`PipRecipeBundleReader`) now reads from `getMarketplace(bundle)`, and the install-response `recipes` bolt-on is retired (dropped from the Python response and the `InstallRecipesResponse` DTO; the response is back to `{recipesInstalled, version}`, matching the other ecosystems). Local-path installs with no package identity stay unattributed and fall back to the requested bundle.

### Whole-tree (one-shot) PrepareRecipe + recursive validation

`PrepareRecipe` now prepares the whole recipe tree in one call and returns it as `recipeList` (the child prepared responses), mirroring the other servers, so the host builds the tree locally instead of a `PrepareRecipe` round trip per child. Required-option validation lives in that recursion (`_prepare_instance`), so it covers the whole tree — each node is validated against the values its parent set, not just the root. A child hosted on the peer (an `RpcRecipe`) is emitted as `delegatesTo` for the host to resolve; the rest are prepared and validated recursively.

## Testing

- New attribution tests (per-row `packageName` emit, unattributed → `None`) and prepare tests (missing required option rejected at the root and recursively for a composite's child; whole-tree `recipeList`).
- Migrated the two install-response attribution tests to the GetMarketplace path.
- Python suite green; `rewrite-python` Java compiles.
