### PR TITLE
golang: per-bundle recipe attribution and whole-tree PrepareRecipe

### DIFF
--- a/rewrite-go/cmd/rpc/cross_ecosystem_test.go
+++ b/rewrite-go/cmd/rpc/cross_ecosystem_test.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+)
+
+// goDelegatingRecipe delegates entirely to a Java host recipe. The Go server can't run it, so
+// PrepareRecipe answers with delegatesTo{recipeName, options} and the Java host resolves the
+// recipe from its own marketplace instead of wrapping the Go recipe in an RpcRecipe.
+type goDelegatingRecipe struct{ recipe.Base }
+
+func (*goDelegatingRecipe) Name() string           { return "org.openrewrite.go.test.Delegating" }
+func (*goDelegatingRecipe) DisplayName() string    { return "Delegating" }
+func (*goDelegatingRecipe) Description() string     { return "Delegates to a Java recipe." }
+func (*goDelegatingRecipe) JavaRecipeName() string { return "org.openrewrite.java.ChangeType" }
+func (*goDelegatingRecipe) JavaOptions() map[string]any {
+	return map[string]any{
+		"oldFullyQualifiedTypeName": "a.A",
+		"newFullyQualifiedTypeName": "b.B",
+	}
+}
+
+// goCompositeWithJavaChild is a Go composite whose only child delegates to a Java recipe — the
+// cross-ecosystem case the host's whole-tree path resolves from the prepared recipeList.
+type goCompositeWithJavaChild struct{ recipe.Base }
+
+func (*goCompositeWithJavaChild) Name() string        { return "org.openrewrite.go.test.CompositeWithJavaChild" }
+func (*goCompositeWithJavaChild) DisplayName() string { return "Composite with Java child" }
+func (*goCompositeWithJavaChild) Description() string { return "A composite whose child delegates to a Java recipe." }
+func (*goCompositeWithJavaChild) RecipeList() []recipe.Recipe {
+	return []recipe.Recipe{&goDelegatingRecipe{}}
+}
+
+func prepareOK(t *testing.T, s *server, id string) prepareRecipeResponse {
+	t.Helper()
+	params, err := json.Marshal(prepareRecipeRequest{ID: id})
+	if err != nil {
+		t.Fatalf("marshal prepare request: %v", err)
+	}
+	resp, rpcErr := s.handlePrepareRecipe(params)
+	if rpcErr != nil {
+		t.Fatalf("handlePrepareRecipe error: %+v", rpcErr)
+	}
+	return resp.(prepareRecipeResponse)
+}
+
+// A root recipe that delegates to a Java recipe answers with delegatesTo and no child tree, so the
+// host loads the Java recipe locally rather than wrapping the Go recipe in an RpcRecipe.
+func TestPrepareRecipeRootDelegatesToJavaRecipe(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.registry.Register(&goDelegatingRecipe{})
+
+	pr := prepareOK(t, s, "org.openrewrite.go.test.Delegating")
+
+	if pr.DelegatesTo == nil {
+		t.Fatal("expected delegatesTo to be set, got nil")
+	}
+	if got := pr.DelegatesTo.RecipeName; got != "org.openrewrite.java.ChangeType" {
+		t.Errorf("delegatesTo.recipeName = %q, want org.openrewrite.java.ChangeType", got)
+	}
+	want := map[string]any{
+		"oldFullyQualifiedTypeName": "a.A",
+		"newFullyQualifiedTypeName": "b.B",
+	}
+	if !reflect.DeepEqual(pr.DelegatesTo.Options, want) {
+		t.Errorf("delegatesTo.options = %+v, want %+v", pr.DelegatesTo.Options, want)
+	}
+	if len(pr.RecipeList) != 0 {
+		t.Errorf("a delegating recipe carries no child tree, got %d children", len(pr.RecipeList))
+	}
+}
+
+// A composite's child that delegates to a Java recipe is emitted inside the prepared recipeList as
+// a delegatesTo node (its descriptor named for the Java recipe), so the host resolves it
+// cross-ecosystem while building the tree locally — no PrepareRecipe round trip and no Go-side
+// recursion into the delegated child.
+func TestPrepareRecipeCompositeChildDelegatesToJavaRecipe(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.registry.Register(&goCompositeWithJavaChild{})
+
+	pr := prepareOK(t, s, "org.openrewrite.go.test.CompositeWithJavaChild")
+
+	if pr.DelegatesTo != nil {
+		t.Errorf("the composite itself should not delegate, got %+v", pr.DelegatesTo)
+	}
+	if len(pr.RecipeList) != 1 {
+		t.Fatalf("expected 1 prepared child, got %d: %+v", len(pr.RecipeList), pr.RecipeList)
+	}
+	child := pr.RecipeList[0]
+	if child.DelegatesTo == nil {
+		t.Fatal("expected the child to carry delegatesTo, got nil")
+	}
+	if got := child.DelegatesTo.RecipeName; got != "org.openrewrite.java.ChangeType" {
+		t.Errorf("child delegatesTo.recipeName = %q, want org.openrewrite.java.ChangeType", got)
+	}
+	if got := child.Descriptor.Name; got != "org.openrewrite.java.ChangeType" {
+		t.Errorf("child descriptor name = %q, want the Java recipe name", got)
+	}
+}

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -135,6 +135,11 @@ type server struct {
 	registry  *recipe.Registry
 	installer *installer.Installer
 
+	// recipeOrigin maps a recipe name to the package that contributed it,
+	// recorded at install time and read by GetMarketplace so each row is
+	// attributed to its own bundle on the host.
+	recipeOrigin map[string]string
+
 	// recipeWorkspaceCleanup removes the temp recipe install dir created
 	// when --recipe-install-dir was not supplied. Nil when the caller
 	// provided the path (in which case lifetime is the caller's concern).
@@ -223,6 +228,7 @@ func newServer(cfg serverConfig) *server {
 		logger:                  logger,
 		registry:                reg,
 		installer:               inst,
+		recipeOrigin:            make(map[string]string),
 		recipeWorkspaceCleanup:  recipeWorkspaceCleanup,
 	}
 
@@ -998,6 +1004,13 @@ func (s *server) handleInstallRecipes(params json.RawMessage) (any, *rpcError) {
 		return nil, &rpcError{Code: -32603, Message: fmt.Sprintf("Install package failed: %v", err)}
 	}
 
+	// Attribute the recipes this package contributed to it, so GetMarketplace can tag each row
+	// with its origin and the host can bind it to the right bundle. A local-path install has no
+	// package identity, so its recipes stay unattributed and fall back to the requested bundle.
+	for _, r := range info.Recipes {
+		s.recipeOrigin[r.Name] = pkg.PackageName
+	}
+
 	afterCount := len(s.registry.AllRecipes())
 	var version *string
 	if info.Version != "" {
@@ -1201,6 +1214,9 @@ func parseOrderedColumns(raw json.RawMessage) ([]recipe.ColumnValue, error) {
 type marketplaceRow struct {
 	Descriptor    marketplaceDescriptor   `json:"descriptor"`
 	CategoryPaths [][]marketplaceCategory `json:"categoryPaths"`
+	// PackageName is the package that contributed this recipe (nil when unattributed, e.g. a
+	// local-path install), so the host attributes each row to its own bundle.
+	PackageName *string `json:"packageName"`
 }
 
 // marketplaceDescriptor matches Java's RecipeDescriptor (minimal fields).
@@ -1261,9 +1277,14 @@ func (s *server) handleGetMarketplace(params json.RawMessage) (any, *rpcError) {
 			})
 		}
 
+		var packageName *string
+		if origin, ok := s.recipeOrigin[desc.Name]; ok {
+			packageName = &origin
+		}
 		rows = append(rows, marketplaceRow{
 			Descriptor:    marketplaceDescriptorFromRecipe(desc),
 			CategoryPaths: [][]marketplaceCategory{categoryPath},
+			PackageName:   packageName,
 		})
 	}
 	if rows == nil {

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -1478,6 +1478,10 @@ type prepareRecipeResponse struct {
 	ScanVisitor       *string               `json:"scanVisitor,omitempty"`
 	ScanPreconditions []any                 `json:"scanPreconditions"`
 	DelegatesTo       *delegatesToResponse  `json:"delegatesTo,omitempty"`
+	// RecipeList carries the prepared child recipes of a composite so the host builds the tree
+	// locally instead of re-preparing each child by name. Always emitted (an empty list for a
+	// leaf; null only for a delegating recipe, whose children the host resolves itself).
+	RecipeList []prepareRecipeResponse `json:"recipeList"`
 }
 
 type delegatesToResponse struct {
@@ -1517,22 +1521,62 @@ func (s *server) handlePrepareRecipe(params json.RawMessage) (any, *rpcError) {
 		}, nil
 	}
 
-	// Create recipe instance with options
+	// Create recipe instance with options. A nil instance means an installer-loaded recipe with no
+	// constructor (the bootstrap binary's descriptor-only registration) — it can't run here, only
+	// be described, so return the stored descriptor with no prepared child tree. Execution happens
+	// in the CLI-built binary, where the recipe module is linked and its constructor exists, so
+	// prepareInstance below runs and returns the whole tree.
 	instance := reg.Constructor(req.Options)
-
-	var desc recipe.RecipeDescriptor
-	if instance != nil {
-		desc = recipe.Describe(instance)
-	} else {
-		// Installer-loaded recipes have no constructor; use stored descriptor
-		desc = reg.Descriptor
+	if instance == nil {
+		recipeID := uuid.New().String()
+		// Store the nil instance keyed by id so a later Visit can fail loudly by recipe name
+		// (stale/missing CLI-built binary) instead of "Unknown recipe: <uuid>".
+		s.preparedRecipes[recipeID] = instance
+		s.preparedRecipeNames[recipeID] = req.ID
+		return prepareRecipeResponse{
+			ID:                recipeID,
+			Descriptor:        marketplaceDescriptorFromRecipe(reg.Descriptor),
+			EditVisitor:       "edit:" + recipeID,
+			EditPreconditions: []any{},
+			ScanPreconditions: []any{},
+			RecipeList:        []prepareRecipeResponse{},
+		}, nil
 	}
 
-	// response.ID must be the per-instance UUID, not the recipe name —
-	// callers echo it back to identify the prepared instance.
+	resp, rerr := s.prepareInstance(instance, req.ID)
+	if rerr != nil {
+		return nil, rerr
+	}
+	return resp, nil
+}
+
+// prepareInstance prepares a recipe instance and, recursively, its whole child tree — storing every
+// node in preparedRecipes and returning the response with recipeList populated, so the host builds
+// the tree locally instead of a PrepareRecipe round trip per child.
+//
+// Mirrors the C#, JS, and Python servers. Required options are validated as each node is prepared,
+// which covers the whole tree (the root against the caller's options and each child against the
+// values its parent set). A child that delegates to a Java recipe is emitted as delegatesTo for the
+// host to resolve; the rest are prepared and validated recursively. Delegating recipes forward
+// validation to the recipe they delegate to, so they are not validated here.
+func (s *server) prepareInstance(instance recipe.Recipe, name string) (prepareRecipeResponse, *rpcError) {
+	desc := recipe.Describe(instance)
+
+	_, isDelegating := instance.(recipe.DelegatesTo)
+	if !isDelegating {
+		for _, opt := range instance.Options() {
+			if opt.Required && opt.Value == nil {
+				return prepareRecipeResponse{}, &rpcError{
+					Code:    -32602,
+					Message: fmt.Sprintf("Missing required option `%s` for recipe `%s`.", opt.Name, desc.Name),
+				}
+			}
+		}
+	}
+
 	recipeID := uuid.New().String()
 	s.preparedRecipes[recipeID] = instance
-	s.preparedRecipeNames[recipeID] = req.ID
+	s.preparedRecipeNames[recipeID] = name
 
 	resp := prepareRecipeResponse{
 		ID:                recipeID,
@@ -1542,43 +1586,61 @@ func (s *server) handlePrepareRecipe(params json.RawMessage) (any, *rpcError) {
 		ScanPreconditions: []any{},
 	}
 
-	// Introspect Editor() once at prepare time. If the recipe wrapped its
-	// editor in preconditions.Check(...), extract the precondition's wire
-	// identity (so the Java host can evaluate it locally and skip the
-	// visit RPC for non-matching files) and cache the bare editor (so a
-	// subsequent dispatch via instantiateVisitor returns the unwrapped
-	// editor — otherwise the precondition would also run Go-side and
-	// double the cost).
-	if instance != nil {
-		if _, isScan := instance.(recipe.ScanningRecipe); !isScan {
-			if editor := instance.Editor(); editor != nil {
-				if checkV, ok := editor.(*preconditions.CheckVisitor); ok {
-					if entry, ok := preconditionWireEntry(checkV.Check); ok {
-						resp.EditPreconditions = append(resp.EditPreconditions, entry)
-						s.preparedEditorOverrides[recipeID] = checkV.V
-					}
+	// Introspect Editor() once: if it's wrapped in preconditions.Check(...), extract the
+	// precondition's wire identity (so the Java host can evaluate it locally and skip the visit
+	// RPC for non-matching files) and cache the bare editor (so a subsequent dispatch via
+	// instantiateVisitor returns the unwrapped editor — otherwise the precondition runs Go-side
+	// too and doubles the cost).
+	_, isScan := instance.(recipe.ScanningRecipe)
+	if !isScan {
+		if editor := instance.Editor(); editor != nil {
+			if checkV, ok := editor.(*preconditions.CheckVisitor); ok {
+				if entry, ok := preconditionWireEntry(checkV.Check); ok {
+					resp.EditPreconditions = append(resp.EditPreconditions, entry)
+					s.preparedEditorOverrides[recipeID] = checkV.V
 				}
 			}
 		}
 	}
-
-	// Check if this is a scanning recipe
-	if instance != nil {
-		if _, isScan := instance.(recipe.ScanningRecipe); isScan {
-			scanVis := "scan:" + recipeID
-			resp.ScanVisitor = &scanVis
-		}
+	if isScan {
+		scanVis := "scan:" + recipeID
+		resp.ScanVisitor = &scanVis
 	}
 
-	// Check for delegation
-	if instance != nil {
-		if del, ok := instance.(recipe.DelegatesTo); ok {
-			resp.DelegatesTo = &delegatesToResponse{
-				RecipeName: del.JavaRecipeName(),
-				Options:    del.JavaOptions(),
+	if del, ok := instance.(recipe.DelegatesTo); ok {
+		resp.DelegatesTo = &delegatesToResponse{
+			RecipeName: del.JavaRecipeName(),
+			Options:    del.JavaOptions(),
+		}
+		return resp, nil
+	}
+
+	// Whole-tree: prepare each child. A child that delegates to a Java recipe is emitted as
+	// delegatesTo for the host to resolve; the rest are prepared and validated recursively.
+	childResponses := []prepareRecipeResponse{}
+	for _, child := range instance.RecipeList() {
+		if del, ok := child.(recipe.DelegatesTo); ok {
+			childID := uuid.New().String()
+			childResponses = append(childResponses, prepareRecipeResponse{
+				ID:                childID,
+				Descriptor:        delegateDescriptor(del.JavaRecipeName()),
+				EditVisitor:       "edit:" + childID,
+				EditPreconditions: []any{},
+				ScanPreconditions: []any{},
+				DelegatesTo: &delegatesToResponse{
+					RecipeName: del.JavaRecipeName(),
+					Options:    del.JavaOptions(),
+				},
+			})
+		} else {
+			childResp, rerr := s.prepareInstance(child, recipe.Describe(child).Name)
+			if rerr != nil {
+				return prepareRecipeResponse{}, rerr
 			}
+			childResponses = append(childResponses, childResp)
 		}
 	}
+	resp.RecipeList = childResponses
 
 	return resp, nil
 }

--- a/rewrite-go/cmd/rpc/whole_tree_test.go
+++ b/rewrite-go/cmd/rpc/whole_tree_test.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+)
+
+// goReqOptRecipe declares a required option with no value, so preparing it must fail validation.
+type goReqOptRecipe struct{ recipe.Base }
+
+func (*goReqOptRecipe) Name() string        { return "org.openrewrite.go.test.RequiresOpt" }
+func (*goReqOptRecipe) DisplayName() string { return "Requires opt" }
+func (*goReqOptRecipe) Description() string { return "A recipe with a required option." }
+func (*goReqOptRecipe) Options() []recipe.OptionDescriptor {
+	return []recipe.OptionDescriptor{recipe.Option("text", "Text", "Required text.")}
+}
+
+type goLeafRecipe struct{ recipe.Base }
+
+func (*goLeafRecipe) Name() string        { return "org.openrewrite.go.test.Leaf" }
+func (*goLeafRecipe) DisplayName() string { return "Leaf" }
+func (*goLeafRecipe) Description() string { return "A leaf recipe." }
+
+type goCompositeRecipe struct{ recipe.Base }
+
+func (*goCompositeRecipe) Name() string                { return "org.openrewrite.go.test.Composite" }
+func (*goCompositeRecipe) DisplayName() string         { return "Composite" }
+func (*goCompositeRecipe) Description() string         { return "A composite recipe." }
+func (*goCompositeRecipe) RecipeList() []recipe.Recipe { return []recipe.Recipe{&goLeafRecipe{}} }
+
+type goCompositeInvalidChild struct{ recipe.Base }
+
+func (*goCompositeInvalidChild) Name() string        { return "org.openrewrite.go.test.CompositeInvalid" }
+func (*goCompositeInvalidChild) DisplayName() string { return "Composite invalid" }
+func (*goCompositeInvalidChild) Description() string { return "A composite whose child lacks a required option." }
+func (*goCompositeInvalidChild) RecipeList() []recipe.Recipe {
+	return []recipe.Recipe{&goReqOptRecipe{}}
+}
+
+func prepareErr(t *testing.T, s *server, id string) *rpcError {
+	t.Helper()
+	params, err := json.Marshal(prepareRecipeRequest{ID: id})
+	if err != nil {
+		t.Fatalf("marshal prepare request: %v", err)
+	}
+	_, rpcErr := s.handlePrepareRecipe(params)
+	return rpcErr
+}
+
+func TestPrepareRecipeRejectsMissingRequiredOption(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.registry.Register(&goReqOptRecipe{})
+
+	rpcErr := prepareErr(t, s, "org.openrewrite.go.test.RequiresOpt")
+
+	if rpcErr == nil {
+		t.Fatal("expected a missing-required-option error, got success")
+	}
+	if !strings.Contains(rpcErr.Message, "Missing required option") || !strings.Contains(rpcErr.Message, "text") {
+		t.Errorf("error %q does not report the missing `text` option", rpcErr.Message)
+	}
+}
+
+// Validation recurses through the whole prepared tree (like the C#, JS, and Python servers).
+func TestPrepareRecipeValidatesChildRequiredOptions(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.registry.Register(&goCompositeInvalidChild{})
+
+	rpcErr := prepareErr(t, s, "org.openrewrite.go.test.CompositeInvalid")
+
+	if rpcErr == nil {
+		t.Fatal("expected a missing-required-option error for the child, got success")
+	}
+	if !strings.Contains(rpcErr.Message, "Missing required option") || !strings.Contains(rpcErr.Message, "text") {
+		t.Errorf("error %q does not report the child's missing `text` option", rpcErr.Message)
+	}
+}
+
+// PrepareRecipe returns the whole prepared tree (recipeList) so the host builds it locally.
+func TestPrepareRecipeReturnsWholeChildTree(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.registry.Register(&goCompositeRecipe{})
+
+	params, err := json.Marshal(prepareRecipeRequest{ID: "org.openrewrite.go.test.Composite"})
+	if err != nil {
+		t.Fatalf("marshal prepare request: %v", err)
+	}
+	resp, rpcErr := s.handlePrepareRecipe(params)
+	if rpcErr != nil {
+		t.Fatalf("handlePrepareRecipe error: %+v", rpcErr)
+	}
+
+	pr := resp.(prepareRecipeResponse)
+	if len(pr.RecipeList) != 1 {
+		t.Fatalf("expected 1 prepared child, got %d: %+v", len(pr.RecipeList), pr.RecipeList)
+	}
+	if got := pr.RecipeList[0].Descriptor.Name; got != "org.openrewrite.go.test.Leaf" {
+		t.Errorf("expected child Leaf, got %q", got)
+	}
+}


### PR DESCRIPTION
## What

Brings the Go RPC recipe server to parity with the C#, JS, and Python servers across the three features.

### Per-bundle recipe attribution (GetMarketplace)

The Go server returned origin-less `GetMarketplace` rows, so the host force-tagged every recipe with the single requested bundle. `InstallRecipes` now records each recipe's origin package (from the installer's `RecipeModuleInfo`, which names exactly the package's recipes) in a `recipeOrigin` map, and `GetMarketplace` emits it as `packageName` on each row, so the host attributes each recipe to its own bundle. Local-path installs have no package identity and stay unattributed.

### Whole-tree (one-shot) PrepareRecipe + recursive validation

`PrepareRecipe` now prepares the whole recipe tree in one call and returns it as `recipeList` (the child prepared responses), mirroring the other servers, so the host builds the tree locally instead of a `PrepareRecipe` round trip per child. Required-option validation lives in that recursion (`prepareInstance`), so it covers the whole tree. A child that delegates to a Java recipe is emitted as `delegatesTo`; the rest are prepared and validated recursively.

Note on Go's two-binary model: only constructor-backed recipes recurse. An installer-loaded recipe with no constructor (the bootstrap binary's descriptor-only registration) can't run and returns the stored descriptor with no child tree; execution happens in the CLI-built binary, where the recipe module is linked and the constructor exists.

## Testing

- New tests: missing required option rejected at the root and recursively for a composite's child; whole-tree `recipeList`. The existing metadata-only-fails-loudly test still passes.
- `go build` + `go vet` clean.
