### PR TITLE
Fix AddPropertyComment skipping identical comments on consecutive commented-out properties

### DIFF
--- a/rewrite-properties/src/main/java/org/openrewrite/properties/service/PropertiesCommentService.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/service/PropertiesCommentService.java
@@ -68,12 +68,18 @@ public class PropertiesCommentService extends CommentService {
         if (file == null) {
             return (Tree) cursor.getValue();
         }
-        if (hasEquivalentComment(cursor, text)) {
-            return file;
-        }
         List<Properties.Content> content = file.getContent();
         int idx = indexOf(content, cursor.getValue());
         if (idx < 0) {
+            return file;
+        }
+        // Idempotency is scoped to the insertion point (Placement.BEFORE): skip only when the comment
+        // immediately preceding the element is already equivalent. Scanning the whole preceding run
+        // (as getComments does) would misfire here, because a neighbouring property that has been
+        // commented out is itself a Properties.Comment and so merges into the run, letting an
+        // equivalent comment belonging to an earlier property suppress this one.
+        if (idx > 0 && content.get(idx - 1) instanceof Properties.Comment &&
+                equivalent(((Properties.Comment) content.get(idx - 1)).getMessage(), text)) {
             return file;
         }
         Properties.Content element = content.get(idx);

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/AddPropertyCommentTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/AddPropertyCommentTest.java
@@ -171,6 +171,34 @@ class AddPropertyCommentTest implements RewriteTest {
     }
 
     @Test
+    void shouldAddIdenticalCommentToConsecutiveCommentedOutProperties() {
+        rewriteRun(
+          spec -> spec.recipes(
+            new AddPropertyComment("zookeeper.connection.timeout.ms", "Removed", true),
+            new AddPropertyComment("zookeeper.session.timeout.ms", "Removed", true),
+            new AddPropertyComment("zookeeper.sync.time.ms", "Removed", true)
+          ),
+          properties(
+            """
+              broker.id=0
+              zookeeper.connection.timeout.ms=18000
+              zookeeper.session.timeout.ms=6000
+              zookeeper.sync.time.ms=2000
+              """,
+            """
+              broker.id=0
+              # Removed
+              # zookeeper.connection.timeout.ms=18000
+              # Removed
+              # zookeeper.session.timeout.ms=6000
+              # Removed
+              # zookeeper.sync.time.ms=2000
+              """
+          )
+        );
+    }
+
+    @Test
     void shouldASkipCommentOutProperty() {
         rewriteRun(
           spec -> spec.recipe(new AddPropertyComment(


### PR DESCRIPTION
## Problem

When several `AddPropertyComment` recipes with `commentOutProperty: true` run over consecutive properties that share the same comment text, the comment is added for the first one or two properties and silently skipped for the rest:

```properties
# before
broker.id=0
zookeeper.connection.timeout.ms=18000
zookeeper.session.timeout.ms=6000
zookeeper.sync.time.ms=2000
```
```properties
# actual (buggy) — comments missing for session/sync
broker.id=0
# Removed
# zookeeper.connection.timeout.ms=18000
# zookeeper.session.timeout.ms=6000
# zookeeper.sync.time.ms=2000
```

- This surfaced as a CI regression in downstream `moderneinc/rewrite-kafka` (`MigrateToKafka40Test.commentOutZookeeperBrokerPropertiesForKRaft`) after #8131, which introduced the `Comments` trait and the `if not already present` idempotency.

## Root cause

`PropertiesCommentService.addComment` guarded with `hasEquivalentComment(cursor, text)`, which scans the **entire** run of preceding `Properties.Comment` siblings (via `getComments`). Because `commentOutProperty` rewrites a neighbouring property into a `Properties.Comment`, that property's commented-out line does not break the run — so the descriptive comment added for an earlier property (identical text) is attributed to the later property and falsely satisfies the "already present" check.

## Fix

Scope the idempotency check to the insertion point. `addComment(..., Placement.BEFORE)` inserts immediately before the element, so it should skip only when the comment **immediately preceding** the element is already equivalent. This matches the documented `addComment` contract ("adding a comment equivalent to one that already exists *at that placement*") and remains idempotent on re-run (the second run sees the descriptive comment directly above the property and skips).

## Verification

- New regression test `AddPropertyCommentTest.shouldAddIdenticalCommentToConsecutiveCommentedOutProperties`.
- Full `:rewrite-properties:test` passes.
- Validated end-to-end: with this build published to Maven-local, `moderneinc/rewrite-kafka`'s `MigrateToKafka40Test` goes green.