### PR TITLE
Use the `rewrite-javascript-version.txt` in NPM publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -64,10 +64,12 @@ jobs:
       - shell: bash
         run: sudo npm install -g npm@latest
 
-      # The `ci` run records the exact Maven snapshot version it deployed for
-      # rewrite-javascript and uploads it as the `published-snapshot-version` artifact.
-      # Download it so the npm package can mirror that version 1:1. Best-effort: absent
-      # on the `publish` tag path (and on older `ci` runs), in which case the step below
+      # The `ci` run records the exact version string baked into its rewrite-javascript jar
+      # (META-INF/rewrite-javascript-version.txt) and uploads it as the
+      # `published-snapshot-version` artifact. Download it so the npm package publishes that
+      # identical string — a downstream consumer feeds the jar's embedded value to
+      # `npx --package=@openrewrite/rewrite@<version>`, so npm must match it exactly. Best-effort:
+      # absent on the `publish` tag path (and on older `ci` runs), in which case the step below
       # falls back to Gradle's own snapshot-version derivation.
       - if: github.event.workflow_run.name == 'ci'
         continue-on-error: true
@@ -80,9 +82,9 @@ jobs:
 
       # For a tag-triggered upstream `publish` run, `head_branch` is the tag name
       # (e.g. `v8.83.0`). Strip the leading `v` and publish to dist-tag `latest`.
-      # Otherwise this is the `ci`-triggered snapshot path: mirror the exact Maven
-      # snapshot version handed off above (so every Maven snapshot gets a 1:1 npm
-      # counterpart), and publish to dist-tag `next`.
+      # Otherwise this is the `ci`-triggered snapshot path: publish the exact version string
+      # handed off above (= the version embedded in the ci run's jar), and publish to
+      # dist-tag `next`.
       - id: ver
         shell: bash
         env:
@@ -97,7 +99,7 @@ jobs:
           F=$(find .published-version -name publishedVersion.txt 2>/dev/null | head -1)
           if [[ -n "$F" ]]; then
             V=$(tr -d '[:space:]' < "$F")
-            echo "Mirroring Maven snapshot version handed off from the ci run: $V"
+            echo "Publishing the version handed off from the ci run (== jar's embedded version): $V"
           else
             echo "No handed-off version found; falling back to Gradle-derived snapshot version"
           fi

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -249,40 +249,37 @@ testing {
 //
 // npm publishing is decoupled from the Maven snapshot publish (it runs in a separate
 // `workflow_run` triggered by `ci`, because npm Trusted Publisher binds to a single workflow
-// filename). To still tie every npm snapshot to the exact Maven snapshot deploy, this task reads
-// the unique snapshot version that Gradle assigned to `org.openrewrite:rewrite-javascript`
-// (e.g. `8.86.0-20260625.164513-55`). Gradle's maven-publish computes that version client-side and
-// stages the very `maven-metadata.xml` it uploads under
-// `build/tmp/publish<Pub>PublicationTo<Repo>Repository/snapshot-maven-metadata.xml`; we read the
-// `<value>` straight from that local file — no network read-back.
+// filename), so the `ci` run must hand off the exact version string to publish. That string is NOT
+// the Maven snapshot coordinate (`8.86.0-<yyyyMMdd>.<HHmmss>-<buildNumber>`, a deploy-time
+// timestamp): it MUST be the value baked into the jar's
+// `META-INF/rewrite-javascript-version.txt` (= `datedSnapshotVersion`, a git-commit-time
+// timestamp). A downstream consumer reads that embedded value and feeds it verbatim to
+// `npx --package=@openrewrite/rewrite@<version>` when spawning the JS RPC server (see
+// JavaScriptRewriteRpc). If npm carries the deploy timestamp instead, it diverges from the
+// embedded value by however long elapses between commit and deploy, so the consumer asks npm for a
+// version that was never published and the RPC process dies on startup.
 //
-// The raw Maven `<value>` carries the repository-layout suffix `<yyyyMMdd>.<HHmmss>-<buildNumber>`,
-// whose `.` separator and trailing build number are Maven artifacts that don't belong in an npm
-// version. We normalize it to the npm dated-snapshot convention `<base>-<yyyyMMdd>-<HHmmss>` (same
-// as `gitCommitTimestamp()`), dropping the build number — the second-resolution timestamp already
-// makes it unique (a same-second double-deploy is not realistic). The `ci` run uploads the recorded
-// version as an artifact and `npm-publish.yml` pins the npm version to it.
+// So we record `datedSnapshotVersion` itself, and assert it matches the jar that was just built.
+// The `ci` run uploads the recorded version as an artifact and `npm-publish.yml` pins npm to it.
 val recordPublishedSnapshotVersion = tasks.register("recordPublishedSnapshotVersion") {
-    description = "Records the unique Sonatype snapshot version of rewrite-javascript for npm-publish to mirror."
+    description = "Records the npm snapshot version (identical to the jar's embedded version.txt) for npm-publish to mirror."
     val baseVersion = project.version.toString()
-    val buildDirectory = layout.buildDirectory
-    val versionFile = buildDirectory.file("npm/publishedVersion.txt")
+    val recordedVersion = datedSnapshotVersion
+    val versionFile = layout.buildDirectory.file("npm/publishedVersion.txt")
     onlyIf { baseVersion.endsWith("-SNAPSHOT") }
     doLast {
-        val staged = buildDirectory.dir("tmp").get().asFile.walkTopDown()
-            .firstOrNull { it.name == "snapshot-maven-metadata.xml" }
-        val resolved = staged?.readText()
-            ?.let { Regex("<value>([^<]+)</value>").find(it)?.groupValues?.get(1) }
-        if (resolved == null) {
-            logger.warn("Could not find the staged snapshot metadata under build/tmp; " +
-                    "npm-publish will fall back to its default version derivation.")
-            return@doLast
+        // `extractVersionFromJar()` returns null only if the jar is absent; this task is
+        // `finalizedBy` the `publish` that builds it, so in practice it is always present here.
+        val embedded = extractVersionFromJar()
+        check(embedded == null || embedded == recordedVersion) {
+            "npm publish version ($recordedVersion) must equal the jar's embedded " +
+                    "META-INF/rewrite-javascript-version.txt ($embedded); a downstream consumer derives the " +
+                    "`npx --package=@openrewrite/rewrite@<version>` coordinate from the embedded value."
         }
-        val normalized = resolved.replace(Regex("(\\d{8})\\.(\\d{6})-\\d+$"), "$1-$2")
         val out = versionFile.get().asFile
         out.parentFile.mkdirs()
-        out.writeText(normalized)
-        logger.lifecycle("Recorded published snapshot version for npm: $normalized (from Maven $resolved)")
+        out.writeText(recordedVersion)
+        logger.lifecycle("Recorded published snapshot version for npm: $recordedVersion")
     }
 }
 


### PR DESCRIPTION
## What's changed?
- Another attempt at fixing what #8128 was trying to fix.
Now using the `rewrite-javascript-version.txt` baked into the rewrite-javascript JAR for npm-publishing as the version string for NPM publishing.

## What's your motivation?

Make sure rewrite-javascript Maven and NPM snapshots have align on snapshot version names.
That is needed for derived modules' RPC to work.