### PR TITLE
Fix rewrite-scala temp dir leak

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/internal/ScalaCompilerContext.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/internal/ScalaCompilerContext.java
@@ -25,6 +25,8 @@ import org.openrewrite.scheduling.WorkingDirectoryExecutionContextView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -100,43 +102,62 @@ public class ScalaCompilerContext {
         java.util.List<SourceEntry> sourceList = new ArrayList<>(entries);
         java.util.List<String> cpList = new ArrayList<>(classpathStrings);
 
-        // Get a working directory for compiler output (.class files)
+        // Get a working directory for compiler output (.class/.tasty files).
         String outputDir;
+        Path ownedTempDir = null;
         try {
             Path root = executionContext.getMessage(WorkingDirectoryExecutionContextView.WORKING_DIRECTORY_ROOT);
             if (root == null) {
-                root = java.nio.file.Files.createTempDirectory("rewrite-scala");
+                root = ownedTempDir = Files.createTempDirectory("rewrite-scala");
             }
-            outputDir = java.nio.file.Files.createDirectories(root.resolve("scala-compiler")).toString();
-        } catch (java.io.IOException e) {
+            outputDir = Files.createDirectories(root.resolve("scala-compiler")).toString();
+        } catch (IOException e) {
             outputDir = System.getProperty("java.io.tmpdir");
         }
 
-        // Batch compile
-        Map<String, ScalaParseResult> compiled = bridge.compileAll(sourceList, cpList, outputDir);
+        try {
+            // Batch compile
+            Map<String, ScalaParseResult> compiled = bridge.compileAll(sourceList, cpList, outputDir);
 
-        // Convert to ParseResult map
-        Map<String, ParseResult> results = new LinkedHashMap<>();
-        for (Map.Entry<String, ScalaParseResult> entry : compiled.entrySet()) {
-            String path = entry.getKey();
-            ScalaParseResult result = entry.getValue();
+            // Convert to ParseResult map
+            Map<String, ParseResult> results = new LinkedHashMap<>();
+            for (Map.Entry<String, ScalaParseResult> entry : compiled.entrySet()) {
+                String path = entry.getKey();
+                ScalaParseResult result = entry.getValue();
 
-            List<ParseWarning> warnings = new ArrayList<>();
-            for (int i = 0; i < result.warnings().size(); i++) {
-                ScalaWarning w = result.warnings().get(i);
-                Parser.Input input = inputsByPath.get(path);
-                String location = (input != null ? input.getPath().toString() : path);
-                String formatted = location + " at line " + w.line() + ":" + w.column() + " " + w.message();
-                warnings.add(new ParseWarning(Tree.randomId(), formatted));
-                if (logCompilationWarningsAndErrors) {
-                    logger.warn(formatted);
+                List<ParseWarning> warnings = new ArrayList<>();
+                for (int i = 0; i < result.warnings().size(); i++) {
+                    ScalaWarning w = result.warnings().get(i);
+                    Parser.Input input = inputsByPath.get(path);
+                    String location = (input != null ? input.getPath().toString() : path);
+                    String formatted = location + " at line " + w.line() + ":" + w.column() + " " + w.message();
+                    warnings.add(new ParseWarning(Tree.randomId(), formatted));
+                    if (logCompilationWarningsAndErrors) {
+                        logger.warn(formatted);
+                    }
                 }
+
+                results.put(path, new ParseResult(result, warnings));
             }
 
-            results.put(path, new ParseResult(result, warnings));
+            return results;
+        } finally {
+            if (ownedTempDir != null) {
+                deleteRecursively(ownedTempDir);
+            }
         }
+    }
 
-        return results;
+    private static void deleteRecursively(Path path) {
+        try {
+            if (Files.isDirectory(path)) {
+                try (java.util.stream.Stream<Path> children = Files.list(path)) {
+                    children.forEach(ScalaCompilerContext::deleteRecursively);
+                }
+            }
+            Files.delete(path);
+        } catch (IOException ignore) {
+        }
     }
 
     /**

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaParserTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaParserTest.java
@@ -227,4 +227,34 @@ class ScalaParserTest {
         J.Block block = (J.Block) forLoop.getBody();
         assertThat(block.getStatements()).hasSize(2);
     }
+
+    @Test
+    void doesNotLeakTempDirectories() throws java.io.IOException {
+        // given
+        java.nio.file.Path tmpRoot = java.nio.file.Paths.get(System.getProperty("java.io.tmpdir"));
+        java.util.Set<java.nio.file.Path> before = listRewriteScalaTempDirs(tmpRoot);
+
+        // when
+        ScalaParser parser = ScalaParser.builder().build();
+        List<SourceFile> parsed = parser.parse("val x = 42\n").collect(Collectors.toList());
+
+        // then
+        assertThat(parsed).hasSize(1);
+        assertThat(parsed.get(0)).isInstanceOf(S.CompilationUnit.class);
+
+        java.util.Set<java.nio.file.Path> after = listRewriteScalaTempDirs(tmpRoot);
+        after.removeAll(before);
+        assertThat(after)
+            .as("Parsing should not leak any rewrite-scala temp directories")
+            .isEmpty();
+    }
+
+    private static java.util.Set<java.nio.file.Path> listRewriteScalaTempDirs(java.nio.file.Path tmpRoot) throws java.io.IOException {
+        try (java.util.stream.Stream<java.nio.file.Path> entries = java.nio.file.Files.list(tmpRoot)) {
+            return entries
+                .filter(java.nio.file.Files::isDirectory)
+                .filter(p -> p.getFileName().toString().startsWith("rewrite-scala"))
+                .collect(Collectors.toCollection(java.util.HashSet::new));
+        }
+    }
 }


### PR DESCRIPTION
## What's changed?

Fixing Scala parser to clean up `rewrite-scala` temporary directories after itself.

## What's your motivation?

I have noticed by accident that there were 650K `rewrite-scala*` directories in my `$TMP_DIR`.
It manifested by some weird Gradle warnings printed out on unrelated Gradle operations.
It turned out our Scala parser leaks these directories.