### PR TITLE
Remove evolution comments

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcRecipe.java
@@ -140,10 +140,9 @@ public class RpcRecipe extends ScanningRecipe<Integer> {
                         .map(rpc::recipeFromPrepareResponse)
                         .collect(toList());
             } else {
-                // Fallback: peers whose servers don't yet return a prepared child tree
-                // (Python/JS/Go until updated). This is the pre-existing by-name path, unchanged.
-                // TODO(remove-fallback): delete this branch once every RPC server populates
-                // `recipeList`. The C# server (this change) always takes the branch above.
+                // Fallback by-name path: peers whose servers don't yet return a prepared child tree
+                // (Python/JS/Go until updated). The C# server always takes the branch above.
+                // TODO(remove-fallback): delete this branch once every RPC server populates `recipeList`.
                 recipeList = descriptor.getRecipeList().stream()
                         .map(r -> rpc.prepareRecipe(r.getName(), r.getOptions().stream()
                                 .filter(opt -> opt.getValue() != null)

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipePath.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipePath.java
@@ -24,9 +24,7 @@ import java.util.AbstractList;
  * A persistent, immutable path from the root recipe down to a descendant recipe.
  * <p>
  * Each node references its {@code parent}, so deriving a child path via {@link #child(Recipe)}
- * is O(1) and shares the entire ancestor chain instead of copying it. This replaces the
- * previous approach of copying a {@link java.util.Stack} for every node visited during a
- * recipe-tree traversal, which is rebuilt identically for every source file and every cycle.
+ * is O(1) and shares the entire ancestor chain instead of copying it.
  * <p>
  * Because it implements {@link java.util.List List&lt;Recipe&gt;} (ordered root-first, leaf-last),
  * it drops directly into consumers expecting the recipe path as a list, with no copying.

--- a/rewrite-core/src/test/java/org/openrewrite/internal/BackwardCompatibleObjectIdModuleTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/BackwardCompatibleObjectIdModuleTest.java
@@ -64,15 +64,13 @@ class BackwardCompatibleObjectIdModuleTest {
     }
 
     /**
-     * The "new" wire format writes the {@code @ref} id as the first property of a shared {@code @Value} type, so a
-     * bounded reader can decide the encoding from the prefix alone and stream the (potentially large) remainder. The
-     * old reader instead copies the entire nested subtree into a {@code TokenBuffer} before constructing anything,
-     * which is the allocation churn this change removes.
+     * The {@code @ref} id is written as the first property of a shared {@code @Value} type, so a bounded reader can
+     * decide the encoding from the prefix alone and construct the object while streaming the (potentially large)
+     * remainder, rather than copying the entire nested subtree into a {@code TokenBuffer} before constructing anything.
      * <p>
      * Total tokens read from the source parser are identical either way — the difference is <em>when</em> they are
      * read relative to object construction. We assert that the first {@link Node} is constructed while the source
-     * parser is still near the start of the stream. Against the current implementation the whole subtree is drained
-     * first, so the source-token count at first construction equals the full token total and this fails.
+     * parser is still near the start of the stream.
      */
     @Test
     void newFormatObjectIsBuiltBeforeSubtreeIsBuffered() throws IOException {
@@ -88,8 +86,8 @@ class BackwardCompatibleObjectIdModuleTest {
         }
 
         assertThat(parsed).isEqualTo(root);
-        // After the fix the root is built from the @ref prefix only; before it, the whole subtree is buffered first
-        // so the count at first construction is on the order of the full token total (> childCount).
+        // The root is built from the @ref prefix only, so few source tokens are consumed before first construction
+        // (otherwise the whole subtree would be buffered first, putting the count on the order of childCount).
         assertThat(Probe.minSourceTokensAtBuild).isLessThan(200L);
     }
 

--- a/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/CSharpRecipeTest.java
+++ b/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/CSharpRecipeTest.java
@@ -187,8 +187,8 @@ class CSharpRecipeTest implements RewriteTest {
     void structuredDocCommentSurvivesPrintRoundTrip() throws Exception {
         // A CSharpVisitor pass converts the raw doc comment into a structured CsDocComment tree.
         // When the modified tree is printed (serialized back to the C# side), the structured
-        // comment is decomposed over RPC and the C# side re-flattens it to text. This used to
-        // throw "Unexpected comment type ...$DocComment" / fail to map the type on the C# side.
+        // comment is decomposed over RPC and the C# side must re-flatten it to text without
+        // failing to map the type (e.g. "Unexpected comment type ...$DocComment").
         String source = "class Foo {\n    /// <summary>Does <c>x</c>.</summary>\n    void Test() {\n    }\n}\n";
         CSharpRewriteRpc rpc = CSharpRewriteRpc.getOrStart();
         Path tempDir = Files.createTempDirectory("csharp-doc-test-");

--- a/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpRecipeArtifactIsolationTest.java
+++ b/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpRecipeArtifactIsolationTest.java
@@ -93,9 +93,8 @@ class CSharpRecipeArtifactIsolationTest {
         NuGetRecipeBundleResolver resolver = new NuGetRecipeBundleResolver(rpc);
         RecipeMarketplace marketplace = new RecipeMarketplace();
 
-        // Install all three bundles in dependency order.
-        // Migration.Dotnet depends on Core, so installing Migration would previously
-        // pull Core's assemblies into Migration's scan dir and steal its recipes.
+        // Install all three bundles in dependency order. Migration.Dotnet depends on Core, so its
+        // install must not pull Core's assemblies into Migration's scan dir and steal Core's recipes.
         install(marketplace, resolver, "OpenRewrite.Recipes.CSharp.Core", PACKAGE_VERSION);
         install(marketplace, resolver, "OpenRewrite.Recipes.CSharp.CodeQuality", PACKAGE_VERSION);
         install(marketplace, resolver, "OpenRewrite.Recipes.CSharp.Migration.Dotnet", PACKAGE_VERSION);

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/NestedReturnEditCorruptionTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/NestedReturnEditCorruptionTest.java
@@ -34,19 +34,15 @@ import static org.openrewrite.golang.Assertions.go;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
 /**
- * Regression test for the {@code receiveBlockBody} baseline fix in
- * {@code rewrite-go/pkg/rpc/java_receiver.go}.
+ * Editing a statement inside an {@code if} (or {@code for}) must round-trip cleanly over RPC. The
+ * {@code receiveBlockBody} path in {@code rewrite-go/pkg/rpc/java_receiver.go} has to pass the correct
+ * baseline when reconstructing {@code J.If.thenPart} and {@code ForLoop/ForEachLoop.body}; otherwise on
+ * a CHANGE every NO_CHANGE sibling field resolves to its zero value — the then-block's whitespace
+ * collapses (printing {@code if ...; a != 0{returnb}}) and, when wrapped in a {@code for}, the inner
+ * {@code if}'s {@code Condition} is dropped entirely.
  * <p>
- * Editing a statement inside an {@code if} (or {@code for}) used to corrupt the
- * enclosing block on RPC round-trip: the receiver passed a {@code nil} baseline
- * when reconstructing {@code J.If.thenPart} and {@code ForLoop/ForEachLoop.body},
- * so on a CHANGE every NO_CHANGE sibling field resolved to its zero value — the
- * then-block's whitespace collapsed (printing {@code if ...; a != 0{returnb}})
- * and, when wrapped in a {@code for}, the inner {@code if}'s {@code Condition}
- * was dropped entirely.
- * <p>
- * A one-line {@code toRecipe} visitor that renames {@code a} to {@code b} is
- * enough — the bug is structural, not recipe-specific.
+ * A one-line {@code toRecipe} visitor that renames {@code a} to {@code b} is enough to exercise this —
+ * the corruption is structural, not recipe-specific.
  */
 @Timeout(value = 120, unit = TimeUnit.SECONDS)
 class NestedReturnEditCorruptionTest implements RewriteTest {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GradleSnippetGlobalTransformReproTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GradleSnippetGlobalTransformReproTest.java
@@ -73,7 +73,8 @@ class GradleSnippetGlobalTransformReproTest {
 
         SourceFile parsed = parse(tmp);
 
-        // Before the fix this produced a ParseError: "Failed to parse build.gradle at cursor position N".
+        // An AST-mutating global transform on the classpath must not yield a ParseError
+        // ("Failed to parse build.gradle at cursor position N").
         assertThat(parsed).isNotInstanceOf(ParseError.class);
         // Registered only on the compile classpath, which the classpath-free transformLoader never scans.
         assertThat(InjectClosureStatementTransformation.executed)

--- a/rewrite-javascript/rewrite/test/javascript/parser/method.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/method.test.ts
@@ -298,7 +298,7 @@ describe('method mapping', () => {
 
     test('tolerates a MethodDeclaration with undefined dimensionsAfterName (pre-#6992 LST)', () => {
         // given a visitor that strips dimensionsAfterName, simulating a legacy LST deserialized
-        // without the field (Java backfills it via @JsonCreator, the JS side previously did not)
+        // without the field (Java backfills it via @JsonCreator; the JS side must tolerate it too)
         const legacyVisitor = class extends JavaScriptVisitor<ExecutionContext> {
             protected async visitMethodDeclaration(method: J.MethodDeclaration, p: ExecutionContext): Promise<J | undefined> {
                 const legacy = {...method, dimensionsAfterName: undefined as unknown as J.MethodDeclaration["dimensionsAfterName"]};

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinVisitorReturnTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinVisitorReturnTest.java
@@ -31,8 +31,8 @@ class KotlinVisitorReturnTest implements RewriteTest {
     /**
      * A {@link org.openrewrite.kotlin.tree.K.Return} wraps a {@link J.Return}. A Java recipe (such as
      * {@code TestMethodsShouldBeVoid}) may rewrite that inner {@code J.Return} into a different statement,
-     * e.g. unwrapping {@code return foo()} to {@code foo()}. {@code KotlinVisitor.visitReturn} previously
-     * cast the visited expression straight back to {@code J.Return}, throwing a {@link ClassCastException}.
+     * e.g. unwrapping {@code return foo()} to {@code foo()}. {@code KotlinVisitor.visitReturn} must handle
+     * the visited expression no longer being a {@code J.Return} without throwing a {@link ClassCastException}.
      */
     @Test
     void unwrapReturnIntoItsExpression() {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -635,7 +635,7 @@ class MethodDeclarationTest implements RewriteTest {
         @Test
         void consecutiveBracelessExtensionsWithMethodCallBody() {
             // Two consecutive braceless extensions where the first's method body is a
-            // method invocation used to duplicate the first extension on print.
+            // method invocation must each print once, not duplicate the first on print.
             rewriteRun(
                 scala(
                     """


### PR DESCRIPTION
## What's changed?

Removing some of the code comments added recently. And/or editing them not to reflect the history or focus on the change actually being made at that time.

## What's your motivation?

Keep only relevant and current information.