### PR TITLE
JavaScript: keep <default> as the method name in type attribution whe…

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -2168,6 +2168,7 @@ export class JavaScriptParserVisitor {
         }
 
         if (name && name.simpleName.length > 0) {
+            const methodType = this.mapMethodType(node);
             return {
                 kind: J.Kind.MethodInvocation,
                 id: randomId(),
@@ -2177,10 +2178,10 @@ export class JavaScriptParserVisitor {
                 typeParameters: typeArguments,
                 name: {
                     ...name,
-                    type: undefined
+                    type: methodType && methodType.name.startsWith('<') ? {...methodType} : undefined
                 },
                 arguments: this.mapCommaSeparatedList(node.getChildren(this.sourceFile).slice(-3)),
-                methodType: this.mapMethodType(node)
+                methodType: methodType
             }
         } else {
             return {

--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -1012,8 +1012,11 @@ export class JavaScriptTypeMapping {
                             flags: 0, // TODO - determine flags
                             fullyQualifiedName: moduleSpecifier
                         } as Type.FullyQualified;
-                        // For aliased imports, use the original function name from the aliased symbol
-                        if (aliasedSymbol && aliasedSymbol.name) {
+                        // A default import binds an `ImportClause`; its aliased symbol carries the internal
+                        // name of the default export (e.g. `e` for express), so represent it as `<default>`.
+                        // Named imports (`ImportSpecifier`) keep the original exported name.
+                        const isDefaultImport = exprSymbol?.declarations?.some(ts.isImportClause) ?? false;
+                        if (!isDefaultImport && aliasedSymbol && aliasedSymbol.name) {
                             methodName = aliasedSymbol.name;
                         } else {
                             methodName = '<default>';


### PR DESCRIPTION
…n calling default export methods

## What's changed?

For JavaScript fix the type attribution of method invocations, which invoke the default export methods. Make sure they are called `<default>` instead of using the local alias.

## What's your motivation?

This is to fix the existing integration test which is failing: `FindMethodsTest.defaultExportFunctions`