### PR TITLE
JavaScript: DependencyWorkspace to use pid to isolate parallel runs

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/dependency-workspace.ts
+++ b/rewrite-javascript/rewrite/src/javascript/dependency-workspace.ts
@@ -19,6 +19,16 @@ import * as os from 'os';
 import * as crypto from 'crypto';
 import {execSync} from 'child_process';
 
+function isProcessAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (error: any) {
+        // ESRCH: no such process. EPERM: process exists but is owned by another user.
+        return error.code === 'EPERM';
+    }
+}
+
 interface BaseWorkspaceOptions {
     /**
      * Optional target directory. If provided, creates workspace in this directory
@@ -465,8 +475,25 @@ export class DependencyWorkspace {
 
             const workspaceDir = path.join(this.WORKSPACE_BASE, entry.name);
 
-            // Always clean up temporary directories (incomplete operations)
-            if (entry.name.includes('.tmp-')) {
+            // Temporary directories are named `<key>.tmp-<pid>-...`. Only reap one
+            // whose owning process is gone — otherwise a shutdown here would delete
+            // another live process's install cwd mid-run (npm then exits 7). Names
+            // without a parseable pid fall back to age-based reaping.
+            const tmpIdx = entry.name.indexOf('.tmp-');
+            if (tmpIdx >= 0) {
+                const ownerPid = parseInt(entry.name.substring(tmpIdx + 5).split('-')[0], 10);
+                if (!isNaN(ownerPid) && isProcessAlive(ownerPid)) {
+                    continue;
+                }
+                if (isNaN(ownerPid)) {
+                    try {
+                        if (now - fs.statSync(workspaceDir).mtimeMs <= maxAgeMs) {
+                            continue;
+                        }
+                    } catch (error) {
+                        // fall through to deletion
+                    }
+                }
                 try {
                     fs.rmSync(workspaceDir, {recursive: true, force: true});
                 } catch (error) {

--- a/rewrite-javascript/rewrite/test/javascript/dependency-workspace.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/dependency-workspace.test.ts
@@ -20,6 +20,7 @@ import {RecipeSpec} from "../../src/test";
 import {withDir} from "tmp-promise";
 import * as fs from "fs";
 import * as path from "path";
+import * as os from "os";
 
 describe('dependency workspace', () => {
     afterAll(() => {
@@ -114,6 +115,31 @@ describe('dependency workspace', () => {
 
         expect(foundMethodInvocation).toBe(true);
     }, 60000);
+
+    test('reaper keeps temp dirs owned by a live process', () => {
+        // given
+        const base = path.join(os.tmpdir(), 'openrewrite-js-workspaces');
+        fs.mkdirSync(base, {recursive: true});
+        const tag = `reapertest-${process.pid}-${Date.now()}`;
+        const alive = path.join(base, `${tag}_Npm.tmp-${process.pid}-123-abc`);
+        const dead = path.join(base, `${tag}_Npm.tmp-2147483647-456-def`);
+        const legacyRecent = path.join(base, `${tag}_Npm.tmp-legacyname`);
+        for (const dir of [alive, dead, legacyRecent]) {
+            fs.mkdirSync(dir, {recursive: true});
+        }
+
+        // when
+        DependencyWorkspace.cleanupOldWorkspaces();
+
+        // then
+        expect(fs.existsSync(alive)).toBe(true);
+        expect(fs.existsSync(dead)).toBe(false);
+        expect(fs.existsSync(legacyRecent)).toBe(true);
+
+        for (const dir of [alive, legacyRecent]) {
+            fs.rmSync(dir, {recursive: true, force: true});
+        }
+    });
 
     test('type attribution with on-disk dependencies (comparison)', async () => {
         const spec = new RecipeSpec();

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/DependencyWorkspace.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/DependencyWorkspace.java
@@ -21,6 +21,7 @@ import org.openrewrite.javascript.marker.NodeResolutionResult.PackageManager;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -111,8 +112,10 @@ class DependencyWorkspace {
             // createDirectories is idempotent and safe to call even if directory exists
             Files.createDirectories(WORKSPACE_BASE);
 
-            // Use temp directory for atomic creation
-            Path tempDir = Files.createTempDirectory(WORKSPACE_BASE, key + ".tmp-");
+            // Use temp directory for atomic creation. The pid is stamped into the name so the
+            // TS RPC server's workspace reaper (dependency-workspace.ts) can tell this in-flight
+            // install apart from a crashed one and won't delete the package manager's cwd mid-run.
+            Path tempDir = Files.createTempDirectory(WORKSPACE_BASE, key + ".tmp-" + currentPid() + "-");
 
             try {
                 // Write package.json
@@ -221,6 +224,21 @@ class DependencyWorkspace {
         if (!result.isSuccess()) {
             throw new RuntimeException(executor.getName() + " install failed (exit "
                     + result.getExitCode() + "): " + result.getStderr());
+        }
+    }
+
+    /**
+     * The current process id, used to tag in-flight install temp dirs so a cross-process
+     * reaper can distinguish them from abandoned ones. Java 8 has no {@code ProcessHandle},
+     * so derive it from the {@code pid@host} runtime name; falls back to {@code 0} if absent.
+     */
+    private static long currentPid() {
+        String name = ManagementFactory.getRuntimeMXBean().getName();
+        int at = name.indexOf('@');
+        try {
+            return Long.parseLong(at > 0 ? name.substring(0, at) : name);
+        } catch (NumberFormatException e) {
+            return 0;
         }
     }
 


### PR DESCRIPTION
## What's changed?

Fix JavaScript's `DependencyWorkspace` management of temporary workspaces.
Specifically in the clean-up phase remove only its own (determined by the owner's PID).

## What's your motivation?

The direct trigger for me is to fix failing integration tests e.g. `LockFileParserParityTest.parityNpmExpressEnginesAndLicense` and others.
In theory this could also apply to Moderne CLI executions, but we don't actively support parallel runs of CLI.