### PR TITLE
Go: Parse _test.go files too

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -2029,7 +2029,7 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		switch {
 		case filepath.Base(path) == "go.mod":
 			disc.goMods = append(disc.goMods, path)
-		case strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go"):
+		case strings.HasSuffix(path, ".go"):
 			disc.goFiles = append(disc.goFiles, path)
 		}
 		return nil
@@ -2115,6 +2115,13 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		if !ok {
 			continue
 		}
+		// Test files are parseable project sources, but they must not feed
+		// sibling-package symbol resolution: Go's importer never exposes a
+		// package's `_test.go` files, and a black-box `package foo_test`
+		// file would corrupt the imported package's type-check.
+		if strings.HasSuffix(goFile, "_test.go") {
+			continue
+		}
 		m := closestModule(filepath.Dir(goFile))
 		if m == nil {
 			continue
@@ -2125,7 +2132,13 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 	// Group files by (owning module, package directory). Each group
 	// parses together via ParsePackage so file-A-references-file-B
 	// resolves within a package.
-	type groupKey struct{ moduleDir, pkgDir string }
+	// pkgName is the literal `package` clause, so it splits a directory by
+	// the package each file actually declares. Production code and white-box
+	// `_test.go` files share `package foo` (pkgName "foo"); black-box tests
+	// declare `package foo_test` (pkgName "foo_test") and thus form a second
+	// group. Without this split they'd share a key and go/types would
+	// silently drop every file whose clause disagrees with the group's first.
+	type groupKey struct{ moduleDir, pkgDir, pkgName string }
 	type fileEntry struct {
 		idx        int
 		path       string
@@ -2155,7 +2168,7 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		if m != nil {
 			moduleDir = m.dir
 		}
-		key := groupKey{moduleDir: moduleDir, pkgDir: filepath.Dir(goFile)}
+		key := groupKey{moduleDir: moduleDir, pkgDir: filepath.Dir(goFile), pkgName: goparser.PackageNameOf(goFile, src)}
 		groups[key] = append(groups[key], fileEntry{
 			idx:        i,
 			path:       goFile,

--- a/rewrite-go/cmd/rpc/parse_project_test_files_test.go
+++ b/rewrite-go/cmd/rpc/parse_project_test_files_test.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// TestParseProjectParsesTestFiles pins down that `_test.go` files are parsed
+// as project sources (previously excluded), and that a black-box external
+// test package (`package foo_test`) co-located with its production package
+// still gets type attribution — i.e. it is type-checked separately from the
+// production files and resolves the production package through the importer.
+func TestParseProjectParsesTestFiles(t *testing.T) {
+	// given
+	s, _ := newTestServer(t)
+	projectDir := t.TempDir()
+	writeFile(t, filepath.Join(projectDir, "go.mod"), "module example.com/m\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(projectDir, "foo", "foo.go"),
+		"package foo\n\nfunc Hello() string { return \"hi\" }\n")
+	// In-package (white-box) test: same `package foo`.
+	writeFile(t, filepath.Join(projectDir, "foo", "foo_internal_test.go"),
+		"package foo\n\nfunc internalHello() string { return Hello() }\n")
+	// Black-box (external) test: `package foo_test`, co-located with the
+	// production package. It must be type-checked as its own package — if it
+	// were lumped in with `package foo`, go/types would drop the whole file
+	// and `helper()` below would lose its type attribution.
+	writeFile(t, filepath.Join(projectDir, "foo", "foo_test.go"),
+		"package foo_test\n\nfunc helper() string { return \"x\" }\nfunc useHelper() string { return helper() }\n")
+
+	relativeTo := projectDir
+	params, err := json.Marshal(parseProjectRequest{ProjectPath: projectDir, RelativeTo: &relativeTo})
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+
+	// when
+	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
+		t.Fatalf("handleParseProject: %v", rpcErr.Message)
+	}
+
+	// then
+	cusByPath := map[string]*golang.CompilationUnit{}
+	for _, obj := range s.localObjects {
+		if cu, ok := obj.(*golang.CompilationUnit); ok {
+			cusByPath[filepath.ToSlash(cu.SourcePath)] = cu
+		}
+	}
+	for _, want := range []string{"foo/foo.go", "foo/foo_internal_test.go", "foo/foo_test.go"} {
+		if _, ok := cusByPath[want]; !ok {
+			t.Errorf("expected %q to be parsed into a CompilationUnit", want)
+		}
+	}
+
+	// The black-box test's `helper()` call must be type-attributed, which only
+	// holds if the file was type-checked as its own `foo_test` package rather
+	// than lumped in with the co-located `package foo` sources.
+	blackBox := cusByPath["foo/foo_test.go"]
+	if blackBox == nil {
+		t.Fatal("black-box test CU missing; cannot check attribution")
+	}
+	var attributed bool
+	java.WalkTree(blackBox, func(tr java.Tree) bool {
+		if mi, ok := tr.(*java.MethodInvocation); ok && mi.Name != nil &&
+			mi.Name.Name == "helper" && mi.MethodType != nil {
+			attributed = true
+			return false
+		}
+		return true
+	})
+	if !attributed {
+		t.Error("expected helper() in the black-box test package to be type-attributed")
+	}
+}

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -166,6 +166,19 @@ func (gp *GoParser) ParsePackage(files []FileInput) ([]*golang.CompilationUnit, 
 	return cus, nil
 }
 
+// PackageNameOf returns the package clause name of a Go source file, or ""
+// if it can't be parsed. A single directory can hold two packages — `foo`
+// (production code plus in-package `_test.go` files) and `foo_test` (the
+// black-box external test package) — which must be type-checked separately.
+// Callers use this to group files by their actual package, not just by dir.
+func PackageNameOf(path, content string) string {
+	f, err := parser.ParseFile(token.NewFileSet(), path, content, parser.PackageClauseOnly)
+	if err != nil || f.Name == nil {
+		return ""
+	}
+	return f.Name.Name
+}
+
 // parseContext holds the state needed during AST-to-LST mapping.
 type parseContext struct {
 	src      []byte


### PR DESCRIPTION
## What's changed?

Making the Go parser not exclude `_test.go` files.

## What's your motivation?

Users want to apply code maintenance to test code too.
Both white-box and black-box tests.
