### PR TITLE
Go: relativize paths before importer registration

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -2119,7 +2119,12 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		if m == nil {
 			continue
 		}
-		piByModule[m.dir].AddSource(goFile, src)
+		rel, err := filepath.Rel(m.dir, goFile)
+		if err != nil {
+			s.logger.Printf("ParseProject: cannot relativize %s to module %s: %v", goFile, m.dir, err)
+			continue
+		}
+		piByModule[m.dir].AddSource(filepath.ToSlash(rel), src)
 	}
 
 	// Group files by (owning module, package directory). Each group

--- a/rewrite-go/pkg/test/spec.go
+++ b/rewrite-go/pkg/test/spec.go
@@ -284,18 +284,29 @@ func parsePackageGroups(t *testing.T, p *parser.GoParser, flat []SourceSpec) map
 //   - intra-project imports type-check against real sources;
 //   - imports of declared third-party modules resolve to stub packages.
 //
+// SourceSpec paths may be absolute when tests model ParseProject's
+// filesystem-discovery shape; ProjectImporter still needs module-relative
+// paths so its import-path index matches the module path.
+//
 // Returns nil when there's no module context — the caller should fall
 // back to importer.Default().
 func buildProjectImporter(flat []SourceSpec) *parser.ProjectImporter {
 	var mrr *golang.GoResolutionResult
+	moduleRoot := ""
 	for _, s := range flat {
 		if found := FindGoResolutionResult(s); found != nil && found.ModulePath != "" {
 			mrr = found
+			if path.IsAbs(s.Path) {
+				moduleRoot = path.Dir(path.Clean(s.Path))
+			}
 			break
 		}
 	}
 	if mrr == nil {
 		return nil
+	}
+	if moduleRoot == "" {
+		moduleRoot = commonAbsoluteSourceRoot(flat)
 	}
 	pi := parser.NewProjectImporter(mrr.ModulePath, nil)
 	for _, req := range mrr.Requires {
@@ -305,9 +316,56 @@ func buildProjectImporter(flat []SourceSpec) *parser.ProjectImporter {
 		if !strings.HasSuffix(s.Path, ".go") {
 			continue
 		}
-		pi.AddSource(s.Path, s.Before)
+		pi.AddSource(moduleRelativeSourcePath(s.Path, moduleRoot), s.Before)
 	}
 	return pi
+}
+
+func commonAbsoluteSourceRoot(flat []SourceSpec) string {
+	root := ""
+	for _, s := range flat {
+		if !strings.HasSuffix(s.Path, ".go") || !path.IsAbs(s.Path) {
+			continue
+		}
+		dir := path.Dir(path.Clean(s.Path))
+		if root == "" {
+			root = dir
+		} else {
+			root = commonPathPrefix(root, dir)
+		}
+	}
+	return root
+}
+
+func commonPathPrefix(a, b string) string {
+	if a == b {
+		return a
+	}
+	aParts := strings.Split(strings.Trim(a, "/"), "/")
+	bParts := strings.Split(strings.Trim(b, "/"), "/")
+	n := 0
+	for n < len(aParts) && n < len(bParts) && aParts[n] == bParts[n] {
+		n++
+	}
+	if n == 0 {
+		return "/"
+	}
+	return "/" + strings.Join(aParts[:n], "/")
+}
+
+func moduleRelativeSourcePath(sourcePath, moduleRoot string) string {
+	if moduleRoot == "" {
+		return sourcePath
+	}
+	cleaned := path.Clean(sourcePath)
+	if !path.IsAbs(cleaned) {
+		return sourcePath
+	}
+	root := path.Clean(moduleRoot)
+	if strings.HasPrefix(cleaned, root+"/") {
+		return strings.TrimPrefix(cleaned, root+"/")
+	}
+	return sourcePath
 }
 
 // Golang creates a SourceSpec for Go source code.

--- a/rewrite-go/test/project_type_attribution_test.go
+++ b/rewrite-go/test/project_type_attribution_test.go
@@ -120,6 +120,42 @@ func TestGoProjectWiresImporterIntoHarness(t *testing.T) {
 	)
 }
 
+// TestGoProjectWithAbsolutePathsResolvesSiblingPackageImports documents the
+// production ParseProject shape without writing files to disk. ParseProject
+// discovers absolute file paths, but ProjectImporter must receive
+// module-relative paths so sibling package imports are indexed under the
+// module import path.
+func TestGoProjectWithAbsolutePathsResolvesSiblingPackageImports(t *testing.T) {
+	mainSrc := test.Golang(`
+		package main
+
+		import "example.com/foo/sub"
+
+		func main() { _ = sub.Hello() }
+	`).WithPath("/workspace/main.go")
+	mainSrc.AfterRecipe = func(t *testing.T, cu *golang.CompilationUnit) {
+		t.Helper()
+		test.ExpectMethodType(t, cu, "Hello", "example.com/foo/sub")
+	}
+
+	spec := test.NewRecipeSpec()
+	spec.RewriteRun(t,
+		test.GoProject("foo",
+			test.GoMod(`
+				module example.com/foo
+
+				go 1.22
+			`),
+			test.Golang(`
+				package sub
+
+				func Hello() string { return "hi" }
+			`).WithPath("/workspace/sub/sub.go"),
+			mainSrc,
+		),
+	)
+}
+
 // collectIdentTypes walks the tree and returns a map of identifier name
 // → its Type (whichever last assignment wins; sufficient for these tests).
 func collectIdentTypes(cu *golang.CompilationUnit) map[string]java.JavaType {


### PR DESCRIPTION
## What's changed?

Add a logic to relative paths of source files before Go importer registration.

## What's your motivation?

Otherwise they might end up being absolute and when evaluated in relative context, they end up invalid.

- Before: `/Users/greg/project/sub/sub.go -> example.com/foo//Users/greg/project/sub`
- After: `sub/sub.go -> example.com/foo/sub`