### PR TITLE
Fix UpdateMavenModel discarding a parent POM's update when an aggregated child module fails to re-resolve

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
@@ -199,28 +198,22 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
         MavenPomDownloader downloader = new MavenPomDownloader(projectPoms, ctx, getResolutionResult().getMavenSettings(),
                 getResolutionResult().getActiveProfiles());
 
-        AtomicReference<MavenDownloadingExceptions> exceptions = new AtomicReference<>();
         try {
             ResolvedPom resolved = resolutionResult.getPom().resolve(ctx, downloader);
-            MavenResolutionResult mrr = resolutionResult
+            return resolutionResult
                     .withPom(resolved)
+                    // Re-resolve modules best-effort: a module that is transiently unresolvable mid-recipe keeps
+                    // its previous resolution rather than discarding this pom's own valid update.
                     .withModules(ListUtils.map(resolutionResult.getModules(), module -> {
                         try {
                             return updateResult(ctx, module, projectPoms);
                         } catch (MavenDownloadingExceptions e) {
-                            exceptions.set(MavenDownloadingExceptions.append(exceptions.get(), e));
                             return module;
                         }
                     }))
                     .resolveDependencies(downloader, ctx);
-            if (exceptions.get() != null) {
-                throw exceptions.get();
-            }
-            return mrr;
-        } catch (MavenDownloadingExceptions e) {
-            throw MavenDownloadingExceptions.append(exceptions.get(), e);
         } catch (MavenDownloadingException e) {
-            throw MavenDownloadingExceptions.append(exceptions.get(), e);
+            throw MavenDownloadingExceptions.append(null, e);
         }
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -385,6 +385,105 @@ class UpgradeDependencyVersionTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/8145")
+    @Test
+    void changeDependencyThenUpgradeManagedVersionInParentOfMultiModule() {
+        rewriteRun(
+          spec -> spec.recipes(
+            // Phase 1: rename javax -> jakarta (EE9 migration)
+            new ChangeDependencyGroupIdAndArtifactId(
+              "javax.servlet", "javax.servlet-api",
+              "jakarta.servlet", "jakarta.servlet-api",
+              "5.0.x", null),
+            // Phase 2: bump jakarta EE9 -> EE10, which must upgrade the parent's managed version
+            new UpgradeDependencyVersion(
+              "jakarta.servlet", "jakarta.servlet-api",
+              "6.0.x", null, null, null)
+          ),
+          mavenProject("parent",
+            pomXml(
+              """
+                <project>
+                    <groupId>com.example</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <packaging>pom</packaging>
+                    <modules>
+                        <module>child</module>
+                    </modules>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.servlet</groupId>
+                                <artifactId>javax.servlet-api</artifactId>
+                                <version>4.0.0</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """,
+              """
+                <project>
+                    <groupId>com.example</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <packaging>pom</packaging>
+                    <modules>
+                        <module>child</module>
+                    </modules>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>jakarta.servlet</groupId>
+                                <artifactId>jakarta.servlet-api</artifactId>
+                                <version>6.0.0</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """
+            ),
+            // The child inherits the version from the parent, so it must remain version-less
+            mavenProject("child",
+              pomXml(
+                """
+                  <project>
+                      <parent>
+                          <groupId>com.example</groupId>
+                          <artifactId>parent</artifactId>
+                          <version>1.0-SNAPSHOT</version>
+                      </parent>
+                      <artifactId>child</artifactId>
+                      <dependencies>
+                          <dependency>
+                              <groupId>javax.servlet</groupId>
+                              <artifactId>javax.servlet-api</artifactId>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """,
+                """
+                  <project>
+                      <parent>
+                          <groupId>com.example</groupId>
+                          <artifactId>parent</artifactId>
+                          <version>1.0-SNAPSHOT</version>
+                      </parent>
+                      <artifactId>child</artifactId>
+                      <dependencies>
+                          <dependency>
+                              <groupId>jakarta.servlet</groupId>
+                              <artifactId>jakarta.servlet-api</artifactId>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """
+              )
+            )
+          )
+        );
+    }
+
     @Test
     void upgradeVersionSuccessively() {
         rewriteRun(


### PR DESCRIPTION
## What's changed

- Fixes #8145
- Closes openrewrite/rewrite-spring#275

In a multi-module Maven project, chaining a model-mutating recipe such as `ChangeDependency` followed by `UpgradeDependencyVersion` in the same run left the parent POM's `<dependencyManagement>` entry un-upgraded.

The root cause is in `UpdateMavenModel.updateResult`. When `maybeUpdateModel()` refreshes a parent POM's resolved model, it also re-resolves the parent's aggregated child modules recursively. Mid-recipe a child can be in a transient, inconsistent state — e.g. `ChangeDependency` just renamed a managed dependency in the parent, but the child still references the old (now unmanaged) coordinates and therefore can't resolve a version. That threw `MavenDownloadingExceptions`, which the old code collected and re-threw, causing the **entire** parent update to be discarded (`e.warn(document)`). The parent's resolved `MavenResolutionResult` was left stale, so the subsequent `UpgradeDependencyVersion` couldn't find the managed dependency and left the parent at the old version.

Module re-resolution is now **best-effort**: a module that is transiently unresolvable keeps its previous resolution — it is refreshed when its own source file is updated later in the run — and no longer invalidates the parent POM's own valid update.

## Testing

- Added `UpgradeDependencyVersionTest.changeDependencyThenUpgradeManagedVersionInParentOfMultiModule`, which reproduces the #8145 scenario: after `ChangeDependency`, the parent's managed version is upgraded and the child stays version-less. It fails on `main` (parent stuck at the intermediate version) and passes with this fix.
- Full `:rewrite-maven:test` suite passes.

## Related

The original #8145 report also observed a spurious `<version>` being added to the child when the dependency uses `provided` scope. That is an independent `ChangeDependencyGroupIdAndArtifactId` bug, split out into #8179.