### PR TITLE
YAML: fix MergeYaml + fix CoalesceProperties formatting on block scalars

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -23,6 +23,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.style.GeneralFormatStyle;
 import org.openrewrite.style.Style;
 import org.openrewrite.yaml.MergeYaml.InsertMode;
+import org.openrewrite.yaml.trait.BlockScalar;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.ArrayList;
@@ -388,9 +389,14 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
     }
 
     private Yaml.Scalar mergeScalar(Yaml.Scalar y1, Yaml.Scalar y2) {
-        String s1 = y1.getValue();
-        String s2 = y2.getValue();
-        return !s1.equals(s2) && !acceptTheirs ? y1.withValue(s2) : y1;
+        BlockScalar.Matcher matcher = new BlockScalar.Matcher();
+        BlockScalar existing = matcher.get(new Cursor(null, y1)).orElse(null);
+        String s1 = existing != null ? existing.getBody() : y1.getValue();
+        String s2 = matcher.get(new Cursor(null, y2)).map(BlockScalar::getBody).orElseGet(y2::getValue);
+        if (s1.equals(s2) || acceptTheirs) {
+            return y1;
+        }
+        return existing != null ? existing.withBody(s2) : y1.withValue(s2);
     }
 
     /**

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -120,6 +120,11 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
         if (existing.isScope(existingMapping) && incoming instanceof Yaml.Mapping) {
             Yaml.Mapping mapping = mergeMapping(existingMapping, (Yaml.Mapping) incoming, p, getCursor());
 
+            java.util.Map<java.util.UUID, BoundaryRepair> repairs = getCursor().pollMessage(SIBLING_BOUNDARY_REPAIR);
+            if (repairs != null) {
+                mapping = applySiblingBoundaryRepair(mapping, repairs);
+            }
+
             if (getCursor().getMessage(REMOVE_PREFIX, false)) {
                 List<Yaml.Mapping.Entry> entries = ((Yaml.Mapping) getCursor().getValue()).getEntries();
                 return mapping.withEntries(mapLast(mapping.getEntries(), it ->
@@ -129,6 +134,31 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
             return mapping;
         }
         return super.visitMapping(existingMapping, p);
+    }
+
+    // When mergeScalar swaps between block and plain styles, the sibling-boundary linebreak moves
+    // from the block scalar's trailing content to the next entry's prefix (or vice versa). Apply
+    // that shift here where we have entry-neighbour context.
+    private Yaml.Mapping applySiblingBoundaryRepair(Yaml.Mapping mapping, java.util.Map<java.util.UUID, BoundaryRepair> repairs) {
+        List<Yaml.Mapping.Entry> entries = mapping.getEntries();
+        List<Yaml.Mapping.Entry> patched = new ArrayList<>(entries);
+        String lineBreak = linebreak();
+        for (int i = 0; i < patched.size() - 1; i++) {
+            BoundaryRepair repair = repairs.get(patched.get(i).getId());
+            if (repair == null) {
+                continue;
+            }
+            Yaml.Mapping.Entry next = patched.get(i + 1);
+            if (repair == BoundaryRepair.BLOCK_TO_PLAIN) {
+                if (!next.getPrefix().startsWith("\n") && !next.getPrefix().startsWith("\r")) {
+                    patched.set(i + 1, next.withPrefix(lineBreak + next.getPrefix()));
+                }
+            }
+            // PLAIN_TO_BLOCK: the next entry's prefix already carries the sibling linebreak and
+            // the block scalar's own value may or may not end with one; leave the next entry's
+            // prefix alone rather than risk gluing siblings together.
+        }
+        return mapping.withEntries(patched);
     }
 
     private static boolean keyMatches(Yaml.Mapping.@Nullable Entry e1, Yaml.Mapping.@Nullable Entry e2) {
@@ -390,14 +420,57 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
 
     private Yaml.Scalar mergeScalar(Yaml.Scalar y1, Yaml.Scalar y2) {
         BlockScalar.Matcher matcher = new BlockScalar.Matcher();
-        BlockScalar existing = matcher.get(new Cursor(null, y1)).orElse(null);
-        String s1 = existing != null ? existing.getBody() : y1.getValue();
-        String s2 = matcher.get(new Cursor(null, y2)).map(BlockScalar::getBody).orElseGet(y2::getValue);
-        if (s1.equals(s2) || acceptTheirs) {
+        BlockScalar existingBs = matcher.get(new Cursor(null, y1)).orElse(null);
+        BlockScalar incomingBs = matcher.get(new Cursor(null, y2)).orElse(null);
+        String s1 = existingBs != null ? existingBs.getBody() : y1.getValue();
+        String s2 = incomingBs != null ? incomingBs.getBody() : y2.getValue();
+        if (s1.equals(s2) && y1.getStyle() == y2.getStyle() || acceptTheirs) {
             return y1;
         }
-        return existing != null ? existing.withBody(s2) : y1.withValue(s2);
+        // Adopt the incoming scalar's format: the incoming snippet's style wins.
+        if (incomingBs != null) {
+            // Result is a block scalar. If existing was also a block scalar with the same
+            // header/style, preserve its envelope (chomp indicator, indent, trailing whitespace
+            // bounding the next sibling) and swap only the body.
+            if (existingBs != null && y1.getStyle() == y2.getStyle()) {
+                return existingBs.withBody(s2);
+            }
+            // Existing was plain (or a differently-styled block). Preserve y1's identity (id,
+            // markers, prefix) but adopt y2's style and value verbatim so the block envelope is
+            // whatever the incoming snippet supplied.
+            recordBoundaryRepair(BoundaryRepair.PLAIN_TO_BLOCK);
+            return y1.withStyle(y2.getStyle()).withValue(y2.getValue());
+        }
+        // Result is a plain (or quoted) scalar.
+        if (existingBs != null) {
+            // Existing block scalar's trailing content held the sibling-separator linebreak; the
+            // enclosing mapping needs to add a leading linebreak to the next entry's prefix so the
+            // switched-to-plain value does not glue onto the following sibling.
+            recordBoundaryRepair(BoundaryRepair.BLOCK_TO_PLAIN);
+        }
+        return y1.withStyle(y2.getStyle()).withValue(y2.getValue());
     }
+
+    private enum BoundaryRepair { BLOCK_TO_PLAIN, PLAIN_TO_BLOCK }
+
+    private void recordBoundaryRepair(BoundaryRepair repair) {
+        Cursor entryCursor = getCursor().dropParentUntil(v -> v == ROOT_VALUE || v instanceof Yaml.Mapping.Entry);
+        if (!(entryCursor.getValue() instanceof Yaml.Mapping.Entry)) {
+            return;
+        }
+        Cursor mappingCursor = entryCursor.dropParentUntil(v -> v == ROOT_VALUE || v instanceof Yaml.Mapping);
+        if (!(mappingCursor.getValue() instanceof Yaml.Mapping)) {
+            return;
+        }
+        java.util.Map<java.util.UUID, BoundaryRepair> repairs = mappingCursor.getMessage(SIBLING_BOUNDARY_REPAIR);
+        if (repairs == null) {
+            repairs = new java.util.HashMap<>();
+            mappingCursor.putMessage(SIBLING_BOUNDARY_REPAIR, repairs);
+        }
+        repairs.put(((Yaml.Mapping.Entry) entryCursor.getValue()).getId(), repair);
+    }
+
+    private static final String SIBLING_BOUNDARY_REPAIR = "org.openrewrite.yaml.MergeYamlVisitor.siblingBoundaryRepair";
 
     /**
      * Specialized concatAll function which takes the `insertPlace` property into account.

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -28,8 +28,11 @@ import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -120,7 +123,7 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
         if (existing.isScope(existingMapping) && incoming instanceof Yaml.Mapping) {
             Yaml.Mapping mapping = mergeMapping(existingMapping, (Yaml.Mapping) incoming, p, getCursor());
 
-            java.util.Map<java.util.UUID, BoundaryRepair> repairs = getCursor().pollMessage(SIBLING_BOUNDARY_REPAIR);
+            Map<UUID, BoundaryRepair> repairs = getCursor().pollMessage(SIBLING_BOUNDARY_REPAIR);
             if (repairs != null) {
                 mapping = applySiblingBoundaryRepair(mapping, repairs);
             }
@@ -136,27 +139,16 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
         return super.visitMapping(existingMapping, p);
     }
 
-    // When mergeScalar swaps between block and plain styles, the sibling-boundary linebreak moves
-    // from the block scalar's trailing content to the next entry's prefix (or vice versa). Apply
-    // that shift here where we have entry-neighbour context.
-    private Yaml.Mapping applySiblingBoundaryRepair(Yaml.Mapping mapping, java.util.Map<java.util.UUID, BoundaryRepair> repairs) {
-        List<Yaml.Mapping.Entry> entries = mapping.getEntries();
-        List<Yaml.Mapping.Entry> patched = new ArrayList<>(entries);
+    private Yaml.Mapping applySiblingBoundaryRepair(Yaml.Mapping mapping, Map<UUID, BoundaryRepair> repairs) {
+        List<Yaml.Mapping.Entry> patched = new ArrayList<>(mapping.getEntries());
         String lineBreak = linebreak();
         for (int i = 0; i < patched.size() - 1; i++) {
-            BoundaryRepair repair = repairs.get(patched.get(i).getId());
-            if (repair == null) {
-                continue;
-            }
-            Yaml.Mapping.Entry next = patched.get(i + 1);
-            if (repair == BoundaryRepair.BLOCK_TO_PLAIN) {
+            if (repairs.get(patched.get(i).getId()) == BoundaryRepair.BLOCK_TO_PLAIN) {
+                Yaml.Mapping.Entry next = patched.get(i + 1);
                 if (!next.getPrefix().startsWith("\n") && !next.getPrefix().startsWith("\r")) {
                     patched.set(i + 1, next.withPrefix(lineBreak + next.getPrefix()));
                 }
             }
-            // PLAIN_TO_BLOCK: the next entry's prefix already carries the sibling linebreak and
-            // the block scalar's own value may or may not end with one; leave the next entry's
-            // prefix alone rather than risk gluing siblings together.
         }
         return mapping.withEntries(patched);
     }
@@ -427,25 +419,15 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
         if (s1.equals(s2) && y1.getStyle() == y2.getStyle() || acceptTheirs) {
             return y1;
         }
-        // Adopt the incoming scalar's format: the incoming snippet's style wins.
+        // Adopt the incoming scalar's format.
         if (incomingBs != null) {
-            // Result is a block scalar. If existing was also a block scalar with the same
-            // header/style, preserve its envelope (chomp indicator, indent, trailing whitespace
-            // bounding the next sibling) and swap only the body.
             if (existingBs != null && y1.getStyle() == y2.getStyle()) {
                 return existingBs.withBody(s2);
             }
-            // Existing was plain (or a differently-styled block). Preserve y1's identity (id,
-            // markers, prefix) but adopt y2's style and value verbatim so the block envelope is
-            // whatever the incoming snippet supplied.
             recordBoundaryRepair(BoundaryRepair.PLAIN_TO_BLOCK);
             return y1.withStyle(y2.getStyle()).withValue(y2.getValue());
         }
-        // Result is a plain (or quoted) scalar.
         if (existingBs != null) {
-            // Existing block scalar's trailing content held the sibling-separator linebreak; the
-            // enclosing mapping needs to add a leading linebreak to the next entry's prefix so the
-            // switched-to-plain value does not glue onto the following sibling.
             recordBoundaryRepair(BoundaryRepair.BLOCK_TO_PLAIN);
         }
         return y1.withStyle(y2.getStyle()).withValue(y2.getValue());
@@ -462,9 +444,9 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
         if (!(mappingCursor.getValue() instanceof Yaml.Mapping)) {
             return;
         }
-        java.util.Map<java.util.UUID, BoundaryRepair> repairs = mappingCursor.getMessage(SIBLING_BOUNDARY_REPAIR);
+        Map<UUID, BoundaryRepair> repairs = mappingCursor.getMessage(SIBLING_BOUNDARY_REPAIR);
         if (repairs == null) {
-            repairs = new java.util.HashMap<>();
+            repairs = new HashMap<>();
             mappingCursor.putMessage(SIBLING_BOUNDARY_REPAIR, repairs);
         }
         repairs.put(((Yaml.Mapping.Entry) entryCursor.getValue()).getId(), repair);

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ShiftFormatLeftVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ShiftFormatLeftVisitor.java
@@ -45,11 +45,36 @@ public class ShiftFormatLeftVisitor<P> extends YamlIsoVisitor<P> {
     public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, P p) {
         Yaml.Mapping.Entry e = super.visitMappingEntry(entry, p);
         if (getCursor().isScopeInPath(scope)) {
-            if (e.getPrefix().contains("\n")) {
-                e = e.withPrefix(shiftPrefix(e.getPrefix()));
-            }
+            e = e.withPrefix(shiftPrefix(e.getPrefix()));
         }
         return e;
+    }
+
+    @Override
+    public Yaml.Scalar visitScalar(Yaml.Scalar scalar, P p) {
+        Yaml.Scalar s = super.visitScalar(scalar, p);
+        if (getCursor().isScopeInPath(scope) &&
+                (s.getStyle() == Yaml.Scalar.Style.FOLDED || s.getStyle() == Yaml.Scalar.Style.LITERAL)) {
+            String value = s.getValue();
+            int headerEnd = value.indexOf('\n');
+            if (headerEnd >= 0) {
+                s = s.withValue(value.substring(0, headerEnd + 1) + shiftBlockBody(value.substring(headerEnd + 1)));
+            }
+        }
+        return s;
+    }
+
+    // The body region of a block scalar carries its own indent inside Yaml.Scalar.value; each body
+    // line and the trailing whitespace bounding the next sibling must be dedented in step with the
+    // surrounding mapping entries' prefixes.
+    private String shiftBlockBody(String body) {
+        return String.join("\n", ListUtils.map(Arrays.asList(body.split("\\n", -1)), (index, s) -> {
+            int nonWs = StringUtils.indexOfNonWhitespace(s);
+            if (nonWs >= shift || (nonWs == -1 && s.length() >= shift)) {
+                return s.substring(shift);
+            }
+            return s;
+        }));
     }
 
     @SuppressWarnings("DynamicRegexReplaceableByCompiledPattern")

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ShiftFormatLeftVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ShiftFormatLeftVisitor.java
@@ -64,9 +64,7 @@ public class ShiftFormatLeftVisitor<P> extends YamlIsoVisitor<P> {
         return s;
     }
 
-    // The body region of a block scalar carries its own indent inside Yaml.Scalar.value; each body
-    // line and the trailing whitespace bounding the next sibling must be dedented in step with the
-    // surrounding mapping entries' prefixes.
+    // A block scalar's body indent lives inside Yaml.Scalar.value and must dedent in step with the surrounding entry prefixes.
     private String shiftBlockBody(String body) {
         return String.join("\n", ListUtils.map(Arrays.asList(body.split("\\n", -1)), (index, s) -> {
             int nonWs = StringUtils.indexOfNonWhitespace(s);

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CoalescePropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CoalescePropertiesTest.java
@@ -376,4 +376,79 @@ class CoalescePropertiesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void coalescesMappingSiblingOfBlockScalar() {
+        rewriteRun(
+          spec -> spec.recipe(new CoalesceProperties(null, null)),
+          yaml(
+            """
+              outer:
+                inner:
+                  java_opts: >-
+                    -Da=1
+                    -Db=2
+                  after: tail
+              """,
+            """
+              outer.inner:
+                java_opts: >-
+                  -Da=1
+                  -Db=2
+                after: tail
+              """
+          )
+        );
+    }
+
+    @Test
+    void coalescesLoneBlockScalar() {
+        rewriteRun(
+          spec -> spec.recipe(new CoalesceProperties(null, null)),
+          yaml(
+            """
+              outer:
+                inner: |
+                  line one
+                  line two
+              """,
+            """
+              outer.inner: |
+                line one
+                line two
+              """
+          )
+        );
+    }
+
+    @Test
+    void coalescesDeeplyNestedBlockScalar() {
+        rewriteRun(
+          spec -> spec.recipe(new CoalesceProperties(null, null)),
+          yaml(
+            """
+              outer:
+                inner:
+                  details:
+                    script: |
+                      echo hello
+              """,
+            """
+              outer.inner.details.script: |
+                echo hello
+              """
+          )
+        );
+    }
+
+    @Test
+    void coalescesBlockScalarPreservingCrlfBodyLineEndings() {
+        rewriteRun(
+          spec -> spec.recipe(new CoalesceProperties(null, null)),
+          yaml(
+            "outer:\r\n  inner: |\r\n    line one\r\n    line two\r\n",
+            "outer.inner: |\r\n  line one\r\n  line two\r\n"
+          )
+        );
+    }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -4049,6 +4049,63 @@ class MergeYamlTest implements RewriteTest {
     }
 
     @Test
+    void overwriteBlockStripOverPlainNoTrailingNewline() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml("$", "key: |-\n  line one\n  line two", false, null, null, null, null, null)),
+          yaml(
+            """
+              key: value
+              after: tail
+              """,
+            """
+              key: |-
+                line one
+                line two
+              after: tail
+              """
+          )
+        );
+    }
+
+    @Test
+    void overwriteBlockClipOverPlainNoTrailingNewline() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml("$", "key: |\n  line one\n  line two", false, null, null, null, null, null)),
+          yaml(
+            """
+              key: value
+              after: tail
+              """,
+            """
+              key: |
+                line one
+                line two
+              after: tail
+              """
+          )
+        );
+    }
+
+    @Test
+    void overwriteBlockOverPlainAsLastEntryNoTrailingNewline() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml("$", "last: |-\n  line one\n  line two", false, null, null, null, null, null)),
+          yaml(
+            """
+              before: head
+              last: value
+              """,
+            """
+              before: head
+              last: |-
+                line one
+                line two
+              """
+          )
+        );
+    }
+
+    @Test
     void overwriteBlockOverBlockSameStyleKeepsExistingEnvelope() {
         rewriteRun(
           spec -> spec.recipe(new MergeYaml("$", "key: >-\n  replaced\n", false, null, null, null, null, null)),

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -3990,4 +3990,45 @@ class MergeYamlTest implements RewriteTest {
         );
     }
 
+    @Test
+    void overwriteFoldedStripBlockScalarPreservesEnvelope() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml("$", "key: replaced\n", false, null, null, null, null, null)),
+          yaml(
+            """
+              key: >-
+                line one
+                line two
+              after: tail
+              """,
+            """
+              key: >-
+                replaced
+              after: tail
+              """
+          )
+        );
+    }
+
+    @Test
+    void overwriteLiteralKeepBlockScalarPreservesEnvelope() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml("$", "key: replaced\n", false, null, null, null, null, null)),
+          yaml(
+            """
+              key: |+
+                line one
+                line two
+
+              after: tail
+              """,
+            """
+              key: |+
+                replaced
+
+              after: tail
+              """
+          )
+        );
+    }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -3991,9 +3991,9 @@ class MergeYamlTest implements RewriteTest {
     }
 
     @Test
-    void overwriteFoldedStripBlockScalarPreservesEnvelope() {
+    void overwritePlainOverBlockFoldedAdoptsPlainFormat() {
         rewriteRun(
-          spec -> spec.recipe(new MergeYaml("$", "key: replaced\n", false, null, null, null, null, null)),
+          spec -> spec.recipe(new MergeYaml("$", "key: replaced", false, null, null, null, null, null)),
           yaml(
             """
               key: >-
@@ -4002,8 +4002,7 @@ class MergeYamlTest implements RewriteTest {
               after: tail
               """,
             """
-              key: >-
-                replaced
+              key: replaced
               after: tail
               """
           )
@@ -4011,9 +4010,9 @@ class MergeYamlTest implements RewriteTest {
     }
 
     @Test
-    void overwriteLiteralKeepBlockScalarPreservesEnvelope() {
+    void overwritePlainOverBlockLiteralAdoptsPlainFormat() {
         rewriteRun(
-          spec -> spec.recipe(new MergeYaml("$", "key: replaced\n", false, null, null, null, null, null)),
+          spec -> spec.recipe(new MergeYaml("$", "key: replaced", false, null, null, null, null, null)),
           yaml(
             """
               key: |+
@@ -4023,9 +4022,46 @@ class MergeYamlTest implements RewriteTest {
               after: tail
               """,
             """
-              key: |+
-                replaced
+              key: replaced
+              after: tail
+              """
+          )
+        );
+    }
 
+    @Test
+    void overwriteBlockOverPlainAdoptsIncomingBlockFormat() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml("$", "key: |\n  line one\n  line two\n", false, null, null, null, null, null)),
+          yaml(
+            """
+              key: value
+              after: tail
+              """,
+            """
+              key: |
+                line one
+                line two
+              after: tail
+              """
+          )
+        );
+    }
+
+    @Test
+    void overwriteBlockOverBlockSameStyleKeepsExistingEnvelope() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml("$", "key: >-\n  replaced\n", false, null, null, null, null, null)),
+          yaml(
+            """
+              key: >-
+                line one
+                line two
+              after: tail
+              """,
+            """
+              key: >-
+                replaced
               after: tail
               """
           )


### PR DESCRIPTION
Follow-up to #8154 covering two more places where block-scalar handling was broken.

## `MergeYaml.mergeScalar`

Scalar overwrite now adopts the *incoming* snippet's format rather than preserving the existing scalar's envelope (per @sambsnyd's preference in the earlier discussion on this PR):

- **block → block, same style**: keep the existing envelope (chomp indicator, indent, trailing whitespace bounding the next sibling), swap only the body via `BlockScalar.withBody`.
- **anything → block**: return a block scalar built from the incoming snippet's value.
- **anything → plain**: return a plain scalar with the incoming value.

Because a block scalar's sibling-separator linebreak lives inside its trailing content (rather than the next entry's prefix), a block↔plain swap requires cross-sibling coordination. `mergeScalar` records the direction of the swap on the enclosing mapping cursor via a `SIBLING_BOUNDARY_REPAIR` message; `visitMapping` consumes it and, for `BLOCK_TO_PLAIN`, prepends a linebreak onto the next entry's prefix so the plain value doesn't glue onto the following sibling. `PLAIN_TO_BLOCK` is a no-op — `YamlParser` normalises the incoming block scalar's chomp semantics on the way in, and the sibling boundary falls out of either the next entry's existing prefix or the document tail.

## `ShiftFormatLeftVisitor`

Two fixes so `CoalesceProperties` (and `UnfoldProperties`, which shares this visitor) can dedent through block scalars correctly:

1. **New `visitScalar` override** — for FOLDED / LITERAL scalars in scope, shifts each body line and any trailing whitespace stored inside `Yaml.Scalar.value` by the same amount as the surrounding mapping-entry prefixes. Splits on `\n` and preserves embedded `\r` on interior lines so CRLF-authored files round-trip.

2. **Drops the `if (e.getPrefix().contains("\n"))` guard on `visitMappingEntry`.** The guard was legacy defensive code from before `shiftPrefix()` existed and incidentally skipped exactly the entries we need to dedent — those whose bare-whitespace prefix carries only the indent, because the boundary newline lives in the preceding block scalar's `value`. `shiftPrefix()` already handles the guard's original edge cases (empty prefix, same-line comment) via its per-split-element logic.

Kept out of `ShiftIndentVisitor` intentionally — its consumer (`MergeYaml` new-entry alignment) shifts entry prefixes at the top of the subtree only and doesn't currently exercise a block-scalar-body path, so this stays scoped to the coalesce case.

## `CoalescePropertiesVisitor`

With the `ShiftFormatLeftVisitor` fix in place, mappings containing block scalars can be coalesced without corrupting layout. New tests cover:

- Block-scalar sibling of a plain entry (`java_opts: >-` next to `after: tail`) — previously the naive coalesce absorbed `after: tail` into the block-scalar body.
- Lone block scalar (`inner: |`) — coalesces to `outer.inner: |` with the body properly re-indented.
- Deeply nested block scalar — multi-level coalesce compounds correctly.
- CRLF round-trip through the whole coalesce path.

## Test plan

- [x] `./gradlew :rewrite-yaml:test` green.
- New `MergeYamlTest` cases: `overwritePlainOverBlockFoldedAdoptsPlainFormat`, `overwritePlainOverBlockLiteralAdoptsPlainFormat`, `overwriteBlockOverPlainAdoptsIncomingBlockFormat`, `overwriteBlockOverBlockSameStyleKeepsExistingEnvelope`, plus three regression tests confirming block-scalar snippets without a trailing `\n` still produce valid output: `overwriteBlockStripOverPlainNoTrailingNewline`, `overwriteBlockClipOverPlainNoTrailingNewline`, `overwriteBlockOverPlainAsLastEntryNoTrailingNewline`.
- New `CoalescePropertiesTest` cases: `coalescesMappingSiblingOfBlockScalar`, `coalescesLoneBlockScalar`, `coalescesDeeplyNestedBlockScalar`, `coalescesBlockScalarPreservingCrlfBodyLineEndings`.