### PR TITLE
Report non-string declarative recipe tags as validation errors

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -265,9 +265,20 @@ public class YamlResourceLoader implements ResourceLoader {
         String description = (String) yaml.get("description");
 
         Set<String> tags = emptySet();
-        List<String> rawTags = (List<String>) yaml.get("tags");
+        List<Object> invalidTags = emptyList();
+        List<Object> rawTags = (List<Object>) yaml.get("tags");
         if (rawTags != null) {
-            tags = new HashSet<>(rawTags);
+            tags = new HashSet<>(rawTags.size());
+            for (Object rawTag : rawTags) {
+                if (rawTag instanceof String) {
+                    tags.add((String) rawTag);
+                } else {
+                    if (invalidTags.isEmpty()) {
+                        invalidTags = new ArrayList<>();
+                    }
+                    invalidTags.add(rawTag);
+                }
+            }
         }
 
         String estimatedEffortPerOccurrenceStr = (String) yaml.get("estimatedEffortPerOccurrence");
@@ -306,6 +317,14 @@ public class YamlResourceLoader implements ResourceLoader {
                 source,
                 (boolean) yaml.getOrDefault("causesAnotherCycle", false),
                 maintainers);
+
+        for (Object invalidTag : invalidTags) {
+            recipe.addValidation(invalid(
+                    name + ".tags",
+                    invalidTag,
+                    "tags must be a list of strings, but found a " +
+                            (invalidTag == null ? "null value" : invalidTag.getClass().getSimpleName())));
+        }
 
         List<Object> recipeList = (List<Object>) yaml.get("recipeList");
         if (recipeList == null) {

--- a/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
@@ -175,6 +175,40 @@ class YamlResourceLoaderTest implements RewriteTest {
     }
 
     @Test
+    void nonStringTagsAreReportedAsValidationErrorsInsteadOfThrowing() {
+        Environment env = Environment.builder()
+          .load(new YamlResourceLoader(new ByteArrayInputStream(
+            //language=yml
+            """
+              type: specs.openrewrite.org/v1beta/recipe
+              name: test.ChangeTextToHello
+              displayName: Change text to hello
+              tags:
+                - fine
+                - not_string_tag: boom
+              recipeList:
+                  - org.openrewrite.text.ChangeText:
+                      toText: Hello!
+              """.getBytes()
+          ), URI.create("rewrite.yml"), new Properties()))
+          .build();
+
+        Recipe recipe = env.listRecipes().iterator().next();
+
+        // Only valid String tags are retained, so iterating getTags() does not throw a ClassCastException
+        assertThat(recipe.getTags()).containsExactly("fine");
+        recipe.getTags().forEach(tag -> assertThat(tag).isInstanceOf(String.class));
+
+        // The non-string tag surfaces as a validation error rather than crashing at runtime
+        assertThat(recipe.validate().isValid()).isFalse();
+        assertThat(recipe.validate().failures())
+          .anySatisfy(failure -> {
+              assertThat(failure.getProperty()).isEqualTo("test.ChangeTextToHello.tags");
+              assertThat(failure.getMessage()).contains("tags must be a list of strings");
+          });
+    }
+
+    @Test
     void maintainers() {
         Environment env = Environment.builder()
           .load(new YamlResourceLoader(new ByteArrayInputStream(


### PR DESCRIPTION
- Fixes #8161. A tag defined in a declarative YAML recipe as a non-string value (e.g. a mapping) slipped into the recipe's `Set<String>` through an erased cast, so a `ClassCastException` was thrown later when consumers iterated `getTags()`. `YamlResourceLoader.mapToRecipe` now filters tags to strings—keeping `getTags()` type-safe—and reports any non-string entry through the recipe's `Validated` channel so the malformed recipe surfaces via `validate()` instead of crashing. Added a `YamlResourceLoaderTest` case covering a mix of valid and invalid tags.