### PR TITLE
Go: Set GOROOT for Go RPC

### DIFF
--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoRootTrimpathAttributionIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoRootTrimpathAttributionIntegTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.rpc;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.golang.Assertions.expectMethodType;
+import static org.openrewrite.golang.Assertions.go;
+
+/**
+ * Regression test for method-type attribution when the RPC binary is built
+ * with {@code -trimpath} (as the Moderne CLI ships it). {@code -trimpath}
+ * strips the binary's baked-in GOROOT, so the parser's go/types importer
+ * can't resolve the stdlib and every {@code J.MethodInvocation} loses its
+ * {@code JavaType.Method}. {@link GoRewriteRpc} recovers GOROOT from the host
+ * toolchain and passes it to the subprocess; this verifies attribution
+ * survives.
+ */
+@Timeout(value = 180, unit = TimeUnit.SECONDS)
+class GoRootTrimpathAttributionIntegTest implements RewriteTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void before() throws Exception {
+        Path trimpathBinary = tempDir.resolve("rewrite-go-rpc-trimpath");
+        Process build = new ProcessBuilder("go", "build", "-trimpath",
+                "-o", trimpathBinary.toAbsolutePath().toString(), "./cmd/rpc")
+                .directory(new File(".").getAbsoluteFile())
+                .redirectErrorStream(true)
+                .start();
+        StringBuilder out = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(build.getInputStream(), StandardCharsets.UTF_8))) {
+            for (String line; (line = reader.readLine()) != null; ) {
+                out.append(line).append('\n');
+            }
+        }
+        assertThat(build.waitFor(150, TimeUnit.SECONDS)).as("go build -trimpath finished").isTrue();
+        assertThat(build.exitValue()).as("go build -trimpath succeeded:\n" + out).isZero();
+
+        GoRewriteRpc.setFactory(GoRewriteRpc.builder()
+                .goBinaryPath(trimpathBinary)
+                .log(tempDir.resolve("go-rpc.log")));
+    }
+
+    @AfterEach
+    void after() {
+        GoRewriteRpc.shutdownCurrent();
+    }
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.typeValidationOptions(TypeValidation.builder()
+                .allowNonWhitespaceInWhitespace(true)
+                .build());
+    }
+
+    @Test
+    void methodTypesResolveDespiteTrimpath() {
+        rewriteRun(
+                go(
+                        """
+                                package main
+
+                                import "net/http"
+
+                                func fetch() {
+                                \thttp.Get("http://example.com/api")
+                                }
+
+                                func doIt(c *http.Client, req *http.Request) {
+                                \tc.Do(req)
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            expectMethodType(cu, "Get", "net/http");
+                            expectMethodType(cu, "Do", "net/http.Client");
+                        })
+                )
+        );
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
@@ -33,10 +33,13 @@ import org.openrewrite.tree.ParseError;
 import org.openrewrite.tree.ParsingEventListener;
 import org.openrewrite.tree.ParsingExecutionContextView;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -48,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Spliterator;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -427,6 +431,7 @@ public class GoRewriteRpc extends RewriteRpc {
             }
             process.setStderrRedirect(log);
             process.environment().putAll(environment);
+            ensureGoRoot(process.environment());
             process.start();
 
             try {
@@ -440,5 +445,58 @@ public class GoRewriteRpc extends RewriteRpc {
                 throw new UncheckedIOException(e);
             }
         }
+    }
+
+    private static volatile boolean goRootResolved;
+    private static volatile @Nullable String resolvedGoRoot;
+
+    // The RPC binary is built with `-trimpath`, which strips its baked-in
+    // GOROOT. Without GOROOT the parser's go/types importer can't resolve the
+    // stdlib, so every J.MethodInvocation loses its JavaType.Method. If nothing
+    // else supplies GOROOT, discover it from the host toolchain and pass it in.
+    private static void ensureGoRoot(Map<String, String> env) {
+        String parent = System.getenv("GOROOT");
+        if (env.containsKey("GOROOT") || (parent != null && !parent.trim().isEmpty())) {
+            return;
+        }
+        String goRoot = discoverGoRoot();
+        if (goRoot != null) {
+            env.put("GOROOT", goRoot);
+        }
+    }
+
+    private static @Nullable String discoverGoRoot() {
+        if (!goRootResolved) {
+            synchronized (GoRewriteRpc.class) {
+                if (!goRootResolved) {
+                    resolvedGoRoot = queryGoEnvGoRoot();
+                    goRootResolved = true;
+                }
+            }
+        }
+        return resolvedGoRoot;
+    }
+
+    private static @Nullable String queryGoEnvGoRoot() {
+        try {
+            Process p = new ProcessBuilder("go", "env", "GOROOT").start();
+            String line;
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
+                line = reader.readLine();
+            }
+            if (!p.waitFor(10, TimeUnit.SECONDS)) {
+                p.destroyForcibly();
+                return null;
+            }
+            if (p.exitValue() == 0 && line != null && !line.trim().isEmpty()) {
+                return line.trim();
+            }
+        } catch (IOException ignored) {
+            // `go` not on PATH — nothing to inject; behavior is unchanged.
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## What's changed?

Passing `GOROOT` environment variable to the Go RPC process (unless already set).

## What's your motivation?

- for building we use `-trimpath` flag which strips the absolute paths, so that the result is identitical regardless of which machine is the parsing happening at
- as a consequence of using `-trimpath`, the RPC binary we build has no `GOROOT` (or might have no `GOROOT`) and therefore has no access to the standard library
- which in turns is observable by missing type attribution for standard library Go methods