### PR TITLE
Add Kotlin test coverage for `AddCommentToMethodInvocations`

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/trait/CommentsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/trait/CommentsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.trait;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Cursor;
+import org.openrewrite.SourceFile;
+import org.openrewrite.text.PlainTextParser;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CommentsTest {
+
+    @Test
+    void errorsOnSourceFileWithoutCommentService() {
+        SourceFile text = new PlainTextParser().parse("hello").findFirst().orElseThrow();
+        Comments comments = Comments.of(new Cursor(new Cursor(null, Cursor.ROOT_VALUE), text));
+        assertThatThrownBy(comments::getComments)
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessageContaining("CommentService");
+        assertThatThrownBy(() -> comments.comment(" not supported here"))
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessageContaining("CommentService");
+    }
+
+    @Test
+    void requiresCursorRootedAtSourceFile() {
+        Comments comments = Comments.of(new Cursor(null, Cursor.ROOT_VALUE));
+        assertThatThrownBy(() -> comments.comment(" x"))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("SourceFile");
+    }
+}

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AddCommentToMethodInvocationsTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AddCommentToMethodInvocationsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.AddCommentToMethodInvocations;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class AddCommentToMethodInvocationsTest implements RewriteTest {
+
+    @Test
+    void addCommentToKotlinMethodInvocation() {
+        rewriteRun(
+          spec -> spec.recipe(new AddCommentToMethodInvocations("TODO: review for migration", "Foo bar(..)")),
+          kotlin(
+            """
+              class Foo {
+                  fun bar(arg: String) {
+                  }
+              }
+
+              fun test(foo: Foo) {
+                  foo.bar("a")
+              }
+              """,
+            """
+              class Foo {
+                  fun bar(arg: String) {
+                  }
+              }
+
+              fun test(foo: Foo) {
+                  /* TODO: review for migration */
+                  foo.bar("a")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotAddCommentIfKotlinSourceAlreadyHasIt() {
+        rewriteRun(
+          spec -> spec.recipe(new AddCommentToMethodInvocations("TODO: review for migration", "Foo bar(..)")),
+          kotlin(
+            """
+              class Foo {
+                  fun bar(arg: String) {
+                  }
+              }
+
+              fun test(foo: Foo) {
+                  // TODO: review for migration
+                  foo.bar("a")
+                  /* TODO: review for migration */
+                  foo.bar("b")
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?

Test-only change:
- `rewrite-kotlin`: a Kotlin counterpart to `AddCommentToMethodInvocationsTest` proving the recipe adds a comment to a Kotlin method invocation and stays idempotent when an equivalent line or block comment already exists.
- `rewrite-core`: a `Comments` trait test pinning that a source file whose language registers no `CommentService` is a hard `UnsupportedOperationException`, not a silent skip, and that the trait requires a cursor rooted at a `SourceFile`.

## What's your motivation?

A customer running `org.openrewrite.java.AddCommentToMethodInvocations` against Kotlin sources hit:

```
java.lang.UnsupportedOperationException: Service class org.openrewrite.internal.CommentService not supported
  org.openrewrite.kotlin.tree.K$CompilationUnit.service(K.java:363)
  org.openrewrite.trait.Comments.service(Comments.java:169)
```

- (moderneinc/customer-requests#2673)

- Since #8131, `JavaSourceFile.service()` resolves `CommentService` to `JavaCommentService`, and `K.CompilationUnit.service()` falls back to it — so Kotlin (like Groovy) is served by the shared `J`-model implementation and the failure no longer reproduces on a coherent 8.86.0+ classpath. The crash only occurs when an older `rewrite-java` is mixed with a newer `rewrite-core`/`rewrite-kotlin`. These tests pin the working behavior so it cannot regress, and document that erroring out (rather than silently skipping) is the intended contract for languages without a `CommentService`.

## Anyone you would like to review specifically?

@timtebeek