### PR TITLE
Add AttributeValue trait for non-literal annotation attribute values

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/AttributeValueTraitTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/AttributeValueTraitTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.groovy;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.java.trait.Annotated;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RewriteTest;
@@ -23,9 +24,13 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.groovy.Assertions.groovy;
 
 /**
- * Pins the {@link org.openrewrite.java.trait.AttributeValue} degradations documented
- * for Groovy sources: no constant folding, no enum discrimination, list literals as
- * opaque expressions.
+ * The {@link org.openrewrite.java.trait.AttributeValue} behavior on Groovy sources,
+ * asserting the same semantics the trait has on javac-attributed Java sources.
+ * Tests annotated {@link ExpectedToFail} document known Groovy parser/type-mapping
+ * gaps: property-access references carry no {@code fieldType}
+ * ({@code GroovyParserVisitor#visitPropertyExpression}), no
+ * {@code JavaType.Annotation} element values are built (no constant folding), and
+ * list literals are {@code G.ListLiteral}, not {@code J.NewArray}.
  */
 class AttributeValueTraitTest implements RewriteTest {
 
@@ -91,8 +96,9 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
+    @ExpectedToFail("Groovy list literals are G.ListLiteral, not J.NewArray; getElements() cannot normalize them from rewrite-java")
     @Test
-    void listLiteralIsAnOpaqueExpression() {
+    void listLiteralArray() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
             .asVisitor(a -> SearchResult.found(a.getTree(),
@@ -114,7 +120,7 @@ class AttributeValueTraitTest implements RewriteTest {
                   String[] tags()
               }
 
-              /*~~(EXPRESSION:elements=1)~~>*/@Example(tags = ["a", "b"])
+              /*~~(ARRAY:elements=2)~~>*/@Example(tags = ["a", "b"])
               class Test {
               }
               """
@@ -122,8 +128,9 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
+    @ExpectedToFail("GroovyParserVisitor#visitPropertyExpression attaches no type to the idiomatic bare class reference")
     @Test
-    void bareClassReferenceDegradesToConstantReference() {
+    void bareClassReference() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
             .asVisitor(a -> SearchResult.found(a.getTree(),
@@ -145,7 +152,7 @@ class AttributeValueTraitTest implements RewriteTest {
                   Class type()
               }
 
-              /*~~(CONSTANT_REFERENCE:field=false:class=false)~~>*/@Example(type = String)
+              /*~~(CLASS_LITERAL:field=false:class=true)~~>*/@Example(type = String)
               class Test {
               }
               """
@@ -153,8 +160,9 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
+    @ExpectedToFail("GroovyParserVisitor#visitPropertyExpression hard-codes fieldType=null on property-access references, so Flag.Enum is unavailable")
     @Test
-    void enumConstantDegradesToConstantReference() {
+    void enumConstant() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
             .asVisitor(a -> SearchResult.found(a.getTree(),
@@ -184,7 +192,7 @@ class AttributeValueTraitTest implements RewriteTest {
                   E e()
               }
 
-              /*~~(CONSTANT_REFERENCE:isEnum=false)~~>*/@Example(e = E.ONE)
+              /*~~(ENUM_CONSTANT:isEnum=true)~~>*/@Example(e = E.ONE)
               class Test {
               }
               """
@@ -192,8 +200,9 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
+    @ExpectedToFail("GroovyTypeMapping builds no JavaType.Annotation element values, so the compiler's constant fold is unavailable")
     @Test
-    void constantReferenceDoesNotFold() {
+    void constantReferenceFolds() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
             .asVisitor(a -> SearchResult.found(a.getTree(),
@@ -223,7 +232,7 @@ class AttributeValueTraitTest implements RewriteTest {
                   static final String NAME = "n"
               }
 
-              /*~~(CONSTANT_REFERENCE:null)~~>*/@Example(name = Constants.NAME)
+              /*~~(CONSTANT_REFERENCE:n)~~>*/@Example(name = Constants.NAME)
               class Test {
               }
               """

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/AttributeValueTraitTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/AttributeValueTraitTest.java
@@ -125,6 +125,79 @@ class AttributeValueTraitTest implements RewriteTest {
     }
 
     @Test
+    void bareClassReferenceDegradesToConstantReference() {
+        // idiomatic Groovy `type = String` (no `.class`) parses as a plain type tree,
+        // invisible to the class-literal channel
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getAttributeValue("type")
+                .map(v -> v.getKind() + ":field=" + (v.getReferencedField() != null) + ":class=" + (v.getClassValue() != null))
+                .orElse("missing"))))),
+          groovy(
+            """
+              @interface Example {
+                  Class type()
+              }
+
+              @Example(type = String)
+              class Test {
+              }
+              """,
+            """
+              @interface Example {
+                  Class type()
+              }
+
+              /*~~(CONSTANT_REFERENCE:field=false:class=false)~~>*/@Example(type = String)
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void enumConstantDegradesToConstantReference() {
+        // the Groovy type mapping does not set Flag.Enum on the referenced variable
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getAttributeValue("e")
+                .map(v -> v.getKind() + ":isEnum=" + v.isEnumConstant("E", "ONE"))
+                .orElse("missing"))))),
+          groovy(
+            """
+              enum E {
+                  ONE, TWO
+              }
+
+              @interface Example {
+                  E e()
+              }
+
+              @Example(e = E.ONE)
+              class Test {
+              }
+              """,
+            """
+              enum E {
+                  ONE, TWO
+              }
+
+              @interface Example {
+                  E e()
+              }
+
+              /*~~(CONSTANT_REFERENCE:isEnum=false)~~>*/@Example(e = E.ONE)
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void constantReferenceDoesNotFold() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/AttributeValueTraitTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/AttributeValueTraitTest.java
@@ -23,11 +23,9 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.groovy.Assertions.groovy;
 
 /**
- * Pins the {@link org.openrewrite.java.trait.AttributeValue} behavior on Groovy sources.
- * Groovy never populates {@link org.openrewrite.java.tree.JavaType.Annotation} element
- * values, so constant folding degrades to {@code null}; Groovy list literals are
- * {@code G.ListLiteral}, not {@code J.NewArray}, so they classify as
- * {@code Kind.EXPRESSION} without element normalization.
+ * Pins the {@link org.openrewrite.java.trait.AttributeValue} degradations documented
+ * for Groovy sources: no constant folding, no enum discrimination, list literals as
+ * opaque expressions.
  */
 class AttributeValueTraitTest implements RewriteTest {
 
@@ -126,8 +124,6 @@ class AttributeValueTraitTest implements RewriteTest {
 
     @Test
     void bareClassReferenceDegradesToConstantReference() {
-        // idiomatic Groovy `type = String` (no `.class`) parses as a plain type tree,
-        // invisible to the class-literal channel
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
             .asVisitor(a -> SearchResult.found(a.getTree(),
@@ -159,7 +155,6 @@ class AttributeValueTraitTest implements RewriteTest {
 
     @Test
     void enumConstantDegradesToConstantReference() {
-        // the Groovy type mapping does not set Flag.Enum on the referenced variable
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
             .asVisitor(a -> SearchResult.found(a.getTree(),

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/AttributeValueTraitTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/AttributeValueTraitTest.java
@@ -96,7 +96,7 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Groovy list literals are G.ListLiteral, not J.NewArray; getElements() cannot normalize them from rewrite-java")
+    @ExpectedToFail("Groovy list literals are G.ListLiteral, not J.NewArray; getElements() cannot normalize them from rewrite-java — https://github.com/openrewrite/rewrite/issues/8170")
     @Test
     void listLiteralArray() {
         rewriteRun(
@@ -128,7 +128,7 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("GroovyParserVisitor#visitPropertyExpression attaches no type to the idiomatic bare class reference")
+    @ExpectedToFail("GroovyParserVisitor#visitPropertyExpression attaches no type to the idiomatic bare class reference — https://github.com/openrewrite/rewrite/issues/8170")
     @Test
     void bareClassReference() {
         rewriteRun(
@@ -160,7 +160,7 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("GroovyParserVisitor#visitPropertyExpression hard-codes fieldType=null on property-access references, so Flag.Enum is unavailable")
+    @ExpectedToFail("GroovyParserVisitor#visitPropertyExpression hard-codes fieldType=null on property-access references, so Flag.Enum is unavailable — https://github.com/openrewrite/rewrite/issues/8170")
     @Test
     void enumConstant() {
         rewriteRun(
@@ -200,7 +200,7 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("GroovyTypeMapping builds no JavaType.Annotation element values, so the compiler's constant fold is unavailable")
+    @ExpectedToFail("GroovyTypeMapping builds no JavaType.Annotation element values, so the compiler's constant fold is unavailable — https://github.com/openrewrite/rewrite/issues/8170")
     @Test
     void constantReferenceFolds() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/AttributeValueTraitTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/AttributeValueTraitTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.trait.Annotated;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.groovy.Assertions.groovy;
+
+/**
+ * Pins the {@link org.openrewrite.java.trait.AttributeValue} behavior on Groovy sources.
+ * Groovy never populates {@link org.openrewrite.java.tree.JavaType.Annotation} element
+ * values, so constant folding degrades to {@code null}; Groovy list literals are
+ * {@code G.ListLiteral}, not {@code J.NewArray}, so they classify as
+ * {@code Kind.EXPRESSION} without element normalization.
+ */
+class AttributeValueTraitTest implements RewriteTest {
+
+    @Test
+    void implicitValueAttribute() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getDefaultAttributeValue(null)
+                .map(v -> v.getKind() + ":" + v.getConstantValue() + ":" + v.getName())
+                .orElse("missing"))))),
+          groovy(
+            """
+              @interface Example {
+                  String value()
+              }
+
+              @Example("x")
+              class Test {
+              }
+              """,
+            """
+              @interface Example {
+                  String value()
+              }
+
+              /*~~(LITERAL:x:value)~~>*/@Example("x")
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void namedAttribute() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getAttributeValue("name")
+                .map(v -> v.getKind() + ":" + v.getConstantValue())
+                .orElse("missing"))))),
+          groovy(
+            """
+              @interface Example {
+                  String name()
+              }
+
+              @Example(name = "x")
+              class Test {
+              }
+              """,
+            """
+              @interface Example {
+                  String name()
+              }
+
+              /*~~(LITERAL:x)~~>*/@Example(name = "x")
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void listLiteralIsAnOpaqueExpression() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getAttributeValue("tags")
+                .map(v -> v.getKind() + ":elements=" + v.getElements().size())
+                .orElse("missing"))))),
+          groovy(
+            """
+              @interface Example {
+                  String[] tags()
+              }
+
+              @Example(tags = ["a", "b"])
+              class Test {
+              }
+              """,
+            """
+              @interface Example {
+                  String[] tags()
+              }
+
+              /*~~(EXPRESSION:elements=1)~~>*/@Example(tags = ["a", "b"])
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void constantReferenceDoesNotFold() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getAttributeValue("name")
+                .map(v -> v.getKind() + ":" + v.getConstantValue())
+                .orElse("missing"))))),
+          groovy(
+            """
+              @interface Example {
+                  String name()
+              }
+
+              class Constants {
+                  static final String NAME = "n"
+              }
+
+              @Example(name = Constants.NAME)
+              class Test {
+              }
+              """,
+            """
+              @interface Example {
+                  String name()
+              }
+
+              class Constants {
+                  static final String NAME = "n"
+              }
+
+              /*~~(CONSTANT_REFERENCE:null)~~>*/@Example(name = Constants.NAME)
+              class Test {
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/Annotated.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/Annotated.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
+import org.openrewrite.Incubating;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.AnnotationMatcher;
@@ -34,6 +35,61 @@ import java.util.Optional;
 @Value
 public class Annotated implements Trait<J.Annotation> {
     Cursor cursor;
+
+    /**
+     * The value of the given attribute in any syntactic shape — literal, class literal,
+     * enum constant, constant reference, nested annotation, or array of these.
+     * <p>
+     * {@code getAttributeValue("value")} also matches a positional argument, since
+     * {@code @Foo("x")} is shorthand for {@code @Foo(value = "x")}.
+     *
+     * @param attribute The name of the annotation attribute.
+     * @return The attribute's value, or empty when the attribute is not explicitly
+     * present in the source. Defaults declared on the annotation type are not resolved.
+     */
+    @Incubating(since = "8.87.0")
+    public Optional<AttributeValue> getAttributeValue(String attribute) {
+        if (getTree().getArguments() == null) {
+            return Optional.empty();
+        }
+        for (Expression argument : getTree().getArguments()) {
+            if (argument instanceof J.Assignment) {
+                J.Assignment assignment = (J.Assignment) argument;
+                if (assignment.getVariable() instanceof J.Identifier &&
+                    ((J.Identifier) assignment.getVariable()).getSimpleName().equals(attribute)) {
+                    return new AttributeValue.Matcher().get(
+                            assignment.getAssignment(),
+                            new Cursor(cursor, argument)
+                    );
+                }
+            } else if ("value".equals(attribute)) {
+                return new AttributeValue.Matcher().get(argument, cursor);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Like {@link #getAttributeValue(String)}, but for the implicit {@code value}
+     * attribute: returns the positional argument if present, then the explicit
+     * {@code value} attribute, then the given alias. "Default" refers to the implicit
+     * value element (JLS §9.7.3), not to defaults declared on the annotation type —
+     * those are never resolved.
+     *
+     * @param defaultAlias The name of the annotation attribute that is aliased to
+     *                     "value", if any.
+     * @return The attribute value in any syntactic shape.
+     */
+    @Incubating(since = "8.87.0")
+    public Optional<AttributeValue> getDefaultAttributeValue(@Nullable String defaultAlias) {
+        Optional<AttributeValue> valueAttr = getAttributeValue("value");
+        if (valueAttr.isPresent()) {
+            return valueAttr;
+        }
+        return defaultAlias != null ?
+                getAttributeValue(defaultAlias) :
+                Optional.empty();
+    }
 
     /**
      * @param defaultAlias The name of the annotation attribute that is aliased to

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/Annotated.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/Annotated.java
@@ -37,12 +37,6 @@ public class Annotated implements Trait<J.Annotation> {
     Cursor cursor;
 
     /**
-     * The value of the given attribute in any syntactic shape — literal, class literal,
-     * enum constant, constant reference, nested annotation, or array of these.
-     * <p>
-     * {@code getAttributeValue("value")} also matches a positional argument, since
-     * {@code @Foo("x")} is shorthand for {@code @Foo(value = "x")}.
-     *
      * @param attribute The name of the annotation attribute.
      * @return The attribute's value, or empty when the attribute is not explicitly
      * present in the source. Defaults declared on the annotation type are not resolved.
@@ -55,13 +49,15 @@ public class Annotated implements Trait<J.Annotation> {
         for (Expression argument : getTree().getArguments()) {
             if (argument instanceof J.Assignment) {
                 J.Assignment assignment = (J.Assignment) argument;
-                if (assignment.getVariable() instanceof J.Identifier &&
-                    ((J.Identifier) assignment.getVariable()).getSimpleName().equals(attribute)) {
-                    return new AttributeValue.Matcher().get(
-                            assignment.getAssignment(),
-                            new Cursor(cursor, argument)
-                    );
+                if (!(assignment.getVariable() instanceof J.Identifier) ||
+                        !((J.Identifier) assignment.getVariable()).getSimpleName().equals(attribute)) {
+                    continue;
                 }
+
+                return new AttributeValue.Matcher().get(
+                        assignment.getAssignment(),
+                        new Cursor(cursor, argument)
+                );
             } else if ("value".equals(attribute)) {
                 return new AttributeValue.Matcher().get(argument, cursor);
             }
@@ -70,12 +66,6 @@ public class Annotated implements Trait<J.Annotation> {
     }
 
     /**
-     * Like {@link #getAttributeValue(String)}, but for the implicit {@code value}
-     * attribute: returns the positional argument if present, then the explicit
-     * {@code value} attribute, then the given alias. "Default" refers to the implicit
-     * value element (JLS §9.7.3), not to defaults declared on the annotation type —
-     * those are never resolved.
-     *
      * @param defaultAlias The name of the annotation attribute that is aliased to
      *                     "value", if any.
      * @return The attribute value in any syntactic shape.

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/AttributeValue.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/AttributeValue.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.Incubating;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.trait.SimpleTraitMatcher;
+import org.openrewrite.trait.Trait;
+import org.openrewrite.trait.VisitFunction2;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+/**
+ * The value of an annotation attribute (a JLS §9.7.1 "element value"), in any of the
+ * syntactic shapes annotations permit — not only the plain literals covered by {@link Literal}:
+ * <ul>
+ *   <li>{@link Kind#LITERAL} — {@code @Foo(name = "s")}, {@code @Foo(count = -1)}</li>
+ *   <li>{@link Kind#CLASS_LITERAL} — {@code @Foo(clazz = A.class)}, {@code int.class},
+ *       {@code String[].class}; Kotlin {@code A::class} and {@code A::class.java}</li>
+ *   <li>{@link Kind#ENUM_CONSTANT} — {@code @Retention(RetentionPolicy.RUNTIME)}, in
+ *       qualified, fully qualified, or statically imported spelling</li>
+ *   <li>{@link Kind#CONSTANT_REFERENCE} — {@code @Foo(name = Constants.NAME)} or a
+ *       statically imported {@code NAME}</li>
+ *   <li>{@link Kind#NESTED_ANNOTATION} — {@code @Foo(bar = @Bar("x"))}</li>
+ *   <li>{@link Kind#ARRAY} — {@code @Foo(exclude = {A.class, B.class})}</li>
+ *   <li>{@link Kind#EXPRESSION} — everything else, e.g. {@code @Foo(name = "a" + "b")}</li>
+ * </ul>
+ * Classification is syntax-first and never throws on missing type attribution; only the
+ * distinction between enum constants and other constant references requires attribution
+ * ({@link Flag#Enum} on the referenced {@link JavaType.Variable}). Unattributed references
+ * degrade to {@link Kind#CONSTANT_REFERENCE} with a {@code null}
+ * {@link #getReferencedField()}.
+ * <p>
+ * The trait is cursor-bearing: {@link #getTree()} / {@link #getCursor()} give recipes the
+ * exact expression to edit, and for arrays {@link #getElements()} yields one cursor-bearing
+ * value per element. Parentheses are transparent for classification and value access;
+ * {@link #getTree()} still returns the original expression.
+ * <p>
+ * {@link Optional#empty()} from {@link Annotated#getAttributeValue(String)} means only that
+ * the attribute is not explicitly present in the source. A present value whose typed
+ * accessors return {@code null} means "present but not resolvable that way" — the two
+ * conditions the {@code Optional<Literal>} accessors used to conflate.
+ *
+ * @see JavaType.Annotation.ElementValue
+ * @see Annotated#getAttributeValue(String)
+ */
+@Incubating(since = "8.87.0")
+@RequiredArgsConstructor
+public class AttributeValue implements Trait<Expression> {
+
+    /**
+     * The syntactic shape of an annotation attribute value. Exactly one kind applies to
+     * any value; unrecognized or compound shapes classify as {@link #EXPRESSION}.
+     */
+    public enum Kind {
+        LITERAL,
+        CLASS_LITERAL,
+        ENUM_CONSTANT,
+        CONSTANT_REFERENCE,
+        NESTED_ANNOTATION,
+        ARRAY,
+        EXPRESSION
+    }
+
+    @Getter
+    private final Cursor cursor;
+
+    private final ObjectMapper mapper;
+
+    public Kind getKind() {
+        Expression e = unwrapped();
+        if (e instanceof J.Literal) {
+            // note: `-1` parses as a single J.Literal, not a J.Unary
+            return Kind.LITERAL;
+        }
+        if (e instanceof J.NewArray) {
+            return Kind.ARRAY;
+        }
+        if (e instanceof J.Annotation) {
+            return Kind.NESTED_ANNOTATION;
+        }
+        if (e instanceof J.MemberReference) {
+            // Kotlin `A::class`
+            return isClassMemberReference((J.MemberReference) e) ? Kind.CLASS_LITERAL : Kind.EXPRESSION;
+        }
+        if (e instanceof J.FieldAccess) {
+            J.FieldAccess fieldAccess = (J.FieldAccess) e;
+            if ("class".equals(fieldAccess.getSimpleName())) {
+                return Kind.CLASS_LITERAL;
+            }
+            if ("java".equals(fieldAccess.getSimpleName()) &&
+                fieldAccess.getTarget() instanceof J.MemberReference &&
+                isClassMemberReference((J.MemberReference) fieldAccess.getTarget())) {
+                // Kotlin `A::class.java`
+                return Kind.CLASS_LITERAL;
+            }
+            return referenceKind(fieldAccess.getName().getFieldType());
+        }
+        if (e instanceof J.Identifier) {
+            // in annotation value position a bare name can only reference a constant
+            return referenceKind(((J.Identifier) e).getFieldType());
+        }
+        return Kind.EXPRESSION;
+    }
+
+    private static Kind referenceKind(JavaType.@Nullable Variable fieldType) {
+        return fieldType != null && fieldType.hasFlags(Flag.Enum) ?
+                Kind.ENUM_CONSTANT :
+                Kind.CONSTANT_REFERENCE;
+    }
+
+    public boolean isLiteral() {
+        return getKind() == Kind.LITERAL;
+    }
+
+    public boolean isClassLiteral() {
+        return getKind() == Kind.CLASS_LITERAL;
+    }
+
+    /**
+     * @param fullyQualifiedName The fully qualified name of a reference type.
+     * @return {@code true} if this value is a class literal referencing the given type.
+     * Requires type attribution; inner class {@code $} and {@code .} spellings are
+     * considered equal. Primitive and array class literals never match.
+     */
+    public boolean isClassLiteral(String fullyQualifiedName) {
+        JavaType.FullyQualified fq = TypeUtils.asFullyQualified(getClassValue());
+        return fq != null && TypeUtils.fullyQualifiedNamesAreEqual(fq.getFullyQualifiedName(), fullyQualifiedName);
+    }
+
+    /**
+     * @return {@code true} if this value references an enum constant, in any spelling.
+     * Requires type attribution; without it enum constants are indistinguishable from
+     * other constant references and classify as {@link Kind#CONSTANT_REFERENCE}.
+     */
+    public boolean isEnumConstant() {
+        return getKind() == Kind.ENUM_CONSTANT;
+    }
+
+    /**
+     * @param fullyQualifiedEnumName The fully qualified name of the enum type.
+     * @param constantName           The name of the enum constant.
+     * @return {@code true} if this value is the given enum constant, e.g.
+     * {@code isEnumConstant("java.lang.annotation.RetentionPolicy", "RUNTIME")}. Covers
+     * the qualified, fully qualified, and statically imported spellings uniformly.
+     */
+    public boolean isEnumConstant(String fullyQualifiedEnumName, String constantName) {
+        JavaType.Variable field = getReferencedField();
+        return field != null &&
+               field.hasFlags(Flag.Enum) &&
+               constantName.equals(field.getName()) &&
+               TypeUtils.isOfClassType(field.getOwner(), fullyQualifiedEnumName);
+    }
+
+    public boolean isConstantReference() {
+        return getKind() == Kind.CONSTANT_REFERENCE;
+    }
+
+    public boolean isNestedAnnotation() {
+        return getKind() == Kind.NESTED_ANNOTATION;
+    }
+
+    /**
+     * @return {@code true} if this value is written as an explicit array initializer
+     * ({@code J.NewArray}). The brace-less single-element form {@code @Foo(exclude = A.class)}
+     * of an array-typed attribute is NOT syntactically an array; use {@link #getElements()}
+     * for uniformly normalized element access.
+     */
+    public boolean isArray() {
+        return getKind() == Kind.ARRAY;
+    }
+
+    /**
+     * @return the name of the annotation attribute this value is assigned to, or
+     * {@code "value"} for a positional (implicit) value. Array elements report the name
+     * of their containing attribute.
+     */
+    public String getName() {
+        for (Cursor c = cursor.getParentTreeCursor(); !c.isRoot(); c = c.getParentTreeCursor()) {
+            Object value = c.getValue();
+            if (value instanceof J.Assignment) {
+                Expression variable = ((J.Assignment) value).getVariable();
+                if (variable instanceof J.Identifier) {
+                    return ((J.Identifier) variable).getSimpleName();
+                }
+                break;
+            }
+            if (!(value instanceof J.NewArray || value instanceof J.Parentheses)) {
+                break;
+            }
+        }
+        return "value";
+    }
+
+    /**
+     * The values of this attribute normalized to a list: an array initializer yields one
+     * {@code AttributeValue} per element, each with its own cursor, so that both reads and
+     * surgical edits can address individual elements; every scalar shape yields
+     * {@code singletonList(this)}. This mirrors the normalization the JLS applies to
+     * array-typed attributes, where the brace-less single-element form
+     * {@code @Foo(exclude = A.class)} means {@code {A.class}} — both forms iterate
+     * identically here. An empty initializer {@code {}} yields an empty list.
+     *
+     * @return the individual values of this attribute.
+     */
+    public List<AttributeValue> getElements() {
+        Expression e = unwrapped();
+        if (!(e instanceof J.NewArray)) {
+            return singletonList(this);
+        }
+        List<Expression> initializer = ((J.NewArray) e).getInitializer();
+        if (initializer == null) {
+            return emptyList();
+        }
+        Cursor arrayCursor = unwrappedCursor();
+        List<AttributeValue> elements = new ArrayList<>(initializer.size());
+        for (Expression element : initializer) {
+            if (!(element instanceof J.Empty)) {
+                elements.add(new AttributeValue(new Cursor(arrayCursor, element), mapper));
+            }
+        }
+        return elements;
+    }
+
+    /**
+     * @return this value as the {@link Literal} trait when it is a {@code J.Literal} or an
+     * array composed entirely of literals — exactly the shapes {@link Literal.Matcher}
+     * matches. Unlike the {@code Optional<Literal>} accessors on {@link Annotated}, this
+     * sees through parentheses. Note this answers "is it {@link Literal}-compatible", which
+     * differs from {@link #isLiteral()} for all-literal arrays.
+     */
+    public Optional<Literal> asLiteral() {
+        return new Literal.Matcher().mapper(mapper).get(unwrappedCursor());
+    }
+
+    /**
+     * @return this value as the {@link Annotated} trait when it is a nested annotation,
+     * enabling recursive attribute access.
+     */
+    public Optional<Annotated> asAnnotated() {
+        Cursor c = unwrappedCursor();
+        return c.getValue() instanceof J.Annotation ?
+                Optional.of(new Annotated(c)) :
+                Optional.empty();
+    }
+
+    /**
+     * @return for a class literal, the referenced type: a {@link JavaType.FullyQualified}
+     * for {@code A.class}, a {@link JavaType.Primitive} for {@code int.class}, a
+     * {@link JavaType.Array} for {@code String[].class}. {@code null} when this value is
+     * not a class literal or type attribution is missing.
+     */
+    public @Nullable JavaType getClassValue() {
+        if (getKind() != Kind.CLASS_LITERAL) {
+            return null;
+        }
+        Expression e = unwrapped();
+        if (e instanceof J.MemberReference) {
+            // Kotlin `A::class`
+            return nullIfUnknown(((J.MemberReference) e).getContaining().getType());
+        }
+        J.FieldAccess fieldAccess = (J.FieldAccess) e;
+        if (fieldAccess.getTarget() instanceof J.MemberReference) {
+            // Kotlin `A::class.java`
+            return nullIfUnknown(((J.MemberReference) fieldAccess.getTarget()).getContaining().getType());
+        }
+        JavaType targetType = nullIfUnknown(fieldAccess.getTarget().getType());
+        if (targetType != null) {
+            return targetType;
+        }
+        // the class literal's own type is `Class<A>`
+        if (fieldAccess.getType() instanceof JavaType.Parameterized &&
+            ((JavaType.Parameterized) fieldAccess.getType()).getTypeParameters().size() == 1) {
+            return nullIfUnknown(((JavaType.Parameterized) fieldAccess.getType()).getTypeParameters().get(0));
+        }
+        JavaType.Variable classField = fieldAccess.getName().getFieldType();
+        return classField != null ? nullIfUnknown(classField.getOwner()) : null;
+    }
+
+    private static @Nullable JavaType nullIfUnknown(@Nullable JavaType type) {
+        return type instanceof JavaType.Unknown ? null : type;
+    }
+
+    /**
+     * @return the static field referenced by this value when it is an enum constant or a
+     * constant reference: the variable's {@code owner} is the declaring type and its
+     * {@code name} the constant's name — identical across the qualified, fully qualified,
+     * and statically imported spellings. Distinguish enums via {@link #isEnumConstant()}.
+     * {@code null} when this value is not a reference or attribution is missing; class
+     * literals return {@code null} here (their synthetic {@code Variable{name="class"}}
+     * is deliberately hidden — use {@link #getClassValue()}).
+     */
+    public JavaType.@Nullable Variable getReferencedField() {
+        Kind kind = getKind();
+        if (kind != Kind.ENUM_CONSTANT && kind != Kind.CONSTANT_REFERENCE) {
+            return null;
+        }
+        Expression e = unwrapped();
+        if (e instanceof J.FieldAccess) {
+            return ((J.FieldAccess) e).getName().getFieldType();
+        }
+        if (e instanceof J.Identifier) {
+            return ((J.Identifier) e).getFieldType();
+        }
+        return null;
+    }
+
+    /**
+     * The compile-time constant represented by this value, if one can be determined:
+     * a {@link J.Literal}'s value directly. Enum constants, class literals, nested
+     * annotations, and arrays are references or containers, not constants — use
+     * {@link #getReferencedField()}, {@link #getClassValue()}, {@link #asAnnotated()},
+     * or {@link #getElements()} for those.
+     *
+     * @return the constant value, or {@code null} when this value does not represent a
+     * determinable constant.
+     */
+    public @Nullable Object getConstantValue() {
+        if (getKind() == Kind.LITERAL) {
+            return ((J.Literal) unwrapped()).getValue();
+        }
+        return null;
+    }
+
+    /**
+     * {@link #getConstantValue()} coerced with Jackson, using the same mapper and
+     * scalar-to-collection normalization as {@link Literal#getValue(Class)}.
+     *
+     * @return the coerced constant value, or {@code null} when unresolvable or not coercible.
+     */
+    public <T> @Nullable T getValue(Class<T> type) {
+        return convert(getConstantValue(), mapper.constructType(type));
+    }
+
+    /**
+     * @see #getValue(Class)
+     */
+    public <T> @Nullable T getValue(TypeReference<T> type) {
+        return convert(getConstantValue(), mapper.constructType(type));
+    }
+
+    private <T> @Nullable T convert(@Nullable Object value, com.fasterxml.jackson.databind.JavaType type) {
+        if (value == null) {
+            return null;
+        }
+        Object normalized = value;
+        if (type.isCollectionLikeType() && !(value instanceof Collection)) {
+            normalized = singletonList(value);
+        }
+        try {
+            return mapper.convertValue(normalized, type);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private Expression unwrapped() {
+        return unwrappedCursor().getValue();
+    }
+
+    private Cursor unwrappedCursor() {
+        Cursor c = cursor;
+        while (c.getValue() instanceof J.Parentheses) {
+            J inner = ((J.Parentheses<?>) c.getValue()).getTree();
+            if (!(inner instanceof Expression)) {
+                break;
+            }
+            c = new Cursor(c, inner);
+        }
+        return c;
+    }
+
+    private static boolean isClassMemberReference(J.MemberReference memberReference) {
+        return "class".equals(memberReference.getReference().getSimpleName());
+    }
+
+    /**
+     * Matches expressions in annotation attribute value position: a positional argument of
+     * a {@link J.Annotation}, or the right-hand side of a named argument's
+     * {@link J.Assignment}. Attribute name identifiers, {@link J.Empty} (as in
+     * {@code @Foo()}), and array initializer ELEMENTS are not matched standalone —
+     * elements are reachable through {@link AttributeValue#getElements()}.
+     */
+    public static class Matcher extends SimpleTraitMatcher<AttributeValue> {
+        private static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper();
+
+        private ObjectMapper mapper = DEFAULT_MAPPER;
+
+        /**
+         * @param mapper A customized mapper, which should be rare. See {@link Literal.Matcher#mapper(ObjectMapper)}.
+         * @return This matcher with a customized mapper set.
+         */
+        @SuppressWarnings("unused")
+        public Matcher mapper(ObjectMapper mapper) {
+            this.mapper = mapper;
+            return this;
+        }
+
+        @Override
+        protected @Nullable AttributeValue test(Cursor cursor) {
+            Object value = cursor.getValue();
+            if (!(value instanceof Expression) ||
+                value instanceof J.Assignment ||
+                value instanceof J.Empty) {
+                return null;
+            }
+            Cursor parentCursor = cursor.getParentTreeCursor();
+            Object parent = parentCursor.getValue();
+            if (parent instanceof J.Annotation) {
+                List<Expression> arguments = ((J.Annotation) parent).getArguments();
+                //noinspection SuspiciousMethodCalls
+                return arguments != null && arguments.contains(value) ?
+                        new AttributeValue(cursor, mapper) :
+                        null;
+            }
+            if (parent instanceof J.Assignment && ((J.Assignment) parent).getAssignment() == value) {
+                Cursor grandparentCursor = parentCursor.getParentTreeCursor();
+                if (grandparentCursor.getValue() instanceof J.Annotation) {
+                    List<Expression> arguments = ((J.Annotation) grandparentCursor.getValue()).getArguments();
+                    //noinspection SuspiciousMethodCalls
+                    return arguments != null && arguments.contains(parent) ?
+                            new AttributeValue(cursor, mapper) :
+                            null;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public <P> TreeVisitor<? extends Tree, P> asVisitor(VisitFunction2<AttributeValue, P> visitor) {
+            return new JavaVisitor<P>() {
+                @Override
+                public @Nullable J preVisit(J tree, P p) {
+                    if (tree instanceof Expression) {
+                        AttributeValue value = test(getCursor());
+                        if (value != null) {
+                            return (J) visitor.visit(value, p);
+                        }
+                    }
+                    return tree;
+                }
+            };
+        }
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/AttributeValue.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/AttributeValue.java
@@ -57,7 +57,11 @@ import static java.util.Collections.singletonList;
  * distinction between enum constants and other constant references requires attribution
  * ({@link Flag#Enum} on the referenced {@link JavaType.Variable}). Unattributed references
  * degrade to {@link Kind#CONSTANT_REFERENCE} with a {@code null}
- * {@link #getReferencedField()}.
+ * {@link #getReferencedField()}. The same degradation applies on Groovy and Kotlin
+ * sources, whose type mappings do not set {@link Flag#Enum}: there enum constants always
+ * classify as {@link Kind#CONSTANT_REFERENCE}. Groovy and Kotlin list literals are not
+ * {@link J.NewArray} and classify as {@link Kind#EXPRESSION} without element
+ * normalization.
  * <p>
  * The trait is cursor-bearing: {@link #getTree()} / {@link #getCursor()} give recipes the
  * exact expression to edit, and for arrays {@link #getElements()} yields one cursor-bearing
@@ -158,8 +162,10 @@ public class AttributeValue implements Trait<Expression> {
 
     /**
      * @return {@code true} if this value references an enum constant, in any spelling.
-     * Requires type attribution; without it enum constants are indistinguishable from
-     * other constant references and classify as {@link Kind#CONSTANT_REFERENCE}.
+     * Requires type attribution that sets {@link Flag#Enum} on the referenced field —
+     * without it (unattributed sources, but also Groovy and Kotlin sources, whose type
+     * mappings do not set the flag) enum constants are indistinguishable from other
+     * constant references and classify as {@link Kind#CONSTANT_REFERENCE}.
      */
     public boolean isEnumConstant() {
         return getKind() == Kind.ENUM_CONSTANT;
@@ -349,11 +355,11 @@ public class AttributeValue implements Trait<Expression> {
      * The constant fold is only available where the parser records
      * {@link JavaType.Annotation} element values on the annotated declaration: sources
      * attributed by javac (including constants from binary dependencies). It is
-     * unavailable — and this method returns {@code null} — for Groovy sources and
-     * reflection-mapped types, for annotations in positions other than variable, method,
-     * and class declarations, and for annotations whose values cannot be unambiguously
-     * located on the declaration (e.g. repeated annotations, which javac stores under
-     * their container type).
+     * unavailable — and this method returns {@code null} — for Groovy and Kotlin sources
+     * and reflection-mapped types (none of which build element values), for annotations
+     * in positions other than variable, method, and class declarations, and for
+     * annotations whose values cannot be unambiguously located on the declaration
+     * (e.g. repeated annotations, which javac stores under their container type).
      *
      * @return the constant value, or {@code null} when this value does not represent a
      * determinable constant.
@@ -433,7 +439,15 @@ public class AttributeValue implements Trait<Expression> {
             return null;
         }
 
-        List<JavaType.FullyQualified> declaredAnnotations = declaredAnnotations(annotationCursor.getParentTreeCursor().getValue());
+        // an annotation written after a modifier parents under J.Modifier or J.AnnotatedType
+        // rather than directly under the declaration (`private @Foo String f;`); skip only
+        // these wrappers so deeper nestings (type arguments etc.) still bail to null
+        Cursor declarationCursor = annotationCursor.getParentTreeCursor();
+        while (declarationCursor.getValue() instanceof J.Modifier ||
+               declarationCursor.getValue() instanceof J.AnnotatedType) {
+            declarationCursor = declarationCursor.getParentTreeCursor();
+        }
+        List<JavaType.FullyQualified> declaredAnnotations = declaredAnnotations(declarationCursor.getValue());
         if (declaredAnnotations == null) {
             return null;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/AttributeValue.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/AttributeValue.java
@@ -102,7 +102,7 @@ public class AttributeValue implements Trait<Expression> {
     public Kind getKind() {
         Expression e = unwrapped();
         if (e instanceof J.Literal) {
-            // note: `-1` parses as a single J.Literal, not a J.Unary
+            // `-1` parses as a single J.Literal, not a J.Unary
             return Kind.LITERAL;
         }
         if (e instanceof J.NewArray) {
@@ -158,17 +158,6 @@ public class AttributeValue implements Trait<Expression> {
     public boolean isClassLiteral(String fullyQualifiedName) {
         JavaType.FullyQualified fq = TypeUtils.asFullyQualified(getClassValue());
         return fq != null && TypeUtils.fullyQualifiedNamesAreEqual(fq.getFullyQualifiedName(), fullyQualifiedName);
-    }
-
-    /**
-     * @return {@code true} if this value references an enum constant, in any spelling.
-     * Requires type attribution that sets {@link Flag#Enum} on the referenced field —
-     * without it (unattributed sources, but also Groovy and Kotlin sources, whose type
-     * mappings do not set the flag) enum constants are indistinguishable from other
-     * constant references and classify as {@link Kind#CONSTANT_REFERENCE}.
-     */
-    public boolean isEnumConstant() {
-        return getKind() == Kind.ENUM_CONSTANT;
     }
 
     /**
@@ -319,7 +308,7 @@ public class AttributeValue implements Trait<Expression> {
      * @return the static field referenced by this value when it is an enum constant or a
      * constant reference: the variable's {@code owner} is the declaring type and its
      * {@code name} the constant's name — identical across the qualified, fully qualified,
-     * and statically imported spellings. Distinguish enums via {@link #isEnumConstant()}.
+     * and statically imported spellings. Distinguish enums via {@link #isEnumConstant(String, String)}.
      * {@code null} when this value is not a reference or attribution is missing; class
      * literals return {@code null} here (their synthetic {@code Variable{name="class"}}
      * is deliberately hidden — use {@link #getClassValue()}).
@@ -340,27 +329,7 @@ public class AttributeValue implements Trait<Expression> {
     }
 
     /**
-     * The compile-time constant represented by this value, if one can be determined:
-     * <ul>
-     *   <li>a {@link J.Literal}'s value directly;</li>
-     *   <li>for constant references and constant expressions ({@code Constants.NAME},
-     *       a statically imported {@code NAME}, {@code "a" + "b"}), the constant the
-     *       compiler folded into the {@link JavaType.Annotation.ElementValue}s on the
-     *       annotated declaration's type attribution — best-effort, see below.</li>
-     * </ul>
-     * Enum constants, class literals, nested annotations, and arrays are references or
-     * containers, not constants — use {@link #getReferencedField()},
-     * {@link #getClassValue()}, {@link #asAnnotated()}, or {@link #getElements()} for those.
-     * <p>
-     * The constant fold is only available where the parser records
-     * {@link JavaType.Annotation} element values on the annotated declaration: sources
-     * attributed by javac (including constants from binary dependencies). It is
-     * unavailable — and this method returns {@code null} — for Groovy and Kotlin sources
-     * and reflection-mapped types (none of which build element values), for annotations
-     * in positions other than variable, method, and class declarations, and for
-     * annotations whose values cannot be unambiguously located on the declaration
-     * (e.g. repeated annotations, which javac stores under their container type).
-     *
+     * The compile-time constant represented by this value, if one can be determined.
      * @return the constant value, or {@code null} when this value does not represent a
      * determinable constant.
      */
@@ -377,14 +346,9 @@ public class AttributeValue implements Trait<Expression> {
     }
 
     /**
-     * Resolves the compiler's constant fold for this value from the annotated
-     * declaration's type attribution. Element values are not carried by
-     * {@code J.Annotation#getType()} at the use site; they live on the annotated
-     * element's {@link JavaType.Variable}/{@link JavaType.Method}/{@link JavaType.FullyQualified}.
+     * Resolves the compiler's constant fold for this value from the annotated declaration's type attribution.
      */
     private @Nullable Object foldedConstantValue() {
-        // walk up to the enclosing annotation, recording the attribute name and the
-        // position of this value inside an array initializer
         String attributeName = null;
         int index = -1;
         Cursor annotationCursor = null;
@@ -439,9 +403,6 @@ public class AttributeValue implements Trait<Expression> {
             return null;
         }
 
-        // an annotation written after a modifier parents under J.Modifier or J.AnnotatedType
-        // rather than directly under the declaration (`private @Foo String f;`); skip only
-        // these wrappers so deeper nestings (type arguments etc.) still bail to null
         Cursor declarationCursor = annotationCursor.getParentTreeCursor();
         while (declarationCursor.getValue() instanceof J.Modifier ||
                declarationCursor.getValue() instanceof J.AnnotatedType) {
@@ -456,7 +417,7 @@ public class AttributeValue implements Trait<Expression> {
             if (declared instanceof JavaType.Annotation &&
                 TypeUtils.fullyQualifiedNamesAreEqual(declared.getFullyQualifiedName(), annotationType.getFullyQualifiedName())) {
                 if (match != null) {
-                    // ambiguous; never risk returning another occurrence's value
+                    // ambiguous
                     return null;
                 }
                 match = (JavaType.Annotation) declared;

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/AttributeValue.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/AttributeValue.java
@@ -335,17 +335,162 @@ public class AttributeValue implements Trait<Expression> {
 
     /**
      * The compile-time constant represented by this value, if one can be determined:
-     * a {@link J.Literal}'s value directly. Enum constants, class literals, nested
-     * annotations, and arrays are references or containers, not constants — use
-     * {@link #getReferencedField()}, {@link #getClassValue()}, {@link #asAnnotated()},
-     * or {@link #getElements()} for those.
+     * <ul>
+     *   <li>a {@link J.Literal}'s value directly;</li>
+     *   <li>for constant references and constant expressions ({@code Constants.NAME},
+     *       a statically imported {@code NAME}, {@code "a" + "b"}), the constant the
+     *       compiler folded into the {@link JavaType.Annotation.ElementValue}s on the
+     *       annotated declaration's type attribution — best-effort, see below.</li>
+     * </ul>
+     * Enum constants, class literals, nested annotations, and arrays are references or
+     * containers, not constants — use {@link #getReferencedField()},
+     * {@link #getClassValue()}, {@link #asAnnotated()}, or {@link #getElements()} for those.
+     * <p>
+     * The constant fold is only available where the parser records
+     * {@link JavaType.Annotation} element values on the annotated declaration: sources
+     * attributed by javac (including constants from binary dependencies). It is
+     * unavailable — and this method returns {@code null} — for Groovy sources and
+     * reflection-mapped types, for annotations in positions other than variable, method,
+     * and class declarations, and for annotations whose values cannot be unambiguously
+     * located on the declaration (e.g. repeated annotations, which javac stores under
+     * their container type).
      *
      * @return the constant value, or {@code null} when this value does not represent a
      * determinable constant.
      */
     public @Nullable Object getConstantValue() {
-        if (getKind() == Kind.LITERAL) {
-            return ((J.Literal) unwrapped()).getValue();
+        switch (getKind()) {
+            case LITERAL:
+                return ((J.Literal) unwrapped()).getValue();
+            case CONSTANT_REFERENCE:
+            case EXPRESSION:
+                return foldedConstantValue();
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Resolves the compiler's constant fold for this value from the annotated
+     * declaration's type attribution. Element values are not carried by
+     * {@code J.Annotation#getType()} at the use site; they live on the annotated
+     * element's {@link JavaType.Variable}/{@link JavaType.Method}/{@link JavaType.FullyQualified}.
+     */
+    private @Nullable Object foldedConstantValue() {
+        // walk up to the enclosing annotation, recording the attribute name and the
+        // position of this value inside an array initializer
+        String attributeName = null;
+        int index = -1;
+        Cursor annotationCursor = null;
+        Tree child = cursor.getValue();
+        for (Cursor c = cursor.getParentTreeCursor(); !c.isRoot(); c = c.getParentTreeCursor()) {
+            Object value = c.getValue();
+            if (value instanceof J.Annotation) {
+                annotationCursor = c;
+                break;
+            }
+            if (value instanceof J.Assignment) {
+                Expression variable = ((J.Assignment) value).getVariable();
+                if (!(variable instanceof J.Identifier)) {
+                    return null;
+                }
+                attributeName = ((J.Identifier) variable).getSimpleName();
+            } else if (value instanceof J.NewArray) {
+                if (index != -1) {
+                    // annotation values cannot contain nested array initializers
+                    return null;
+                }
+                List<Expression> initializer = ((J.NewArray) value).getInitializer();
+                if (initializer == null) {
+                    return null;
+                }
+                int i = 0;
+                int found = -1;
+                for (Expression element : initializer) {
+                    if (element == child) {
+                        found = i;
+                        break;
+                    }
+                    if (!(element instanceof J.Empty)) {
+                        i++;
+                    }
+                }
+                if (found == -1) {
+                    return null;
+                }
+                index = found;
+            } else if (!(value instanceof J.Parentheses)) {
+                return null;
+            }
+            child = (Tree) value;
+        }
+        if (annotationCursor == null) {
+            return null;
+        }
+        J.Annotation annotation = annotationCursor.getValue();
+        JavaType.FullyQualified annotationType = TypeUtils.asFullyQualified(annotation.getType());
+        if (annotationType == null) {
+            return null;
+        }
+
+        List<JavaType.FullyQualified> declaredAnnotations = declaredAnnotations(annotationCursor.getParentTreeCursor().getValue());
+        if (declaredAnnotations == null) {
+            return null;
+        }
+        JavaType.Annotation match = null;
+        for (JavaType.FullyQualified declared : declaredAnnotations) {
+            if (declared instanceof JavaType.Annotation &&
+                TypeUtils.fullyQualifiedNamesAreEqual(declared.getFullyQualifiedName(), annotationType.getFullyQualifiedName())) {
+                if (match != null) {
+                    // ambiguous; never risk returning another occurrence's value
+                    return null;
+                }
+                match = (JavaType.Annotation) declared;
+            }
+        }
+        if (match == null) {
+            return null;
+        }
+
+        String attribute = attributeName == null ? "value" : attributeName;
+        for (JavaType.Annotation.ElementValue elementValue : match.getValues()) {
+            JavaType element = elementValue.getElement();
+            if (element instanceof JavaType.Method && attribute.equals(((JavaType.Method) element).getName())) {
+                if (elementValue instanceof JavaType.Annotation.SingleElementValue) {
+                    return index < 0 ?
+                            ((JavaType.Annotation.SingleElementValue) elementValue).getConstantValue() :
+                            null;
+                }
+                if (elementValue instanceof JavaType.Annotation.ArrayElementValue) {
+                    Object[] constantValues = ((JavaType.Annotation.ArrayElementValue) elementValue).getConstantValues();
+                    if (constantValues == null) {
+                        return null;
+                    }
+                    if (index < 0) {
+                        // attribution normalizes the brace-less single-element form to an array
+                        return constantValues.length == 1 ? constantValues[0] : null;
+                    }
+                    return index < constantValues.length ? constantValues[index] : null;
+                }
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static @Nullable List<JavaType.FullyQualified> declaredAnnotations(Object declaration) {
+        if (declaration instanceof J.VariableDeclarations) {
+            for (J.VariableDeclarations.NamedVariable variable : ((J.VariableDeclarations) declaration).getVariables()) {
+                if (variable.getVariableType() != null) {
+                    return variable.getVariableType().getAnnotations();
+                }
+            }
+        } else if (declaration instanceof J.MethodDeclaration) {
+            JavaType.Method methodType = ((J.MethodDeclaration) declaration).getMethodType();
+            return methodType != null ? methodType.getAnnotations() : null;
+        } else if (declaration instanceof J.ClassDeclaration) {
+            JavaType.FullyQualified type = TypeUtils.asFullyQualified(((J.ClassDeclaration) declaration).getType());
+            return type != null ? type.getAnnotations() : null;
         }
         return null;
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/Literal.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/Literal.java
@@ -121,6 +121,10 @@ public class Literal implements Trait<Expression> {
     private List<Object> untypedInitializerLiterals(J.NewArray newArray) {
         List<Object> acc = new ArrayList<>();
         for (Expression init : requireNonNull(newArray.getInitializer())) {
+            if (init instanceof J.Empty) {
+                // an empty initializer `{}` is represented as a single J.Empty element
+                continue;
+            }
             if (init instanceof J.Literal) {
                 //noinspection DataFlowIssue
                 acc.add(((J.Literal) init).getValue());
@@ -163,6 +167,10 @@ public class Literal implements Trait<Expression> {
                     return false;
                 }
                 for (Expression expr : init) {
+                    if (expr instanceof J.Empty) {
+                        // an empty initializer `{}` is represented as a single J.Empty element
+                        continue;
+                    }
                     if (!(expr instanceof J.Literal) &&
                         !isNewArrayWithLiteralInitializer(expr)) {
                         return false;

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/Literal.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/Literal.java
@@ -126,7 +126,6 @@ public class Literal implements Trait<Expression> {
         List<Object> acc = new ArrayList<>();
         for (Expression init : requireNonNull(newArray.getInitializer())) {
             if (init instanceof J.Empty) {
-                // an empty initializer `{}` is represented as a single J.Empty element
                 continue;
             }
             if (init instanceof J.Literal) {
@@ -172,7 +171,6 @@ public class Literal implements Trait<Expression> {
                 }
                 for (Expression expr : init) {
                     if (expr instanceof J.Empty) {
-                        // an empty initializer `{}` is represented as a single J.Empty element
                         continue;
                     }
                     if (!(expr instanceof J.Literal) &&

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/Literal.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/Literal.java
@@ -37,8 +37,12 @@ import static java.util.Objects.requireNonNull;
 /**
  * A literal in Java is either a {@link J.Literal} or a {@link J.NewArray}
  * that has a non-null initializer that, itself, contains literals or new
- * arrays that recursively contain these constraints. In other languages
+ * arrays that recursively contain these constraints. An empty array
+ * initializer {@code {}} is an (empty) array literal. In other languages
  * this trait is inclusive of constructs like list or map literals.
+ * <p>
+ * For annotation attribute values that are not literals (class literals,
+ * enum constants, constant references), see {@link AttributeValue}.
  */
 @RequiredArgsConstructor
 public class Literal implements Trait<Expression> {

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
@@ -141,6 +141,65 @@ class AnnotatedTest implements RewriteTest {
     }
 
     @Test
+    void oldDefaultAccessorStopsAtPositionalNonLiteral() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+            new Annotated.Matcher("@Example").asVisitor(a -> SearchResult.found(a.getTree(),
+              "old=" + a.getDefaultAttribute("alias").isPresent() +
+              ":new=" + a.getDefaultAttributeValue("alias").map(v -> v.getKind().toString()).orElse("empty")))
+          )),
+          java(
+            """
+              class Constants {
+                  static final String NAME = "n";
+              }
+              """
+          ),
+          java(
+            """
+              @interface Example {
+                  String value() default "";
+                  String alias() default "";
+              }
+              """
+          ),
+          java(
+            """
+              @Example(Constants.NAME)
+              class Test {
+              }
+              """,
+            """
+              /*~~(old=false:new=CONSTANT_REFERENCE)~~>*/@Example(Constants.NAME)
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void matcherFromAnnotationClass() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+            new Annotated.Matcher(Deprecated.class).asVisitor(a -> SearchResult.found(a.getTree()))
+          )),
+          java(
+            """
+              @Deprecated
+              class Test {
+              }
+              """,
+            """
+              /*~~>*/@Deprecated
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void emptyArrayAttribute() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() ->
@@ -191,7 +250,7 @@ class AnnotatedTest implements RewriteTest {
               @Target(ElementType.TYPE)
               @Retention(RetentionPolicy.RUNTIME)
               @interface Example {
-                  String[] other;
+                  String[] other();
               }
               """
           ),

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
@@ -63,6 +63,88 @@ class AnnotatedTest implements RewriteTest {
     }
 
     @Test
+    void attributesViaAttributeValue() {
+        // the mechanical migration of attributes(): getDefaultAttribute -> getDefaultAttributeValue
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+            new Annotated.Matcher("@Example").asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getDefaultAttributeValue("name")
+                .map(v -> v.getValue(String.class))
+                .orElse("unknown"))
+            )
+          )),
+          java(
+            """
+              import java.lang.annotation.Repeatable;
+              @Repeatable
+              @interface Example {
+                  String value() default "";
+                  String name() default "";
+              }
+              """
+          ),
+          java(
+            """
+              @Example("test")
+              @Example(value = "test")
+              @Example(name = "test")
+              class Test {
+              }
+              """,
+            """
+              /*~~(test)~~>*/@Example("test")
+              /*~~(test)~~>*/@Example(value = "test")
+              /*~~(test)~~>*/@Example(name = "test")
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void oldAccessorFallsThroughToAliasWhenValueIsNotLiteral() {
+        // Documents a deliberate divergence: the Optional<Literal> accessor cannot see a
+        // non-literal `value` attribute and falls through to the alias, while
+        // getDefaultAttributeValue surfaces the `value` attribute in any shape.
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+            new Annotated.Matcher("@Example").asVisitor(a -> SearchResult.found(a.getTree(),
+              "old=" + a.getDefaultAttribute("alias").map(lit -> lit.getValue(String.class)).orElse("empty") +
+              ":new=" + a.getDefaultAttributeValue("alias").map(v -> v.getKind().toString()).orElse("empty"))
+            )
+          )),
+          java(
+            """
+              class Constants {
+                  static final String NAME = "n";
+              }
+              """
+          ),
+          java(
+            """
+              @interface Example {
+                  String value() default "";
+                  String alias() default "";
+              }
+              """
+          ),
+          java(
+            """
+              @Example(value = Constants.NAME, alias = "x")
+              class Test {
+              }
+              """,
+            """
+              /*~~(old=x:new=CONSTANT_REFERENCE)~~>*/@Example(value = Constants.NAME, alias = "x")
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void emptyArrayAttribute() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() ->

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
@@ -63,6 +63,38 @@ class AnnotatedTest implements RewriteTest {
     }
 
     @Test
+    void emptyArrayAttribute() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+            new Annotated.Matcher("@Example").asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getAttribute("other")
+                .map(lit -> "size:" + lit.getStrings().size())
+                .orElse("missing"))
+            )
+          )),
+          java(
+            """
+              @interface Example {
+                  String[] other() default {};
+              }
+              """
+          ),
+          java(
+            """
+              @Example(other = {})
+              class Test {
+              }
+              """,
+            """
+              /*~~(size:0)~~>*/@Example(other = {})
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void checkOnArray() {
         rewriteRun(
           spec ->

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
@@ -64,7 +64,6 @@ class AnnotatedTest implements RewriteTest {
 
     @Test
     void attributesViaAttributeValue() {
-        // the mechanical migration of attributes(): getDefaultAttribute -> getDefaultAttributeValue
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() ->
             new Annotated.Matcher("@Example").asVisitor(a -> SearchResult.found(a.getTree(),
@@ -104,9 +103,6 @@ class AnnotatedTest implements RewriteTest {
 
     @Test
     void oldAccessorFallsThroughToAliasWhenValueIsNotLiteral() {
-        // Documents a deliberate divergence: the Optional<Literal> accessor cannot see a
-        // non-literal `value` attribute and falls through to the alias, while
-        // getDefaultAttributeValue surfaces the `value` attribute in any shape.
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() ->
             new Annotated.Matcher("@Example").asVisitor(a -> SearchResult.found(a.getTree(),

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/AttributeValueTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/AttributeValueTest.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.java.trait;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -609,7 +611,7 @@ class AttributeValueTest implements RewriteTest {
                     assertThat(elements.get(i).getTree()).isSameAs(array.getInitializer().get(i));
                     assertThat((Object) elements.get(i).getCursor().getParentTreeCursor().getValue()).isSameAs(array);
                 }
-                return a.getTree();
+                return SearchResult.found(a.getTree());
             }))),
           java(
             """
@@ -621,6 +623,11 @@ class AttributeValueTest implements RewriteTest {
           java(
             """
               @Example(exclude = {String.class, Integer.class})
+              class Test {
+              }
+              """,
+            """
+              /*~~>*/@Example(exclude = {String.class, Integer.class})
               class Test {
               }
               """
@@ -788,7 +795,8 @@ class AttributeValueTest implements RewriteTest {
                 "/" + v.isEnumConstant("com.x.E", "ONE") +
                 "/" + v.isClassLiteral("com.x.A") +
                 "/" + (v.getReferencedField() != null) +
-                "/" + (v.getClassValue() != null)))))
+                "/" + (v.getClassValue() != null) +
+                "/" + v.getConstantValue()))))
             .typeValidationOptions(TypeValidation.none()),
           java(
             """
@@ -801,12 +809,195 @@ class AttributeValueTest implements RewriteTest {
               }
               """,
             """
-              @Example(e = /*~~(CONSTANT_REFERENCE/false/false/false/false)~~>*/E.ONE)
+              @Example(e = /*~~(CONSTANT_REFERENCE/false/false/false/false/null)~~>*/E.ONE)
               class Test1 {
               }
 
-              @Example(clazz = /*~~(CLASS_LITERAL/false/false/false/false)~~>*/A.class)
+              @Example(clazz = /*~~(CLASS_LITERAL/false/false/false/false/null)~~>*/A.class)
               class Test2 {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void constantValueIsNullForNonConstantKinds() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new AttributeValue.Matcher().mapper(new ObjectMapper())
+            .asVisitor((v, ctx) -> SearchResult.found(v.getTree(), v.getKind() + "=" + v.getConstantValue())))),
+          java(
+            """
+              @interface Bar {
+                  String value() default "";
+              }
+
+              enum E {
+                  ONE
+              }
+
+              @interface Example {
+                  Class<?> clazz() default Object.class;
+                  Bar bar() default @Bar;
+                  E e() default E.ONE;
+                  String[] tags() default {};
+              }
+              """
+          ),
+          java(
+            """
+              @Example(clazz = String.class, bar = @Bar("x"), e = E.ONE, tags = {"a"})
+              class Test {
+              }
+              """,
+            """
+              @Example(clazz = /*~~(CLASS_LITERAL=null)~~>*/String.class, bar = /*~~(NESTED_ANNOTATION=null)~~>*/@Bar(/*~~(LITERAL=x)~~>*/"x"), e = /*~~(ENUM_CONSTANT=null)~~>*/E.ONE, tags = /*~~(ARRAY=null)~~>*/{"a"})
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void typedValueCoercion() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@Example", "tags",
+            v -> "list=" + v.getValue(new TypeReference<List<String>>() {}) + ":int=" + v.getValue(Integer.class))),
+          java(
+            """
+              @interface Example {
+                  String[] tags() default {};
+              }
+              """
+          ),
+          java(
+            """
+              @Example(tags = "a")
+              class Test {
+              }
+              """,
+            """
+              /*~~(list=[a]:int=null)~~>*/@Example(tags = "a")
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void parenthesizedArrayElements() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@Example", "tags",
+            v -> v.getElements().stream()
+              .map(e -> e.getKind() + "/" + e.getConstantValue() + "/" + e.getName())
+              .collect(Collectors.joining(",")))),
+          java(
+            """
+              class Constants {
+                  static final String NAME = "n";
+              }
+              """
+          ),
+          java(
+            """
+              @interface Example {
+                  String[] tags() default {};
+              }
+              """
+          ),
+          java(
+            """
+              @Example(tags = {("a"), (Constants.NAME)})
+              class Test {
+              }
+              """,
+            """
+              /*~~(LITERAL/a/tags,CONSTANT_REFERENCE/n/tags)~~>*/@Example(tags = {("a"), (Constants.NAME)})
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void positionalArrayElements() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@Example", "value",
+            v -> v.getElements().stream()
+              .map(e -> e.getKind() + "/" + e.getConstantValue() + "/" + e.getName())
+              .collect(Collectors.joining(",")))),
+          java(
+            """
+              class Constants {
+                  static final String NAME = "n";
+              }
+              """
+          ),
+          java(
+            """
+              @interface Example {
+                  String[] value();
+              }
+              """
+          ),
+          java(
+            """
+              @Example({Constants.NAME, "b"})
+              class Test {
+              }
+              """,
+            """
+              /*~~(CONSTANT_REFERENCE/n/value,LITERAL/b/value)~~>*/@Example({Constants.NAME, "b"})
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void constantReferencesDoNotFoldOnUnsupportedDeclarations() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@Example", "name",
+            v -> v.getKind() + ":" + v.getConstantValue())),
+          java(
+            """
+              class Constants {
+                  static final String NAME = "n";
+              }
+              """
+          ),
+          java(
+            """
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+
+              @Target({ElementType.FIELD, ElementType.TYPE_PARAMETER})
+              @interface Example {
+                  String name() default "";
+              }
+              """
+          ),
+          java(
+            """
+              enum Status {
+                  @Example(name = Constants.NAME)
+                  ACTIVE
+              }
+
+              class Poly<@Example(name = Constants.NAME) T> {
+              }
+              """,
+            """
+              enum Status {
+                  /*~~(CONSTANT_REFERENCE:null)~~>*/@Example(name = Constants.NAME)
+                  ACTIVE
+              }
+
+              class Poly</*~~(CONSTANT_REFERENCE:null)~~>*/@Example(name = Constants.NAME) T> {
               }
               """
           )

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/AttributeValueTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/AttributeValueTest.java
@@ -1,0 +1,665 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.java;
+
+class AttributeValueTest implements RewriteTest {
+
+    private static org.openrewrite.Recipe describeAttribute(String annotationSignature, String attribute,
+                                                            Function<AttributeValue, String> describer) {
+        return RewriteTest.toRecipe(() -> new Annotated.Matcher(annotationSignature)
+          .asVisitor(a -> a.getAttributeValue(attribute)
+            .map(value -> (J.Annotation) SearchResult.found(a.getTree(), describer.apply(value)))
+            .orElseGet(() -> SearchResult.found(a.getTree(), "missing"))));
+    }
+
+    @Test
+    void literalValues() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@Example", "name",
+            v -> v.getKind() + ":" + v.getConstantValue() + ":" + v.getValue(String.class))),
+          java(
+            """
+              @interface Example {
+                  String name() default "";
+              }
+              """
+          ),
+          java(
+            """
+              @Example(name = "s")
+              class Test {
+              }
+              """,
+            """
+              /*~~(LITERAL:s:s)~~>*/@Example(name = "s")
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void negativeNumberIsLiteral() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@Example", "count",
+            v -> v.getKind() + ":" + v.getConstantValue())),
+          java(
+            """
+              @interface Example {
+                  int count() default 0;
+              }
+              """
+          ),
+          java(
+            """
+              @Example(count = -1)
+              class Test {
+              }
+              """,
+            """
+              /*~~(LITERAL:-1)~~>*/@Example(count = -1)
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void parenthesesAreTransparentButOldAccessorIsUnchanged() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> {
+                AttributeValue value = a.getAttributeValue("name").orElseThrow(IllegalStateException::new);
+                //noinspection deprecation
+                return SearchResult.found(a.getTree(),
+                  value.getKind() + ":" + value.getConstantValue() +
+                  ":asLiteral=" + value.asLiteral().isPresent() +
+                  ":oldApi=" + a.getAttribute("name").isPresent());
+            }))),
+          java(
+            """
+              @interface Example {
+                  String name() default "";
+              }
+              """
+          ),
+          java(
+            """
+              @Example(name = ("a"))
+              class Test {
+              }
+              """,
+            """
+              /*~~(LITERAL:a:asLiteral=true:oldApi=false)~~>*/@Example(name = ("a"))
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void binaryExpression() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@Example", "name",
+            v -> v.getKind() + ":" + v.getConstantValue())),
+          java(
+            """
+              @interface Example {
+                  String name() default "";
+              }
+              """
+          ),
+          java(
+            """
+              @Example(name = "a" + "b")
+              class Test {
+              }
+              """,
+            """
+              /*~~(EXPRESSION:null)~~>*/@Example(name = "a" + "b")
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void classLiterals() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@com.x.Example", "clazz", v -> {
+              JavaType.FullyQualified fq = TypeUtils.asFullyQualified(v.getClassValue());
+              JavaType classValue = v.getClassValue();
+              return v.getKind() +
+                     ":" + (fq != null ? fq.getFullyQualifiedName() : classValue == null ? "null" : classValue.getClass().getSimpleName()) +
+                     ":" + v.isClassLiteral("com.x.A");
+          })),
+          java(
+            """
+              package com.x;
+              public @interface Example {
+                  Class<?> clazz() default Object.class;
+              }
+              """
+          ),
+          java(
+            """
+              package com.x;
+              public class A {
+              }
+              """
+          ),
+          java(
+            """
+              import com.x.A;
+              import com.x.Example;
+
+              @Example(clazz = A.class)
+              class Test1 {
+              }
+
+              @Example(clazz = int.class)
+              class Test2 {
+              }
+
+              @Example(clazz = String[].class)
+              class Test3 {
+              }
+              """,
+            """
+              import com.x.A;
+              import com.x.Example;
+
+              /*~~(CLASS_LITERAL:com.x.A:true)~~>*/@Example(clazz = A.class)
+              class Test1 {
+              }
+
+              /*~~(CLASS_LITERAL:Primitive:false)~~>*/@Example(clazz = int.class)
+              class Test2 {
+              }
+
+              /*~~(CLASS_LITERAL:Array:false)~~>*/@Example(clazz = String[].class)
+              class Test3 {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void classLiteralArrayAndBracelessForm() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@com.x.Example", "exclude",
+            v -> v.getKind() + ":array=" + v.isArray() + ":" + v.getElements().stream()
+              .map(e -> e.getKind() + "/" + e.isClassLiteral("com.x.A") + "/" + e.getName())
+              .collect(Collectors.joining(",")))),
+          java(
+            """
+              package com.x;
+              public @interface Example {
+                  Class<?>[] exclude() default {};
+              }
+              """
+          ),
+          java(
+            """
+              package com.x;
+              public class A {
+              }
+              """
+          ),
+          java(
+            """
+              package com.x;
+              public class B {
+              }
+              """
+          ),
+          java(
+            """
+              import com.x.A;
+              import com.x.B;
+              import com.x.Example;
+
+              @Example(exclude = {A.class, B.class})
+              class Test1 {
+              }
+
+              @Example(exclude = A.class)
+              class Test2 {
+              }
+
+              @Example(exclude = {})
+              class Test3 {
+              }
+              """,
+            """
+              import com.x.A;
+              import com.x.B;
+              import com.x.Example;
+
+              /*~~(ARRAY:array=true:CLASS_LITERAL/true/exclude,CLASS_LITERAL/false/exclude)~~>*/@Example(exclude = {A.class, B.class})
+              class Test1 {
+              }
+
+              /*~~(CLASS_LITERAL:array=false:CLASS_LITERAL/true/exclude)~~>*/@Example(exclude = A.class)
+              class Test2 {
+              }
+
+              /*~~(ARRAY:array=true:)~~>*/@Example(exclude = {})
+              class Test3 {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void enumConstantsInAllSpellings() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@com.x.Example", "e", v -> {
+              JavaType.Variable field = v.getReferencedField();
+              return v.getKind() +
+                     ":" + v.isEnumConstant("com.x.E", "ONE") +
+                     ":" + (field != null ? TypeUtils.asFullyQualified(field.getOwner()).getFullyQualifiedName() + "." + field.getName() : "null");
+          })),
+          java(
+            """
+              package com.x;
+              public @interface Example {
+                  E e() default E.ONE;
+              }
+              """
+          ),
+          java(
+            """
+              package com.x;
+              public enum E {
+                  ONE, TWO
+              }
+              """
+          ),
+          java(
+            """
+              import com.x.E;
+              import com.x.Example;
+
+              import static com.x.E.ONE;
+
+              @Example(e = E.ONE)
+              class Test1 {
+              }
+
+              @Example(e = com.x.E.TWO)
+              class Test2 {
+              }
+
+              @Example(e = ONE)
+              class Test3 {
+              }
+              """,
+            """
+              import com.x.E;
+              import com.x.Example;
+
+              import static com.x.E.ONE;
+
+              /*~~(ENUM_CONSTANT:true:com.x.E.ONE)~~>*/@Example(e = E.ONE)
+              class Test1 {
+              }
+
+              /*~~(ENUM_CONSTANT:false:com.x.E.TWO)~~>*/@Example(e = com.x.E.TWO)
+              class Test2 {
+              }
+
+              /*~~(ENUM_CONSTANT:true:com.x.E.ONE)~~>*/@Example(e = ONE)
+              class Test3 {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void constantReferencesInAllSpellings() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@com.x.Example", "name", v -> {
+              JavaType.Variable field = v.getReferencedField();
+              return v.getKind() +
+                     ":" + (field != null ? TypeUtils.asFullyQualified(field.getOwner()).getFullyQualifiedName() + "." + field.getName() : "null") +
+                     ":" + v.getConstantValue();
+          })),
+          java(
+            """
+              package com.x;
+              public @interface Example {
+                  String name() default "";
+              }
+              """
+          ),
+          java(
+            """
+              package com.x;
+              public class Constants {
+                  public static final String NAME = "n";
+              }
+              """
+          ),
+          java(
+            """
+              import com.x.Constants;
+              import com.x.Example;
+
+              import static com.x.Constants.NAME;
+
+              @Example(name = Constants.NAME)
+              class Test1 {
+              }
+
+              @Example(name = NAME)
+              class Test2 {
+              }
+
+              @Example(name = Test3.LOCAL)
+              class Test3 {
+                  static final String LOCAL = "l";
+              }
+              """,
+            """
+              import com.x.Constants;
+              import com.x.Example;
+
+              import static com.x.Constants.NAME;
+
+              /*~~(CONSTANT_REFERENCE:com.x.Constants.NAME:null)~~>*/@Example(name = Constants.NAME)
+              class Test1 {
+              }
+
+              /*~~(CONSTANT_REFERENCE:com.x.Constants.NAME:null)~~>*/@Example(name = NAME)
+              class Test2 {
+              }
+
+              /*~~(CONSTANT_REFERENCE:Test3.LOCAL:null)~~>*/@Example(name = Test3.LOCAL)
+              class Test3 {
+                  static final String LOCAL = "l";
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void nestedAnnotation() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@Example", "bar",
+            v -> v.getKind() + ":" + v.asAnnotated()
+              .flatMap(nested -> nested.getDefaultAttributeValue(null))
+              .map(nested -> nested.getKind() + "/" + nested.getConstantValue() + "/" + nested.getName())
+              .orElse("none"))),
+          java(
+            """
+              @interface Bar {
+                  String value();
+              }
+              """
+          ),
+          java(
+            """
+              @interface Example {
+                  Bar bar();
+              }
+              """
+          ),
+          java(
+            """
+              @Example(bar = @Bar("x"))
+              class Test {
+              }
+              """,
+            """
+              /*~~(NESTED_ANNOTATION:LITERAL/x/value)~~>*/@Example(bar = @Bar("x"))
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void mixedArray() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@Example", "tags",
+            v -> v.getKind() + ":" + v.getElements().stream()
+              .map(e -> e.getKind().toString())
+              .collect(Collectors.joining(",")) +
+              ":asLiteral=" + v.asLiteral().isPresent())),
+          java(
+            """
+              @interface Example {
+                  String[] tags() default {};
+              }
+              """
+          ),
+          java(
+            """
+              class Constants {
+                  static final String NAME = "n";
+              }
+              """
+          ),
+          java(
+            """
+              @Example(tags = {"a", Constants.NAME})
+              class Test {
+              }
+              """,
+            """
+              /*~~(ARRAY:LITERAL,CONSTANT_REFERENCE:asLiteral=false)~~>*/@Example(tags = {"a", Constants.NAME})
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void positionalValueAttribute() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getAttributeValue("value").map(v -> "byName=" + v.getConstantValue() + "/" + v.getName()).orElse("byName=missing") +
+              ":" +
+              a.getDefaultAttributeValue(null).map(v -> "byDefault=" + v.getConstantValue()).orElse("byDefault=missing"))))),
+          java(
+            """
+              @interface Example {
+                  String value();
+              }
+              """
+          ),
+          java(
+            """
+              @Example("x")
+              class Test {
+              }
+              """,
+            """
+              /*~~(byName=x/value:byDefault=x)~~>*/@Example("x")
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void absentAttributeAndEmptyParens() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              "attr=" + a.getAttributeValue("name").isPresent() +
+              ":default=" + a.getDefaultAttributeValue("name").isPresent())))),
+          java(
+            """
+              @interface Example {
+                  String name() default "";
+              }
+              """
+          ),
+          java(
+            """
+              @Example
+              class Test1 {
+              }
+
+              @Example()
+              class Test2 {
+              }
+              """,
+            """
+              /*~~(attr=false:default=false)~~>*/@Example
+              class Test1 {
+              }
+
+              /*~~(attr=false:default=false)~~>*/@Example()
+              class Test2 {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void matcherMatchesOnlyTopLevelValuePositions() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new AttributeValue.Matcher()
+            .asVisitor((v, ctx) -> SearchResult.found(v.getTree(), v.getKind().toString())))),
+          java(
+            """
+              @interface Example {
+                  String name() default "";
+                  Class<?>[] exclude() default {};
+              }
+              """
+          ),
+          java(
+            """
+              @Example(name = "s", exclude = {String.class})
+              class Test1 {
+              }
+
+              @Example()
+              class Test2 {
+              }
+              """,
+            """
+              @Example(name = /*~~(LITERAL)~~>*/"s", exclude = /*~~(ARRAY)~~>*/{String.class})
+              class Test1 {
+              }
+
+              @Example()
+              class Test2 {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void elementsAreIdentityBoundToTheTree() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> {
+                AttributeValue value = a.getAttributeValue("exclude").orElseThrow(IllegalStateException::new);
+                List<AttributeValue> elements = value.getElements();
+                J.NewArray array = (J.NewArray) value.getTree();
+                assertThat(elements).hasSize(2);
+                for (int i = 0; i < elements.size(); i++) {
+                    assertThat(elements.get(i).getTree()).isSameAs(array.getInitializer().get(i));
+                    assertThat((Object) elements.get(i).getCursor().getParentTreeCursor().getValue()).isSameAs(array);
+                }
+                return a.getTree();
+            }))),
+          java(
+            """
+              @interface Example {
+                  Class<?>[] exclude() default {};
+              }
+              """
+          ),
+          java(
+            """
+              @Example(exclude = {String.class, Integer.class})
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void degradesGracefullyWithoutTypeAttribution() {
+        rewriteRun(
+          spec -> spec
+            .recipe(RewriteTest.toRecipe(() -> new AttributeValue.Matcher()
+              .asVisitor((v, ctx) -> SearchResult.found(v.getTree(),
+                v.getKind() +
+                "/" + v.isEnumConstant("com.x.E", "ONE") +
+                "/" + v.isClassLiteral("com.x.A") +
+                "/" + (v.getReferencedField() != null) +
+                "/" + (v.getClassValue() != null)))))
+            .typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              @Example(e = E.ONE)
+              class Test1 {
+              }
+
+              @Example(clazz = A.class)
+              class Test2 {
+              }
+              """,
+            """
+              @Example(e = /*~~(CONSTANT_REFERENCE/false/false/false/false)~~>*/E.ONE)
+              class Test1 {
+              }
+
+              @Example(clazz = /*~~(CLASS_LITERAL/false/false/false/false)~~>*/A.class)
+              class Test2 {
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/AttributeValueTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/AttributeValueTest.java
@@ -147,7 +147,7 @@ class AttributeValueTest implements RewriteTest {
               }
               """,
             """
-              /*~~(EXPRESSION:null)~~>*/@Example(name = "a" + "b")
+              /*~~(EXPRESSION:ab)~~>*/@Example(name = "a" + "b")
               class Test {
               }
               """
@@ -402,15 +402,15 @@ class AttributeValueTest implements RewriteTest {
 
               import static com.x.Constants.NAME;
 
-              /*~~(CONSTANT_REFERENCE:com.x.Constants.NAME:null)~~>*/@Example(name = Constants.NAME)
+              /*~~(CONSTANT_REFERENCE:com.x.Constants.NAME:n)~~>*/@Example(name = Constants.NAME)
               class Test1 {
               }
 
-              /*~~(CONSTANT_REFERENCE:com.x.Constants.NAME:null)~~>*/@Example(name = NAME)
+              /*~~(CONSTANT_REFERENCE:com.x.Constants.NAME:n)~~>*/@Example(name = NAME)
               class Test2 {
               }
 
-              /*~~(CONSTANT_REFERENCE:Test3.LOCAL:null)~~>*/@Example(name = Test3.LOCAL)
+              /*~~(CONSTANT_REFERENCE:Test3.LOCAL:l)~~>*/@Example(name = Test3.LOCAL)
               class Test3 {
                   static final String LOCAL = "l";
               }
@@ -461,7 +461,7 @@ class AttributeValueTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(describeAttribute("@Example", "tags",
             v -> v.getKind() + ":" + v.getElements().stream()
-              .map(e -> e.getKind().toString())
+              .map(e -> e.getKind() + "/" + e.getConstantValue())
               .collect(Collectors.joining(",")) +
               ":asLiteral=" + v.asLiteral().isPresent())),
           java(
@@ -485,7 +485,7 @@ class AttributeValueTest implements RewriteTest {
               }
               """,
             """
-              /*~~(ARRAY:LITERAL,CONSTANT_REFERENCE:asLiteral=false)~~>*/@Example(tags = {"a", Constants.NAME})
+              /*~~(ARRAY:LITERAL/a,CONSTANT_REFERENCE/n:asLiteral=false)~~>*/@Example(tags = {"a", Constants.NAME})
               class Test {
               }
               """
@@ -621,6 +621,100 @@ class AttributeValueTest implements RewriteTest {
           java(
             """
               @Example(exclude = {String.class, Integer.class})
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void foldsConstantsOnFieldMethodAndParameterDeclarations() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getAttributeValue("name").map(v -> "name=" + v.getConstantValue())
+                .orElseGet(() -> a.getAttributeValue("count").map(v -> "count=" + v.getConstantValue())
+                  .orElse("missing")))))),
+          java(
+            """
+              @interface Example {
+                  String name() default "";
+                  int count() default 0;
+              }
+              """
+          ),
+          java(
+            """
+              class Constants {
+                  static final String NAME = "n";
+              }
+              """
+          ),
+          java(
+            """
+              class Test {
+                  @Example(name = Constants.NAME)
+                  String field;
+
+                  @Example(name = Constants.NAME)
+                  void method(@Example(count = Integer.MAX_VALUE) int param) {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  /*~~(name=n)~~>*/@Example(name = Constants.NAME)
+                  String field;
+
+                  /*~~(name=n)~~>*/@Example(name = Constants.NAME)
+                  void method(/*~~(count=2147483647)~~>*/@Example(count = Integer.MAX_VALUE) int param) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void repeatedAnnotationsDoNotFold() {
+        rewriteRun(
+          spec -> spec.recipe(describeAttribute("@Example", "name",
+            v -> v.getKind() + ":" + v.getConstantValue())),
+          java(
+            """
+              import java.lang.annotation.Repeatable;
+
+              @Repeatable(Examples.class)
+              @interface Example {
+                  String name() default "";
+              }
+              """
+          ),
+          java(
+            """
+              @interface Examples {
+                  Example[] value();
+              }
+              """
+          ),
+          java(
+            """
+              class Constants {
+                  static final String NAME = "n";
+              }
+              """
+          ),
+          java(
+            """
+              @Example(name = Constants.NAME)
+              @Example(name = "b")
+              class Test {
+              }
+              """,
+            """
+              /*~~(CONSTANT_REFERENCE:null)~~>*/@Example(name = Constants.NAME)
+              /*~~(LITERAL:b)~~>*/@Example(name = "b")
               class Test {
               }
               """

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/AttributeValueTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/AttributeValueTest.java
@@ -221,7 +221,7 @@ class AttributeValueTest implements RewriteTest {
     void classLiteralArrayAndBracelessForm() {
         rewriteRun(
           spec -> spec.recipe(describeAttribute("@com.x.Example", "exclude",
-            v -> v.getKind() + ":array=" + v.isArray() + ":" + v.getElements().stream()
+            v -> v.getKind() + ":array=" + v.isArray() + ":asLiteral=" + v.asLiteral().isPresent() + ":" + v.getElements().stream()
               .map(e -> e.getKind() + "/" + e.isClassLiteral("com.x.A") + "/" + e.getName())
               .collect(Collectors.joining(",")))),
           java(
@@ -269,15 +269,15 @@ class AttributeValueTest implements RewriteTest {
               import com.x.B;
               import com.x.Example;
 
-              /*~~(ARRAY:array=true:CLASS_LITERAL/true/exclude,CLASS_LITERAL/false/exclude)~~>*/@Example(exclude = {A.class, B.class})
+              /*~~(ARRAY:array=true:asLiteral=false:CLASS_LITERAL/true/exclude,CLASS_LITERAL/false/exclude)~~>*/@Example(exclude = {A.class, B.class})
               class Test1 {
               }
 
-              /*~~(CLASS_LITERAL:array=false:CLASS_LITERAL/true/exclude)~~>*/@Example(exclude = A.class)
+              /*~~(CLASS_LITERAL:array=false:asLiteral=false:CLASS_LITERAL/true/exclude)~~>*/@Example(exclude = A.class)
               class Test2 {
               }
 
-              /*~~(ARRAY:array=true:)~~>*/@Example(exclude = {})
+              /*~~(ARRAY:array=true:asLiteral=true:)~~>*/@Example(exclude = {})
               class Test3 {
               }
               """
@@ -657,6 +657,10 @@ class AttributeValueTest implements RewriteTest {
                   @Example(name = Constants.NAME)
                   String field;
 
+                  private @Example(name = Constants.NAME) String afterModifier;
+
+                  static @Example(name = Constants.NAME) final String betweenModifiers = "x";
+
                   @Example(name = Constants.NAME)
                   void method(@Example(count = Integer.MAX_VALUE) int param) {
                   }
@@ -667,9 +671,61 @@ class AttributeValueTest implements RewriteTest {
                   /*~~(name=n)~~>*/@Example(name = Constants.NAME)
                   String field;
 
+                  private /*~~(name=n)~~>*/@Example(name = Constants.NAME) String afterModifier;
+
+                  static /*~~(name=n)~~>*/@Example(name = Constants.NAME) final String betweenModifiers = "x";
+
                   /*~~(name=n)~~>*/@Example(name = Constants.NAME)
                   void method(/*~~(count=2147483647)~~>*/@Example(count = Integer.MAX_VALUE) int param) {
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void foldsPositionalAndBracelessArrayValues() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getDefaultAttributeValue(null)
+                .map(v -> String.valueOf(v.getConstantValue()))
+                .orElseGet(() -> a.getAttributeValue("tags")
+                  .map(v -> "tags=" + v.getConstantValue())
+                  .orElse("missing")))))),
+          java(
+            """
+              @interface Example {
+                  String value() default "";
+                  String[] tags() default {};
+              }
+              """
+          ),
+          java(
+            """
+              class Constants {
+                  static final String NAME = "n";
+              }
+              """
+          ),
+          java(
+            """
+              @Example(Constants.NAME)
+              class Test1 {
+              }
+
+              @Example(tags = Constants.NAME)
+              class Test2 {
+              }
+              """,
+            """
+              /*~~(n)~~>*/@Example(Constants.NAME)
+              class Test1 {
+              }
+
+              /*~~(tags=n)~~>*/@Example(tags = Constants.NAME)
+              class Test2 {
               }
               """
           )

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/LiteralTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/LiteralTest.java
@@ -59,6 +59,35 @@ class LiteralTest implements RewriteTest {
     }
 
     @Test
+    void emptyArrayLiteral() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+              new Literal.Matcher().asVisitor(lit -> {
+                  assertThat(lit.isArray()).isTrue();
+                  assertThat(lit.isNotNull()).isTrue();
+                  assertThat(lit.getStrings()).isEmpty();
+                  return SearchResult.found(lit.getTree());
+              })
+            )
+          ),
+          java(
+            """
+              class Test {
+                String[] s = {};
+                int[] n = new int[] {};
+              }
+              """,
+            """
+              class Test {
+                String[] s = /*~~>*/{};
+                int[] n = /*~~>*/new int[] {};
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void arrayLiteral() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() ->

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/LiteralTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/LiteralTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.trait;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.marker.SearchResult;
@@ -45,13 +46,115 @@ class LiteralTest implements RewriteTest {
             """
               class Test {
                 int n = 0;
-                int d = 0.0;
+                double d = 0.0;
               }
               """,
             """
               class Test {
                 int n = /*~~(0)~~>*/0;
-                int d = /*~~(0)~~>*/0.0;
+                double d = /*~~(0)~~>*/0.0;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void nullLiteral() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+              new Literal.Matcher().asVisitor(lit ->
+                SearchResult.found(lit.getTree(),
+                  "null=" + lit.isNull() + ":string=" + lit.getString() + ":value=" + lit.getValue(String.class)))
+            )
+          ),
+          java(
+            """
+              class Test {
+                String s = null;
+              }
+              """,
+            """
+              class Test {
+                String s = /*~~(null=true:string=null:value=null)~~>*/null;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void stringAccessors() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+              new Literal.Matcher().asVisitor(lit ->
+                SearchResult.found(lit.getTree(),
+                  "string=" + lit.getString() + ":strings=" + String.join(",", lit.getStrings())))
+            )
+          ),
+          java(
+            """
+              class Test {
+                String s = "a";
+                String[] t = { "b" };
+              }
+              """,
+            """
+              class Test {
+                String s = /*~~(string=a:strings=a)~~>*/"a";
+                String[] t = /*~~(string=null:strings=b)~~>*/{ /*~~(string=b:strings=b)~~>*/"b" };
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void nestedArrayLiteral() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+              new Literal.Matcher().asVisitor(lit ->
+                SearchResult.found(lit.getTree(), String.valueOf(lit.getValue(Object.class))))
+            )
+          ),
+          java(
+            """
+              class Test {
+                int[][] n = { { 1, 2 }, { 3 } };
+              }
+              """,
+            """
+              class Test {
+                int[][] n = /*~~([[1, 2], [3]])~~>*/{ /*~~([1, 2])~~>*/{ /*~~(1)~~>*/1, /*~~(2)~~>*/2 }, /*~~([3])~~>*/{ /*~~(3)~~>*/3 } };
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void nonCoercibleValueThrows() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+              new Literal.Matcher().mapper(new ObjectMapper()).asVisitor(lit -> {
+                  // diverges from AttributeValue.getValue, which returns null instead of throwing
+                  try {
+                      return SearchResult.found(lit.getTree(), "coerced=" + lit.getValue(Integer.class));
+                  } catch (IllegalArgumentException e) {
+                      return SearchResult.found(lit.getTree(), "throws");
+                  }
+              })
+            )
+          ),
+          java(
+            """
+              class Test {
+                String s = "abc";
+              }
+              """,
+            """
+              class Test {
+                String s = /*~~(throws)~~>*/"abc";
               }
               """
           )

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -1168,7 +1168,10 @@ class KotlinTypeMapping(
 
     @OptIn(SymbolInternals::class)
     fun variableType(variable: FirVariable, parent: Any?, signature: String): Variable {
-        val variableFlags = mapToFlagsBitmap(variable.visibility, variable.modality, variable.isStatic)
+        var variableFlags = mapToFlagsBitmap(variable.visibility, variable.modality, variable.isStatic)
+        if (variable is FirEnumEntry) {
+            variableFlags = variableFlags or (1L shl 14) // Enum
+        }
         val resolvedName = variableName(variable.name.asString())
         return typeFactory.variableFor(signature) {
             val vt = Variable(null, variableFlags, resolvedName, null, null, null)

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
@@ -27,10 +27,8 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
 /**
  * Pins the {@link org.openrewrite.java.trait.AttributeValue} behavior on Kotlin sources:
  * {@code A::class} / {@code A::class.java} class references, and the documented
- * degradations — Kotlin collection literals ({@code K.ListLiteral} is not a
- * {@code J.NewArray}), enum constants (no {@code Flag.Enum} from the Kotlin type
- * mapping), and constant references (no {@code JavaType.Annotation} element values,
- * so no fold).
+ * degradations — no constant folding, no enum discrimination, collection literals as
+ * opaque expressions.
  */
 class AttributeValueTraitTest implements RewriteTest {
 
@@ -93,7 +91,6 @@ class AttributeValueTraitTest implements RewriteTest {
 
     @Test
     void enumConstantDegradesToConstantReference() {
-        // the Kotlin type mapping does not set Flag.Enum on the referenced variable
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
             .asVisitor(a -> SearchResult.found(a.getTree(),

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
@@ -124,7 +124,7 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("KotlinTypeMapping#variableType does not set Flag.Enum on enum entries (mapToFlagsBitmap uses only visibility/modality/static)")
+    @ExpectedToFail("KotlinTypeMapping#variableType does not set Flag.Enum on enum entries (mapToFlagsBitmap uses only visibility/modality/static) — https://github.com/openrewrite/rewrite/issues/8170")
     @Test
     void enumConstant() {
         rewriteRun(
@@ -158,7 +158,7 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("KotlinTypeMapping builds no JavaType.Annotation element values, so the compiler's constant fold is unavailable")
+    @ExpectedToFail("KotlinTypeMapping builds no JavaType.Annotation element values, so the compiler's constant fold is unavailable — https://github.com/openrewrite/rewrite/issues/8170")
     @Test
     void constantReferenceFolds() {
         rewriteRun(
@@ -192,7 +192,7 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Kotlin collection literals are K.ListLiteral, not J.NewArray; getElements() cannot normalize them from rewrite-java")
+    @ExpectedToFail("Kotlin collection literals are K.ListLiteral, not J.NewArray; getElements() cannot normalize them from rewrite-java — https://github.com/openrewrite/rewrite/issues/8170")
     @Test
     void collectionLiteralArray() {
         rewriteRun(

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.trait.Annotated;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+/**
+ * Pins the {@link org.openrewrite.java.trait.AttributeValue} behavior on Kotlin sources:
+ * {@code A::class} class references, and the degradation of Kotlin collection literals
+ * ({@code K.ListLiteral} is not a {@code J.NewArray}).
+ */
+class AttributeValueTraitTest implements RewriteTest {
+
+    @Test
+    void classReference() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getAttributeValue("clazz")
+                .map(v -> {
+                    JavaType.FullyQualified fq = TypeUtils.asFullyQualified(v.getClassValue());
+                    return v.getKind() + ":" + (fq != null ? fq.getFullyQualifiedName() : "null");
+                })
+                .orElse("missing"))))),
+          kotlin(
+            """
+              import kotlin.reflect.KClass
+
+              annotation class Example(val clazz: KClass<*>)
+
+              @Example(clazz = String::class)
+              class Test
+              """,
+            """
+              import kotlin.reflect.KClass
+
+              annotation class Example(val clazz: KClass<*>)
+
+              /*~~(CLASS_LITERAL:kotlin.String)~~>*/@Example(clazz = String::class)
+              class Test
+              """
+          )
+        );
+    }
+
+    @Test
+    void collectionLiteralIsAnOpaqueExpression() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getAttributeValue("tags")
+                .map(v -> v.getKind() + ":elements=" + v.getElements().size())
+                .orElse("missing"))))),
+          kotlin(
+            """
+              annotation class Example(val tags: Array<String>)
+
+              @Example(tags = ["a", "b"])
+              class Test
+              """,
+            """
+              annotation class Example(val tags: Array<String>)
+
+              /*~~(EXPRESSION:elements=1)~~>*/@Example(tags = ["a", "b"])
+              class Test
+              """
+          )
+        );
+    }
+}

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
@@ -26,8 +26,11 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
 
 /**
  * Pins the {@link org.openrewrite.java.trait.AttributeValue} behavior on Kotlin sources:
- * {@code A::class} class references, and the degradation of Kotlin collection literals
- * ({@code K.ListLiteral} is not a {@code J.NewArray}).
+ * {@code A::class} / {@code A::class.java} class references, and the documented
+ * degradations — Kotlin collection literals ({@code K.ListLiteral} is not a
+ * {@code J.NewArray}), enum constants (no {@code Flag.Enum} from the Kotlin type
+ * mapping), and constant references (no {@code JavaType.Annotation} element values,
+ * so no fold).
  */
 class AttributeValueTraitTest implements RewriteTest {
 
@@ -57,6 +60,130 @@ class AttributeValueTraitTest implements RewriteTest {
               annotation class Example(val clazz: KClass<*>)
 
               /*~~(CLASS_LITERAL:kotlin.String)~~>*/@Example(clazz = String::class)
+              class Test
+              """
+          )
+        );
+    }
+
+    @Test
+    void implicitValueAttribute() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getDefaultAttributeValue(null)
+                .map(v -> v.getKind() + ":" + v.getConstantValue())
+                .orElse("missing"))))),
+          kotlin(
+            """
+              annotation class Example(val name: String)
+
+              @Example("x")
+              class Test
+              """,
+            """
+              annotation class Example(val name: String)
+
+              /*~~(LITERAL:x)~~>*/@Example("x")
+              class Test
+              """
+          )
+        );
+    }
+
+    @Test
+    void enumConstantDegradesToConstantReference() {
+        // the Kotlin type mapping does not set Flag.Enum on the referenced variable
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getAttributeValue("e")
+                .map(v -> v.getKind() + ":isEnum=" + v.isEnumConstant("E", "ONE"))
+                .orElse("missing"))))),
+          kotlin(
+            """
+              enum class E {
+                  ONE, TWO
+              }
+
+              annotation class Example(val e: E)
+
+              @Example(e = E.ONE)
+              class Test
+              """,
+            """
+              enum class E {
+                  ONE, TWO
+              }
+
+              annotation class Example(val e: E)
+
+              /*~~(CONSTANT_REFERENCE:isEnum=false)~~>*/@Example(e = E.ONE)
+              class Test
+              """
+          )
+        );
+    }
+
+    @Test
+    void classReferenceViaClassJava() {
+        rewriteRun(
+          spec -> spec
+            .recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@org.junit.jupiter.api.extension.ExtendWith")
+              .asVisitor(a -> SearchResult.found(a.getTree(),
+                a.getDefaultAttributeValue(null)
+                  .map(v -> {
+                      JavaType.FullyQualified fq = TypeUtils.asFullyQualified(v.getClassValue());
+                      return v.getKind() + ":" + (fq != null ? fq.getFullyQualifiedName() : "null");
+                  })
+                  .orElse("missing")))))
+            .parser(KotlinParser.builder().classpath("junit-jupiter-api")),
+          kotlin(
+            """
+              import org.junit.jupiter.api.extension.ExtendWith
+              import org.junit.jupiter.api.extension.Extension
+
+              @ExtendWith(Extension::class.java)
+              class Test
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith
+              import org.junit.jupiter.api.extension.Extension
+
+              /*~~(CLASS_LITERAL:org.junit.jupiter.api.extension.Extension)~~>*/@ExtendWith(Extension::class.java)
+              class Test
+              """
+          )
+        );
+    }
+
+    @Test
+    void constantReferenceDoesNotFold() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getAttributeValue("name")
+                .map(v -> v.getKind() + ":" + v.getConstantValue())
+                .orElse("missing"))))),
+          kotlin(
+            """
+              object Constants {
+                  const val NAME = "n"
+              }
+
+              annotation class Example(val name: String)
+
+              @Example(name = Constants.NAME)
+              class Test
+              """,
+            """
+              object Constants {
+                  const val NAME = "n"
+              }
+
+              annotation class Example(val name: String)
+
+              /*~~(CONSTANT_REFERENCE:null)~~>*/@Example(name = Constants.NAME)
               class Test
               """
           )

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
@@ -29,9 +29,9 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
  * The {@link org.openrewrite.java.trait.AttributeValue} behavior on Kotlin sources,
  * asserting the same semantics the trait has on javac-attributed Java sources.
  * Tests annotated {@link ExpectedToFail} document known Kotlin type-mapping gaps:
- * {@code KotlinTypeMapping#variableType} does not set {@code Flag.Enum} on enum
- * entries, no {@code JavaType.Annotation} element values are built (no constant
- * folding), and collection literals are {@code K.ListLiteral}, not {@code J.NewArray}.
+ * {@code KotlinTypeMapping} builds no {@code JavaType.Annotation} element values (no
+ * constant folding), and collection literals are {@code K.ListLiteral}, not
+ * {@code J.NewArray}.
  */
 class AttributeValueTraitTest implements RewriteTest {
 
@@ -124,7 +124,6 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("KotlinTypeMapping#variableType does not set Flag.Enum on enum entries (mapToFlagsBitmap uses only visibility/modality/static) — https://github.com/openrewrite/rewrite/issues/8170")
     @Test
     void enumConstant() {
         rewriteRun(

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.kotlin;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.java.trait.Annotated;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
@@ -25,10 +26,12 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
 /**
- * Pins the {@link org.openrewrite.java.trait.AttributeValue} behavior on Kotlin sources:
- * {@code A::class} / {@code A::class.java} class references, and the documented
- * degradations — no constant folding, no enum discrimination, collection literals as
- * opaque expressions.
+ * The {@link org.openrewrite.java.trait.AttributeValue} behavior on Kotlin sources,
+ * asserting the same semantics the trait has on javac-attributed Java sources.
+ * Tests annotated {@link ExpectedToFail} document known Kotlin type-mapping gaps:
+ * {@code KotlinTypeMapping#variableType} does not set {@code Flag.Enum} on enum
+ * entries, no {@code JavaType.Annotation} element values are built (no constant
+ * folding), and collection literals are {@code K.ListLiteral}, not {@code J.NewArray}.
  */
 class AttributeValueTraitTest implements RewriteTest {
 
@@ -90,39 +93,6 @@ class AttributeValueTraitTest implements RewriteTest {
     }
 
     @Test
-    void enumConstantDegradesToConstantReference() {
-        rewriteRun(
-          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
-            .asVisitor(a -> SearchResult.found(a.getTree(),
-              a.getAttributeValue("e")
-                .map(v -> v.getKind() + ":isEnum=" + v.isEnumConstant("E", "ONE"))
-                .orElse("missing"))))),
-          kotlin(
-            """
-              enum class E {
-                  ONE, TWO
-              }
-
-              annotation class Example(val e: E)
-
-              @Example(e = E.ONE)
-              class Test
-              """,
-            """
-              enum class E {
-                  ONE, TWO
-              }
-
-              annotation class Example(val e: E)
-
-              /*~~(CONSTANT_REFERENCE:isEnum=false)~~>*/@Example(e = E.ONE)
-              class Test
-              """
-          )
-        );
-    }
-
-    @Test
     void classReferenceViaClassJava() {
         rewriteRun(
           spec -> spec
@@ -154,8 +124,43 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
+    @ExpectedToFail("KotlinTypeMapping#variableType does not set Flag.Enum on enum entries (mapToFlagsBitmap uses only visibility/modality/static)")
     @Test
-    void constantReferenceDoesNotFold() {
+    void enumConstant() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
+            .asVisitor(a -> SearchResult.found(a.getTree(),
+              a.getAttributeValue("e")
+                .map(v -> v.getKind() + ":isEnum=" + v.isEnumConstant("E", "ONE"))
+                .orElse("missing"))))),
+          kotlin(
+            """
+              enum class E {
+                  ONE, TWO
+              }
+
+              annotation class Example(val e: E)
+
+              @Example(e = E.ONE)
+              class Test
+              """,
+            """
+              enum class E {
+                  ONE, TWO
+              }
+
+              annotation class Example(val e: E)
+
+              /*~~(ENUM_CONSTANT:isEnum=true)~~>*/@Example(e = E.ONE)
+              class Test
+              """
+          )
+        );
+    }
+
+    @ExpectedToFail("KotlinTypeMapping builds no JavaType.Annotation element values, so the compiler's constant fold is unavailable")
+    @Test
+    void constantReferenceFolds() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
             .asVisitor(a -> SearchResult.found(a.getTree(),
@@ -180,15 +185,16 @@ class AttributeValueTraitTest implements RewriteTest {
 
               annotation class Example(val name: String)
 
-              /*~~(CONSTANT_REFERENCE:null)~~>*/@Example(name = Constants.NAME)
+              /*~~(CONSTANT_REFERENCE:n)~~>*/@Example(name = Constants.NAME)
               class Test
               """
           )
         );
     }
 
+    @ExpectedToFail("Kotlin collection literals are K.ListLiteral, not J.NewArray; getElements() cannot normalize them from rewrite-java")
     @Test
-    void collectionLiteralIsAnOpaqueExpression() {
+    void collectionLiteralArray() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() -> new Annotated.Matcher("@Example")
             .asVisitor(a -> SearchResult.found(a.getTree(),
@@ -205,7 +211,7 @@ class AttributeValueTraitTest implements RewriteTest {
             """
               annotation class Example(val tags: Array<String>)
 
-              /*~~(EXPRESSION:elements=1)~~>*/@Example(tags = ["a", "b"])
+              /*~~(ARRAY:elements=2)~~>*/@Example(tags = ["a", "b"])
               class Test
               """
           )


### PR DESCRIPTION
## What's changed?

A new cursor-bearing `AttributeValue` trait in `org.openrewrite.java.trait` that classifies every shape a JLS §9.7.1 annotation element value can take — literals, class literals, enum constants, constant references, nested annotations, and arrays — plus new `Annotated#getAttributeValue(String)` / `#getDefaultAttributeValue(@Nullable String)` accessors returning it.

- `getElements()` iterates braced arrays and the brace-less single-element form (`exclude = A.class`) uniformly, one cursor-bearing value per element for surgical edits
- `getClassValue()` / `isClassLiteral(fqn)` resolve class literals; `getReferencedField()` / `isEnumConstant(fqn, name)` cover enum constants and constant references in qualified, fully-qualified, and statically imported spellings
- `getConstantValue()` resolves constant references and constant expressions (`Constants.NAME`, `"a" + "b"`) to the compiler's fold recorded in `JavaType.Annotation.ElementValue` on the annotated declaration — including constants from binary dependencies
- `asLiteral()` / `asAnnotated()` bridge to the existing traits; accessor naming mirrors `SingleElementValue`'s constant/reference duality
- `Optional.empty()` now means only "attribute not explicitly written"; a present value whose typed accessors return null means "present but not resolvable that way" — the two conditions the `Optional<Literal>` accessors conflate
- Bug fix: `Literal` now matches empty array initializers — `{}` parses with a phantom `J.Empty` element, so `@Foo(x = {})` was indistinguishable from an absent attribute
- Groovy/Kotlin behavior is pinned by tests in both modules (list literals degrade to `EXPRESSION`, no constant fold, enum constants classify as `CONSTANT_REFERENCE` since neither type mapping sets `Flag.Enum`; Kotlin `A::class` / `A::class.java` classify as class literals)

## What's your motivation?

- Fixes https://github.com/openrewrite/rewrite/issues/8160 — class literals, enum constants, and constant references were unreachable through `Annotated`, forcing recipes to hand-roll `J.Annotation#getArguments()` walking (e.g. `MinimumJreConditions` in rewrite-testing-frameworks). Motivating case: a Spring Boot 4.0 migration recipe appending `UserDetailsServiceAutoConfiguration.class` to `exclude` attributes that are arrays of class literals.

## Any additional context

The existing `Optional<Literal>` accessors are untouched and not yet deprecated; all current consumers keep their exact behavior. The one deliberate behavior change is the `{}` fix: an explicitly empty array attribute now yields a present `Literal` with zero values, matching runtime reflection semantics (an annotation attribute is never "absent" at runtime; `{}` is an empty array). Per an org-wide `FindMethods` run over the recipe artifacts, only two artifacts currently consume the affected accessors and may be affected: https://app.moderne.io/results/C7GrmeXMY — follow-up PRs will add the one-line guards there and migrate `SpringRequestMapping` to the new API as its first adoption.

Planned follow-ups (separate PRs): docs (`traits.md`), rewrite-recipe-starter, a migration recipe in rewrite-rewrite, and only then `@Deprecated` on the old accessors.
