### PR TITLE
Add NpmDependency and NugetDependency traits

### DIFF
--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/trait/NugetDependency.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/trait/NugetDependency.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.trait;
+
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.csharp.marker.MSBuildProject;
+import org.openrewrite.trait.SimpleTraitMatcher;
+import org.openrewrite.trait.Trait;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * A {@code <PackageReference>} declaration in an MSBuild project file, joined with its
+ * candidate versions from the {@link MSBuildProject} marker. Analog of
+ * {@code org.openrewrite.maven.trait.MavenDependency} for the NuGet ecosystem.
+ */
+@Value
+public class NugetDependency implements Trait<Xml.Tag> {
+    Cursor cursor;
+    String packageId;
+    Set<String> versions;
+
+    public static class Matcher extends SimpleTraitMatcher<NugetDependency> {
+        private static final XPathMatcher PACKAGE_REFERENCE_MATCHER = new XPathMatcher("/Project/ItemGroup/PackageReference");
+
+        @Override
+        protected @Nullable NugetDependency test(Cursor cursor) {
+            Object value = cursor.getValue();
+            if (!(value instanceof Xml.Tag)) {
+                return null;
+            }
+            Xml.Tag tag = (Xml.Tag) value;
+            // `XPathMatcher` is still a bit expensive
+            if (!"PackageReference".equals(tag.getName()) || !PACKAGE_REFERENCE_MATCHER.matches(cursor)) {
+                return null;
+            }
+            String include = attribute(tag, "Include");
+            if (include == null) {
+                return null;
+            }
+            Xml.Document doc = cursor.firstEnclosing(Xml.Document.class);
+            MSBuildProject msbuild = doc == null ? null :
+                    doc.getMarkers().findFirst(MSBuildProject.class).orElse(null);
+            if (msbuild == null) {
+                return null;
+            }
+            String declaredVersion = attribute(tag, "Version");
+            Set<String> versions = new LinkedHashSet<>();
+            for (MSBuildProject.TargetFramework tf : msbuild.getTargetFrameworks()) {
+                for (MSBuildProject.PackageReference pr : tf.getPackageReferences()) {
+                    if (include.equalsIgnoreCase(pr.getInclude()) &&
+                            (declaredVersion == null || declaredVersion.equals(pr.getRequestedVersion()))) {
+                        String version = pr.getResolvedVersion() != null ? pr.getResolvedVersion() : pr.getRequestedVersion();
+                        if (version != null) {
+                            versions.add(version);
+                        }
+                    }
+                }
+            }
+            if (versions.isEmpty() && declaredVersion != null) {
+                versions.add(declaredVersion);
+            }
+            return new NugetDependency(cursor, include, versions);
+        }
+
+        private static @Nullable String attribute(Xml.Tag tag, String name) {
+            for (Xml.Attribute attribute : tag.getAttributes()) {
+                if (name.equals(attribute.getKeyAsString())) {
+                    return attribute.getValueAsString();
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/trait/NugetDependencyTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/trait/NugetDependencyTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.trait;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.csharp.marker.MSBuildProject;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.List;
+
+import static org.openrewrite.csharp.Assertions.csproj;
+import static org.openrewrite.xml.Assertions.xml;
+
+class NugetDependencyTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(RewriteTest.toRecipe(() -> new NugetDependency.Matcher().asVisitor((dep, ctx) ->
+          SearchResult.found(dep.getTree(), dep.getPackageId() + ":" + String.join(",", dep.getVersions())))));
+    }
+
+    @Test
+    void matchesPackageReferenceWithDeclaredVersion() {
+        rewriteRun(
+          //language=xml
+          csproj(
+            """
+              <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                      <TargetFramework>net6.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                      <PackageReference Include="bootstrap" Version="4.6.2" />
+                  </ItemGroup>
+              </Project>
+              """,
+            """
+              <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                      <TargetFramework>net6.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                      <!--~~(bootstrap:4.6.2)~~>--><PackageReference Include="bootstrap" Version="4.6.2" />
+                  </ItemGroup>
+              </Project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void conditionalTagsMatchTheirOwnDeclaredVersion() {
+        rewriteRun(
+          //language=xml
+          csproj(
+            """
+              <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                      <TargetFrameworks>net472;net6.0</TargetFrameworks>
+                  </PropertyGroup>
+                  <ItemGroup>
+                      <PackageReference Include="bootstrap" Version="4.6.2" Condition="'$(TargetFramework)'=='net472'" />
+                      <PackageReference Include="bootstrap" Version="5.3.3" Condition="'$(TargetFramework)'=='net6.0'" />
+                  </ItemGroup>
+              </Project>
+              """,
+            """
+              <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                      <TargetFrameworks>net472;net6.0</TargetFrameworks>
+                  </PropertyGroup>
+                  <ItemGroup>
+                      <!--~~(bootstrap:4.6.2)~~>--><PackageReference Include="bootstrap" Version="4.6.2" Condition="'$(TargetFramework)'=='net472'" />
+                      <!--~~(bootstrap:5.3.3)~~>--><PackageReference Include="bootstrap" Version="5.3.3" Condition="'$(TargetFramework)'=='net6.0'" />
+                  </ItemGroup>
+              </Project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void versionsFromMarkerWhenTagHasNoVersionAttribute() {
+        MSBuildProject marker = MSBuildProject.builder()
+          .sdk("Microsoft.NET.Sdk")
+          .targetFrameworks(List.of(MSBuildProject.TargetFramework.builder()
+            .targetFramework("net6.0")
+            .packageReferences(List.of(MSBuildProject.PackageReference.builder()
+              .include("bootstrap").requestedVersion("4.6.2").resolvedVersion("4.6.2").build()))
+            .build()))
+          .build();
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <Project Sdk="Microsoft.NET.Sdk">
+                  <ItemGroup>
+                      <PackageReference Include="bootstrap" />
+                  </ItemGroup>
+              </Project>
+              """,
+            """
+              <Project Sdk="Microsoft.NET.Sdk">
+                  <ItemGroup>
+                      <!--~~(bootstrap:4.6.2)~~>--><PackageReference Include="bootstrap" />
+                  </ItemGroup>
+              </Project>
+              """,
+            spec -> spec.path("demo.csproj").markers(marker)
+          )
+        );
+    }
+
+    @Test
+    void doesNotMatchOutsideProjectItemGroup() {
+        rewriteRun(
+          //language=xml
+          csproj(
+            """
+              <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                      <TargetFramework>net6.0</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="AddBuildTimePackages">
+                      <ItemGroup>
+                          <PackageReference Include="bootstrap" Version="4.6.2" />
+                      </ItemGroup>
+                  </Target>
+              </Project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotMatchWithoutMSBuildProjectMarker() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <Project Sdk="Microsoft.NET.Sdk">
+                  <ItemGroup>
+                      <PackageReference Include="bootstrap" Version="4.6.2" />
+                  </ItemGroup>
+              </Project>
+              """,
+            spec -> spec.path("demo.csproj")
+          )
+        );
+    }
+}

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/trait/NpmDependency.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/trait/NpmDependency.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript.trait;
+
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.javascript.marker.NodeResolutionResult;
+import org.openrewrite.json.JsonPathMatcher;
+import org.openrewrite.json.tree.Json;
+import org.openrewrite.json.tree.JsonKey;
+import org.openrewrite.trait.SimpleTraitMatcher;
+import org.openrewrite.trait.Trait;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * A dependency declaration inside one of package.json's dependency sections, joined with its
+ * request and resolution from the {@link NodeResolutionResult} marker. Analog of
+ * {@code org.openrewrite.maven.trait.MavenDependency} for the npm ecosystem.
+ */
+@Value
+public class NpmDependency implements Trait<Json.Member> {
+    Cursor cursor;
+    String name;
+    @Nullable String versionConstraint;
+    @Nullable String resolvedVersion;
+
+    @Nullable
+    public String getVersion() {
+        return resolvedVersion != null ? resolvedVersion : minimumVersion(versionConstraint);
+    }
+
+    private static @Nullable String minimumVersion(@Nullable String constraint) {
+        if (constraint == null) {
+            return null;
+        }
+        String c = constraint.trim();
+        if (c.contains(":") || c.contains("/") || c.contains("|") || c.contains(" ") ||
+                c.startsWith(">") || c.startsWith("<")) {
+            return null;
+        }
+        int start = 0;
+        while (start < c.length() && !Character.isDigit(c.charAt(start))) {
+            start++;
+        }
+        int end = start;
+        while (end < c.length() && (Character.isDigit(c.charAt(end)) || c.charAt(end) == '.')) {
+            end++;
+        }
+        return start == end ? null : c.substring(start, end);
+    }
+
+    public static class Matcher extends SimpleTraitMatcher<NpmDependency> {
+        // JsonPath is anchored at the document root, so only the top-level dependency sections
+        // match (never same-named keys nested elsewhere, e.g. inside `overrides`).
+        private static final Map<String, JsonPathMatcher> DEPENDENCY_SECTIONS;
+
+        static {
+            Map<String, JsonPathMatcher> sections = new LinkedHashMap<>();
+            for (String section : Arrays.asList("dependencies", "devDependencies", "peerDependencies",
+                    "optionalDependencies", "bundledDependencies")) {
+                sections.put(section, new JsonPathMatcher("$." + section));
+            }
+            DEPENDENCY_SECTIONS = sections;
+        }
+
+        @Override
+        protected @Nullable NpmDependency test(Cursor cursor) {
+            Object value = cursor.getValue();
+            if (!(value instanceof Json.Member)) {
+                return null;
+            }
+            // A dependency declaration is a member of the object value of a section member.
+            Cursor sectionCursor = cursor.getParentTreeCursor().getParentTreeCursor();
+            if (!(sectionCursor.getValue() instanceof Json.Member)) {
+                return null;
+            }
+            String section = keyName(((Json.Member) sectionCursor.getValue()).getKey());
+            JsonPathMatcher sectionMatcher = section == null ? null : DEPENDENCY_SECTIONS.get(section);
+            if (sectionMatcher == null || !sectionMatcher.matches(sectionCursor)) {
+                return null;
+            }
+            String name = keyName(((Json.Member) value).getKey());
+            if (name == null) {
+                return null;
+            }
+            Json.Document doc = cursor.firstEnclosing(Json.Document.class);
+            NodeResolutionResult resolution = doc == null ? null :
+                    doc.getMarkers().findFirst(NodeResolutionResult.class).orElse(null);
+            if (resolution == null) {
+                return null;
+            }
+            NodeResolutionResult.Dependency declared = null;
+            for (NodeResolutionResult.Dependency d : sectionDependencies(resolution, section)) {
+                if (name.equals(d.getName())) {
+                    declared = d;
+                    break;
+                }
+            }
+            NodeResolutionResult.ResolvedDependency resolved = declared != null && declared.getResolved() != null ?
+                    declared.getResolved() : resolution.getResolvedDependency(name);
+            return new NpmDependency(cursor, name,
+                    declared == null ? null : declared.getVersionConstraint(),
+                    resolved == null ? null : resolved.getVersion());
+        }
+
+        private static List<NodeResolutionResult.Dependency> sectionDependencies(NodeResolutionResult npm, String section) {
+            switch (section) {
+                case "dependencies":
+                    return npm.getDependencies();
+                case "devDependencies":
+                    return npm.getDevDependencies();
+                case "peerDependencies":
+                    return npm.getPeerDependencies();
+                case "optionalDependencies":
+                    return npm.getOptionalDependencies();
+                case "bundledDependencies":
+                    return npm.getBundledDependencies();
+                default:
+                    return emptyList();
+            }
+        }
+
+        private static @Nullable String keyName(JsonKey key) {
+            if (key instanceof Json.Literal) {
+                Object value = ((Json.Literal) key).getValue();
+                return value == null ? null : value.toString();
+            }
+            if (key instanceof Json.Identifier) {
+                return ((Json.Identifier) key).getName();
+            }
+            return null;
+        }
+    }
+}

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/trait/NpmDependencyTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/trait/NpmDependencyTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript.trait;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Tree;
+import org.openrewrite.javascript.marker.NodeResolutionResult;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.openrewrite.json.Assertions.json;
+
+class NpmDependencyTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(RewriteTest.toRecipe(() -> new NpmDependency.Matcher().asVisitor((dep, ctx) ->
+          SearchResult.found(dep.getTree(), dep.getName() + ":" + dep.getVersion()))));
+    }
+
+    private static NodeResolutionResult marker(List<NodeResolutionResult.Dependency> dependencies,
+                                               List<NodeResolutionResult.Dependency> devDependencies,
+                                               List<NodeResolutionResult.ResolvedDependency> resolved) {
+        return new NodeResolutionResult(Tree.randomId(), "demo", "1.0.0", null, "package.json", null,
+          dependencies, devDependencies, emptyList(), emptyList(), emptyList(),
+          resolved, NodeResolutionResult.PackageManager.Npm, null, null);
+    }
+
+    @Test
+    void matchesDeclarationsAcrossSectionsWithResolvedVersions() {
+        NodeResolutionResult.ResolvedDependency angularCore = new NodeResolutionResult.ResolvedDependency(
+          "@angular/core", "15.2.10", null, null, null, null, null, null);
+        NodeResolutionResult.ResolvedDependency express = new NodeResolutionResult.ResolvedDependency(
+          "express", "4.19.2", null, null, null, null, null, null);
+        rewriteRun(
+          //language=json
+          json(
+            """
+              {
+                "dependencies": {
+                  "@angular/core": "^15.2.0"
+                },
+                "devDependencies": {
+                  "express": "^4.18.0"
+                }
+              }
+              """,
+            """
+              {
+                "dependencies": {
+                  /*~~(@angular/core:15.2.10)~~>*/"@angular/core": "^15.2.0"
+                },
+                "devDependencies": {
+                  /*~~(express:4.19.2)~~>*/"express": "^4.18.0"
+                }
+              }
+              """,
+            spec -> spec.path("package.json").markers(marker(
+              List.of(new NodeResolutionResult.Dependency("@angular/core", "^15.2.0", angularCore)),
+              List.of(new NodeResolutionResult.Dependency("express", "^4.18.0", express)),
+              List.of(angularCore, express)))
+          )
+        );
+    }
+
+    @Test
+    void fallsBackToConstraintFloorWithoutResolution() {
+        rewriteRun(
+          //language=json
+          json(
+            """
+              {
+                "dependencies": {
+                  "express": "^3.21.0"
+                }
+              }
+              """,
+            """
+              {
+                "dependencies": {
+                  /*~~(express:3.21.0)~~>*/"express": "^3.21.0"
+                }
+              }
+              """,
+            spec -> spec.path("package.json").markers(marker(
+              List.of(new NodeResolutionResult.Dependency("express", "^3.21.0", null)),
+              emptyList(), emptyList()))
+          )
+        );
+    }
+
+    @Test
+    void noVersionFloorForProtocolAndOpenRangeConstraints() {
+        rewriteRun(
+          //language=json
+          json(
+            """
+              {
+                "dependencies": {
+                  "bootstrap": "file:../vendor/bootstrap",
+                  "react": ">=17 <19"
+                }
+              }
+              """,
+            """
+              {
+                "dependencies": {
+                  /*~~(bootstrap:null)~~>*/"bootstrap": "file:../vendor/bootstrap",
+                  /*~~(react:null)~~>*/"react": ">=17 <19"
+                }
+              }
+              """,
+            spec -> spec.path("package.json").markers(marker(
+              List.of(new NodeResolutionResult.Dependency("bootstrap", "file:../vendor/bootstrap", null),
+                new NodeResolutionResult.Dependency("react", ">=17 <19", null)),
+              emptyList(), emptyList()))
+          )
+        );
+    }
+
+    @Test
+    void doesNotMatchSameNamedSectionsNestedInOverrides() {
+        NodeResolutionResult.ResolvedDependency express = new NodeResolutionResult.ResolvedDependency(
+          "express", "3.21.2", null, null, null, null, null, null);
+        rewriteRun(
+          //language=json
+          json(
+            """
+              {
+                "overrides": {
+                  "some-lib": {
+                    "dependencies": {
+                      "express": "^3.21.0"
+                    }
+                  }
+                }
+              }
+              """,
+            spec -> spec.path("package.json").markers(marker(
+              List.of(new NodeResolutionResult.Dependency("express", "^3.21.0", express)),
+              emptyList(), List.of(express)))
+          )
+        );
+    }
+
+    @Test
+    void doesNotMatchWithoutResolutionMarker() {
+        rewriteRun(
+          //language=json
+          json(
+            """
+              {
+                "dependencies": {
+                  "express": "^3.21.0"
+                }
+              }
+              """,
+            spec -> spec.path("package.json")
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Two new traits:
- `org.openrewrite.javascript.trait.NpmDependency` — matches a dependency declaration in any of package.json's top-level dependency sections (`dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`, `bundledDependencies`) and joins it with its version constraint and resolved version from the `NodeResolutionResult` marker. Falls back to the constraint's version floor (e.g. `^4.18.0` → `4.18.0`) when no resolution is available; protocol constraints (`file:`, `github:`) and open ranges yield no version.
- `org.openrewrite.csharp.trait.NugetDependency` — matches `<PackageReference>` tags in MSBuild project files and collects candidate versions per target framework from the `MSBuildProject` marker, preferring resolved over requested versions.

## What's your motivation?
Recipes over package.json / MSBuild project files currently have to hand-roll this matching and marker lookup. These traits are the analog of `org.openrewrite.maven.trait.MavenDependency` for the npm and NuGet ecosystems.

## Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)