### PR TITLE
Fix `KotlinTemplate` stub generation for annotations on methods and variables

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
@@ -45,9 +45,9 @@ public class AnnotationTemplateGenerator {
 
         J j = cursor.getValue();
         if (j instanceof J.MethodDeclaration) {
-            after.insert(0, " void $method() {}");
+            addDummyMethod(after);
         } else if (j instanceof J.VariableDeclarations) {
-            after.insert(0, " int $variable;");
+            addDummyVariable(after);
         } else if (j instanceof J.ClassDeclaration) {
             addDummyClass(cursor, after);
         }
@@ -83,9 +83,9 @@ public class AnnotationTemplateGenerator {
                     }
 
                     if (j instanceof J.MethodDeclaration || annotationParent instanceof J.MethodDeclaration) {
-                        after.insert(0, " void $method() {}");
+                        addDummyMethod(after);
                     } else if (j instanceof J.VariableDeclarations || annotationParent instanceof J.VariableDeclarations) {
-                        after.insert(0, " int $variable;");
+                        addDummyVariable(after);
                     } else if (j instanceof J.ClassDeclaration || annotationParent instanceof J.ClassDeclaration) {
                         // Check if this is a top-level class or nested class
                         Cursor classCursor = j instanceof J.ClassDeclaration ? cursor : cursor.getParent(level);
@@ -103,6 +103,14 @@ public class AnnotationTemplateGenerator {
         } else {
             after.insert(0, "static class $Clazz {}");
         }
+    }
+
+    protected void addDummyMethod(StringBuilder after) {
+        after.insert(0, " void $method() {}");
+    }
+
+    protected void addDummyVariable(StringBuilder after) {
+        after.insert(0, " int $variable;");
     }
 
     protected void addDummyAnnotationType(StringBuilder after) {
@@ -375,7 +383,7 @@ public class AnnotationTemplateGenerator {
         return annotationService.getAllAnnotations(cursor).contains(maybeAnnotation);
     }
 
-    private String variable(J.VariableDeclarations variable, Cursor cursor) {
+    protected String variable(J.VariableDeclarations variable, Cursor cursor) {
         StringBuilder varBuilder = new StringBuilder();
         if (variable.getTypeExpression() != null) {
             for (J.Modifier modifier : variable.getModifiers()) {

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinAnnotationTemplateGenerator.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinAnnotationTemplateGenerator.java
@@ -17,7 +17,9 @@ package org.openrewrite.kotlin.internal.template;
 
 import org.openrewrite.Cursor;
 import org.openrewrite.java.internal.template.AnnotationTemplateGenerator;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.Space;
 
 import java.util.Set;
 
@@ -37,6 +39,25 @@ public class KotlinAnnotationTemplateGenerator extends AnnotationTemplateGenerat
     @Override
     protected void addDummyAnnotationType(StringBuilder after) {
         after.append("\nannotation class `$Placeholder` {}");
+    }
+
+    @Override
+    protected void addDummyMethod(StringBuilder after) {
+        after.insert(0, " fun `$method`() {};");
+    }
+
+    @Override
+    protected void addDummyVariable(StringBuilder after) {
+        after.insert(0, " val `$variable`: Int = 0;");
+    }
+
+    @Override
+    protected String variable(J.VariableDeclarations variable, Cursor cursor) {
+        if (variable.getTypeExpression() == null) {
+            return variable.getVariables().get(0).getSimpleName();
+        }
+        return "val " + variable.getVariables().get(0).getSimpleName() + ": " +
+               variable.getTypeExpression().withPrefix(Space.EMPTY).printTrimmed(cursor);
     }
 
 }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -691,6 +691,44 @@ class KotlinTemplateTest implements RewriteTest {
     }
 
     @Test
+    void replaceAnnotationArgumentsOnLocalVariablePrecededByUntypedLocal() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("Suppress".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null &&
+                      annotation.getArguments().stream().noneMatch(a -> a.toString().contains("RedundantSuppression"))) {
+                      return KotlinTemplate.builder("\"RedundantSuppression\"")
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments());
+                  }
+                  return annotation;
+              }
+          })),
+          kotlin(
+            """
+              class Test {
+                  fun foo() {
+                      val y = 1
+                      @Suppress("UNCHECKED_CAST")
+                      val x = y
+                  }
+              }
+              """,
+            """
+              class Test {
+                  fun foo() {
+                      val y = 1
+                      @Suppress("RedundantSuppression")
+                      val x = y
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
     void addAnnotationToMethod() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
@@ -453,5 +454,271 @@ class KotlinTemplateTest implements RewriteTest {
         // caller-scope T appeared in the template as `<T>` without bound. With the fix the bound
         // round-trips, so the captured template includes "T : ".
         assertThat(capturedTemplate.toString()).contains("class Template<T");
+    }
+
+    @Test
+    void replaceAnnotationArgumentsOnMethod() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("Suppress".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null &&
+                      annotation.getArguments().stream().noneMatch(a -> a.toString().contains("RedundantSuppression"))) {
+                      return KotlinTemplate.builder("\"RedundantSuppression\"")
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments());
+                  }
+                  return annotation;
+              }
+          })),
+          kotlin(
+            """
+              class Test {
+                  @Suppress("UNCHECKED_CAST")
+                  fun foo() {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  @Suppress("RedundantSuppression")
+                  fun foo() {
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void replaceAnnotationArgumentsOnMethodWithParameterSubstitution() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("Suppress".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null && annotation.getArguments().size() == 1) {
+                      return KotlinTemplate.builder("#{any()}, \"RedundantSuppression\"")
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments(),
+                          annotation.getArguments().getFirst());
+                  }
+                  return annotation;
+              }
+          })),
+          kotlin(
+            """
+              class Test {
+                  @Suppress("UNCHECKED_CAST")
+                  fun foo() {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  @Suppress("UNCHECKED_CAST", "RedundantSuppression")
+                  fun foo() {
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void replaceAnnotationArgumentsOnProperty() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("Suppress".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null &&
+                      annotation.getArguments().stream().noneMatch(a -> a.toString().contains("RedundantSuppression"))) {
+                      return KotlinTemplate.builder("\"RedundantSuppression\"")
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments());
+                  }
+                  return annotation;
+              }
+          })),
+          kotlin(
+            """
+              class Test {
+                  @Suppress("UNCHECKED_CAST")
+                  val foo: Int = 0
+              }
+              """,
+            """
+              class Test {
+                  @Suppress("RedundantSuppression")
+                  val foo: Int = 0
+              }
+              """
+          ));
+    }
+
+    @Test
+    void replaceAnnotationArgumentsOnClass() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("Suppress".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null &&
+                      annotation.getArguments().stream().noneMatch(a -> a.toString().contains("RedundantSuppression"))) {
+                      return KotlinTemplate.builder("\"RedundantSuppression\"")
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments());
+                  }
+                  return annotation;
+              }
+          })),
+          kotlin(
+            """
+              @Suppress("UNCHECKED_CAST")
+              class Test
+              """,
+            """
+              @Suppress("RedundantSuppression")
+              class Test
+              """
+          ));
+    }
+
+    @Test
+    void replaceAnnotationArgumentsOnTopLevelFunction() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("Suppress".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null &&
+                      annotation.getArguments().stream().noneMatch(a -> a.toString().contains("RedundantSuppression"))) {
+                      return KotlinTemplate.builder("\"RedundantSuppression\"")
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments());
+                  }
+                  return annotation;
+              }
+          })),
+          kotlin(
+            """
+              @Suppress("UNCHECKED_CAST")
+              fun foo() {
+              }
+              """,
+            """
+              @Suppress("RedundantSuppression")
+              fun foo() {
+              }
+              """
+          ));
+    }
+
+    @Test
+    void replaceAnnotationArgumentsOnLocalVariableInFunctionWithReturnType() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("Suppress".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null &&
+                      annotation.getArguments().stream().noneMatch(a -> a.toString().contains("RedundantSuppression"))) {
+                      return KotlinTemplate.builder("\"RedundantSuppression\"")
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments());
+                  }
+                  return annotation;
+              }
+          })),
+          kotlin(
+            """
+              class Test {
+                  fun foo(): Int {
+                      @Suppress("UNCHECKED_CAST")
+                      val x = 0
+                      return x
+                  }
+              }
+              """,
+            """
+              class Test {
+                  fun foo(): Int {
+                      @Suppress("RedundantSuppression")
+                      val x = 0
+                      return x
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void replaceAnnotationArgumentsOnLocalVariablePrecededByTypedLocal() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("Suppress".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null &&
+                      annotation.getArguments().stream().noneMatch(a -> a.toString().contains("RedundantSuppression"))) {
+                      return KotlinTemplate.builder("\"RedundantSuppression\"")
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments());
+                  }
+                  return annotation;
+              }
+          })),
+          kotlin(
+            """
+              class Test {
+                  fun foo() {
+                      val y: Int = 1
+                      @Suppress("UNCHECKED_CAST")
+                      val x = y
+                  }
+              }
+              """,
+            """
+              class Test {
+                  fun foo() {
+                      val y: Int = 1
+                      @Suppress("RedundantSuppression")
+                      val x = y
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void addAnnotationToMethod() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
+              @Override
+              public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                  if (method.getLeadingAnnotations().isEmpty()) {
+                      return KotlinTemplate.builder("@Suppress(\"RedundantSuppression\")")
+                        .build()
+                        .apply(getCursor(), method.getCoordinates().addAnnotation(
+                          Comparator.comparing(J.Annotation::getSimpleName)));
+                  }
+                  return method;
+              }
+          })),
+          kotlin(
+            """
+              class Test {
+                  fun foo() {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  @Suppress("RedundantSuppression")
+                  fun foo() {
+                  }
+              }
+              """
+          ));
     }
 }


### PR DESCRIPTION
## What's changed?

`AnnotationTemplateGenerator` hardcoded Java syntax for the dummy declarations that annotation template stubs attach to (` void $method() {}` and ` int $variable;`). This change extracts them into protected hooks — `addDummyMethod(StringBuilder)`, `addDummyVariable(StringBuilder)`, and the `variable()` helper — alongside the existing `addDummyClass`/`addDummyAnnotationType` hooks from #6522, and overrides them in `KotlinAnnotationTemplateGenerator` with Kotlin syntax.

## What's your motivation?

Any `KotlinTemplate` applied with annotation coordinates (e.g. `annotation.getCoordinates().replaceArguments()`) on a method or property failed, because the generated stub mixed Java member syntax into a Kotlin source:

```
Could not parse as Java:
class Test{/*__TEMPLATE_cfcc2025-6662__*/@Example("RedundantSuppression")
 void $method() {}}
annotation class `$Placeholder` {}
```

Two subtleties beyond the plain syntax swap:

- Stub fragments are concatenated on a single line, and a `return ...;` is appended when the enclosing function declares a return type — so the Kotlin stubs need explicit `;` terminators (`` val `$variable`: Int = 0; ``), otherwise a local `val` annotation inside `fun foo(): Int` produced the unparseable `` val `$variable`: Int = 0return null; ``.
- `variable()` (used to stub out locals that precede the templated annotation) emitted Java declaration order (`Int y;`); the Kotlin override emits `val y: Int`.

Base implementations keep byte-identical output, so Java and Groovy templates are unaffected.

## Anything in particular you'd like reviewers to focus on?

- `ScalaAnnotationTemplateGenerator` has the same latent gap (it still inherits the Java method/variable stubs), left for a follow-up since rewrite-scala has no annotation-template test coverage yet.
- Test coverage spans the distinct stub-assembly paths: method in class, top-level function, property, class, local `val` (with enclosing return type, and preceded by a typed local), parameter substitution (`#{any()}`), and cursor-at-declaration via `addAnnotation`.

## Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/recipes/recipes/recipeconventionsandbestpractices)
- [x] I've used the [IntelliJ IDEA auto-formatter](https://docs.openrewrite.org/reference/building-openrewrite-from-source#code-style) on affected files
