### PR TITLE
Support Gradle wrapper version detection for custom distribution URLs

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
@@ -43,6 +43,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -123,28 +124,64 @@ public class GradleWrapper {
             );
         }
 
+        Optional<GradleVersion> privateArtifactoryVersion = selectPrivateArtifactoryVersion(currentDistributionUrl, versionComparator, distributionType, ctx);
+        if (privateArtifactoryVersion.isPresent()) {
+            return privateArtifactoryVersion.get();
+        }
+
+        return substituteCustomDistributionVersion(currentDistributionUrl, version, versionComparator, distributionType, ctx);
+    }
+
+    /**
+     * Opportunistically ask Artifactory which Gradle versions the repository actually hosts, so we don't suggest a
+     * version it doesn't contain. This is best-effort: it only works when Artifactory is served under the conventional
+     * "/artifactory" context path and exposes the storage API. Returns empty when the URL isn't a recognizable
+     * Artifactory storage layout, the listing fails, or no hosted version satisfies the requested selector, in which
+     * case the caller falls back to resolving against the public Gradle version list.
+     */
+    private static Optional<GradleVersion> selectPrivateArtifactoryVersion(String currentDistributionUrl, VersionComparator versionComparator,
+                                                                           DistributionType distributionType, ExecutionContext ctx) {
         URI currentDistributionUri = URI.create(currentDistributionUrl);
-        if (currentDistributionUri.getScheme().startsWith("http") && currentDistributionUri.getPath().startsWith("/artifactory")) {
+        if (!currentDistributionUri.getScheme().startsWith("http") || !currentDistributionUri.getPath().startsWith("/artifactory")) {
+            return Optional.empty();
+        }
+        try {
             String artifactoryUrl = currentDistributionUrl.substring(0, currentDistributionUrl.lastIndexOf("/"));
-            List<GradleVersion> allVersions = listAllPrivateArtifactoryVersions(artifactoryUrl, ctx);
-            return allVersions.stream()
+            return listAllPrivateArtifactoryVersions(artifactoryUrl, ctx).stream()
+                    .filter(v -> versionComparator.isValid(null, v.version))
+                    .filter(v -> v.distributionType == distributionType)
+                    .max((v1, v2) -> versionComparator.compare(null, v1.version, v2.version));
+        } catch (Exception ignored) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Resolve the target version for a Gradle distribution hosted in an arbitrary repository (an arbitrary Maven
+     * repository in Artifactory or Nexus, an S3 bucket, a CDN, etc.) that can't be queried for its available versions.
+     * For a wildcard selector the concrete version is resolved from the public Gradle version list; the resolved
+     * version is then substituted into the existing URL, preserving the custom host and path layout already present
+     * in the wrapper properties.
+     */
+    private static GradleVersion substituteCustomDistributionVersion(String currentDistributionUrl, @Nullable String version, VersionComparator versionComparator,
+                                                                     DistributionType distributionType, ExecutionContext ctx) {
+        String resolvedVersion = version;
+        if (!(versionComparator instanceof ExactVersion)) {
+            resolvedVersion = listAllPublicVersions(ctx).stream()
                     .filter(v -> versionComparator.isValid(null, v.version))
                     .filter(v -> v.distributionType == distributionType)
                     .max((v1, v2) -> versionComparator.compare(null, v1.version, v2.version))
-                    .orElseThrow(() -> new IllegalStateException(String.format("Expected to find at least one Gradle wrapper version to select from %s.", artifactoryUrl)));
+                    .map(GradleVersion::getVersion)
+                    .orElseThrow(() -> new IllegalStateException(String.format("Expected to find at least one Gradle wrapper version to select from %s.", GRADLE_DOWNLOADS_URL)));
         }
 
-        if (versionComparator instanceof ExactVersion) {
-            return new GradleVersion(
-                    version,
-                    currentDistributionUrl.replaceAll("(.*gradle-)(\\d+\\.\\d+(?:\\.\\d+)?)(.*-)(?:bin|all).zip", "$1" + version + "$3" + distributionType.getFileSuffix() + ".zip"),
-                    distributionType,
-                    null,
-                    null
-            );
-        }
-
-        throw new IllegalStateException("Unsupported distribution url for Gradle wrapper version detection: " + currentDistributionUrl);
+        return new GradleVersion(
+                resolvedVersion,
+                currentDistributionUrl.replaceAll("(.*gradle-)(\\d+\\.\\d+(?:\\.\\d+)?)(.*-)(?:bin|all).zip", "$1" + resolvedVersion + "$3" + distributionType.getFileSuffix() + ".zip"),
+                distributionType,
+                null,
+                null
+        );
     }
 
     public static List<GradleVersion> listAllPublicVersions(ExecutionContext ctx) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
@@ -129,7 +129,7 @@ public class GradleWrapper {
             return privateArtifactoryVersion.get();
         }
 
-        return substituteCustomDistributionVersion(currentDistributionUrl, version, versionComparator, distributionType, ctx);
+        return resolveCustomDistributionVersion(currentDistributionUrl, version, versionComparator, distributionType);
     }
 
     /**
@@ -137,7 +137,7 @@ public class GradleWrapper {
      * version it doesn't contain. This is best-effort: it only works when Artifactory is served under the conventional
      * "/artifactory" context path and exposes the storage API. Returns empty when the URL isn't a recognizable
      * Artifactory storage layout, the listing fails, or no hosted version satisfies the requested selector, in which
-     * case the caller falls back to resolving against the public Gradle version list.
+     * case the caller falls back to {@link #resolveCustomDistributionVersion}.
      */
     private static Optional<GradleVersion> selectPrivateArtifactoryVersion(String currentDistributionUrl, VersionComparator versionComparator,
                                                                            DistributionType distributionType, ExecutionContext ctx) {
@@ -157,27 +157,26 @@ public class GradleWrapper {
     }
 
     /**
-     * Resolve the target version for a Gradle distribution hosted in an arbitrary repository (an arbitrary Maven
-     * repository in Artifactory or Nexus, an S3 bucket, a CDN, etc.) that can't be queried for its available versions.
-     * For a wildcard selector the concrete version is resolved from the public Gradle version list; the resolved
-     * version is then substituted into the existing URL, preserving the custom host and path layout already present
-     * in the wrapper properties.
+     * Resolve the target version for a Gradle distribution hosted at a non-standard URL (an arbitrary Maven repository
+     * in Artifactory or Nexus, an S3 bucket, a CDN, etc.) that can't be queried for its available versions.
+     * <p>
+     * An exact version is substituted into the existing URL, preserving the custom host and path layout already present
+     * in the wrapper properties. A dynamic selector (e.g. {@code 7.x}) can't be resolved without querying an external
+     * service such as {@code services.gradle.org}, which is frequently unavailable in the enterprise environments that
+     * host distributions at non-standard URLs. Rather than failing the (often deeply chained) recipe run, the version
+     * already present in the URL is returned so the caller leaves the wrapper unchanged.
      */
-    private static GradleVersion substituteCustomDistributionVersion(String currentDistributionUrl, @Nullable String version, VersionComparator versionComparator,
-                                                                     DistributionType distributionType, ExecutionContext ctx) {
-        String resolvedVersion = version;
+    private static GradleVersion resolveCustomDistributionVersion(String currentDistributionUrl, @Nullable String version, VersionComparator versionComparator,
+                                                                  DistributionType distributionType) {
         if (!(versionComparator instanceof ExactVersion)) {
-            resolvedVersion = listAllPublicVersions(ctx).stream()
-                    .filter(v -> versionComparator.isValid(null, v.version))
-                    .filter(v -> v.distributionType == distributionType)
-                    .max((v1, v2) -> versionComparator.compare(null, v1.version, v2.version))
-                    .map(GradleVersion::getVersion)
-                    .orElseThrow(() -> new IllegalStateException(String.format("Expected to find at least one Gradle wrapper version to select from %s.", GRADLE_DOWNLOADS_URL)));
+            Matcher matcher = GRADLE_VERSION_PATTERN.matcher(currentDistributionUrl);
+            String existingVersion = matcher.find() ? matcher.group(1) : version;
+            return new GradleVersion(existingVersion, currentDistributionUrl, distributionType, null, null);
         }
 
         return new GradleVersion(
-                resolvedVersion,
-                currentDistributionUrl.replaceAll("(.*gradle-)(\\d+\\.\\d+(?:\\.\\d+)?)(.*-)(?:bin|all).zip", "$1" + resolvedVersion + "$3" + distributionType.getFileSuffix() + ".zip"),
+                version,
+                currentDistributionUrl.replaceAll("(.*gradle-)(\\d+\\.\\d+(?:\\.\\d+)?)(.*-)(?:bin|all).zip", "$1" + version + "$3" + distributionType.getFileSuffix() + ".zip"),
                 distributionType,
                 null,
                 null

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -1163,75 +1163,54 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     /**
-     * Verifies version detection works when the repository is served at the host root without an "/artifactory" context path.
+     * A dynamic version selector can't be resolved for a distribution hosted at a non-standard URL (here the host
+     * merely contains "artifactory" while the path does not) without querying services.gradle.org, which is frequently
+     * blocked where such URLs are used, so the wrapper is left unchanged rather than failing the recipe run.
      */
     @Test
-    void updatesCustomDistributionUrlHostedUnderNonArtifactoryPath() {
-        upgradeCustomDistributionUrl(
-          "https\\://artifactory.aexp.com/gradle-distributions/gradle-6.9.1-bin.zip",
-          "https\\://artifactory.aexp.com/gradle-distributions/gradle-7.6.6-bin.zip"
-        );
-    }
-
-    /**
-     * Verifies version detection works for a non-Artifactory repository (e.g. Nexus) that never matched the old "/artifactory" heuristic.
-     */
-    @Test
-    void updatesCustomDistributionUrlOnArbitraryRepository() {
-        upgradeCustomDistributionUrl(
-          "https\\://nexus.company.com/repository/gradle-distributions/gradle-6.9.1-bin.zip",
-          "https\\://nexus.company.com/repository/gradle-distributions/gradle-7.6.6-bin.zip"
-        );
-    }
-
-    private void upgradeCustomDistributionUrl(String beforeUrl, String afterUrl) {
-        HttpSender versionsList = request -> {
-            if ("https://services.gradle.org/versions/all".equals(request.getUrl().toString())) {
-                return new HttpSender.Response(200, new ByteArrayInputStream("""
-                  [ {
-                    "version" : "8.5",
-                    "downloadUrl" : "https://services.gradle.org/distributions/gradle-8.5-bin.zip",
-                    "checksumUrl" : "https://services.gradle.org/distributions/gradle-8.5-bin.zip.sha256",
-                    "wrapperChecksumUrl" : "https://services.gradle.org/distributions/gradle-8.5-wrapper.jar.sha256"
-                  }, {
-                    "version" : "7.6.6",
-                    "downloadUrl" : "https://services.gradle.org/distributions/gradle-7.6.6-bin.zip",
-                    "checksumUrl" : "https://services.gradle.org/distributions/gradle-7.6.6-bin.zip.sha256",
-                    "wrapperChecksumUrl" : "https://services.gradle.org/distributions/gradle-7.6.6-wrapper.jar.sha256"
-                  }, {
-                    "version" : "7.4",
-                    "downloadUrl" : "https://services.gradle.org/distributions/gradle-7.4-bin.zip",
-                    "checksumUrl" : "https://services.gradle.org/distributions/gradle-7.4-bin.zip.sha256",
-                    "wrapperChecksumUrl" : "https://services.gradle.org/distributions/gradle-7.4-wrapper.jar.sha256"
-                  } ]
-                  """.getBytes(StandardCharsets.UTF_8)), () -> {
-                });
-            }
-            return new HttpUrlConnectionSender().send(request);
-        };
-        HttpSenderExecutionContextView ctx = HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
-          .setHttpSender(versionsList)
-          .setLargeFileHttpSender(versionsList);
+    void leavesCustomDistributionUrlUnchangedForDynamicVersion() {
         rewriteRun(
-          // addIfMissing=false so the recipe only rewrites the existing properties file and never downloads a distribution
           spec -> spec.recipe(new UpdateGradleWrapper("7.x", null, false, null, null))
             .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "6.9.1")))
-            .executionContext(ctx),
+            .executionContext(rejectGradleOrgRequests()),
           properties(
             """
               distributionBase=GRADLE_USER_HOME
               distributionPath=wrapper/dists
-              distributionUrl=%s
+              distributionUrl=https\\://artifactory.example.com/gradle-distributions/gradle-6.9.1-bin.zip
               zipStoreBase=GRADLE_USER_HOME
               zipStorePath=wrapper/dists
-              """.formatted(beforeUrl),
+              """,
+            spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
+          )
+        );
+    }
+
+    /**
+     * An exact version is substituted into a non-standard distribution URL without any call to gradle.org, preserving
+     * the custom host and path.
+     */
+    @Test
+    void updatesCustomDistributionUrlForExactVersionWithoutQueryingGradleOrg() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateGradleWrapper("7.6.6", null, false, null, null))
+            .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "6.9.1")))
+            .executionContext(rejectGradleOrgRequests()),
+          properties(
             """
               distributionBase=GRADLE_USER_HOME
               distributionPath=wrapper/dists
-              distributionUrl=%s
+              distributionUrl=https\\://nexus.company.com/repository/gradle-distributions/gradle-6.9.1-bin.zip
               zipStoreBase=GRADLE_USER_HOME
               zipStorePath=wrapper/dists
-              """.formatted(afterUrl),
+              """,
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://nexus.company.com/repository/gradle-distributions/gradle-7.6.6-bin.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              """,
             spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
               .afterRecipe(gradleWrapperProperties ->
                 assertThat(gradleWrapperProperties.getMarkers().findFirst(BuildTool.class)).hasValueSatisfying(buildTool -> {
@@ -1240,6 +1219,23 @@ class UpdateGradleWrapperTest implements RewriteTest {
                 }))
           )
         );
+    }
+
+    /**
+     * Distributions hosted at a non-standard URL must never fall back to gradle.org for version detection, since that
+     * host is commonly unavailable in the environments that rely on such URLs.
+     */
+    private static HttpSenderExecutionContextView rejectGradleOrgRequests() {
+        HttpSender noGradleOrg = request -> {
+            if (request.getUrl().toString().contains("gradle.org")) {
+                throw new IllegalStateException("Unexpected request to " + request.getUrl() +
+                                                "; custom distribution URLs must not query gradle.org");
+            }
+            return new HttpUrlConnectionSender().send(request);
+        };
+        return HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
+          .setHttpSender(noGradleOrg)
+          .setLargeFileHttpSender(noGradleOrg);
     }
 
     @Test

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -1162,6 +1162,86 @@ class UpdateGradleWrapperTest implements RewriteTest {
         );
     }
 
+    /**
+     * Verifies version detection works when the repository is served at the host root without an "/artifactory" context path.
+     */
+    @Test
+    void updatesCustomDistributionUrlHostedUnderNonArtifactoryPath() {
+        upgradeCustomDistributionUrl(
+          "https\\://artifactory.aexp.com/gradle-distributions/gradle-6.9.1-bin.zip",
+          "https\\://artifactory.aexp.com/gradle-distributions/gradle-7.6.6-bin.zip"
+        );
+    }
+
+    /**
+     * Verifies version detection works for a non-Artifactory repository (e.g. Nexus) that never matched the old "/artifactory" heuristic.
+     */
+    @Test
+    void updatesCustomDistributionUrlOnArbitraryRepository() {
+        upgradeCustomDistributionUrl(
+          "https\\://nexus.company.com/repository/gradle-distributions/gradle-6.9.1-bin.zip",
+          "https\\://nexus.company.com/repository/gradle-distributions/gradle-7.6.6-bin.zip"
+        );
+    }
+
+    private void upgradeCustomDistributionUrl(String beforeUrl, String afterUrl) {
+        HttpSender versionsList = request -> {
+            if ("https://services.gradle.org/versions/all".equals(request.getUrl().toString())) {
+                return new HttpSender.Response(200, new ByteArrayInputStream("""
+                  [ {
+                    "version" : "8.5",
+                    "downloadUrl" : "https://services.gradle.org/distributions/gradle-8.5-bin.zip",
+                    "checksumUrl" : "https://services.gradle.org/distributions/gradle-8.5-bin.zip.sha256",
+                    "wrapperChecksumUrl" : "https://services.gradle.org/distributions/gradle-8.5-wrapper.jar.sha256"
+                  }, {
+                    "version" : "7.6.6",
+                    "downloadUrl" : "https://services.gradle.org/distributions/gradle-7.6.6-bin.zip",
+                    "checksumUrl" : "https://services.gradle.org/distributions/gradle-7.6.6-bin.zip.sha256",
+                    "wrapperChecksumUrl" : "https://services.gradle.org/distributions/gradle-7.6.6-wrapper.jar.sha256"
+                  }, {
+                    "version" : "7.4",
+                    "downloadUrl" : "https://services.gradle.org/distributions/gradle-7.4-bin.zip",
+                    "checksumUrl" : "https://services.gradle.org/distributions/gradle-7.4-bin.zip.sha256",
+                    "wrapperChecksumUrl" : "https://services.gradle.org/distributions/gradle-7.4-wrapper.jar.sha256"
+                  } ]
+                  """.getBytes(StandardCharsets.UTF_8)), () -> {
+                });
+            }
+            return new HttpUrlConnectionSender().send(request);
+        };
+        HttpSenderExecutionContextView ctx = HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
+          .setHttpSender(versionsList)
+          .setLargeFileHttpSender(versionsList);
+        rewriteRun(
+          // addIfMissing=false so the recipe only rewrites the existing properties file and never downloads a distribution
+          spec -> spec.recipe(new UpdateGradleWrapper("7.x", null, false, null, null))
+            .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "6.9.1")))
+            .executionContext(ctx),
+          properties(
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=%s
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              """.formatted(beforeUrl),
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=%s
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              """.formatted(afterUrl),
+            spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
+              .afterRecipe(gradleWrapperProperties ->
+                assertThat(gradleWrapperProperties.getMarkers().findFirst(BuildTool.class)).hasValueSatisfying(buildTool -> {
+                    assertThat(buildTool.getType()).isEqualTo(BuildTool.Type.Gradle);
+                    assertThat(buildTool.getVersion()).isEqualTo("7.6.6");
+                }))
+          )
+        );
+    }
+
     @Test
     void usesExecutableJarFrom8_14() {
         rewriteRun(


### PR DESCRIPTION
## What's changed

`UpdateGradleWrapper` (invoked with a wildcard version, e.g. via `MigrateToGradle7`'s `version: 7.x`) threw `IllegalStateException: Unsupported distribution url for Gradle wrapper version detection` when the existing `distributionUrl` pointed at a custom repository whose path did **not** start with `/artifactory` — e.g. `https://nexus.company.com/gradle-distributions/gradle-6.9.1-bin.zip`, where the name is only in the host.

Version detection was keyed off the literal `/artifactory` path segment, but a Gradle distribution can live in any Maven repository (Artifactory served at the host root, Nexus, an S3 bucket, a CDN, etc.), so it shouldn't depend on a particular host or path name.

`GradleWrapper.determineGradleVersion` now handles custom URLs in three clear steps:

1. gradle.org host — unchanged.
2. `selectPrivateArtifactoryVersion(...)` — best-effort JFrog storage-API listing (only when served under `/artifactory`); returns `Optional`, and on no-match/failure falls through instead of throwing.
3. `substituteCustomDistributionVersion(...)` — repo-agnostic fallback: resolve the concrete version from the public Gradle version list (for wildcards) and substitute it into the existing URL, preserving the custom host and path.

This matches the recipe's documented contract (queries `downloads.gradle.org` for available releases while preferring the existing artifact-repository URL) and removes the hard failure.

### Notes / limitations
- Exact versions on a custom URL resolve fully offline (pure substitution, no gradle.org call) — unchanged behavior.
- Wildcard versions on a custom URL still need `services.gradle.org` to resolve the concrete version. If that host is blocked, the update fails with a network error rather than the previous `IllegalStateException` (outcome unchanged; previously it also failed). Private-repo-first resolution for fully air-gapped shops is left as a possible follow-up.
