### PR TITLE
Forward visit methods declared on a delegate superclass under `adapt()`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/TreeVisitorAdapter.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/TreeVisitorAdapter.java
@@ -18,13 +18,23 @@ package org.openrewrite.internal;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import io.quarkus.gizmo.*;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.lang.reflect.*;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class TreeVisitorAdapter {
     private static final Integer classCreationLock = 1;
@@ -106,28 +116,30 @@ public class TreeVisitorAdapter {
                         );
                         setCursor.returnValue(null);
 
-                        // Walk delegate's class hierarchy (down to but excluding TreeVisitor)
-                        // and collect every visit-like method declared at each level — typed
-                        // overrides AND synthetic bridges. JVM virtual dispatch picks based on
-                        // erased descriptor; e.g., J.Annotation.acceptJava emits
-                        // invokevirtual JavaVisitor.visitAnnotation(J.Annotation, Object) → J,
-                        // and the proxy must define a method with that exact descriptor
-                        // (not just the typed RemoveAnnotationVisitor.visitAnnotation(..., ExecutionContext))
-                        // for the forwarding to actually be the dispatch target.
-                        java.util.LinkedHashMap<MethodKey, Method> methodsByKey = new java.util.LinkedHashMap<>();
-                        for (Method m : delegate.getClass().getDeclaredMethods()) {
-                            if (!isVisitLike(m) || Modifier.isStatic(m.getModifiers()) || Modifier.isPrivate(m.getModifiers())) {
-                                continue;
+                        // Collect the user's visit-like overrides from the leaf up to (but not into) the
+                        // iso-visitor, so overrides declared on a shared superclass are forwarded too.
+                        // Leaf-first, so the most-derived override wins.
+                        Map<MethodKey, Method> methodsByKey = new LinkedHashMap<>();
+                        Class<?> leafClass = delegate.getClass();
+                        for (Class<?> c = leafClass;
+                             c != null && c != Object.class && !TreeVisitor.class.equals(c);
+                             c = c.getSuperclass()) {
+                            if (c == delegateType && c != leafClass) {
+                                break;
                             }
-                            MethodKey key = new MethodKey(m.getName(), m.getParameterTypes(), m.getReturnType());
-                            methodsByKey.putIfAbsent(key, m);
+                            for (Method m : c.getDeclaredMethods()) {
+                                if (!isVisitLike(m) || Modifier.isStatic(m.getModifiers()) || Modifier.isPrivate(m.getModifiers())) {
+                                    continue;
+                                }
+                                methodsByKey.putIfAbsent(new MethodKey(m.getName(), m.getParameterTypes(), m.getReturnType()), m);
+                            }
+                            if (c == delegateType) {
+                                break;
+                            }
                         }
 
-                        // For visit*(SpecificNode) override-skip: name+arity match against any
-                        // user-declared (non-synthetic) mixin method. If the mixin overrides
-                        // visitClassDeclaration at one signature, skip generating proxy methods
-                        // for ALL same-name same-arity delegate methods (typed + bridges), so
-                        // dispatch falls through to the mixin via inheritance.
+                        // If the mixin declares its own visitX override, don't proxy the delegate's
+                        // same-name/arity methods (typed or bridge) — let dispatch fall through to it.
                         for (Method method : methodsByKey.values()) {
                             boolean isPreOrPost = "preVisit".equals(method.getName()) || "postVisit".equals(method.getName());
                             boolean mixinOverridesByName = mixinClass != null && !isPreOrPost &&
@@ -206,11 +218,8 @@ public class TreeVisitorAdapter {
     }
 
     private static boolean declaresUserOverrideByNameAndArity(Class<?> mixinClass, Class<?> adaptTo, Method baseMethod) {
-        // Only consider methods declared on the immediate mixin class —
-        // that is, what the user wrote. Methods inherited from the language
-        // iso-visitor (e.g., JavaIsoVisitor declares visitIdentifier) or from
-        // adaptTo are ambient, not real overrides, and would otherwise cause
-        // us to skip generating forwarding for nearly every visit method.
+        // Only methods the user actually declared on the mixin count; inherited iso-visitor/adaptTo
+        // methods are ambient, not real overrides.
         for (Method m : mixinClass.getDeclaredMethods()) {
             if (m.isSynthetic() || m.isBridge()) {
                 continue;
@@ -242,12 +251,12 @@ public class TreeVisitorAdapter {
             MethodKey other = (MethodKey) o;
             return name.equals(other.name) &&
                    returnType.equals(other.returnType) &&
-                   java.util.Arrays.equals(paramTypes, other.paramTypes);
+                   Arrays.equals(paramTypes, other.paramTypes);
         }
 
         @Override
         public int hashCode() {
-            return name.hashCode() * 31 + returnType.hashCode() + java.util.Arrays.hashCode(paramTypes);
+            return name.hashCode() * 31 + returnType.hashCode() + Arrays.hashCode(paramTypes);
         }
     }
 
@@ -324,13 +333,11 @@ public class TreeVisitorAdapter {
         }
     }
 
-    private static @org.jspecify.annotations.Nullable TreeVisitor<?, ?> discoverRegisteredMixin(
+    private static @Nullable TreeVisitor<?, ?> discoverRegisteredMixin(
             TreeVisitorAdapterClassLoader cache, TreeVisitor<?, ?> delegate, Class<?> adaptTo) {
-        // adapt() is invoked once per node of a foreign-language subtree, so the
-        // classpath scan in discoverRegisteredMixinClass would otherwise run per node.
-        // The cache resolves the mixin class (or "none") keyed by delegate + adaptTo,
-        // then we instantiate a fresh mixin per call (the proxy copies the mixin's fields).
-        java.util.Optional<Class<?>> mixinClass = cache.mixinClass(delegate.getClass(), adaptTo);
+        // Cache the per-(delegate, adaptTo) classpath scan — adapt() runs once per node — and
+        // instantiate a fresh mixin each call (the proxy copies its fields).
+        Optional<Class<?>> mixinClass = cache.mixinClass(delegate.getClass(), adaptTo);
         if (!mixinClass.isPresent()) {
             return null;
         }
@@ -342,34 +349,25 @@ public class TreeVisitorAdapter {
         }
     }
 
-    static java.util.Optional<Class<?>> discoverRegisteredMixinClass(Class<?> delegateClass, Class<?> adaptTo) {
-        // Each language module ships per-base-visitor registry files at
-        //   META-INF/rewrite/mixins/<base-visitor-fqn>
-        // listing mixin classes that should compose with that base. Same
-        // namespace already used by rewrite-YAML resources, not the JDK
-        // ServiceLoader namespace — we don't use {@link ServiceLoader} because
-        // its subtype check rejects mixins (a mixin extends the language
-        // module's iso-visitor, e.g. KotlinIsoVisitor, not the base visitor
-        // it composes with, e.g. RemoveAnnotationVisitor). The visitor role
-        // is shared structurally, not by inheritance.
-        //
-        // Anchor resource lookup to adaptTo's classloader so the language
-        // module's own registry files (shipped in the language module's JAR)
-        // are visible.
+    static Optional<Class<?>> discoverRegisteredMixinClass(Class<?> delegateClass, Class<?> adaptTo) {
+        // Mixins are registered in META-INF/rewrite/mixins/<base-visitor-fqn>. Not ServiceLoader:
+        // its subtype check rejects mixins, which extend the language iso-visitor (e.g.
+        // KotlinIsoVisitor) rather than the base visitor they compose with. Anchor lookup to
+        // adaptTo's classloader so the language module's own registry files are visible.
         ClassLoader cl = adaptTo.getClassLoader();
         if (cl == null) {
             cl = Thread.currentThread().getContextClassLoader();
         }
         if (cl == null) {
-            return java.util.Optional.empty();
+            return Optional.empty();
         }
         String resource = "META-INF/rewrite/mixins/" + delegateClass.getName();
         try {
-            java.util.Enumeration<java.net.URL> urls = cl.getResources(resource);
+            Enumeration<URL> urls = cl.getResources(resource);
             while (urls.hasMoreElements()) {
-                java.net.URL url = urls.nextElement();
-                try (java.io.BufferedReader reader = new java.io.BufferedReader(
-                        new java.io.InputStreamReader(url.openStream(), java.nio.charset.StandardCharsets.UTF_8))) {
+                URL url = urls.nextElement();
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))) {
                     String line;
                     while ((line = reader.readLine()) != null) {
                         int hash = line.indexOf('#');
@@ -389,7 +387,7 @@ public class TreeVisitorAdapter {
                             if (!adaptTo.isAssignableFrom(mixinClass)) {
                                 continue;
                             }
-                            return java.util.Optional.of(mixinClass);
+                            return Optional.of(mixinClass);
                         } catch (ClassNotFoundException e) {
                             throw new IllegalStateException(
                                     "Failed to load registered mixin " + line + " (from " + url + ").", e);
@@ -397,10 +395,10 @@ public class TreeVisitorAdapter {
                     }
                 }
             }
-        } catch (java.io.IOException e) {
+        } catch (IOException e) {
             // Couldn't enumerate mixin registry resources; treat as no registration.
         }
-        return java.util.Optional.empty();
+        return Optional.empty();
     }
 
     @SuppressWarnings("rawtypes")

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/TreeVisitorAdapterTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/TreeVisitorAdapterTest.java
@@ -112,6 +112,76 @@ class TreeVisitorAdapterTest {
 
         jv.visitNonNull(cu, 0);
     }
+
+    @Test
+    void preVisitDeclaredOnSuperclassIsForwarded() {
+        AtomicInteger n = new AtomicInteger();
+        // preVisit is declared on the SUPERCLASS, not the leaf delegate class.
+        //noinspection unchecked
+        JavaVisitor<Integer> jv = TreeVisitorAdapter.adapt(new PreVisitSubclass(n), JavaVisitor.class);
+        J.CompilationUnit cu = JavaParser.fromJavaVersion().build().parse("class Test {}")
+          .findFirst()
+          .map(J.CompilationUnit.class::cast)
+          .orElseThrow(() -> new IllegalArgumentException("Could not parse as Java"));
+        jv.visit(cu, 0);
+        // Must fire per node exactly as if preVisit were declared on the leaf (see adapter()).
+        assertThat(n.get()).isEqualTo(4);
+    }
+
+    @Test
+    void visitMethodDeclaredOnIsoVisitorSuperclassIsForwarded() {
+        AtomicInteger n = new AtomicInteger();
+        // visitIdentifier is declared on a user superclass that extends JavaIsoVisitor; the adapter
+        // must collect it (walking up to, but not into, JavaIsoVisitor).
+        //noinspection unchecked
+        JavaVisitor<Integer> jv = TreeVisitorAdapter.adapt(new IdentifierCountingSubclass(n), JavaVisitor.class);
+        J.CompilationUnit cu = JavaParser.fromJavaVersion().build().parse("class Test {}")
+          .findFirst()
+          .map(J.CompilationUnit.class::cast)
+          .orElseThrow(() -> new IllegalArgumentException("Could not parse as Java"));
+        jv.visit(cu, 0);
+        assertThat(n.get()).isEqualTo(1);
+    }
+
+    static class IdentifierCountingBase extends JavaIsoVisitor<Integer> {
+        final AtomicInteger n;
+
+        IdentifierCountingBase(AtomicInteger n) {
+            this.n = n;
+        }
+
+        @Override
+        public J.Identifier visitIdentifier(J.Identifier identifier, Integer p) {
+            n.incrementAndGet();
+            return identifier;
+        }
+    }
+
+    static class IdentifierCountingSubclass extends IdentifierCountingBase {
+        IdentifierCountingSubclass(AtomicInteger n) {
+            super(n);
+        }
+    }
+}
+
+class PreVisitBase extends TreeVisitor<Tree, Integer> {
+    final AtomicInteger visitCount;
+
+    PreVisitBase(AtomicInteger visitCount) {
+        this.visitCount = visitCount;
+    }
+
+    @Override
+    public Tree preVisit(Tree tree, Integer p) {
+        visitCount.incrementAndGet();
+        return super.preVisit(tree, p);
+    }
+}
+
+class PreVisitSubclass extends PreVisitBase {
+    PreVisitSubclass(AtomicInteger visitCount) {
+        super(visitCount);
+    }
 }
 
 @Value


### PR DESCRIPTION
### What's changed

`TreeVisitorAdapter` collected the visit-like methods to proxy-forward from `delegate.getClass().getDeclaredMethods()` — the **leaf class only**. So `preVisit`/`postVisit`/`visitX` declared on a *superclass* of the delegate were never forwarded, and silently did not fire when the visitor was adapted to another language (C#/Python/Kotlin/Groovy). Java is unaffected because it runs natively, without `adapt()` — which is why this stayed hidden.

The fix walks the delegate's class hierarchy from the leaf up to — but not into — the language iso-visitor (`delegateType`), collecting the user's visit-like methods at every level (leaf-first, so the most-derived override wins). Stopping at the iso-visitor matters: crossing into it would forward the framework's own `visitX` to the foreign-language delegate and break native traversal.

### Why it matters

Any visitor that factors shared behavior into a base class (e.g. a common scanning base that overrides `preVisit`/`postVisit`) misbehaves under cross-language `adapt()` today, with no error — the overrides just don't run.

### Tests

Two regression tests in `TreeVisitorAdapterTest`:
- `preVisit` declared on a `TreeVisitor` superclass is forwarded.
- `visitIdentifier` declared on a `JavaIsoVisitor` superclass is forwarded (exercises the iso-visitor stop-boundary).

Both fail on `main` and pass with this change; existing adapter tests, `rewrite-groovy`, and `rewrite-core` stay green.

### Also

Incidental cleanup of the touched file: inline fully-qualified class names replaced with imports, and a few verbose comments trimmed.
