### PR TITLE
feat: resolve Jenkins shared library methods from @Library annotations and analysis scope

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
@@ -101,6 +101,31 @@ public class GroovyParser implements Parser {
 
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sources, @Nullable Path relativeTo, ExecutionContext ctx) {
+        Map<String, String> stepToLibraryMap = new HashMap<>();
+        for (Input input : sources) {
+            Path path = input.getPath();
+            String pathStr = path.toString().replace('\\', '/');
+            int varsIndex = pathStr.indexOf("/vars/");
+            if (varsIndex == -1 && pathStr.startsWith("vars/")) {
+                varsIndex = 0;
+            }
+            if (varsIndex != -1 && pathStr.endsWith(".groovy")) {
+                String stepName = pathStr.substring(pathStr.lastIndexOf('/') + 1, pathStr.length() - 7);
+                String libraryName = "";
+                if (varsIndex > 0) {
+                    String sub = pathStr.substring(0, varsIndex);
+                    int lastSlash = sub.lastIndexOf('/');
+                    libraryName = lastSlash == -1 ? sub : sub.substring(lastSlash + 1);
+                } else {
+                    libraryName = "unknown";
+                }
+                stepToLibraryMap.put(stepName, libraryName);
+            }
+        }
+        if (!stepToLibraryMap.isEmpty()) {
+            ctx.putMessage("org.openrewrite.groovy.jenkins.sharedLibrarySteps", stepToLibraryMap);
+        }
+
         CompilerConfiguration configuration = new CompilerConfiguration();
         configuration.setTolerance(Integer.MAX_VALUE);
         configuration.setWarningLevel(WarningMessage.NONE);

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -91,6 +91,7 @@ public class GroovyParserVisitor {
     private final Charset charset;
     private final boolean charsetBomMarked;
     private final GroovyTypeMapping typeMapping;
+    private final ExecutionContext ctx;
 
     private int cursor = 0;
 
@@ -108,8 +109,10 @@ public class GroovyParserVisitor {
     /**
      * Elements within GString expressions which omit curly braces have column positions which are incorrect.
      * The column positions act like there *is* a curly brace.
+     * @param sourcePath
      */
     private int columnOffset;
+    private List<String> libraryNames = Collections.emptyList();
 
     @Nullable
     private static Boolean olderThanGroovy3;
@@ -138,6 +141,7 @@ public class GroovyParserVisitor {
         this.charsetBomMarked = source.isCharsetBomMarked();
         JavaTypeFactory factory = typeFactory != null ? typeFactory : new org.openrewrite.java.internal.DefaultJavaTypeFactory(typeCache);
         this.typeMapping = new GroovyTypeMapping(factory);
+        this.ctx = ctx;
     }
 
     private static int groovyMajorVersion() {
@@ -160,6 +164,7 @@ public class GroovyParserVisitor {
     }
 
     public G.CompilationUnit visit(SourceUnit unit, ModuleNode ast) throws GroovyParsingException {
+        this.libraryNames = getLibraryNames(ast);
         NavigableMap<LineColumn, ASTNode> sortedByPosition = new TreeMap<>();
         for (org.codehaus.groovy.ast.stmt.Statement s : ast.getStatementBlock().getStatements()) {
             if (!isSynthetic(s)) {
@@ -2825,6 +2830,36 @@ public class GroovyParserVisitor {
                 } else {
                     methodType = typeMapping.methodType(methodNode);
                 }
+
+                if (methodType == null && call.isImplicitThis()) {
+                    String libraryName = null;
+                    Map<String, String> sharedLibrarySteps = ctx.getMessage("org.openrewrite.groovy.jenkins.sharedLibrarySteps");
+                    if (sharedLibrarySteps != null) {
+                        libraryName = sharedLibrarySteps.get(name.getSimpleName());
+                    }
+                    if (libraryName == null && !libraryNames.isEmpty()) {
+                        libraryName = libraryNames.get(0);
+                    }
+                    if (libraryName != null) {
+                        String sanitizedLib = libraryName.replaceAll("[-.]", "_");
+                        String declaringTypeFqn = "jenkins.sharedlibrary." + sanitizedLib + ".Vars";
+                        JavaType.FullyQualified declaringType = JavaType.ShallowClass.build(declaringTypeFqn);
+                        methodType = new JavaType.Method(
+                                null,
+                                Flag.Public.getBitMask(),
+                                declaringType,
+                                name.getSimpleName(),
+                                JavaType.Primitive.Void,
+                                (List<String>) null,
+                                (List<JavaType>) null,
+                                (List<JavaType>) null,
+                                (List<JavaType.FullyQualified>) null,
+                                null,
+                                null
+                        );
+                    }
+                }
+
                 return new J.MethodInvocation(randomId(), fmt, markers, select, typeParameters, name, args, methodType);
             }));
         }
@@ -4625,5 +4660,128 @@ public class GroovyParserVisitor {
         modifierNameToType.put("non-sealed", J.Modifier.Type.NonSealed);
         modifierNameToType.put("default", J.Modifier.Type.Default);
         modifierNameToType.put("strictfp", J.Modifier.Type.Strictfp);
+    }
+
+    private List<String> getLibraryNames(ModuleNode ast) {
+        List<String> libraryNames = new ArrayList<>();
+        if (ast.getPackage() != null) {
+            for (AnnotationNode annotation : ast.getPackage().getAnnotations()) {
+                if (isLibraryAnnotation(annotation)) {
+                    addLibraryNames(annotation, libraryNames);
+                }
+            }
+        }
+        for (ImportNode anImport : ast.getImports()) {
+            for (AnnotationNode annotation : anImport.getAnnotations()) {
+                if (isLibraryAnnotation(annotation)) {
+                    addLibraryNames(annotation, libraryNames);
+                }
+            }
+        }
+        for (ImportNode anImport : ast.getStarImports()) {
+            for (AnnotationNode annotation : anImport.getAnnotations()) {
+                if (isLibraryAnnotation(annotation)) {
+                    addLibraryNames(annotation, libraryNames);
+                }
+            }
+        }
+        for (ImportNode anImport : ast.getStaticImports().values()) {
+            for (AnnotationNode annotation : anImport.getAnnotations()) {
+                if (isLibraryAnnotation(annotation)) {
+                    addLibraryNames(annotation, libraryNames);
+                }
+            }
+        }
+        for (ClassNode aClass : ast.getClasses()) {
+            for (AnnotationNode annotation : aClass.getAnnotations()) {
+                if (isLibraryAnnotation(annotation)) {
+                    addLibraryNames(annotation, libraryNames);
+                }
+            }
+            for (FieldNode field : aClass.getFields()) {
+                for (AnnotationNode annotation : field.getAnnotations()) {
+                    if (isLibraryAnnotation(annotation)) {
+                        addLibraryNames(annotation, libraryNames);
+                    }
+                }
+            }
+            for (MethodNode method : aClass.getMethods()) {
+                for (AnnotationNode annotation : method.getAnnotations()) {
+                    if (isLibraryAnnotation(annotation)) {
+                        addLibraryNames(annotation, libraryNames);
+                    }
+                }
+                for (Parameter param : method.getParameters()) {
+                    for (AnnotationNode annotation : param.getAnnotations()) {
+                        if (isLibraryAnnotation(annotation)) {
+                            addLibraryNames(annotation, libraryNames);
+                        }
+                    }
+                }
+            }
+        }
+        for (org.codehaus.groovy.ast.stmt.Statement s : ast.getStatementBlock().getStatements()) {
+            collectAnnotations(s, libraryNames);
+        }
+        return libraryNames;
+    }
+
+    private void collectAnnotations(@Nullable ASTNode node, List<String> libraryNames) {
+        if (node == null) {
+            return;
+        }
+        if (node instanceof AnnotatedNode) {
+            for (AnnotationNode annotation : ((AnnotatedNode) node).getAnnotations()) {
+                if (isLibraryAnnotation(annotation)) {
+                    addLibraryNames(annotation, libraryNames);
+                }
+            }
+        }
+        if (node instanceof BlockStatement) {
+            for (org.codehaus.groovy.ast.stmt.Statement s : ((BlockStatement) node).getStatements()) {
+                collectAnnotations(s, libraryNames);
+            }
+        } else if (node instanceof ExpressionStatement) {
+            collectAnnotations(((ExpressionStatement) node).getExpression(), libraryNames);
+        } else if (node instanceof DeclarationExpression) {
+            collectAnnotations(((DeclarationExpression) node).getLeftExpression(), libraryNames);
+            collectAnnotations(((DeclarationExpression) node).getRightExpression(), libraryNames);
+        } else if (node instanceof IfStatement) {
+            collectAnnotations(((IfStatement) node).getIfBlock(), libraryNames);
+            collectAnnotations(((IfStatement) node).getElseBlock(), libraryNames);
+        } else if (node instanceof TryCatchStatement) {
+            collectAnnotations(((TryCatchStatement) node).getTryStatement(), libraryNames);
+            for (CatchStatement cs : ((TryCatchStatement) node).getCatchStatements()) {
+                collectAnnotations(cs, libraryNames);
+            }
+            collectAnnotations(((TryCatchStatement) node).getFinallyStatement(), libraryNames);
+        } else if (node instanceof CatchStatement) {
+            collectAnnotations(((CatchStatement) node).getCode(), libraryNames);
+        }
+    }
+
+    private boolean isLibraryAnnotation(AnnotationNode annotation) {
+        String name = annotation.getClassNode().getUnresolvedName();
+        String fqn = annotation.getClassNode().getName();
+        return "Library".equals(name) || "org.jenkinsci.plugins.workflow.libs.Library".equals(fqn);
+    }
+
+    private void addLibraryNames(AnnotationNode annotation, List<String> libraryNames) {
+        org.codehaus.groovy.ast.expr.Expression value = annotation.getMember("value");
+        if (value instanceof org.codehaus.groovy.ast.expr.ConstantExpression) {
+            Object val = ((org.codehaus.groovy.ast.expr.ConstantExpression) value).getValue();
+            if (val != null) {
+                libraryNames.add(val.toString());
+            }
+        } else if (value instanceof org.codehaus.groovy.ast.expr.ListExpression) {
+            for (org.codehaus.groovy.ast.expr.Expression expr : ((org.codehaus.groovy.ast.expr.ListExpression) value).getExpressions()) {
+                if (expr instanceof org.codehaus.groovy.ast.expr.ConstantExpression) {
+                    Object val = ((org.codehaus.groovy.ast.expr.ConstantExpression) expr).getValue();
+                    if (val != null) {
+                        libraryNames.add(val.toString());
+                    }
+                }
+            }
+        }
     }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/JenkinsFileTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/JenkinsFileTest.java
@@ -17,6 +17,8 @@ package org.openrewrite.groovy;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.groovy.Assertions.groovy;
@@ -158,6 +160,63 @@ class JenkinsFileTest implements RewriteTest {
               foo()
               """,
             spec -> spec.path("Jenkinsfile")
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7229")
+    @Test
+    void jenkinsSharedLibraryMethodResolutionFromScope() {
+        rewriteRun(
+          groovy(
+            "sbPipeline()",
+            spec -> spec.path("Jenkinsfile")
+              .afterRecipe(sourceFile -> {
+                  if (sourceFile.getSourcePath().toString().contains("Jenkinsfile")) {
+                      G.CompilationUnit cu = (G.CompilationUnit) sourceFile;
+                      J.MethodInvocation m = cu.getStatements().stream()
+                              .filter(J.MethodInvocation.class::isInstance)
+                              .map(J.MethodInvocation.class::cast)
+                              .filter(it -> "sbPipeline".equals(it.getSimpleName()))
+                              .findFirst()
+                              .orElseThrow();
+                      org.assertj.core.api.Assertions.assertThat(m.getMethodType()).isNotNull();
+                      org.assertj.core.api.Assertions.assertThat(m.getMethodType().getDeclaringType().getFullyQualifiedName())
+                              .isEqualTo("jenkins.sharedlibrary.my_library.Vars");
+                  }
+              })
+          ),
+          groovy(
+            "def call() { }",
+            spec -> spec.path("my-library/vars/sbPipeline.groovy")
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/7229")
+    @Test
+    void jenkinsSharedLibraryMethodResolutionFromLibraryAnnotation() {
+        rewriteRun(
+          groovy(
+            """
+            @Library('my-pipeline-library') _
+            sbPipeline()
+            """,
+            spec -> spec.path("Jenkinsfile")
+              .afterRecipe(sourceFile -> {
+                  if (sourceFile.getSourcePath().toString().contains("Jenkinsfile")) {
+                      G.CompilationUnit cu = (G.CompilationUnit) sourceFile;
+                      J.MethodInvocation m = cu.getStatements().stream()
+                              .filter(J.MethodInvocation.class::isInstance)
+                              .map(J.MethodInvocation.class::cast)
+                              .filter(it -> "sbPipeline".equals(it.getSimpleName()))
+                              .findFirst()
+                              .orElseThrow();
+                      org.assertj.core.api.Assertions.assertThat(m.getMethodType()).isNotNull();
+                      org.assertj.core.api.Assertions.assertThat(m.getMethodType().getDeclaringType().getFullyQualifiedName())
+                              .isEqualTo("jenkins.sharedlibrary.my_pipeline_library.Vars");
+                  }
+              })
           )
         );
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Implemented type resolution and attribution for Jenkins shared library steps (`vars/*.groovy`) in the Groovy parser:
1. **Analysis Scope Scanning**: Added scanning in `GroovyParser.java` to index all `vars/*.groovy` files in the input sources.
2. **Annotation Scanning**: Added scanning of package, imports, and statement blocks in `GroovyParserVisitor.java` for `@Library` annotations.
3. **Type Attribution**: In `GroovyParserVisitor.visitMethodCallExpression`, unresolved method calls on implicit `this` are resolved and attributed to the identified shared libraries (resolving to `jenkins.sharedlibrary.<library_name>.Vars`) if they match scope steps or when the `@Library` annotation is present.

## What's your motivation?
- Closes #7229. Resolves the issue where methods provided by shared libraries imported via the `@Library` annotation in a `Jenkinsfile` are not type-attributed, which causes downstream recipes (like `FindCallGraph`) to report "Method type not found" warnings or fail to match.

## Anything in particular you'd like reviewers to focus on?
- The implementation of `collectAnnotations` in `GroovyParserVisitor.java` which recursively traverses statement blocks to capture `@Library` annotations attached to script-level variable/field declarations (e.g. `@Library('lib') _`).
- The use of `ExecutionContext` to pass the `sharedLibrarySteps` map collected during `parseInputs` down to the `GroovyParserVisitor` instances.

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
Considered compiling all files together in a single `CompilationUnit`, but that would disrupt the lazy streaming design of `GroovyParser.parseInputs` and potentially introduce compilation order/dependency issues. The current design allows files to compile individually while sharing type metadata.

## Any additional context
N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files