### PR TITLE
Add Reassignable trait

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/Reassignable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/Reassignable.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait;
+
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.Incubating;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.Flag;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.trait.SimpleTraitMatcher;
+import org.openrewrite.trait.Trait;
+import org.openrewrite.trait.VisitFunction2;
+
+/**
+ * A syntactic check that an expression could be the target of a plain assignment
+ * {@code target = ...} without introducing a compile error. Handles two shapes:
+ * <ul>
+ *     <li>a {@link J.Identifier} referring to a non-final local declared in an
+ *         enclosing block (method parameters are excluded because reassigning a
+ *         parameter silently drops the caller's expected mutation), and</li>
+ *     <li>a {@link J.FieldAccess} whose target is a bare {@link J.Identifier}
+ *         (e.g. {@code this.f} or {@code holder.f}) and whose field is non-final.</li>
+ * </ul>
+ * Array-element writes, parenthesized targets, method-chain receivers, and
+ * multi-hop qualified field access (e.g. {@code a.b.c}) are intentionally not
+ * matched. Effectively-final semantics are not modelled.
+ */
+@Incubating(since = "8.68.0")
+@Value
+public class Reassignable implements Trait<Expression> {
+    Cursor cursor;
+
+    public static class Matcher extends SimpleTraitMatcher<Reassignable> {
+
+        @Override
+        public <P> TreeVisitor<? extends Tree, P> asVisitor(VisitFunction2<Reassignable, P> visitor) {
+            return new JavaVisitor<P>() {
+                @Override
+                public J visitIdentifier(J.Identifier ident, P p) {
+                    Reassignable r = test(getCursor());
+                    return r != null ?
+                            (J) visitor.visit(r, p) :
+                            super.visitIdentifier(ident, p);
+                }
+
+                @Override
+                public J visitFieldAccess(J.FieldAccess fieldAccess, P p) {
+                    Reassignable r = test(getCursor());
+                    return r != null ?
+                            (J) visitor.visit(r, p) :
+                            super.visitFieldAccess(fieldAccess, p);
+                }
+            };
+        }
+
+        @Override
+        protected @Nullable Reassignable test(Cursor cursor) {
+            Object value = cursor.getValue();
+            if (value instanceof J.Identifier && isReassignableLocalIdentifier(cursor, (J.Identifier) value)) {
+                return new Reassignable(cursor);
+            }
+            if (value instanceof J.FieldAccess && isReassignableFieldAccess((J.FieldAccess) value)) {
+                return new Reassignable(cursor);
+            }
+            return null;
+        }
+
+        private static boolean isReassignableLocalIdentifier(Cursor cursor, J.Identifier ident) {
+            // Skip identifiers that appear as the name-part of a larger construct
+            // (field-access field name, method-invocation name, declaration name, etc.).
+            Object parent = cursor.getParentTreeCursor().getValue();
+            if (parent instanceof J.FieldAccess && ((J.FieldAccess) parent).getName() == ident) {
+                return false;
+            }
+            if (parent instanceof J.MethodInvocation && ((J.MethodInvocation) parent).getName() == ident) {
+                return false;
+            }
+            if (parent instanceof J.VariableDeclarations.NamedVariable &&
+                    ((J.VariableDeclarations.NamedVariable) parent).getName() == ident) {
+                return false;
+            }
+
+            if (ident.getFieldType() != null && ident.getFieldType().hasFlags(Flag.Final)) {
+                return false;
+            }
+            String name = ident.getSimpleName();
+            Cursor c = cursor.getParent();
+            while (c != null) {
+                Object v = c.getValue();
+                if (v instanceof J.Block) {
+                    for (Statement stmt : ((J.Block) v).getStatements()) {
+                        if (stmt instanceof J.VariableDeclarations) {
+                            J.VariableDeclarations vd = (J.VariableDeclarations) stmt;
+                            for (J.VariableDeclarations.NamedVariable nv : vd.getVariables()) {
+                                if (name.equals(nv.getName().getSimpleName()) &&
+                                        TypeUtils.isOfType(nv.getName().getType(), ident.getType())) {
+                                    return !vd.hasModifier(J.Modifier.Type.Final);
+                                }
+                            }
+                        }
+                    }
+                }
+                if (v instanceof J.MethodDeclaration) {
+                    for (Statement p : ((J.MethodDeclaration) v).getParameters()) {
+                        if (p instanceof J.VariableDeclarations) {
+                            for (J.VariableDeclarations.NamedVariable nv : ((J.VariableDeclarations) p).getVariables()) {
+                                if (name.equals(nv.getName().getSimpleName())) {
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                    return false;
+                }
+                c = c.getParent();
+            }
+            return false;
+        }
+
+        private static boolean isReassignableFieldAccess(J.FieldAccess fa) {
+            if (!(fa.getTarget() instanceof J.Identifier)) {
+                return false;
+            }
+            JavaType.Variable v = fa.getName().getFieldType();
+            return v != null && !v.hasFlags(Flag.Final);
+        }
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/Reassignable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/Reassignable.java
@@ -34,17 +34,9 @@ import org.openrewrite.trait.VisitFunction2;
 
 /**
  * A syntactic check that an expression could be the target of a plain assignment
- * {@code target = ...} without introducing a compile error. Handles two shapes:
- * <ul>
- *     <li>a {@link J.Identifier} referring to a non-final local declared in an
- *         enclosing block (method parameters are excluded because reassigning a
- *         parameter silently drops the caller's expected mutation), and</li>
- *     <li>a {@link J.FieldAccess} whose target is a bare {@link J.Identifier}
- *         (e.g. {@code this.f} or {@code holder.f}) and whose field is non-final.</li>
- * </ul>
- * Array-element writes, parenthesized targets, method-chain receivers, and
- * multi-hop qualified field access (e.g. {@code a.b.c}) are intentionally not
- * matched. Effectively-final semantics are not modelled.
+ * {@code target = ...}. Matches a non-final local {@link J.Identifier} declared
+ * in an enclosing block, or a {@link J.FieldAccess} on a non-final field whose
+ * target is a bare {@link J.Identifier}.
  */
 @Incubating(since = "8.68.0")
 @Value

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/Reassignable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/Reassignable.java
@@ -18,7 +18,6 @@ package org.openrewrite.java.trait;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
-import org.openrewrite.Incubating;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaVisitor;
@@ -38,7 +37,6 @@ import org.openrewrite.trait.VisitFunction2;
  * in an enclosing block, or a {@link J.FieldAccess} on a non-final field whose
  * target is a bare {@link J.Identifier}.
  */
-@Incubating(since = "8.68.0")
 @Value
 public class Reassignable implements Trait<Expression> {
     Cursor cursor;

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/ReassignableTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/ReassignableTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Recipe;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+@SuppressWarnings("ALL")
+class ReassignableTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(markReassignables());
+    }
+
+    @DocumentExample
+    @Test
+    void nonFinalLocalIsReassignable() {
+        rewriteRun(
+          java(
+            """
+              class T {
+                  void run() {
+                      String local = "";
+                      local = "x";
+                  }
+              }
+              """,
+            """
+              class T {
+                  void run() {
+                      String local = "";
+                      /*~~>*/local = "x";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void finalLocalIsNotReassignable() {
+        rewriteRun(
+          java(
+            """
+              class T {
+                  void run() {
+                      final String local = "";
+                      System.out.println(local);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodParameterIsNotReassignable() {
+        rewriteRun(
+          java(
+            """
+              class T {
+                  void run(String param) {
+                      param = "x";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void nonFinalThisFieldIsReassignable() {
+        rewriteRun(
+          java(
+            """
+              class T {
+                  String field = "";
+                  void run() {
+                      this.field = "x";
+                  }
+              }
+              """,
+            """
+              class T {
+                  String field = "";
+                  void run() {
+                      /*~~>*/this.field = "x";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void finalThisFieldIsNotReassignable() {
+        rewriteRun(
+          java(
+            """
+              class T {
+                  final String field = "";
+                  void run() {
+                      System.out.println(this.field);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    Recipe markReassignables() {
+        return toRecipe(() -> new Reassignable.Matcher().asVisitor(r -> SearchResult.found(r.getTree())));
+    }
+}


### PR DESCRIPTION
## What

A new incubating `Reassignable` trait under `org.openrewrite.java.trait` that answers a syntactic question recipes tend to re-invent locally: *could this expression be the target of a plain assignment `target = ...` without introducing a compile error?*

## Why

- Recipes that mechanically rewrite `x.setFoo(...)` shapes into `x = x.rebuild()....build()` — or any other transformation that needs to reassign a receiver — currently either duplicate the walk-up-the-cursor-and-check-flags logic each time, or silently skip cases where the receiver is a field access. Concrete example: the `Reassignable`-shaped guard that landed in [`rewrite-jackson#153`](https://github.com/openrewrite/rewrite-jackson/pull/153) (`MigrateMapperSettersToBuilder#isReassignableReceiver`).

Extracting the check as a trait gives future recipes a one-liner and gives us one place to sharpen the semantics.

## Scope for v1

Deliberately narrow, matching the jackson recipe's semantics:

- **Matches** a `J.Identifier` referring to a non-final local declared in an enclosing block, and a `J.FieldAccess` whose target is a bare `J.Identifier` and whose field is non-final.
- **Rejects** method parameters (reassigning a parameter silently drops the caller's expected mutation), final locals and final fields, multi-hop qualified field access (`a.b.c`), array-element writes, parenthesized targets, and method-chain receivers.
- **Does not model** effectively-final semantics, definite assignment, or any control-flow analysis.

Follow-up: migrate the jackson recipe to use the trait once this lands.

## Test plan

- [x] `./gradlew :rewrite-java:test --tests 'org.openrewrite.java.trait.ReassignableTest'` — 5 cases (non-final local ✓, final local ✗, method parameter ✗, non-final `this.field` ✓, final `this.field` ✗).
- [x] `./gradlew :rewrite-java:test --tests 'org.openrewrite.java.trait.*'` — no regression in other trait tests.