### PR TITLE
use gradle property assignment for distributionUrl

### DIFF
--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle.yml
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle.yml
@@ -27,6 +27,8 @@ recipeList:
   - org.openrewrite.gradle.RemoveRedundantSecurityResolutionRules
   - org.openrewrite.gradle.SortDependencies
   - org.openrewrite.gradle.security.UseHttpsForRepositories
+  - org.openrewrite.gradle.UsePropertyAssignmentSyntax:
+      propertyName: distributionUrl
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.gradle.EnableGradleBuildCache

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleBestPracticesTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleBestPracticesTest.java
@@ -138,4 +138,36 @@ class GradleBestPracticesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void usePropertyAssignmentSyntaxForDistributionUrl() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins { id 'java' }
+
+              wrapper {
+                  distributionUrl("https://example.com/files/example.zip")
+              }
+              """,
+            """
+              plugins { id 'java' }
+
+              wrapper {
+                  distributionUrl = "https://example.com/files/example.zip"
+              }
+              """),
+          properties(
+            //language=properties
+            """
+              """,
+            //language=properties
+            """
+              org.gradle.caching=true
+              org.gradle.parallel=true
+              """,
+            spec -> spec.path("gradle.properties")
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Add `org.openrewrite.gradle.UsePropertyAssignmentSyntax` (with `propertyName: distributionUrl`) to the `GradleBestPractices` recipe list so that the Gradle wrapper's `distributionUrl(...)` method call is rewritten to property assignment syntax:

```groovy
wrapper {
    distributionUrl("https://example.com/files/example.zip")
}
```

becomes:

```groovy
wrapper {
    distributionUrl = "https://example.com/files/example.zip"
}
```

## Testing

Added a test (`usePropertyAssignmentSyntaxForDistributionUrl`) to `GradleBestPracticesTest` covering the transformation.