### PR TITLE
Kotlin: set Flag.Enum on enum entries in KotlinTypeMapping

### DIFF
--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -1168,7 +1168,10 @@ class KotlinTypeMapping(
 
     @OptIn(SymbolInternals::class)
     fun variableType(variable: FirVariable, parent: Any?, signature: String): Variable {
-        val variableFlags = mapToFlagsBitmap(variable.visibility, variable.modality, variable.isStatic)
+        var variableFlags = mapToFlagsBitmap(variable.visibility, variable.modality, variable.isStatic)
+        if (variable is FirEnumEntry) {
+            variableFlags = variableFlags or (1L shl 14) // Enum
+        }
         val resolvedName = variableName(variable.name.asString())
         return typeFactory.variableFor(signature) {
             val vt = Variable(null, variableFlags, resolvedName, null, null, null)

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AttributeValueTraitTest.java
@@ -29,9 +29,9 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
  * The {@link org.openrewrite.java.trait.AttributeValue} behavior on Kotlin sources,
  * asserting the same semantics the trait has on javac-attributed Java sources.
  * Tests annotated {@link ExpectedToFail} document known Kotlin type-mapping gaps:
- * {@code KotlinTypeMapping#variableType} does not set {@code Flag.Enum} on enum
- * entries, no {@code JavaType.Annotation} element values are built (no constant
- * folding), and collection literals are {@code K.ListLiteral}, not {@code J.NewArray}.
+ * {@code KotlinTypeMapping} builds no {@code JavaType.Annotation} element values (no
+ * constant folding), and collection literals are {@code K.ListLiteral}, not
+ * {@code J.NewArray}.
  */
 class AttributeValueTraitTest implements RewriteTest {
 
@@ -124,7 +124,6 @@ class AttributeValueTraitTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("KotlinTypeMapping#variableType does not set Flag.Enum on enum entries (mapToFlagsBitmap uses only visibility/modality/static) — https://github.com/openrewrite/rewrite/issues/8170")
     @Test
     void enumConstant() {
         rewriteRun(


### PR DESCRIPTION
- Fixes gap 1 of #8170.

### What

`KotlinTypeMapping#variableType(FirVariable, …)` computed its flags via `mapToFlagsBitmap(visibility, modality, isStatic)` with no enum-entry branch — even though enum entries flow through this exact method and the enum *class* already gets the bit (`flags or (1L shl 14)`). As a result `Flag.Enum` was never set on enum entries, so `AttributeValue#isEnumConstant(..)` degraded to `CONSTANT_REFERENCE` on Kotlin sources instead of `ENUM_CONSTANT`.

This sets `1L shl 14` when the variable is a `FirEnumEntry`, aligning Kotlin with the javac-attributed Java contract the `AttributeValue` trait relies on.

### Test

Drops `@ExpectedToFail` from `AttributeValueTraitTest.enumConstant`, which now asserts `ENUM_CONSTANT:isEnum=true` and passes. The class javadoc is updated to no longer list the enum-entry gap.

- The remaining `@ExpectedToFail` cases (no `JavaType.Annotation` element values → constant fold, and `K.ListLiteral` array normalization — gaps 3 & 4 of #8170) are untouched.

### Stacking

- Stacked on #8160 (the `AttributeValue` trait + its `@ExpectedToFail` Kotlin/Groovy tests). Should merge after or with that PR.