### PR TITLE
Fix ChangeDependencyGroupIdAndArtifactId adding a version to provided/test dependency managed by a local parent

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -427,20 +427,26 @@ public class ChangeDependencyGroupIdAndArtifactId extends ScanningRecipe<ChangeD
                 MavenResolutionResult result = getResolutionResult();
                 for (ResolvedManagedDependency managedDependency : result.getPom().getDependencyManagement()) {
                     if (groupId.equals(managedDependency.getGroupId()) && artifactId.equals(managedDependency.getArtifactId())) {
-                        return scope.isInClasspathOf(managedDependency.getScope());
+                        return scopeIsManagedBy(scope, managedDependency.getScope());
                     }
                 }
                 return false;
             }
 
+            // A managed version applies whenever coordinates match regardless of scope, so an identical scope
+            // qualifies; isInClasspathOf alone wrongly returns false for provided/provided and test/test.
+            private boolean scopeIsManagedBy(Scope dependencyScope, @Nullable Scope managedScope) {
+                return managedScope == null || dependencyScope == managedScope || dependencyScope.isInClasspathOf(managedScope);
+            }
+
             private boolean canAffectManagedDependency(MavenResolutionResult result, Scope scope, String groupId, String artifactId) {
-                // We're only going to be able to effect managed dependencies that are either direct or are brought in as direct via a local parent
+                // We're only going to be able to affect managed dependencies that are either direct or are brought in as direct via a local parent
                 // `ChangeManagedDependencyGroupIdAndArtifactId` cannot manipulate BOM imported managed dependencies nor direct dependencies from remote parents
                 Pom requestedPom = result.getPom().getRequested();
                 for (ManagedDependency requestedManagedDependency : requestedPom.getDependencyManagement()) {
                     if (matchesGlob(requestedManagedDependency.getGroupId(), groupId) && matchesGlob(requestedManagedDependency.getArtifactId(), artifactId)) {
                         if (requestedManagedDependency instanceof ManagedDependency.Defined) {
-                            return scope.isInClasspathOf(Scope.fromName(((ManagedDependency.Defined) requestedManagedDependency).getScope()));
+                            return scopeIsManagedBy(scope, Scope.fromName(((ManagedDependency.Defined) requestedManagedDependency).getScope()));
                         }
                     }
                 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -1501,6 +1501,101 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/8145")
+    @Test
+    void providedDependencyManagedByLocalParentDoesNotGetExplicitVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
+            "javax.servlet", "javax.servlet-api",
+            "jakarta.servlet", "jakarta.servlet-api",
+            "5.0.x", null)),
+          mavenProject("parent",
+            pomXml(
+              """
+                <project>
+                    <groupId>com.example</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <packaging>pom</packaging>
+                    <modules>
+                        <module>child</module>
+                    </modules>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.servlet</groupId>
+                                <artifactId>javax.servlet-api</artifactId>
+                                <version>4.0.0</version>
+                                <scope>provided</scope>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """,
+              """
+                <project>
+                    <groupId>com.example</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <packaging>pom</packaging>
+                    <modules>
+                        <module>child</module>
+                    </modules>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>jakarta.servlet</groupId>
+                                <artifactId>jakarta.servlet-api</artifactId>
+                                <version>5.0.0</version>
+                                <scope>provided</scope>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """
+            ),
+            mavenProject("child",
+              pomXml(
+                """
+                  <project>
+                      <parent>
+                          <groupId>com.example</groupId>
+                          <artifactId>parent</artifactId>
+                          <version>1.0-SNAPSHOT</version>
+                      </parent>
+                      <artifactId>child</artifactId>
+                      <dependencies>
+                          <dependency>
+                              <groupId>javax.servlet</groupId>
+                              <artifactId>javax.servlet-api</artifactId>
+                              <scope>provided</scope>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """,
+                """
+                  <project>
+                      <parent>
+                          <groupId>com.example</groupId>
+                          <artifactId>parent</artifactId>
+                          <version>1.0-SNAPSHOT</version>
+                      </parent>
+                      <artifactId>child</artifactId>
+                      <dependencies>
+                          <dependency>
+                              <groupId>jakarta.servlet</groupId>
+                              <artifactId>jakarta.servlet-api</artifactId>
+                              <scope>provided</scope>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """
+              )
+            )
+          )
+        );
+    }
+
     @Test
     void latestPatch() {
         rewriteRun(


### PR DESCRIPTION
## What's changed

- Split off from #8155.

In a multi-module Maven project, `ChangeDependencyGroupIdAndArtifactId` added a spurious explicit `<version>` to a child dependency whose version is managed by a local parent POM, when the dependency uses `provided` (or `test`) scope.

The managed-dependency detection (`isDependencyManaged` / `canAffectManagedDependency`) used `Scope.isInClasspathOf`, which models *transitive* classpath visibility and returns `false` for `provided`/`provided` and `test`/`test`. As a result, a `provided` child dependency managed by a `provided` entry in a local parent was treated as unmanaged, so an explicit version was added instead of leaving it inherited.

A managed version applies whenever the coordinates match regardless of scope, so an identical scope now correctly counts as managed (via a small `scopeIsManagedBy` helper). Also fixes a pre-existing "effect" → "affect" typo in a neighboring comment.

## Testing

- Added `ChangeDependencyGroupIdAndArtifactIdTest.providedDependencyManagedByLocalParentDoesNotGetExplicitVersion` (multi-module parent/child, `provided` scope).
- Full `:rewrite-maven:test` suite passes.