### PR TITLE
C#: Preserve raw XML doc comments in CSharpVisitor.visitSpace

### DIFF
--- a/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/CSharpRecipeTest.java
+++ b/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/CSharpRecipeTest.java
@@ -15,20 +15,25 @@
  */
 package org.openrewrite.csharp;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.SourceFile;
 import org.openrewrite.csharp.rpc.CSharpRewriteRpc;
 import org.openrewrite.csharp.tree.Cs;
+import org.openrewrite.csharp.tree.CsDocCommentRawComment;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.*;
 import org.openrewrite.java.search.FindMethods;
 import org.openrewrite.java.search.FindTypes;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
@@ -41,10 +46,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.csharp.Assertions.csharp;
 import static org.openrewrite.csharp.Assertions.csproj;
+import static org.openrewrite.test.RewriteTest.toRecipe;
 
 @Timeout(value = 120, unit = TimeUnit.SECONDS)
 class CSharpRecipeTest implements RewriteTest {
@@ -134,6 +141,21 @@ class CSharpRecipeTest implements RewriteTest {
         return rpc.parseSolution(csproj, tempDir, new InMemoryExecutionContext()).toList();
     }
 
+    private static Cs.CompilationUnit parseSingleCs(CSharpRewriteRpc rpc, String source) throws IOException {
+        Path tempDir = Files.createTempDirectory("csharp-recipe-test-");
+        try (OutputStream os = Files.newOutputStream(tempDir.resolve("Test.cs"))) {
+            os.write(source.getBytes(StandardCharsets.UTF_8));
+        }
+        Path csproj = tempDir.resolve("Test.csproj");
+        try (OutputStream os = Files.newOutputStream(csproj)) {
+            os.write(("<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n" +
+              "    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>\n")
+              .getBytes(StandardCharsets.UTF_8));
+        }
+        return (Cs.CompilationUnit) rpc.parseSolution(csproj, tempDir, new InMemoryExecutionContext())
+          .filter(f -> f instanceof Cs.CompilationUnit).toList().getFirst();
+    }
+
     private static J.MethodInvocation findFirstMethodInvocation(Object tree) {
         if (tree instanceof J.MethodInvocation mi) {
             return mi;
@@ -185,30 +207,88 @@ class CSharpRecipeTest implements RewriteTest {
 
     @Test
     void structuredDocCommentSurvivesPrintRoundTrip() throws Exception {
-        // A CSharpVisitor pass converts the raw doc comment into a structured CsDocComment tree.
-        // When the modified tree is printed (serialized back to the C# side), the structured
-        // comment is decomposed over RPC and the C# side must re-flatten it to text without
-        // failing to map the type (e.g. "Unexpected comment type ...$DocComment").
         String source = "class Foo {\n    /// <summary>Does <c>x</c>.</summary>\n    void Test() {\n    }\n}\n";
         CSharpRewriteRpc rpc = CSharpRewriteRpc.getOrStart();
-        Path tempDir = Files.createTempDirectory("csharp-doc-test-");
-        try (OutputStream os = Files.newOutputStream(tempDir.resolve("Test.cs"))) {
-            os.write(source.getBytes(StandardCharsets.UTF_8));
-        }
-        Path csproj = tempDir.resolve("Test.csproj");
-        try (OutputStream os = Files.newOutputStream(csproj)) {
-            os.write(("<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n" +
-              "    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>\n")
-              .getBytes(StandardCharsets.UTF_8));
-        }
-        SourceFile sf = rpc.parseSolution(csproj, tempDir, new InMemoryExecutionContext())
-          .filter(f -> f instanceof Cs.CompilationUnit).toList().getFirst();
+        Cs.CompilationUnit sf = parseSingleCs(rpc, source);
 
-        SourceFile modified = (SourceFile) new CSharpIsoVisitor<InMemoryExecutionContext>()
-          .visit(sf, new InMemoryExecutionContext());
+        SourceFile modified = (SourceFile) new CSharpIsoVisitor<InMemoryExecutionContext>() {
+            @Override
+            public Space visitSpace(@Nullable Space space, Space.Location loc, InMemoryExecutionContext ctx) {
+                if (space == null || space.getComments().isEmpty()) {
+                    return space;
+                }
+                return space.withComments(ListUtils.map(space.getComments(), c ->
+                  c instanceof CsDocCommentRawComment ? CsDocCommentParser.parse((CsDocCommentRawComment) c) : c));
+            }
+        }.visit(sf, new InMemoryExecutionContext());
 
+        assertThat(modified).as("Forced doc comment conversion should modify the tree").isNotSameAs(sf);
         String printed = rpc.print(modified);
         assertThat(printed).contains("<summary>Does <c>x</c>.</summary>");
+    }
+
+    @Test
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2696")
+    void noOpVisitorReturnsIdenticalTreeWhenDocCommentsPresent() throws Exception {
+        String source = "class Foo {\n    /// <summary>Does <c>x</c>. See <see cref=\"System.Math\"/>.</summary>\n    void Test() {\n    }\n}\n";
+        CSharpRewriteRpc rpc = CSharpRewriteRpc.getOrStart();
+        Cs.CompilationUnit sf = parseSingleCs(rpc, source);
+
+        SourceFile visited = (SourceFile) new CSharpIsoVisitor<InMemoryExecutionContext>()
+          .visit(sf, new InMemoryExecutionContext());
+
+        assertThat(visited).isSameAs(sf);
+    }
+
+    @Test
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2696")
+    void readOnlyRecipeLeavesXmlDocCommentsUnchanged() {
+        rewriteRun(
+          spec -> spec
+            .recipe(toRecipe(() -> new JavaIsoVisitor<>()))
+            .typeValidationOptions(TypeValidation.builder()
+              .allowNonWhitespaceInWhitespace(true)
+              .build()),
+          csharp(
+            """
+              /// <summary>
+              /// A simple calculator. See <see cref="System.Math"/>.
+              /// </summary>
+              public class Calculator
+              {
+                  /// <summary>
+                  /// Adds two numbers together.
+                  /// </summary>
+                  /// <param name="left">The left operand.</param>
+                  /// <param name="right">The right operand.</param>
+                  /// <returns>The sum of the two operands.</returns>
+                  public int Add(int left, int right) => left + right;
+
+                  /// <summary>
+                  /// Returns the first item.
+                  /// </summary>
+                  /// <typeparam name="T">The element type.</typeparam>
+                  /// <param name="items">The source list.</param>
+                  public T First<T>(System.Collections.Generic.IList<T> items) => items[0];
+              }
+              """,
+            s -> s.afterRecipe(cu -> {
+                AtomicBoolean foundRawDocComment = new AtomicBoolean();
+                new CSharpIsoVisitor<AtomicBoolean>() {
+                    @Override
+                    public Space visitSpace(@Nullable Space space, Space.Location loc, AtomicBoolean found) {
+                        if (space != null && space.getComments().stream().anyMatch(CsDocCommentRawComment.class::isInstance)) {
+                            found.set(true);
+                        }
+                        return space;
+                    }
+                }.visit(cu, foundRawDocComment);
+                assertThat(foundRawDocComment)
+                  .as("XML doc comments should be parsed as CsDocCommentRawComment and survive a read-only recipe run")
+                  .isTrue();
+            })
+          )
+        );
     }
 
     @Test

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/CSharpVisitor.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/CSharpVisitor.java
@@ -57,7 +57,8 @@ public class CSharpVisitor<P> extends JavaVisitor<P>
             if (comment instanceof CsDocCommentRawComment) {
                 // Convert raw doc comment from RPC into structured tree, then visit
                 CsDocComment.DocComment parsed = CsDocCommentParser.parse((CsDocCommentRawComment) comment);
-                return visitCsDocCommentComment(parsed, p);
+                Comment visited = visitCsDocCommentComment(parsed, p);
+                return visited == parsed ? comment : visited;
             } else if (comment instanceof CsDocComment.DocComment) {
                 return visitCsDocCommentComment((CsDocComment.DocComment) comment, p);
             }

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/CSharpVisitor.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/CSharpVisitor.java
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * -------------------THIS FILE IS AUTO GENERATED--------------------------
- * Changes to this file may cause incorrect behavior and will be lost if
- * the code is regenerated.
-*/
-
 package org.openrewrite.csharp;
 
 import org.jspecify.annotations.Nullable;

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/CSharpVisitorDocCommentIdentityTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/CSharpVisitorDocCommentIdentityTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Cursor;
+import org.openrewrite.Issue;
+import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.csharp.tree.CsDocComment;
+import org.openrewrite.csharp.tree.CsDocCommentRawComment;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Issue("https://github.com/moderneinc/customer-requests/issues/2696")
+class CSharpVisitorDocCommentIdentityTest {
+
+    private static final String DOC_TEXT = "/ <summary>\n" +
+                                           "/// Adds two numbers together. See <see cref=\"System.Math\"/>.\n" +
+                                           "/// </summary>\n" +
+                                           "/// <param name=\"left\">The left operand.</param>";
+
+    private static Space spaceWithComment(Comment comment) {
+        return Space.build("\n    ", List.of(comment));
+    }
+
+    @Test
+    void noOpVisitReturnsIdenticalSpaceForRawDocComment() {
+        Space space = spaceWithComment(new CsDocCommentRawComment(DOC_TEXT, "\n    ", Markers.EMPTY));
+
+        Space visited = new CSharpIsoVisitor<Integer>().visitSpace(space, Space.Location.ANY, 0);
+
+        assertThat(visited).isSameAs(space);
+    }
+
+    @Test
+    void noOpVisitReturnsIdenticalSpaceForStructuredDocComment() {
+        CsDocComment.DocComment parsed = CsDocCommentParser.parse(
+                new CsDocCommentRawComment(DOC_TEXT, "\n    ", Markers.EMPTY));
+        Space space = spaceWithComment(parsed);
+
+        Space visited = new CSharpIsoVisitor<Integer>().visitSpace(space, Space.Location.ANY, 0);
+
+        assertThat(visited).isSameAs(space);
+    }
+
+    @Test
+    void modifyingVisitStillReplacesRawCommentWithStructuredTree() {
+        Space space = spaceWithComment(new CsDocCommentRawComment(DOC_TEXT, "\n    ", Markers.EMPTY));
+        CSharpVisitor<Integer> visitor = new CSharpVisitor<>() {
+            @Override
+            protected CsDocCommentVisitor<Integer> getCsDocCommentVisitor() {
+                return new CsDocCommentVisitor<>(this) {
+                    @Override
+                    public CsDocComment visitXmlText(CsDocComment.XmlText text, Integer p) {
+                        return text.withText(text.getText().replace("Adds", "Sums"));
+                    }
+                };
+            }
+        };
+
+        Space visited = visitor.visitSpace(space, Space.Location.ANY, 0);
+
+        assertThat(visited).isNotSameAs(space);
+        Comment comment = visited.getComments().get(0);
+        assertThat(comment).isInstanceOf(CsDocComment.DocComment.class);
+        PrintOutputCapture<Integer> out = new PrintOutputCapture<>(0);
+        new CsDocCommentPrinter<Integer>().visit((CsDocComment.DocComment) comment, out, new Cursor(null, Cursor.ROOT_VALUE));
+        assertThat(out.getOut()).contains("Sums two numbers together");
+    }
+}


### PR DESCRIPTION
## What's wrong?

`CSharpVisitor.visitSpace` eagerly replaced every `CsDocCommentRawComment` (as delivered by the RPC parser) with a freshly parsed structured `CsDocComment.DocComment` on *every* traversal. This made any read-only recipe return a modified tree for any C# file containing XML doc comments — the file registered as changed and reprinted lossily over RPC, dropping the XML attribute *values*:

```
-/// <param name="left">The left operand.</param>   -/// <see cref="System.Math"/>
+/// <param name>The left operand.</param>           +/// <see cref/>
```

Because `Cs.CompilationUnit implements JavaSourceFile`, plain `JavaIsoVisitor`-based recipes hit this too — which is how it surfaced (a Prethink run over C# code produced spurious diffs).

## What's the fix?

Keep the original raw comment when visiting the parsed tree leaves it unchanged (`visited == parsed`), only substituting the structured tree when a visitor actually modified it. `CsDocCommentVisitor` is identity-preserving (`ListUtils.map`/`withX`), so the guard holds for every read-only visitor — the same identity contract as the `JRightPadded` check already in this file.

## Anything else?

- Unit coverage (`CSharpVisitorDocCommentIdentityTest`, no .NET SDK needed): no-op visit returns the identical `Space` for both raw and structured doc comments; a modifying visit still swaps in the structured tree.
- RPC/integ coverage (`CSharpRecipeTest`): a read-only `JavaIsoVisitor` over the issue's exact sample leaves the source unchanged; tree identity is preserved; the structured-tree RPC print path is still exercised by an explicit conversion.

- Fixes moderneinc/customer-requests#2696