### PR TITLE
Deduplicating codec for `RecipesThatMadeChanges`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/RecipesThatMadeChanges.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/RecipesThatMadeChanges.java
@@ -18,15 +18,25 @@ package org.openrewrite.marker;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.With;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.Recipe;
 import org.openrewrite.Tree;
+import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.internal.ObjectMappers;
+import org.openrewrite.rpc.RpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
 
+import java.time.Duration;
 import java.util.*;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 
 @Value
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @With
-public class RecipesThatMadeChanges implements Marker {
+public class RecipesThatMadeChanges implements Marker, RpcCodec<RecipesThatMadeChanges> {
     @EqualsAndHashCode.Include
     UUID id;
 
@@ -36,5 +46,130 @@ public class RecipesThatMadeChanges implements Marker {
         List<List<Recipe>> recipeStackList = new ArrayList<>(1);
         recipeStackList.add(recipeStack);
         return new RecipesThatMadeChanges(Tree.randomId(), recipeStackList);
+    }
+
+    @Override
+    public void rpcSend(RecipesThatMadeChanges after, RpcSendQueue q) {
+        q.getAndSend(after, RecipesThatMadeChanges::getId);
+        q.getAndSendListAsRef(after, r -> WireForm.from(r).recipeTable, System::identityHashCode, null);
+        q.getAndSend(after, r -> WireForm.from(r).stacks);
+    }
+
+    @Override
+    public RecipesThatMadeChanges rpcReceive(RecipesThatMadeChanges before, RpcReceiveQueue q) {
+        UUID id = q.receive(before.getId(), null);
+        WireForm beforeWire = WireForm.from(before);
+        List<Object> recipeTable = q.receiveList(beforeWire.recipeTable, null);
+        List<List<Integer>> stacks = q.receive(beforeWire.stacks, null);
+        List<Recipe> recipesById = new ArrayList<>(recipeTable.size());
+        for (Object recipe : recipeTable) {
+            recipesById.add(SnapshotRecipe.from(recipe));
+        }
+
+        List<List<Recipe>> recipes = new ArrayList<>(stacks.size());
+        for (List<Integer> stack : stacks) {
+            List<Recipe> recipeStack = new ArrayList<>(stack.size());
+            for (Integer recipeIndex : stack) {
+                recipeStack.add(recipesById.get(recipeIndex));
+            }
+            recipes.add(recipeStack);
+        }
+        return new RecipesThatMadeChanges(id, recipes);
+    }
+
+    private static class WireForm {
+        final List<Object> recipeTable = new ArrayList<>();
+        final List<List<Integer>> stacks = new ArrayList<>();
+        final IdentityHashMap<Recipe, Integer> recipeIds = new IdentityHashMap<>();
+
+        static WireForm from(@Nullable RecipesThatMadeChanges marker) {
+            WireForm wire = new WireForm();
+            if (marker == null || marker.getRecipes() == null) {
+                return wire;
+            }
+
+            for (List<Recipe> stack : marker.getRecipes()) {
+                List<Integer> stackIds = new ArrayList<>(stack.size());
+                for (Recipe recipe : stack) {
+                    Integer id = wire.recipeIds.get(recipe);
+                    if (id == null) {
+                        id = wire.recipeTable.size();
+                        wire.recipeIds.put(recipe, id);
+                        wire.recipeTable.add(recipe instanceof SnapshotRecipe ?
+                                ((SnapshotRecipe) recipe).getWireValue() : recipe);
+                    }
+                    stackIds.add(id);
+                }
+                wire.stacks.add(stackIds);
+            }
+            return wire;
+        }
+    }
+
+    static class SnapshotRecipe extends Recipe {
+        private final Object wireValue;
+        private final RecipeDescriptor descriptor;
+
+        private SnapshotRecipe(Object wireValue, RecipeDescriptor descriptor) {
+            this.wireValue = wireValue;
+            this.descriptor = descriptor;
+        }
+
+        Object getWireValue() {
+            return wireValue;
+        }
+
+        static Recipe from(Object wireValue) {
+            if (wireValue instanceof Recipe) {
+                return (Recipe) wireValue;
+            }
+            return new SnapshotRecipe(wireValue, descriptorFrom(wireValue));
+        }
+
+        @Override
+        public String getName() {
+            return descriptor.getName();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return descriptor.getDisplayName();
+        }
+
+        @Override
+        public String getDescription() {
+            return descriptor.getDescription();
+        }
+
+        @Override
+        public Set<String> getTags() {
+            return descriptor.getTags() == null ? emptySet() : descriptor.getTags();
+        }
+
+        @Override
+        public @Nullable Duration getEstimatedEffortPerOccurrence() {
+            return descriptor.getEstimatedEffortPerOccurrence();
+        }
+
+        @Override
+        public List<Recipe> getRecipeList() {
+            return emptyList();
+        }
+
+        @Override
+        protected RecipeDescriptor createRecipeDescriptor() {
+            return descriptor;
+        }
+
+        private static RecipeDescriptor descriptorFrom(Object wireValue) {
+            Object descriptorValue = wireValue;
+            if (wireValue instanceof Map) {
+                Object nestedDescriptor = ((Map<?, ?>) wireValue).get("descriptor");
+                if (nestedDescriptor != null) {
+                    descriptorValue = nestedDescriptor;
+                }
+            }
+            return ObjectMappers.propertyBasedMapper(null).convertValue(descriptorValue, RecipeDescriptor.class);
+        }
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/marker/RecipesThatMadeChangesTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marker/RecipesThatMadeChangesTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.marker;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Recipe;
+import org.openrewrite.rpc.RpcObjectData;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecipesThatMadeChangesTest {
+
+    @Test
+    void rpcCodecSendsRepeatedRecipesOnce() {
+        Recipe recipe = Recipe.noop();
+        RecipesThatMadeChanges marker = new RecipesThatMadeChanges(UUID.randomUUID(), List.of(
+          List.of(recipe, recipe),
+          List.of(recipe)
+        ));
+        RecipesThatMadeChanges marker2 = new RecipesThatMadeChanges(UUID.randomUUID(), List.of(
+          List.of(recipe)
+        ));
+
+        Deque<List<RpcObjectData>> batches = new ArrayDeque<>();
+        RpcSendQueue send = new RpcSendQueue(100, batches::addLast, new IdentityHashMap<>(), null, false);
+        send.send(marker, null, null);
+        send.send(marker2, null, null);
+        send.flush();
+
+        List<RpcObjectData> messages = batches.removeFirst();
+        assertThat(messages).hasSize(12);
+        assertThat(messages.get(0).getValueType()).isEqualTo(RecipesThatMadeChanges.class.getName());
+        assertThat((Object) messages.get(0).getValue()).isNull();
+
+        assertThat((Object) messages.get(2).getValue()).isNull();
+        assertThat((Object) messages.get(3).getValue()).isEqualTo(List.of(-1));
+        assertThat(messages.get(4).getValueType()).isEqualTo(recipe.getClass().getName());
+        assertThat(messages.get(4).getRef()).isNotNull();
+        assertThat((Object) messages.get(5).getValue()).isEqualTo(List.of(List.of(0, 0), List.of(0)));
+
+        assertThat((Object) messages.get(8).getValue()).isNull();
+        assertThat((Object) messages.get(9).getValue()).isEqualTo(List.of(-1));
+        assertThat(messages.get(10).getValueType()).isNull();
+        assertThat((Object) messages.get(10).getValue()).isNull();
+        assertThat(messages.get(10).getRef()).isEqualTo(messages.get(4).getRef());
+        assertThat((Object) messages.get(11).getValue()).isEqualTo(List.of(List.of(0)));
+
+        batches.addLast(messages);
+        RpcReceiveQueue receive = new RpcReceiveQueue(new HashMap<>(), batches::removeFirst, null, null);
+        RecipesThatMadeChanges roundTrip = receive.receive(null);
+        RecipesThatMadeChanges roundTrip2 = receive.receive(null);
+
+        List<List<Recipe>> recipes = new ArrayList<>(roundTrip.getRecipes());
+        assertThat(recipes).hasSize(2);
+        assertThat(recipes.get(0)).hasSize(2);
+        assertThat(recipes.get(1)).hasSize(1);
+        assertThat(recipes.get(0).get(0)).isSameAs(recipes.get(0).get(1));
+        assertThat(recipes.get(0).get(0)).isSameAs(recipes.get(1).get(0));
+        assertThat(new ArrayList<>(roundTrip2.getRecipes()).get(0).get(0)).isSameAs(recipes.get(0).get(0));
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipesThatMadeChanges.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipesThatMadeChanges.cs
@@ -32,7 +32,7 @@ public sealed class RecipesThatMadeChanges(Guid id, IList<IList<object?>> recipe
     {
         q.GetAndSend(after, m => m.Id);
         q.GetAndSendListAsRef(after, m => WireForm.From(m).RecipeTable,
-            RuntimeHelpers.GetHashCode, null);
+            recipe => RuntimeHelpers.GetHashCode(recipe), null);
         q.GetAndSend(after, m => WireForm.From(m).Stacks);
     }
 
@@ -41,7 +41,8 @@ public sealed class RecipesThatMadeChanges(Guid id, IList<IList<object?>> recipe
         var id = q.ReceiveAndGet<Guid, string>(before.Id, Guid.Parse);
         var beforeWire = WireForm.From(before);
         var recipeTable = q.ReceiveList(beforeWire.RecipeTable, null) ?? [];
-        var stacks = ToStacks(q.Receive<object>(beforeWire.Stacks) ?? []);
+        var stacksValue = q.Receive<object>(beforeWire.Stacks);
+        var stacks = ToStacks(stacksValue ?? new List<List<int>>());
 
         var recipes = new List<IList<object?>>(stacks.Count);
         foreach (var stack in stacks)

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipesThatMadeChanges.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipesThatMadeChanges.cs
@@ -13,19 +13,104 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-using Newtonsoft.Json;
+using System.Runtime.CompilerServices;
+using OpenRewrite.Core.Rpc;
 
 namespace OpenRewrite.Core;
 
 /// <summary>
 /// Marker that records which recipes made changes to a source file.
-/// This is an opaque marker — C# stores the raw recipe data without interpreting it.
+/// C# stores recipe payloads opaquely; the RPC codec interns repeated payloads.
 /// </summary>
-public sealed class RecipesThatMadeChanges : Marker
+public sealed class RecipesThatMadeChanges(Guid id, IList<IList<object?>> recipes)
+    : Marker, IRpcCodec<RecipesThatMadeChanges>, IEquatable<RecipesThatMadeChanges>
 {
-    [JsonProperty("id")]
-    public Guid Id { get; init; }
+    public Guid Id { get; } = id;
+    public IList<IList<object?>> Recipes { get; } = recipes;
 
-    [JsonProperty("recipes")]
-    public object? Recipes { get; init; }
+    public void RpcSend(RecipesThatMadeChanges after, RpcSendQueue q)
+    {
+        q.GetAndSend(after, m => m.Id);
+        q.GetAndSendListAsRef(after, m => WireForm.From(m).RecipeTable,
+            RuntimeHelpers.GetHashCode, null);
+        q.GetAndSend(after, m => WireForm.From(m).Stacks);
+    }
+
+    public RecipesThatMadeChanges RpcReceive(RecipesThatMadeChanges before, RpcReceiveQueue q)
+    {
+        var id = q.ReceiveAndGet<Guid, string>(before.Id, Guid.Parse);
+        var beforeWire = WireForm.From(before);
+        var recipeTable = q.ReceiveList(beforeWire.RecipeTable, null) ?? [];
+        var stacks = ToStacks(q.Receive<object>(beforeWire.Stacks) ?? []);
+
+        var recipes = new List<IList<object?>>(stacks.Count);
+        foreach (var stack in stacks)
+        {
+            var recipeStack = new List<object?>(stack.Count);
+            foreach (var recipeIndex in stack)
+            {
+                recipeStack.Add(recipeIndex < 0 ? null : recipeTable[recipeIndex]);
+            }
+            recipes.Add(recipeStack);
+        }
+        return new RecipesThatMadeChanges(id, recipes);
+    }
+
+    public bool Equals(RecipesThatMadeChanges? other) => other is not null && Id == other.Id;
+    public override bool Equals(object? obj) => Equals(obj as RecipesThatMadeChanges);
+    public override int GetHashCode() => Id.GetHashCode();
+
+    private sealed class WireForm
+    {
+        public List<object?> RecipeTable { get; } = [];
+        public List<List<int>> Stacks { get; } = [];
+        private readonly Dictionary<object, int> _recipeIds = new(ReferenceEqualityComparer.Instance);
+
+        public static WireForm From(RecipesThatMadeChanges? marker)
+        {
+            var wire = new WireForm();
+            if (marker?.Recipes == null)
+            {
+                return wire;
+            }
+
+            foreach (var stack in marker.Recipes)
+            {
+                var stackIds = new List<int>(stack.Count);
+                foreach (var recipe in stack)
+                {
+                    if (recipe == null)
+                    {
+                        stackIds.Add(-1);
+                        continue;
+                    }
+
+                    if (!wire._recipeIds.TryGetValue(recipe, out var recipeId))
+                    {
+                        recipeId = wire.RecipeTable.Count;
+                        wire._recipeIds[recipe] = recipeId;
+                        wire.RecipeTable.Add(recipe);
+                    }
+                    stackIds.Add(recipeId);
+                }
+                wire.Stacks.Add(stackIds);
+            }
+            return wire;
+        }
+    }
+
+    private static List<List<int>> ToStacks(object value)
+    {
+        if (value is List<List<int>> typed)
+        {
+            return typed;
+        }
+
+        if (value is IEnumerable<object?> outer)
+        {
+            return outer.Select(stack => ((IEnumerable<object?>)stack!).Select(Convert.ToInt32).ToList()).ToList();
+        }
+
+        return [];
+    }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/OpaqueRpcPayload.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/OpaqueRpcPayload.cs
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenRewrite.Core.Rpc;
+
+internal sealed class OpaqueRpcPayload(string javaType, object? value)
+{
+    public string JavaType { get; } = javaType;
+    public object? Value { get; } = value;
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
@@ -395,7 +395,12 @@ public class RpcReceiveQueue
     /// </summary>
     internal static T DeserializeInline<T>(string javaTypeName, object value)
     {
-        var type = FromJavaTypeName(javaTypeName) ?? typeof(T);
+        var type = FromJavaTypeName(javaTypeName);
+        if (type == null && typeof(T) == typeof(object))
+        {
+            return (T)(object)new OpaqueRpcPayload(javaTypeName, value);
+        }
+        type ??= typeof(T);
 
         // Enum types: parse the string value directly
         if (type.IsEnum)

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
@@ -61,6 +61,7 @@ public class RpcSendQueue
     /// </summary>
     private IRpcCodec? GetCodecFor(object val)
     {
+        if (val is OpaqueRpcPayload) return null;
         if (val is IRpcCodec selfCodec) return selfCodec;
         if (val is Marker) return null; // Markers without IRpcCodec are serialized as plain values
         if (_treeCodec != null && GetValueType(val) != null) return _treeCodec;
@@ -158,7 +159,7 @@ public class RpcSendQueue
             {
                 State = CHANGE,
                 ValueType = GetValueType(afterVal),
-                Value = onChange == null && afterCodec == null ? afterVal : null
+                Value = onChange == null && afterCodec == null ? InlineValue(afterVal) : null
             });
             DoChange(afterVal, beforeVal, onChange, afterCodec);
         }
@@ -259,7 +260,7 @@ public class RpcSendQueue
         {
             State = ADD,
             ValueType = GetValueType(afterVal),
-            Value = onChange == null && afterCodec == null ? afterVal : null,
+            Value = onChange == null && afterCodec == null ? InlineValue(afterVal) : null,
             Ref = refValue
         });
         DoChange(afterVal, null, onChange, afterCodec);
@@ -292,6 +293,7 @@ public class RpcSendQueue
     private static string? GetValueType(object? after)
     {
         if (after == null) return null;
+        if (after is OpaqueRpcPayload opaque) return opaque.JavaType;
 
         var type = after.GetType();
         if (type.IsPrimitive || type.IsArray ||
@@ -309,6 +311,9 @@ public class RpcSendQueue
 
         return ToJavaTypeName(type);
     }
+
+    private static object? InlineValue(object after) =>
+        after is OpaqueRpcPayload opaque ? opaque.Value : after;
 
     /// <summary>
     /// Maps a C# type to its equivalent Java type name for RPC protocol compatibility.
@@ -347,6 +352,7 @@ public class RpcSendQueue
             {
                 "Markers" => "org.openrewrite.marker.Markers",
                 "SearchResult" => "org.openrewrite.marker.SearchResult",
+                "RecipesThatMadeChanges" => "org.openrewrite.marker.RecipesThatMadeChanges",
                 "Markup" => "org.openrewrite.marker.Markup",
                 "Space" => "org.openrewrite.java.tree.Space",
                 "TextComment" => "org.openrewrite.java.tree.TextComment",

--- a/rewrite-go/pkg/rpc/marker_codec_test.go
+++ b/rewrite-go/pkg/rpc/marker_codec_test.go
@@ -137,3 +137,55 @@ func TestGoResolutionResultEmptyListsRoundTrip(t *testing.T) {
 		t.Errorf("ModulePath: want %q, got %q", "example.com/empty", got.ModulePath)
 	}
 }
+
+func TestRecipesThatMadeChangesMarkerRoundTripSharesRecipePayloads(t *testing.T) {
+	recipe := &opaqueRpcPayload{
+		JavaType: "org.openrewrite.rpc.RpcRecipe",
+		Value: map[string]any{
+			"descriptor": map[string]any{
+				"name":        "example.Recipe",
+				"displayName": "Example recipe",
+			},
+		},
+	}
+	firstID := uuid.MustParse("aaaaaaaa-1111-2222-3333-444444444444")
+	secondID := uuid.MustParse("bbbbbbbb-1111-2222-3333-444444444444")
+	first := java.RecipesThatMadeChanges{
+		Ident:   firstID,
+		Recipes: [][]any{{recipe, recipe}},
+	}
+	second := java.RecipesThatMadeChanges{
+		Ident:   secondID,
+		Recipes: [][]any{{recipe}},
+	}
+	before := java.Markers{ID: uuid.New(), Entries: []java.Marker{first, second}}
+
+	after := roundTripMarkers(t, before)
+	if len(after.Entries) != 2 {
+		t.Fatalf("entries: want 2, got %d", len(after.Entries))
+	}
+
+	gotFirst, ok := after.Entries[0].(java.RecipesThatMadeChanges)
+	if !ok {
+		t.Fatalf("first entry is %T, want java.RecipesThatMadeChanges", after.Entries[0])
+	}
+	gotSecond, ok := after.Entries[1].(java.RecipesThatMadeChanges)
+	if !ok {
+		t.Fatalf("second entry is %T, want java.RecipesThatMadeChanges", after.Entries[1])
+	}
+	if gotFirst.Ident != firstID {
+		t.Errorf("first Ident: want %s, got %s", firstID, gotFirst.Ident)
+	}
+	if gotSecond.Ident != secondID {
+		t.Errorf("second Ident: want %s, got %s", secondID, gotSecond.Ident)
+	}
+	if len(gotFirst.Recipes) != 1 || len(gotFirst.Recipes[0]) != 2 || len(gotSecond.Recipes) != 1 || len(gotSecond.Recipes[0]) != 1 {
+		t.Fatalf("unexpected recipe stack shape: first=%#v second=%#v", gotFirst.Recipes, gotSecond.Recipes)
+	}
+	if gotFirst.Recipes[0][0] != gotFirst.Recipes[0][1] {
+		t.Fatalf("first marker did not preserve shared recipe payload identity")
+	}
+	if gotFirst.Recipes[0][0] != gotSecond.Recipes[0][0] {
+		t.Fatalf("recipe payload identity was not shared across markers")
+	}
+}

--- a/rewrite-go/pkg/rpc/opaque_payload.go
+++ b/rewrite-go/pkg/rpc/opaque_payload.go
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+type opaqueRpcPayload struct {
+	JavaType string
+	Value    any
+}

--- a/rewrite-go/pkg/rpc/receive_queue.go
+++ b/rewrite-go/pkg/rpc/receive_queue.go
@@ -94,6 +94,10 @@ func (q *ReceiveQueue) Receive(before any, onChange func(any) any) any {
 					before = gm
 				}
 			}
+			if op, ok := before.(*opaqueRpcPayload); ok {
+				op.Value = msg.Value
+				before = op
+			}
 		}
 		if ref != nil {
 			// Store before deserialization to handle cycles
@@ -278,5 +282,5 @@ func newObj(javaClassName string) any {
 	if strings.Contains(javaClassName, "marker") || strings.Contains(javaClassName, "Marker") {
 		return java.GenericMarker{JavaType: javaClassName}
 	}
-	panic(fmt.Sprintf("no factory registered for type: %s", javaClassName))
+	return &opaqueRpcPayload{JavaType: javaClassName}
 }

--- a/rewrite-go/pkg/rpc/send_queue.go
+++ b/rewrite-go/pkg/rpc/send_queue.go
@@ -197,7 +197,13 @@ func (q *SendQueue) add(after any, onChange func(any)) {
 	vt := getValueType(afterVal)
 	var val any
 	skipDoChange := false
-	if gm, ok := afterVal.(java.GenericMarker); ok && !hasGenericMarkerCodec(gm.JavaType) {
+	if op, ok := afterVal.(*opaqueRpcPayload); ok {
+		if op.JavaType != "" {
+			vt = &op.JavaType
+		}
+		val = op.Value
+		skipDoChange = true
+	} else if gm, ok := afterVal.(java.GenericMarker); ok && !hasGenericMarkerCodec(gm.JavaType) {
 		// No RpcCodec on either side for this marker — inline the marker's
 		// data as the ADD message's Value so the receiver can reconstruct
 		// the typed instance. Skip sub-field dispatch, which would otherwise
@@ -305,6 +311,9 @@ func getValueType(v any) *string {
 	// GenericMarker carries the original Java class name
 	if gm, ok := v.(java.GenericMarker); ok && gm.JavaType != "" {
 		return &gm.JavaType
+	}
+	if op, ok := v.(*opaqueRpcPayload); ok && op.JavaType != "" {
+		return &op.JavaType
 	}
 	// Check padding types (Go generics have no reflect.Name())
 	return getValueTypeForPadding(v)

--- a/rewrite-go/pkg/rpc/space_rpc.go
+++ b/rewrite-go/pkg/rpc/space_rpc.go
@@ -40,6 +40,74 @@ func emptyAsNil(s string) any {
 	return s
 }
 
+func recipesThatMadeChangesWire(m java.RecipesThatMadeChanges) ([]any, []any) {
+	recipeTable := make([]any, 0)
+	stacks := make([]any, 0, len(m.Recipes))
+	recipeIds := make(map[uintptr]int)
+	wrapped := make(map[uintptr]*opaqueRpcPayload)
+
+	for _, stack := range m.Recipes {
+		stackIds := make([]any, 0, len(stack))
+		for _, recipe := range stack {
+			payload := recipeWirePayload(recipe, wrapped)
+			key := ptrKey(payload)
+			idx, ok := recipeIds[key]
+			if !ok {
+				idx = len(recipeTable)
+				recipeIds[key] = idx
+				recipeTable = append(recipeTable, payload)
+			}
+			stackIds = append(stackIds, idx)
+		}
+		stacks = append(stacks, stackIds)
+	}
+
+	return recipeTable, stacks
+}
+
+func recipeWirePayload(recipe any, wrapped map[uintptr]*opaqueRpcPayload) *opaqueRpcPayload {
+	if payload, ok := recipe.(*opaqueRpcPayload); ok {
+		return payload
+	}
+
+	if key := ptrKey(recipe); key != 0 {
+		if payload, ok := wrapped[key]; ok {
+			return payload
+		}
+		payload := &opaqueRpcPayload{Value: recipe}
+		wrapped[key] = payload
+		return payload
+	}
+
+	return &opaqueRpcPayload{Value: recipe}
+}
+
+func toIntStacks(v any) [][]int {
+	if v == nil {
+		return nil
+	}
+	rawStacks, ok := v.([]any)
+	if !ok {
+		if typed, ok := v.([][]int); ok {
+			return typed
+		}
+		return nil
+	}
+	stacks := make([][]int, len(rawStacks))
+	for i, rawStack := range rawStacks {
+		switch stack := rawStack.(type) {
+		case []any:
+			stacks[i] = make([]int, len(stack))
+			for j, rawIdx := range stack {
+				stacks[i][j] = toInt(rawIdx)
+			}
+		case []int:
+			stacks[i] = stack
+		}
+	}
+	return stacks
+}
+
 // Matches JavaSender.visitSpace field order: comments (list), whitespace.
 func sendSpace(s java.Space, q *SendQueue) {
 	q.GetAndSendList(s,
@@ -136,6 +204,7 @@ func hasGenericMarkerCodec(javaType string) bool {
 	switch javaType {
 	case "org.openrewrite.Checksum",
 		"org.openrewrite.FileAttributes",
+		"org.openrewrite.marker.RecipesThatMadeChanges",
 		"org.openrewrite.marker.Markup$Error",
 		"org.openrewrite.marker.Markup$Warn",
 		"org.openrewrite.marker.Markup$Info",
@@ -165,6 +234,19 @@ func sendMarkerCodecFields(v any, q *SendQueue) {
 		// SearchResult.rpcSend sends: id (UUID string), description (nullable string)
 		q.GetAndSend(m, func(x any) any { return x.(java.SearchResult).Ident.String() }, nil)
 		q.GetAndSend(m, func(x any) any { return x.(java.SearchResult).Description }, nil)
+	case java.RecipesThatMadeChanges:
+		q.GetAndSend(m, func(x any) any { return x.(java.RecipesThatMadeChanges).Ident.String() }, nil)
+		q.GetAndSendListAsRef(m,
+			func(x any) []any {
+				table, _ := recipesThatMadeChangesWire(x.(java.RecipesThatMadeChanges))
+				return table
+			},
+			func(x any) any { return x },
+			nil)
+		q.GetAndSend(m, func(x any) any {
+			_, stacks := recipesThatMadeChangesWire(x.(java.RecipesThatMadeChanges))
+			return stacks
+		}, nil)
 	case golang.GroupedImport:
 		// GroupedImport.rpcSend sends: id (UUID string), before whitespace (string)
 		q.GetAndSend(m, func(x any) any { return x.(golang.GroupedImport).Ident.String() }, nil)
@@ -336,6 +418,25 @@ func receiveMarkersCodec(q *ReceiveQueue, before java.Markers) java.Markers {
 			desc := q.Receive(m.Description, nil)
 			if desc != nil {
 				m.Description = desc.(string)
+			}
+			return m
+		case java.RecipesThatMadeChanges:
+			idStr := receiveScalar[string](q, m.Ident.String())
+			if idStr != "" {
+				if parsed, err := uuid.Parse(idStr); err == nil {
+					m.Ident = parsed
+				}
+			}
+			beforeTable, beforeStacks := recipesThatMadeChangesWire(m)
+			table := q.ReceiveList(beforeTable, nil)
+			stacksAny := q.Receive(beforeStacks, nil)
+			stacks := toIntStacks(stacksAny)
+			m.Recipes = make([][]any, len(stacks))
+			for i, stack := range stacks {
+				m.Recipes[i] = make([]any, len(stack))
+				for j, recipeIdx := range stack {
+					m.Recipes[i][j] = table[recipeIdx]
+				}
 			}
 			return m
 		case golang.GroupedImport:

--- a/rewrite-go/pkg/rpc/value_types.go
+++ b/rewrite-go/pkg/rpc/value_types.go
@@ -118,6 +118,7 @@ func init() {
 	RegisterValueType(reflect.TypeOf(golang.TrailingComma{}), "org.openrewrite.golang.marker.TrailingComma")
 	RegisterValueType(reflect.TypeOf(java.SearchResult{}), "org.openrewrite.marker.SearchResult")
 	RegisterValueType(reflect.TypeOf(java.ParseExceptionResult{}), "org.openrewrite.ParseExceptionResult")
+	RegisterValueType(reflect.TypeOf(java.RecipesThatMadeChanges{}), "org.openrewrite.marker.RecipesThatMadeChanges")
 	RegisterValueType(reflect.TypeOf(golang.Semicolon{}), "org.openrewrite.java.marker.Semicolon")
 	RegisterValueType(reflect.TypeOf(golang.GoProject{}), "org.openrewrite.golang.marker.GoProject")
 	RegisterValueType(reflect.TypeOf(golang.GoResolutionResult{}), "org.openrewrite.golang.marker.GoResolutionResult")
@@ -226,8 +227,9 @@ func init() {
 	RegisterFactory("org.openrewrite.FileAttributes", func() any { return java.GenericMarker{JavaType: "org.openrewrite.FileAttributes"} })
 
 	// Java-side markers that may appear when recipes modify trees or during LST writing.
+	// RecipesThatMadeChanges implements RpcCodec and interns repeated recipe payloads.
+	RegisterFactory("org.openrewrite.marker.RecipesThatMadeChanges", func() any { return java.RecipesThatMadeChanges{} })
 	// These markers do NOT implement RpcCodec and are serialized as raw values.
-	RegisterFactory("org.openrewrite.marker.RecipesThatMadeChanges", func() any { return java.GenericMarker{JavaType: "org.openrewrite.marker.RecipesThatMadeChanges"} })
 	RegisterFactory("org.openrewrite.marker.LstProvenance", func() any { return java.GenericMarker{JavaType: "org.openrewrite.marker.LstProvenance"} })
 	RegisterFactory("org.openrewrite.marker.BuildMetadata", func() any { return java.GenericMarker{JavaType: "org.openrewrite.marker.BuildMetadata"} })
 	RegisterFactory("org.openrewrite.marker.GitTreeEntry", func() any { return java.GenericMarker{JavaType: "org.openrewrite.marker.GitTreeEntry"} })

--- a/rewrite-go/pkg/tree/java/markers.go
+++ b/rewrite-go/pkg/tree/java/markers.go
@@ -46,6 +46,15 @@ type SearchResultMarker struct {
 
 func (m SearchResultMarker) ID() uuid.UUID { return m.Ident }
 
+// RecipesThatMadeChanges records recipe stacks that changed a source file.
+// Recipe payloads are intentionally opaque to Go and preserved for RPC round-trips.
+type RecipesThatMadeChanges struct {
+	Ident   uuid.UUID
+	Recipes [][]any
+}
+
+func (m RecipesThatMadeChanges) ID() uuid.UUID { return m.Ident }
+
 func FindMarker[T any](markers Markers) *T {
 	for _, m := range markers.Entries {
 		if t, ok := m.(T); ok {

--- a/rewrite-javascript/rewrite/src/markers.ts
+++ b/rewrite-javascript/rewrite/src/markers.ts
@@ -20,6 +20,7 @@ export const MarkersKind = {
     Markers: "org.openrewrite.marker.Markers",
     NamedStyles: "org.openrewrite.style.NamedStyles",
     SearchResult: "org.openrewrite.marker.SearchResult",
+    RecipesThatMadeChanges: "org.openrewrite.marker.RecipesThatMadeChanges",
     ParseExceptionResult: "org.openrewrite.ParseExceptionResult",
 
     // Markup markers for errors, warnings, info, and debug messages
@@ -134,6 +135,11 @@ export const emptyMarkers: Markers = asRef({
 export interface SearchResult extends Marker {
     readonly kind: typeof MarkersKind.SearchResult,
     readonly description?: string
+}
+
+export interface RecipesThatMadeChanges extends Marker {
+    readonly kind: typeof MarkersKind.RecipesThatMadeChanges,
+    readonly recipes: any[][]
 }
 
 export function foundSearchResult<T extends { markers: Markers }>(t: T, description?: string): T {

--- a/rewrite-javascript/rewrite/src/rpc/index.ts
+++ b/rewrite-javascript/rewrite/src/rpc/index.ts
@@ -15,7 +15,16 @@
  */
 import {Checksum, FileAttributes, TreeKind} from "../tree";
 import {RpcCodecs, RpcReceiveQueue, RpcSendQueue} from "./queue";
-import {Markers, MarkersKind, MarkupDebug, MarkupError, MarkupInfo, MarkupWarn, SearchResult} from "../markers";
+import {
+    Markers,
+    MarkersKind,
+    MarkupDebug,
+    MarkupError,
+    MarkupInfo,
+    MarkupWarn,
+    RecipesThatMadeChanges,
+    SearchResult
+} from "../markers";
 import {asRef} from "../reference";
 import {updateIfChanged} from "../util";
 
@@ -78,6 +87,29 @@ RpcCodecs.registerCodec(MarkersKind.Markers, {
     }
 });
 
+function recipesThatMadeChangesWire(marker: Partial<RecipesThatMadeChanges> | undefined): {
+    recipeTable: any[],
+    stacks: number[][]
+} {
+    const recipeTable: any[] = [];
+    const stacks: number[][] = [];
+    const recipeIds = new Map<any, number>();
+    for (const stack of marker?.recipes ?? []) {
+        const stackIds: number[] = [];
+        for (const recipe of stack) {
+            let recipeId = recipeIds.get(recipe);
+            if (recipeId === undefined) {
+                recipeId = recipeTable.length;
+                recipeIds.set(recipe, recipeId);
+                recipeTable.push(recipe);
+            }
+            stackIds.push(recipeId);
+        }
+        stacks.push(stackIds);
+    }
+    return {recipeTable, stacks};
+}
+
 // Register codecs for all Java markers with additional properties
 RpcCodecs.registerCodec(MarkersKind.SearchResult, {
     async rpcReceive(before: SearchResult, q: RpcReceiveQueue): Promise<SearchResult> {
@@ -90,6 +122,25 @@ RpcCodecs.registerCodec(MarkersKind.SearchResult, {
     async rpcSend(after: SearchResult, q: RpcSendQueue): Promise<void> {
         await q.getAndSend(after, a => a.id);
         await q.getAndSend(after, a => a.description);
+    }
+});
+
+RpcCodecs.registerCodec(MarkersKind.RecipesThatMadeChanges, {
+    async rpcReceive(before: RecipesThatMadeChanges, q: RpcReceiveQueue): Promise<RecipesThatMadeChanges> {
+        const beforeWire = recipesThatMadeChangesWire(before);
+        const id = await q.receive(before.id);
+        const recipeTable = (await q.receiveList(beforeWire.recipeTable)) ?? [];
+        const stacks = (await q.receive(beforeWire.stacks)) ?? [];
+        return updateIfChanged(before, {
+            id,
+            recipes: stacks.map(stack => stack.map(recipeIndex => recipeTable[recipeIndex])),
+        });
+    },
+
+    async rpcSend(after: RecipesThatMadeChanges, q: RpcSendQueue): Promise<void> {
+        await q.getAndSend(after, a => a.id);
+        await q.getAndSendList(after, a => recipesThatMadeChangesWire(a).recipeTable.map(recipe => asRef(recipe)), recipe => recipe);
+        await q.getAndSend(after, a => recipesThatMadeChangesWire(a).stacks);
     }
 });
 

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
@@ -35,6 +35,7 @@ import org.openrewrite.javascript.JavaScriptParser;
 import org.openrewrite.javascript.UpgradeDependencyVersion;
 import org.openrewrite.javascript.style.Autodetect;
 import org.openrewrite.marker.Markup;
+import org.openrewrite.marker.RecipesThatMadeChanges;
 import org.openrewrite.marketplace.RecipeBundle;
 import org.openrewrite.marketplace.RecipeBundleReader;
 import org.openrewrite.marketplace.RecipeBundleResolver;
@@ -174,6 +175,29 @@ class JavaScriptRewriteRpcTest implements RewriteTest {
           javascript(
             "const hello = 'world'",
             "const /*~~>*/hello = 'world'"
+          )
+        );
+    }
+
+    @Test
+    void printsChangedJavaScriptSourceWithRecipesThatMadeChangesMarker() {
+        installRecipes();
+        rewriteRun(
+          spec -> spec
+            .recipe(client().prepareRecipe("org.openrewrite.example.javascript.find-identifier",
+              Map.of("identifier", "hello"))),
+          javascript(
+            "const hello = 'world'",
+            "const /*~~>*/hello = 'world'",
+            spec -> spec.afterRecipe(cu -> {
+                RecipesThatMadeChanges marker = cu.getMarkers()
+                  .findFirst(RecipesThatMadeChanges.class)
+                  .orElseThrow(() -> new AssertionError("Expected RecipesThatMadeChanges marker"));
+                assertThat(marker.getRecipes().stream().flatMap(List::stream))
+                  .anyMatch(RpcRecipe.class::isInstance);
+
+                assertThat(client().print(cu)).isEqualTo("const /*~~>*/hello = 'world'");
+            })
           )
         );
     }

--- a/rewrite-python/rewrite/src/rewrite/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/__init__.py
@@ -91,6 +91,7 @@ __all__ = [
     'Marker',
     'Markers',
     'SearchResult',
+    'RecipesThatMadeChanges',
     'Markup',
     'MarkupWarn',
     'MarkupError',

--- a/rewrite-python/rewrite/src/rewrite/markers.py
+++ b/rewrite-python/rewrite/src/rewrite/markers.py
@@ -147,6 +147,16 @@ class SearchResult(Marker):
         return tree.replace(_markers=new_markers)
 
 
+@dataclass(frozen=True, eq=False, slots=True)
+class RecipesThatMadeChanges(Marker):
+    _id: UUID
+    _recipes: List[List[Any]]
+
+    @property
+    def recipes(self) -> List[List[Any]]:
+        return self._recipes
+
+
 class Markup(Marker, ABC):
     """
     Base class for markup markers that provide visual indicators (warnings, errors, info, debug).

--- a/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
@@ -1227,6 +1227,45 @@ def _receive_search_result(marker, q: RpcReceiveQueue):
     return SearchResult(_id=new_id, _description=description)
 
 
+def _recipes_that_made_changes_wire(marker):
+    recipe_table = []
+    stacks = []
+    recipe_ids = {}
+    if marker is None:
+        return recipe_table, stacks
+
+    for stack in marker.recipes or []:
+        stack_ids = []
+        for recipe in stack:
+            recipe_key = id(recipe)
+            recipe_id = recipe_ids.get(recipe_key)
+            if recipe_id is None:
+                recipe_id = len(recipe_table)
+                recipe_ids[recipe_key] = recipe_id
+                recipe_table.append(recipe)
+            stack_ids.append(recipe_id)
+        stacks.append(stack_ids)
+    return recipe_table, stacks
+
+
+def _receive_recipes_that_made_changes(marker, q: RpcReceiveQueue):
+    """Codec for receiving RecipesThatMadeChanges marker."""
+    from rewrite.markers import RecipesThatMadeChanges
+
+    before_id = id_to_str(marker._id) if marker is not None and marker._id is not None else None
+    id_str = q.receive(before_id)
+    before_recipe_table, before_stacks = _recipes_that_made_changes_wire(marker)
+    recipe_table = q.receive_list(before_recipe_table) or []
+    stacks = q.receive(before_stacks) or []
+
+    recipes = []
+    for stack in stacks:
+        recipes.append([recipe_table[int(recipe_index)] for recipe_index in stack])
+
+    new_id = id_to_int(id_str) if id_str else (marker._id if marker else None)
+    return RecipesThatMadeChanges(_id=new_id, _recipes=recipes)
+
+
 def _receive_parse_exception_result(marker, q: RpcReceiveQueue):
     """Codec for receiving ParseExceptionResult marker.
 
@@ -1260,6 +1299,13 @@ def _send_search_result(marker, q):
     """
     q.get_and_send(marker, lambda x: id_to_str(x._id))
     q.get_and_send(marker, lambda x: x.description)
+
+
+def _send_recipes_that_made_changes(marker, q):
+    """Codec for sending RecipesThatMadeChanges marker."""
+    q.get_and_send(marker, lambda x: id_to_str(x._id))
+    q.get_and_send_list_as_ref(marker, lambda x: _recipes_that_made_changes_wire(x)[0], id, None)
+    q.get_and_send(marker, lambda x: _recipes_that_made_changes_wire(x)[1])
 
 
 def _send_parse_exception_result(marker, q):
@@ -1727,7 +1773,7 @@ def _register_support_type_codecs():
 
 def _register_core_marker_codecs():
     """Register codecs for core marker types."""
-    from rewrite.markers import Markers, ParseExceptionResult, SearchResult
+    from rewrite.markers import Markers, ParseExceptionResult, RecipesThatMadeChanges, SearchResult
     from rewrite.rpc.receive_queue import (
         register_codec_with_both_names,
         make_dataclass_factory,
@@ -1748,6 +1794,14 @@ def _register_core_marker_codecs():
         _receive_search_result,
         make_dataclass_factory(SearchResult),
         sender=_send_search_result
+    )
+    # RecipesThatMadeChanges - full payload is preserved but repeated recipe payloads are interned
+    register_codec_with_both_names(
+        'org.openrewrite.marker.RecipesThatMadeChanges',
+        RecipesThatMadeChanges,
+        _receive_recipes_that_made_changes,
+        make_dataclass_factory(RecipesThatMadeChanges),
+        sender=_send_recipes_that_made_changes
     )
     # ParseExceptionResult - has specific fields to receive/send
     register_codec_with_both_names(

--- a/rewrite-python/rewrite/src/rewrite/rpc/receive_queue.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/receive_queue.py
@@ -49,6 +49,14 @@ class RpcObjectData(NamedTuple):
     trace: Optional[str] = None
 
 
+class OpaqueRpcPayload:
+    __slots__ = ('value_type', 'value')
+
+    def __init__(self, value_type: str, value: Any):
+        self.value_type = value_type
+        self.value = value
+
+
 class RpcReceiveQueue:
     """Queue for receiving and deserializing RpcObjectData from Java.
 
@@ -196,6 +204,8 @@ class RpcReceiveQueue:
             codec = self._get_codec(before)
             if codec is not None:
                 after = codec(before, self)
+            elif isinstance(before, OpaqueRpcPayload) and message.value is not None:
+                after = OpaqueRpcPayload(before.value_type, message.value)
             elif message.value is not None:
                 if message.value_type:
                     after = {'kind': message.value_type, **message.value} if isinstance(message.value, dict) else message.value
@@ -320,8 +330,7 @@ class RpcReceiveQueue:
         if factory is not None:
             return factory()
 
-        # Fallback: return a dict with kind field
-        return {'kind': value_type}
+        return OpaqueRpcPayload(value_type, None)
 
     def _get_codec(self, obj: Any) -> Optional[Callable[[Any, 'RpcReceiveQueue'], Any]]:
         """Get the deserializer codec for an object.
@@ -534,5 +543,4 @@ def make_dataclass_factory(cls):
         return factory
     else:
         return lambda: object.__new__(cls)
-
 

--- a/rewrite-python/rewrite/src/rewrite/rpc/send_queue.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/send_queue.py
@@ -268,9 +268,12 @@ class RpcSendQueue:
         # Import python_receiver to ensure codecs are registered before get_java_type_name
         from rewrite.rpc import python_receiver  # noqa: F401 - triggers codec registration
         from rewrite.rpc.receive_queue import get_java_type_name
+        from rewrite.rpc.receive_queue import OpaqueRpcPayload
 
         if obj is None:
             return None
+        if isinstance(obj, OpaqueRpcPayload):
+            return obj.value_type
 
         obj_type = type(obj)
 
@@ -316,8 +319,11 @@ class RpcSendQueue:
     def _get_primitive_value(self, obj: Any) -> Any:
         """Get the primitive value representation for serialization."""
         import math
+        from rewrite.rpc.receive_queue import OpaqueRpcPayload
         if obj is None:
             return None
+        if isinstance(obj, OpaqueRpcPayload):
+            return obj.value
         if isinstance(obj, bool):
             return obj
         if isinstance(obj, int):


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
