### PR TITLE
Fix MavenSettings value equality dropping LST-carried mirrors

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.maven;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.DelegatingExecutionContext;
 import org.openrewrite.ExecutionContext;
@@ -52,6 +54,8 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
     private static final String MAVEN_REPOSITORIES = "org.openrewrite.maven.repos";
     private static final String MAVEN_PINNED_SNAPSHOT_VERSIONS = "org.openrewrite.maven.pinnedSnapshotVersions";
     private static final String MAVEN_POM_CACHE = "org.openrewrite.maven.pomCache";
+    private static final String MAVEN_EFFECTIVE_SETTINGS_CACHE = "org.openrewrite.maven.effectiveSettingsCache";
+    private static final String MAVEN_MIRRORS_CACHE = "org.openrewrite.maven.mirrorsCache";
     private static final String MAVEN_ARTIFACT_CACHE = "org.openrewrite.maven.artifactCache";
     private static final String MAVEN_RESOLUTION_LISTENER = "org.openrewrite.maven.resolutionListener";
     private static final String MAVEN_RESOLUTION_TIME = "org.openrewrite.maven.resolutionTime";
@@ -103,6 +107,7 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
 
     public MavenExecutionContextView setMirrors(@Nullable Collection<MavenRepositoryMirror> mirrors) {
         putMessage(MAVEN_MIRRORS, mirrors);
+        putMessage(MAVEN_MIRRORS_CACHE, null);
         return this;
     }
 
@@ -112,15 +117,20 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
 
     /**
      * Get mirrors set on this execution context, unless overridden by a supplied maven settings file.
+     * Supplied settings take precedence: when they differ in value from the settings on this context,
+     * their mirrors replace (not merge with) the context's mirror list, including a list installed
+     * explicitly via {@link #setMirrors(Collection)}.
      *
      * @param mavenSettings The maven settings defining mirrors to use, if any.
      * @return The mirrors to use for dependency resolution.
      */
     public Collection<MavenRepositoryMirror> getMirrors(@Nullable MavenSettings mavenSettings) {
-        if (mavenSettings != null && !Objects.equals(mavenSettings, getSettings())) {
-            return mapMirrors(mavenSettings);
+        if (mavenSettings == null) {
+            return getMirrors();
         }
-        return getMirrors();
+        return this.<Collection<MavenRepositoryMirror>>getIdentityCache(MAVEN_MIRRORS_CACHE)
+                .get(mavenSettings, settings ->
+                        !Objects.equals(settings, getSettings()) ? mapMirrors(settings) : getMirrors());
     }
 
     public MavenExecutionContextView setCredentials(Collection<MavenRepositoryCredentials> credentials) {
@@ -312,6 +322,8 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
         }
 
         putMessage(MAVEN_SETTINGS, settings);
+        putMessage(MAVEN_EFFECTIVE_SETTINGS_CACHE, null);
+        putMessage(MAVEN_MIRRORS_CACHE, null);
         List<String> effectiveActiveProfiles = mapActiveProfiles(settings, activeProfiles);
         setActiveProfiles(effectiveActiveProfiles);
         setCredentials(mapCredentials(settings));
@@ -332,13 +344,26 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
      *
      */
     public @Nullable MavenSettings effectiveSettings(MavenResolutionResult mrr) {
-        MavenSettings effectiveSettings = getMessage(MAVEN_SETTINGS);
-        if (effectiveSettings == null) {
-            effectiveSettings = mrr.getMavenSettings();
-        } else {
-            effectiveSettings = effectiveSettings.merge(mrr.getMavenSettings());
+        MavenSettings contextSettings = getMessage(MAVEN_SETTINGS);
+        MavenSettings parsedSettings = mrr.getMavenSettings();
+        if (contextSettings == null) {
+            return parsedSettings;
         }
-        return effectiveSettings;
+        if (parsedSettings == null) {
+            return contextSettings;
+        }
+        // Recipes construct a downloader per visited tag, so memoize the merge per parsed-settings
+        // instance; returning a stable instance also lets getMirrors(MavenSettings) memoize.
+        return this.<MavenSettings>getIdentityCache(MAVEN_EFFECTIVE_SETTINGS_CACHE)
+                .get(parsedSettings, contextSettings::merge);
+    }
+
+    private <T> Cache<MavenSettings, T> getIdentityCache(String key) {
+        // Weak keys give identity comparison and let entries die with the settings instances they
+        // memoize for, so a long run over many repositories does not pin every parsed settings graph.
+        //noinspection unchecked
+        return (Cache<MavenSettings, T>) getMessages().computeIfAbsent(key,
+                k -> Caffeine.newBuilder().weakKeys().build());
     }
 
     private static List<String> mapActiveProfiles(MavenSettings settings, String... activeProfiles) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
@@ -40,6 +40,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import static java.util.Collections.emptyList;
@@ -217,6 +218,41 @@ public class MavenSettings {
         );
     }
 
+    /**
+     * Entries from {@code preferred} win over same-id entries from {@code other}, and duplicate ids
+     * within one side collapse to the last value at the first position, as Maven does. Entries without
+     * an id cannot be correlated, so both sides' are kept; merging two equal settings stays idempotent
+     * only through the equality short-circuit in {@link #merge(MavenSettings)}.
+     */
+    private static <T> List<T> mergeById(List<T> preferred, @Nullable List<T> other, Function<T, @Nullable String> id) {
+        List<T> merged = new ArrayList<>(preferred.size());
+        Map<String, Integer> indexOfId = new HashMap<>();
+        for (T t : preferred) {
+            String tId = id.apply(t);
+            Integer existing = tId == null ? null : indexOfId.get(tId);
+            if (existing != null) {
+                merged.set(existing, t);
+            } else {
+                if (tId != null) {
+                    indexOfId.put(tId, merged.size());
+                }
+                merged.add(t);
+            }
+        }
+        if (other != null) {
+            for (T t : other) {
+                String tId = id.apply(t);
+                if (tId == null || !indexOfId.containsKey(tId)) {
+                    if (tId != null) {
+                        indexOfId.put(tId, merged.size());
+                    }
+                    merged.add(t);
+                }
+            }
+        }
+        return merged;
+    }
+
     public List<RawRepositories.Repository> getActiveRepositories(Iterable<String> activeProfiles) {
         LinkedHashMap<String, RawRepositories.Repository> activeRepositories = new LinkedHashMap<>();
 
@@ -346,14 +382,8 @@ public class MavenSettings {
         List<Profile> profiles = emptyList();
 
         public Profiles merge(@Nullable Profiles profiles) {
-            final Map<String, Profile> merged = new LinkedHashMap<>();
-            for (Profile profile : this.profiles) {
-                merged.put(profile.id, profile);
-            }
-            if (profiles != null) {
-                profiles.getProfiles().forEach(profile -> merged.putIfAbsent(profile.getId(), profile));
-            }
-            return new Profiles(new ArrayList<>(merged.values()));
+            return new Profiles(
+                    mergeById(this.profiles, profiles == null ? null : profiles.getProfiles(), Profile::getId));
         }
     }
 
@@ -419,14 +449,7 @@ public class MavenSettings {
         List<Mirror> mirrors = emptyList();
 
         public Mirrors merge(@Nullable Mirrors mirrors) {
-            final Map<String, Mirror> merged = new LinkedHashMap<>();
-            for (Mirror mirror : this.mirrors) {
-                merged.put(mirror.id, mirror);
-            }
-            if (mirrors != null) {
-                mirrors.getMirrors().forEach(mirror -> merged.putIfAbsent(mirror.getId(), mirror));
-            }
-            return new Mirrors(new ArrayList<>(merged.values()));
+            return new Mirrors(mergeById(this.mirrors, mirrors == null ? null : mirrors.getMirrors(), Mirror::getId));
         }
     }
 
@@ -462,14 +485,7 @@ public class MavenSettings {
         List<Server> servers = emptyList();
 
         public Servers merge(@Nullable Servers servers) {
-            final Map<String, Server> merged = new LinkedHashMap<>();
-            for (Server server : this.servers) {
-                merged.put(server.id, server);
-            }
-            if (servers != null) {
-                servers.getServers().forEach(server -> merged.putIfAbsent(server.getId(), server));
-            }
-            return new Servers(new ArrayList<>(merged.values()));
+            return new Servers(mergeById(this.servers, servers == null ? null : servers.getServers(), Server::getId));
         }
     }
 
@@ -498,22 +514,7 @@ public class MavenSettings {
         List<Proxy> proxies = emptyList();
 
         public Proxies merge(@Nullable Proxies proxies) {
-            final Map<String, Proxy> merged = new LinkedHashMap<>();
-            int nullIndex = 0;
-            for (Proxy proxy : this.proxies) {
-                String key = proxy.id != null ? proxy.id : "__null_" + nullIndex++;
-                merged.put(key, proxy);
-            }
-            if (proxies != null) {
-                for (Proxy proxy : proxies.getProxies()) {
-                    if (proxy.getId() != null) {
-                        merged.putIfAbsent(proxy.getId(), proxy);
-                    } else {
-                        merged.put("__null_" + nullIndex++, proxy);
-                    }
-                }
-            }
-            return new Proxies(new ArrayList<>(merged.values()));
+            return new Proxies(mergeById(this.proxies, proxies == null ? null : proxies.getProxies(), Proxy::getId));
         }
     }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
@@ -47,26 +47,30 @@ import static org.openrewrite.maven.tree.MavenRepository.MAVEN_LOCAL_DEFAULT;
 
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 @ToString(onlyExplicitlyIncluded = true)
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Data
 @AllArgsConstructor
 @JacksonXmlRootElement(localName = "settings")
 public class MavenSettings {
     @Nullable
+    @ToString.Include
     String localRepository;
 
     @Nullable
     @NonFinal
     @JsonIgnore
+    @EqualsAndHashCode.Exclude
     MavenRepository mavenLocal;
 
     @Nullable
+    @ToString.Include
     Profiles profiles;
 
     @Nullable
+    @ToString.Include
     ActiveProfiles activeProfiles;
 
     @Nullable
+    @ToString.Include
     Mirrors mirrors;
 
     @Nullable
@@ -203,7 +207,7 @@ public class MavenSettings {
     }
 
     public MavenSettings merge(@Nullable MavenSettings installSettings) {
-        return installSettings == null ? this : new MavenSettings(
+        return installSettings == null || equals(installSettings) ? this : new MavenSettings(
                 localRepository == null ? installSettings.localRepository : localRepository,
                 profiles == null ? installSettings.profiles : profiles.merge(installSettings.profiles),
                 activeProfiles == null ? installSettings.activeProfiles : activeProfiles.merge(installSettings.activeProfiles),
@@ -332,6 +336,8 @@ public class MavenSettings {
     @FieldDefaults(level = AccessLevel.PRIVATE)
     @Getter
     @Setter
+    @EqualsAndHashCode
+    @ToString
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Profiles {
@@ -354,6 +360,8 @@ public class MavenSettings {
     @FieldDefaults(level = AccessLevel.PRIVATE)
     @Getter
     @Setter
+    @EqualsAndHashCode
+    @ToString
     @AllArgsConstructor
     @NoArgsConstructor
     public static class ActiveProfiles {
@@ -401,6 +409,8 @@ public class MavenSettings {
     @FieldDefaults(level = AccessLevel.PRIVATE)
     @Getter
     @Setter
+    @EqualsAndHashCode
+    @ToString
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Mirrors {
@@ -442,6 +452,7 @@ public class MavenSettings {
     @FieldDefaults(level = AccessLevel.PRIVATE)
     @Getter
     @Setter
+    @EqualsAndHashCode
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Servers {
@@ -478,6 +489,7 @@ public class MavenSettings {
     @FieldDefaults(level = AccessLevel.PRIVATE)
     @Getter
     @Setter
+    @EqualsAndHashCode
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Proxies {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawRepositories.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawRepositories.java
@@ -28,6 +28,8 @@ import static java.util.Collections.emptyList;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 @Getter
 @Setter
+@EqualsAndHashCode
+@ToString
 public class RawRepositories {
     @JacksonXmlProperty(localName = "repository")
     @JacksonXmlElementWrapper(useWrapping = false)
@@ -51,6 +53,7 @@ public class RawRepositories {
 
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode
+    @ToString
     @Getter
     public static class ArtifactPolicy {
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenCentralMirrorTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenCentralMirrorTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.intellij.lang.annotations.Language;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.HttpSenderExecutionContextView;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.Recipe;
+import org.openrewrite.ipc.http.HttpSender;
+import org.openrewrite.maven.internal.MavenPomDownloader;
+import org.openrewrite.maven.table.MavenMetadataFailures;
+import org.openrewrite.maven.trait.MavenDependency;
+import org.openrewrite.maven.tree.GroupArtifact;
+import org.openrewrite.maven.tree.MavenMetadata;
+import org.openrewrite.maven.tree.MavenRepository;
+import org.openrewrite.maven.tree.MavenResolutionResult;
+import org.openrewrite.semver.Semver;
+import org.openrewrite.semver.VersionComparator;
+import org.openrewrite.xml.tree.Xml;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the guarantee that a {@code <mirrorOf>central</mirrorOf>} (or {@code *}) mirror carried in an LST's
+ * {@link MavenResolutionResult#getMavenSettings()} redirects all resolution traffic to the mirror,
+ * including the implicitly added Maven Central, and that {@code repo.maven.apache.org} is never contacted.
+ * <p>
+ * In particular this guards the behavior fixed in <a href="https://github.com/openrewrite/rewrite/pull/4956">#4956</a>:
+ * Maven settings supplied on the {@link ExecutionContext} at recipe run time must be merged with, not
+ * replace, the settings captured in the LST at parse time.
+ */
+class MavenCentralMirrorTest {
+
+    private static final String MIRROR_URL = "https://artifacts.example.com/maven2";
+
+    @Language("xml")
+    private static final String POM = """
+      <project>
+          <modelVersion>4.0.0</modelVersion>
+          <groupId>com.mycompany.app</groupId>
+          <artifactId>my-app</artifactId>
+          <version>1</version>
+      </project>
+      """;
+
+    @Language("xml")
+    private static final String METADATA = """
+      <metadata>
+          <groupId>org.example.hermetic</groupId>
+          <artifactId>example-lib</artifactId>
+          <versioning>
+              <latest>1.1</latest>
+              <release>1.1</release>
+              <versions>
+                  <version>1.0</version>
+                  <version>1.1</version>
+              </versions>
+          </versioning>
+      </metadata>
+      """;
+
+    /**
+     * Serves canned metadata for any {@code maven-metadata.xml} request and records every requested URL,
+     * so tests can assert on which hosts resolution actually contacted without any real network access.
+     */
+    static class RecordingHttpSender implements HttpSender {
+        final List<String> requestedUrls = new CopyOnWriteArrayList<>();
+
+        @Override
+        public Response send(Request request) {
+            String url = request.getUrl().toString();
+            requestedUrls.add(url);
+            byte[] body = url.endsWith("maven-metadata.xml") ? METADATA.getBytes(StandardCharsets.UTF_8) : new byte[0];
+            return new Response(200, new ByteArrayInputStream(body), () -> {
+            });
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"central", "*"})
+    void lstMirrorHonoredWhenContextSettingsHaveNoMirror(String mirrorOf) throws MavenDownloadingException {
+        // At recipe run time settings are often supplied on the execution context, e.g. to carry
+        // credentials. Their presence must not discard the mirror captured in the LST (#4956).
+        MavenResolutionResult mrr = parsePomWith(settingsWithMirror(mirrorOf));
+        ExecutionContext ctx = runContext();
+        MavenExecutionContextView.view(ctx).setMavenSettings(settingsWithServerCredentialsOnly());
+
+        String newerVersion = findNewerVersion(mrr, ctx);
+
+        assertThat(newerVersion).isEqualTo("1.1");
+        assertOnlyMirrorContacted(ctx);
+    }
+
+    @Test
+    void lstMirrorHonoredWhenContextHasNoSettings() throws MavenDownloadingException {
+        MavenResolutionResult mrr = parsePomWith(settingsWithMirror("central"));
+        ExecutionContext ctx = runContext();
+
+        String newerVersion = findNewerVersion(mrr, ctx);
+
+        assertThat(newerVersion).isEqualTo("1.1");
+        assertOnlyMirrorContacted(ctx);
+    }
+
+    @Test
+    void implicitlyAddedCentralRedirectedToMirror() throws MavenDownloadingException {
+        // Even when no repository is supplied at all, the downloader implicitly adds Maven Central;
+        // that injected repository must also come out redirected to the mirror.
+        ExecutionContext ctx = runContext();
+        MavenPomDownloader downloader = new MavenPomDownloader(emptyMap(), ctx, settingsWithMirror("central"), null);
+
+        MavenRepository normalizedCentral = downloader.normalizeRepository(
+          MavenRepository.MAVEN_CENTRAL, MavenExecutionContextView.view(ctx), null);
+        assertThat(normalizedCentral).isNotNull();
+        assertThat(normalizedCentral.getUri()).startsWith(MIRROR_URL);
+        assertThat(normalizedCentral.getId()).isEqualTo("internal-mirror");
+
+        MavenMetadata metadata = downloader.downloadMetadata(
+          new GroupArtifact("org.example.hermetic", "example-lib"), null, emptyList());
+
+        assertThat(metadata.getVersioning().getVersions()).contains("1.0", "1.1");
+        assertOnlyMirrorContacted(ctx);
+    }
+
+    private static MavenSettings settingsWithMirror(String mirrorOf) {
+        //language=xml
+        return requireNonNull(MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"), """
+          <settings>
+              <mirrors>
+                  <mirror>
+                      <id>internal-mirror</id>
+                      <url>%s</url>
+                      <mirrorOf>%s</mirrorOf>
+                  </mirror>
+              </mirrors>
+          </settings>
+          """.formatted(MIRROR_URL, mirrorOf)), throwingContext()));
+    }
+
+    private static MavenSettings settingsWithServerCredentialsOnly() {
+        //language=xml
+        return requireNonNull(MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"), """
+          <settings>
+              <servers>
+                  <server>
+                      <id>internal-mirror</id>
+                      <username>ci</username>
+                      <password>secret</password>
+                  </server>
+              </servers>
+          </settings>
+          """), throwingContext()));
+    }
+
+    /**
+     * Parses a pom with the given settings on the parsing context, as an LST producer would, and returns
+     * the resolution result marker carrying those settings.
+     */
+    private static MavenResolutionResult parsePomWith(MavenSettings settings) {
+        ExecutionContext parseCtx = parseContext(settings);
+        Xml.Document pom = (Xml.Document) MavenParser.builder().build()
+          .parse(parseCtx, POM)
+          .findFirst()
+          .orElseThrow();
+        RecordingHttpSender parseSender = (RecordingHttpSender)
+          HttpSenderExecutionContextView.view(parseCtx).getHttpSender();
+        assertThat(parseSender.requestedUrls).isEmpty();
+
+        MavenResolutionResult mrr = pom.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+        assertThat(requireNonNull(mrr.getMavenSettings()).getMirrors()).isNotNull();
+        return mrr;
+    }
+
+    private static ExecutionContext parseContext(MavenSettings settings) {
+        ExecutionContext parseCtx = runContext();
+        MavenExecutionContextView.view(parseCtx).setMavenSettings(settings);
+        return parseCtx;
+    }
+
+    private static ExecutionContext runContext() {
+        ExecutionContext ctx = throwingContext();
+        HttpSenderExecutionContextView.view(ctx).setHttpSender(new RecordingHttpSender());
+        // The local repository is consulted through the filesystem, invisible to the recording
+        // sender; disable it so the developer's ~/.m2 cannot influence results.
+        MavenExecutionContextView.view(ctx).setAddLocalRepository(false);
+        return ctx;
+    }
+
+    private static InMemoryExecutionContext throwingContext() {
+        return new InMemoryExecutionContext(t -> {
+            throw new RuntimeException(t);
+        });
+    }
+
+    private static @Nullable String findNewerVersion(MavenResolutionResult mrr, ExecutionContext ctx)
+      throws MavenDownloadingException {
+        VersionComparator latestRelease = requireNonNull(Semver.validate("latest.release", null).getValue());
+        return MavenDependency.findNewerVersion(
+          "org.example.hermetic", "example-lib", "1.0", mrr,
+          new MavenMetadataFailures(Recipe.noop()), latestRelease, ctx);
+    }
+
+    private static void assertOnlyMirrorContacted(ExecutionContext ctx) {
+        RecordingHttpSender sender = (RecordingHttpSender)
+          HttpSenderExecutionContextView.view(ctx).getHttpSender();
+        assertThat(sender.requestedUrls)
+          .as("all resolution traffic must be redirected to the mirror")
+          .allSatisfy(url -> assertThat(url).startsWith(MIRROR_URL))
+          .as("at least one metadata request must have reached the mirror")
+          .anySatisfy(url -> assertThat(url).endsWith("maven-metadata.xml"));
+    }
+}

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
@@ -911,6 +911,190 @@ class MavenSettingsTest {
               .hasFieldOrPropertyWithValue("username", "foo")
               .hasFieldOrPropertyWithValue("password", null);
         }
+
+        @Test
+        void keepsIdLessEntriesFromBothSides() {
+            var first = MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"),
+              //language=xml
+              """
+                <settings>
+                    <profiles>
+                        <profile>
+                            <repositories>
+                                <repository>
+                                    <id>first-repo</id>
+                                    <url>https://first.example.com/maven2</url>
+                                </repository>
+                            </repositories>
+                        </profile>
+                    </profiles>
+                    <mirrors>
+                        <mirror>
+                            <url>https://first.example.com/maven2</url>
+                            <mirrorOf>central</mirrorOf>
+                        </mirror>
+                    </mirrors>
+                    <servers>
+                        <server>
+                            <username>first</username>
+                            <password>secret</password>
+                        </server>
+                    </servers>
+                    <proxies>
+                        <proxy>
+                            <host>first-proxy.example.com</host>
+                        </proxy>
+                    </proxies>
+                </settings>
+                """
+            ), ctx);
+            var second = MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"),
+              //language=xml
+              """
+                <settings>
+                    <profiles>
+                        <profile>
+                            <repositories>
+                                <repository>
+                                    <id>second-repo</id>
+                                    <url>https://second.example.com/maven2</url>
+                                </repository>
+                            </repositories>
+                        </profile>
+                    </profiles>
+                    <mirrors>
+                        <mirror>
+                            <url>https://second.example.com/maven2</url>
+                            <mirrorOf>*</mirrorOf>
+                        </mirror>
+                    </mirrors>
+                    <servers>
+                        <server>
+                            <username>second</username>
+                            <password>secret</password>
+                        </server>
+                    </servers>
+                    <proxies>
+                        <proxy>
+                            <host>second-proxy.example.com</host>
+                        </proxy>
+                    </proxies>
+                </settings>
+                """
+            ), ctx);
+
+            var mergedSettings = first.merge(second);
+
+            assertThat(mergedSettings.getProfiles().getProfiles())
+              .extracting(p -> p.getRepositories().getRepositories().getFirst().getId())
+              .containsExactly("first-repo", "second-repo");
+            assertThat(mergedSettings.getMirrors().getMirrors())
+              .extracting(MavenSettings.Mirror::getUrl)
+              .containsExactly("https://first.example.com/maven2", "https://second.example.com/maven2");
+            assertThat(mergedSettings.getServers().getServers())
+              .extracting(MavenSettings.Server::getUsername)
+              .containsExactly("first", "second");
+            assertThat(mergedSettings.getProxies().getProxies())
+              .extracting(MavenSettings.Proxy::getHost)
+              .containsExactly("first-proxy.example.com", "second-proxy.example.com");
+        }
+
+        @Test
+        void collapsesDuplicateIdsWithinOneSideToTheLastValue() {
+            var first = MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"),
+              //language=xml
+              """
+                <settings>
+                    <mirrors>
+                        <mirror>
+                            <id>duplicate</id>
+                            <url>https://stale.example.com/maven2</url>
+                            <mirrorOf>central</mirrorOf>
+                        </mirror>
+                        <mirror>
+                            <id>tail</id>
+                            <url>https://tail.example.com/maven2</url>
+                            <mirrorOf>*</mirrorOf>
+                        </mirror>
+                        <mirror>
+                            <id>duplicate</id>
+                            <url>https://effective.example.com/maven2</url>
+                            <mirrorOf>central</mirrorOf>
+                        </mirror>
+                    </mirrors>
+                    <servers>
+                        <server>
+                            <id>duplicate</id>
+                            <username>stale</username>
+                            <password>secret</password>
+                        </server>
+                        <server>
+                            <id>duplicate</id>
+                            <username>effective</username>
+                            <password>secret</password>
+                        </server>
+                    </servers>
+                </settings>
+                """
+            ), ctx);
+            var second = MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"),
+              //language=xml
+              """
+                <settings>
+                    <localRepository>/tmp/other-repo</localRepository>
+                </settings>
+                """
+            ), ctx);
+
+            var mergedSettings = first.merge(second);
+
+            assertThat(mergedSettings.getMirrors().getMirrors())
+              .extracting(MavenSettings.Mirror::getUrl)
+              .containsExactly("https://effective.example.com/maven2", "https://tail.example.com/maven2");
+            assertThat(mergedSettings.getServers().getServers())
+              .extracting(MavenSettings.Server::getUsername)
+              .containsExactly("effective");
+        }
+
+        @Test
+        void replacesProxiesWithMatchingIds() {
+            var first = MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"),
+              //language=xml
+              """
+                <settings>
+                    <proxies>
+                        <proxy>
+                            <id>corp</id>
+                            <host>preferred.example.com</host>
+                        </proxy>
+                    </proxies>
+                </settings>
+                """
+            ), ctx);
+            var second = MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"),
+              //language=xml
+              """
+                <settings>
+                    <proxies>
+                        <proxy>
+                            <id>corp</id>
+                            <host>other.example.com</host>
+                        </proxy>
+                        <proxy>
+                            <id>backup</id>
+                            <host>backup.example.com</host>
+                        </proxy>
+                    </proxies>
+                </settings>
+                """
+            ), ctx);
+
+            var mergedSettings = first.merge(second);
+
+            assertThat(mergedSettings.getProxies().getProxies())
+              .extracting(MavenSettings.Proxy::getHost)
+              .containsExactly("preferred.example.com", "backup.example.com");
+        }
     }
 
     /**

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
@@ -1048,4 +1048,103 @@ class MavenSettingsTest {
         assertThat(proxy.getPassword()).isEqualTo("proxypass");
         assertThat(proxy.getNonProxyHosts()).isEqualTo("localhost|*.example.com");
     }
+
+    /**
+     * {@link MavenExecutionContextView#getMirrors(MavenSettings)} decides whether supplied settings
+     * override those on the execution context by comparing them for equality, so {@link MavenSettings}
+     * must compare by value across all of its nested types.
+     */
+    @Nested
+    class Equality {
+        //language=xml
+        private final String settingsXml = """
+          <settings>
+              <localRepository>~/.m2/repository</localRepository>
+              <activeProfiles>
+                  <activeProfile>repo</activeProfile>
+              </activeProfiles>
+              <profiles>
+                  <profile>
+                      <id>repo</id>
+                      <activation>
+                          <activeByDefault>false</activeByDefault>
+                          <jdk>11</jdk>
+                          <property>
+                              <name>env</name>
+                              <value>ci</value>
+                          </property>
+                      </activation>
+                      <repositories>
+                          <repository>
+                              <id>internal</id>
+                              <url>https://artifacts.example.com/maven2</url>
+                              <snapshots>
+                                  <enabled>false</enabled>
+                              </snapshots>
+                          </repository>
+                      </repositories>
+                  </profile>
+              </profiles>
+              <mirrors>
+                  <mirror>
+                      <id>internal-mirror</id>
+                      <url>https://artifacts.example.com/maven2</url>
+                      <mirrorOf>central</mirrorOf>
+                  </mirror>
+              </mirrors>
+              <servers>
+                  <server>
+                      <id>internal-mirror</id>
+                      <username>ci</username>
+                      <password>secret</password>
+                      <configuration>
+                          <timeout>30000</timeout>
+                          <httpHeaders>
+                              <property>
+                                  <name>X-Custom</name>
+                                  <value>value</value>
+                              </property>
+                          </httpHeaders>
+                      </configuration>
+                  </server>
+              </servers>
+              <proxies>
+                  <proxy>
+                      <id>my-proxy</id>
+                      <host>proxy.example.com</host>
+                  </proxy>
+                  <proxy>
+                      <host>anonymous-proxy.example.com</host>
+                  </proxy>
+              </proxies>
+          </settings>
+          """;
+
+        private MavenSettings parse(String xml) {
+            MavenSettings settings = MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"), xml), ctx);
+            assertThat(settings).isNotNull();
+            return settings;
+        }
+
+        @Test
+        void equalWhenParsedFromSameDocument() {
+            assertThat(parse(settingsXml))
+              .isEqualTo(parse(settingsXml))
+              .hasSameHashCodeAs(parse(settingsXml));
+        }
+
+        @Test
+        void notEqualWhenMirrorsDiffer() {
+            MavenSettings withMirror = parse(settingsXml);
+            MavenSettings withoutMirror = parse(settingsXml.replaceAll("(?s)<mirrors>.*</mirrors>", ""));
+            assertThat(withMirror).isNotEqualTo(withoutMirror);
+        }
+
+        @Test
+        void lazyMavenLocalCacheDoesNotAffectEquality() {
+            MavenSettings primed = parse(settingsXml);
+            primed.getMavenLocal();
+            assertThat(primed).isEqualTo(parse(settingsXml));
+        }
+    }
 }


### PR DESCRIPTION
## What's changed?

`MavenSettings` and its nested types now compare by value. The class was annotated `@EqualsAndHashCode(onlyExplicitlyIncluded = true)` with no field included, so any two instances were equal and every instance had the same hash code, while the nested list-holder types compared by identity. The lazily computed `mavenLocal` cache field is excluded from equality, and `toString` now prints the non-credential fields.

`MavenSettings#merge` short-circuits on equal inputs and merges profiles, mirrors, servers, and proxies through one shared id-keyed helper, so entries without an id are no longer collapsed onto a single map key.

Since recipes construct a `MavenPomDownloader` per visited tag, `MavenExecutionContextView` now memoizes the effective settings and the mapped mirrors per parsed-settings instance (Caffeine, weak keys).

A new `MavenCentralMirrorTest` pins the guarantee that a `mirrorOf=central` (or `*`) mirror carried in an LST's `MavenResolutionResult#getMavenSettings()` redirects all metadata resolution to the mirror, including the implicitly added Maven Central repository and when the run-time `ExecutionContext` carries settings without any mirror, and that `repo.maven.apache.org` is never contacted. Equality and merge regression tests were added to `MavenSettingsTest`.

## What's your motivation?

- Organizations use `<mirrorOf>central</mirrorOf>` in their Maven settings to keep all dependency resolution on an internal repository manager, with public Maven Central often blocked at the network level. `MavenExecutionContextView#getMirrors(MavenSettings)` decides whether supplied settings override the mirrors on the execution context by comparing the two for equality. With the degenerate `equals`, that comparison always reported "same" whenever the context carried settings, so the mirrors of the effective settings computed per #4956 were silently discarded and resolution fell through to public Maven Central. In environments where Central is blocked this manifests as long connection timeouts while the recipe run otherwise appears to succeed.

## Anything in particular you'd like reviewers to focus on?

- Value-based equals/hashCode on these mutable Jackson-bound classes: an audit found no hash-keyed or equality-dependent consumer anywhere besides the `getMirrors` guard, which value equality makes behave as its javadoc describes. I'd appreciate a second opinion on that.
- `MavenSecuritySettings` and `RawGradleModule` carry the same annotation pattern but have no equality consumer today; they were left untouched to keep the change focused.

## Have you considered any alternatives or workarounds?

A reference-equality check in the `getMirrors` guard would fix the known call sites without touching `equals`, but it leaves the identity-blind equality in place for the next consumer to trip on.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases