### PR TITLE
Resolve with effective Maven settings in recipes

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -304,8 +304,7 @@ public class ChangeParentPom extends ScanningRecipe<ChangeParentPom.Accumulator>
                             Pom updatedPom = mrr.getPom().getRequested().withParent(updatedParentRef);
                             ResolvedPom updatedResolvedPom = mrr.getPom()
                                     .withRequested(updatedPom)
-                                    .resolve(ctx, new MavenPomDownloader(
-                                            mrr.getProjectPoms(), ctx, mrr.getMavenSettings(), mrr.getActiveProfiles()));
+                                    .resolve(ctx, MavenPomDownloader.forResolutionResult(mrr, ctx));
                             acc.updatedRootMarker = mrr.withPom(updatedResolvedPom);
                         }
                     } catch (MavenDownloadingException e) {
@@ -409,7 +408,7 @@ public class ChangeParentPom extends ScanningRecipe<ChangeParentPom.Accumulator>
                             }
 
                             // Retain managed versions from the old parent that are not managed in the new parent
-                            MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, mrr.getMavenSettings(), mrr.getActiveProfiles());
+                            MavenPomDownloader mpd = MavenPomDownloader.forResolutionResult(mrr, ctx);
                             ResolvedPom oldParent = mpd.download(new GroupArtifactVersion(currentGroupId, currentArtifactId, oldVersion), null, resolvedPom, resolvedPom.getRepositories())
                                     .resolve(emptyList(), mpd, ctx);
                             ResolvedPom newParent = mpd.download(new GroupArtifactVersion(targetGroupId, targetArtifactId, targetVersion.get()), null, resolvedPom, resolvedPom.getRepositories())

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
@@ -270,7 +270,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                 }
                 try {
                     GroupArtifactVersion parentGav = mrr.getPom().getRequested().getParent().getGav();
-                    MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, mrr.getMavenSettings(), mrr.getActiveProfiles());
+                    MavenPomDownloader mpd = MavenPomDownloader.forResolutionResult(mrr, ctx);
                     ResolvedPom parentPom = mpd.download(parentGav, null, mrr.getPom(), mrr.getPom().getRepositories())
                             .resolve(emptyList(), mpd, ctx);
                     ResolvedManagedDependency parentManagedVersion = parentPom.getDependencyManagement().stream()
@@ -320,7 +320,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                 }
                 try {
                     GroupArtifactVersion parentGav = mrr.getPom().getRequested().getParent().getGav();
-                    MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, mrr.getMavenSettings(), mrr.getActiveProfiles());
+                    MavenPomDownloader mpd = MavenPomDownloader.forResolutionResult(mrr, ctx);
                     ResolvedPom parentPom = mpd.download(parentGav, null, mrr.getPom(), mrr.getPom().getRepositories())
                             .resolve(emptyList(), mpd, ctx);
                     return parentPom.getPluginManagement().stream()

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantProperties.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantProperties.java
@@ -80,11 +80,7 @@ public class RemoveRedundantProperties extends Recipe {
                 MavenResolutionResult mrr = getResolutionResult();
                 Map<String, String> parentProperties;
                 if (mrr.getParent() == null) {
-                    MavenPomDownloader downloader = new MavenPomDownloader(
-                            mrr.getProjectPoms(),
-                            ctx,
-                            mrr.getMavenSettings(),
-                            mrr.getActiveProfiles());
+                    MavenPomDownloader downloader = MavenPomDownloader.forResolutionResult(mrr, ctx);
                     try {
                         // Resolve the external parent POM properties
                         parentProperties = mrr

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveUnusedProperties.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveUnusedProperties.java
@@ -179,8 +179,7 @@ public class RemoveUnusedProperties extends ScanningRecipe<RemoveUnusedPropertie
 
             private boolean parentHasProperty(MavenResolutionResult resolutionResult, String propertyName,
                                               ExecutionContext ctx) {
-                MavenPomDownloader downloader = new MavenPomDownloader(resolutionResult.getProjectPoms(), ctx,
-                        resolutionResult.getMavenSettings(), resolutionResult.getActiveProfiles());
+                MavenPomDownloader downloader = MavenPomDownloader.forResolutionResult(resolutionResult, ctx);
                 try {
                     ResolvedPom resolvedBarePom = resolutionResult.getPom().getRequested()
                             .withProperties(emptyMap())

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
@@ -195,7 +195,8 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
     }
 
     private MavenResolutionResult updateResult(ExecutionContext ctx, MavenResolutionResult resolutionResult, Map<Path, Pom> projectPoms) throws MavenDownloadingExceptions {
-        MavenPomDownloader downloader = new MavenPomDownloader(projectPoms, ctx, getResolutionResult().getMavenSettings(),
+        MavenPomDownloader downloader = new MavenPomDownloader(projectPoms, ctx,
+                MavenExecutionContextView.view(ctx).effectiveSettings(getResolutionResult()),
                 getResolutionResult().getActiveProfiles());
 
         try {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -90,6 +90,11 @@ public class MavenPomDownloader {
     private boolean addLocalRepository;
 
     /**
+     * Prefer {@link #forResolutionResult(MavenResolutionResult, ExecutionContext)} when resolving on
+     * behalf of an already-parsed source: settings passed here replace, rather than combine with, the
+     * settings on the execution context, so passing a resolution result's settings directly discards
+     * run-time configuration such as mirrors.
+     *
      * @param projectPoms    Other POMs in this project.
      * @param ctx            The execution context, which potentially contain Maven settings customization
      *                       and {@link HttpSender} customization.
@@ -106,6 +111,17 @@ public class MavenPomDownloader {
         this.mavenSettings = mavenSettings != null ? mavenSettings : MavenExecutionContextView.view(ctx).getSettings();
         this.mirrors = this.ctx.getMirrors(mavenSettings);
         this.activeProfiles = activeProfiles;
+    }
+
+    /**
+     * A downloader resolving further poms and metadata on behalf of a source that was already parsed,
+     * combining the Maven settings carried by its {@link MavenResolutionResult} with those on the execution
+     * context, so that both parse-time configuration (e.g. mirrors captured in the LST) and run-time
+     * configuration are honored.
+     */
+    public static MavenPomDownloader forResolutionResult(MavenResolutionResult mrr, ExecutionContext ctx) {
+        return new MavenPomDownloader(mrr.getProjectPoms(), ctx,
+                MavenExecutionContextView.view(ctx).effectiveSettings(mrr), mrr.getActiveProfiles());
     }
 
     /**

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindRepositoryOrder.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindRepositoryOrder.java
@@ -54,9 +54,10 @@ public class FindRepositoryOrder extends Recipe {
                 for (MavenRepository repository : mrr.getPom().getRepositories()) {
                     repositories.put(repository.getUri(), repository);
                 }
-                for (MavenRepository repository : MavenExecutionContextView.view(ctx)
+                MavenExecutionContextView mctx = MavenExecutionContextView.view(ctx);
+                for (MavenRepository repository : mctx
                         .getRepositories(
-                                mrr.getMavenSettings(),
+                                mctx.effectiveSettings(mrr),
                                 StreamSupport.stream(mrr.getPom().getActiveProfiles().spliterator(), false)
                                         .collect(toList())
                         )) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
@@ -96,7 +96,7 @@ public class ParentPomInsight extends Recipe {
                 }
 
                 MavenResolutionResult mrr = getResolutionResult();
-                MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, mrr.getMavenSettings(), mrr.getActiveProfiles());
+                MavenPomDownloader mpd = MavenPomDownloader.forResolutionResult(mrr, ctx);
 
                 Parent ancestor = mrr.getPom().getRequested().getParent();
                 String relativePath = tag.getChildValue("relativePath").orElse(null);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/trait/MavenDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/trait/MavenDependency.java
@@ -37,7 +37,6 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
 import static org.openrewrite.internal.StringUtils.matchesGlob;
@@ -87,12 +86,7 @@ public class MavenDependency implements Trait<Xml.Tag> {
             MavenMetadata mavenMetadata;
             try {
                 mavenMetadata = metadataFailures.insertRows(ctx, () -> new MavenPomDownloader(
-                        emptyMap(), ctx,
-                        settings,
-                        Optional.ofNullable(settings)
-                                .map(MavenSettings::getActiveProfiles)
-                                .map(MavenSettings.ActiveProfiles::getActiveProfiles)
-                                .orElse(null)
+                        emptyMap(), ctx, settings, mrr.getActiveProfiles()
                 ).downloadMetadata(new GroupArtifact(groupId, artifactId), null, mrr.getPom().getRepositories()));
             } catch (NumberFormatException e) {
                 // this can happen when we encounter exotic, non-semver version numbers
@@ -115,9 +109,9 @@ public class MavenDependency implements Trait<Xml.Tag> {
                         // This is a best effort attempt to see if the pom is there anyway, in spite of the
                         // fact that it's not in the metadata. Usually it won't be, only in situations like the
                         // MapR repository mentioned in the comment above will it be.
-                        Pom pom = new MavenPomDownloader(emptyMap(), ctx,
-                                mrr.getMavenSettings(), mrr.getActiveProfiles()).download(new GroupArtifactVersion(groupId, artifactId, ((ExactVersion) versionComparator).getVersion()),
-                                null, null, mrr.getPom().getRepositories());
+                        Pom pom = new MavenPomDownloader(emptyMap(), ctx, settings, mrr.getActiveProfiles())
+                                .download(new GroupArtifactVersion(groupId, artifactId, exactVersion),
+                                        null, null, mrr.getPom().getRepositories());
                         if (pom.getGav().getVersion().equals(exactVersion) &&
                             !exactVersion.equals(finalVersion) &&
                             versionComparator.compare(finalVersion, finalVersion, exactVersion) <= 0) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenDependencyPropertyUsageOverlap.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenDependencyPropertyUsageOverlap.java
@@ -112,7 +112,7 @@ public class MavenDependencyPropertyUsageOverlap {
             ResolvedPom currentResolved = current.getPom();
             remainingProperties = filterPropertiesWithOverlapInDependencies(remainingProperties, groupId, artifactId, currentResolved.getRequested(), currentResolved, configuredToChangeManagedDependency);
         }
-        MavenPomDownloader downloader = new MavenPomDownloader(current.getProjectPoms(), ctx);
+        MavenPomDownloader downloader = MavenPomDownloader.forResolutionResult(current, ctx);
         ResolvedPom currentResolved = current.getPom();
         while (currentResolved.getRequested().getParent() != null) {
             if (remainingProperties.isEmpty()) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenCentralMirrorTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenCentralMirrorTest.java
@@ -25,8 +25,10 @@ import org.openrewrite.HttpSenderExecutionContextView;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Parser;
 import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
 import org.openrewrite.ipc.http.HttpSender;
 import org.openrewrite.maven.internal.MavenPomDownloader;
+import org.openrewrite.maven.search.ParentPomInsight;
 import org.openrewrite.maven.table.MavenMetadataFailures;
 import org.openrewrite.maven.trait.MavenDependency;
 import org.openrewrite.maven.tree.GroupArtifact;
@@ -72,6 +74,30 @@ class MavenCentralMirrorTest {
       """;
 
     @Language("xml")
+    private static final String POM_WITH_PARENT = """
+      <project>
+          <modelVersion>4.0.0</modelVersion>
+          <parent>
+              <groupId>org.example.hermetic</groupId>
+              <artifactId>hermetic-parent</artifactId>
+              <version>1</version>
+          </parent>
+          <artifactId>my-app</artifactId>
+      </project>
+      """;
+
+    @Language("xml")
+    private static final String PARENT_POM = """
+      <project>
+          <modelVersion>4.0.0</modelVersion>
+          <groupId>org.example.hermetic</groupId>
+          <artifactId>hermetic-parent</artifactId>
+          <version>1</version>
+          <packaging>pom</packaging>
+      </project>
+      """;
+
+    @Language("xml")
     private static final String METADATA = """
       <metadata>
           <groupId>org.example.hermetic</groupId>
@@ -98,7 +124,14 @@ class MavenCentralMirrorTest {
         public Response send(Request request) {
             String url = request.getUrl().toString();
             requestedUrls.add(url);
-            byte[] body = url.endsWith("maven-metadata.xml") ? METADATA.getBytes(StandardCharsets.UTF_8) : new byte[0];
+            byte[] body;
+            if (url.endsWith("maven-metadata.xml")) {
+                body = METADATA.getBytes(StandardCharsets.UTF_8);
+            } else if (url.endsWith("hermetic-parent-1.pom")) {
+                body = PARENT_POM.getBytes(StandardCharsets.UTF_8);
+            } else {
+                body = new byte[0];
+            }
             return new Response(200, new ByteArrayInputStream(body), () -> {
             });
         }
@@ -128,6 +161,23 @@ class MavenCentralMirrorTest {
 
         assertThat(newerVersion).isEqualTo("1.1");
         assertOnlyMirrorContacted(ctx);
+    }
+
+    @Test
+    void recipeParentResolutionHonorsContextMirror() {
+        // The inverse direction: the LST was produced without any mirror, and the mirror is supplied
+        // on the execution context at recipe run time. A recipe resolving parent poms must route that
+        // traffic through the context's mirror rather than the settings captured in the LST.
+        Xml.Document pom = parsePomWithParent(settingsWithServerCredentialsOnly());
+        ExecutionContext ctx = runContext();
+        MavenExecutionContextView.view(ctx).setMavenSettings(settingsWithMirror("central"));
+
+        Tree after = new ParentPomInsight("com.example.nonexistent", "*", null, null).getVisitor().visit(pom, ctx);
+
+        assertThat(after)
+          .as("parent resolution must succeed (a download failure would attach a warning markup)")
+          .isSameAs(pom);
+        assertOnlyMirrorContacted(ctx, "hermetic-parent-1.pom");
     }
 
     @Test
@@ -199,6 +249,13 @@ class MavenCentralMirrorTest {
         return mrr;
     }
 
+    private static Xml.Document parsePomWithParent(MavenSettings settings) {
+        return (Xml.Document) MavenParser.builder().build()
+          .parse(parseContext(settings), POM_WITH_PARENT)
+          .findFirst()
+          .orElseThrow();
+    }
+
     private static ExecutionContext parseContext(MavenSettings settings) {
         ExecutionContext parseCtx = runContext();
         MavenExecutionContextView.view(parseCtx).setMavenSettings(settings);
@@ -229,12 +286,16 @@ class MavenCentralMirrorTest {
     }
 
     private static void assertOnlyMirrorContacted(ExecutionContext ctx) {
+        assertOnlyMirrorContacted(ctx, "maven-metadata.xml");
+    }
+
+    private static void assertOnlyMirrorContacted(ExecutionContext ctx, String expectedSuffix) {
         RecordingHttpSender sender = (RecordingHttpSender)
           HttpSenderExecutionContextView.view(ctx).getHttpSender();
         assertThat(sender.requestedUrls)
           .as("all resolution traffic must be redirected to the mirror")
           .allSatisfy(url -> assertThat(url).startsWith(MIRROR_URL))
-          .as("at least one metadata request must have reached the mirror")
-          .anySatisfy(url -> assertThat(url).endsWith("maven-metadata.xml"));
+          .as("the request for %s must have reached the mirror", expectedSuffix)
+          .anySatisfy(url -> assertThat(url).endsWith(expectedSuffix));
     }
 }


### PR DESCRIPTION
## What's changed?

Recipes that construct their own `MavenPomDownloader` (`UpdateMavenModel`, `ChangeParentPom`, `RemoveRedundantDependencyVersions`, `RemoveUnusedProperties`, `RemoveRedundantProperties`, `ParentPomInsight`, `MavenDependencyPropertyUsageOverlap`, and `MavenDependency`'s exact-version fallback) passed the raw LST-carried settings, or none at all, to the downloader. A new `MavenPomDownloader#forResolutionResult` factory combines the LST-carried settings with those on the execution context, and every such call site now uses it (or `effectiveSettings` directly where a caller-supplied project poms map is load-bearing). `FindRepositoryOrder` gets the same treatment on the `getRepositories` path.

A recipe-level test is added to `MavenCentralMirrorTest`: an LST produced without any mirror, resolved by a recipe under an execution context that carries one, must route all parent pom traffic through the context's mirror. The test fails if any converted call site regresses to passing raw LST settings.

## What's your motivation?

Mirrors and repositories supplied on the execution context at run time were silently ignored during parent pom, metadata, and repository-order resolution in these recipes: the settings argument of `MavenPomDownloader` replaces, rather than combines with, the settings on the execution context. `MavenVisitor` and `UpgradeDependencyVersion` already resolved with the effective settings; this aligns the remaining call sites and gives the pattern a single named entry point so the next recipe gets it right by default.

## Any additional context

- Builds on #8189, which makes the settings equality underlying `effectiveSettings` meaningful; the base branch is set accordingly and this PR should be retargeted or rebased once #8189 merges.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases