### PR TITLE
Serialize outgoing JS RPC messages without V8's 512MB string cap

### DIFF
--- a/rewrite-javascript/rewrite/src/rpc/message-encoder.ts
+++ b/rewrite-javascript/rewrite/src/rpc/message-encoder.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type {Message, MessageWriterOptions} from "vscode-jsonrpc/node";
+
+/**
+ * The content-type encoder shape vscode-jsonrpc's {@link MessageWriterOptions} accepts. Derived
+ * from the writer options rather than deep-imported, because the concrete `ContentTypeEncoder`
+ * type is not re-exported from the package entrypoint.
+ */
+export type JsonRpcContentTypeEncoder = NonNullable<MessageWriterOptions["contentTypeEncoder"]>;
+
+// Flush the accumulated JSON text to a Buffer once it reaches this many UTF-16 code units. This
+// keeps the transient string far below V8's ~512 MB String.kMaxLength while bounding how many
+// intermediate Buffers we concatenate. A single scalar/key fragment is never split, so the pending
+// string only ever exceeds the threshold by one whole fragment.
+const FLUSH_THRESHOLD = 1 << 20; // 1 MiB
+
+/**
+ * True for values that {@code JSON.stringify} drops: an object property with such a value is
+ * omitted, and such an array element serializes as {@code null}.
+ */
+function isJsonIgnored(value: unknown): boolean {
+    return value === undefined || typeof value === "function" || typeof value === "symbol";
+}
+
+/**
+ * Yields a value as the sequence of JSON text fragments that concatenate to exactly
+ * {@code JSON.stringify(value)}, without ever building the whole document as one string. Every
+ * scalar and every object key is serialized by the engine's {@code JSON.stringify} — so escaping,
+ * number formatting, {@code undefined}/function/symbol handling, and {@code toJSON} all match it
+ * exactly — and only the structural punctuation is emitted here.
+ */
+export function* jsonFragments(value: unknown): Generator<string> {
+    // Mirror JSON.stringify's toJSON step before deciding container vs. scalar, so e.g. a Date
+    // collapses to its string form rather than being walked as an object.
+    if (value !== null && typeof value === "object" && typeof (value as { toJSON?: unknown }).toJSON === "function") {
+        yield* jsonFragments((value as { toJSON(): unknown }).toJSON());
+        return;
+    }
+
+    if (Array.isArray(value)) {
+        yield "[";
+        for (let i = 0; i < value.length; i++) {
+            if (i > 0) {
+                yield ",";
+            }
+            if (isJsonIgnored(value[i])) {
+                yield "null";
+            } else {
+                yield* jsonFragments(value[i]);
+            }
+        }
+        yield "]";
+        return;
+    }
+
+    if (value !== null && typeof value === "object") {
+        yield "{";
+        let first = true;
+        for (const key of Object.keys(value as object)) {
+            const propValue = (value as Record<string, unknown>)[key];
+            if (isJsonIgnored(propValue)) {
+                continue;
+            }
+            if (!first) {
+                yield ",";
+            }
+            first = false;
+            yield JSON.stringify(key);
+            yield ":";
+            yield* jsonFragments(propValue);
+        }
+        yield "}";
+        return;
+    }
+
+    // Scalar: string, number, boolean, or null (a bigint throws here, exactly as JSON.stringify does).
+    yield JSON.stringify(value) as string;
+}
+
+/**
+ * A drop-in replacement for vscode-jsonrpc's default `application/json` content-type encoder that
+ * serializes a message to UTF-8 bytes without ever materializing the whole document as a single JS
+ * string. The default encoder does {@code Buffer.from(JSON.stringify(msg))}; a large enough
+ * PrepareRecipe response (a deep recipe tree) overflows V8's single-string limit and throws
+ * "Cannot create a string longer than 0x1fffffe8 characters", hanging the RPC call. Streaming the
+ * fragments into a Buffer raises the ceiling to Node's Buffer.MAX_LENGTH (multiple GB) while
+ * producing byte-identical output. (True unbounded streaming needs chunked framing — Content-Length
+ * still requires the whole body up front — so this is a ceiling raise, not a removal.)
+ */
+export const chunkedJsonEncoder: JsonRpcContentTypeEncoder = {
+    name: "application/json",
+    encode(msg: Message, options: { charset: BufferEncoding }): Promise<Uint8Array> {
+        const buffers: Buffer[] = [];
+        let pending = "";
+        for (const fragment of jsonFragments(msg)) {
+            pending += fragment;
+            if (pending.length >= FLUSH_THRESHOLD) {
+                buffers.push(Buffer.from(pending, options.charset));
+                pending = "";
+            }
+        }
+        if (pending.length > 0) {
+            buffers.push(Buffer.from(pending, options.charset));
+        }
+        return Promise.resolve(Buffer.concat(buffers));
+    }
+};

--- a/rewrite-javascript/rewrite/src/rpc/server.ts
+++ b/rewrite-javascript/rewrite/src/rpc/server.ts
@@ -16,6 +16,7 @@
  */
 import * as rpc from "vscode-jsonrpc/node";
 import {RewriteRpc} from "./rewrite-rpc";
+import {chunkedJsonEncoder} from "./message-encoder";
 import * as fs from "fs";
 import {Command} from 'commander';
 import {dir} from 'tmp-promise';
@@ -142,7 +143,10 @@ async function main() {
     // Create the connection with the custom logger
     const connection = rpc.createMessageConnection(
         new rpc.StreamMessageReader(process.stdin),
-        new rpc.StreamMessageWriter(process.stdout),
+        // Serialize outgoing messages without materializing the whole document as one JS string:
+        // a large PrepareRecipe response (a deep recipe tree) overflows V8's ~512 MB string limit
+        // in the default `Buffer.from(JSON.stringify(msg))` encoder and hangs the call.
+        new rpc.StreamMessageWriter(process.stdout, {contentTypeEncoder: chunkedJsonEncoder}),
         logger
     );
 

--- a/rewrite-javascript/rewrite/test/rpc/message-encoder.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/message-encoder.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {PassThrough} from "stream";
+import {StreamMessageReader, StreamMessageWriter} from "vscode-jsonrpc/node";
+import {chunkedJsonEncoder, jsonFragments} from "../../src/rpc/message-encoder";
+
+// Values whose fragment stream must concatenate to exactly JSON.stringify(value). Excludes
+// top-level undefined/function/symbol (JSON.stringify yields undefined there), which never occurs
+// as a whole JSON-RPC message.
+const parityCases: [string, unknown][] = [
+    ["empty object", {}],
+    ["empty array", []],
+    ["null", null],
+    ["true", true],
+    ["false", false],
+    ["zero", 0],
+    ["negative zero", -0],
+    ["float", 1.5],
+    ["large exponent", 1e21],
+    ["small exponent", -1e-7],
+    ["NaN -> null", NaN],
+    ["Infinity -> null", Infinity],
+    ["-Infinity -> null", -Infinity],
+    ["empty string", ""],
+    ["plain string", "simple"],
+    ["quotes and backslash", 'with "quotes" and \\ backslash'],
+    ["control chars", "null\u0000 newline\n tab\t"],
+    ["unicode", "café 你好 😀 π"],
+    ["number array", [1, 2, 3]],
+    ["mixed ignored array", [undefined, null, () => 1, Symbol("s"), 4]],
+    ["sparse array", [, , 3]],
+    ["nested object", {a: {b: [1, {c: "x"}], d: true}}],
+    ["dropped undefined prop", {a: undefined, b: 2, c: undefined}],
+    ["dropped function/symbol prop", {a: () => 1, b: Symbol("s"), c: 3}],
+    ["escaped keys", {'a"b': 1, "π": 2, "": 3}],
+    ["date via toJSON", new Date(0)],
+    ["object holding date", {when: new Date(1234567890123)}],
+    ["nested toJSON", {a: [new Date(0), {b: new Date(1)}]}],
+    ["jsonrpc-shaped message", {
+        jsonrpc: "2.0",
+        id: 7,
+        result: {
+            id: "abc",
+            descriptor: {name: "org.example.Recipe", description: "Does a thing.", recipeList: []},
+            editVisitor: "edit:abc",
+            editPreconditions: [],
+            scanPreconditions: [],
+            recipeList: [
+                {id: "d1", descriptor: {name: "org.example.Child", recipeList: []}, delegatesTo: {recipeName: "org.example.Java", options: {x: 1}}}
+            ]
+        }
+    }],
+];
+
+describe("chunked JSON message encoder", () => {
+    test.each(parityCases)("jsonFragments concatenates to JSON.stringify: %s", (_name, value) => {
+        expect([...jsonFragments(value)].join("")).toBe(JSON.stringify(value));
+    });
+
+    test.each(parityCases)("encode() produces JSON.stringify bytes: %s", async (_name, value) => {
+        // A JSON-RPC message is always an object; wrap scalars so the encoder gets a Message shape.
+        const msg = {jsonrpc: "2.0", id: 1, result: value} as any;
+        const bytes = await chunkedJsonEncoder.encode(msg, {charset: "utf-8"});
+        const expected = Buffer.from(JSON.stringify(msg), "utf-8");
+        expect(Buffer.from(bytes).equals(expected)).toBe(true);
+    });
+
+    test("multi-buffer path stays byte-identical past the flush threshold", async () => {
+        // A payload whose serialized form comfortably exceeds the 1 MiB flush threshold, forcing
+        // several Buffer flushes + concat — the path a large recipe tree exercises.
+        const big = {
+            jsonrpc: "2.0",
+            id: 42,
+            result: {
+                recipeList: Array.from({length: 40_000}, (_, i) => ({
+                    name: `org.example.Recipe${i}`,
+                    description: "A recipe that does something moderately interesting. 你好 😀",
+                    recipeList: [],
+                }))
+            }
+        } as any;
+        const expected = Buffer.from(JSON.stringify(big), "utf-8");
+        expect(expected.length).toBeGreaterThan(1 << 20); // actually crossed the threshold
+        const bytes = await chunkedJsonEncoder.encode(big, {charset: "utf-8"});
+        expect(Buffer.from(bytes).equals(expected)).toBe(true);
+    });
+
+    test("surrogate pairs survive fragment boundaries", async () => {
+        // Emoji (surrogate pairs) live entirely within a single scalar fragment, so UTF-8 encoding
+        // per flush never splits one. Repeat enough to span a flush boundary.
+        const value = {s: "😀".repeat(400_000)};
+        const msg = {jsonrpc: "2.0", id: 1, result: value} as any;
+        const bytes = await chunkedJsonEncoder.encode(msg, {charset: "utf-8"});
+        expect(Buffer.from(bytes).equals(Buffer.from(JSON.stringify(msg), "utf-8"))).toBe(true);
+    });
+
+    test("round-trips through StreamMessageWriter/Reader framing", async () => {
+        // Wire the encoder into a real StreamMessageWriter and read it back with the default
+        // StreamMessageReader: proves the option is honored and the Content-Length framing is
+        // correct across the multi-buffer output, not just that encode() bytes match in isolation.
+        const pipe = new PassThrough();
+        const writer = new StreamMessageWriter(pipe, {contentTypeEncoder: chunkedJsonEncoder});
+        const reader = new StreamMessageReader(pipe);
+        const msg = {
+            jsonrpc: "2.0",
+            id: 5,
+            result: {
+                recipeList: Array.from({length: 5_000}, (_, i) => ({name: `org.example.R${i}`, description: "😀 does a thing"}))
+            }
+        };
+        const received = new Promise<unknown>((resolve) => reader.listen(m => resolve(m)));
+        await writer.write(msg as any);
+        expect(await received).toEqual(msg);
+    });
+});


### PR DESCRIPTION
## What

The npm (JavaScript) RPC recipe server serialized every outgoing message through vscode-jsonrpc's default content-type encoder, which does `Buffer.from(JSON.stringify(msg))`. A large `PrepareRecipe` response — a deep recipe tree returned whole in a single message — overflows V8's ~512 MB `String::kMaxLength` and throws:

```
Cannot create a string longer than 0x1fffffe8 characters
```

The RPC call then hangs until it times out (observed as a ~1 hr CI hang on a large recipe run).

## Fix

Wire a custom `contentTypeEncoder` into the server's `StreamMessageWriter` that serializes the message to UTF-8 bytes **without ever building the whole document as one JS string**:

- Structural punctuation (`{ } [ ] : ,`) is emitted directly.
- Every scalar and every object **key** is serialized by the engine's `JSON.stringify`, so escaping, number formatting, `undefined`/function/symbol dropping, and `toJSON` all match byte-for-byte.
- Fragments accumulate into 1 MiB `Buffer` flushes and one `Buffer.concat`.

Output is **byte-identical** to the default encoder, so the receiver sees the same wire bytes. The ceiling rises from the ~512 MB string cap to Node's multi-GB `Buffer.MAX_LENGTH`. The payload shape is unchanged, keeping the JS server consistent with the Java, C#, Go, and Python servers.

## Scope

- **Send path only.** The default decoder (`JSON.parse(buffer.toString())`) is untouched. It's not a latent problem: every large *inbound* payload rides the batched `GetObject`/`RpcObjectData` channel (bounded per message), and the one payload that inlines a whole tree — the `PrepareRecipe` response — is outbound from the server.
- **Ceiling raise, not removal.** Content-Length framing still requires the whole body up front, so this doesn't stream to the socket. For recipe trees large enough to exceed a Buffer (e.g. Spring Boot 4.0-scale, 4000+ vertices), the durable follow-up is to carry the prepared tree over the same batched `GetObject` channel the LSTs already use.

## Tests

`test/rpc/message-encoder.test.ts` (new):
- Byte-parity vs `JSON.stringify` across scalars, unicode, control chars, `NaN`/`Infinity`, sparse arrays, dropped props, escaped keys, `toJSON`, and a JSON-RPC-shaped message.
- Multi-buffer path past the 1 MiB flush threshold.
- Surrogate-pair fragment-boundary safety.
- End-to-end round-trip through a real `StreamMessageWriter` → `StreamMessageReader` (proves the option is honored and Content-Length framing is correct).

Verified: typecheck clean, production build clean, 61/61 new tests pass, existing `rewrite-rpc.test.ts` 22 passed / 1 skipped (real server traffic through the rebuilt server).