### PR TITLE
Fix MergeYaml indenting new entries to a column that mismatches siblings

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -165,6 +165,11 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
             return existingEntry;
         });
 
+        // The indentation of the existing entries, so newly added entries can be aligned to match them.
+        // `autoFormat` derives indentation from the file's auto-detected indent size, which does not
+        // necessarily match a block whose actual indentation deviates from that size.
+        int existingIndent = shouldAutoFormat ? blockIndent(m1) : -1;
+
         // Transform new entries with spacing, remove entries already existing in original mapping
         List<Yaml.Mapping.Entry> newEntries = map(m2.getEntries(), it -> {
             for (Yaml.Mapping.Entry existingEntry : m1.getEntries()) {
@@ -176,7 +181,10 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
                 MultilineScalarChanged marker = new MultilineScalarChanged(randomId(), true, calculateMultilineIndent(it));
                 it = it.withValue(it.getValue().withMarkers(it.getValue().getMarkers().add(marker)));
             }
-            return shouldAutoFormat ? autoFormat(it, p, cursor) : it;
+            if (!shouldAutoFormat) {
+                return it;
+            }
+            return alignToIndent((Yaml.Mapping.Entry) autoFormat(it, p, cursor), existingIndent);
         });
 
         // Merge existing and new entries together
@@ -433,6 +441,45 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
     private String substringOfAfterFirstLineBreak(String s) {
         String[] lines = LINE_BREAK.split(s, -1);
         return lines.length > 1 ? String.join(linebreak(), Arrays.copyOfRange(lines, 1, lines.length)) : "";
+    }
+
+    /**
+     * The indentation column shared by the entries of an existing mapping, or {@code -1} when it
+     * cannot be determined (e.g. an empty mapping or a mapping whose only entry is on the same line
+     * as its parent key).
+     */
+    private static int blockIndent(Yaml.Mapping mapping) {
+        for (Yaml.Mapping.Entry entry : mapping.getEntries()) {
+            int indent = lastLineIndent(entry.getPrefix());
+            if (indent >= 0) {
+                return indent;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Re-indents a newly added entry (and its nested content) so it lines up with the existing
+     * sibling entries, preserving the relative indentation produced by {@code autoFormat}.
+     */
+    private Yaml.Mapping.Entry alignToIndent(Yaml.Mapping.Entry entry, int targetIndent) {
+        if (targetIndent < 0) {
+            return entry;
+        }
+        int currentIndent = lastLineIndent(entry.getPrefix());
+        if (currentIndent < 0 || currentIndent == targetIndent) {
+            return entry;
+        }
+        return (Yaml.Mapping.Entry) new ShiftFormatVisitor<Integer>(entry, targetIndent - currentIndent).visitNonNull(entry, 0);
+    }
+
+    /**
+     * The number of whitespace characters after the last line break of a prefix, or {@code -1} when
+     * the prefix has no line break (i.e. the element is not on its own line).
+     */
+    private static int lastLineIndent(String prefix) {
+        int idx = Math.max(prefix.lastIndexOf('\n'), prefix.lastIndexOf('\r'));
+        return idx < 0 ? -1 : prefix.length() - idx - 1;
     }
 
     private int calculateMultilineIndent(Yaml.Mapping.Entry entry) {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -466,11 +466,7 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
         if (targetIndent < 0) {
             return entry;
         }
-        int currentIndent = lastLineIndent(entry.getPrefix());
-        if (currentIndent < 0 || currentIndent == targetIndent) {
-            return entry;
-        }
-        return (Yaml.Mapping.Entry) new ShiftFormatVisitor<Integer>(entry, targetIndent - currentIndent).visitNonNull(entry, 0);
+        return (Yaml.Mapping.Entry) ShiftIndentVisitor.<Integer>toIndent(entry, targetIndent).visitNonNull(entry, 0);
     }
 
     /**

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ShiftFormatVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ShiftFormatVisitor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.yaml;
+
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.Arrays;
+
+/**
+ * Shifts the indentation of every element within {@code scope} by a fixed amount.
+ * A positive {@code shift} adds whitespace (moves right); a negative {@code shift}
+ * removes whitespace (moves left). The relative indentation between nested elements
+ * is preserved, so the whole subtree simply moves as a block.
+ */
+public class ShiftFormatVisitor<P> extends YamlIsoVisitor<P> {
+    private final Yaml scope;
+    private final int shift;
+
+    public ShiftFormatVisitor(Yaml scope, int shift) {
+        this.scope = scope;
+        this.shift = shift;
+    }
+
+    @Override
+    public Yaml.Sequence.Entry visitSequenceEntry(Yaml.Sequence.Entry entry, P p) {
+        Yaml.Sequence.Entry e = super.visitSequenceEntry(entry, p);
+        if (getCursor().isScopeInPath(scope) && e.isDash() && e.getPrefix().contains("\n")) {
+            e = e.withPrefix(shiftPrefix(e.getPrefix()));
+        }
+        return e;
+    }
+
+    @Override
+    public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, P p) {
+        Yaml.Mapping.Entry e = super.visitMappingEntry(entry, p);
+        if (getCursor().isScopeInPath(scope) && e.getPrefix().contains("\n")) {
+            e = e.withPrefix(shiftPrefix(e.getPrefix()));
+        }
+        return e;
+    }
+
+    @SuppressWarnings("DynamicRegexReplaceableByCompiledPattern")
+    private String shiftPrefix(String prefix) {
+        return String.join("\n", ListUtils.map(Arrays.asList(prefix.split("\\n")), (index, s) -> {
+            // The segment before the first line break stays on the previous element's line
+            // (it may hold a trailing inline comment), so it is never re-indented.
+            if (index == 0) {
+                return s;
+            }
+            if (shift >= 0) {
+                return StringUtils.repeat(" ", shift) + s;
+            }
+            // Only remove whitespace when there is enough available on this line, mirroring the
+            // safeguards in ShiftFormatLeftVisitor so comments are not mangled.
+            int amount = -shift;
+            if (StringUtils.indexOfNonWhitespace(s) >= amount || (StringUtils.indexOfNonWhitespace(s) == -1 && s.length() >= amount)) {
+                return s.substring(amount);
+            }
+            return s;
+        }));
+    }
+}

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ShiftIndentVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ShiftIndentVisitor.java
@@ -22,24 +22,37 @@ import org.openrewrite.yaml.tree.Yaml;
 import java.util.Arrays;
 
 /**
- * Shifts the indentation of every element within {@code scope} by a fixed amount.
- * A positive {@code shift} adds whitespace (moves right); a negative {@code shift}
- * removes whitespace (moves left). The relative indentation between nested elements
- * is preserved, so the whole subtree simply moves as a block.
+ * Shifts the indentation of every element within {@code scope} by a fixed amount, preserving the
+ * relative indentation between nested elements so the whole subtree moves as a block. A positive
+ * {@code shift} adds whitespace (moves right); a negative {@code shift} removes whitespace (moves
+ * left).
+ * <p>
+ * Use {@link #toIndent(Yaml, int)} when the desired absolute indentation of {@code scope} is known
+ * rather than the relative offset.
  */
-public class ShiftFormatVisitor<P> extends YamlIsoVisitor<P> {
+public class ShiftIndentVisitor<P> extends YamlIsoVisitor<P> {
     private final Yaml scope;
     private final int shift;
 
-    public ShiftFormatVisitor(Yaml scope, int shift) {
+    public ShiftIndentVisitor(Yaml scope, int shift) {
         this.scope = scope;
         this.shift = shift;
+    }
+
+    /**
+     * Creates a visitor that moves {@code scope} (and its nested content) so that {@code scope}
+     * itself lands at {@code targetColumn}. Leaves the tree unchanged when {@code scope}'s current
+     * indentation cannot be determined (it does not begin its own line) or already matches.
+     */
+    public static <P> ShiftIndentVisitor<P> toIndent(Yaml scope, int targetColumn) {
+        int currentIndent = currentIndent(scope.getPrefix());
+        return new ShiftIndentVisitor<>(scope, currentIndent < 0 ? 0 : targetColumn - currentIndent);
     }
 
     @Override
     public Yaml.Sequence.Entry visitSequenceEntry(Yaml.Sequence.Entry entry, P p) {
         Yaml.Sequence.Entry e = super.visitSequenceEntry(entry, p);
-        if (getCursor().isScopeInPath(scope) && e.isDash() && e.getPrefix().contains("\n")) {
+        if (shift != 0 && getCursor().isScopeInPath(scope) && e.isDash() && e.getPrefix().contains("\n")) {
             e = e.withPrefix(shiftPrefix(e.getPrefix()));
         }
         return e;
@@ -48,7 +61,7 @@ public class ShiftFormatVisitor<P> extends YamlIsoVisitor<P> {
     @Override
     public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, P p) {
         Yaml.Mapping.Entry e = super.visitMappingEntry(entry, p);
-        if (getCursor().isScopeInPath(scope) && e.getPrefix().contains("\n")) {
+        if (shift != 0 && getCursor().isScopeInPath(scope) && e.getPrefix().contains("\n")) {
             e = e.withPrefix(shiftPrefix(e.getPrefix()));
         }
         return e;
@@ -56,7 +69,9 @@ public class ShiftFormatVisitor<P> extends YamlIsoVisitor<P> {
 
     @SuppressWarnings("DynamicRegexReplaceableByCompiledPattern")
     private String shiftPrefix(String prefix) {
-        return String.join("\n", ListUtils.map(Arrays.asList(prefix.split("\\n")), (index, s) -> {
+        // Split with a negative limit so a trailing line break (e.g. a bare "\n" prefix on a
+        // zero-indent entry) is preserved rather than dropped.
+        return String.join("\n", ListUtils.map(Arrays.asList(prefix.split("\\n", -1)), (index, s) -> {
             // The segment before the first line break stays on the previous element's line
             // (it may hold a trailing inline comment), so it is never re-indented.
             if (index == 0) {
@@ -65,13 +80,22 @@ public class ShiftFormatVisitor<P> extends YamlIsoVisitor<P> {
             if (shift >= 0) {
                 return StringUtils.repeat(" ", shift) + s;
             }
-            // Only remove whitespace when there is enough available on this line, mirroring the
-            // safeguards in ShiftFormatLeftVisitor so comments are not mangled.
+            // Only remove whitespace when there is enough available on this line, so comments and
+            // content are never mangled.
             int amount = -shift;
             if (StringUtils.indexOfNonWhitespace(s) >= amount || (StringUtils.indexOfNonWhitespace(s) == -1 && s.length() >= amount)) {
                 return s.substring(amount);
             }
             return s;
         }));
+    }
+
+    /**
+     * The number of whitespace characters after the last line break of a prefix, or {@code -1} when
+     * the prefix has no line break (i.e. the element is not on its own line).
+     */
+    private static int currentIndent(String prefix) {
+        int idx = Math.max(prefix.lastIndexOf('\n'), prefix.lastIndexOf('\r'));
+        return idx < 0 ? -1 : prefix.length() - idx - 1;
     }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -3752,4 +3752,164 @@ class MergeYamlTest implements RewriteTest {
         );
     }
 
+    @Test
+    void newEntryMatchesSiblingIndentWhenGreaterThanDetected() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$.settings",
+            //language=yaml
+            "retry_on_error: true",
+            false,
+            null,
+            null,
+            null,
+            null,
+            true
+          )),
+          yaml(
+            """
+              common:
+                foo: 1
+                bar: 2
+              settings:
+                  # Tool will only check for accesses, only within the last N days
+                  access_days_threshold: 30
+                  ignore_dependencies: false
+                  vms_options:
+                    keep: 'none'
+              """,
+            """
+              common:
+                foo: 1
+                bar: 2
+              settings:
+                  # Tool will only check for accesses, only within the last N days
+                  access_days_threshold: 30
+                  ignore_dependencies: false
+                  vms_options:
+                    keep: 'none'
+                  retry_on_error: true
+              """
+          )
+        );
+    }
+
+    @Test
+    void newEntryMatchesSiblingIndentWhenDeeplyNested() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$.parent.child",
+            //language=yaml
+            "retry_on_error: true",
+            false,
+            null,
+            null,
+            null,
+            null,
+            true
+          )),
+          yaml(
+            """
+              common:
+                foo: 1
+                bar: 2
+              parent:
+                child:
+                        access_days_threshold: 30
+                        ignore_dependencies: false
+              """,
+            """
+              common:
+                foo: 1
+                bar: 2
+              parent:
+                child:
+                        access_days_threshold: 30
+                        ignore_dependencies: false
+                        retry_on_error: true
+              """
+          )
+        );
+    }
+
+    @Test
+    void newNestedEntryMatchesSiblingIndentAndKeepsRelativeChildIndent() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$.settings",
+            //language=yaml
+            """
+              vms_options:
+                cleanup: true
+              """,
+            false,
+            null,
+            null,
+            null,
+            null,
+            true
+          )),
+          yaml(
+            """
+              common:
+                foo: 1
+                bar: 2
+              settings:
+                  access_days_threshold: 30
+                  ignore_dependencies: false
+              """,
+            """
+              common:
+                foo: 1
+                bar: 2
+              settings:
+                  access_days_threshold: 30
+                  ignore_dependencies: false
+                  vms_options:
+                    cleanup: true
+              """
+          )
+        );
+    }
+
+    @Test
+    void newEntryMatchesSiblingIndentWhenLessThanDetected() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$.settings",
+            //language=yaml
+            "retry_on_error: true",
+            false,
+            null,
+            null,
+            null,
+            null,
+            true
+          )),
+          yaml(
+            """
+              common:
+                  foo: 1
+                  bar: 2
+                  nested:
+                      baz: 3
+              settings:
+                access_days_threshold: 30
+                ignore_dependencies: false
+              """,
+            """
+              common:
+                  foo: 1
+                  bar: 2
+                  nested:
+                      baz: 3
+              settings:
+                access_days_threshold: 30
+                ignore_dependencies: false
+                retry_on_error: true
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?

When `MergeYaml` merges a snippet into an existing mapping, new entries were positioned by `autoFormat`, which derives indentation from the file's auto-detected indent size (`parentIndent + detectedIndentSize`). When a block's actual indentation deviates from that detected step, the new entry landed at the wrong column, producing invalid YAML.

For example, a `settings` block indented with a 4-space step in a file whose detected step is 2 would get a new entry at 2 spaces instead of 4:

```yaml
settings:
    access_days_threshold: 30
    ignore_dependencies: false
  retry_on_error: true          # <-- wrong: 2 spaces, breaks the file
```

New entries are now re-indented to match the existing sibling entries' actual indentation, preserving the relative indentation `autoFormat` produced for any nested content.

A new `ShiftFormatVisitor` is added as a bidirectional companion to the existing `ShiftFormatLeftVisitor`, shifting a subtree left or right by a fixed amount.

## What's your motivation?

New entries were merged at an indentation that did not line up with their siblings when the target block's indentation differed from the rest of the file, breaking the resulting YAML even though the recipe promises the indentation "will be adjusted to match."

## Anything in particular you'd like reviewers to focus on?

The alignment is only applied when `shouldAutoFormat` is enabled and the target mapping has existing sibling entries; it is a no-op (delta 0) for well-behaved files, so existing behavior is unchanged.

## Checklist

- [x] I've added unit tests covering both shift directions, deeper nesting, and nested incoming snippets.