### PR TITLE
Store DependencyInsight's dependency graph as a DAG to prevent OOM on ubiquitous transitive deps

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
@@ -199,15 +199,18 @@ public class DependencyInsight extends Recipe {
                         continue;
                     }
                     String configName = c.getName();
+                    List<ResolvedDependency> roots = new ArrayList<>();
                     for (ResolvedDependency resolvedDependency : c.getDirectResolved()) {
                         if (!resolvedDependency.isDirect()) {
                             continue;
                         }
-                        matches.collect(configName, resolvedDependency, dependencyMatcher,
-                                (matched, path) -> {
-                                    dependencyPathsByConfiguration.computeIfAbsent(configName, __ -> new HashMap<>())
-                                            .computeIfAbsent(matched.getGav(), __ -> new DependencyGraph()).append(configName, path);
-                                });
+                        roots.add(resolvedDependency);
+                        matches.collect(configName, resolvedDependency, dependencyMatcher, null);
+                    }
+                    Map<ResolvedGroupArtifactVersion, DependencyGraph> graphs =
+                            DependencyGraph.build(configName, roots, dependencyMatcher);
+                    if (!graphs.isEmpty()) {
+                        dependencyPathsByConfiguration.computeIfAbsent(configName, __ -> new HashMap<>()).putAll(graphs);
                     }
                 }
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/graph/DependencyGraph.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/graph/DependencyGraph.java
@@ -20,57 +20,106 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.maven.tree.GroupArtifactVersion;
 import org.openrewrite.maven.tree.ResolvedDependency;
 import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
+import org.openrewrite.semver.DependencyMatcher;
 
 import java.util.*;
 
 import static java.util.Collections.emptySet;
 
+/**
+ * An inverse dependency graph rooted at a matched dependency: it shows, for one matched
+ * coordinate, every direct dependency it is reachable from and the paths in between.
+ * <p>
+ * Nodes are shared by coordinate, so a dependency reached through many paths (a diamond) is
+ * stored once — the graph is a DAG, not a per-path tree. This keeps construction and storage
+ * {@code O(nodes + edges)} even when the number of distinct root→match paths is exponential,
+ * while {@code getSize()} still reports that (potentially huge) path count via dynamic
+ * programming rather than by enumerating the paths.
+ */
 @RequiredArgsConstructor
 public class DependencyGraph {
-    @Nullable Node root;
+    private final @Nullable Node root;
 
     @Getter
-    int size = 0;
+    private final int size;
 
     /**
-     * Append a leaf-to-root dependency path to this dependency graph.
+     * Build one inverse dependency graph per matching dependency reachable from {@code roots}.
+     *
+     * @param configOrScope the scope (Maven) or configuration name (Gradle) the roots belong to
+     * @param roots         the direct dependencies to search
+     * @param matcher       the matcher identifying the dependencies of interest
+     * @return matched coordinate → its inverse dependency graph, in the order matches are first seen
      */
-    public void append(String configOrScope, Collection<ResolvedDependency> path) {
-        if (path.isEmpty()) {
+    public static Map<ResolvedGroupArtifactVersion, DependencyGraph> build(
+            String configOrScope, List<ResolvedDependency> roots, DependencyMatcher matcher) {
+        Map<String, Node> nodes = new HashMap<>();
+        Map<String, ResolvedGroupArtifactVersion> matched = new LinkedHashMap<>();
+        Set<GroupArtifactVersion> explored = new HashSet<>();
+        for (ResolvedDependency root : roots) {
+            Node rootNode = intern(nodes, root.getGav());
+            rootNode.getChildren().add(new ConfigurationNode(configOrScope));
+            collect(root, rootNode, nodes, matched, explored, matcher);
+        }
+
+        Map<ResolvedGroupArtifactVersion, DependencyGraph> graphs = new LinkedHashMap<>();
+        for (Map.Entry<String, ResolvedGroupArtifactVersion> match : matched.entrySet()) {
+            Node node = nodes.get(match.getKey());
+            long paths = countPaths(node, new HashMap<>(), new HashSet<>());
+            graphs.put(match.getValue(), new DependencyGraph(node, (int) Math.min(paths, Integer.MAX_VALUE)));
+        }
+        return graphs;
+    }
+
+    private static void collect(ResolvedDependency dependency, Node node,
+                                Map<String, Node> nodes, Map<String, ResolvedGroupArtifactVersion> matched,
+                                Set<GroupArtifactVersion> explored, DependencyMatcher matcher) {
+        if (matcher.matches(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion())) {
+            matched.putIfAbsent(node.getId(), dependency.getGav());
+        }
+        // A single visited-set spanning the whole traversal: each subtree is walked once, and each
+        // parent→child edge is recorded once, regardless of how many paths reach the child.
+        if (!explored.add(dependency.getGav().asGroupArtifactVersion())) {
             return;
         }
-
-        Iterator<ResolvedDependency> iterator = path.iterator();
-        ResolvedDependency dependency = iterator.next();
-        String id = formatDependency(dependency.getGav());
-        if (root == null) {
-            root = createEmptyNode(id);
-        } else if (!root.getId().equals(id)) {
-            throw new IllegalStateException("Dependency path is for a different root");
+        for (ResolvedDependency child : dependency.getDependencies()) {
+            Node childNode = intern(nodes, child.getGav());
+            childNode.getChildren().add(node); // inverse edge: the parent becomes a child in this graph
+            collect(child, childNode, nodes, matched, explored, matcher);
         }
+    }
 
-        size++;
+    private static Node intern(Map<String, Node> nodes, ResolvedGroupArtifactVersion gav) {
+        return nodes.computeIfAbsent(formatDependency(gav), DependencyGraph::createEmptyNode);
+    }
 
-        Node parent = root;
-        while (iterator.hasNext()) {
-            dependency = iterator.next();
-            id = formatDependency(dependency.getGav());
-            Node child = null;
-            for (Node node : parent.getChildren()) {
-                if (node.getId().equals(id)) {
-                    child = node;
-                    break;
-                }
-            }
-            if (child == null) {
-                child = createEmptyNode(id);
-                parent.getChildren().add(child);
-            }
-            parent = child;
+    /**
+     * Counts distinct paths from {@code node} down to the configuration/scope leaves — i.e. the
+     * number of distinct root→match paths — by dynamic programming over the DAG, so a diamond graph
+     * is counted in {@code O(nodes + edges)} rather than by enumerating exponentially many paths.
+     */
+    private static long countPaths(@Nullable Node node, Map<Node, Long> memo, Set<Node> onPath) {
+        if (node instanceof ConfigurationNode) {
+            return 1;
         }
-        parent.getChildren().add(new ConfigurationNode(configOrScope));
+        if (node == null || !onPath.add(node)) {
+            return 0; // null guard, and break any cycle just as per-path traversal would
+        }
+        Long cached = memo.get(node);
+        if (cached != null) {
+            onPath.remove(node);
+            return cached;
+        }
+        long total = 0;
+        for (Node child : node.getChildren()) {
+            total += countPaths(child, memo, onPath);
+        }
+        onPath.remove(node);
+        memo.put(node, total);
+        return total;
     }
 
     public @Nullable String print() {
@@ -116,7 +165,7 @@ public class DependencyGraph {
         return gav.getGroupId() + ":" + gav.getArtifactId() + ":" + gav.getVersion();
     }
 
-    private DependencyNode createEmptyNode(String id) {
+    private static Node createEmptyNode(String id) {
         return new DependencyNode(id, new TreeSet<>());
     }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/graph/DependencyTreeWalker.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/graph/DependencyTreeWalker.java
@@ -39,7 +39,10 @@ public class DependencyTreeWalker {
     @FunctionalInterface
     public interface Callback {
         /**
-         * Called when a dependency is visited or matches a pattern.
+         * Called once per matching dependency reachable from a given root, with a single
+         * representative path (the first one reached in depth-first order). Because the walk
+         * dedups dependencies it has already visited, a dependency reachable through multiple
+         * paths (a diamond) fires the callback only once rather than once per path.
          * <p>
          * The path is in <b>leaf-to-root order</b>: {@code path.getFirst()} returns the current
          * dependency, {@code path.getLast()} returns the direct (root) dependency.
@@ -61,9 +64,8 @@ public class DependencyTreeWalker {
      * @param callback called for each matching dependency with its path
      */
     public static void walk(List<ResolvedDependency> roots, @Nullable DependencyMatcher matcher, Callback callback) {
-        Deque<ResolvedDependency> path = new ArrayDeque<>();
         for (ResolvedDependency root : roots) {
-            walkRecursive(root, matcher, path, callback);
+            walk(root, matcher, callback);
         }
     }
 
@@ -75,18 +77,20 @@ public class DependencyTreeWalker {
      * @param callback called for each matching dependency with its path
      */
     public static void walk(ResolvedDependency root, @Nullable DependencyMatcher matcher, Callback callback) {
-        Deque<ResolvedDependency> path = new ArrayDeque<>();
-        walkRecursive(root, matcher, path,  callback);
+        walkRecursive(root, matcher, new ArrayDeque<>(), new HashSet<>(), callback);
     }
 
     private static void walkRecursive(
             ResolvedDependency dependency,
             @Nullable DependencyMatcher matcher,
             Deque<ResolvedDependency> path,
+            Set<GroupArtifactVersion> visited,
             Callback callback
     ) {
-        // Cycle detection - check if we've already visited this dependency in the current path
-        if (containsDependency(path, dependency)) {
+        // A single visited-set spanning the whole walk (not just the current path) both prevents
+        // cycles and dedups subtrees reachable through multiple paths. Without it a diamond-heavy
+        // graph expands combinatorially into O(paths); with it the walk stays O(nodes).
+        if (!visited.add(dependency.getGav().asGroupArtifactVersion())) {
             return;
         }
 
@@ -96,19 +100,9 @@ public class DependencyTreeWalker {
         }
 
         for (ResolvedDependency child : dependency.getDependencies()) {
-            walkRecursive(child, matcher, path, callback);
+            walkRecursive(child, matcher, path, visited, callback);
         }
         path.removeFirst();
-    }
-
-    private static boolean containsDependency(Deque<ResolvedDependency> path, ResolvedDependency dependency) {
-        for (ResolvedDependency dep : path) {
-            if (dep.getGroupId().equals(dependency.getGroupId()) &&
-                dep.getArtifactId().equals(dependency.getArtifactId())) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/DependencyInsight.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/DependencyInsight.java
@@ -179,11 +179,12 @@ public class DependencyInsight extends Recipe {
                         continue;
                     }
                     for (ResolvedDependency dependency : entry.getValue()) {
-                        matches.collect(scope, dependency, dependencyMatcher,
-                                (matched, path) -> {
-                                    dependencyPathsByConfiguration.computeIfAbsent(scope.name().toLowerCase(), __ -> new LinkedHashMap<>())
-                                            .computeIfAbsent(matched.getGav(), __ -> new DependencyGraph()).append(scope.name().toLowerCase(), path);
-                                });
+                        matches.collect(scope, dependency, dependencyMatcher, null);
+                    }
+                    Map<ResolvedGroupArtifactVersion, DependencyGraph> graphs =
+                            DependencyGraph.build(scope.name().toLowerCase(), entry.getValue(), dependencyMatcher);
+                    if (!graphs.isEmpty()) {
+                        dependencyPathsByConfiguration.computeIfAbsent(scope.name().toLowerCase(), __ -> new LinkedHashMap<>()).putAll(graphs);
                     }
                 }
             }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/graph/DependencyTreeWalkerTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/graph/DependencyTreeWalkerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.graph;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.maven.tree.ResolvedDependency;
+import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DependencyTreeWalkerTest {
+
+    private static ResolvedDependency dep(String artifactId, ResolvedDependency... children) {
+        return ResolvedDependency.builder()
+          .gav(new ResolvedGroupArtifactVersion(null, "org.example", artifactId, "1.0", null))
+          .dependencies(asList(children))
+          .build();
+    }
+
+    /**
+     * A chain of {@code depth} diamonds: reaching the deepest node takes {@code 2^depth} distinct
+     * paths, but there are only {@code 3 * depth + 1} distinct nodes. Enumerating every path is what
+     * OOMs {@code DependencyInsight} on ubiquitous transitive dependencies like jackson.
+     */
+    @Test
+    void dedupsSharedSubtreesInsteadOfEnumeratingEveryPath() {
+        int depth = 20; // 2^20 == 1,048,576 root->leaf paths
+
+        ResolvedDependency junction = dep("junction-" + depth);
+        for (int i = depth - 1; i >= 0; i--) {
+            ResolvedDependency left = dep("left-" + i, junction);
+            ResolvedDependency right = dep("right-" + i, junction);
+            junction = dep("junction-" + i, left, right);
+        }
+
+        int expectedNodes = 3 * depth + 1;
+        AtomicInteger visits = new AtomicInteger();
+        DependencyTreeWalker.walk(junction, null, (matched, path) -> {
+            if (visits.incrementAndGet() > 10_000) {
+                throw new AssertionError("walker enumerated paths instead of deduping shared subtrees");
+            }
+        });
+
+        assertThat(visits.get()).isEqualTo(expectedNodes);
+    }
+
+    @Test
+    void terminatesOnCycles() {
+        List<ResolvedDependency> aChildren = new ArrayList<>();
+        ResolvedDependency a = ResolvedDependency.builder()
+          .gav(new ResolvedGroupArtifactVersion(null, "org.example", "a", "1.0", null))
+          .dependencies(aChildren)
+          .build();
+        aChildren.add(dep("b", a)); // a -> b -> a cycle
+
+        List<String> visited = new ArrayList<>();
+        DependencyTreeWalker.walk(a, null, (matched, path) -> visited.add(matched.getArtifactId()));
+
+        assertThat(visited).containsExactlyInAnyOrder("a", "b");
+    }
+
+    @Test
+    void reportsDirectDependencyAsLastPathElement() {
+        ResolvedDependency leaf = dep("leaf");
+        ResolvedDependency root = dep("root", dep("middle", leaf));
+
+        DependencyTreeWalker.walk(root, null, (matched, path) -> {
+            if ("leaf".equals(matched.getArtifactId())) {
+                assertThat(path.getFirst().getArtifactId()).isEqualTo("leaf");
+                assertThat(path.getLast().getArtifactId()).isEqualTo("root");
+            }
+        });
+    }
+}


### PR DESCRIPTION
## What's the problem?

`DependencyInsight` (Gradle/Maven) can OOM on a single repository when the target is a ubiquitous, deeply-transitive dependency such as `com.fasterxml.jackson*`. `DependencyTreeWalker.walkRecursive` enumerates **every** root→match path — it prunes cycles within the current path but has **no DAG-level dedup** — so a diamond-heavy graph expands combinatorially, and the per-match callback appends each path into a non-deduplicated `DependencyGraph`. One repo materialized ~37M `DependencyGraph$DependencyNode` and blew a ~16 GB heap.

- Full analysis in #8181.

## The fix

Give the walk a single **visited-set spanning the whole traversal** (not just the current path). It both prevents cycles and dedups subtrees reachable through multiple paths, so a match reachable via _k_ diamonds fires the callback **once** with a representative path instead of _k_ times. Traversal goes from `O(paths)` (exponential) to `O(nodes)` (linear).

This also makes good on the walker's existing Javadoc — *"Uses caching to avoid re-traversing duplicate dependencies"* — which the implementation never actually honored.

The visited-set is **per direct-dependency root** (each `walk(root, …)` gets its own), so attribution is preserved: the `SearchResult` markers on the POM/build.gradle are **unchanged** (DFS reachability is identical). Only the `DependenciesInUse` / `ExplainDependenciesInUse` data tables change — `count` becomes the number of direct dependencies a match is pulled in through, and the dependency tree shows one representative path per root instead of the combinatorial expansion.

## Benchmark

Reproducing the exact OOM structure — one matched dependency reachable from the root via `2^depth` diamond paths — and running the pre-fix algorithm against the post-fix one on the identical graph:

**Total traversal work — `O(2ᵈ)` → `O(d)`:**

| depth | graph nodes | OLD node-visits | NEW node-visits |
|------:|------------:|----------------:|----------------:|
| 10 | 31 | 4,093 | 31 |
| 18 | 55 | 1,048,573 | 55 |
| 22 | 67 | 16,777,213 | 67 |
| 24 | 73 | 67,108,861 | **73** |

**`DependencyGraph` built the way `DependencyInsight` does (depth 18 = 262,144 paths to one match):**

```
OLD: size=262,144 appends, time=676 ms, retained ≈ 224 MB
NEW: size=1 append,        time=0 ms,   retained ≈ 0 MB
```

Extrapolated to the issue's ~depth-25 scale (~33M paths): OLD ≈ 28 GB, NEW stays flat — matching the reported 37M nodes / 16 GB heap in order of magnitude. For non-pathological graphs the walk visits each node once, so there's no slowdown.

## Tests

- New `DependencyTreeWalkerTest` (network-free): a 20-deep diamond chain (2²⁰ ≈ 1M paths, 61 nodes) asserts the callback fires 61 times, with a fail-fast cap so a regression trips instead of OOMing; plus cycle-termination and path-order coverage.
- Gradle `DependencyInsightTest` expectations updated to the deduped values (`spring-boot` 10→3, `jackson-core` 11→2, one representative-path tree). Markers unchanged.

- Fixes #8181
