### PR TITLE
Key local recipe installs by their absolute path across ecosystems

### DIFF
--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleResolver.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleResolver.java
@@ -44,7 +44,7 @@ public class NuGetRecipeBundleResolver implements RecipeBundleResolver {
             // directory may differ from ours, so it needs the absolute form to load the assembly —
             // and aligning the bundle's packageName with it keeps the install origin the server
             // records and the marketplace filter key (the bundle's packageName) the same value.
-            String absolutePath = pkgPath.toAbsolutePath().toString();
+            String absolutePath = pkgPath.toAbsolutePath().normalize().toString();
             bundle.setPackageName(absolutePath);
             response = rpc.installRecipes(absolutePath, bundle.getVersion());
         } else {

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -952,6 +952,9 @@ func (s *server) handleInstallRecipes(params json.RawMessage) (any, *rpcError) {
 		if err != nil {
 			return nil, &rpcError{Code: -32603, Message: fmt.Sprintf("Install from path failed: %v", err)}
 		}
+		for _, r := range info.Recipes {
+			s.recipeOrigin[r.Name] = localPath
+		}
 		afterCount := len(s.registry.AllRecipes())
 		return &installRecipesResponse{
 			RecipesInstalled: afterCount - beforeCount,

--- a/rewrite-go/src/main/java/org/openrewrite/golang/marketplace/GolangRecipeBundleResolver.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/marketplace/GolangRecipeBundleResolver.java
@@ -50,9 +50,15 @@ public class GolangRecipeBundleResolver implements RecipeBundleResolver {
     @Override
     public RecipeBundleReader resolve(RecipeBundle bundle) {
         Path pkgPath = Paths.get(bundle.getPackageName());
-        InstallRecipesResponse response = Files.exists(pkgPath)
-                ? rpc.installRecipes(pkgPath.toFile())
-                : rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
+        InstallRecipesResponse response;
+        if (Files.exists(pkgPath)) {
+            // Key the bundle on the absolute, normalized path so it matches the origin the server records for it.
+            Path absolute = pkgPath.toAbsolutePath().normalize();
+            bundle.setPackageName(absolute.toString());
+            response = rpc.installRecipes(absolute.toFile());
+        } else {
+            response = rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
+        }
         this.lastResponse = response;
         if (response.getVersion() != null) {
             bundle.setVersion(response.getVersion());

--- a/rewrite-javascript/rewrite/src/rpc/request/install-recipes.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/install-recipes.ts
@@ -150,16 +150,12 @@ export class InstallRecipes {
                         throw new Error(`${recipesName} does not export an 'activate' function`);
                     }
 
-                    // Attribute the recipes this install contributed to their package, so GetMarketplace
-                    // can tag each row with its origin and the host can bind it to the right bundle.
-                    // Local-path installs have no package identity, so they stay unattributed and fall
-                    // back to the requested bundle on the host.
-                    if (typeof request.recipes === "object") {
-                        const packageName = request.recipes.packageName;
-                        for (const recipe of marketplace.allRecipes()) {
-                            if (!beforeNames.has(recipe.name)) {
-                                recipeOrigin.set(recipe.name, packageName);
-                            }
+                    const origin = typeof request.recipes === "object"
+                        ? request.recipes.packageName
+                        : request.recipes;
+                    for (const recipe of marketplace.allRecipes()) {
+                        if (!beforeNames.has(recipe.name)) {
+                            recipeOrigin.set(recipe.name, origin);
                         }
                     }
 

--- a/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
@@ -311,7 +311,7 @@ describe("InstallRecipes", () => {
 
     describe("recipe attribution", () => {
 
-        test("does not attribute recipes installed from a local path", async () => {
+        test("attributes recipes installed from a local path to that path", async () => {
             await withDir(async (dir) => {
                 const recipeModulePath = path.join(dir.path, "local-recipe.js");
                 fs.writeFileSync(recipeModulePath, `
@@ -337,9 +337,8 @@ describe("InstallRecipes", () => {
                 await handler({recipes: recipeModulePath} as any);
 
                 expect(marketplace.allRecipes().length).toBe(1);
-                // A local-path install has no package identity, so it stays unattributed and falls
-                // back to the requested bundle on the host.
-                expect(recipeOrigin.size).toBe(0);
+                // Attributed to the install path (the host's bundle identity), not left unattributed.
+                expect(recipeOrigin.get("local.recipe")).toBe(recipeModulePath);
             }, {unsafeCleanup: true});
         });
 

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleResolver.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleResolver.java
@@ -40,7 +40,10 @@ public class NpmRecipeBundleResolver implements RecipeBundleResolver {
         Path pkgPath = Paths.get(bundle.getPackageName());
         InstallRecipesResponse response;
         if (Files.exists(pkgPath)) {
-            response = rpc.installRecipes(pkgPath.toFile());
+            // Key the bundle on the absolute, normalized path so it matches the origin the server records for it.
+            Path absolute = pkgPath.toAbsolutePath().normalize();
+            bundle.setPackageName(absolute.toString());
+            response = rpc.installRecipes(absolute.toFile());
         } else {
             response = rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
         }

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -845,7 +845,7 @@ def handle_install_recipes(params: dict) -> dict:
             before = recipe_name_set(marketplace)
             _import_and_activate_package(package_name, marketplace, local_path)
             added = recipe_name_set(marketplace) - before
-            _attribution.record(package_name, added)
+            _attribution.record(recipes, added)
             recipes_added = len(added)
 
     elif isinstance(recipes, dict):

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -271,8 +271,46 @@ def test_get_marketplace_row_carries_package_name(monkeypatch):
     assert row["packageName"] == "my-recipes-package"
 
 
+def test_handle_install_recipes_local_path_attributes_to_the_path(tmp_path, monkeypatch):
+    """A local-path install attributes its recipes to the install path (the host's bundle identity),
+    not the distribution name — the host's marketplace filter keys on that path."""
+    import rewrite.rpc.server as server
+    from rewrite.discovery import RecipeAttribution
+    from rewrite import CategoryDescriptor, RecipeMarketplace, Recipe
+
+    class _MyRecipe(Recipe):
+        @property
+        def name(self): return "org.example.MyRecipe"
+        @property
+        def display_name(self): return "My Recipe"
+        @property
+        def description(self): return "A recipe."
+
+    marketplace = RecipeMarketplace()
+    monkeypatch.setattr(server, "_marketplace", marketplace)
+    monkeypatch.setattr(server, "_attribution", RecipeAttribution())
+    monkeypatch.setattr(server, "_recipe_install_dir", None)
+    # The distribution name deliberately differs from the install path — attributing to it was the bug.
+    monkeypatch.setattr(server, "_find_package_name", lambda path: "some-distribution-name")
+    monkeypatch.setattr(server, "_import_and_activate_package",
+                        lambda pkg, mkt, local_path=None: mkt.install(_MyRecipe, [CategoryDescriptor(display_name="Test")]))
+
+    local = tmp_path / "my-recipe"
+    local.mkdir()
+
+    response = server.handle_install_recipes({"recipes": str(local)})
+
+    assert response["recipesInstalled"] == 1
+    # Attributed to the path, not the distribution name.
+    assert server._attribution.package_for("org.example.MyRecipe") == str(local)
+    # And GetMarketplace surfaces that path as the row's origin, so the host keeps the recipe.
+    rows = server._collect_marketplace_rows(marketplace)
+    row = next(r for r in rows if r["descriptor"]["name"] == "org.example.MyRecipe")
+    assert row["packageName"] == str(local)
+
+
 def test_get_marketplace_row_unattributed_has_none_package_name(monkeypatch):
-    """An unattributed recipe (e.g. a local-path install with no package identity)
+    """An unattributed recipe (e.g. a built-in the server recorded no origin for)
     leaves packageName None so the host falls back to the requested bundle."""
     import rewrite.rpc.server as server
     from rewrite.discovery import RecipeAttribution

--- a/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
@@ -40,7 +40,10 @@ public class PipRecipeBundleResolver implements RecipeBundleResolver {
         Path pkgPath = Paths.get(bundle.getPackageName());
         InstallRecipesResponse response;
         if (Files.exists(pkgPath)) {
-            response = rpc.installRecipes(pkgPath.toFile());
+            // Key the bundle on the absolute, normalized path so it matches the origin the server records for it.
+            Path absolute = pkgPath.toAbsolutePath().normalize();
+            bundle.setPackageName(absolute.toString());
+            response = rpc.installRecipes(absolute.toFile());
         } else {
             response = rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
         }


### PR DESCRIPTION
## Problem

A local (by-file) recipe install was attributed inconsistently across the RPC ecosystems, and the host filters `GetMarketplace` rows by the bundle's `packageName`:

| Ecosystem | Local-install attribution (before) | Result |
|---|---|---|
| python | pyproject distribution name | name ≠ path bundle key → **all recipes dropped ("Found 0 recipes")** |
| npm / go | unattributed (`null`) | falls back onto **every** bundle (cross-bundle leak) |
| csharp / nuget | the received path | correct |

## Fix

Make all four ecosystems agree on one identity for a local install:

- The **resolver** keys the bundle on the **absolute, normalized path** (`toAbsolutePath().normalize()`) and sends that same path to the server (`Pip`/`Npm`/`Golang`/`NuGet` resolvers).
- Each **server** attributes a local install to the **path it received** (python `server.py`, npm `install-recipes.ts`, go `main.go`; C# already did).

The bundle key and the server's attribution are then the same value, so the shared `GetMarketplaceResponse.toMarketplace` filter keeps the recipes for that bundle only — no drop, no leak. The package-install path is unchanged.

## Tests

- python: local-path install attributes recipes to the install path (`test_server.py`)
- npm: updated to assert local installs are attributed to the path (`install-recipes.test.ts`)

## Note

Pairs with a companion Moderne CLI change that keys local recipe bundles by their absolute path on install/uninstall; both are needed for the end-to-end fix.