### PR TITLE
Scala: fix printing of two cases in one line separated by semicolon

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -1657,8 +1657,12 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             if (!indented) {
                 p.append('{');
             }
-            for (Statement caseStmt : cases.getStatements()) {
-                visit(caseStmt, p);
+            for (JRightPadded<Statement> rp : cases.getPadding().getStatements()) {
+                visit(rp.getElement(), p);
+                visitSpace(rp.getAfter(), Space.Location.LANGUAGE_EXTENSION, p);
+                if (rp.getMarkers().findFirst(Semicolon.class).isPresent()) {
+                    p.append(';');
+                }
             }
             visitSpace(cases.getEnd(), Space.Location.BLOCK_END, p);
             if (!indented) {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/MatchTest.java
@@ -569,6 +569,17 @@ class MatchTest implements RewriteTest {
     }
 
     @Test
+    void partialFunctionLiteralCasesSeparatedBySemicolon() {
+        rewriteRun(
+          scala(
+            """
+            val r = List(1).map { case '\\t' => '\\t'; case _ => ' ' }
+            """
+          )
+        );
+    }
+
+    @Test
     void dottedMatchOnRightSideOfInfixOperator() {
         rewriteRun(
           scala(


### PR DESCRIPTION
**What**: Fixing printing of two cases in one line separated by a semicolon in Scala.
**Why**: It suffers from idempotency issues.