### PR TITLE
Go: GoResolutionResult marker to include module graph

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -2102,6 +2102,16 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		if sumData, err := os.ReadFile(sumPath); err == nil {
 			mrr.ResolvedDependencies = goparser.ParseGoSum(string(sumData))
 		}
+		// Enrich the resolved build list with go list/go mod graph metadata + the
+		// package->module map. Best-effort: on any toolchain/network failure keep
+		// the go.sum-only result (never fail the parse).
+		moduleDir := filepath.Dir(modPath)
+		if resolved, pkgs, rerr := goparser.ResolveModuleGraph(moduleDir); rerr != nil {
+			s.logger.Printf("ParseProject: module resolution failed for %s (go.sum-only): %v", moduleDir, rerr)
+		} else {
+			mrr.ResolvedDependencies = goparser.MergeResolvedDependencies(mrr.ResolvedDependencies, resolved)
+			mrr.PackageModules = pkgs
+		}
 		mods[filepath.Dir(modPath)] = &modCtx{dir: filepath.Dir(modPath), mrr: mrr}
 	}
 

--- a/rewrite-go/cmd/rpc/parse_project_resolve_test.go
+++ b/rewrite-go/cmd/rpc/parse_project_resolve_test.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+)
+
+// TestParseProjectResolvesModuleGraph pins the parse-time resolution wiring:
+// handleParseProject must run the go toolchain against the module dir and land
+// the resolved build list + package->module map on the GoResolutionResult
+// marker. Uses a stdlib-only module so resolution needs no network.
+func TestParseProjectResolvesModuleGraph(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not on PATH")
+	}
+
+	// given: a dependency-free module on disk
+	s, _ := newTestServer(t)
+	projectDir := t.TempDir()
+	writeFile(t, filepath.Join(projectDir, "go.mod"), "module example.com/foo\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(projectDir, "main.go"),
+		"package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Println(\"hi\") }\n")
+
+	relativeTo := projectDir
+	params, err := json.Marshal(parseProjectRequest{ProjectPath: projectDir, RelativeTo: &relativeTo})
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+
+	// when
+	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
+		t.Fatalf("handleParseProject: %v", rpcErr.Message)
+	}
+
+	// then: the GoResolutionResult marker carries toolchain-resolved data
+	mrr := findGoResolutionResult(t, s)
+
+	var main *golang.GoResolvedDependency
+	for i := range mrr.ResolvedDependencies {
+		if mrr.ResolvedDependencies[i].ModulePath == "example.com/foo" {
+			main = &mrr.ResolvedDependencies[i]
+		}
+	}
+	if main == nil {
+		t.Fatalf("main module missing from resolved build list: %+v", mrr.ResolvedDependencies)
+	}
+	if !main.Main {
+		t.Errorf("main module should have Main=true: %+v", main)
+	}
+
+	var sawStdlib, sawMainPkg bool
+	for _, p := range mrr.PackageModules {
+		if p.ImportPath == "fmt" && p.Standard {
+			sawStdlib = true
+		}
+		if p.ImportPath == "example.com/foo" && p.ModulePath == "example.com/foo" {
+			sawMainPkg = true
+		}
+	}
+	if !sawStdlib {
+		t.Errorf("expected stdlib package fmt (Standard) in PackageModules: %+v", mrr.PackageModules)
+	}
+	if !sawMainPkg {
+		t.Errorf("expected the main package mapped to its module in PackageModules: %+v", mrr.PackageModules)
+	}
+}
+
+func findGoResolutionResult(t *testing.T, s *server) golang.GoResolutionResult {
+	t.Helper()
+	for _, obj := range s.localObjects {
+		gm, ok := obj.(*golang.GoMod)
+		if !ok {
+			continue
+		}
+		for _, m := range gm.Markers.Entries {
+			if mrr, ok := m.(golang.GoResolutionResult); ok {
+				return mrr
+			}
+		}
+	}
+	t.Fatal("no GoResolutionResult marker found on any produced GoMod")
+	return golang.GoResolutionResult{}
+}

--- a/rewrite-go/pkg/parser/gomod_resolve.go
+++ b/rewrite-go/pkg/parser/gomod_resolve.go
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+)
+
+// resolveTimeout bounds each `go` invocation so a hung proxy fetch can never
+// block the parse indefinitely. On timeout the command errors and the caller
+// falls back to go.sum-only.
+const resolveTimeout = 120 * time.Second
+
+// ResolveModuleGraph runs the Go toolchain in moduleDir to produce the resolved
+// build list (with graph edges) and the imported-package -> module map that
+// go.sum alone cannot provide. It is a pure function of the on-disk module: no
+// marker coupling, no mutation of go.mod/go.sum (readonly + -e).
+//
+// It degrades gracefully: any hard toolchain/network failure returns an error
+// so the caller can keep today's go.sum-only behavior. Partial output from an
+// untidy module (surfaced via -e) is kept rather than discarded.
+func ResolveModuleGraph(moduleDir string) (mods []golang.GoResolvedDependency, pkgs []golang.GoPackageModule, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			mods, pkgs, err = nil, nil, fmt.Errorf("resolve panicked: %v", r)
+		}
+	}()
+
+	// The build list is mandatory: without it there is nothing to enrich, so a
+	// failure here propagates and the caller falls back to go.sum-only.
+	mods, err = goListModules(moduleDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Graph edges and the package map are best-effort: a partial build list is
+	// still useful, so sub-failures are swallowed rather than discarding mods.
+	if edges, gerr := goModGraph(moduleDir); gerr == nil {
+		attachEdges(mods, edges)
+	}
+	pkgs, _ = goListPackages(moduleDir)
+	return mods, pkgs, nil
+}
+
+// goModule is the subset of `go list -m -json` / `go list -deps -json` output we consume.
+type goModule struct {
+	Path      string
+	Version   string
+	Main      bool
+	Indirect  bool
+	GoVersion string
+	Replace   *goModule
+}
+
+type goPackage struct {
+	ImportPath string
+	Standard   bool
+	Module     *goModule
+}
+
+func goListModules(dir string) ([]golang.GoResolvedDependency, error) {
+	stdout, err := runGo(dir, "list", "-mod=readonly", "-e", "-m", "-json", "all")
+	if err != nil && len(stdout) == 0 {
+		return nil, err
+	}
+	var out []golang.GoResolvedDependency
+	dec := json.NewDecoder(bytes.NewReader(stdout))
+	for {
+		var m goModule
+		if derr := dec.Decode(&m); derr == io.EOF {
+			break
+		} else if derr != nil {
+			return out, fmt.Errorf("go list -m decode: %w", derr)
+		}
+		if m.Path == "" {
+			continue
+		}
+		rd := golang.GoResolvedDependency{
+			ModulePath:      m.Path,
+			Version:         m.Version,
+			Main:            m.Main,
+			Indirect:        m.Indirect,
+			ModuleGoVersion: m.GoVersion,
+		}
+		if m.Replace != nil {
+			rd.ReplacePath = m.Replace.Path
+			rd.ReplaceVersion = m.Replace.Version
+		}
+		out = append(out, rd)
+	}
+	return out, nil
+}
+
+func goListPackages(dir string) ([]golang.GoPackageModule, error) {
+	stdout, err := runGo(dir, "list", "-mod=readonly", "-e", "-deps", "-json", "./...")
+	if err != nil && len(stdout) == 0 {
+		return nil, err
+	}
+	var out []golang.GoPackageModule
+	dec := json.NewDecoder(bytes.NewReader(stdout))
+	for {
+		var p goPackage
+		if derr := dec.Decode(&p); derr == io.EOF {
+			break
+		} else if derr != nil {
+			return out, fmt.Errorf("go list -deps decode: %w", derr)
+		}
+		if p.ImportPath == "" {
+			continue
+		}
+		pm := golang.GoPackageModule{ImportPath: p.ImportPath, Standard: p.Standard}
+		if p.Module != nil {
+			pm.ModulePath = p.Module.Path
+			pm.Version = p.Module.Version
+		}
+		out = append(out, pm)
+	}
+	return out, nil
+}
+
+type moduleEdge struct {
+	fromPath, toPath, toVersion string
+}
+
+func goModGraph(dir string) ([]moduleEdge, error) {
+	stdout, err := runGo(dir, "mod", "graph")
+	if err != nil && len(stdout) == 0 {
+		return nil, err
+	}
+	var edges []moduleEdge
+	for _, line := range strings.Split(string(stdout), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			continue
+		}
+		fromPath, _ := splitModuleVersion(parts[0])
+		toPath, toVersion := splitModuleVersion(parts[1])
+		edges = append(edges, moduleEdge{fromPath: fromPath, toPath: toPath, toVersion: toVersion})
+	}
+	return edges, nil
+}
+
+func splitModuleVersion(s string) (path, version string) {
+	if i := strings.Index(s, "@"); i >= 0 {
+		return s[:i], s[i+1:]
+	}
+	return s, ""
+}
+
+// attachEdges sets each build-list node's Deps from the module graph. Edges are
+// keyed by the source module path (MVS selects one version per path), so a node
+// receives the direct dependencies its selected version requires.
+func attachEdges(mods []golang.GoResolvedDependency, edges []moduleEdge) {
+	byPath := make(map[string]int, len(mods))
+	for i := range mods {
+		byPath[mods[i].ModulePath] = i
+	}
+	for _, e := range edges {
+		i, ok := byPath[e.fromPath]
+		if !ok {
+			continue
+		}
+		mods[i].Deps = append(mods[i].Deps, golang.GoModuleRef{ModulePath: e.toPath, Version: e.toVersion})
+	}
+}
+
+func runGo(dir string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), resolveTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GO111MODULE=on", "GOFLAGS=-mod=readonly")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.Bytes(), fmt.Errorf("go %s: %v: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+// MergeResolvedDependencies overlays the toolchain-resolved build list onto the
+// go.sum-derived hash rows, keyed by module@version. Build-list nodes are
+// authoritative (they carry the selected version, indirect/main flags, replace
+// info and graph edges) and inherit the go.sum content hashes for their version.
+// go.sum rows whose version is not in the selected build list (stale/extra
+// hashes) are preserved. Pure function — unit-testable without the toolchain.
+func MergeResolvedDependencies(fromSum, fromList []golang.GoResolvedDependency) []golang.GoResolvedDependency {
+	key := func(d golang.GoResolvedDependency) string { return d.ModulePath + "@" + d.Version }
+	sumByKey := make(map[string]golang.GoResolvedDependency, len(fromSum))
+	for _, d := range fromSum {
+		sumByKey[key(d)] = d
+	}
+	out := make([]golang.GoResolvedDependency, 0, len(fromList)+len(fromSum))
+	seen := make(map[string]bool, len(fromList))
+	for _, m := range fromList {
+		k := key(m)
+		if s, ok := sumByKey[k]; ok {
+			m.ModuleHash = s.ModuleHash
+			m.GoModHash = s.GoModHash
+		}
+		out = append(out, m)
+		seen[k] = true
+	}
+	for _, s := range fromSum {
+		if !seen[key(s)] {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/rewrite-go/pkg/parser/gomod_resolve_test.go
+++ b/rewrite-go/pkg/parser/gomod_resolve_test.go
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+)
+
+func TestMergeResolvedDependencies(t *testing.T) {
+	// given: go.sum hashes and a toolchain-resolved build list that overlap on one module
+	fromSum := []golang.GoResolvedDependency{
+		{ModulePath: "github.com/a/b", Version: "v1.0.0", ModuleHash: "h1:mod=", GoModHash: "h1:gomod="},
+		{ModulePath: "github.com/a/b", Version: "v0.9.0", ModuleHash: "h1:stale="}, // superseded version
+	}
+	fromList := []golang.GoResolvedDependency{
+		{ModulePath: "github.com/a/b", Version: "v1.0.0", Indirect: true, ModuleGoVersion: "1.20",
+			Deps: []golang.GoModuleRef{{ModulePath: "github.com/c/d", Version: "v2.0.0"}}},
+	}
+
+	// when
+	merged := MergeResolvedDependencies(fromSum, fromList)
+
+	// then: the build-list node is authoritative and inherits the go.sum hashes
+	if len(merged) != 2 {
+		t.Fatalf("want 2 entries (1 build-list + 1 stale sum), got %d: %+v", len(merged), merged)
+	}
+	got := merged[0]
+	if got.ModulePath != "github.com/a/b" || got.Version != "v1.0.0" {
+		t.Fatalf("first entry should be the selected build-list node, got %+v", got)
+	}
+	if !got.Indirect || got.ModuleGoVersion != "1.20" || len(got.Deps) != 1 {
+		t.Errorf("build-list metadata not preserved: %+v", got)
+	}
+	if got.ModuleHash != "h1:mod=" || got.GoModHash != "h1:gomod=" {
+		t.Errorf("go.sum hashes not inherited onto build-list node: %+v", got)
+	}
+	// and: the superseded go.sum row is preserved
+	if merged[1].Version != "v0.9.0" || merged[1].ModuleHash != "h1:stale=" {
+		t.Errorf("stale go.sum row should be preserved, got %+v", merged[1])
+	}
+}
+
+func TestMergeResolvedDependenciesEmpty(t *testing.T) {
+	// given / when: no build list (resolution unavailable) leaves go.sum rows untouched
+	fromSum := []golang.GoResolvedDependency{{ModulePath: "x", Version: "v1", ModuleHash: "h1:x="}}
+
+	// then
+	merged := MergeResolvedDependencies(fromSum, nil)
+	if len(merged) != 1 || merged[0].ModuleHash != "h1:x=" {
+		t.Fatalf("go.sum-only merge should pass through, got %+v", merged)
+	}
+	if got := MergeResolvedDependencies(nil, nil); len(got) != 0 {
+		t.Errorf("empty inputs should yield empty, got %+v", got)
+	}
+}
+
+func TestAttachEdges(t *testing.T) {
+	// given
+	mods := []golang.GoResolvedDependency{
+		{ModulePath: "example.com/main"},
+		{ModulePath: "github.com/a/b", Version: "v1.0.0"},
+	}
+	edges := []moduleEdge{
+		{fromPath: "example.com/main", toPath: "github.com/a/b", toVersion: "v1.0.0"},
+		{fromPath: "github.com/gone", toPath: "github.com/x/y", toVersion: "v1"}, // unknown source: dropped
+	}
+
+	// when
+	attachEdges(mods, edges)
+
+	// then
+	if len(mods[0].Deps) != 1 || mods[0].Deps[0].ModulePath != "github.com/a/b" {
+		t.Fatalf("edge not attached to source node: %+v", mods[0].Deps)
+	}
+	if len(mods[1].Deps) != 0 {
+		t.Errorf("node with no outgoing edges should have no Deps: %+v", mods[1].Deps)
+	}
+}
+
+func TestSplitModuleVersion(t *testing.T) {
+	// given / when / then
+	if p, v := splitModuleVersion("github.com/a/b@v1.2.3"); p != "github.com/a/b" || v != "v1.2.3" {
+		t.Errorf("got %q %q", p, v)
+	}
+	if p, v := splitModuleVersion("example.com/main"); p != "example.com/main" || v != "" {
+		t.Errorf("main module (no version) got %q %q", p, v)
+	}
+}
+
+// TestResolveModuleGraphStdlibOnly exercises the real toolchain path offline:
+// a module importing only the standard library resolves with no network access.
+func TestResolveModuleGraphStdlibOnly(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not on PATH")
+	}
+	// given: a minimal, dependency-free module on disk
+	dir := t.TempDir()
+	writeFile(t, dir, "go.mod", "module example.com/testmod\n\ngo 1.21\n")
+	writeFile(t, dir, "main.go", "package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Println(\"hi\") }\n")
+
+	// when
+	mods, pkgs, err := ResolveModuleGraph(dir)
+	if err != nil {
+		t.Fatalf("resolve failed: %v", err)
+	}
+
+	// then: the build list contains the main module
+	var main *golang.GoResolvedDependency
+	for i := range mods {
+		if mods[i].ModulePath == "example.com/testmod" {
+			main = &mods[i]
+		}
+	}
+	if main == nil {
+		t.Fatalf("main module missing from build list: %+v", mods)
+	}
+	if !main.Main {
+		t.Errorf("main module should have Main=true: %+v", main)
+	}
+
+	// and: the package map classifies stdlib and the main package
+	var sawStdlib, sawMain bool
+	for _, p := range pkgs {
+		if p.ImportPath == "fmt" && p.Standard {
+			sawStdlib = true
+		}
+		if p.ImportPath == "example.com/testmod" && p.ModulePath == "example.com/testmod" {
+			sawMain = true
+		}
+	}
+	if !sawStdlib {
+		t.Errorf("expected stdlib package fmt with Standard=true in %+v", pkgs)
+	}
+	if !sawMain {
+		t.Errorf("expected the main package mapped to its module in %+v", pkgs)
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}

--- a/rewrite-go/pkg/rpc/go_resolution_result_codec.go
+++ b/rewrite-go/pkg/rpc/go_resolution_result_codec.go
@@ -39,6 +39,10 @@ import (
 //  9. retracts (List<Retract>, ref-by-key)
 //
 // 10. resolvedDependencies (List<ResolvedDependency>, ref-by-key)
+// 11. packageModules (List<PackageModule>, ref-by-key)
+//
+// Each ResolvedDependency element sends, after goModHash: indirect, main,
+// replacePath, replaceVersion, moduleGoVersion, then deps (List<ModuleRef>).
 //
 // Each list element invokes its own rpcSend on the Java side; we mirror
 // the same field order in the per-element onChange callback.
@@ -109,6 +113,33 @@ func sendGoResolutionResult(m golang.GoResolutionResult, q *SendQueue) {
 			q.GetAndSend(d, func(y any) any { return y.(golang.GoResolvedDependency).Version }, nil)
 			q.GetAndSend(d, func(y any) any { return emptyAsNil(y.(golang.GoResolvedDependency).ModuleHash) }, nil)
 			q.GetAndSend(d, func(y any) any { return emptyAsNil(y.(golang.GoResolvedDependency).GoModHash) }, nil)
+			q.GetAndSend(d, func(y any) any { return y.(golang.GoResolvedDependency).Indirect }, nil)
+			q.GetAndSend(d, func(y any) any { return y.(golang.GoResolvedDependency).Main }, nil)
+			q.GetAndSend(d, func(y any) any { return emptyAsNil(y.(golang.GoResolvedDependency).ReplacePath) }, nil)
+			q.GetAndSend(d, func(y any) any { return emptyAsNil(y.(golang.GoResolvedDependency).ReplaceVersion) }, nil)
+			q.GetAndSend(d, func(y any) any { return emptyAsNil(y.(golang.GoResolvedDependency).ModuleGoVersion) }, nil)
+			q.GetAndSendListAsRef(d,
+				func(y any) []any { return moduleRefSlice(y.(golang.GoResolvedDependency).Deps) },
+				func(y any) any {
+					r := y.(golang.GoModuleRef)
+					return r.ModulePath + "@" + r.Version
+				},
+				func(y any) {
+					r := y.(golang.GoModuleRef)
+					q.GetAndSend(r, func(z any) any { return z.(golang.GoModuleRef).ModulePath }, nil)
+					q.GetAndSend(r, func(z any) any { return z.(golang.GoModuleRef).Version }, nil)
+				})
+		})
+
+	q.GetAndSendListAsRef(m,
+		func(x any) []any { return packageModuleSlice(x.(golang.GoResolutionResult).PackageModules) },
+		func(x any) any { return x.(golang.GoPackageModule).ImportPath },
+		func(x any) {
+			p := x.(golang.GoPackageModule)
+			q.GetAndSend(p, func(y any) any { return y.(golang.GoPackageModule).ImportPath }, nil)
+			q.GetAndSend(p, func(y any) any { return emptyAsNil(y.(golang.GoPackageModule).ModulePath) }, nil)
+			q.GetAndSend(p, func(y any) any { return emptyAsNil(y.(golang.GoPackageModule).Version) }, nil)
+			q.GetAndSend(p, func(y any) any { return y.(golang.GoPackageModule).Standard }, nil)
 		})
 }
 
@@ -131,6 +162,7 @@ func receiveGoResolutionResult(before golang.GoResolutionResult, q *ReceiveQueue
 	before.Excludes = recvExcludes(q, before.Excludes)
 	before.Retracts = recvRetracts(q, before.Retracts)
 	before.ResolvedDependencies = recvResolvedDeps(q, before.ResolvedDependencies)
+	before.PackageModules = recvPackageModules(q, before.PackageModules)
 	return before
 }
 
@@ -217,6 +249,12 @@ func recvResolvedDeps(q *ReceiveQueue, before []golang.GoResolvedDependency) []g
 		d.Version = receiveScalar[string](q, d.Version)
 		d.ModuleHash = receiveNullableString(q, d.ModuleHash)
 		d.GoModHash = receiveNullableString(q, d.GoModHash)
+		d.Indirect = receiveScalar[bool](q, d.Indirect)
+		d.Main = receiveScalar[bool](q, d.Main)
+		d.ReplacePath = receiveNullableString(q, d.ReplacePath)
+		d.ReplaceVersion = receiveNullableString(q, d.ReplaceVersion)
+		d.ModuleGoVersion = receiveNullableString(q, d.ModuleGoVersion)
+		d.Deps = recvModuleRefs(q, d.Deps)
 		return d
 	})
 	if afterAny == nil {
@@ -225,6 +263,44 @@ func recvResolvedDeps(q *ReceiveQueue, before []golang.GoResolvedDependency) []g
 	out := make([]golang.GoResolvedDependency, len(afterAny))
 	for i, v := range afterAny {
 		out[i] = v.(golang.GoResolvedDependency)
+	}
+	return out
+}
+
+func recvModuleRefs(q *ReceiveQueue, before []golang.GoModuleRef) []golang.GoModuleRef {
+	beforeAny := moduleRefSlice(before)
+	afterAny := q.ReceiveList(beforeAny, func(v any) any {
+		r := v.(golang.GoModuleRef)
+		r.ModulePath = receiveScalar[string](q, r.ModulePath)
+		r.Version = receiveScalar[string](q, r.Version)
+		return r
+	})
+	if afterAny == nil {
+		return nil
+	}
+	out := make([]golang.GoModuleRef, len(afterAny))
+	for i, v := range afterAny {
+		out[i] = v.(golang.GoModuleRef)
+	}
+	return out
+}
+
+func recvPackageModules(q *ReceiveQueue, before []golang.GoPackageModule) []golang.GoPackageModule {
+	beforeAny := packageModuleSlice(before)
+	afterAny := q.ReceiveList(beforeAny, func(v any) any {
+		p := v.(golang.GoPackageModule)
+		p.ImportPath = receiveScalar[string](q, p.ImportPath)
+		p.ModulePath = receiveNullableString(q, p.ModulePath)
+		p.Version = receiveNullableString(q, p.Version)
+		p.Standard = receiveScalar[bool](q, p.Standard)
+		return p
+	})
+	if afterAny == nil {
+		return nil
+	}
+	out := make([]golang.GoPackageModule, len(afterAny))
+	for i, v := range afterAny {
+		out[i] = v.(golang.GoPackageModule)
 	}
 	return out
 }
@@ -274,6 +350,28 @@ func retractSlice(s []golang.GoRetract) []any {
 }
 
 func resolvedSlice(s []golang.GoResolvedDependency) []any {
+	if s == nil {
+		return nil
+	}
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}
+
+func moduleRefSlice(s []golang.GoModuleRef) []any {
+	if s == nil {
+		return nil
+	}
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}
+
+func packageModuleSlice(s []golang.GoPackageModule) []any {
 	if s == nil {
 		return nil
 	}

--- a/rewrite-go/pkg/rpc/marker_codec_test.go
+++ b/rewrite-go/pkg/rpc/marker_codec_test.go
@@ -97,7 +97,23 @@ func TestGoResolutionResultMarkerRoundTrip(t *testing.T) {
 			{VersionRange: "[v1.0.0, v1.0.5]"},
 		},
 		ResolvedDependencies: []golang.GoResolvedDependency{
-			{ModulePath: "github.com/google/uuid", Version: "v1.6.0", ModuleHash: "h1:abc=", GoModHash: "h1:def="},
+			{
+				ModulePath: "github.com/google/uuid", Version: "v1.6.0",
+				ModuleHash: "h1:abc=", GoModHash: "h1:def=",
+				Main: true, ModuleGoVersion: "1.22",
+				Deps: []golang.GoModuleRef{
+					{ModulePath: "golang.org/x/mod", Version: "v0.35.0"},
+				},
+			},
+			{
+				ModulePath: "golang.org/x/mod", Version: "v0.35.0",
+				ModuleHash: "h1:ghi=", GoModHash: "h1:jkl=",
+				Indirect: true, ReplacePath: "github.com/forked/mod", ReplaceVersion: "v0.35.1",
+			},
+		},
+		PackageModules: []golang.GoPackageModule{
+			{ImportPath: "fmt", Standard: true},
+			{ImportPath: "github.com/google/uuid", ModulePath: "github.com/google/uuid", Version: "v1.6.0"},
 		},
 	}
 	before := java.Markers{ID: uuid.New(), Entries: []java.Marker{mrr}}

--- a/rewrite-go/pkg/rpc/value_types.go
+++ b/rewrite-go/pkg/rpc/value_types.go
@@ -128,6 +128,8 @@ func init() {
 	RegisterValueType(reflect.TypeOf(golang.GoExclude{}), "org.openrewrite.golang.marker.GoResolutionResult$Exclude")
 	RegisterValueType(reflect.TypeOf(golang.GoRetract{}), "org.openrewrite.golang.marker.GoResolutionResult$Retract")
 	RegisterValueType(reflect.TypeOf(golang.GoResolvedDependency{}), "org.openrewrite.golang.marker.GoResolutionResult$ResolvedDependency")
+	RegisterValueType(reflect.TypeOf(golang.GoModuleRef{}), "org.openrewrite.golang.marker.GoResolutionResult$ModuleRef")
+	RegisterValueType(reflect.TypeOf(golang.GoPackageModule{}), "org.openrewrite.golang.marker.GoResolutionResult$PackageModule")
 
 	// JavaType types
 	RegisterValueType(reflect.TypeOf((*java.JavaTypeClass)(nil)), "org.openrewrite.java.tree.JavaType$Class")
@@ -263,6 +265,8 @@ func init() {
 	RegisterFactory("org.openrewrite.golang.marker.GoResolutionResult$Exclude", func() any { return golang.GoExclude{} })
 	RegisterFactory("org.openrewrite.golang.marker.GoResolutionResult$Retract", func() any { return golang.GoRetract{} })
 	RegisterFactory("org.openrewrite.golang.marker.GoResolutionResult$ResolvedDependency", func() any { return golang.GoResolvedDependency{} })
+	RegisterFactory("org.openrewrite.golang.marker.GoResolutionResult$ModuleRef", func() any { return golang.GoModuleRef{} })
+	RegisterFactory("org.openrewrite.golang.marker.GoResolutionResult$PackageModule", func() any { return golang.GoPackageModule{} })
 
 	RegisterFactory("org.openrewrite.java.tree.Space", func() any { return java.Space{} })
 	RegisterFactory("org.openrewrite.marker.Markers", func() any { return java.Markers{} })

--- a/rewrite-go/pkg/test/spec.go
+++ b/rewrite-go/pkg/test/spec.go
@@ -157,6 +157,34 @@ func mergeGoSumIntoGoMod(specs []SourceSpec) {
 	specs[modIdx].Markers[markerIdx] = mrr
 }
 
+// GoModGraph decorates a GoMod SourceSpec with a resolved build list and
+// package->module map, as if parse-time toolchain resolution (ResolveModuleGraph)
+// had run. It lets recipes that consume ResolvedDependency.Deps / PackageModules
+// be unit-tested without invoking the go toolchain (which the Go unit harness
+// cannot run). No-op when the spec carries no GoResolutionResult marker.
+//
+// Example:
+//
+//	test.GoModGraph(
+//	    test.GoMod("module example.com/foo\ngo 1.22\n"),
+//	    []golang.GoResolvedDependency{{ModulePath: "example.com/foo", Main: true}},
+//	    []golang.GoPackageModule{{ImportPath: "fmt", Standard: true}},
+//	)
+func GoModGraph(mod SourceSpec, resolved []golang.GoResolvedDependency, pkgs []golang.GoPackageModule) SourceSpec {
+	markers := make([]java.Marker, len(mod.Markers))
+	copy(markers, mod.Markers)
+	for i, m := range markers {
+		if mrr, ok := m.(golang.GoResolutionResult); ok {
+			mrr.ResolvedDependencies = resolved
+			mrr.PackageModules = pkgs
+			markers[i] = mrr
+			break
+		}
+	}
+	mod.Markers = markers
+	return mod
+}
+
 // GoProject groups a go.mod and one or more .go SourceSpecs as siblings of
 // a single project. Every child receives a golang.GoProject marker. Mirrors
 // the Java-side Assertions.goProject(name, sources...).

--- a/rewrite-go/pkg/tree/golang/go_resolution_result.go
+++ b/rewrite-go/pkg/tree/golang/go_resolution_result.go
@@ -34,6 +34,11 @@ type GoResolutionResult struct {
 	Excludes             []GoExclude
 	Retracts             []GoRetract
 	ResolvedDependencies []GoResolvedDependency
+	// PackageModules maps an imported package path to its providing module.
+	// Go-specific: unlike other ecosystems the import path is not the module
+	// coordinate, so this mapping requires toolchain resolution. Empty unless
+	// the parse-time resolution gate is on.
+	PackageModules []GoPackageModule
 }
 
 func (m GoResolutionResult) ID() uuid.UUID { return m.Ident }
@@ -51,6 +56,15 @@ func (m GoResolutionResult) FindResolved(modulePath string) *GoResolvedDependenc
 	for i := range m.ResolvedDependencies {
 		if m.ResolvedDependencies[i].ModulePath == modulePath {
 			return &m.ResolvedDependencies[i]
+		}
+	}
+	return nil
+}
+
+func (m GoResolutionResult) FindPackageModule(importPath string) *GoPackageModule {
+	for i := range m.PackageModules {
+		if m.PackageModules[i].ImportPath == importPath {
+			return &m.PackageModules[i]
 		}
 	}
 	return nil
@@ -84,11 +98,41 @@ type GoRetract struct {
 	Rationale    string // empty if no `// ...` comment
 }
 
+// GoResolvedDependency is one node in the resolved build list. It merges what
+// go.sum records (content hashes) with what the toolchain resolves (`go list -m`
+// build-list metadata and `go mod graph` edges). The toolchain-sourced fields
+// are zero-valued when the parse-time resolution gate is off (go.sum-only).
 type GoResolvedDependency struct {
+	ModulePath      string
+	Version         string
+	ModuleHash      string // h1:... — empty if only the go.mod hash is recorded
+	GoModHash       string
+	Indirect        bool   // from `go list -m`: present only transitively
+	Main            bool   // from `go list -m`: this is the main module
+	ReplacePath     string // toolchain-applied replace target, empty if none
+	ReplaceVersion  string
+	ModuleGoVersion string // this module's own `go` directive, from `go list -m`
+	// Deps are the direct module dependencies of this node (from `go mod graph`),
+	// referenced by module@version. Resolve against ResolvedDependencies. Nil when
+	// the graph is unavailable. Edges (not nested nodes) keep this cycle-safe and
+	// value-typed; Go's MVS gives one selected version per module path.
+	Deps []GoModuleRef
+}
+
+// GoModuleRef identifies a module version, used as a graph edge target.
+type GoModuleRef struct {
 	ModulePath string
 	Version    string
-	ModuleHash string // h1:... — empty if only the go.mod hash is recorded
-	GoModHash  string
+}
+
+// GoPackageModule maps an imported package path to the module that provides it,
+// from `go list -deps -json ./...`. ModulePath is empty for the standard library
+// (Standard is true).
+type GoPackageModule struct {
+	ImportPath string
+	ModulePath string
+	Version    string
+	Standard   bool
 }
 
 // The directive slices are initialized to empty (non-nil) values. Go has no
@@ -108,5 +152,6 @@ func NewGoResolutionResult(modulePath, goVersion, toolchain, path string) GoReso
 		Excludes:             []GoExclude{},
 		Retracts:             []GoRetract{},
 		ResolvedDependencies: []GoResolvedDependency{},
+		PackageModules:       []GoPackageModule{},
 	}
 }

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/MarkerRoundTripTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/MarkerRoundTripTest.java
@@ -122,7 +122,15 @@ class MarkerRoundTripTest {
                         new GoResolutionResult.ResolvedDependency(
                                 "github.com/google/uuid", "v1.6.0",
                                 "h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=",
-                                "h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=")
+                                "h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=",
+                                false, true, null, null, "1.22",
+                                Collections.singletonList(
+                                        new GoResolutionResult.ModuleRef("golang.org/x/mod", "v0.35.0")))
+                ),
+                Arrays.asList(
+                        new GoResolutionResult.PackageModule("fmt", null, null, true),
+                        new GoResolutionResult.PackageModule("github.com/google/uuid",
+                                "github.com/google/uuid", "v1.6.0", false)
                 )
         );
         cu = cu.withMarkers(cu.getMarkers().addIfAbsent(marker));
@@ -147,6 +155,7 @@ class MarkerRoundTripTest {
                 null,
                 null,
                 "go.mod",
+                Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),
@@ -180,6 +189,7 @@ class MarkerRoundTripTest {
                         Collections.emptyList(),
                         Collections.emptyList(),
                         Collections.emptyList(),
+                        Collections.emptyList(),
                         Collections.emptyList()
                 ));
         cu = cu.withMarkers(markers);
@@ -208,7 +218,16 @@ class MarkerRoundTripTest {
                         Collections.singletonList(
                                 new GoResolutionResult.Require("github.com/google/uuid", "v1.6.0", false)),
                         Collections.emptyList(), Collections.emptyList(),
-                        Collections.emptyList(), Collections.emptyList())));
+                        Collections.emptyList(),
+                        Collections.singletonList(
+                                new GoResolutionResult.ResolvedDependency(
+                                        "github.com/google/uuid", "v1.6.0", "h1:abc=", "h1:def=",
+                                        false, true, null, null, "1.22",
+                                        Collections.singletonList(
+                                                new GoResolutionResult.ModuleRef("golang.org/x/mod", "v0.35.0")))),
+                        Collections.singletonList(
+                                new GoResolutionResult.PackageModule("github.com/google/uuid",
+                                        "github.com/google/uuid", "v1.6.0", false)))));
 
         var recipe = rpc.prepareRecipe("org.openrewrite.golang.test.RenameXToFlag");
         Tree result = recipe.getVisitor().visit(cu, new org.openrewrite.InMemoryExecutionContext());
@@ -226,6 +245,16 @@ class MarkerRoundTripTest {
         assertThat(mrr.getModulePath()).isEqualTo("example.com/foo");
         assertThat(mrr.getRequires()).hasSize(1);
         assertThat(mrr.getRequires().get(0).getModulePath()).isEqualTo("github.com/google/uuid");
+        assertThat(mrr.getResolvedDependencies()).hasSize(1);
+        GoResolutionResult.ResolvedDependency rd = mrr.getResolvedDependencies().get(0);
+        assertThat(rd.isMain()).isTrue();
+        assertThat(rd.getModuleGoVersion()).isEqualTo("1.22");
+        assertThat(rd.getDeps()).singleElement().satisfies(ref ->
+                assertThat(ref.getModulePath()).isEqualTo("golang.org/x/mod"));
+        assertThat(mrr.getPackageModules()).singleElement().satisfies(pm -> {
+            assertThat(pm.getImportPath()).isEqualTo("github.com/google/uuid");
+            assertThat(pm.getModulePath()).isEqualTo("github.com/google/uuid");
+        });
     }
 
     /**

--- a/rewrite-go/src/main/java/org/openrewrite/golang/GoModParser.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/GoModParser.java
@@ -233,7 +233,8 @@ public class GoModParser implements Parser {
                 replaces,
                 excludes,
                 retracts,
-                resolved
+                resolved,
+                new ArrayList<>()
         );
     }
 
@@ -326,7 +327,8 @@ public class GoModParser implements Parser {
         }
         for (java.util.Map.Entry<String, String[]> e : byKey.entrySet()) {
             String[] parts = e.getKey().split("@", 2);
-            resolved.add(new ResolvedDependency(parts[0], parts[1], e.getValue()[0], e.getValue()[1]));
+            resolved.add(new ResolvedDependency(parts[0], parts[1], e.getValue()[0], e.getValue()[1],
+                    false, false, null, null, null, null));
         }
         return resolved;
     }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/marker/GoResolutionResult.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/marker/GoResolutionResult.java
@@ -98,9 +98,20 @@ public class GoResolutionResult implements Marker, RpcCodec<GoResolutionResult> 
     List<Retract> retracts;
 
     /**
-     * Transitive resolutions from go.sum. Each module version appears once with its content hash.
+     * The resolved build list. One node per selected {@code module@version}, carrying go.sum
+     * content hashes and — when parse-time resolution ran — {@code go list -m} build-list metadata
+     * and {@code go mod graph} edges (see {@link ResolvedDependency#deps}).
      */
     List<ResolvedDependency> resolvedDependencies;
+
+    /**
+     * Import-path -&gt; providing-module map from {@code go list -deps -json ./...}.
+     * <p>
+     * Go-specific: no sibling ecosystem has an import-to-coordinate map because their import name is
+     * (near enough) the coordinate; Go's import path and module path diverge, so this must be
+     * toolchain-derived. Empty unless parse-time resolution ran.
+     */
+    List<PackageModule> packageModules;
 
     public @Nullable Require findRequire(String module) {
         for (Require r : requires) {
@@ -115,6 +126,15 @@ public class GoResolutionResult implements Marker, RpcCodec<GoResolutionResult> 
         for (ResolvedDependency rd : resolvedDependencies) {
             if (rd.getModulePath().equals(module)) {
                 return rd;
+            }
+        }
+        return null;
+    }
+
+    public @Nullable PackageModule findPackageModule(String importPath) {
+        for (PackageModule pm : packageModules) {
+            if (pm.getImportPath().equals(importPath)) {
+                return pm;
             }
         }
         return null;
@@ -142,6 +162,9 @@ public class GoResolutionResult implements Marker, RpcCodec<GoResolutionResult> 
         q.getAndSendListAsRef(after, r -> r.getResolvedDependencies() != null ? r.getResolvedDependencies() : emptyList(),
                 rd -> rd.getModulePath() + "@" + rd.getVersion(),
                 rd -> rd.rpcSend(rd, q));
+        q.getAndSendListAsRef(after, r -> r.getPackageModules() != null ? r.getPackageModules() : emptyList(),
+                PackageModule::getImportPath,
+                pm -> pm.rpcSend(pm, q));
     }
 
     @Override
@@ -156,7 +179,8 @@ public class GoResolutionResult implements Marker, RpcCodec<GoResolutionResult> 
                 .withReplaces(q.receiveList(before.replaces, r -> r.rpcReceive(r, q)))
                 .withExcludes(q.receiveList(before.excludes, r -> r.rpcReceive(r, q)))
                 .withRetracts(q.receiveList(before.retracts, r -> r.rpcReceive(r, q)))
-                .withResolvedDependencies(q.receiveList(before.resolvedDependencies, r -> r.rpcReceive(r, q)));
+                .withResolvedDependencies(q.receiveList(before.resolvedDependencies, r -> r.rpcReceive(r, q)))
+                .withPackageModules(q.receiveList(before.packageModules, pm -> pm.rpcReceive(pm, q)));
     }
 
     /**
@@ -273,7 +297,9 @@ public class GoResolutionResult implements Marker, RpcCodec<GoResolutionResult> 
     }
 
     /**
-     * A resolved dependency from go.sum. Each module version appears once with its content hash.
+     * A resolved module in the build list. Merges go.sum content hashes with {@code go list -m}
+     * build-list metadata and {@code go mod graph} edges. The toolchain-sourced fields are
+     * empty/false/null when parse-time resolution did not run (go.sum-only fallback).
      */
     @Value
     @With
@@ -295,12 +321,42 @@ public class GoResolutionResult implements Marker, RpcCodec<GoResolutionResult> 
          */
         @Nullable String goModHash;
 
+        /** From {@code go list -m}: this module is present only transitively. */
+        boolean indirect;
+
+        /** From {@code go list -m}: this is the main module. */
+        boolean main;
+
+        /** Toolchain-applied {@code replace} target path, null if none. */
+        @Nullable String replacePath;
+
+        @Nullable String replaceVersion;
+
+        /** This module's own {@code go} directive version, from {@code go list -m}. */
+        @Nullable String moduleGoVersion;
+
+        /**
+         * Direct module dependencies of this node (from {@code go mod graph}), by {@code module@version}
+         * edge reference. Resolve against {@link #resolvedDependencies}. Null when the graph is
+         * unavailable. Edges (not nested nodes) keep this cycle-safe; Go's MVS gives one selected
+         * version per module path.
+         */
+        @Nullable List<ModuleRef> deps;
+
         @Override
         public void rpcSend(ResolvedDependency after, RpcSendQueue q) {
             q.getAndSend(after, ResolvedDependency::getModulePath);
             q.getAndSend(after, ResolvedDependency::getVersion);
             q.getAndSend(after, ResolvedDependency::getModuleHash);
             q.getAndSend(after, ResolvedDependency::getGoModHash);
+            q.getAndSend(after, ResolvedDependency::isIndirect);
+            q.getAndSend(after, ResolvedDependency::isMain);
+            q.getAndSend(after, ResolvedDependency::getReplacePath);
+            q.getAndSend(after, ResolvedDependency::getReplaceVersion);
+            q.getAndSend(after, ResolvedDependency::getModuleGoVersion);
+            q.getAndSendListAsRef(after, r -> r.getDeps() != null ? r.getDeps() : emptyList(),
+                    ref -> ref.getModulePath() + "@" + ref.getVersion(),
+                    ref -> ref.rpcSend(ref, q));
         }
 
         @Override
@@ -309,7 +365,71 @@ public class GoResolutionResult implements Marker, RpcCodec<GoResolutionResult> 
                     .withModulePath(q.receive(before.modulePath))
                     .withVersion(q.receive(before.version))
                     .withModuleHash(q.receive(before.moduleHash))
-                    .withGoModHash(q.receive(before.goModHash));
+                    .withGoModHash(q.receive(before.goModHash))
+                    .withIndirect(q.receive(before.indirect))
+                    .withMain(q.receive(before.main))
+                    .withReplacePath(q.receive(before.replacePath))
+                    .withReplaceVersion(q.receive(before.replaceVersion))
+                    .withModuleGoVersion(q.receive(before.moduleGoVersion))
+                    .withDeps(q.receiveList(before.deps, ref -> ref.rpcReceive(ref, q)));
+        }
+    }
+
+    /**
+     * A {@code module@version} reference — a {@code go mod graph} edge target.
+     */
+    @Value
+    @With
+    @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
+    public static class ModuleRef implements RpcCodec<ModuleRef> {
+        String modulePath;
+        String version;
+
+        @Override
+        public void rpcSend(ModuleRef after, RpcSendQueue q) {
+            q.getAndSend(after, ModuleRef::getModulePath);
+            q.getAndSend(after, ModuleRef::getVersion);
+        }
+
+        @Override
+        public ModuleRef rpcReceive(ModuleRef before, RpcReceiveQueue q) {
+            return before
+                    .withModulePath(q.receive(before.modulePath))
+                    .withVersion(q.receive(before.version));
+        }
+    }
+
+    /**
+     * Which module provides an imported package, from {@code go list -deps -json ./...}.
+     * {@link #modulePath} is null for the standard library ({@link #standard} true).
+     */
+    @Value
+    @With
+    @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
+    public static class PackageModule implements RpcCodec<PackageModule> {
+        String importPath;
+
+        @Nullable String modulePath;
+
+        @Nullable String version;
+
+        boolean standard;
+
+        @Override
+        public void rpcSend(PackageModule after, RpcSendQueue q) {
+            q.getAndSend(after, PackageModule::getImportPath);
+            q.getAndSend(after, PackageModule::getModulePath);
+            q.getAndSend(after, PackageModule::getVersion);
+            q.getAndSend(after, PackageModule::isStandard);
+        }
+
+        @Override
+        public PackageModule rpcReceive(PackageModule before, RpcReceiveQueue q) {
+            return before
+                    .withImportPath(q.receive(before.importPath))
+                    .withModulePath(q.receive(before.modulePath))
+                    .withVersion(q.receive(before.version))
+                    .withStandard(q.receive(before.standard));
         }
     }
 }


### PR DESCRIPTION
## What's changed?

Enhancing the Go's GoResolutionResult marker to include more information, mostly the full module graph.

## What's your motivation?

It's needed for the dependency management recipes.