### PR TITLE
Go: add support for parsing go.sum files

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -675,8 +675,7 @@ func (s *server) handleParse(params json.RawMessage) (any, *rpcError) {
 		goModByIdx[r.idx] = gm
 	}
 
-	// Index the GoResolutionResult of each parsed go.mod by directory so a
-	// sibling go.sum can carry the module's resolved build list as a marker.
+	// Index each go.mod's GoResolutionResult by directory for sibling go.sum.
 	mrrByDir := make(map[string]*golang.GoResolutionResult, len(goModByIdx))
 	for _, gm := range goModByIdx {
 		for i := range gm.Markers.Entries {
@@ -687,9 +686,6 @@ func (s *server) handleParse(params json.RawMessage) (any, *rpcError) {
 		}
 	}
 
-	// Parse every go.sum input into a lossless GoSum LST, mirroring the go.mod
-	// path. Attach the sibling go.mod's GoResolutionResult marker when the two
-	// arrive in the same batch so go.sum recipes can read the resolved graph.
 	goSumByIdx := make(map[int]*golang.GoSum, len(resolvedInputs))
 	for _, r := range resolvedInputs {
 		if filepath.Base(r.sourcePath) != "go.sum" {
@@ -2376,10 +2372,7 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		})
 	}
 
-	// Emit each sibling go.sum as a lossless GoSum LST so recipes can edit
-	// the checksum file directly. The module's GoResolutionResult — already
-	// parsed above — rides along as a marker so a go.sum recipe can read the
-	// resolved build list.
+	// Emit each sibling go.sum as a GoSum LST, carrying the module's marker.
 	for _, modPath := range disc.goMods {
 		sumPath := filepath.Join(filepath.Dir(modPath), "go.sum")
 		data, err := os.ReadFile(sumPath)

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -467,6 +467,7 @@ func (s *server) handleGetLanguages() []string {
 	return []string{
 		"org.openrewrite.golang.tree.Go$CompilationUnit",
 		"org.openrewrite.golang.tree.GoMod",
+		"org.openrewrite.golang.tree.GoSum",
 	}
 }
 
@@ -674,6 +675,37 @@ func (s *server) handleParse(params json.RawMessage) (any, *rpcError) {
 		goModByIdx[r.idx] = gm
 	}
 
+	// Index the GoResolutionResult of each parsed go.mod by directory so a
+	// sibling go.sum can carry the module's resolved build list as a marker.
+	mrrByDir := make(map[string]*golang.GoResolutionResult, len(goModByIdx))
+	for _, gm := range goModByIdx {
+		for i := range gm.Markers.Entries {
+			if mrr, ok := gm.Markers.Entries[i].(golang.GoResolutionResult); ok {
+				mrrByDir[filepath.Dir(gm.SourcePath)] = &mrr
+				break
+			}
+		}
+	}
+
+	// Parse every go.sum input into a lossless GoSum LST, mirroring the go.mod
+	// path. Attach the sibling go.mod's GoResolutionResult marker when the two
+	// arrive in the same batch so go.sum recipes can read the resolved graph.
+	goSumByIdx := make(map[int]*golang.GoSum, len(resolvedInputs))
+	for _, r := range resolvedInputs {
+		if filepath.Base(r.sourcePath) != "go.sum" {
+			continue
+		}
+		gs, err := goparser.ParseGoSumFile(r.sourcePath, r.source)
+		if err != nil {
+			parseErrByIdx[r.idx] = err
+			continue
+		}
+		if mrr, ok := mrrByDir[filepath.Dir(r.sourcePath)]; ok && mrr != nil {
+			gs.Markers.Entries = append(gs.Markers.Entries, *mrr)
+		}
+		goSumByIdx[r.idx] = gs
+	}
+
 	ids := make([]string, 0, len(req.Inputs))
 	for _, r := range resolvedInputs {
 		if cu, ok := cuByIdx[r.idx]; ok && cu != nil {
@@ -685,6 +717,12 @@ func (s *server) handleParse(params json.RawMessage) (any, *rpcError) {
 		if gm, ok := goModByIdx[r.idx]; ok && gm != nil {
 			id := gm.Ident.String()
 			s.localObjects[id] = gm
+			ids = append(ids, id)
+			continue
+		}
+		if gs, ok := goSumByIdx[r.idx]; ok && gs != nil {
+			id := gs.Ident.String()
+			s.localObjects[id] = gs
 			ids = append(ids, id)
 			continue
 		}
@@ -772,7 +810,16 @@ func (s *server) handlePrint(params json.RawMessage) (any, *rpcError) {
 		return printer.Print(cu), nil
 	}
 	if gm, ok := obj.(*golang.GoMod); ok {
+		if mp != nil {
+			return printer.PrintGoModWithMarkers(gm, mp), nil
+		}
 		return printer.PrintGoMod(gm), nil
+	}
+	if gs, ok := obj.(*golang.GoSum); ok {
+		if mp != nil {
+			return printer.PrintGoSumWithMarkers(gs, mp), nil
+		}
+		return printer.PrintGoSum(gs), nil
 	}
 	if t, ok := obj.(java.Tree); ok {
 		if mp != nil {
@@ -2325,6 +2372,39 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		items = append(items, parseProjectResponseItem{
 			ID:             id,
 			SourceFileType: "org.openrewrite.golang.tree.GoMod",
+			SourcePath:     sourcePath,
+		})
+	}
+
+	// Emit each sibling go.sum as a lossless GoSum LST so recipes can edit
+	// the checksum file directly. The module's GoResolutionResult — already
+	// parsed above — rides along as a marker so a go.sum recipe can read the
+	// resolved build list.
+	for _, modPath := range disc.goMods {
+		sumPath := filepath.Join(filepath.Dir(modPath), "go.sum")
+		data, err := os.ReadFile(sumPath)
+		if err != nil {
+			continue
+		}
+		sourcePath := sumPath
+		if req.RelativeTo != nil && *req.RelativeTo != "" {
+			if rel, err := filepath.Rel(*req.RelativeTo, sumPath); err == nil {
+				sourcePath = rel
+			}
+		}
+		gs, err := goparser.ParseGoSumFile(sourcePath, string(data))
+		if err != nil {
+			s.logger.Printf("ParseProject: skip go.sum LST %s: %v", sumPath, err)
+			continue
+		}
+		if m, ok := mods[filepath.Dir(modPath)]; ok && m.mrr != nil {
+			gs.Markers.Entries = append(gs.Markers.Entries, *m.mrr)
+		}
+		id := gs.Ident.String()
+		s.localObjects[id] = gs
+		items = append(items, parseProjectResponseItem{
+			ID:             id,
+			SourceFileType: "org.openrewrite.golang.tree.GoSum",
 			SourcePath:     sourcePath,
 		})
 	}

--- a/rewrite-go/pkg/parser/gosum_lst.go
+++ b/rewrite-go/pkg/parser/gosum_lst.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// ParseGoSumFile parses go.sum content into a lossless GoSum LST. Mirrors
+// org.openrewrite.golang.tree.GoSum on the Java side (the LST path, not the
+// legacy data-marker path that stays in ParseGoSum).
+//
+// go.sum is a flat list of `module version[/go.mod] h1:hash` lines. Leading
+// whitespace and blank lines are captured into the next line's Prefix (or the
+// trailing Eof); the line terminator and any trailing whitespace ride along in
+// each line's RightPadded.After. Re-printing yields the input verbatim for
+// canonical (toolchain-written) files.
+//
+// A non-blank line that does not match the go.sum grammar is a hard parse
+// error: unlike go.mod (which tolerates unknown directives), go.sum has a
+// single fixed line shape, so a malformed line means the file is not a go.sum
+// and the caller should fall back to a verbatim (PlainText/ParseError) source.
+func ParseGoSumFile(path, content string) (*golang.GoSum, error) {
+	gs := &golang.GoSum{
+		Ident:      uuid.New(),
+		Markers:    java.Markers{ID: uuid.New()},
+		SourcePath: path,
+		Charset:    "UTF-8",
+	}
+
+	cursor := 0
+	i := 0
+	var lines []java.RightPadded[*golang.GoSumLine]
+	for i < len(content) {
+		lineStart := i
+		j := i
+		for j < len(content) && content[j] != '\n' {
+			j++
+		}
+		lineEnd := j
+		if lineEnd < len(content) {
+			lineEnd++ // include the newline
+		}
+		lineText := content[lineStart:j]
+
+		if strings.TrimSpace(lineText) == "" {
+			// Blank line: fold into the next line's Prefix (or Eof) by
+			// leaving the cursor untouched and advancing past it.
+			i = lineEnd
+			continue
+		}
+
+		m := goSumLine.FindStringSubmatchIndex(lineText)
+		if m == nil {
+			return nil, fmt.Errorf("go.sum: malformed line %q", lineText)
+		}
+		moduleStart := lineStart + m[2]
+		hashEnd := lineStart + m[9]
+
+		line := &golang.GoSumLine{
+			Ident:      uuid.New(),
+			Prefix:     java.ParseSpace(content[cursor:moduleStart]),
+			Markers:    java.Markers{ID: uuid.New()},
+			ModulePath: lineText[m[2]:m[3]],
+			Version:    lineText[m[4]:m[5]],
+			GoMod:      m[6] != -1,
+			Hash:       "h1:" + lineText[m[8]:m[9]],
+		}
+		after := java.ParseSpace(content[hashEnd:lineEnd])
+		lines = append(lines, java.RightPadded[*golang.GoSumLine]{
+			Element: line,
+			After:   after,
+			Markers: java.Markers{ID: uuid.New()},
+		})
+		cursor = lineEnd
+		i = lineEnd
+	}
+
+	gs.Lines = lines
+	gs.Eof = java.ParseSpace(content[cursor:])
+	return gs, nil
+}

--- a/rewrite-go/pkg/parser/gosum_lst.go
+++ b/rewrite-go/pkg/parser/gosum_lst.go
@@ -25,20 +25,8 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
 
-// ParseGoSumFile parses go.sum content into a lossless GoSum LST. Mirrors
-// org.openrewrite.golang.tree.GoSum on the Java side (the LST path, not the
-// legacy data-marker path that stays in ParseGoSum).
-//
-// go.sum is a flat list of `module version[/go.mod] h1:hash` lines. Leading
-// whitespace and blank lines are captured into the next line's Prefix (or the
-// trailing Eof); the line terminator and any trailing whitespace ride along in
-// each line's RightPadded.After. Re-printing yields the input verbatim for
-// canonical (toolchain-written) files.
-//
-// A non-blank line that does not match the go.sum grammar is a hard parse
-// error: unlike go.mod (which tolerates unknown directives), go.sum has a
-// single fixed line shape, so a malformed line means the file is not a go.sum
-// and the caller should fall back to a verbatim (PlainText/ParseError) source.
+// ParseGoSumFile parses go.sum content into a lossless GoSum LST. A malformed
+// non-blank line is a hard error, so the caller falls back to a verbatim source.
 func ParseGoSumFile(path, content string) (*golang.GoSum, error) {
 	gs := &golang.GoSum{
 		Ident:      uuid.New(),
@@ -58,13 +46,11 @@ func ParseGoSumFile(path, content string) (*golang.GoSum, error) {
 		}
 		lineEnd := j
 		if lineEnd < len(content) {
-			lineEnd++ // include the newline
+			lineEnd++
 		}
 		lineText := content[lineStart:j]
 
 		if strings.TrimSpace(lineText) == "" {
-			// Blank line: fold into the next line's Prefix (or Eof) by
-			// leaving the cursor untouched and advancing past it.
 			i = lineEnd
 			continue
 		}
@@ -85,10 +71,9 @@ func ParseGoSumFile(path, content string) (*golang.GoSum, error) {
 			GoMod:      m[6] != -1,
 			Hash:       "h1:" + lineText[m[8]:m[9]],
 		}
-		after := java.ParseSpace(content[hashEnd:lineEnd])
 		lines = append(lines, java.RightPadded[*golang.GoSumLine]{
 			Element: line,
-			After:   after,
+			After:   java.ParseSpace(content[hashEnd:lineEnd]),
 			Markers: java.Markers{ID: uuid.New()},
 		})
 		cursor = lineEnd

--- a/rewrite-go/pkg/parser/gosum_lst_test.go
+++ b/rewrite-go/pkg/parser/gosum_lst_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 )
 
-// roundTripSum parses go.sum content into a GoSum LST and prints it back,
-// asserting byte-for-byte equality — the lossless contract.
 func roundTripSum(t *testing.T, content string) {
 	t.Helper()
 	gs, err := ParseGoSumFile("go.sum", content)

--- a/rewrite-go/pkg/parser/gosum_lst_test.go
+++ b/rewrite-go/pkg/parser/gosum_lst_test.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+)
+
+// roundTripSum parses go.sum content into a GoSum LST and prints it back,
+// asserting byte-for-byte equality — the lossless contract.
+func roundTripSum(t *testing.T, content string) {
+	t.Helper()
+	gs, err := ParseGoSumFile("go.sum", content)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	got := printer.PrintGoSum(gs)
+	if got != content {
+		t.Fatalf("not lossless\n--- want ---\n%q\n--- got ---\n%q", content, got)
+	}
+}
+
+func TestGoSumLossless(t *testing.T) {
+	cases := map[string]string{
+		"empty": "",
+
+		"single_pair": "github.com/a/b v1.0.0 h1:aaaa=\n" +
+			"github.com/a/b v1.0.0/go.mod h1:bbbb=\n",
+
+		"multiple_modules": "github.com/a/b v1.0.0 h1:aaaa=\n" +
+			"github.com/a/b v1.0.0/go.mod h1:bbbb=\n" +
+			"github.com/c/d v2.3.4 h1:cccc=\n" +
+			"github.com/c/d v2.3.4/go.mod h1:dddd=\n",
+
+		"gomod_only": "github.com/a/b v1.0.0/go.mod h1:bbbb=\n",
+
+		"pseudo_version": "github.com/a/b v0.0.0-20200101000000-abcdef123456 h1:aaaa=\n" +
+			"github.com/a/b v0.0.0-20200101000000-abcdef123456/go.mod h1:bbbb=\n",
+
+		"incompatible": "github.com/a/b v2.0.0+incompatible h1:aaaa=\n" +
+			"github.com/a/b v2.0.0+incompatible/go.mod h1:bbbb=\n",
+
+		"no_trailing_newline": "github.com/a/b v1.0.0 h1:aaaa=",
+
+		"blank_lines": "github.com/a/b v1.0.0 h1:aaaa=\n" +
+			"\n" +
+			"github.com/c/d v2.0.0 h1:cccc=\n",
+
+		"leading_blank_line": "\ngithub.com/a/b v1.0.0 h1:aaaa=\n",
+
+		"trailing_blank_lines": "github.com/a/b v1.0.0 h1:aaaa=\n\n\n",
+
+		"crlf_endings": "github.com/a/b v1.0.0 h1:aaaa=\r\n" +
+			"github.com/a/b v1.0.0/go.mod h1:bbbb=\r\n",
+	}
+
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			roundTripSum(t, content)
+		})
+	}
+}
+
+func TestGoSumFields(t *testing.T) {
+	// given
+	content := "github.com/a/b v1.0.0 h1:zip=\n" +
+		"github.com/a/b v1.0.0/go.mod h1:mod=\n"
+
+	// when
+	gs, err := ParseGoSumFile("go.sum", content)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	// then
+	if len(gs.Lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(gs.Lines))
+	}
+	zip := gs.Lines[0].Element
+	if zip.ModulePath != "github.com/a/b" || zip.Version != "v1.0.0" || zip.GoMod || zip.Hash != "h1:zip=" {
+		t.Fatalf("zip line fields wrong: %#v", zip)
+	}
+	mod := gs.Lines[1].Element
+	if !mod.GoMod || mod.Hash != "h1:mod=" {
+		t.Fatalf("go.mod line fields wrong: %#v", mod)
+	}
+}
+
+func TestGoSumMalformedLineErrors(t *testing.T) {
+	// given a line that is not a valid go.sum entry
+	// when / then
+	if _, err := ParseGoSumFile("go.sum", "not a valid go.sum line\n"); err == nil {
+		t.Fatal("expected error for malformed go.sum line, got nil")
+	}
+}

--- a/rewrite-go/pkg/printer/gosum_printer.go
+++ b/rewrite-go/pkg/printer/gosum_printer.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package printer
+
+import (
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+)
+
+// PrintGoSum renders a GoSum LST back to source. Because every byte of
+// whitespace is preserved on the tree, an unmodified GoSum re-prints to the
+// original bytes verbatim (for canonical, toolchain-written go.sum files).
+func PrintGoSum(gs *golang.GoSum) string {
+	return printGoSum(gs, NewPrintOutputCapture())
+}
+
+// PrintGoSumWithMarkers renders a GoSum LST to source, printing cross-cutting
+// markers (SearchResult, Markup) via the given MarkerPrinter — so search
+// recipes can be tested with the same /*~~>*/ convention used for .go sources.
+func PrintGoSumWithMarkers(gs *golang.GoSum, mp MarkerPrinter) string {
+	return printGoSum(gs, NewPrintOutputCaptureWithMarkers(mp))
+}
+
+func printGoSum(gs *golang.GoSum, out *PrintOutputCapture) string {
+	out.BeforePrefix(gs.Markers)
+	printGoModSpace(gs.Prefix, out)
+	out.BeforeSyntax(gs.Markers)
+	for _, rp := range gs.Lines {
+		printGoSumLine(rp.Element, out)
+		printGoModSpace(rp.After, out)
+	}
+	out.AfterSyntax(gs.Markers)
+	printGoModSpace(gs.Eof, out)
+	return out.String()
+}
+
+func printGoSumLine(l *golang.GoSumLine, out *PrintOutputCapture) {
+	out.BeforePrefix(l.Markers)
+	printGoModSpace(l.Prefix, out)
+	out.BeforeSyntax(l.Markers)
+	out.Append(l.ModulePath)
+	out.Append(" ")
+	out.Append(l.Version)
+	if l.GoMod {
+		out.Append("/go.mod")
+	}
+	out.Append(" ")
+	out.Append(l.Hash)
+	out.AfterSyntax(l.Markers)
+}

--- a/rewrite-go/pkg/printer/gosum_printer.go
+++ b/rewrite-go/pkg/printer/gosum_printer.go
@@ -19,16 +19,10 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 )
 
-// PrintGoSum renders a GoSum LST back to source. Because every byte of
-// whitespace is preserved on the tree, an unmodified GoSum re-prints to the
-// original bytes verbatim (for canonical, toolchain-written go.sum files).
 func PrintGoSum(gs *golang.GoSum) string {
 	return printGoSum(gs, NewPrintOutputCapture())
 }
 
-// PrintGoSumWithMarkers renders a GoSum LST to source, printing cross-cutting
-// markers (SearchResult, Markup) via the given MarkerPrinter — so search
-// recipes can be tested with the same /*~~>*/ convention used for .go sources.
 func PrintGoSumWithMarkers(gs *golang.GoSum, mp MarkerPrinter) string {
 	return printGoSum(gs, NewPrintOutputCaptureWithMarkers(mp))
 }

--- a/rewrite-go/pkg/rpc/go_receiver.go
+++ b/rewrite-go/pkg/rpc/go_receiver.go
@@ -56,6 +56,10 @@ func (r *GoReceiver) Visit(t java.Tree, p any) java.Tree {
 		c := *gm
 		return receiveGoMod(&c, p.(*ReceiveQueue))
 	}
+	if gs, ok := t.(*golang.GoSum); ok {
+		c := *gs
+		return receiveGoSum(&c, p.(*ReceiveQueue))
+	}
 	return r.GoVisitor.Visit(t, p)
 }
 

--- a/rewrite-go/pkg/rpc/go_sender.go
+++ b/rewrite-go/pkg/rpc/go_sender.go
@@ -59,6 +59,10 @@ func (s *GoSender) Visit(t java.Tree, p any) java.Tree {
 		sendGoMod(gm, p.(*SendQueue))
 		return gm
 	}
+	if gs, ok := t.(*golang.GoSum); ok {
+		sendGoSum(gs, p.(*SendQueue))
+		return gs
+	}
 	return s.GoVisitor.Visit(t, p)
 }
 

--- a/rewrite-go/pkg/rpc/gosum_codec.go
+++ b/rewrite-go/pkg/rpc/gosum_codec.go
@@ -22,13 +22,8 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
 
-// GoSum is a SourceFile but not a J node, so — like GoMod and java.ParseError —
-// it is special-cased ahead of the J-dispatch in GoSender.Visit / GoReceiver.Visit
-// and serialized by this self-contained codec rather than the generic padding
-// helpers (which assume J elements).
-//
-// The field order below is the single source of truth: the Go send/receive here
-// and the Java GoSumRpcCodec#rpcSend/#rpcReceive must all agree on it.
+// Field order here is the single source of truth shared with the Java
+// GoSumRpcCodec; both must agree exactly.
 
 func init() {
 	RegisterValueType(reflect.TypeOf((*golang.GoSum)(nil)), "org.openrewrite.golang.tree.GoSum")

--- a/rewrite-go/pkg/rpc/gosum_codec.go
+++ b/rewrite-go/pkg/rpc/gosum_codec.go
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"reflect"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// GoSum is a SourceFile but not a J node, so — like GoMod and java.ParseError —
+// it is special-cased ahead of the J-dispatch in GoSender.Visit / GoReceiver.Visit
+// and serialized by this self-contained codec rather than the generic padding
+// helpers (which assume J elements).
+//
+// The field order below is the single source of truth: the Go send/receive here
+// and the Java GoSumRpcCodec#rpcSend/#rpcReceive must all agree on it.
+
+func init() {
+	RegisterValueType(reflect.TypeOf((*golang.GoSum)(nil)), "org.openrewrite.golang.tree.GoSum")
+	RegisterValueType(reflect.TypeOf((*golang.GoSumLine)(nil)), "org.openrewrite.golang.tree.GoSum$Line")
+
+	RegisterFactory("org.openrewrite.golang.tree.GoSum", func() any { return &golang.GoSum{} })
+	RegisterFactory("org.openrewrite.golang.tree.GoSum$Line", func() any { return &golang.GoSumLine{} })
+}
+
+func sendGoSum(gs *golang.GoSum, q *SendQueue) {
+	q.GetAndSend(gs, func(v any) any { return v.(*golang.GoSum).Ident.String() }, nil)
+	q.GetAndSend(gs, func(v any) any { return v.(*golang.GoSum).Prefix },
+		func(v any) { sendSpace(v.(java.Space), q) })
+	q.GetAndSend(gs, func(v any) any { return v.(*golang.GoSum).Markers },
+		func(v any) { SendMarkersCodec(v.(java.Markers), q) })
+	q.GetAndSend(gs, func(v any) any { return v.(*golang.GoSum).SourcePath }, nil)
+	q.GetAndSend(gs, func(v any) any { return v.(*golang.GoSum).Charset }, nil)
+	q.GetAndSend(gs, func(v any) any { return v.(*golang.GoSum).CharsetBomMarked }, nil)
+	q.GetAndSend(gs, func(_ any) any { return nil }, nil) // checksum
+	q.GetAndSend(gs, func(_ any) any { return nil }, nil) // fileAttributes
+	q.GetAndSendList(gs,
+		func(v any) []any { return goSumLineSlice(v.(*golang.GoSum).Lines) },
+		goSumLineRPID,
+		func(v any) { sendGoSumRightPadded(v, q) })
+	q.GetAndSend(gs, func(v any) any { return v.(*golang.GoSum).Eof },
+		func(v any) { sendSpace(v.(java.Space), q) })
+}
+
+func sendGoSumRightPadded(rp any, q *SendQueue) {
+	q.GetAndSend(rp, func(v any) any { return v.(java.RightPadded[*golang.GoSumLine]).Element },
+		func(v any) { sendGoSumLine(v.(*golang.GoSumLine), q) })
+	q.GetAndSend(rp, func(v any) any { return v.(java.RightPadded[*golang.GoSumLine]).After },
+		func(v any) { sendSpace(v.(java.Space), q) })
+	q.GetAndSend(rp, func(v any) any { return v.(java.RightPadded[*golang.GoSumLine]).Markers },
+		func(v any) { SendMarkersCodec(v.(java.Markers), q) })
+}
+
+func sendGoSumLine(l *golang.GoSumLine, q *SendQueue) {
+	q.GetAndSend(l, func(v any) any { return v.(*golang.GoSumLine).Ident.String() }, nil)
+	q.GetAndSend(l, func(v any) any { return v.(*golang.GoSumLine).Prefix },
+		func(v any) { sendSpace(v.(java.Space), q) })
+	q.GetAndSend(l, func(v any) any { return v.(*golang.GoSumLine).Markers },
+		func(v any) { SendMarkersCodec(v.(java.Markers), q) })
+	q.GetAndSend(l, func(v any) any { return v.(*golang.GoSumLine).ModulePath }, nil)
+	q.GetAndSend(l, func(v any) any { return v.(*golang.GoSumLine).Version }, nil)
+	q.GetAndSend(l, func(v any) any { return v.(*golang.GoSumLine).GoMod }, nil)
+	q.GetAndSend(l, func(v any) any { return v.(*golang.GoSumLine).Hash }, nil)
+}
+
+func receiveGoSum(gs *golang.GoSum, q *ReceiveQueue) *golang.GoSum {
+	gs.Ident = recvGoModID(q, gs.Ident)
+	gs.Prefix = recvGoModSpace(q, gs.Prefix)
+	gs.Markers = recvGoModMarkers(q, gs.Markers)
+	gs.SourcePath = receiveScalar[string](q, gs.SourcePath)
+	gs.Charset = receiveScalar[string](q, gs.Charset)
+	gs.CharsetBomMarked = receiveScalar[bool](q, gs.CharsetBomMarked)
+	q.Receive(nil, nil) // checksum
+	q.Receive(nil, nil) // fileAttributes
+	gs.Lines = recvGoSumLineList(q, gs.Lines)
+	gs.Eof = recvGoModSpace(q, gs.Eof)
+	return gs
+}
+
+func recvGoSumLineList(q *ReceiveQueue, before []java.RightPadded[*golang.GoSumLine]) []java.RightPadded[*golang.GoSumLine] {
+	afterAny := q.ReceiveList(goSumLineSlice(before), func(v any) any { return recvGoSumRightPadded(v, q) })
+	if afterAny == nil {
+		return nil
+	}
+	out := make([]java.RightPadded[*golang.GoSumLine], len(afterAny))
+	for i, v := range afterAny {
+		out[i] = v.(java.RightPadded[*golang.GoSumLine])
+	}
+	return out
+}
+
+func recvGoSumRightPadded(v any, q *ReceiveQueue) any {
+	var beforeElem *golang.GoSumLine
+	beforeAfter := java.EmptySpace
+	var beforeMarkers java.Markers
+	if rp, ok := v.(java.RightPadded[*golang.GoSumLine]); ok {
+		beforeElem, beforeAfter, beforeMarkers = rp.Element, rp.After, rp.Markers
+	}
+	elemAny := q.Receive(beforeElem, func(e any) any { return recvGoSumLine(e, q) })
+	after := recvGoModSpace(q, beforeAfter)
+	markers := recvGoModMarkers(q, beforeMarkers)
+	var elem *golang.GoSumLine
+	if elemAny != nil {
+		elem = elemAny.(*golang.GoSumLine)
+	}
+	return java.RightPadded[*golang.GoSumLine]{Element: elem, After: after, Markers: markers}
+}
+
+func recvGoSumLine(baseline any, q *ReceiveQueue) any {
+	l, ok := baseline.(*golang.GoSumLine)
+	if !ok {
+		l = &golang.GoSumLine{}
+	}
+	l.Ident = recvGoModID(q, l.Ident)
+	l.Prefix = recvGoModSpace(q, l.Prefix)
+	l.Markers = recvGoModMarkers(q, l.Markers)
+	l.ModulePath = receiveScalar[string](q, l.ModulePath)
+	l.Version = receiveScalar[string](q, l.Version)
+	l.GoMod = receiveScalar[bool](q, l.GoMod)
+	l.Hash = receiveScalar[string](q, l.Hash)
+	return l
+}
+
+func goSumLineSlice(s []java.RightPadded[*golang.GoSumLine]) []any {
+	if s == nil {
+		return nil
+	}
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}
+
+func goSumLineRPID(rp any) any {
+	return rp.(java.RightPadded[*golang.GoSumLine]).Element.Ident.String()
+}

--- a/rewrite-go/pkg/rpc/gosum_codec_test.go
+++ b/rewrite-go/pkg/rpc/gosum_codec_test.go
@@ -23,9 +23,6 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 )
 
-// TestGoSumRPCRoundTrip parses go.sum into a GoSum, ships it Go→wire→Go through
-// the sender/receiver, and asserts the received tree prints identically — i.e.
-// the RPC codec preserves the lossless tree.
 func TestGoSumRPCRoundTrip(t *testing.T) {
 	cases := map[string]string{
 		"single": "github.com/a/b v1.0.0 h1:aaaa=\n" +
@@ -62,8 +59,6 @@ func TestGoSumRPCRoundTrip(t *testing.T) {
 	}
 }
 
-// TestGoSumRPCPreservesResolutionMarker verifies a GoResolutionResult attached
-// to GoSum.Markers survives the RPC round-trip.
 func TestGoSumRPCPreservesResolutionMarker(t *testing.T) {
 	content := "github.com/x/y v1.2.3 h1:aaaa=\n" +
 		"github.com/x/y v1.2.3/go.mod h1:bbbb=\n"

--- a/rewrite-go/pkg/rpc/gosum_codec_test.go
+++ b/rewrite-go/pkg/rpc/gosum_codec_test.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+)
+
+// TestGoSumRPCRoundTrip parses go.sum into a GoSum, ships it Go→wire→Go through
+// the sender/receiver, and asserts the received tree prints identically — i.e.
+// the RPC codec preserves the lossless tree.
+func TestGoSumRPCRoundTrip(t *testing.T) {
+	cases := map[string]string{
+		"single": "github.com/a/b v1.0.0 h1:aaaa=\n" +
+			"github.com/a/b v1.0.0/go.mod h1:bbbb=\n",
+		"multiple": "github.com/a/b v1.0.0 h1:aaaa=\n" +
+			"github.com/a/b v1.0.0/go.mod h1:bbbb=\n" +
+			"github.com/c/d v2.3.4 h1:cccc=\n" +
+			"github.com/c/d v2.3.4/go.mod h1:dddd=\n",
+		"blank_lines": "github.com/a/b v1.0.0 h1:aaaa=\n\ngithub.com/c/d v2.0.0 h1:cccc=\n",
+		"no_newline":  "github.com/a/b v1.0.0 h1:aaaa=",
+	}
+
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			// given: a parsed GoSum LST
+			before, err := parser.ParseGoSumFile("go.sum", content)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+
+			// when: round-tripped through the RPC sender/receiver
+			seed := &golang.GoSum{Ident: before.Ident}
+			got := roundTripNode(t, before, seed)
+
+			// then: the received tree prints identically to the original
+			gs, ok := got.(*golang.GoSum)
+			if !ok {
+				t.Fatalf("expected *golang.GoSum, got %T", got)
+			}
+			if printed := printer.PrintGoSum(gs); printed != content {
+				t.Fatalf("RPC round-trip not lossless\n--- want ---\n%q\n--- got ---\n%q", content, printed)
+			}
+		})
+	}
+}
+
+// TestGoSumRPCPreservesResolutionMarker verifies a GoResolutionResult attached
+// to GoSum.Markers survives the RPC round-trip.
+func TestGoSumRPCPreservesResolutionMarker(t *testing.T) {
+	content := "github.com/x/y v1.2.3 h1:aaaa=\n" +
+		"github.com/x/y v1.2.3/go.mod h1:bbbb=\n"
+	before, err := parser.ParseGoSumFile("go.sum", content)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	mrr, err := parser.ParseGoMod("go.mod", "module example.com/foo\n\nrequire github.com/x/y v1.2.3\n")
+	if err != nil {
+		t.Fatalf("marker parse error: %v", err)
+	}
+	before.Markers.Entries = append(before.Markers.Entries, *mrr)
+
+	seed := &golang.GoSum{Ident: before.Ident}
+	got := roundTripNode(t, before, seed).(*golang.GoSum)
+
+	var found *golang.GoResolutionResult
+	for i := range got.Markers.Entries {
+		if r, ok := got.Markers.Entries[i].(golang.GoResolutionResult); ok {
+			found = &r
+		}
+	}
+	if found == nil {
+		t.Fatalf("GoResolutionResult marker lost in round-trip; markers=%#v", got.Markers.Entries)
+	}
+	if found.ModulePath != "example.com/foo" || len(found.Requires) != 1 {
+		t.Fatalf("marker fields not preserved: %#v", found)
+	}
+}

--- a/rewrite-go/pkg/test/spec.go
+++ b/rewrite-go/pkg/test/spec.go
@@ -586,6 +586,8 @@ func (spec *RecipeSpec) RewriteRun(t *testing.T, sources ...Sources) {
 			parsed[i].tree = spec.parseGoSource(t, p, parsedByIdx, i, src)
 		case path.Base(src.Path) == "go.mod":
 			parsed[i].tree = spec.parseGoMod(t, src)
+		case path.Base(src.Path) == "go.sum":
+			parsed[i].tree = spec.parseGoSum(t, src)
 		}
 	}
 
@@ -690,6 +692,28 @@ func (spec *RecipeSpec) parseGoMod(t *testing.T, src SourceSpec) *golang.GoMod {
 	return gm
 }
 
+func (spec *RecipeSpec) parseGoSum(t *testing.T, src SourceSpec) *golang.GoSum {
+	t.Helper()
+
+	gs, err := parser.ParseGoSumFile(src.Path, src.Before)
+	if err != nil {
+		t.Fatalf("go.sum parse error: %v", err)
+	}
+
+	for _, m := range src.Markers {
+		gs = gs.WithMarkers(java.AddMarker(gs.Markers, m))
+	}
+
+	if spec.CheckParsePrintIdempotence {
+		if printed := printer.PrintGoSum(gs); printed != src.Before {
+			t.Errorf("go.sum parse-print idempotence failed\n\nexpected:\n%s\n\nactual:\n%s\n\ndiff positions:", src.Before, printed)
+			showDiff(t, src.Before, printed)
+		}
+	}
+
+	return gs
+}
+
 func (spec *RecipeSpec) compareSource(t *testing.T, ps parsedSource) {
 	t.Helper()
 	src := ps.spec
@@ -772,6 +796,9 @@ func (spec *RecipeSpec) markerPrinter() printer.MarkerPrinter {
 func printTree(t java.Tree, mp printer.MarkerPrinter) string {
 	if gm, ok := t.(*golang.GoMod); ok {
 		return printer.PrintGoModWithMarkers(gm, mp)
+	}
+	if gs, ok := t.(*golang.GoSum); ok {
+		return printer.PrintGoSumWithMarkers(gs, mp)
 	}
 	return printer.PrintWithMarkers(t, mp)
 }

--- a/rewrite-go/pkg/tree/golang/gosum.go
+++ b/rewrite-go/pkg/tree/golang/gosum.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package golang
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// GoSum is the lossless LST for a Go `go.sum` file. It mirrors
+// org.openrewrite.golang.tree.GoSum on the Java side.
+//
+// Like GoMod, GoSum is NOT a J node: go.sum tokens are not Java
+// expressions, so the tree carries its own minimal node set and is
+// special-cased ahead of the J-dispatch in the RPC sender/receiver.
+//
+// go.sum has no nested structure — it is a flat list of hash lines, each
+// of the form `module version[/go.mod] h1:hash`. Every byte of the
+// original file is recoverable: leading whitespace and blank lines live
+// in java.Space prefixes and the After of each line (the line terminator).
+// Re-printing a parsed GoSum yields the original bytes verbatim for
+// canonical (toolchain-written) go.sum files.
+type GoSum struct {
+	Ident            uuid.UUID
+	Prefix           java.Space
+	Markers          java.Markers
+	SourcePath       string
+	Charset          string
+	CharsetBomMarked bool
+	Lines            []java.RightPadded[*GoSumLine]
+	Eof              java.Space
+}
+
+func (*GoSum) IsTree()       {}
+func (*GoSum) IsSourceFile() {}
+
+func (n *GoSum) GetSourcePath() string { return n.SourcePath }
+
+func (n *GoSum) WithPrefix(prefix java.Space) *GoSum {
+	c := *n
+	c.Prefix = prefix
+	return &c
+}
+
+func (n *GoSum) WithMarkers(markers java.Markers) *GoSum {
+	c := *n
+	c.Markers = markers
+	return &c
+}
+
+func (n *GoSum) WithLines(lines []java.RightPadded[*GoSumLine]) *GoSum {
+	c := *n
+	c.Lines = lines
+	return &c
+}
+
+func (n *GoSum) WithEof(eof java.Space) *GoSum {
+	c := *n
+	c.Eof = eof
+	return &c
+}
+
+// GoSumLine is one go.sum entry: `module version[/go.mod] h1:hash`.
+//
+// Each module version appears on two lines — one for the module zip and
+// one for its go.mod — distinguished by GoMod. The module/version/hash
+// tokens are stored verbatim; the canonical single-space separators are
+// reconstructed by the printer.
+type GoSumLine struct {
+	Ident      uuid.UUID
+	Prefix     java.Space
+	Markers    java.Markers
+	ModulePath string
+	Version    string
+	// GoMod is true when this line records the hash of the module's
+	// go.mod (the `/go.mod` version suffix); false for the module zip.
+	GoMod bool
+	// Hash is the full `h1:…` checksum token.
+	Hash string
+}
+
+func (*GoSumLine) IsTree() {}
+
+func (n *GoSumLine) WithPrefix(prefix java.Space) *GoSumLine {
+	c := *n
+	c.Prefix = prefix
+	return &c
+}
+
+func (n *GoSumLine) WithMarkers(markers java.Markers) *GoSumLine {
+	c := *n
+	c.Markers = markers
+	return &c
+}
+
+func (n *GoSumLine) WithModulePath(modulePath string) *GoSumLine {
+	c := *n
+	c.ModulePath = modulePath
+	return &c
+}
+
+func (n *GoSumLine) WithVersion(version string) *GoSumLine {
+	c := *n
+	c.Version = version
+	return &c
+}
+
+func (n *GoSumLine) WithGoMod(goMod bool) *GoSumLine {
+	c := *n
+	c.GoMod = goMod
+	return &c
+}
+
+func (n *GoSumLine) WithHash(hash string) *GoSumLine {
+	c := *n
+	c.Hash = hash
+	return &c
+}

--- a/rewrite-go/pkg/tree/golang/gosum.go
+++ b/rewrite-go/pkg/tree/golang/gosum.go
@@ -22,19 +22,6 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
 
-// GoSum is the lossless LST for a Go `go.sum` file. It mirrors
-// org.openrewrite.golang.tree.GoSum on the Java side.
-//
-// Like GoMod, GoSum is NOT a J node: go.sum tokens are not Java
-// expressions, so the tree carries its own minimal node set and is
-// special-cased ahead of the J-dispatch in the RPC sender/receiver.
-//
-// go.sum has no nested structure — it is a flat list of hash lines, each
-// of the form `module version[/go.mod] h1:hash`. Every byte of the
-// original file is recoverable: leading whitespace and blank lines live
-// in java.Space prefixes and the After of each line (the line terminator).
-// Re-printing a parsed GoSum yields the original bytes verbatim for
-// canonical (toolchain-written) go.sum files.
 type GoSum struct {
 	Ident            uuid.UUID
 	Prefix           java.Space
@@ -76,22 +63,14 @@ func (n *GoSum) WithEof(eof java.Space) *GoSum {
 }
 
 // GoSumLine is one go.sum entry: `module version[/go.mod] h1:hash`.
-//
-// Each module version appears on two lines — one for the module zip and
-// one for its go.mod — distinguished by GoMod. The module/version/hash
-// tokens are stored verbatim; the canonical single-space separators are
-// reconstructed by the printer.
 type GoSumLine struct {
 	Ident      uuid.UUID
 	Prefix     java.Space
 	Markers    java.Markers
 	ModulePath string
 	Version    string
-	// GoMod is true when this line records the hash of the module's
-	// go.mod (the `/go.mod` version suffix); false for the module zip.
-	GoMod bool
-	// Hash is the full `h1:…` checksum token.
-	Hash string
+	GoMod      bool
+	Hash       string
 }
 
 func (*GoSumLine) IsTree() {}

--- a/rewrite-go/pkg/visitor/go_visitor.go
+++ b/rewrite-go/pkg/visitor/go_visitor.go
@@ -292,8 +292,6 @@ type VisitorI interface {
 	VisitGoModDirective(d *golang.GoModDirective, p any) java.Tree
 	VisitGoModBlock(b *golang.GoModBlock, p any) java.Tree
 	VisitGoModValue(val *golang.GoModValue, p any) java.Tree
-	// go.sum nodes are Tree, not J (their tokens are not Java
-	// expressions), so these return java.Tree rather than java.J.
 	VisitGoSum(gs *golang.GoSum, p any) java.Tree
 	VisitGoSumLine(l *golang.GoSumLine, p any) java.Tree
 	VisitIdentifier(ident *java.Identifier, p any) java.J
@@ -1215,9 +1213,6 @@ func visitGoModStatementList(v *GoVisitor, list []java.RightPadded[golang.GoModS
 	return result
 }
 
-// visitGoSumLineList visits a right-padded list of go.sum lines. GoSumLine is
-// a java.Tree (not java.J), so the J-constrained visitRightPaddedList helper
-// can't be reused here.
 func visitGoSumLineList(v *GoVisitor, list []java.RightPadded[*golang.GoSumLine], p any) []java.RightPadded[*golang.GoSumLine] {
 	result := make([]java.RightPadded[*golang.GoSumLine], 0, len(list))
 	for _, rp := range list {

--- a/rewrite-go/pkg/visitor/go_visitor.go
+++ b/rewrite-go/pkg/visitor/go_visitor.go
@@ -129,6 +129,10 @@ func (v *GoVisitor) Visit(t java.Tree, p any) java.Tree {
 		return v.self().VisitGoModBlock(n, p)
 	case *golang.GoModValue:
 		return v.self().VisitGoModValue(n, p)
+	case *golang.GoSum:
+		return v.self().VisitGoSum(n, p)
+	case *golang.GoSumLine:
+		return v.self().VisitGoSumLine(n, p)
 	case *java.Identifier:
 		return v.self().VisitIdentifier(n, p)
 	case *java.Literal:
@@ -288,6 +292,10 @@ type VisitorI interface {
 	VisitGoModDirective(d *golang.GoModDirective, p any) java.Tree
 	VisitGoModBlock(b *golang.GoModBlock, p any) java.Tree
 	VisitGoModValue(val *golang.GoModValue, p any) java.Tree
+	// go.sum nodes are Tree, not J (their tokens are not Java
+	// expressions), so these return java.Tree rather than java.J.
+	VisitGoSum(gs *golang.GoSum, p any) java.Tree
+	VisitGoSumLine(l *golang.GoSumLine, p any) java.Tree
 	VisitIdentifier(ident *java.Identifier, p any) java.J
 	VisitLiteral(lit *java.Literal, p any) java.J
 	VisitBinary(bin *java.Binary, p any) java.J
@@ -427,6 +435,20 @@ func (v *GoVisitor) VisitGoModValue(val *golang.GoModValue, p any) java.Tree {
 	val = val.WithPrefix(v.self().VisitSpace(val.Prefix, p))
 	val = val.WithMarkers(v.visitMarkers(val.Markers, p))
 	return val
+}
+
+func (v *GoVisitor) VisitGoSum(gs *golang.GoSum, p any) java.Tree {
+	gs = gs.WithPrefix(v.self().VisitSpace(gs.Prefix, p))
+	gs = gs.WithMarkers(v.visitMarkers(gs.Markers, p))
+	gs = gs.WithLines(visitGoSumLineList(v, gs.Lines, p))
+	gs = gs.WithEof(v.self().VisitSpace(gs.Eof, p))
+	return gs
+}
+
+func (v *GoVisitor) VisitGoSumLine(l *golang.GoSumLine, p any) java.Tree {
+	l = l.WithPrefix(v.self().VisitSpace(l.Prefix, p))
+	l = l.WithMarkers(v.visitMarkers(l.Markers, p))
+	return l
 }
 
 func (v *GoVisitor) VisitIdentifier(ident *java.Identifier, p any) java.J {
@@ -1187,6 +1209,23 @@ func visitGoModStatementList(v *GoVisitor, list []java.RightPadded[golang.GoModS
 			continue
 		}
 		rp.Element = visited.(golang.GoModStatement)
+		rp.After = v.self().VisitSpace(rp.After, p)
+		result = append(result, rp)
+	}
+	return result
+}
+
+// visitGoSumLineList visits a right-padded list of go.sum lines. GoSumLine is
+// a java.Tree (not java.J), so the J-constrained visitRightPaddedList helper
+// can't be reused here.
+func visitGoSumLineList(v *GoVisitor, list []java.RightPadded[*golang.GoSumLine], p any) []java.RightPadded[*golang.GoSumLine] {
+	result := make([]java.RightPadded[*golang.GoSumLine], 0, len(list))
+	for _, rp := range list {
+		visited := v.self().Visit(rp.Element, p)
+		if visited == nil {
+			continue
+		}
+		rp.Element = visited.(*golang.GoSumLine)
 		rp.After = v.self().VisitSpace(rp.After, p)
 		result = append(result, rp)
 	}

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/GoSumParserTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/GoSumParserTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.golang.rpc.GoRewriteRpc;
+import org.openrewrite.golang.tree.GoSum;
+import org.openrewrite.test.RewriteTest;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.golang.Assertions.goSum;
+
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class GoSumParserTest implements RewriteTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void before() {
+        Path binaryPath = Paths.get("build/rewrite-go-rpc").toAbsolutePath();
+        GoRewriteRpc.setFactory(GoRewriteRpc.builder()
+                .goBinaryPath(binaryPath)
+                .log(tempDir.resolve("go-rpc.log")));
+    }
+
+    @AfterEach
+    void after() {
+        GoRewriteRpc.shutdownCurrent();
+    }
+
+    @Test
+    void singleModulePair() {
+        rewriteRun(
+                goSum(
+                        """
+                                github.com/stretchr/testify v1.8.0 h1:aaaa=
+                                github.com/stretchr/testify v1.8.0/go.mod h1:bbbb=
+                                """,
+                        spec -> spec.afterRecipe(doc -> {
+                            assertThat(doc.getLines()).hasSize(2);
+                            GoSum.Line zip = doc.getLines().get(0).getElement();
+                            assertThat(zip.getModulePath()).isEqualTo("github.com/stretchr/testify");
+                            assertThat(zip.getVersion()).isEqualTo("v1.8.0");
+                            assertThat(zip.isGoMod()).isFalse();
+                            assertThat(zip.getHash()).isEqualTo("h1:aaaa=");
+
+                            GoSum.Line mod = doc.getLines().get(1).getElement();
+                            assertThat(mod.isGoMod()).isTrue();
+                            assertThat(mod.getHash()).isEqualTo("h1:bbbb=");
+                        })
+                )
+        );
+    }
+
+    @Test
+    void multipleModulesWithBlankLine() {
+        rewriteRun(
+                goSum(
+                        """
+                                github.com/a/b v1.0.0 h1:aaaa=
+                                github.com/a/b v1.0.0/go.mod h1:bbbb=
+
+                                github.com/c/d v2.3.4 h1:cccc=
+                                github.com/c/d v2.3.4/go.mod h1:dddd=
+                                """,
+                        spec -> spec.afterRecipe(doc -> assertThat(doc.getLines()).hasSize(4))
+                )
+        );
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/Assertions.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/Assertions.java
@@ -82,15 +82,6 @@ public final class Assertions {
         return goMod;
     }
 
-    /**
-     * Wrap go.sum content as a sibling SourceSpec, parsed into a lossless
-     * {@link GoSum} LST (via {@link GoSumParser}) so recipes can edit it, just
-     * like {@link #goMod(String)}. When placed inside a
-     * {@link #goProject(String, SourceSpecs...)} alongside a
-     * {@link #goMod(String)}, the go.mod parse also reads the sibling go.sum off
-     * disk (via {@link GoModParser#parseSumContent}) and populates
-     * {@code GoResolutionResult.resolvedDependencies}.
-     */
     public static SourceSpecs goSum(@Nullable String before) {
         return goSum(before, s -> {
         });

--- a/rewrite-go/src/main/java/org/openrewrite/golang/Assertions.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/Assertions.java
@@ -21,12 +21,12 @@ import org.openrewrite.Tree;
 import org.openrewrite.golang.marker.GoProject;
 import org.openrewrite.golang.tree.Go;
 import org.openrewrite.golang.tree.GoMod;
+import org.openrewrite.golang.tree.GoSum;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.test.SourceSpec;
 import org.openrewrite.test.SourceSpecs;
-import org.openrewrite.text.PlainText;
 
 import java.util.function.Consumer;
 
@@ -83,24 +83,21 @@ public final class Assertions {
     }
 
     /**
-     * Wrap go.sum content as a sibling SourceSpec. When placed inside a
+     * Wrap go.sum content as a sibling SourceSpec, parsed into a lossless
+     * {@link GoSum} LST (via {@link GoSumParser}) so recipes can edit it, just
+     * like {@link #goMod(String)}. When placed inside a
      * {@link #goProject(String, SourceSpecs...)} alongside a
-     * {@link #goMod(String)}, the parser reads the sibling go.sum off disk
-     * during parse (via {@link GoModParser#parseSumContent}) and populates
+     * {@link #goMod(String)}, the go.mod parse also reads the sibling go.sum off
+     * disk (via {@link GoModParser#parseSumContent}) and populates
      * {@code GoResolutionResult.resolvedDependencies}.
-     * <p>
-     * Today there is no dedicated parser for go.sum — content round-trips as
-     * a {@link PlainText}. The marker side-effect happens during go.mod
-     * parsing.
      */
     public static SourceSpecs goSum(@Nullable String before) {
         return goSum(before, s -> {
         });
     }
 
-    public static SourceSpecs goSum(@Nullable String before, Consumer<SourceSpec<PlainText>> spec) {
-        SourceSpec<PlainText> goSum = new SourceSpec<>(PlainText.class, null,
-                org.openrewrite.text.PlainTextParser.builder(), before, null);
+    public static SourceSpecs goSum(@Nullable String before, Consumer<SourceSpec<GoSum>> spec) {
+        SourceSpec<GoSum> goSum = new SourceSpec<>(GoSum.class, null, GoSumParser.builder(), before, null);
         goSum.path("go.sum");
         spec.accept(goSum);
         return goSum;
@@ -112,9 +109,8 @@ public final class Assertions {
     }
 
     public static SourceSpecs goSum(@Nullable String before, String after,
-                                    Consumer<SourceSpec<PlainText>> spec) {
-        SourceSpec<PlainText> goSum = new SourceSpec<>(PlainText.class, null,
-                org.openrewrite.text.PlainTextParser.builder(), before, s -> after);
+                                    Consumer<SourceSpec<GoSum>> spec) {
+        SourceSpec<GoSum> goSum = new SourceSpec<>(GoSum.class, null, GoSumParser.builder(), before, s -> after);
         goSum.path("go.sum");
         spec.accept(goSum);
         return goSum;

--- a/rewrite-go/src/main/java/org/openrewrite/golang/GoSumParser.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/GoSumParser.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
+import org.openrewrite.golang.rpc.GoRewriteRpc;
+import org.openrewrite.golang.tree.GoSum;
+
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+/**
+ * Parses Go {@code go.sum} files into a lossless {@link GoSum} LST.
+ * <p>
+ * Like {@link GoModParser}, the actual parsing happens on the Go side (which
+ * ships the tree over RPC); this is the Java-side client. go.sum is a flat list
+ * of {@code module version[/go.mod] h1:hash} lines with no structured metadata of
+ * its own — the module's {@code GoResolutionResult} is attached as a marker by
+ * the Go server when a sibling go.mod is available in the same parse batch.
+ */
+public class GoSumParser implements Parser {
+
+    @Override
+    public Stream<SourceFile> parseInputs(Iterable<Input> sources, @Nullable Path relativeTo, ExecutionContext ctx) {
+        GoRewriteRpc rpc = GoRewriteRpc.getOrStart();
+        return rpc.parse(sources, relativeTo, this, GoSum.class.getName(), ctx);
+    }
+
+    @Override
+    public boolean accept(Path path) {
+        Path fileName = path.getFileName();
+        return fileName != null && "go.sum".equals(fileName.toString());
+    }
+
+    @Override
+    public Path sourcePathFromSourceText(Path prefix, String sourceCode) {
+        return prefix.resolve("go.sum");
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends Parser.Builder {
+        public Builder() {
+            super(GoSum.class);
+        }
+
+        @Override
+        public GoSumParser build() {
+            return new GoSumParser();
+        }
+
+        @Override
+        public String getDslName() {
+            return "gosum";
+        }
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/GoSumParser.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/GoSumParser.java
@@ -25,15 +25,6 @@ import org.openrewrite.golang.tree.GoSum;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
-/**
- * Parses Go {@code go.sum} files into a lossless {@link GoSum} LST.
- * <p>
- * Like {@link GoModParser}, the actual parsing happens on the Go side (which
- * ships the tree over RPC); this is the Java-side client. go.sum is a flat list
- * of {@code module version[/go.mod] h1:hash} lines with no structured metadata of
- * its own — the module's {@code GoResolutionResult} is attached as a marker by
- * the Go server when a sibling go.mod is available in the same parse batch.
- */
 public class GoSumParser implements Parser {
 
     @Override

--- a/rewrite-go/src/main/java/org/openrewrite/golang/GoSumVisitor.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/GoSumVisitor.java
@@ -26,12 +26,6 @@ import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 
-/**
- * Java-side visitor for the {@code go.sum} LST, analogous to {@link GoModVisitor}
- * for {@code go.mod}. It traverses the bespoke {@link GoSum} node set (the flat
- * list of hash lines) so recipes can inspect and rewrite go.sum entirely in Java;
- * printing still goes through the Go RPC server.
- */
 @SuppressWarnings("unused")
 public class GoSumVisitor<P> extends TreeVisitor<GoSumTree, P> {
 
@@ -61,10 +55,6 @@ public class GoSumVisitor<P> extends TreeVisitor<GoSumTree, P> {
         return l;
     }
 
-    /**
-     * go.sum {@link Space} carries no location taxonomy (unlike {@code J}), so
-     * this is a plain identity hook for subclasses to override.
-     */
     public Space visitSpace(Space space, P p) {
         return space;
     }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/GoSumVisitor.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/GoSumVisitor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.SourceFile;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.golang.tree.GoSum;
+import org.openrewrite.golang.tree.GoSumTree;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+
+/**
+ * Java-side visitor for the {@code go.sum} LST, analogous to {@link GoModVisitor}
+ * for {@code go.mod}. It traverses the bespoke {@link GoSum} node set (the flat
+ * list of hash lines) so recipes can inspect and rewrite go.sum entirely in Java;
+ * printing still goes through the Go RPC server.
+ */
+@SuppressWarnings("unused")
+public class GoSumVisitor<P> extends TreeVisitor<GoSumTree, P> {
+
+    @Override
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
+        return sourceFile instanceof GoSum;
+    }
+
+    @Override
+    public String getLanguage() {
+        return "gosum";
+    }
+
+    public GoSumTree visitGoSum(GoSum goSum, P p) {
+        GoSum g = goSum;
+        g = g.withPrefix(visitSpace(g.getPrefix(), p));
+        g = g.withMarkers(visitMarkers(g.getMarkers(), p));
+        g = g.withLines(ListUtils.map(g.getLines(), l -> visitRightPadded(l, p)));
+        g = g.withEof(visitSpace(g.getEof(), p));
+        return g;
+    }
+
+    public GoSumTree visitLine(GoSum.Line line, P p) {
+        GoSum.Line l = line;
+        l = l.withPrefix(visitSpace(l.getPrefix(), p));
+        l = l.withMarkers(visitMarkers(l.getMarkers(), p));
+        return l;
+    }
+
+    /**
+     * go.sum {@link Space} carries no location taxonomy (unlike {@code J}), so
+     * this is a plain identity hook for subclasses to override.
+     */
+    public Space visitSpace(Space space, P p) {
+        return space;
+    }
+
+    public <T extends GoSumTree> @Nullable JRightPadded<T> visitRightPadded(@Nullable JRightPadded<T> right, P p) {
+        if (right == null) {
+            return null;
+        }
+        setCursor(new Cursor(getCursor(), right));
+        T t = visitAndCast(right.getElement(), p);
+        setCursor(getCursor().getParent());
+        if (t == null) {
+            return null;
+        }
+        Space after = visitSpace(right.getAfter(), p);
+        Markers markers = visitMarkers(right.getMarkers(), p);
+        return after == right.getAfter() && t == right.getElement() && markers == right.getMarkers() ?
+                right : new JRightPadded<>(t, after, markers);
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/RegenerateGoSum.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/RegenerateGoSum.java
@@ -24,6 +24,7 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.golang.internal.LockFileRegeneration;
+import org.openrewrite.golang.tree.GoSum;
 import org.openrewrite.marker.Markup;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextParser;
@@ -128,10 +129,12 @@ public class RegenerateGoSum extends ScanningRecipe<RegenerateGoSum.Accumulator>
             @Override
             public Tree preVisit(Tree tree, ExecutionContext ctx) {
                 stopAfterPreVisit();
-                if (!(tree instanceof PlainText)) {
+                // go.sum may arrive as a lossless GoSum LST (Go RPC pipeline) or
+                // as PlainText (pure-Java pipeline); handle both.
+                if (!(tree instanceof SourceFile)) {
                     return tree;
                 }
-                PlainText goSum = (PlainText) tree;
+                SourceFile goSum = (SourceFile) tree;
                 if (!"go.sum".equals(fileName(goSum.getSourcePath()))) {
                     return tree;
                 }
@@ -144,10 +147,21 @@ public class RegenerateGoSum extends ScanningRecipe<RegenerateGoSum.Accumulator>
                 }
 
                 String regenerated = result.getLockFileContent();
-                if (regenerated == null || regenerated.equals(goSum.getText())) {
+                if (regenerated == null || regenerated.equals(goSum.printAll())) {
                     return tree;
                 }
-                return goSum.withText(regenerated);
+                if (goSum instanceof PlainText) {
+                    return ((PlainText) goSum).withText(regenerated);
+                }
+                if (goSum instanceof GoSum) {
+                    return GoSumParser.builder().build().parse(regenerated)
+                            .findFirst()
+                            .map(reparsed -> (Tree) reparsed
+                                    .withSourcePath(goSum.getSourcePath())
+                                    .withMarkers(goSum.getMarkers()))
+                            .orElse(tree);
+                }
+                return tree;
             }
         };
     }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/RegenerateGoSum.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/RegenerateGoSum.java
@@ -129,8 +129,7 @@ public class RegenerateGoSum extends ScanningRecipe<RegenerateGoSum.Accumulator>
             @Override
             public Tree preVisit(Tree tree, ExecutionContext ctx) {
                 stopAfterPreVisit();
-                // go.sum may arrive as a lossless GoSum LST (Go RPC pipeline) or
-                // as PlainText (pure-Java pipeline); handle both.
+                // go.sum may arrive as a GoSum LST or as PlainText.
                 if (!(tree instanceof SourceFile)) {
                     return tree;
                 }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GoSumRpcCodec.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GoSumRpcCodec.java
@@ -31,15 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
 
-/**
- * RPC codec for the {@link GoSum} SourceFile. The field order here is the single
- * source of truth shared with the Go-side {@code sendGoSum}/{@code receiveGoSum}
- * (pkg/rpc/gosum_codec.go) — both must agree exactly or the cross-language queue
- * desyncs.
- * <p>
- * Like {@link GoModRpcCodec}, this serializes go.sum's bespoke node set manually
- * rather than via the J-element padding helpers.
- */
+// Field order must match the Go-side gosum_codec.go exactly.
 @Getter
 public class GoSumRpcCodec extends DynamicDispatchRpcCodec<GoSum> {
 

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GoSumRpcCodec.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GoSumRpcCodec.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.internal.rpc;
+
+import lombok.Getter;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.golang.tree.GoSum;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.rpc.DynamicDispatchRpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+/**
+ * RPC codec for the {@link GoSum} SourceFile. The field order here is the single
+ * source of truth shared with the Go-side {@code sendGoSum}/{@code receiveGoSum}
+ * (pkg/rpc/gosum_codec.go) — both must agree exactly or the cross-language queue
+ * desyncs.
+ * <p>
+ * Like {@link GoModRpcCodec}, this serializes go.sum's bespoke node set manually
+ * rather than via the J-element padding helpers.
+ */
+@Getter
+public class GoSumRpcCodec extends DynamicDispatchRpcCodec<GoSum> {
+
+    @Override
+    public String getSourceFileType() {
+        return GoSum.class.getName();
+    }
+
+    @Override
+    public Class<? extends GoSum> getType() {
+        return GoSum.class;
+    }
+
+    @Override
+    public void rpcSend(GoSum after, RpcSendQueue q) {
+        GolangSender sender = new GolangSender();
+        q.getAndSend(after, Tree::getId);
+        q.getAndSend(after, GoSum::getPrefix, space -> sender.visitSpace(space, q));
+        q.getAndSend(after, Tree::getMarkers);
+        q.getAndSend(after, (GoSum g) -> g.getSourcePath().toString());
+        q.getAndSend(after, (GoSum g) -> g.getCharset().name());
+        q.getAndSend(after, GoSum::isCharsetBomMarked);
+        q.getAndSend(after, GoSum::getChecksum);
+        q.getAndSend(after, GoSum::getFileAttributes);
+        q.getAndSendList(after, GoSum::getLines,
+                rp -> rp.getElement().getId(),
+                rp -> sendRightPadded(sender, rp, q));
+        q.getAndSend(after, GoSum::getEof, space -> sender.visitSpace(space, q));
+    }
+
+    private static void sendRightPadded(GolangSender sender, JRightPadded<GoSum.Line> rp, RpcSendQueue q) {
+        q.getAndSend(rp, JRightPadded::getElement, el -> sendLine(sender, el, q));
+        q.getAndSend(rp, JRightPadded::getAfter, space -> sender.visitSpace(space, q));
+        q.getAndSend(rp, JRightPadded::getMarkers);
+    }
+
+    private static void sendLine(GolangSender sender, GoSum.Line l, RpcSendQueue q) {
+        q.getAndSend(l, GoSum.Line::getId);
+        q.getAndSend(l, GoSum.Line::getPrefix, space -> sender.visitSpace(space, q));
+        q.getAndSend(l, GoSum.Line::getMarkers);
+        q.getAndSend(l, GoSum.Line::getModulePath);
+        q.getAndSend(l, GoSum.Line::getVersion);
+        q.getAndSend(l, GoSum.Line::isGoMod);
+        q.getAndSend(l, GoSum.Line::getHash);
+    }
+
+    @Override
+    public GoSum rpcReceive(GoSum before, RpcReceiveQueue q) {
+        GolangReceiver receiver = new GolangReceiver();
+        GoSum t = before;
+        t = t.withId(q.receiveAndGet(t.getId(), UUID::fromString));
+        t = t.withPrefix(q.receive(t.getPrefix(), space -> receiver.visitSpace(space, q)));
+        t = t.withMarkers(q.receive(t.getMarkers()));
+        t = t.withSourcePath(q.<Path, String>receiveAndGet(t.getSourcePath(), Paths::get));
+        t = (GoSum) t.withCharset(q.<Charset, String>receiveAndGet(t.getCharset(), Charset::forName));
+        t = t.withCharsetBomMarked(q.receive(t.isCharsetBomMarked()));
+        t = t.withChecksum(q.receive(t.getChecksum()));
+        t = t.withFileAttributes(q.receive(t.getFileAttributes()));
+        t = t.withLines(q.receiveList(t.getLines(), rp -> receiveRightPadded(receiver, rp, q)));
+        t = t.withEof(q.receive(t.getEof(), space -> receiver.visitSpace(space, q)));
+        return t;
+    }
+
+    private static JRightPadded<GoSum.Line> receiveRightPadded(GolangReceiver receiver,
+                                                               @Nullable JRightPadded<GoSum.Line> rp,
+                                                               RpcReceiveQueue q) {
+        GoSum.Line beforeElem = rp == null ? null : rp.getElement();
+        GoSum.Line elem = q.receive(beforeElem, el -> receiveLine(receiver, el, q));
+        Space after = q.receive(rp == null ? null : rp.getAfter(), space -> receiver.visitSpace(space, q));
+        Markers markers = q.receive(rp == null ? null : rp.getMarkers());
+        return new JRightPadded<>(elem, after, markers);
+    }
+
+    private static GoSum.Line receiveLine(GolangReceiver receiver, GoSum.Line l, RpcReceiveQueue q) {
+        return l.withId(q.receiveAndGet(l.getId(), UUID::fromString))
+                .withPrefix(q.receive(l.getPrefix(), space -> receiver.visitSpace(space, q)))
+                .withMarkers(q.receive(l.getMarkers()))
+                .withModulePath(q.receive(l.getModulePath()))
+                .withVersion(q.receive(l.getVersion()))
+                .withGoMod(q.receive(l.isGoMod()))
+                .withHash(q.receive(l.getHash()));
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/GoSum.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/GoSum.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.tree;
+
+import lombok.AccessLevel;
+import lombok.With;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Checksum;
+import org.openrewrite.Cursor;
+import org.openrewrite.FileAttributes;
+import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.golang.GoSumVisitor;
+import org.openrewrite.golang.rpc.GoRewriteRpc;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.rpc.request.Print;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Lossless LST for a Go {@code go.sum} file. Mirrors {@code golang.GoSum} on the
+ * Go side, which does the actual parsing and ships the tree over RPC.
+ * <p>
+ * {@code GoSum} is a {@link SourceFile} but, like {@link GoMod} and
+ * {@link org.openrewrite.tree.ParseError}, not a {@code J} node — go.sum tokens
+ * are not Java expressions. It is serialized by {@code GoSumRpcCodec} and printed
+ * by the Go RPC server.
+ * <p>
+ * go.sum is a flat list of {@code module version[/go.mod] h1:hash} lines. Every
+ * byte of whitespace is recoverable: leading whitespace and blank lines live in
+ * {@link Space} prefixes and in the {@link JRightPadded#getAfter() after} of each
+ * line. The module's structured metadata is not duplicated here; it rides along
+ * as a {@code GoResolutionResult} marker.
+ */
+@lombok.Value
+@With
+public class GoSum implements SourceFile, GoSumTree {
+
+    UUID id;
+
+    Space prefix;
+
+    Markers markers;
+
+    Path sourcePath;
+
+    @Nullable
+    @With(AccessLevel.PRIVATE)
+    String charsetName;
+
+    boolean charsetBomMarked;
+
+    @Nullable
+    Checksum checksum;
+
+    @Nullable
+    FileAttributes fileAttributes;
+
+    /**
+     * The go.sum entries, each right-padded with its line terminator.
+     */
+    List<JRightPadded<Line>> lines;
+
+    Space eof;
+
+    @Override
+    public Charset getCharset() {
+        return charsetName == null ? StandardCharsets.UTF_8 : Charset.forName(charsetName);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public SourceFile withCharset(Charset charset) {
+        return withCharsetName(charset.name());
+    }
+
+    @Override
+    public <P> GoSumTree acceptGoSum(GoSumVisitor<P> v, P p) {
+        return v.visitGoSum(this, p);
+    }
+
+    @Override
+    public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+        return new TreeVisitor<Tree, PrintOutputCapture<P>>() {
+            @Override
+            public @Nullable Tree preVisit(Tree tree, PrintOutputCapture<P> p) {
+                GoRewriteRpc rpc = GoRewriteRpc.getOrStart();
+                p.append(rpc.print(tree, cursor, Print.MarkerPrinter.from(p.getMarkerPrinter())));
+                stopAfterPreVisit();
+                return tree;
+            }
+        };
+    }
+
+    /**
+     * One go.sum entry: {@code module version[/go.mod] h1:hash}. Each module
+     * version appears on two lines — one for the module zip and one for its
+     * go.mod — distinguished by {@link #isGoMod()}.
+     */
+    @lombok.Value
+    @With
+    public static class Line implements GoSumTree {
+        UUID id;
+        Space prefix;
+        Markers markers;
+
+        String modulePath;
+
+        String version;
+
+        /**
+         * {@code true} when this line records the hash of the module's go.mod
+         * (the {@code /go.mod} version suffix); {@code false} for the module zip.
+         */
+        boolean goMod;
+
+        /**
+         * The full {@code h1:…} checksum token.
+         */
+        String hash;
+
+        @Override
+        public <P> GoSumTree acceptGoSum(GoSumVisitor<P> v, P p) {
+            return v.visitLine(this, p);
+        }
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/GoSum.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/GoSum.java
@@ -38,21 +38,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
 
-/**
- * Lossless LST for a Go {@code go.sum} file. Mirrors {@code golang.GoSum} on the
- * Go side, which does the actual parsing and ships the tree over RPC.
- * <p>
- * {@code GoSum} is a {@link SourceFile} but, like {@link GoMod} and
- * {@link org.openrewrite.tree.ParseError}, not a {@code J} node — go.sum tokens
- * are not Java expressions. It is serialized by {@code GoSumRpcCodec} and printed
- * by the Go RPC server.
- * <p>
- * go.sum is a flat list of {@code module version[/go.mod] h1:hash} lines. Every
- * byte of whitespace is recoverable: leading whitespace and blank lines live in
- * {@link Space} prefixes and in the {@link JRightPadded#getAfter() after} of each
- * line. The module's structured metadata is not duplicated here; it rides along
- * as a {@code GoResolutionResult} marker.
- */
 @lombok.Value
 @With
 public class GoSum implements SourceFile, GoSumTree {
@@ -77,9 +62,6 @@ public class GoSum implements SourceFile, GoSumTree {
     @Nullable
     FileAttributes fileAttributes;
 
-    /**
-     * The go.sum entries, each right-padded with its line terminator.
-     */
     List<JRightPadded<Line>> lines;
 
     Space eof;
@@ -113,31 +95,16 @@ public class GoSum implements SourceFile, GoSumTree {
         };
     }
 
-    /**
-     * One go.sum entry: {@code module version[/go.mod] h1:hash}. Each module
-     * version appears on two lines — one for the module zip and one for its
-     * go.mod — distinguished by {@link #isGoMod()}.
-     */
+    // One go.sum entry: `module version[/go.mod] h1:hash`.
     @lombok.Value
     @With
     public static class Line implements GoSumTree {
         UUID id;
         Space prefix;
         Markers markers;
-
         String modulePath;
-
         String version;
-
-        /**
-         * {@code true} when this line records the hash of the module's go.mod
-         * (the {@code /go.mod} version suffix); {@code false} for the module zip.
-         */
         boolean goMod;
-
-        /**
-         * The full {@code h1:…} checksum token.
-         */
         String hash;
 
         @Override

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/GoSumTree.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/GoSumTree.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.tree;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.golang.GoSumVisitor;
+
+/**
+ * Node family for the {@code go.sum} LST: {@link GoSum} and its lines.
+ * <p>
+ * Mirrors {@link GoModTree}: extending {@link Tree} gives every node
+ * {@code Tree}'s {@code @c} polymorphic type id so the elements survive
+ * {@code .lst} (de)serialization, and the {@code accept} dispatch routes
+ * traversal to a {@link GoSumVisitor}. Printing remains delegated to the Go
+ * RPC server.
+ */
+public interface GoSumTree extends Tree {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    default <R extends Tree, P> @Nullable R accept(TreeVisitor<R, P> v, P p) {
+        return (R) acceptGoSum(v.adapt(GoSumVisitor.class), p);
+    }
+
+    default <P> @Nullable GoSumTree acceptGoSum(GoSumVisitor<P> v, P p) {
+        return v.defaultValue(this, p);
+    }
+
+    @Override
+    default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
+        return v.isAdaptableTo(GoSumVisitor.class);
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/GoSumTree.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/GoSumTree.java
@@ -20,15 +20,6 @@ import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.golang.GoSumVisitor;
 
-/**
- * Node family for the {@code go.sum} LST: {@link GoSum} and its lines.
- * <p>
- * Mirrors {@link GoModTree}: extending {@link Tree} gives every node
- * {@code Tree}'s {@code @c} polymorphic type id so the elements survive
- * {@code .lst} (de)serialization, and the {@code accept} dispatch routes
- * traversal to a {@link GoSumVisitor}. Printing remains delegated to the Go
- * RPC server.
- */
 public interface GoSumTree extends Tree {
 
     @SuppressWarnings("unchecked")

--- a/rewrite-go/src/main/resources/META-INF/services/org.openrewrite.rpc.DynamicDispatchRpcCodec
+++ b/rewrite-go/src/main/resources/META-INF/services/org.openrewrite.rpc.DynamicDispatchRpcCodec
@@ -1,5 +1,6 @@
 org.openrewrite.golang.internal.rpc.GolangRpcCodec
 org.openrewrite.golang.internal.rpc.GoModRpcCodec
+org.openrewrite.golang.internal.rpc.GoSumRpcCodec
 org.openrewrite.golang.internal.rpc.GolangRightPaddedRpcCodec
 org.openrewrite.golang.internal.rpc.GolangLeftPaddedRpcCodec
 org.openrewrite.golang.internal.rpc.GolangContainerRpcCodec

--- a/rewrite-go/src/test/java/org/openrewrite/golang/GoSumSerializationTest.java
+++ b/rewrite-go/src/test/java/org/openrewrite/golang/GoSumSerializationTest.java
@@ -30,13 +30,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Guards the {@code go.sum} LST against the same {@code .lst} round-trip failure
- * {@link GoModSerializationTest} covers for go.mod: {@link GoSum.Line} must carry
- * {@code Tree}'s {@code @c} polymorphic type id, otherwise each
- * {@link JRightPadded#getElement() line element} deserializes to {@code null} and
- * later NPEs in {@code GoSumRpcCodec.rpcSend}.
- */
 class GoSumSerializationTest {
 
     private static final ObjectMapper MAPPER = ObjectMappers.propertyBasedMapper(null);

--- a/rewrite-go/src/test/java/org/openrewrite/golang/GoSumSerializationTest.java
+++ b/rewrite-go/src/test/java/org/openrewrite/golang/GoSumSerializationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Tree;
+import org.openrewrite.golang.tree.GoSum;
+import org.openrewrite.internal.ObjectMappers;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the {@code go.sum} LST against the same {@code .lst} round-trip failure
+ * {@link GoModSerializationTest} covers for go.mod: {@link GoSum.Line} must carry
+ * {@code Tree}'s {@code @c} polymorphic type id, otherwise each
+ * {@link JRightPadded#getElement() line element} deserializes to {@code null} and
+ * later NPEs in {@code GoSumRpcCodec.rpcSend}.
+ */
+class GoSumSerializationTest {
+
+    private static final ObjectMapper MAPPER = ObjectMappers.propertyBasedMapper(null);
+
+    @Test
+    void lineElementsSurviveLstRoundTrip() throws Exception {
+        // given: a parsed-shape GoSum with a zip + go.mod line
+        GoSum before = goSumWithOnePair();
+        assertThat(before.getLines()).allSatisfy(rp ->
+                assertThat(rp.getElement()).as("element non-null before serialization").isNotNull());
+
+        // when: round-tripped through the LST serializer (mirrors mod build -> mod run)
+        byte[] bytes = MAPPER.writeValueAsBytes(before);
+        GoSum after = MAPPER.readValue(bytes, GoSum.class);
+
+        // then: every line still has its concrete element
+        assertThat(after.getLines()).hasSize(before.getLines().size());
+        assertThat(after.getLines()).allSatisfy(rp ->
+                assertThat(rp.getElement())
+                        .as("line element must survive the .lst round-trip")
+                        .isNotNull());
+        assertThat(after.getLines().get(1).getElement().isGoMod()).isTrue();
+    }
+
+    private static GoSum goSumWithOnePair() {
+        List<JRightPadded<GoSum.Line>> lines = new ArrayList<>();
+        lines.add(line("github.com/a/b", "v1.0.0", false, "h1:zip="));
+        lines.add(line("github.com/a/b", "v1.0.0", true, "h1:mod="));
+        return new GoSum(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                Paths.get("go.sum"),
+                "UTF-8",
+                false,
+                null,
+                null,
+                lines,
+                Space.EMPTY);
+    }
+
+    private static JRightPadded<GoSum.Line> line(String modulePath, String version, boolean goMod, String hash) {
+        GoSum.Line l = new GoSum.Line(Tree.randomId(), Space.EMPTY, Markers.EMPTY, modulePath, version, goMod, hash);
+        return new JRightPadded<>(l, Space.format("\n"), Markers.EMPTY);
+    }
+}

--- a/rewrite-go/test/gosum_recipe_test.go
+++ b/rewrite-go/test/gosum_recipe_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
 
-// pruneModule removes every go.sum line for a given module path, mirroring the
-// offline-safe "prune" half of a SyncGoSum recipe.
 type pruneModule struct {
 	recipe.Base
 	ModulePath string
@@ -55,7 +53,6 @@ func (v *pruneModuleVisitor) VisitGoSumLine(l *golang.GoSumLine, p any) java.Tre
 	return v.GoVisitor.VisitGoSumLine(l, p)
 }
 
-// findModuleHash marks the hash of every go.sum line for a module.
 type findModuleHash struct {
 	recipe.Base
 	ModulePath string

--- a/rewrite-go/test/gosum_recipe_test.go
+++ b/rewrite-go/test/gosum_recipe_test.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/test"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// pruneModule removes every go.sum line for a given module path, mirroring the
+// offline-safe "prune" half of a SyncGoSum recipe.
+type pruneModule struct {
+	recipe.Base
+	ModulePath string
+}
+
+func (r *pruneModule) Name() string        { return "org.openrewrite.golang.test.PruneModule" }
+func (r *pruneModule) DisplayName() string { return "Prune go.sum lines for a module" }
+func (r *pruneModule) Description() string {
+	return "Removes all `go.sum` entries for the given module path."
+}
+
+func (r *pruneModule) Editor() recipe.TreeVisitor {
+	return visitor.Init(&pruneModuleVisitor{modulePath: r.ModulePath})
+}
+
+type pruneModuleVisitor struct {
+	visitor.GoVisitor
+	modulePath string
+}
+
+func (v *pruneModuleVisitor) VisitGoSumLine(l *golang.GoSumLine, p any) java.Tree {
+	if l.ModulePath == v.modulePath {
+		return nil // delete the line
+	}
+	return v.GoVisitor.VisitGoSumLine(l, p)
+}
+
+// findModuleHash marks the hash of every go.sum line for a module.
+type findModuleHash struct {
+	recipe.Base
+	ModulePath string
+}
+
+func (r *findModuleHash) Name() string        { return "org.openrewrite.golang.test.FindModuleHash" }
+func (r *findModuleHash) DisplayName() string { return "Find go.sum hashes for a module" }
+func (r *findModuleHash) Description() string {
+	return "Marks each `go.sum` line for the given module with a search result."
+}
+
+func (r *findModuleHash) Editor() recipe.TreeVisitor {
+	return visitor.Init(&findModuleHashVisitor{modulePath: r.ModulePath})
+}
+
+type findModuleHashVisitor struct {
+	visitor.GoVisitor
+	modulePath string
+}
+
+func (v *findModuleHashVisitor) VisitGoSumLine(l *golang.GoSumLine, p any) java.Tree {
+	l = v.GoVisitor.VisitGoSumLine(l, p).(*golang.GoSumLine)
+	if l.ModulePath == v.modulePath {
+		l = l.WithMarkers(java.FoundSearchResult(l.Markers, "found"))
+	}
+	return l
+}
+
+func TestGoSumNoChange(t *testing.T) {
+	spec := test.NewRecipeSpec().WithRecipe(&pruneModule{ModulePath: "github.com/absent/mod"})
+	spec.RewriteRun(t,
+		test.GoSum(
+			"github.com/a/b v1.0.0 h1:aaaa=\n"+
+				"github.com/a/b v1.0.0/go.mod h1:bbbb=\n",
+		),
+	)
+}
+
+func TestGoSumPruneModule(t *testing.T) {
+	spec := test.NewRecipeSpec().WithRecipe(&pruneModule{ModulePath: "github.com/c/d"})
+	spec.RewriteRun(t,
+		test.GoSum(
+			"github.com/a/b v1.0.0 h1:aaaa=\n"+
+				"github.com/a/b v1.0.0/go.mod h1:bbbb=\n"+
+				"github.com/c/d v2.0.0 h1:cccc=\n"+
+				"github.com/c/d v2.0.0/go.mod h1:dddd=\n",
+			"github.com/a/b v1.0.0 h1:aaaa=\n"+
+				"github.com/a/b v1.0.0/go.mod h1:bbbb=\n",
+		),
+	)
+}
+
+func TestGoSumSearchRecipe(t *testing.T) {
+	spec := test.NewRecipeSpec().WithRecipe(&findModuleHash{ModulePath: "github.com/a/b"})
+	spec.RewriteRun(t,
+		test.GoSum(
+			"github.com/a/b v1.0.0 h1:aaaa=\n",
+			"/*~~(found)~~>*/github.com/a/b v1.0.0 h1:aaaa=\n",
+		),
+	)
+}


### PR DESCRIPTION
## What's changed?

Parsing `go.sum` files for Go too (similarly to what we already parse: the `go.mod` files).

## What's your motivation?

Needed for some dependency management recipes.