### PR TITLE
Go: test harness to support scanning recipes

### DIFF
--- a/rewrite-go/pkg/test/scanning_recipe_test.go
+++ b/rewrite-go/pkg/test/scanning_recipe_test.go
@@ -31,17 +31,10 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
 
-// importAccumulator collects the distinct external (non-standard-library)
-// import paths seen across every .go file in the scan phase.
 type importAccumulator struct {
 	paths map[string]bool
 }
 
-// collectExternalImports is a cross-file ScanningRecipe: it scans every .go
-// source for external imports, then annotates the sibling go.mod with a
-// SearchResult naming them. It reads state from one set of files and writes
-// to another, so it only makes sense end-to-end — the exact shape the unit
-// harness previously could not drive.
 type collectExternalImports struct {
 	recipe.ScanningBase
 }
@@ -83,8 +76,6 @@ func (v *externalImportScanner) VisitCompilationUnit(cu *golang.CompilationUnit,
 	return cu
 }
 
-// importPath returns an Import's unquoted path (the parser stores the raw
-// quoted source, e.g. `"example.com/a"`, on the Qualid Literal).
 func importPath(imp *java.Import) string {
 	if imp == nil {
 		return ""
@@ -114,9 +105,6 @@ func (v *goModAnnotator) VisitGoMod(gm *golang.GoMod, p any) java.Tree {
 	return gm.WithMarkers(java.AddMarker(gm.Markers, java.SearchResult{Ident: uuid.New(), Description: desc}))
 }
 
-// isExternalImport reports whether path looks like a third-party module
-// import (first segment contains a dot, e.g. "example.com/x") rather than a
-// standard-library package (e.g. "fmt", "net/http").
 func isExternalImport(path string) bool {
 	if path == "" {
 		return false
@@ -128,10 +116,6 @@ func isExternalImport(path string) bool {
 	return strings.Contains(first, ".")
 }
 
-// TestScanningRecipeAnnotatesGoModFromSources is the harness's first
-// ScanningRecipe coverage. It fails as a no-op (go.mod unchanged) unless
-// RewriteRun drives InitialValue -> Scanner over every .go file ->
-// EditorWithData over go.mod.
 func TestScanningRecipeAnnotatesGoModFromSources(t *testing.T) {
 	// given a project whose .go files import two external modules
 	spec := NewRecipeSpec().WithRecipe(&collectExternalImports{})
@@ -184,9 +168,6 @@ func TestScanningRecipeAnnotatesGoModFromSources(t *testing.T) {
 	)
 }
 
-// generateBuildTag is a ScanningRecipe that only generates a new file
-// (its Editor/EditorWithData are no-ops) — exercising the Generate phase and
-// the Generated(...) assertion.
 type generateBuildTag struct {
 	recipe.ScanningBase
 }
@@ -216,8 +197,6 @@ func (r *generateBuildTag) Generate(acc any, _ *recipe.ExecutionContext) []java.
 	return []java.Tree{cu}
 }
 
-// TestScanningRecipeGeneratesFile confirms Generate outputs are driven by the
-// harness and matched against Generated(...) specs by source path.
 func TestScanningRecipeGeneratesFile(t *testing.T) {
 	// given a project that imports an external module
 	spec := NewRecipeSpec().WithRecipe(&generateBuildTag{})
@@ -245,8 +224,6 @@ func TestScanningRecipeGeneratesFile(t *testing.T) {
 	)
 }
 
-// TestScanningRecipeNoMatchesLeavesGoModUnchanged confirms the lifecycle is
-// a faithful no-op when the scan finds nothing to act on.
 func TestScanningRecipeNoMatchesLeavesGoModUnchanged(t *testing.T) {
 	// given .go files that import only the standard library
 	spec := NewRecipeSpec().WithRecipe(&collectExternalImports{})

--- a/rewrite-go/pkg/test/scanning_recipe_test.go
+++ b/rewrite-go/pkg/test/scanning_recipe_test.go
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// importAccumulator collects the distinct external (non-standard-library)
+// import paths seen across every .go file in the scan phase.
+type importAccumulator struct {
+	paths map[string]bool
+}
+
+// collectExternalImports is a cross-file ScanningRecipe: it scans every .go
+// source for external imports, then annotates the sibling go.mod with a
+// SearchResult naming them. It reads state from one set of files and writes
+// to another, so it only makes sense end-to-end — the exact shape the unit
+// harness previously could not drive.
+type collectExternalImports struct {
+	recipe.ScanningBase
+}
+
+func (r *collectExternalImports) Name() string {
+	return "org.openrewrite.golang.test.CollectExternalImports"
+}
+func (r *collectExternalImports) DisplayName() string { return "Collect external imports onto go.mod" }
+func (r *collectExternalImports) Description() string {
+	return "Scans every .go file for external imports and records them as a SearchResult on go.mod."
+}
+
+func (r *collectExternalImports) InitialValue(*recipe.ExecutionContext) any {
+	return &importAccumulator{paths: map[string]bool{}}
+}
+
+func (r *collectExternalImports) Scanner(acc any) recipe.TreeVisitor {
+	return visitor.Init(&externalImportScanner{acc: acc.(*importAccumulator)})
+}
+
+func (r *collectExternalImports) EditorWithData(acc any) recipe.TreeVisitor {
+	return visitor.Init(&goModAnnotator{acc: acc.(*importAccumulator)})
+}
+
+type externalImportScanner struct {
+	visitor.GoVisitor
+	acc *importAccumulator
+}
+
+func (v *externalImportScanner) VisitCompilationUnit(cu *golang.CompilationUnit, p any) java.J {
+	if cu.Imports != nil {
+		for _, rp := range cu.Imports.Elements {
+			path := importPath(rp.Element)
+			if isExternalImport(path) {
+				v.acc.paths[path] = true
+			}
+		}
+	}
+	return cu
+}
+
+// importPath returns an Import's unquoted path (the parser stores the raw
+// quoted source, e.g. `"example.com/a"`, on the Qualid Literal).
+func importPath(imp *java.Import) string {
+	if imp == nil {
+		return ""
+	}
+	lit, ok := imp.Qualid.(*java.Literal)
+	if !ok || lit == nil {
+		return ""
+	}
+	return strings.Trim(lit.Source, "\"`")
+}
+
+type goModAnnotator struct {
+	visitor.GoVisitor
+	acc *importAccumulator
+}
+
+func (v *goModAnnotator) VisitGoMod(gm *golang.GoMod, p any) java.Tree {
+	if len(v.acc.paths) == 0 {
+		return gm
+	}
+	paths := make([]string, 0, len(v.acc.paths))
+	for path := range v.acc.paths {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	desc := fmt.Sprintf("external imports: %s", strings.Join(paths, ", "))
+	return gm.WithMarkers(java.AddMarker(gm.Markers, java.SearchResult{Ident: uuid.New(), Description: desc}))
+}
+
+// isExternalImport reports whether path looks like a third-party module
+// import (first segment contains a dot, e.g. "example.com/x") rather than a
+// standard-library package (e.g. "fmt", "net/http").
+func isExternalImport(path string) bool {
+	if path == "" {
+		return false
+	}
+	first := path
+	if i := strings.IndexByte(path, '/'); i >= 0 {
+		first = path[:i]
+	}
+	return strings.Contains(first, ".")
+}
+
+// TestScanningRecipeAnnotatesGoModFromSources is the harness's first
+// ScanningRecipe coverage. It fails as a no-op (go.mod unchanged) unless
+// RewriteRun drives InitialValue -> Scanner over every .go file ->
+// EditorWithData over go.mod.
+func TestScanningRecipeAnnotatesGoModFromSources(t *testing.T) {
+	// given a project whose .go files import two external modules
+	spec := NewRecipeSpec().WithRecipe(&collectExternalImports{})
+
+	// when the scanning recipe runs across all sources
+	// then the go.mod carries a SearchResult listing the scanned imports
+	spec.RewriteRun(t,
+		GoProject("app",
+			GoMod(
+				`
+					module example.com/app
+
+					go 1.22
+
+					require (
+						example.com/a v1.0.0
+						example.com/b v1.2.0
+					)
+				`,
+				`
+					/*~~(external imports: example.com/a/thing, example.com/b/other)~~>*/module example.com/app
+
+					go 1.22
+
+					require (
+						example.com/a v1.0.0
+						example.com/b v1.2.0
+					)
+				`,
+			),
+			Golang(`
+				package app
+
+				import (
+					"fmt"
+
+					"example.com/a/thing"
+				)
+
+				func A() { fmt.Println(thing.X) }
+			`),
+			Golang(`
+				package app
+
+				import "example.com/b/other"
+
+				func B() { other.Y() }
+			`),
+		),
+	)
+}
+
+// generateBuildTag is a ScanningRecipe that only generates a new file
+// (its Editor/EditorWithData are no-ops) — exercising the Generate phase and
+// the Generated(...) assertion.
+type generateBuildTag struct {
+	recipe.ScanningBase
+}
+
+func (r *generateBuildTag) Name() string        { return "org.openrewrite.golang.test.GenerateBuildTag" }
+func (r *generateBuildTag) DisplayName() string { return "Generate a build-tag file" }
+func (r *generateBuildTag) Description() string {
+	return "Generates tools.go when the project imports any external module."
+}
+
+func (r *generateBuildTag) InitialValue(*recipe.ExecutionContext) any {
+	return &importAccumulator{paths: map[string]bool{}}
+}
+
+func (r *generateBuildTag) Scanner(acc any) recipe.TreeVisitor {
+	return visitor.Init(&externalImportScanner{acc: acc.(*importAccumulator)})
+}
+
+func (r *generateBuildTag) Generate(acc any, _ *recipe.ExecutionContext) []java.Tree {
+	if len(acc.(*importAccumulator).paths) == 0 {
+		return nil
+	}
+	cu, err := parser.NewGoParser().Parse("tools.go", "package app\n")
+	if err != nil {
+		return nil
+	}
+	return []java.Tree{cu}
+}
+
+// TestScanningRecipeGeneratesFile confirms Generate outputs are driven by the
+// harness and matched against Generated(...) specs by source path.
+func TestScanningRecipeGeneratesFile(t *testing.T) {
+	// given a project that imports an external module
+	spec := NewRecipeSpec().WithRecipe(&generateBuildTag{})
+
+	// when the scanning recipe runs
+	// then the harness surfaces the generated tools.go for assertion
+	spec.RewriteRun(t,
+		GoProject("app",
+			GoMod(`
+				module example.com/app
+
+				go 1.22
+
+				require example.com/a v1.0.0
+			`),
+			Golang(`
+				package app
+
+				import "example.com/a/thing"
+
+				func A() { thing.X() }
+			`),
+		),
+		Generated("tools.go", "package app\n"),
+	)
+}
+
+// TestScanningRecipeNoMatchesLeavesGoModUnchanged confirms the lifecycle is
+// a faithful no-op when the scan finds nothing to act on.
+func TestScanningRecipeNoMatchesLeavesGoModUnchanged(t *testing.T) {
+	// given .go files that import only the standard library
+	spec := NewRecipeSpec().WithRecipe(&collectExternalImports{})
+
+	// when the scanning recipe runs
+	// then go.mod is left untouched (no After state)
+	spec.RewriteRun(t,
+		GoProject("app",
+			GoMod(`
+				module example.com/app
+
+				go 1.22
+			`),
+			Golang(`
+				package app
+
+				import "fmt"
+
+				func A() { fmt.Println("hi") }
+			`),
+		),
+	)
+}

--- a/rewrite-go/pkg/test/spec.go
+++ b/rewrite-go/pkg/test/spec.go
@@ -432,21 +432,6 @@ func GolangRaw(before string, after ...string) SourceSpec {
 	return spec
 }
 
-// Generated declares a source file the recipe under test is expected to
-// create in its ScanningRecipe.Generate phase. It carries no "before"
-// content — only the expected output keyed by its source path. RewriteRun
-// matches each generated tree to a Generated spec by source path, so a
-// scanning recipe that emits new files can be asserted alongside the files
-// it edits. Fails the test if the recipe generates a file with no matching
-// Generated spec, or a Generated spec matches nothing.
-//
-//	spec.RewriteRun(t,
-//	    test.GoProject("foo",
-//	        test.GoMod("module example.com/foo\ngo 1.22\n"),
-//	        test.Golang("package main\nfunc main(){}\n"),
-//	    ),
-//	    test.Generated("tools.go", "package main\n"),
-//	)
 func Generated(sourcePath, after string) SourceSpec {
 	a := TrimIndent(after)
 	return SourceSpec{
@@ -552,9 +537,6 @@ func (spec *RecipeSpec) WithMarkerPrinter(mp printer.MarkerPrinter) *RecipeSpec 
 	return spec
 }
 
-// parsedSource pairs a SourceSpec with the tree the harness parsed for it.
-// tree is nil for sources that have no LST yet (e.g. go.sum). result holds
-// the tree after recipe application; it defaults to tree.
 type parsedSource struct {
 	spec   SourceSpec
 	tree   java.Tree
@@ -566,19 +548,11 @@ type parsedSource struct {
 // configured) applies a recipe and checks the result. Accepts both bare
 // SourceSpec values and project wrappers like GoProject — they both
 // implement Sources.
-//
-// Recipe application runs in two passes so cross-file ScanningRecipes work:
-// every source is parsed first, then the recipe is applied over the whole
-// set. A ScanningRecipe is driven through its real
-// InitialValue -> Scanner -> Generate -> EditorWithData lifecycle (mirroring
-// cmd/rpc/main.go and the JavaScript run scheduler); a plain recipe keeps the
-// historical per-source Editor() application.
 func (spec *RecipeSpec) RewriteRun(t *testing.T, sources ...Sources) {
 	t.Helper()
 
 	// Flatten any project wrappers into a flat list of SourceSpecs, with
-	// project markers already attached. Generated(...) specs describe files
-	// the recipe is expected to emit, not inputs — hold them aside.
+	// project markers already attached.
 	var flat []SourceSpec
 	var genSpecs []SourceSpec
 	for _, s := range sources {
@@ -603,10 +577,7 @@ func (spec *RecipeSpec) RewriteRun(t *testing.T, sources ...Sources) {
 		parsedByIdx = parsePackageGroups(t, p, flat)
 	}
 
-	// Pass 1: parse every source and run its per-source validations and
-	// parse-print idempotence check. Recipe application is deferred to
-	// pass 2 so a ScanningRecipe can observe every source before editing
-	// any single file.
+	// Pass 1: parse every source.
 	parsed := make([]parsedSource, len(flat))
 	for i, src := range flat {
 		parsed[i].spec = src
@@ -614,12 +585,7 @@ func (spec *RecipeSpec) RewriteRun(t *testing.T, sources ...Sources) {
 		case strings.HasSuffix(src.Path, ".go"):
 			parsed[i].tree = spec.parseGoSource(t, p, parsedByIdx, i, src)
 		case path.Base(src.Path) == "go.mod":
-			// go.mod parses into a lossless LST, so recipes can run
-			// against it.
 			parsed[i].tree = spec.parseGoMod(t, src)
-		default:
-			// Other non-Go sources (e.g. go.sum) have no LST yet and
-			// round-trip verbatim; tree stays nil.
 		}
 	}
 
@@ -647,9 +613,6 @@ func (spec *RecipeSpec) RewriteRun(t *testing.T, sources ...Sources) {
 	spec.compareGenerated(t, genSpecs, generated)
 }
 
-// parseGoSource parses one .go SourceSpec (reusing the shared package parse
-// when a project context supplied one), attaches project markers, runs the
-// whitespace/idempotence validations, and fires the AfterRecipe callback.
 func (spec *RecipeSpec) parseGoSource(t *testing.T, p *parser.GoParser, parsedByIdx map[int]*golang.CompilationUnit, i int, src SourceSpec) *golang.CompilationUnit {
 	t.Helper()
 
@@ -703,9 +666,6 @@ func (spec *RecipeSpec) parseGoSource(t *testing.T, p *parser.GoParser, parsedBy
 	return cu
 }
 
-// parseGoMod parses a go.mod source into its lossless LST, attaches project
-// markers, and checks parse-print idempotence. GoMod is a SourceFile that is
-// not a *golang.CompilationUnit, so it uses the go.mod-specific parser.
 func (spec *RecipeSpec) parseGoMod(t *testing.T, src SourceSpec) *golang.GoMod {
 	t.Helper()
 
@@ -730,15 +690,11 @@ func (spec *RecipeSpec) parseGoMod(t *testing.T, src SourceSpec) *golang.GoMod {
 	return gm
 }
 
-// compareSource prints a source's recipe result and asserts it against the
-// spec's expected after-state (or, when none is given, that nothing changed).
 func (spec *RecipeSpec) compareSource(t *testing.T, ps parsedSource) {
 	t.Helper()
 	src := ps.spec
 
 	if ps.tree == nil {
-		// Non-LST source (e.g. go.sum): round-trips verbatim; the harness
-		// can't apply recipes to it yet.
 		if src.After != nil && *src.After != src.Before {
 			t.Errorf("non-Go source %q: harness cannot apply recipes to it yet", src.Path)
 		}
@@ -773,10 +729,6 @@ func (spec *RecipeSpec) compareSource(t *testing.T, ps parsedSource) {
 	}
 }
 
-// compareGenerated matches each Generated(...) spec to a tree the recipe
-// emitted (by source path) and asserts its printed form. It flags both a
-// Generated spec that matched nothing and a generated tree with no spec, so
-// generation stays fully covered rather than silently ignored.
 func (spec *RecipeSpec) compareGenerated(t *testing.T, specs []SourceSpec, generated []java.Tree) {
 	t.Helper()
 	if len(specs) == 0 && len(generated) == 0 {
@@ -810,8 +762,6 @@ func (spec *RecipeSpec) compareGenerated(t *testing.T, specs []SourceSpec, gener
 	}
 }
 
-// markerPrinter returns the configured MarkerPrinter, defaulting to
-// DefaultMarkerPrinter so SearchResult/Markup markers render as /*~~>*/.
 func (spec *RecipeSpec) markerPrinter() printer.MarkerPrinter {
 	if spec.MarkerPrinter != nil {
 		return spec.MarkerPrinter
@@ -819,8 +769,6 @@ func (spec *RecipeSpec) markerPrinter() printer.MarkerPrinter {
 	return printer.DefaultMarkerPrinter
 }
 
-// printTree renders a recipe result, picking the go.mod printer for a GoMod
-// and the Go source printer for everything else.
 func printTree(t java.Tree, mp printer.MarkerPrinter) string {
 	if gm, ok := t.(*golang.GoMod); ok {
 		return printer.PrintGoModWithMarkers(gm, mp)
@@ -835,8 +783,6 @@ func generatedSourcePath(t java.Tree) string {
 	return ""
 }
 
-// recipeIsScanning reports whether r, or any recipe in its RecipeList,
-// implements ScanningRecipe.
 func recipeIsScanning(r recipe.Recipe) bool {
 	if _, ok := r.(recipe.ScanningRecipe); ok {
 		return true
@@ -849,12 +795,6 @@ func recipeIsScanning(r recipe.Recipe) bool {
 	return false
 }
 
-// runScanningLifecycle drives spec.Recipe (and any nested recipes) through
-// the real scan-then-edit lifecycle over the whole parsed source set,
-// sharing one ExecutionContext so accumulators live across phases — exactly
-// as the RPC server does. Existing sources are edited in place (results
-// written back onto parsed[i].result); Generate outputs are returned so the
-// caller can assert them against Generated(...) specs.
 func (spec *RecipeSpec) runScanningLifecycle(parsed []parsedSource) []java.Tree {
 	ctx := recipe.NewExecutionContext()
 
@@ -902,9 +842,6 @@ func (spec *RecipeSpec) runScanningLifecycle(parsed []parsedSource) []java.Tree 
 	return working[nExisting:]
 }
 
-// applyEditorAcross visits every tree with editor, draining after-visits per
-// tree, and writes results back in place. Mirrors runRecipe's single-file
-// editor handling: a nil visit result keeps the original tree.
 func applyEditorAcross(editor recipe.TreeVisitor, trees []java.Tree, ctx *recipe.ExecutionContext) {
 	for i, tr := range trees {
 		if tr == nil {

--- a/rewrite-go/pkg/test/spec.go
+++ b/rewrite-go/pkg/test/spec.go
@@ -37,6 +37,7 @@ type SourceSpec struct {
 	Path        string
 	Markers     []java.Marker                                  // markers attached to the parsed source after parse
 	AfterRecipe func(t *testing.T, cu *golang.CompilationUnit) // optional post-parse assertion callback (.go files only)
+	generated   bool                                           // true for a file the recipe is expected to Generate (see Generated)
 }
 
 // Sources is the unit RewriteRun consumes. Single SourceSpecs and project
@@ -431,6 +432,30 @@ func GolangRaw(before string, after ...string) SourceSpec {
 	return spec
 }
 
+// Generated declares a source file the recipe under test is expected to
+// create in its ScanningRecipe.Generate phase. It carries no "before"
+// content — only the expected output keyed by its source path. RewriteRun
+// matches each generated tree to a Generated spec by source path, so a
+// scanning recipe that emits new files can be asserted alongside the files
+// it edits. Fails the test if the recipe generates a file with no matching
+// Generated spec, or a Generated spec matches nothing.
+//
+//	spec.RewriteRun(t,
+//	    test.GoProject("foo",
+//	        test.GoMod("module example.com/foo\ngo 1.22\n"),
+//	        test.Golang("package main\nfunc main(){}\n"),
+//	    ),
+//	    test.Generated("tools.go", "package main\n"),
+//	)
+func Generated(sourcePath, after string) SourceSpec {
+	a := TrimIndent(after)
+	return SourceSpec{
+		After:     &a,
+		Path:      sourcePath,
+		generated: true,
+	}
+}
+
 // TrimIndent removes the common leading whitespace from all non-empty lines,
 // and strips a single leading and trailing blank line (artifacts of backtick
 // string literals that start/end on their own line).
@@ -527,19 +552,43 @@ func (spec *RecipeSpec) WithMarkerPrinter(mp printer.MarkerPrinter) *RecipeSpec 
 	return spec
 }
 
+// parsedSource pairs a SourceSpec with the tree the harness parsed for it.
+// tree is nil for sources that have no LST yet (e.g. go.sum). result holds
+// the tree after recipe application; it defaults to tree.
+type parsedSource struct {
+	spec   SourceSpec
+	tree   java.Tree
+	result java.Tree
+}
+
 // RewriteRun parses each source, checks parse-print idempotence, attaches
 // any markers contributed by project wrappers (GoProject), and (if
 // configured) applies a recipe and checks the result. Accepts both bare
 // SourceSpec values and project wrappers like GoProject — they both
 // implement Sources.
+//
+// Recipe application runs in two passes so cross-file ScanningRecipes work:
+// every source is parsed first, then the recipe is applied over the whole
+// set. A ScanningRecipe is driven through its real
+// InitialValue -> Scanner -> Generate -> EditorWithData lifecycle (mirroring
+// cmd/rpc/main.go and the JavaScript run scheduler); a plain recipe keeps the
+// historical per-source Editor() application.
 func (spec *RecipeSpec) RewriteRun(t *testing.T, sources ...Sources) {
 	t.Helper()
 
 	// Flatten any project wrappers into a flat list of SourceSpecs, with
-	// project markers already attached.
+	// project markers already attached. Generated(...) specs describe files
+	// the recipe is expected to emit, not inputs — hold them aside.
 	var flat []SourceSpec
+	var genSpecs []SourceSpec
 	for _, s := range sources {
-		flat = append(flat, s.Expand()...)
+		for _, ss := range s.Expand() {
+			if ss.generated {
+				genSpecs = append(genSpecs, ss)
+			} else {
+				flat = append(flat, ss)
+			}
+		}
 	}
 
 	p := parser.NewGoParser()
@@ -554,103 +603,110 @@ func (spec *RecipeSpec) RewriteRun(t *testing.T, sources ...Sources) {
 		parsedByIdx = parsePackageGroups(t, p, flat)
 	}
 
+	// Pass 1: parse every source and run its per-source validations and
+	// parse-print idempotence check. Recipe application is deferred to
+	// pass 2 so a ScanningRecipe can observe every source before editing
+	// any single file.
+	parsed := make([]parsedSource, len(flat))
 	for i, src := range flat {
-		if !strings.HasSuffix(src.Path, ".go") {
-			// go.mod parses into a lossless LST, so recipes can run against
-			// it. Other non-Go sources (e.g. go.sum) have no LST yet and
-			// round-trip verbatim.
-			if path.Base(src.Path) == "go.mod" {
-				spec.rewriteGoMod(t, src)
-			} else if src.After != nil && *src.After != src.Before {
-				t.Errorf("non-Go source %q: harness cannot apply recipes to it yet", src.Path)
-			}
-			continue
-		}
-
-		var cu *golang.CompilationUnit
-		if parsedByIdx != nil {
-			cu = parsedByIdx[i]
-		}
-		if cu == nil {
-			// No project context (or project parse missed this source) —
-			// parse this file in isolation so two bare specs sharing a
-			// default Path don't clobber each other.
-			parsed, err := p.Parse(src.Path, src.Before)
-			if err != nil {
-				t.Fatalf("parse error: %v", err)
-			}
-			cu = parsed
-		}
-
-		// Attach any project markers contributed by GoProject(...) wrappers.
-		for _, m := range src.Markers {
-			cu.Markers = java.AddMarker(cu.Markers, m)
-		}
-
-		// Validate that no Space contains non-whitespace syntax
-		if errs := ValidateSpaces(cu); len(errs) > 0 {
-			for _, e := range errs {
-				t.Errorf("space validation: %s", e)
-			}
-		}
-
-		// Assert leading whitespace is attached to the outermost LST element
-		// for every parsed source.
-		if errs := WhitespaceAttachmentViolations(cu); len(errs) > 0 {
-			for _, e := range errs {
-				t.Errorf("whitespace attachment: %s", e)
-			}
-		}
-
-		if src.AfterRecipe != nil {
-			src.AfterRecipe(t, cu)
-		}
-
-		if spec.CheckParsePrintIdempotence {
-			printed := printer.Print(cu)
-			if printed != src.Before {
-				t.Errorf("parse-print idempotence failed\n\nexpected:\n%s\n\nactual:\n%s\n\ndiff positions:", src.Before, printed)
-				showDiff(t, src.Before, printed)
-			}
-		}
-
-		// Apply recipe if configured
-		if spec.Recipe != nil {
-			result := runRecipe(spec.Recipe, cu)
-			if result == nil {
-				if src.After != nil {
-					t.Error("recipe returned nil (deleted source file) but expected an after state")
-				}
-				continue
-			}
-			mp := spec.MarkerPrinter
-			if mp == nil {
-				mp = printer.DefaultMarkerPrinter
-			}
-			actual := printer.PrintWithMarkers(result, mp)
-			if src.After != nil {
-				if actual != *src.After {
-					t.Errorf("recipe result mismatch\n\nexpected:\n%s\n\nactual:\n%s", *src.After, actual)
-					showDiff(t, *src.After, actual)
-				}
-			} else {
-				// No after state: expect no changes
-				if actual != src.Before {
-					t.Errorf("recipe made unexpected changes\n\nexpected (no change):\n%s\n\nactual:\n%s", src.Before, actual)
-				}
-			}
-		} else if src.After != nil {
-			t.Error("after state specified but no recipe configured")
+		parsed[i].spec = src
+		switch {
+		case strings.HasSuffix(src.Path, ".go"):
+			parsed[i].tree = spec.parseGoSource(t, p, parsedByIdx, i, src)
+		case path.Base(src.Path) == "go.mod":
+			// go.mod parses into a lossless LST, so recipes can run
+			// against it.
+			parsed[i].tree = spec.parseGoMod(t, src)
+		default:
+			// Other non-Go sources (e.g. go.sum) have no LST yet and
+			// round-trip verbatim; tree stays nil.
 		}
 	}
+
+	// Pass 2: apply the recipe over the parsed set.
+	var generated []java.Tree
+	if spec.Recipe != nil {
+		for i := range parsed {
+			parsed[i].result = parsed[i].tree
+		}
+		if recipeIsScanning(spec.Recipe) {
+			generated = spec.runScanningLifecycle(parsed)
+		} else {
+			for i := range parsed {
+				if parsed[i].tree != nil {
+					parsed[i].result = runRecipe(spec.Recipe, parsed[i].tree)
+				}
+			}
+		}
+	}
+
+	// Pass 3: compare each source (and any generated files) to expectations.
+	for i := range parsed {
+		spec.compareSource(t, parsed[i])
+	}
+	spec.compareGenerated(t, genSpecs, generated)
 }
 
-// rewriteGoMod parses a go.mod source into its lossless LST, checks
-// parse-print idempotence, and (if a recipe is configured) applies it and
-// compares the printed result to the expected after-state. Mirrors the
-// .go path in RewriteRun, but uses the go.mod-specific parser/printer since
-// GoMod is a SourceFile that is not a *golang.CompilationUnit.
-func (spec *RecipeSpec) rewriteGoMod(t *testing.T, src SourceSpec) {
+// parseGoSource parses one .go SourceSpec (reusing the shared package parse
+// when a project context supplied one), attaches project markers, runs the
+// whitespace/idempotence validations, and fires the AfterRecipe callback.
+func (spec *RecipeSpec) parseGoSource(t *testing.T, p *parser.GoParser, parsedByIdx map[int]*golang.CompilationUnit, i int, src SourceSpec) *golang.CompilationUnit {
+	t.Helper()
+
+	var cu *golang.CompilationUnit
+	if parsedByIdx != nil {
+		cu = parsedByIdx[i]
+	}
+	if cu == nil {
+		// No project context (or project parse missed this source) —
+		// parse this file in isolation so two bare specs sharing a
+		// default Path don't clobber each other.
+		parsed, err := p.Parse(src.Path, src.Before)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		cu = parsed
+	}
+
+	// Attach any project markers contributed by GoProject(...) wrappers.
+	for _, m := range src.Markers {
+		cu.Markers = java.AddMarker(cu.Markers, m)
+	}
+
+	// Validate that no Space contains non-whitespace syntax.
+	if errs := ValidateSpaces(cu); len(errs) > 0 {
+		for _, e := range errs {
+			t.Errorf("space validation: %s", e)
+		}
+	}
+
+	// Assert leading whitespace is attached to the outermost LST element
+	// for every parsed source.
+	if errs := WhitespaceAttachmentViolations(cu); len(errs) > 0 {
+		for _, e := range errs {
+			t.Errorf("whitespace attachment: %s", e)
+		}
+	}
+
+	if src.AfterRecipe != nil {
+		src.AfterRecipe(t, cu)
+	}
+
+	if spec.CheckParsePrintIdempotence {
+		printed := printer.Print(cu)
+		if printed != src.Before {
+			t.Errorf("parse-print idempotence failed\n\nexpected:\n%s\n\nactual:\n%s\n\ndiff positions:", src.Before, printed)
+			showDiff(t, src.Before, printed)
+		}
+	}
+
+	return cu
+}
+
+// parseGoMod parses a go.mod source into its lossless LST, attaches project
+// markers, and checks parse-print idempotence. GoMod is a SourceFile that is
+// not a *golang.CompilationUnit, so it uses the go.mod-specific parser.
+func (spec *RecipeSpec) parseGoMod(t *testing.T, src SourceSpec) *golang.GoMod {
 	t.Helper()
 
 	gm, err := parser.ParseGoModFile(src.Path, src.Before)
@@ -671,6 +727,24 @@ func (spec *RecipeSpec) rewriteGoMod(t *testing.T, src SourceSpec) {
 		}
 	}
 
+	return gm
+}
+
+// compareSource prints a source's recipe result and asserts it against the
+// spec's expected after-state (or, when none is given, that nothing changed).
+func (spec *RecipeSpec) compareSource(t *testing.T, ps parsedSource) {
+	t.Helper()
+	src := ps.spec
+
+	if ps.tree == nil {
+		// Non-LST source (e.g. go.sum): round-trips verbatim; the harness
+		// can't apply recipes to it yet.
+		if src.After != nil && *src.After != src.Before {
+			t.Errorf("non-Go source %q: harness cannot apply recipes to it yet", src.Path)
+		}
+		return
+	}
+
 	if spec.Recipe == nil {
 		if src.After != nil {
 			t.Error("after state specified but no recipe configured")
@@ -678,30 +752,169 @@ func (spec *RecipeSpec) rewriteGoMod(t *testing.T, src SourceSpec) {
 		return
 	}
 
-	result := runRecipe(spec.Recipe, gm)
-	if result == nil {
+	if ps.result == nil {
 		if src.After != nil {
 			t.Error("recipe returned nil (deleted source file) but expected an after state")
 		}
 		return
 	}
-	resultGoMod, ok := result.(*golang.GoMod)
-	if !ok {
-		t.Fatalf("recipe returned %T, want *golang.GoMod", result)
-	}
 
-	mp := spec.MarkerPrinter
-	if mp == nil {
-		mp = printer.DefaultMarkerPrinter
-	}
-	actual := printer.PrintGoModWithMarkers(resultGoMod, mp)
+	actual := printTree(ps.result, spec.markerPrinter())
 	if src.After != nil {
 		if actual != *src.After {
 			t.Errorf("recipe result mismatch\n\nexpected:\n%s\n\nactual:\n%s", *src.After, actual)
 			showDiff(t, *src.After, actual)
 		}
-	} else if actual != src.Before {
+		return
+	}
+	// No after state: expect no changes.
+	if actual != src.Before {
 		t.Errorf("recipe made unexpected changes\n\nexpected (no change):\n%s\n\nactual:\n%s", src.Before, actual)
+	}
+}
+
+// compareGenerated matches each Generated(...) spec to a tree the recipe
+// emitted (by source path) and asserts its printed form. It flags both a
+// Generated spec that matched nothing and a generated tree with no spec, so
+// generation stays fully covered rather than silently ignored.
+func (spec *RecipeSpec) compareGenerated(t *testing.T, specs []SourceSpec, generated []java.Tree) {
+	t.Helper()
+	if len(specs) == 0 && len(generated) == 0 {
+		return
+	}
+
+	mp := spec.markerPrinter()
+	matched := make([]bool, len(generated))
+	for _, gs := range specs {
+		found := false
+		for j, gt := range generated {
+			if matched[j] || gt == nil || generatedSourcePath(gt) != gs.Path {
+				continue
+			}
+			matched[j] = true
+			found = true
+			if actual := printTree(gt, mp); gs.After != nil && actual != *gs.After {
+				t.Errorf("generated file %q mismatch\n\nexpected:\n%s\n\nactual:\n%s", gs.Path, *gs.After, actual)
+				showDiff(t, *gs.After, actual)
+			}
+			break
+		}
+		if !found {
+			t.Errorf("expected recipe to generate file %q, but it was not generated", gs.Path)
+		}
+	}
+	for j, gt := range generated {
+		if !matched[j] && gt != nil {
+			t.Errorf("recipe generated an unexpected file %q; add a test.Generated(...) spec to assert it", generatedSourcePath(gt))
+		}
+	}
+}
+
+// markerPrinter returns the configured MarkerPrinter, defaulting to
+// DefaultMarkerPrinter so SearchResult/Markup markers render as /*~~>*/.
+func (spec *RecipeSpec) markerPrinter() printer.MarkerPrinter {
+	if spec.MarkerPrinter != nil {
+		return spec.MarkerPrinter
+	}
+	return printer.DefaultMarkerPrinter
+}
+
+// printTree renders a recipe result, picking the go.mod printer for a GoMod
+// and the Go source printer for everything else.
+func printTree(t java.Tree, mp printer.MarkerPrinter) string {
+	if gm, ok := t.(*golang.GoMod); ok {
+		return printer.PrintGoModWithMarkers(gm, mp)
+	}
+	return printer.PrintWithMarkers(t, mp)
+}
+
+func generatedSourcePath(t java.Tree) string {
+	if sp, ok := t.(interface{ GetSourcePath() string }); ok {
+		return sp.GetSourcePath()
+	}
+	return ""
+}
+
+// recipeIsScanning reports whether r, or any recipe in its RecipeList,
+// implements ScanningRecipe.
+func recipeIsScanning(r recipe.Recipe) bool {
+	if _, ok := r.(recipe.ScanningRecipe); ok {
+		return true
+	}
+	for _, sub := range r.RecipeList() {
+		if recipeIsScanning(sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// runScanningLifecycle drives spec.Recipe (and any nested recipes) through
+// the real scan-then-edit lifecycle over the whole parsed source set,
+// sharing one ExecutionContext so accumulators live across phases — exactly
+// as the RPC server does. Existing sources are edited in place (results
+// written back onto parsed[i].result); Generate outputs are returned so the
+// caller can assert them against Generated(...) specs.
+func (spec *RecipeSpec) runScanningLifecycle(parsed []parsedSource) []java.Tree {
+	ctx := recipe.NewExecutionContext()
+
+	working := make([]java.Tree, 0, len(parsed))
+	idx := make([]int, 0, len(parsed))
+	for i := range parsed {
+		if parsed[i].tree != nil {
+			working = append(working, parsed[i].tree)
+			idx = append(idx, i)
+		}
+	}
+	nExisting := len(working)
+
+	var walk func(r recipe.Recipe)
+	walk = func(r recipe.Recipe) {
+		if sr, ok := r.(recipe.ScanningRecipe); ok {
+			acc := sr.InitialValue(ctx)
+			if scanner := sr.Scanner(acc); scanner != nil {
+				for _, tr := range working {
+					if tr != nil {
+						scanner.Visit(tr, ctx)
+					}
+				}
+			}
+			for _, g := range sr.Generate(acc, ctx) {
+				if g != nil {
+					working = append(working, g)
+				}
+			}
+			if editor := sr.EditorWithData(acc); editor != nil {
+				applyEditorAcross(editor, working, ctx)
+			}
+		} else if editor := r.Editor(); editor != nil {
+			applyEditorAcross(editor, working, ctx)
+		}
+		for _, sub := range r.RecipeList() {
+			walk(sub)
+		}
+	}
+	walk(spec.Recipe)
+
+	for k, i := range idx {
+		parsed[i].result = working[k]
+	}
+	return working[nExisting:]
+}
+
+// applyEditorAcross visits every tree with editor, draining after-visits per
+// tree, and writes results back in place. Mirrors runRecipe's single-file
+// editor handling: a nil visit result keeps the original tree.
+func applyEditorAcross(editor recipe.TreeVisitor, trees []java.Tree, ctx *recipe.ExecutionContext) {
+	for i, tr := range trees {
+		if tr == nil {
+			continue
+		}
+		result := editor.Visit(tr, ctx)
+		if result != nil {
+			tr = result
+		}
+		trees[i] = visitor.DrainAfterVisits(editor, tr, ctx)
 	}
 }
 


### PR DESCRIPTION
## What's changed?

Amending the Go test harness to support scanning recipes.

## What's your motivation?

- Feature parity with other languages
- Needed for recipe development
