### PR TITLE
Go: handle nested modules in LockFileRegeneration

### DIFF
--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/LockFileRegeneration.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/LockFileRegeneration.java
@@ -86,6 +86,10 @@ public final class LockFileRegeneration {
      * dependencies), or an error message
      */
     public Result regenerate(String manifestContent, @Nullable String existingLockContent, Map<String, String> environment) {
+        return regenerate(Collections.singletonMap(manifestFile, manifestContent), "", existingLockContent, environment);
+    }
+
+    public Result regenerate(Map<String, String> filesByPath, String workSubdir, @Nullable String existingLockContent, Map<String, String> environment) {
         String executablePath = executor.find();
         if (executablePath == null) {
             return Result.failure(executor.getName() + " is not installed or not on PATH");
@@ -95,15 +99,26 @@ public final class LockFileRegeneration {
         try {
             tempDir = Files.createTempDirectory("openrewrite-go-lock-");
 
-            Files.write(tempDir.resolve(manifestFile),
-                    manifestContent.getBytes(StandardCharsets.UTF_8));
+            for (Map.Entry<String, String> entry : filesByPath.entrySet()) {
+                Path target = resolveWithin(tempDir, entry.getKey());
+                if (target == null) {
+                    return Result.failure("refusing to seed file outside the workspace: " + entry.getKey());
+                }
+                Files.createDirectories(target.getParent());
+                Files.write(target, entry.getValue().getBytes(StandardCharsets.UTF_8));
+            }
+
+            Path workDir = resolveWithin(tempDir, workSubdir);
+            if (workDir == null) {
+                return Result.failure("refusing to run outside the workspace: " + workSubdir);
+            }
 
             if (existingLockContent != null) {
-                Files.write(tempDir.resolve(lockFile),
+                Files.write(workDir.resolve(lockFile),
                         existingLockContent.getBytes(StandardCharsets.UTF_8));
             }
 
-            GoExecutor.RunResult runResult = executor.run(tempDir, executablePath, environment, args);
+            GoExecutor.RunResult runResult = executor.run(workDir, executablePath, environment, args);
             if (!runResult.isSuccess()) {
                 String stderr = runResult.getStderr();
                 if (stderr != null && stderr.length() > 2000) {
@@ -113,7 +128,7 @@ public final class LockFileRegeneration {
                         " failed (exit " + runResult.getExitCode() + "): " + stderr);
             }
 
-            Path lockPath = tempDir.resolve(lockFile);
+            Path lockPath = workDir.resolve(lockFile);
             if (!Files.exists(lockPath)) {
                 return Result.success("");
             }
@@ -129,6 +144,11 @@ public final class LockFileRegeneration {
                 cleanupDirectory(tempDir);
             }
         }
+    }
+
+    private static @Nullable Path resolveWithin(Path root, String relative) {
+        Path resolved = root.resolve(relative).normalize();
+        return resolved.startsWith(root) ? resolved : null;
     }
 
     private static void cleanupDirectory(Path dir) {

--- a/rewrite-go/src/test/java/org/openrewrite/golang/internal/LockFileRegenerationTest.java
+++ b/rewrite-go/src/test/java/org/openrewrite/golang/internal/LockFileRegenerationTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Timeout;
 import org.openrewrite.golang.RegenerateGoSum;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,6 +58,28 @@ class LockFileRegenerationTest implements RewriteTest {
         // then
         assertThat(result.isSuccess()).isFalse();
         assertThat(result.getErrorMessage()).isNotNull();
+    }
+
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void seedsLocallyReplacedSiblingModule() {
+        // given a submodule that resolves its parent module through a local `replace`, alongside a public dependency
+        assumeThat(GoExecutor.GO.find()).isNotNull();
+        Map<String, String> workspace = new LinkedHashMap<>();
+        workspace.put("go.mod", "module example.com/root\n\ngo 1.21\n");
+        workspace.put("sub/go.mod",
+          "module example.com/root/sub\n\ngo 1.21\n\n" +
+          "require example.com/root v0.0.0-00010101000000-000000000000\n\n" +
+          "require rsc.io/quote v1.5.2\n\n" +
+          "replace example.com/root => ../\n");
+
+        // when the sibling go.mod is seeded into the workspace and go.sum is regenerated from the sub directory
+        LockFileRegeneration.Result result = LockFileRegeneration.GO_SUM.regenerate(
+          workspace, "sub", null, java.util.Collections.emptyMap());
+
+        // then the local replacement resolves and the public dependency is locked
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getLockFileContent()).contains("rsc.io/quote v1.5.2 h1:");
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

Amending the recently added `LockFileRegeneration` for Go (handling `go.mod/go.sum` files) to handle nested modules with relative references to each other.

## What's your motivation?

This currently fails for real-life complex projects.