### PR TITLE
rewrite-csharp: add ExpectDataTable test assertion + Net48 reference assemblies

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
@@ -160,13 +160,19 @@ public abstract class RewriteTest
             var prevThrow = WhitespaceReconciler.ThrowOnMismatchDefault;
             WhitespaceReconciler.ThrowOnMismatchDefault = validations.FormattingReconciliation;
             List<Result> results;
+            var runCtx = new ExecutionContext();
             try
             {
-                results = RecipeScheduler.Run(recipeSpec.Recipe, sources, new ExecutionContext());
+                results = RecipeScheduler.Run(recipeSpec.Recipe, sources, runCtx);
             }
             finally
             {
                 WhitespaceReconciler.ThrowOnMismatchDefault = prevThrow;
+            }
+
+            foreach (var afterRecipe in recipeSpec.AfterRecipe)
+            {
+                afterRecipe(runCtx);
             }
 
             foreach (var (spec, source) in parsed)
@@ -300,9 +306,36 @@ public class RecipeSpec
     public ReferenceAssemblies? ReferenceAssemblies { get; private set; } = Assemblies.Net90;
     public Validations Validations { get; private set; } = Validations.All;
 
+    private readonly List<Action<ExecutionContext>> _afterRecipe = [];
+
+    /// <summary>
+    /// Assertions run against the execution context after the recipe completes (e.g. to verify
+    /// data table rows written via the recipe's <see cref="OpenRewrite.Core.IDataTableStore"/>).
+    /// </summary>
+    public IReadOnlyList<Action<ExecutionContext>> AfterRecipe => _afterRecipe;
+
     public RecipeSpec SetRecipe(Recipe recipe)
     {
         Recipe = recipe;
+        return this;
+    }
+
+    /// <summary>
+    /// Assert the rows a recipe wrote to a data table. <paramref name="group"/> is the data
+    /// table's bucket key — its <c>Group</c> if set, otherwise its <c>InstanceName</c> (which
+    /// defaults to the display name). The test-default in-memory store is read back, so no RPC
+    /// data-table configuration is required.
+    /// </summary>
+    public RecipeSpec ExpectDataTable<TRow>(string name, string group, Action<IReadOnlyList<TRow>> assertion)
+        where TRow : notnull
+    {
+        _afterRecipe.Add(ctx =>
+        {
+            var store = ctx.GetMessage<OpenRewrite.Core.IDataTableStore>(
+                OpenRewrite.Core.DataTable<TRow>.DataTableStoreKey);
+            var rows = (store?.GetRows(name, group) ?? []).Cast<TRow>().ToList();
+            assertion(rows);
+        });
         return this;
     }
 
@@ -326,6 +359,14 @@ public static class Assemblies
 {
     public static ReferenceAssemblies Net90 => Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90;
     public static ReferenceAssemblies Net100 => Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net100;
+
+    /// <summary>
+    /// .NET Framework 4.8 reference assemblies (via the
+    /// <c>Microsoft.NETFramework.ReferenceAssemblies.net48</c> package). Use for tests that
+    /// need to attest legacy framework types such as <c>System.Web.UI.Page</c>,
+    /// <c>System.ServiceModel.*</c>, or <c>System.Data.Entity.*</c>.
+    /// </summary>
+    public static ReferenceAssemblies Net48 => Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net48.Default;
 
     public static ReferenceAssemblies AspNet90 =>
         Net90.AddPackage("Microsoft.AspNetCore.App.Ref");


### PR DESCRIPTION
- Adds a `RecipeSpec.ExpectDataTable<TRow>(name, group, assertion)` hook to the C# `RewriteTest` harness — backed by an `AfterRecipe` callback that reads the run's in-memory `DataTableStore` — so C# recipe tests can assert the rows a recipe writes to a data table (the test-side complement to the shipped `SetDataTableStore` streaming pipeline, #8135, which had no assertion helper). Also adds `Assemblies.Net48` for tests that need to attest legacy .NET Framework types such as `System.Web.UI.Page`, `System.ServiceModel.*`, and `System.Data.Entity.*`. Scoped to a single file (`RewriteTest.cs`); no production code changes.