### PR TITLE
Java: fix `ReplaceConstant` throwing `IllegalStateException` on Kotlin sources

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ReplaceConstantTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ReplaceConstantTest.java
@@ -77,6 +77,40 @@ class ReplaceConstantTest implements RewriteTest {
         );
     }
 
+    @Test
+    void replaceConstantInLambda() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("guava")),
+          java(
+            """
+              import java.util.function.Supplier;
+              import static com.google.common.base.Charsets.UTF_8;
+
+              class Test {
+                  void run(Supplier<Object> supplier) {
+                  }
+
+                  void method() {
+                      run(() -> UTF_8);
+                  }
+              }
+              """,
+            """
+              import java.util.function.Supplier;
+
+              class Test {
+                  void run(Supplier<Object> supplier) {
+                  }
+
+                  void method() {
+                      run(() -> "UTF_8");
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/1752")
     @Test
     void doesNotChangeOriginalVariableDeclaration() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/ReplaceConstant.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ReplaceConstant.java
@@ -75,11 +75,11 @@ public class ReplaceConstant extends Recipe {
             }
 
             private boolean isVariableDeclaration() {
-                Cursor maybeVariable = getCursor().dropParentUntil(is -> is instanceof J.VariableDeclarations || is instanceof J.CompilationUnit);
-                if (!(maybeVariable.getValue() instanceof J.VariableDeclarations)) {
+                J.VariableDeclarations declaration = getCursor().firstEnclosing(J.VariableDeclarations.class);
+                if (declaration == null) {
                     return false;
                 }
-                JavaType.Variable variableType = ((J.VariableDeclarations) maybeVariable.getValue()).getVariables().get(0).getVariableType();
+                JavaType.Variable variableType = declaration.getVariables().get(0).getVariableType();
                 if (variableType == null) {
                     return true;
                 }
@@ -89,7 +89,7 @@ public class ReplaceConstant extends Recipe {
                     return true;
                 }
 
-                return constantName.equals(((J.VariableDeclarations) maybeVariable.getValue()).getVariables().get(0).getSimpleName()) &&
+                return constantName.equals(declaration.getVariables().get(0).getSimpleName()) &&
                         owningType.equals(ownerFqn.getFullyQualifiedName());
             }
 

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ReplaceConstantTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ReplaceConstantTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.ReplaceConstant;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class ReplaceConstantTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ReplaceConstant("java.nio.charset.StandardCharsets", "UTF_8", "\"UTF-8\""));
+    }
+
+    @Test
+    void replaceConstantInTrailingLambda() {
+        rewriteRun(
+          kotlin(
+            """
+              import java.nio.charset.StandardCharsets.UTF_8
+
+              class Test {
+                  fun supply(name: String, supplier: () -> Any) {}
+                  fun test() {
+                      supply("charset") { UTF_8 }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  fun supply(name: String, supplier: () -> Any) {}
+                  fun test() {
+                      supply("charset") { "UTF-8" }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceConstantInMethodBody() {
+        rewriteRun(
+          kotlin(
+            """
+              import java.nio.charset.StandardCharsets.UTF_8
+
+              class Test {
+                  fun test(): Any {
+                      return UTF_8
+                  }
+              }
+              """,
+            """
+              class Test {
+                  fun test(): Any {
+                      return "UTF-8"
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
`ReplaceConstant.isVariableDeclaration()` now locates the enclosing declaration with `Cursor.firstEnclosing(J.VariableDeclarations.class)` instead of `dropParentUntil(is -> is instanceof J.VariableDeclarations || is instanceof J.CompilationUnit)`.

## What's your motivation?
On non-Java sources the old walk fell off the LST root and threw, because a Kotlin file's root is `K.CompilationUnit` — not a `J.CompilationUnit` — so the terminal condition never matched:

```
java.lang.IllegalStateException: Expected to find a matching parent for Cursor{Identifier->...->Block->Lambda->...->CompilationUnit->root}
  org.openrewrite.Cursor.dropParentUntil(Cursor.java:204)
  org.openrewrite.java.ReplaceConstant$1.isVariableDeclaration(ReplaceConstant.java:78)
```

- Reported via moderneinc/customer-requests#2671 for a constant referenced inside a Kotlin trailing lambda, but the lambda is incidental: qualified references take the `visitFieldAccess` path, which never calls `isVariableDeclaration()`, so any bare-identifier usage in a Kotlin body reproduces it. `firstEnclosing` states the actual question — nearest enclosing variable declaration, or none — is total by construction, and covers Groovy (`G.CompilationUnit`) as well.

- New tests: Kotlin trailing-lambda and plain method-body cases (both fail with the exact reported exception before the fix), plus a Java lambda equivalent. The existing #1752 guard test still passes — Kotlin properties map to `J.VariableDeclarations`, so the declaration-site check keeps working there too.

## Have you considered any alternatives or workarounds?
Keeping `dropParentUntil` with a language-agnostic terminal set (`JavaSourceFile` / `Cursor.ROOT_VALUE`): works, but enumerating walk terminals is exactly what produced this bug, and the root sentinel is plumbing rather than semantics.