### PR TITLE
JavaScript: allow bun, @datadog/pprof scripts

### DIFF
--- a/rewrite-javascript/rewrite/package.json
+++ b/rewrite-javascript/rewrite/package.json
@@ -15,6 +15,10 @@
     "dist/**",
     "src/**"
   ],
+  "allowScripts": {
+    "bun": true,
+    "@datadog/pprof": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## What's changed?

Adding `bun`, `@datadog/pprof` to the list of allowScripts.

## What's your motivation?

npm 12.0.0 got released a few hours ago and I suspect this is what triggered our `npm-publish` flow to start failing with:
```
npm warn install-scripts 2 packages had install scripts blocked because they are not covered by allowScripts:
npm warn install-scripts   @datadog/pprof@5.13.3 (install: exit 0)
npm warn install-scripts   bun@1.3.8 (postinstall: node install.js)
npm warn install-scripts Run `npm install-scripts approve <pkg>` to allow.
```