### PR TITLE
JavaScript: pin to NPM 11 for releasing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -60,9 +60,11 @@ jobs:
 
       # Trusted Publisher auto-detection in `npm publish` requires npm >= 11.5.1.
       # GitHub-hosted ubuntu runners currently ship Node 22 / npm 10.x, and the
-      # global install needs sudo to write under /usr/local.
+      # global install needs sudo to write under /usr/local. Pinned off `@latest`
+      # because npm 12 breaks provenance publish with `Cannot find module 'sigstore'`
+      # (https://github.com/npm/cli/issues/9722); revisit once that ships fixed.
       - shell: bash
-        run: sudo npm install -g npm@latest
+        run: sudo npm install -g npm@11.18.0
 
       # The `ci` run records the exact version string baked into its rewrite-javascript jar
       # (META-INF/rewrite-javascript-version.txt) and uploads it as the

--- a/rewrite-javascript/rewrite/package.json
+++ b/rewrite-javascript/rewrite/package.json
@@ -15,6 +15,10 @@
     "dist/**",
     "src/**"
   ],
+  "allowScripts": {
+    "bun": true,
+    "@datadog/pprof": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## What's changed?

Pinning the GHA workflow to use NPM 11 (not 12) for releasing for now.

## What's your motivation?

We hit:
```
Dist-tag: next
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
```
- in npm-publish which seems to be the same (or related) issue as upstream https://github.com/npm/cli/issues/9722