### PR TITLE
Balance sibling class braces in `AnnotationTemplateGenerator` stubs

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateTest.java
@@ -55,4 +55,42 @@ class GroovyTemplateTest implements RewriteTest {
               """
           ));
     }
+
+    @Test
+    void replaceAnnotationArgumentsOnMethodWithNestedClassSibling() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new GroovyVisitor<>() {
+              @Override
+              public J visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("SuppressWarnings".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null &&
+                      annotation.getArguments().stream().noneMatch(a -> a.toString().contains("all"))) {
+                      return GroovyTemplate.builder("\"all\"")
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments());
+                  }
+                  return annotation;
+              }
+          })),
+          groovy(
+            """
+              class A {
+                  static class Sibling {
+                  }
+
+                  @SuppressWarnings("unchecked")
+                  def method() {}
+              }
+              """,
+            """
+              class A {
+                  static class Sibling {
+                  }
+
+                  @SuppressWarnings("all")
+                  def method() {}
+              }
+              """
+          ));
+    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
@@ -25,6 +25,10 @@ import org.openrewrite.Recipe;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
@@ -119,6 +123,54 @@ class JavaTemplateAnnotationTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void replaceAnnotationArgumentsOnMethodWithNestedClassSibling() {
+        // javac recovers from unbalanced braces in the parse stub, so additionally assert the
+        // stub is well-formed; stricter parsers (Kotlin, Groovy, Scala) reject unbalanced stubs
+        List<String> stubs = new ArrayList<>();
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("SuppressWarnings".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null &&
+                      annotation.getArguments().stream().noneMatch(a -> a.toString().contains("all"))) {
+                      return JavaTemplate.builder("\"all\"")
+                        .doBeforeParseTemplate(stubs::add)
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments());
+                  }
+                  return annotation;
+              }
+          })),
+          java(
+            """
+              class A {
+                  static class Sibling {
+                  }
+
+                  @SuppressWarnings("unchecked")
+                  void method() {}
+              }
+              """,
+            """
+              class A {
+                  static class Sibling {
+                  }
+
+                  @SuppressWarnings("all")
+                  void method() {}
+              }
+              """
+          )
+        );
+        assertThat(stubs)
+          .isNotEmpty()
+          .allSatisfy(stub -> assertThat(stub.chars().filter(c -> c == '{').count())
+            .as("balanced braces in template stub:%n%s", stub)
+            .isEqualTo(stub.chars().filter(c -> c == '}').count()));
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/4634")

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
@@ -164,7 +164,7 @@ public class AnnotationTemplateGenerator {
             }
             return;
         } else if (j instanceof J.ClassDeclaration) {
-            classDeclaration(before, after, (J.ClassDeclaration) j, templated, cursor, prior);
+            classDeclaration(before, after, (J.ClassDeclaration) j, templated, cursor, prior, false);
         } else if (j instanceof J.Block) {
             J parent = next(cursor).getValue();
             if (parent instanceof J.MethodDeclaration) {
@@ -289,9 +289,12 @@ public class AnnotationTemplateGenerator {
         template(next(cursor), j, before, after, templated);
     }
 
-    private void classDeclaration(StringBuilder before, StringBuilder after, J.ClassDeclaration parent, Set<J> templated, Cursor cursor, J prior) {
+    private void classDeclaration(StringBuilder before, StringBuilder after, J.ClassDeclaration parent, Set<J> templated, Cursor cursor, J prior, boolean sibling) {
         J.ClassDeclaration c = parent;
         boolean annotated = isAnnotated(cursor, prior);
+        if (sibling) {
+            before.insert(0, "}\n");
+        }
         if (!annotated) {
             for (Statement statement : c.getBody().getStatements()) {
                 if (templated.contains(statement)) {
@@ -304,10 +307,7 @@ public class AnnotationTemplateGenerator {
                         before.insert(0, variable((J.VariableDeclarations) statement, cursor) + ";\n");
                     }
                 } else if (statement instanceof J.ClassDeclaration) {
-                    // this is a sibling class. we need declarations for all variables and methods.
-                    // setting prior to null will cause them all to be written.
-                    before.insert(0, '}');
-                    classDeclaration(before, after, (J.ClassDeclaration) statement, templated, cursor, prior);
+                    classDeclaration(before, after, (J.ClassDeclaration) statement, templated, cursor, prior, true);
                 }
             }
         }
@@ -323,7 +323,9 @@ public class AnnotationTemplateGenerator {
         } else {
             before.insert(0, braceIndex == -1 ? printed + '{' : printed.substring(0, braceIndex + 1));
         }
-        after.append('}');
+        if (!sibling) {
+            after.append('}');
+        }
     }
 
     private void anonymousClassDeclaration(StringBuilder before, StringBuilder after, J.NewClass nc, Cursor cursor, J prior) {

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -491,6 +491,65 @@ class KotlinTemplateTest implements RewriteTest {
     }
 
     @Test
+    void replaceAnnotationArgumentsOnMethodWithKotlinOnlyClassMembers() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("Suppress".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null && annotation.getArguments().size() == 1) {
+                      return KotlinTemplate.builder("#{any()}, \"RedundantSuppression\"")
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments(),
+                          annotation.getArguments().getFirst());
+                  }
+                  return annotation;
+              }
+          })),
+          kotlin(
+            """
+              interface Api {
+                  fun fetch(): String
+              }
+              """
+          ),
+          kotlin(
+            """
+              class Gateway(private val endpoint: String) : Api {
+                  companion object {
+                      const val REASON = "UNCHECKED_CAST"
+                  }
+
+                  enum class Status { ACTIVE, INACTIVE }
+
+                  init {
+                      require(endpoint.isNotEmpty())
+                  }
+
+                  @Suppress(REASON)
+                  override fun fetch(): String = endpoint
+              }
+              """,
+            """
+              class Gateway(private val endpoint: String) : Api {
+                  companion object {
+                      const val REASON = "UNCHECKED_CAST"
+                  }
+
+                  enum class Status { ACTIVE, INACTIVE }
+
+                  init {
+                      require(endpoint.isNotEmpty())
+                  }
+
+                  @Suppress(REASON, "RedundantSuppression")
+                  override fun fetch(): String = endpoint
+              }
+              """
+          ));
+    }
+
+    @Test
     void replaceAnnotationArgumentsOnMethodWithParameterSubstitution() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaTemplateTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaTemplateTest.java
@@ -136,4 +136,42 @@ class ScalaTemplateTest implements RewriteTest {
               """
           ));
     }
+
+    @Test
+    void replaceAnnotationArgumentsOnMethodWithNestedClassSibling() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new ScalaVisitor<>() {
+              @Override
+              public J visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("deprecated".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null &&
+                      annotation.getArguments().stream().noneMatch(a -> a.toString().contains("new"))) {
+                      return ScalaTemplate.builder("\"new\"")
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments());
+                  }
+                  return annotation;
+              }
+          })),
+          scala(
+            """
+              class Test {
+                  class Sibling {
+                  }
+
+                  @deprecated("old")
+                  def foo(): Unit = {}
+              }
+              """,
+            """
+              class Test {
+                  class Sibling {
+                  }
+
+                  @deprecated("new")
+                  def foo(): Unit = {}
+              }
+              """
+          ));
+    }
 }


### PR DESCRIPTION
## What's changed?

`AnnotationTemplateGenerator.classDeclaration()` now renders a sibling class declaration fully closed — terminated with a newline — into the stub text preceding the template, instead of also appending a stray `}` to the text following it. One test per language (Java, Kotlin, Groovy, Scala) proves annotation-argument templates work on a method whose enclosing class contains sibling class declarations.

## What's your motivation?

Applying a template with annotation coordinates (e.g. `replaceArguments()`) to a member whose enclosing class contains a companion object, nested enum class or other nested class produced a parse stub with one unbalanced closing brace per sibling class:

```
class Test{enum class Status{}/*__TEMPLATE__*/@Example("RedundantSuppression")
 fun `$method`() {};}}
annotation class `$Placeholder` {}
```

- javac error-recovers from a stray top-level brace, so Java templates were unaffected — but stricter parsers reject or misread the stub: Kotlin and Groovy fail with `Could not parse as Java`, and Scala attaches the template marker comment to the sibling class so that `listAnnotations()` finds no annotation to apply (silent no-op). #8168 fixed the dummy member the annotation sits on; the siblings around it still broke the parse.

- This unblocks the three remaining Kotlin `@ExpectedToFail` cases of `MigrateSpringRetryToSpringFramework7` (moderneinc/customer-requests#2718, follow-up to moderneinc/customer-requests#2670) — verified end-to-end against moderneinc/rewrite-spring's test suite with a locally published build: all three shapes (companion-object constants, enum-class-in-body, gateway class shape) now pass.

## Anything in particular you'd like reviewers to focus on?

- The trailing `\n` after the sibling's closing brace is load-bearing: Groovy requires a line break after a class declaration, and the Scala parser otherwise attaches the `/*__TEMPLATE__*/` marker comment to the sibling instead of the annotation.
- The Java test asserts stub brace balance via `doBeforeParseTemplate`, because javac's error recovery makes the parse succeed with or without the fix.

## Any additional context

Known limitation (pre-existing, unchanged by this PR): raw template text that references a companion-object constant by name still fails LST type validation, since the sibling stub's body is emptied. Splicing the original typed expression via `#{any()}` works, as the Kotlin test demonstrates — and is what the migration recipe does.