### PR TITLE
Keep `latest.patch` within the patch range for versions without a numeric minor

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestPatch.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestPatch.java
@@ -20,8 +20,6 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Validated;
 import org.openrewrite.internal.StringUtils;
 
-import java.util.Scanner;
-
 @Value
 public class LatestPatch implements VersionComparator {
     @Nullable
@@ -57,27 +55,18 @@ public class LatestPatch implements VersionComparator {
 
     private static String buildTildeRange(String currentVersion) {
         String major = Semver.majorVersion(currentVersion);
-        String minor = minorSegment(currentVersion);
-        if (minor != null && StringUtils.isNumeric(minor)) {
+        String minor = Semver.versionSegment(currentVersion, 1);
+        if (StringUtils.isNumeric(minor)) {
             return "~" + major + "." + minor;
         }
-        // X-range wildcard minor (e.g. "2.x", "2.+") allows any minor; an absent or non-numeric
-        // minor (e.g. "1", "1.Final") pins the minor to 0 so we stay within the patch range.
-        return minor != null && isXRangeWildcard(minor) ? "~" + major : "~" + major + ".0";
-    }
-
-    private static @Nullable String minorSegment(String version) {
-        Scanner scanner = new Scanner(version);
-        scanner.useDelimiter("[.\\-$]");
-        if (scanner.hasNext()) {
-            scanner.next();
+        if (minor != null && XRange.isWildcard(minor)) {
+            // An X-range wildcard minor (e.g. "2.x", "2.+") leaves the minor unspecified, so allow
+            // any minor within the major.
+            return "~" + major;
         }
-        return scanner.hasNext() ? scanner.next() : null;
-    }
-
-    private static boolean isXRangeWildcard(String segment) {
-        char c = segment.charAt(0);
-        return c == 'x' || c == 'X' || c == '*' || c == '+';
+        // An absent or non-numeric minor (e.g. "1", "1.Final") pins the minor to 0 so we stay
+        // within the patch range instead of ranging across minor versions.
+        return "~" + major + ".0";
     }
 
     public static Validated<LatestPatch> build(String toVersion, @Nullable String metadataPattern) {

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestPatch.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestPatch.java
@@ -60,12 +60,10 @@ public class LatestPatch implements VersionComparator {
             return "~" + major + "." + minor;
         }
         if (minor != null && XRange.isWildcard(minor)) {
-            // An X-range wildcard minor (e.g. "2.x", "2.+") leaves the minor unspecified, so allow
-            // any minor within the major.
+            // A wildcard minor (e.g. "2.x", "2.+") allows any minor within the major.
             return "~" + major;
         }
-        // An absent or non-numeric minor (e.g. "1", "1.Final") pins the minor to 0 so we stay
-        // within the patch range instead of ranging across minor versions.
+        // An absent or non-numeric minor (e.g. "1", "1.Final") stays within the patch range.
         return "~" + major + ".0";
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestPatch.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestPatch.java
@@ -20,6 +20,8 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Validated;
 import org.openrewrite.internal.StringUtils;
 
+import java.util.Scanner;
+
 @Value
 public class LatestPatch implements VersionComparator {
     @Nullable
@@ -55,8 +57,41 @@ public class LatestPatch implements VersionComparator {
 
     private static String buildTildeRange(String currentVersion) {
         String major = Semver.majorVersion(currentVersion);
-        String minor = Semver.minorVersion(currentVersion);
-        return StringUtils.isNumeric(minor) ? "~" + major + "." + minor : "~" + major;
+        String minor = minorSegment(currentVersion);
+        if (minor != null && StringUtils.isNumeric(minor)) {
+            // A numeric minor is present: hold both major and minor fixed and allow only
+            // patch-level (and finer) changes, e.g. "1.2.3" -> "~1.2".
+            return "~" + major + "." + minor;
+        }
+        if (minor != null && isXRangeWildcard(minor)) {
+            // The minor position is an X-range wildcard (e.g. "2.x", "2.+"): the minor is
+            // deliberately unspecified, so allow any minor within the major.
+            return "~" + major;
+        }
+        // No minor segment at all (e.g. "1") or a non-numeric qualifier in the minor position
+        // (e.g. "1.Final"): pin the minor to 0 so "latest.patch" stays within the patch range
+        // instead of ranging across minor versions.
+        return "~" + major + ".0";
+    }
+
+    /**
+     * @return the raw second version segment (the "minor" position) of {@code version}, or
+     * {@code null} if the version has no second segment. Unlike {@link Semver#minorVersion(String)}
+     * this does not fall back to returning the whole version string when the minor is absent or
+     * non-numeric, which would otherwise let "latest.patch" build a too-wide tilde range.
+     */
+    private static @Nullable String minorSegment(String version) {
+        Scanner scanner = new Scanner(version);
+        scanner.useDelimiter("[.\\-$]");
+        if (scanner.hasNext()) {
+            scanner.next();
+        }
+        return scanner.hasNext() ? scanner.next() : null;
+    }
+
+    private static boolean isXRangeWildcard(String segment) {
+        char c = segment.charAt(0);
+        return c == 'x' || c == 'X' || c == '*' || c == '+';
     }
 
     public static Validated<LatestPatch> build(String toVersion, @Nullable String metadataPattern) {

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestPatch.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestPatch.java
@@ -59,27 +59,13 @@ public class LatestPatch implements VersionComparator {
         String major = Semver.majorVersion(currentVersion);
         String minor = minorSegment(currentVersion);
         if (minor != null && StringUtils.isNumeric(minor)) {
-            // A numeric minor is present: hold both major and minor fixed and allow only
-            // patch-level (and finer) changes, e.g. "1.2.3" -> "~1.2".
             return "~" + major + "." + minor;
         }
-        if (minor != null && isXRangeWildcard(minor)) {
-            // The minor position is an X-range wildcard (e.g. "2.x", "2.+"): the minor is
-            // deliberately unspecified, so allow any minor within the major.
-            return "~" + major;
-        }
-        // No minor segment at all (e.g. "1") or a non-numeric qualifier in the minor position
-        // (e.g. "1.Final"): pin the minor to 0 so "latest.patch" stays within the patch range
-        // instead of ranging across minor versions.
-        return "~" + major + ".0";
+        // X-range wildcard minor (e.g. "2.x", "2.+") allows any minor; an absent or non-numeric
+        // minor (e.g. "1", "1.Final") pins the minor to 0 so we stay within the patch range.
+        return minor != null && isXRangeWildcard(minor) ? "~" + major : "~" + major + ".0";
     }
 
-    /**
-     * @return the raw second version segment (the "minor" position) of {@code version}, or
-     * {@code null} if the version has no second segment. Unlike {@link Semver#minorVersion(String)}
-     * this does not fall back to returning the whole version string when the minor is absent or
-     * non-numeric, which would otherwise let "latest.patch" build a too-wide tilde range.
-     */
     private static @Nullable String minorSegment(String version) {
         Scanner scanner = new Scanner(version);
         scanner.useDelimiter("[.\\-$]");

--- a/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
@@ -132,27 +132,29 @@ public class Semver {
     }
 
     public static String majorVersion(String version) {
-        Scanner scanner = new Scanner(version);
-        scanner.useDelimiter("[.\\-$]");
-        if (scanner.hasNext()) {
-            return scanner.next();
-        }
-        return version;
+        String major = versionSegment(version, 0);
+        return major == null ? version : major;
     }
 
     public static String minorVersion(String version) {
+        String minor = versionSegment(version, 1);
+        return StringUtils.isNumeric(minor) ? minor : version;
+    }
+
+    /**
+     * @return the raw version segment at {@code index} (0 = major, 1 = minor, ...) delimited by
+     * {@code '.'}, {@code '-'}, or {@code '$'}, or {@code null} if the version has no such segment.
+     */
+    static @Nullable String versionSegment(String version, int index) {
         Scanner scanner = new Scanner(version);
         scanner.useDelimiter("[.\\-$]");
-        if (scanner.hasNext()) {
+        for (int i = 0; i < index; i++) {
+            if (!scanner.hasNext()) {
+                return null;
+            }
             scanner.next();
         }
-        if (scanner.hasNext()) {
-            String minor = scanner.next();
-            if (StringUtils.isNumeric(minor)) {
-                return minor;
-            }
-        }
-        return version;
+        return scanner.hasNext() ? scanner.next() : null;
     }
 
     public static @Nullable String max(@Nullable String version1, @Nullable String version2) {

--- a/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
@@ -142,8 +142,7 @@ public class Semver {
     }
 
     /**
-     * @return the raw version segment at {@code index} (0 = major, 1 = minor, ...) delimited by
-     * {@code '.'}, {@code '-'}, or {@code '$'}, or {@code null} if the version has no such segment.
+     * @return the raw version segment at {@code index} (0 = major, 1 = minor, ...), or {@code null} if absent.
      */
     static @Nullable String versionSegment(String version, int index) {
         Scanner scanner = new Scanner(version);

--- a/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
@@ -103,8 +103,7 @@ public class XRange extends LatestRelease {
     }
 
     /**
-     * @return whether {@code segment} is an X-range wildcard, i.e. one of {@code *}, {@code x},
-     * {@code X}, or {@code +}.
+     * @return whether {@code segment} is an X-range wildcard: {@code *}, {@code x}, {@code X}, or {@code +}.
      */
     static boolean isWildcard(String segment) {
         return "*".equals(segment) || "x".equals(segment) || "X".equals(segment) || "+".equals(segment);

--- a/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
@@ -99,7 +99,15 @@ public class XRange extends LatestRelease {
     }
 
     private static String normalizeWildcard(String part) {
-        return "*".equals(part) || "x".equals(part) || "X".equals(part) || "+".equals(part) ? "*" : part;
+        return isWildcard(part) ? "*" : part;
+    }
+
+    /**
+     * @return whether {@code segment} is an X-range wildcard, i.e. one of {@code *}, {@code x},
+     * {@code X}, or {@code +}.
+     */
+    static boolean isWildcard(String segment) {
+        return "*".equals(segment) || "x".equals(segment) || "X".equals(segment) || "+".equals(segment);
     }
 
     @Override

--- a/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
@@ -63,6 +63,18 @@ class LatestPatchTest {
     }
 
     @Test
+    void xRangeWildcardMinorAllowsAnyMinorWithinTheMajor() {
+        // A wildcard in the minor position ("2.x"/"2.+") deliberately leaves the minor unspecified,
+        // so any minor within the major is eligible, but a higher major is not.
+        for (String current : List.of("2.x", "2.X", "2.+", "2.*")) {
+            assertThat(latestPatch.isValid(current, "2.1.0")).as(current).isTrue();
+            assertThat(latestPatch.isValid(current, "2.9.9")).as(current).isTrue();
+            assertThat(latestPatch.isValid(current, "3.0.0")).as(current).isFalse();
+            assertThat(latestPatch.upgrade(current, List.of("2.1.0", "2.9.9", "3.0.0"))).contains("2.9.9");
+        }
+    }
+
+    @Test
     void upgrade() {
         var upgrade = latestPatch.upgrade("2.10.10.3.24", List.of("2.10.0"));
         assertThat(upgrade).isEmpty();

--- a/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
@@ -48,6 +48,25 @@ class LatestPatchTest {
     }
 
     @Test
+    void staysWithinPatchRangeWhenMinorIsAbsentOrNonNumeric() {
+        // Current versions with no numeric minor segment must not range across minor (or major)
+        // versions. Previously "1" built a "~1.1" range and "1.Final" built a "~1" range, both of
+        // which let "latest.patch" pick a higher minor version.
+
+        // Bare major: pin minor to 0, so only 1.0.x patches are eligible.
+        assertThat(latestPatch.isValid("1", "1.0.1")).isTrue();
+        assertThat(latestPatch.isValid("1", "1.1.0")).isFalse();
+        assertThat(latestPatch.isValid("1", "2.0.0")).isFalse();
+        assertThat(latestPatch.upgrade("1", List.of("1.0.5", "1.1.0", "2.0.0"))).contains("1.0.5");
+
+        // Qualifier in the minor position: treat as 1.0.x, not "any 1.x".
+        assertThat(latestPatch.isValid("1.Final", "1.0.1")).isTrue();
+        assertThat(latestPatch.isValid("1.Final", "1.9.9")).isFalse();
+        assertThat(latestPatch.isValid("1.Final", "2.0.0")).isFalse();
+        assertThat(latestPatch.upgrade("1.Final", List.of("1.0.5", "1.9.9", "2.0.0"))).contains("1.0.5");
+    }
+
+    @Test
     void upgrade() {
         var upgrade = latestPatch.upgrade("2.10.10.3.24", List.of("2.10.0"));
         assertThat(upgrade).isEmpty();

--- a/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
@@ -49,10 +49,6 @@ class LatestPatchTest {
 
     @Test
     void staysWithinPatchRangeWhenMinorIsAbsentOrNonNumeric() {
-        // Current versions with no numeric minor segment must not range across minor (or major)
-        // versions. Previously "1" built a "~1.1" range and "1.Final" built a "~1" range, both of
-        // which let "latest.patch" pick a higher minor version.
-
         // Bare major: pin minor to 0, so only 1.0.x patches are eligible.
         assertThat(latestPatch.isValid("1", "1.0.1")).isTrue();
         assertThat(latestPatch.isValid("1", "1.1.0")).isFalse();

--- a/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
@@ -49,13 +49,13 @@ class LatestPatchTest {
 
     @Test
     void staysWithinPatchRangeWhenMinorIsAbsentOrNonNumeric() {
-        // Bare major: pin minor to 0, so only 1.0.x patches are eligible.
+        // Bare major.
         assertThat(latestPatch.isValid("1", "1.0.1")).isTrue();
         assertThat(latestPatch.isValid("1", "1.1.0")).isFalse();
         assertThat(latestPatch.isValid("1", "2.0.0")).isFalse();
         assertThat(latestPatch.upgrade("1", List.of("1.0.5", "1.1.0", "2.0.0"))).contains("1.0.5");
 
-        // Qualifier in the minor position: treat as 1.0.x, not "any 1.x".
+        // Qualifier in the minor position.
         assertThat(latestPatch.isValid("1.Final", "1.0.1")).isTrue();
         assertThat(latestPatch.isValid("1.Final", "1.9.9")).isFalse();
         assertThat(latestPatch.isValid("1.Final", "2.0.0")).isFalse();
@@ -64,8 +64,6 @@ class LatestPatchTest {
 
     @Test
     void xRangeWildcardMinorAllowsAnyMinorWithinTheMajor() {
-        // A wildcard in the minor position ("2.x"/"2.+") deliberately leaves the minor unspecified,
-        // so any minor within the major is eligible, but a higher major is not.
         for (String current : List.of("2.x", "2.X", "2.+", "2.*")) {
             assertThat(latestPatch.isValid(current, "2.1.0")).as(current).isTrue();
             assertThat(latestPatch.isValid(current, "2.9.9")).as(current).isTrue();


### PR DESCRIPTION
`latest.patch` was escaping the patch range and picking higher minor versions whenever the current version had no numeric minor segment: `LatestPatch.buildTildeRange` relied on `Semver.minorVersion`, which returns the whole version string as a fallback, so `1.Final` built a `~1` range (any minor in major 1) and a bare `1` built a nonsensical `~1.1`. This fix pins the minor to `0` (`~major.0`) when the minor is absent or a non-numeric qualifier, so `latest.patch` stays patch-bounded, while numeric minors (`~major.minor`) and X-range wildcards like `2.x`/`2.+` (`~major`) keep their existing behavior. Added regression tests covering `1` and `1.Final`; the full semver suite and the Maven `UpgradeDependencyVersion` `latest.patch` tests remain green.