### PR TITLE
Fix `AddDependency` `latest.patch` upgrading managed dependencies to latest release

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
@@ -120,7 +120,7 @@ public class AddDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
                 } else {
                     String versionToUse = null;
                     String managedVersion = getResolutionResult().getPom().getManagedVersion(groupId, artifactId, type, classifier);
-                    if (managedVersion == null || (versionComparator != null && !versionComparator.isValid(version, managedVersion))) {
+                    if (managedVersion == null || (versionComparator != null && !versionComparator.isValid(managedVersion, managedVersion))) {
                         versionToUse = tryGetFamilyVersion();
                         if (versionToUse == null) {
                             try {
@@ -249,7 +249,7 @@ public class AddDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
                             return e.warn(tag);
                         }
                     }
-                } else if (versionComparator != null && !versionComparator.isValid(version, managedVersion)) {
+                } else if (versionComparator != null && !versionComparator.isValid(managedVersion, managedVersion)) {
                     scheduleVersionUpgrade = true;
                 }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -2421,6 +2421,37 @@ class AddDependencyTest implements RewriteTest {
         );
     }
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/8211")
+    void latestPatchWithManagedDependencyDoesNotUpgradeToLatestRelease() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("org.springframework.boot:spring-boot-starter-actuator:latest.patch", null, null, false)),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>3.2.12</version>
+                  <relativePath/>
+                </parent>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-actuator</artifactId>
+                    <version>3.2.12</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
     private AddDependency addDependency(@SuppressWarnings("SameParameterValue") String gav) {
         return addDependency(gav, null, null, null);
     }


### PR DESCRIPTION
- Fixes #8211

## Problem

Calling `AddDependency` with `version: latest.patch` (or `latest.minor`) against a dependency whose version is already controlled by a managed dependency / parent BOM incorrectly resolved and pinned the **absolute latest release** instead of no-op'ing.

For example, with `spring-boot-starter-parent:3.2.12` managing `spring-boot-starter-actuator`, `latest.patch` rewrote the dependency to `4.1.0` rather than leaving `3.2.12` in place.

## Root cause

`AddDependencyVisitor` checked whether the managed version already satisfied the requested selector via:

```java
versionComparator.isValid(version, managedVersion)
```

Here `version` is the *selector string* (`"latest.patch"`), passed as the `currentVersion` argument. Relative comparators (`LatestPatch`, `LatestMinor`) use `currentVersion` to build a tilde range around the current version, so the nonsensical `"latest.patch"` value made the range invalid and `isValid` returned `false`. The recipe then treated the managed version as unsatisfactory and resolved the latest release. Absolute comparators (`ExactVersion`, `LatestRelease`, ranges) ignore `currentVersion`, which is why `latest.release` and exact versions were unaffected.

## Fix

Pass the managed version itself as both arguments — `isValid(managedVersion, managedVersion)` — matching the established idiom already used in `FindDependency` and `FindManagedDependency`. This correctly treats an already-managed dependency as satisfied for `latest.patch`/`latest.minor`, consistent with `latest.release`.

Applied to both the existing-dependency path (`visitTag`) and the new-dependency insertion path (`InsertDependencyInOrder`).

## Test

Added `latestPatchWithManagedDependencyDoesNotUpgradeToLatestRelease`, which reproduces the issue's scenario and asserts a no-op. Verified it fails before the fix (rewrites to `4.1.0`) and passes after.