### PR TITLE
Remove redundant child dependency versions when aggregator parent is upgraded

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -359,6 +359,7 @@ public class ChangeParentPom extends ScanningRecipe<ChangeParentPom.Accumulator>
                         d = d.withMarkers(d.getMarkers().computeByType(mrr,
                                 (original, ignored) -> updatedMarker));
                         maybeUpdateModel();
+                        doAfterVisit(new RemoveRedundantDependencyVersions(null, null, GTE, except).getVisitor());
                     }
                 }
                 return d;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
@@ -26,6 +26,7 @@ import org.openrewrite.test.RewriteTest;
 
 import java.util.List;
 
+import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class UpgradeParentVersionTest implements RewriteTest {
@@ -299,6 +300,104 @@ class UpgradeParentVersionTest implements RewriteTest {
                 </properties>
               </project>
               """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8212")
+    @Test
+    void childDependencyPinRemovedWhenAggregatorParentUpgraded() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeParentVersion(
+            "org.springframework.boot",
+            "spring-boot-starter-parent",
+            "3.1.12",
+            null,
+            null)),
+          mavenProject("sample-root",
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>sample-root</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <packaging>pom</packaging>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>3.0.13</version>
+                        <relativePath/>
+                    </parent>
+                    <modules>
+                        <module>sample-app</module>
+                    </modules>
+                </project>
+                """,
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>sample-root</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <packaging>pom</packaging>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>3.1.12</version>
+                        <relativePath/>
+                    </parent>
+                    <modules>
+                        <module>sample-app</module>
+                    </modules>
+                </project>
+                """
+            )
+          ),
+          mavenProject("sample-app",
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <artifactId>sample-app</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <parent>
+                        <groupId>com.example</groupId>
+                        <artifactId>sample-root</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                        <relativePath>../sample-root/pom.xml</relativePath>
+                    </parent>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.mockito</groupId>
+                            <artifactId>mockito-core</artifactId>
+                            <version>4.11.0</version>
+                            <scope>test</scope>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <artifactId>sample-app</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <parent>
+                        <groupId>com.example</groupId>
+                        <artifactId>sample-root</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                        <relativePath>../sample-root/pom.xml</relativePath>
+                    </parent>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.mockito</groupId>
+                            <artifactId>mockito-core</artifactId>
+                            <scope>test</scope>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
           )
         );
     }


### PR DESCRIPTION
## What's changed

`UpgradeParentVersion` (which delegates to `ChangeParentPom`) runs `RemoveRedundantDependencyVersions(GTE)` after bumping a parent, so a flat single-module pom that pins a dependency below its parent-managed version has that pin stripped once the new parent manages a newer version.

In a multi-module reactor this only happened for the pom whose `<parent>` actually matched (the aggregator). A child module's direct parent is the local aggregator, not the upgraded parent, so its redundant explicit pin (e.g. `mockito-core:4.11.0` when the new Spring Boot parent manages `5.3.1`) was retained — inconsistent with the single-module behavior.

`ChangeParentPom` already updates each descendant's `MavenResolutionResult` marker to reflect the upgraded ancestor. This change additionally runs `RemoveRedundantDependencyVersions(null, null, GTE, except)` against those re-resolved descendants, so redundant child pins are stripped just like in the single-module case.

## Testing

Added `UpgradeParentVersionTest#childDependencyPinRemovedWhenAggregatorParentUpgraded` reproducing the reported scenario. Existing `ChangeParentPomTest`, `UpgradeParentVersionTest`, and `RemoveRedundantDependencyVersionsTest` continue to pass.

- Fixes #8212