### PR TITLE
Go: align the If/Else LST model with Java

### DIFF
--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -1296,7 +1296,7 @@ func (ctx *parseContext) mapIfStmt(stmt *ast.IfStmt) java.Statement {
 	cond := ctx.mapExpr(stmt.Cond)
 	body := ctx.mapBlockStmt(stmt.Body)
 
-	var elsePart *java.RightPadded[java.J]
+	var elsePart *java.Else
 	if stmt.Else != nil {
 		// Find the `else` keyword between the closing `}` of Then and the start of Else
 		elseOff := ctx.findNextString("else")
@@ -1305,8 +1305,11 @@ func (ctx *parseContext) mapIfStmt(stmt *ast.IfStmt) java.Statement {
 			ctx.skip(len("else"))
 			elseBody := ctx.mapStmt(stmt.Else)
 			if elseBody != nil {
-				rp := java.RightPadded[java.J]{Element: elseBody, After: elsePrefix}
-				elsePart = &rp
+				elsePart = &java.Else{
+					ID:     uuid.New(),
+					Prefix: elsePrefix,
+					Body:   java.RightPadded[java.Statement]{Element: elseBody},
+				}
 			}
 		}
 	}
@@ -1319,7 +1322,7 @@ func (ctx *parseContext) mapIfStmt(stmt *ast.IfStmt) java.Statement {
 		ID:        uuid.New(),
 		Prefix:    innerPrefix,
 		Condition: controlParentheses(cond),
-		Then:      body,
+		ThenPart:  java.RightPadded[java.Statement]{Element: body},
 		ElsePart:  elsePart,
 	})
 }

--- a/rewrite-go/pkg/printer/go_printer.go
+++ b/rewrite-go/pkg/printer/go_printer.go
@@ -210,11 +210,12 @@ func (p *GoPrinter) VisitIf(ifStmt *java.If, param any) java.J {
 	p.visitSpace(cond.Prefix, out)
 	p.Visit(cond.Tree.Element, out)
 	p.visitSpace(cond.Tree.After, out)
-	p.Visit(ifStmt.Then, out)
+	p.Visit(ifStmt.ThenPart.Element, out)
+	p.visitSpace(ifStmt.ThenPart.After, out)
 	if ifStmt.ElsePart != nil {
-		p.visitSpace(ifStmt.ElsePart.After, out)
+		p.visitSpace(ifStmt.ElsePart.Prefix, out)
 		out.Append("else")
-		p.Visit(ifStmt.ElsePart.Element, out)
+		p.Visit(ifStmt.ElsePart.Body.Element, out)
 	}
 	p.afterSyntax(ifStmt.Markers, out)
 	return ifStmt

--- a/rewrite-go/pkg/rpc/java_receiver.go
+++ b/rewrite-go/pkg/rpc/java_receiver.go
@@ -31,7 +31,7 @@ type Receiver interface {
 }
 
 // receiveBlockBody receives a `*Block` field that Java ships as a
-// RightPadded<Statement> (J.If.thenPart, J.ForLoop/ForEachLoop.body, ...).
+// RightPadded<Statement> (J.ForLoop/ForEachLoop.body, ...).
 //
 // Passing the existing block as the receive baseline is essential. On a CHANGE
 // — e.g. a recipe edited a single nested statement — the unchanged siblings and
@@ -470,15 +470,13 @@ func (r *JavaReceiver) VisitIf(i *java.If, p any) java.J {
 	if cpResult := q.Receive(i.Condition, func(v any) any { return r.Visit(v.(java.Tree), q) }); cpResult != nil {
 		i.Condition = cpResult.(*java.ControlParentheses)
 	}
-	// thenPart - Java sends RightPadded<Statement> wrapping the Block
-	i.Then = receiveBlockBody(r, q, i.Then)
-	// elsePart - Java sends Else node, convert to RightPadded
-	if elseResult := q.Receive(nil, func(v any) any { return r.Visit(v.(java.Tree), q) }); elseResult != nil {
-		el := elseResult.(*java.Else)
-		i.ElsePart = &java.RightPadded[java.J]{
-			Element: el.Body.Element,
-			After:   el.Prefix,
-		}
+	// thenPart
+	if thenResult := q.Receive(i.ThenPart, func(v any) any { return receiveRightPadded(r, q, v) }); thenResult != nil {
+		i.ThenPart = coerceToStatementRP(thenResult)
+	}
+	// elsePart
+	if elseResult := q.Receive(i.ElsePart, func(v any) any { return r.Visit(v.(java.Tree), q) }); elseResult != nil {
+		i.ElsePart = elseResult.(*java.Else)
 	} else {
 		i.ElsePart = nil
 	}

--- a/rewrite-go/pkg/rpc/java_receiver_if_test.go
+++ b/rewrite-go/pkg/rpc/java_receiver_if_test.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+func TestJavaReceiverVisitIfUsesExistingElsePartAsReceiveBaseline(t *testing.T) {
+	elseType := "org.openrewrite.java.tree.J$If$Else"
+	beforeElseBody := &java.Block{}
+	beforeElsePadding := java.Space{Whitespace: " "}
+	before := &java.If{
+		ElsePart: &java.Else{
+			Prefix: beforeElsePadding,
+			Body: java.RightPadded[java.Statement]{
+				Element: beforeElseBody,
+			},
+		},
+	}
+	// This is the wire shape Java emits when the else node changes, but its
+	// nested prefix and body fields are unchanged relative to the prior tree.
+	messages := []RpcObjectData{
+		{State: NoChange},                     // ifCondition
+		{State: NoChange},                     // thenPart
+		{State: Change, ValueType: &elseType}, // elsePart
+		{State: NoChange},                     // else.id
+		{State: NoChange},                     // else.prefix
+		{State: NoChange},                     // else.markers
+		{State: NoChange},                     // else.body
+	}
+	q := NewReceiveQueue(make(map[int]any), func() []RpcObjectData {
+		return messages
+	})
+
+	got := NewGoReceiver().VisitIf(before, q).(*java.If)
+
+	if got.ElsePart == nil {
+		t.Fatal("ElsePart: got nil, want non-nil")
+	}
+	if !reflect.DeepEqual(got.ElsePart.Prefix, beforeElsePadding) {
+		t.Fatalf("ElsePart.Prefix: got %+v, want %+v", got.ElsePart.Prefix, beforeElsePadding)
+	}
+	if got.ElsePart.Body.Element != beforeElseBody {
+		t.Fatalf("ElsePart.Body.Element: got %p, want existing body %p", got.ElsePart.Body.Element, beforeElseBody)
+	}
+}

--- a/rewrite-go/pkg/rpc/java_sender.go
+++ b/rewrite-go/pkg/rpc/java_sender.go
@@ -192,26 +192,12 @@ func (s *JavaSender) VisitIf(i *java.If, p any) java.J {
 	// ifCondition - the condition is already a ControlParentheses, matching J.If
 	q.GetAndSend(i, func(v any) any { return v.(*java.If).Condition },
 		func(v any) { s.Visit(v.(java.Tree), q) })
-	// thenPart (right-padded)
-	q.GetAndSend(i, func(v any) any {
-		return java.RightPadded[java.Statement]{
-			Element: v.(*java.If).Then,
-			After:   java.EmptySpace,
-		}
-	}, func(v any) { sendRightPadded(s, v, q) })
-	// elsePart - wrap in Else node for Java's J.If.Else model
-	q.GetAndSend(i, func(v any) any {
-		ep := v.(*java.If).ElsePart
-		if ep == nil {
-			return nil
-		}
-		return &java.Else{
-			ID:      uuid.New(),
-			Prefix:  ep.After,
-			Markers: java.Markers{ID: uuid.New()},
-			Body:    java.RightPadded[java.Statement]{Element: ep.Element.(java.Statement), After: java.EmptySpace},
-		}
-	}, func(v any) { s.Visit(v.(java.Tree), q) })
+	// thenPart
+	q.GetAndSend(i, func(v any) any { return v.(*java.If).ThenPart },
+		func(v any) { sendRightPadded(s, v, q) })
+	// elsePart
+	q.GetAndSend(i, func(v any) any { return v.(*java.If).ElsePart },
+		func(v any) { s.Visit(v.(java.Tree), q) })
 	return i
 }
 

--- a/rewrite-go/pkg/template/comparator.go
+++ b/rewrite-go/pkg/template/comparator.go
@@ -138,10 +138,16 @@ func (c *patternComparator) matchProperties(pattern, candidate java.J) bool {
 		if !c.matchNode(p.Condition, cand.Condition) {
 			return false
 		}
-		if !c.matchNode(p.Then, cand.Then) {
+		if !c.matchNode(p.ThenPart.Element, cand.ThenPart.Element) {
 			return false
 		}
-		return c.matchOptionalRightPaddedJ(p.ElsePart, cand.ElsePart)
+		if p.ElsePart == nil && cand.ElsePart == nil {
+			return true
+		}
+		if p.ElsePart == nil || cand.ElsePart == nil {
+			return false
+		}
+		return c.matchNode(p.ElsePart.Body.Element, cand.ElsePart.Body.Element)
 	case *golang.StatementWithInit:
 		cand := candidate.(*golang.StatementWithInit)
 		if !c.matchNode(p.Init.Element, cand.Init.Element) {
@@ -430,16 +436,6 @@ func (c *patternComparator) matchOptionalRightPaddedStmt(pattern, candidate *jav
 }
 
 func (c *patternComparator) matchOptionalRightPaddedExpr(pattern, candidate *java.RightPadded[java.Expression]) bool {
-	if pattern == nil && candidate == nil {
-		return true
-	}
-	if pattern == nil || candidate == nil {
-		return false
-	}
-	return c.matchNode(pattern.Element, candidate.Element)
-}
-
-func (c *patternComparator) matchOptionalRightPaddedJ(pattern, candidate *java.RightPadded[java.J]) bool {
 	if pattern == nil && candidate == nil {
 		return true
 	}

--- a/rewrite-go/pkg/tree/java/j.go
+++ b/rewrite-go/pkg/tree/java/j.go
@@ -329,19 +329,18 @@ func (n *Return) WithMarkers(markers Markers) *Return {
 	return &c
 }
 
-// If represents an if statement. Mirrors Java's J.If exactly: the condition is a
-// ControlParentheses (as in Java) whose inner element is the bare Go condition —
-// Go has no parens, so the wrapper carries no whitespace of its own and the
-// printer emits only the inner element. Go's optional init clause
-// (`if x := f(); cond {}`) has no slot here — it lives on a wrapping
-// golang.StatementWithInit instead.
+// If represents an if statement. The condition is a ControlParentheses whose
+// inner element is the bare Go condition. Go has no parens, so the wrapper
+// carries no whitespace of its own and the printer emits only the inner
+// element. Go's optional init clause (`if x := f(); cond {}`) has no slot here;
+// it lives on a wrapping golang.StatementWithInit instead.
 type If struct {
 	ID        uuid.UUID
 	Prefix    Space
 	Markers   Markers
 	Condition *ControlParentheses
-	Then      *Block
-	ElsePart  *RightPadded[J] // nil if no else clause
+	ThenPart  RightPadded[Statement]
+	ElsePart  *Else // nil if no else clause
 }
 
 func (*If) IsTree()      {}
@@ -366,9 +365,15 @@ func (n *If) WithCondition(condition *ControlParentheses) *If {
 	return &c
 }
 
-func (n *If) WithThen(then *Block) *If {
+func (n *If) WithThenPart(thenPart RightPadded[Statement]) *If {
 	c := *n
-	c.Then = then
+	c.ThenPart = thenPart
+	return &c
+}
+
+func (n *If) WithElsePart(elsePart *Else) *If {
+	c := *n
+	c.ElsePart = elsePart
 	return &c
 }
 

--- a/rewrite-go/pkg/visitor/go_visitor.go
+++ b/rewrite-go/pkg/visitor/go_visitor.go
@@ -498,20 +498,16 @@ func (v *GoVisitor) VisitIf(ifStmt *java.If, p any) java.J {
 	ifStmt = ifStmt.WithPrefix(v.self().VisitSpace(ifStmt.Prefix, p))
 	ifStmt = ifStmt.WithMarkers(v.visitMarkers(ifStmt.Markers, p))
 	ifStmt = ifStmt.WithCondition(visitAndCast[*java.ControlParentheses](v, ifStmt.Condition, p))
-	ifStmt = ifStmt.WithThen(visitAndCast[*java.Block](v, ifStmt.Then, p))
+	thenPart := ifStmt.ThenPart
+	thenPart.Element = v.self().Visit(thenPart.Element, p).(java.Statement)
+	thenPart.After = v.self().VisitSpace(thenPart.After, p)
+	ifStmt = ifStmt.WithThenPart(thenPart)
 	if ifStmt.ElsePart != nil {
-		ep := *ifStmt.ElsePart
-		ep.Element = v.self().Visit(ep.Element, p).(java.J)
-		ep.After = v.self().VisitSpace(ep.After, p)
-		ifStmt.ElsePart = &ep
+		ifStmt = ifStmt.WithElsePart(visitAndCast[*java.Else](v, ifStmt.ElsePart, p))
 	}
 	return ifStmt
 }
 
-// VisitElse handles the synthetic *java.Else wrapper that JavaSender produces
-// for RPC parity with Java's J.If.Else. The node never appears in a parsed
-// Go AST — language-level recipes go through VisitIf instead — so the default
-// implementation simply visits the body so traversal terminates correctly.
 func (v *GoVisitor) VisitElse(el *java.Else, p any) java.J {
 	el = el.WithPrefix(v.self().VisitSpace(el.Prefix, p))
 	el = el.WithMarkers(v.visitMarkers(el.Markers, p))


### PR DESCRIPTION
## What's changed?

Closer alignment of the `J.If` and `J.Else` LST model in rewrite-go with what we have in Java.

## What's your motivation?

- The direct trigger was me looking into some whitespace idempotency issue in one of the recipes.
- But then I figured instead of applying some band-aid, let's have the full fix. I am not aware of any reason for the `J.If` to have a different shape on Go side than on Java side.