### PR TITLE
Kotlin: dedupe conflicting imports in `AddImport` (#8213)

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/AddImport.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/AddImport.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
+import org.openrewrite.java.FullyQualifyTypeReference;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.search.FindMethods;
@@ -138,6 +139,16 @@ public class AddImport<P> extends KotlinIsoVisitor<P> {
                        (ending.equals(member) || "*".equals(ending));
             })) {
                 return cu;
+            }
+
+            // A different type already imported under the same simple name would be ambiguous; fully-qualify
+            // the reference instead of adding a conflicting import, matching `org.openrewrite.java.AddImport`.
+            if (alias == null && member == null && !"*".equals(typeName) &&
+                cu.getImports().stream().anyMatch(i ->
+                        i.getAlias() == null && !i.isStatic() &&
+                        typeName.equals(i.getQualid().getSimpleName()) &&
+                        !fullyQualifiedName.equals(i.getTypeName().replace('$', '.')))) {
+                return new FullyQualifyTypeReference<P>(JavaType.ShallowClass.build(fullyQualifiedName)).visitNonNull(cu, p);
             }
 
             J.Import importToAdd = new J.Import(randomId(),

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AddImportTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AddImportTest.java
@@ -141,6 +141,44 @@ public class AddImportTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/8213")
+    @Test
+    void doesNotAddImportConflictingWithExistingSimpleName() {
+        Recipe recipe = toRecipe(() -> new KotlinIsoVisitor<>() {
+            @Override
+            public K.CompilationUnit visitCompilationUnit(K.CompilationUnit cu, ExecutionContext ctx) {
+                maybeAddImport("c.d.Target", null, true);
+                return cu;
+            }
+        });
+        rewriteRun(
+          spec -> spec.recipe(recipe),
+          kotlin(
+            """
+              package a.b
+              class Target
+              """
+          ),
+          kotlin(
+            """
+              package c.d
+              class Target
+              """
+          ),
+          // `a.b.Target` is already imported, so the same-named `c.d.Target` stays fully qualified.
+          kotlin(
+            """
+              import a.b.Target
+
+              class A {
+                  val local: Target = Target()
+                  val other: c.d.Target = c.d.Target()
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void starFoldPackageTypes() {
         rewriteRun(


### PR DESCRIPTION
- Fixes #8213. When `AddImport` is asked to import a type whose simple name is already imported for a different type, Kotlin previously added the conflicting import unconditionally; a later type migration (e.g. `ChangePackage`) could then rename it onto the existing import, producing a duplicate `import` line. This mirrors `org.openrewrite.java.AddImport`'s ambiguity handling: when a different type is already imported under the same simple name, the reference is fully-qualified instead of adding the conflicting import. Adds a regression test in `AddImportTest`.