### PR TITLE
Kotlin: shorten fully qualified references in `AddImport` (#8214)

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/AddImport.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/AddImport.java
@@ -204,8 +204,9 @@ public class AddImport<P> extends KotlinIsoVisitor<P> {
                   stmt.getPrefix().isEmpty() ? stmt.withPrefix(stmt.getPrefix().withWhitespace(generalFormatStyle.isUseCRLFNewLines() ? "\r\n\r\n" : "\n\n")) : stmt));
             }
 
-            // Shorten fully qualified references to the imported type, as the Java `AddImport` does.
-            if (member == null && alias == null) {
+            // Shorten fully qualified references to the imported type, as the Java `AddImport` does. Skip this
+            // when the simple name is already bound to a different type, since shortening would be ambiguous.
+            if (member == null && alias == null && !simpleNameIsAmbiguous(cu)) {
                 cu = (K.CompilationUnit) new ShortenFullyQualifiedTypeReference().visitNonNull(cu, p, getCursor().getParentOrThrow());
             }
 
@@ -231,6 +232,14 @@ public class AddImport<P> extends KotlinIsoVisitor<P> {
             isTypRef = isOfClassType(((J.FieldAccess) t).getTarget().getType(), fullyQualifiedName);
         }
         return isTypRef;
+    }
+
+    private boolean simpleNameIsAmbiguous(K.CompilationUnit cu) {
+        String simpleName = fullyQualifiedName.substring(fullyQualifiedName.lastIndexOf('.') + 1);
+        return cu.getImports().stream().anyMatch(i ->
+                !i.isStatic() && i.getAlias() == null &&
+                simpleName.equals(i.getQualid().getSimpleName()) &&
+                !fullyQualifiedName.equals(i.getTypeName().replace('$', '.')));
     }
 
     private class ShortenFullyQualifiedTypeReference extends KotlinVisitor<P> {

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/AddImport.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/AddImport.java
@@ -204,6 +204,11 @@ public class AddImport<P> extends KotlinIsoVisitor<P> {
                   stmt.getPrefix().isEmpty() ? stmt.withPrefix(stmt.getPrefix().withWhitespace(generalFormatStyle.isUseCRLFNewLines() ? "\r\n\r\n" : "\n\n")) : stmt));
             }
 
+            // Shorten fully qualified references to the imported type, as the Java `AddImport` does.
+            if (member == null && alias == null) {
+                cu = (K.CompilationUnit) new ShortenFullyQualifiedTypeReference().visitNonNull(cu, p, getCursor().getParentOrThrow());
+            }
+
             j = cu;
         }
         return j;
@@ -226,6 +231,21 @@ public class AddImport<P> extends KotlinIsoVisitor<P> {
             isTypRef = isOfClassType(((J.FieldAccess) t).getTarget().getType(), fullyQualifiedName);
         }
         return isTypRef;
+    }
+
+    private class ShortenFullyQualifiedTypeReference extends KotlinVisitor<P> {
+        @Override
+        public J visitImport(J.Import anImport, P p) {
+            return anImport;
+        }
+
+        @Override
+        public J visitFieldAccess(J.FieldAccess fieldAccess, P p) {
+            if (fieldAccess.isFullyQualifiedClassReference(fullyQualifiedName)) {
+                return fieldAccess.getName().withPrefix(fieldAccess.getPrefix());
+            }
+            return super.visitFieldAccess(fieldAccess, p);
+        }
     }
 
     /**

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
@@ -1097,6 +1097,17 @@ public class SpacesVisitor<P> extends KotlinIsoVisitor<P> {
     @Override
     public J.NewClass visitNewClass(J.NewClass newClass, P p) {
         J.NewClass nc = super.visitNewClass(newClass, p);
+        // Kotlin has no `new` keyword; drop the space a grafted Java `new X()` leaves before the type.
+        if (!nc.getMarkers().findFirst(KObject.class).isPresent() &&
+            !nc.getMarkers().findFirst(TypeReferencePrefix.class).isPresent() &&
+            nc.getPadding().getEnclosing() == null) {
+            if (isCollapsibleSpace(nc.getNew())) {
+                nc = nc.withNew(Space.EMPTY);
+            }
+            if (nc.getClazz() != null && isCollapsibleSpace(nc.getClazz().getPrefix())) {
+                nc = nc.withClazz(nc.getClazz().withPrefix(Space.EMPTY));
+            }
+        }
         if (nc.getPadding().getArguments() != null) {
             nc = nc.getPadding().withArguments(spaceBefore(nc.getPadding().getArguments(), false, true));
             int argsSize = nc.getPadding().getArguments().getElements().size();
@@ -1119,6 +1130,11 @@ public class SpacesVisitor<P> extends KotlinIsoVisitor<P> {
             );
         }
         return nc;
+    }
+
+    private static boolean isCollapsibleSpace(Space space) {
+        return space.getComments().isEmpty() && !space.getWhitespace().isEmpty() &&
+               space.getWhitespace().indexOf('\n') < 0 && space.getWhitespace().indexOf('\r') < 0;
     }
 
     @SuppressWarnings("ConstantValue")

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AddImportTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AddImportTest.java
@@ -481,4 +481,52 @@ public class AddImportTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8214")
+    @Test
+    void doesNotShortenWhenSimpleNameIsAmbiguous() {
+        Recipe recipe = toRecipe(() -> new KotlinIsoVisitor<>() {
+            @Override
+            public K.CompilationUnit visitCompilationUnit(K.CompilationUnit cu, ExecutionContext ctx) {
+                maybeAddImport("b.Foo", null, true);
+                return cu;
+            }
+        });
+        rewriteRun(
+          spec -> spec.recipe(recipe),
+          kotlin(
+            """
+              package a
+              class Foo
+              """
+          ),
+          kotlin(
+            """
+              package b
+              class Foo
+              """
+          ),
+          // `a.Foo` is already imported, so `b.Foo` must stay fully qualified rather than collapse to an
+          // ambiguous `Foo`. (Not adding the conflicting `import b.Foo` is a separate concern; see #8213.)
+          kotlin(
+            """
+              import a.Foo
+
+              class A {
+                  val x: Foo = Foo()
+                  val y: b.Foo = b.Foo()
+              }
+              """,
+            """
+              import a.Foo
+              import b.Foo
+
+              class A {
+                  val x: Foo = Foo()
+                  val y: b.Foo = b.Foo()
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AddImportTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AddImportTest.java
@@ -453,4 +453,32 @@ public class AddImportTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8214")
+    @Test
+    void shortensFullyQualifiedReferencesToNewlyImportedType() {
+        rewriteRun(
+          spec -> spec.recipe(importTypeRecipe("a.b.Target")),
+          kotlin(
+            """
+              package a.b
+              class Target
+              """
+          ),
+          kotlin(
+            """
+              class A {
+                  val type: a.b.Target = a.b.Target()
+              }
+              """,
+            """
+              import a.b.Target
+
+              class A {
+                  val type: Target = Target()
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/NewClassTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/NewClassTemplateTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Issue;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+class NewClassTemplateTest implements RewriteTest {
+
+    @DocumentExample
+    @Issue("https://github.com/openrewrite/rewrite/issues/8214")
+    @Test
+    void alreadyImportedTypeRendersWithoutStrayLeadingSpace() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none())
+            .recipe(toRecipe(() -> new KotlinVisitor<>() {
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    if ("placeholder".equals(method.getSimpleName())) {
+                        return JavaTemplate.builder("new Random()")
+                          .imports("java.util.Random")
+                          .build()
+                          .apply(getCursor(), method.getCoordinates().replace());
+                    }
+                    return super.visitMethodInvocation(method, ctx);
+                }
+            })),
+          kotlin(
+            """
+              import java.util.Random
+
+              fun placeholder(): Any = ""
+              fun test() {
+                  val x = placeholder()
+              }
+              """,
+            """
+              import java.util.Random
+
+              fun placeholder(): Any = ""
+              fun test() {
+                  val x = Random()
+              }
+              """
+          ));
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8214")
+    @Test
+    void freshlyImportedTypeIsShortenedAndRendersWithoutStrayLeadingSpace() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none())
+            .recipe(toRecipe(() -> new KotlinVisitor<>() {
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    if ("placeholder".equals(method.getSimpleName())) {
+                        maybeAddImport("java.util.Random", false);
+                        return JavaTemplate.builder("new java.util.Random()")
+                          .build()
+                          .apply(getCursor(), method.getCoordinates().replace());
+                    }
+                    return super.visitMethodInvocation(method, ctx);
+                }
+            })),
+          kotlin(
+            """
+              fun placeholder(): Any = ""
+              fun test() {
+                  val x = placeholder()
+              }
+              """,
+            """
+              import java.util.Random
+
+              fun placeholder(): Any = ""
+              fun test() {
+                  val x = Random()
+              }
+              """
+          ));
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8214")
+    @Test
+    void constructorWithTypeArgumentsRendersWithoutStrayLeadingSpace() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none())
+            .recipe(toRecipe(() -> new KotlinVisitor<>() {
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    if ("placeholder".equals(method.getSimpleName())) {
+                        return JavaTemplate.builder("new ArrayList<String>()")
+                          .imports("java.util.ArrayList")
+                          .build()
+                          .apply(getCursor(), method.getCoordinates().replace());
+                    }
+                    return super.visitMethodInvocation(method, ctx);
+                }
+            })),
+          kotlin(
+            """
+              import java.util.ArrayList
+
+              fun placeholder(): Any = ""
+              fun test() {
+                  val x = placeholder()
+              }
+              """,
+            """
+              import java.util.ArrayList
+
+              fun placeholder(): Any = ""
+              fun test() {
+                  val x = ArrayList<String>()
+              }
+              """
+          ));
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8214")
+    @Test
+    void constructorInArgumentPositionRendersWithoutStrayLeadingSpace() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none())
+            .recipe(toRecipe(() -> new KotlinVisitor<>() {
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    if ("placeholder".equals(method.getSimpleName())) {
+                        return JavaTemplate.builder("println(new Random())")
+                          .imports("java.util.Random")
+                          .build()
+                          .apply(getCursor(), method.getCoordinates().replace());
+                    }
+                    return super.visitMethodInvocation(method, ctx);
+                }
+            })),
+          kotlin(
+            """
+              import java.util.Random
+
+              fun placeholder() {}
+              fun test() {
+                  placeholder()
+              }
+              """,
+            """
+              import java.util.Random
+
+              fun placeholder() {}
+              fun test() {
+                  println(Random())
+              }
+              """
+          ));
+    }
+}


### PR DESCRIPTION
Fixes #8214. Kotlin's `AddImport` did not shorten fully qualified references to a newly imported type, so a recipe that replaced a reference via a fully qualified `JavaTemplate` (e.g. Jackson's `UseFormatAlignedObjectMappers`) left the reference fully qualified even though it added the import — whereas Java emits the simple name. This mirrors `org.openrewrite.java.AddImport`'s `ShortenFullyQualifiedTypeReferences` step so the reference now uses the simple name backed by the import. Adds a regression test in `AddImportTest`.