### PR TITLE
Kotlin: drop stray leading space when grafting a Java `new X()` template

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
@@ -1097,6 +1097,17 @@ public class SpacesVisitor<P> extends KotlinIsoVisitor<P> {
     @Override
     public J.NewClass visitNewClass(J.NewClass newClass, P p) {
         J.NewClass nc = super.visitNewClass(newClass, p);
+        // Kotlin has no `new` keyword; drop the space a grafted Java `new X()` leaves before the type.
+        if (!nc.getMarkers().findFirst(KObject.class).isPresent() &&
+            !nc.getMarkers().findFirst(TypeReferencePrefix.class).isPresent() &&
+            nc.getPadding().getEnclosing() == null) {
+            if (isCollapsibleSpace(nc.getNew())) {
+                nc = nc.withNew(Space.EMPTY);
+            }
+            if (nc.getClazz() != null && isCollapsibleSpace(nc.getClazz().getPrefix())) {
+                nc = nc.withClazz(nc.getClazz().withPrefix(Space.EMPTY));
+            }
+        }
         if (nc.getPadding().getArguments() != null) {
             nc = nc.getPadding().withArguments(spaceBefore(nc.getPadding().getArguments(), false, true));
             int argsSize = nc.getPadding().getArguments().getElements().size();
@@ -1119,6 +1130,11 @@ public class SpacesVisitor<P> extends KotlinIsoVisitor<P> {
             );
         }
         return nc;
+    }
+
+    private static boolean isCollapsibleSpace(Space space) {
+        return space.getComments().isEmpty() && !space.getWhitespace().isEmpty() &&
+               space.getWhitespace().indexOf('\n') < 0 && space.getWhitespace().indexOf('\r') < 0;
     }
 
     @SuppressWarnings("ConstantValue")

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/NewClassTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/NewClassTemplateTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Issue;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+class NewClassTemplateTest implements RewriteTest {
+
+    @DocumentExample
+    @Issue("https://github.com/openrewrite/rewrite/issues/8214")
+    @Test
+    void alreadyImportedTypeRendersWithoutStrayLeadingSpace() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none())
+            .recipe(toRecipe(() -> new KotlinVisitor<>() {
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    if ("placeholder".equals(method.getSimpleName())) {
+                        return JavaTemplate.builder("new Random()")
+                          .imports("java.util.Random")
+                          .build()
+                          .apply(getCursor(), method.getCoordinates().replace());
+                    }
+                    return super.visitMethodInvocation(method, ctx);
+                }
+            })),
+          kotlin(
+            """
+              import java.util.Random
+
+              fun placeholder(): Any = ""
+              fun test() {
+                  val x = placeholder()
+              }
+              """,
+            """
+              import java.util.Random
+
+              fun placeholder(): Any = ""
+              fun test() {
+                  val x = Random()
+              }
+              """
+          ));
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8214")
+    @Test
+    void freshlyImportedTypeIsShortenedAndRendersWithoutStrayLeadingSpace() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none())
+            .recipe(toRecipe(() -> new KotlinVisitor<>() {
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    if ("placeholder".equals(method.getSimpleName())) {
+                        maybeAddImport("java.util.Random", false);
+                        return JavaTemplate.builder("new java.util.Random()")
+                          .build()
+                          .apply(getCursor(), method.getCoordinates().replace());
+                    }
+                    return super.visitMethodInvocation(method, ctx);
+                }
+            })),
+          kotlin(
+            """
+              fun placeholder(): Any = ""
+              fun test() {
+                  val x = placeholder()
+              }
+              """,
+            """
+              import java.util.Random
+
+              fun placeholder(): Any = ""
+              fun test() {
+                  val x = Random()
+              }
+              """
+          ));
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8214")
+    @Test
+    void constructorWithTypeArgumentsRendersWithoutStrayLeadingSpace() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none())
+            .recipe(toRecipe(() -> new KotlinVisitor<>() {
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    if ("placeholder".equals(method.getSimpleName())) {
+                        return JavaTemplate.builder("new ArrayList<String>()")
+                          .imports("java.util.ArrayList")
+                          .build()
+                          .apply(getCursor(), method.getCoordinates().replace());
+                    }
+                    return super.visitMethodInvocation(method, ctx);
+                }
+            })),
+          kotlin(
+            """
+              import java.util.ArrayList
+
+              fun placeholder(): Any = ""
+              fun test() {
+                  val x = placeholder()
+              }
+              """,
+            """
+              import java.util.ArrayList
+
+              fun placeholder(): Any = ""
+              fun test() {
+                  val x = ArrayList<String>()
+              }
+              """
+          ));
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8214")
+    @Test
+    void constructorInArgumentPositionRendersWithoutStrayLeadingSpace() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none())
+            .recipe(toRecipe(() -> new KotlinVisitor<>() {
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    if ("placeholder".equals(method.getSimpleName())) {
+                        return JavaTemplate.builder("println(new Random())")
+                          .imports("java.util.Random")
+                          .build()
+                          .apply(getCursor(), method.getCoordinates().replace());
+                    }
+                    return super.visitMethodInvocation(method, ctx);
+                }
+            })),
+          kotlin(
+            """
+              import java.util.Random
+
+              fun placeholder() {}
+              fun test() {
+                  placeholder()
+              }
+              """,
+            """
+              import java.util.Random
+
+              fun placeholder() {}
+              fun test() {
+                  println(Random())
+              }
+              """
+          ));
+    }
+}


### PR DESCRIPTION
- Follow-up to #8214 (stacked on #8220).

### Problem

When a language-agnostic Java recipe uses `JavaTemplate.builder("new X()")` and applies it to a **Kotlin** source, the output has a stray leading space where Java's `new` keyword would go — e.g. `= Foo()` rendered as `=  Foo()` (two spaces after `=`):

```kotlin
val x =  Random()   // <- stray leading space
```

Kotlin has no `new` keyword, but the grafted `J.NewClass` still carries the space that followed `new` on the class prefix, and `KotlinPrinter.visitNewClass` drops the `new` text while still emitting that space.

- This reproduces independently of imports — in particular when the constructed type is **already imported**, so `AddImport` never runs. PR #8220 deliberately excluded this because its `AddImport`-scoped shortening only touched the case where a fully qualified reference was also being shortened.

### Fix

Normalize the `getNew()`/class-prefix space in the Kotlin `SpacesVisitor` (`visitNewClass`). This visitor runs during the auto-format step of template application — and because `JavaVisitor#autoFormat` resolves the `AutoFormatService` off the *source file*, applying a plain Java `JavaTemplate` to a Kotlin source runs Kotlin's auto-format, so this is the correct Kotlin-aware layer at the graft boundary (rather than the printer, which merely renders what's in the tree).

A natively parsed Kotlin constructor call has `getNew() == Space.EMPTY` and an empty class prefix; the fix collapses the grafted Java tree to match. The `object : Super()` (`KObject`) and enclosing-type (`TypeReferencePrefix`) forms legitimately rely on that space and are left untouched, as are prefixes carrying comments or line breaks.

- ### Relationship to #8220

- This composes with #8220's `AddImport` shortening: the space is collapsed at graft time, so when #8220 later shortens a freshly imported fully qualified reference down to its simple name, the result is clean (`Random()`, not `tools.jackson...JsonMapper()` and not `=  JsonMapper()`).

### Tests

`NewClassTemplateTest` covers:
- already-imported type (`AddImport` not involved)
- freshly-imported type (composes with #8220's shortening)
- constructor with type arguments (`new ArrayList<String>()` → `J.ParameterizedType` clazz)
- constructor in argument position (`println(new Random())`)

Full `:rewrite-kotlin:test` suite is green.