### PR TITLE
Fix MergeYaml duplicating a preceding entry's trailing comment onto an inserted entry

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -226,6 +226,9 @@ public class MergeYaml extends Recipe {
                     m = (Yaml.Mapping) new MergeYamlVisitor<>(mapping, incoming, accptTheirs,
                             objectIdentifyingProperty, insertMode, insertProperty).visitNonNull(mapping, ctx, getCursor().getParentOrThrow());
                 }
+                if (getCursor().getMessage(REMOVE_PREFIX, false)) {
+                    m = MergeYamlVisitor.removeInlineCommentFromLastEntry(m);
+                }
                 return m;
             }
 

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -444,6 +444,25 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
     }
 
     /**
+     * Strips an inline comment that is stored as the leading part (before the first line break) of
+     * the last entry's prefix. This is used to remove a trailing comment that was copied onto a
+     * newly-inserted entry, so that the comment is not rendered twice. When the mapping being merged
+     * is nested, the comment lives on a sibling entry of an ancestor mapping that is traversed by the
+     * outer visitor rather than the {@link MergeYamlVisitor}, hence this method is invoked from there.
+     */
+    static Yaml.Mapping removeInlineCommentFromLastEntry(Yaml.Mapping mapping) {
+        return mapping.withEntries(mapLast(mapping.getEntries(), entry -> {
+            String prefix = entry.getPrefix();
+            String[] lines = LINE_BREAK.split(prefix, -1);
+            if (lines.length <= 1) {
+                return entry;
+            }
+            String linebreak = prefix.contains("\r\n") ? "\r\n" : "\n";
+            return entry.withPrefix(linebreak + String.join(linebreak, Arrays.copyOfRange(lines, 1, lines.length)));
+        }));
+    }
+
+    /**
      * The indentation column shared by the entries of an existing mapping, or {@code -1} when it
      * cannot be determined (e.g. an empty mapping or a mapping whose only entry is on the same line
      * as its parent key).

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -15,7 +15,11 @@
  */
 package org.openrewrite.yaml;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.Validated;
@@ -23,11 +27,14 @@ import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.test.RewriteTest;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.openrewrite.yaml.Assertions.yaml;
 import static org.openrewrite.yaml.MergeYaml.InsertMode.After;
 import static org.openrewrite.yaml.MergeYaml.InsertMode.Before;
+import static org.openrewrite.yaml.MergeYaml.InsertMode.Last;
 
 @SuppressWarnings({"KubernetesUnknownResourcesInspection", "KubernetesNonEditableResources"})
 class MergeYamlTest implements RewriteTest {
@@ -1717,6 +1724,77 @@ class MergeYamlTest implements RewriteTest {
               new-property: value
               """
           )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("insertPropertyOptions")
+    void doesNotCopyTrailingCommentOfPrecedingEntryToInsertedEntry(MergeYaml.@Nullable InsertMode insertMode,
+                                                                   @Nullable String insertProperty,
+                                                                   String after) {
+        rewriteRun(
+          spec -> spec.recipe(
+            new MergeYaml(
+              "$.config",
+              //language=yaml
+              """
+                new-property: value
+                """,
+              false,
+              null,
+              null,
+              insertMode,
+              insertProperty,
+              null
+            )),
+          yaml(
+            """
+              config:
+                activate-auto: true
+                activate-mep: true # Some comment
+              other: x
+              """,
+            after
+          )
+        );
+    }
+
+    static Stream<Arguments> insertPropertyOptions() {
+        return Stream.of(
+          arguments(null, null,
+            """
+              config:
+                activate-auto: true
+                activate-mep: true # Some comment
+                new-property: value
+              other: x
+              """),
+          arguments(Last, null,
+            """
+              config:
+                activate-auto: true
+                activate-mep: true # Some comment
+                new-property: value
+              other: x
+              """),
+          // Inserted after the commented last entry — also becomes the last entry
+          arguments(After, "activate-mep",
+            """
+              config:
+                activate-auto: true
+                activate-mep: true # Some comment
+                new-property: value
+              other: x
+              """),
+          // Inserted before the commented last entry — comment must remain on `activate-mep`
+          arguments(Before, "activate-mep",
+            """
+              config:
+                activate-auto: true
+                new-property: value
+                activate-mep: true # Some comment
+              other: x
+              """)
         );
     }
 


### PR DESCRIPTION
### What's changed?

When `MergeYaml` inserts a new entry as the **last** entry of a nested mapping, the trailing comment of that block's previous last line (e.g. `activate-mep: true # Some comment`) is stored in the LST as the *prefix of the following element* — a sibling that lives **outside** the merged subtree. The recipe copies that comment onto the inserted entry (so it still renders on the preceding line) and posts a `REMOVE_PREFIX` cursor message to strip the now-duplicated original. However, that message landed on the **outer** visitor's ancestor-mapping cursor, which was only consumed in `visitDocument` — never in `visitMapping`. As a result the original comment was never removed and rendered twice:

```yaml
config:
  activate-auto: true
  activate-mep: true # Some comment
  new-property: value # Some comment   # ← duplicated
other: x
```

This PR consumes the `REMOVE_PREFIX` message in the outer visitor's `visitMapping` and strips the duplicated comment via a new shared `MergeYamlVisitor.removeInlineCommentFromLastEntry` helper, producing the expected:

```yaml
config:
  activate-auto: true
  activate-mep: true # Some comment
  new-property: value
other: x
```

### Anything in particular you'd like reviewers to focus on?

The fix is covered by a parameterized test (`MergeYamlTest#doesNotCopyTrailingCommentOfPrecedingEntryToInsertedEntry`) exercising every `insertMode`/`insertProperty` placement relative to the commented entry. The three last-position placements (`null`, `Last`, `After activate-mep`) fail without the fix; the `Before activate-mep` case confirms inserting before the commented entry keeps the comment where it belongs.