### PR TITLE
Go: TabsAndIndentsVisitor to preserve indenting style

### DIFF
--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/format/TabsAndIndentsStyleTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/format/TabsAndIndentsStyleTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.format;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.golang.rpc.GoRewriteRpc;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static org.openrewrite.golang.Assertions.go;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+/**
+ * The Go formatter emulates gofmt, whose canonical indentation is tabs. But when a recipe touches a
+ * source that was written with spaces, re-indenting the changed region to tabs produces a mixed-style
+ * file and a noisy diff. {@link TabsAndIndentsVisitor} therefore detects the source's own indentation
+ * unit and reuses it, keeping space-indented sources space-indented and tab-indented sources tab-indented.
+ */
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class TabsAndIndentsStyleTest implements RewriteTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void before() {
+        Path binaryPath = Paths.get("build/rewrite-go-rpc").toAbsolutePath();
+        GoRewriteRpc.setFactory(GoRewriteRpc.builder()
+                .goBinaryPath(binaryPath)
+                .log(tempDir.resolve("go-rpc.log")));
+    }
+
+    @AfterEach
+    void after() {
+        GoRewriteRpc.shutdownCurrent();
+    }
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(() -> new TabsAndIndentsVisitor<>(null)))
+                .typeValidationOptions(TypeValidation.builder()
+                        .allowNonWhitespaceInWhitespace(true)
+                        .identifiers(false)
+                        .methodInvocations(false)
+                        .build());
+    }
+
+    @Test
+    void reindentsUsingDetectedSpaceUnit() {
+        // given a space-indented source with an over-indented body,
+        // when the formatter fixes the indentation,
+        // then it uses the source's four-space unit rather than a tab
+        rewriteRun(
+                go(
+                        """
+                        package main
+
+                        func a() {
+                            return
+                        }
+
+                        func b() {
+                                return
+                        }
+                        """,
+                        """
+                        package main
+
+                        func a() {
+                            return
+                        }
+
+                        func b() {
+                            return
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void reindentsUsingDetectedTwoSpaceUnit() {
+        // given a two-space-indented source with an over-indented body,
+        // when the formatter fixes the indentation,
+        // then it uses the source's two-space unit
+        rewriteRun(
+                go(
+                        """
+                        package main
+
+                        func a() {
+                          if x {
+                            return
+                          }
+                        }
+
+                        func b() {
+                              return
+                        }
+                        """,
+                        """
+                        package main
+
+                        func a() {
+                          if x {
+                            return
+                          }
+                        }
+
+                        func b() {
+                          return
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void keepsTabIndentedSourceOnTabs() {
+        // given a canonical tab-indented (gofmt) source,
+        // when the formatter runs,
+        // then it stays on tabs
+        rewriteRun(
+                go(
+                        """
+                        package main
+
+                        func a() {
+                        \treturn
+                        }
+                        """
+                )
+        );
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/format/TabsAndIndentsVisitor.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/format/TabsAndIndentsVisitor.java
@@ -17,6 +17,7 @@ package org.openrewrite.golang.format;
 
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
+import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.golang.GolangVisitor;
 import org.openrewrite.golang.tree.Go;
@@ -26,6 +27,9 @@ import org.openrewrite.java.tree.Space;
 public class TabsAndIndentsVisitor<P> extends GolangVisitor<P> {
     @Nullable
     private final Tree stopAfter;
+
+    @Nullable
+    private String indentUnit;
 
     public TabsAndIndentsVisitor(@Nullable Tree stopAfter) {
         this.stopAfter = stopAfter;
@@ -65,18 +69,100 @@ public class TabsAndIndentsVisitor<P> extends GolangVisitor<P> {
                 depth++;
             }
         }
-        // Build indentation: newlines preserved, then tabs for depth
+        // Build indentation: newlines preserved, then one indent unit per depth level
         String ws = space.getWhitespace();
         int lastNewline = ws.lastIndexOf('\n');
         if (lastNewline >= 0) {
             String beforeLastNewline = ws.substring(0, lastNewline + 1);
+            String unit = indentUnit();
             StringBuilder indent = new StringBuilder();
             for (int i = 0; i < depth; i++) {
-                indent.append('\t');
+                indent.append(unit);
             }
             return space.withWhitespace(beforeLastNewline + indent);
         }
         return space;
+    }
+
+    /**
+     * The indentation string used for a single level of nesting, detected from the
+     * source file's existing style so that space-indented sources stay space-indented
+     * and tab-indented (canonical gofmt) sources stay tab-indented. Defaults to a tab
+     * when the source has no indentation to sample.
+     */
+    private String indentUnit() {
+        if (indentUnit == null) {
+            indentUnit = detectIndentUnit(getCursor().firstEnclosing(SourceFile.class));
+        }
+        return indentUnit;
+    }
+
+    private static String detectIndentUnit(@Nullable Tree cu) {
+        if (cu == null) {
+            return "\t";
+        }
+        IndentUnitCollector collector = new IndentUnitCollector();
+        collector.visit(cu, 0);
+        return collector.indentUnit();
+    }
+
+    private static class IndentUnitCollector extends GolangVisitor<Integer> {
+        private boolean sawTab;
+        private int spaceIndentGcd;
+
+        @Override
+        public Space visitSpace(Space space, Space.Location loc, Integer p) {
+            String ws = space.getWhitespace();
+            int lastNewline = ws.lastIndexOf('\n');
+            if (lastNewline >= 0) {
+                String indent = ws.substring(lastNewline + 1);
+                if (!indent.isEmpty()) {
+                    if (indent.indexOf('\t') >= 0) {
+                        sawTab = true;
+                    } else {
+                        // Fold every observed space-indent width into a running GCD so a
+                        // 4-space file (seen as 4, 8, 12, ...) resolves to 4 while an
+                        // outlier line can't drag the unit below the true step, the way a
+                        // plain minimum would.
+                        spaceIndentGcd = gcd(spaceIndentGcd, indent.length());
+                    }
+                }
+            }
+            return space;
+        }
+
+        private String indentUnit() {
+            if (sawTab || spaceIndentGcd == 0) {
+                return "\t";
+            }
+            StringBuilder unit = new StringBuilder();
+            for (int i = 0; i < normalizeIndentWidth(spaceIndentGcd); i++) {
+                unit.append(' ');
+            }
+            return unit.toString();
+        }
+
+        private static int normalizeIndentWidth(int gcd) {
+            if (gcd == 2 || gcd == 4 || gcd == 8) {
+                return gcd;
+            }
+            if (gcd % 4 == 0) {
+                return 4;
+            }
+            if (gcd % 2 == 0) {
+                return 2;
+            }
+            return 4;
+        }
+
+        private static int gcd(int a, int b) {
+            while (b != 0) {
+                int t = b;
+                b = a % b;
+                a = t;
+            }
+            return a;
+        }
     }
 
     /**


### PR DESCRIPTION
## What's changed?

Amending Go's `TabsAndIndentsVisitor` (part of AutoFormat) to attempt to preserve the indenting style. It's mostly after keeping tabs v. spaces, and count of spaces.

## What's your motivation?

- Less invasive recipes.
- Feature parity with other languages.