### PR TITLE
Go: fix visitor immutability

### DIFF
--- a/rewrite-go/pkg/tree/golang/go.go
+++ b/rewrite-go/pkg/tree/golang/go.go
@@ -40,36 +40,54 @@ func (*CompilationUnit) IsSourceFile() {}
 func (n *CompilationUnit) GetSourcePath() string { return n.SourcePath }
 
 func (n *CompilationUnit) WithPrefix(prefix java.Space) *CompilationUnit {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *CompilationUnit) WithMarkers(markers java.Markers) *CompilationUnit {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *CompilationUnit) WithStatements(statements []java.RightPadded[java.Statement]) *CompilationUnit {
+	if java.SameSlice(n.Statements, statements) {
+		return n
+	}
 	c := *n
 	c.Statements = statements
 	return &c
 }
 
 func (n *CompilationUnit) WithPackageDecl(pkg *java.RightPadded[*java.Identifier]) *CompilationUnit {
+	if n.PackageDecl == pkg {
+		return n
+	}
 	c := *n
 	c.PackageDecl = pkg
 	return &c
 }
 
 func (n *CompilationUnit) WithImports(imports *java.Container[*java.Import]) *CompilationUnit {
+	if n.Imports == imports {
+		return n
+	}
 	c := *n
 	c.Imports = imports
 	return &c
 }
 
 func (n *CompilationUnit) WithEOF(eof java.Space) *CompilationUnit {
+	if java.SpaceEqual(n.EOF, eof) {
+		return n
+	}
 	c := *n
 	c.EOF = eof
 	return &c
@@ -87,12 +105,18 @@ func (*GoStmt) IsJ()         {}
 func (*GoStmt) IsStatement() {}
 
 func (n *GoStmt) WithPrefix(prefix java.Space) *GoStmt {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *GoStmt) WithMarkers(markers java.Markers) *GoStmt {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -110,12 +134,18 @@ func (*Defer) IsJ()         {}
 func (*Defer) IsStatement() {}
 
 func (n *Defer) WithPrefix(prefix java.Space) *Defer {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Defer) WithMarkers(markers java.Markers) *Defer {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -134,12 +164,18 @@ func (*Send) IsJ()         {}
 func (*Send) IsStatement() {}
 
 func (n *Send) WithPrefix(prefix java.Space) *Send {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Send) WithMarkers(markers java.Markers) *Send {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -157,12 +193,18 @@ func (*Goto) IsJ()         {}
 func (*Goto) IsStatement() {}
 
 func (n *Goto) WithPrefix(prefix java.Space) *Goto {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Goto) WithMarkers(markers java.Markers) *Goto {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -179,12 +221,18 @@ func (*Fallthrough) IsJ()         {}
 func (*Fallthrough) IsStatement() {}
 
 func (n *Fallthrough) WithPrefix(prefix java.Space) *Fallthrough {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Fallthrough) WithMarkers(markers java.Markers) *Fallthrough {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -203,12 +251,18 @@ func (*Composite) IsJ()          {}
 func (*Composite) IsExpression() {}
 
 func (n *Composite) WithPrefix(prefix java.Space) *Composite {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Composite) WithMarkers(markers java.Markers) *Composite {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -227,12 +281,18 @@ func (*KeyValue) IsJ()          {}
 func (*KeyValue) IsExpression() {}
 
 func (n *KeyValue) WithPrefix(prefix java.Space) *KeyValue {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *KeyValue) WithMarkers(markers java.Markers) *KeyValue {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -255,12 +315,18 @@ func (*Slice) IsJ()          {}
 func (*Slice) IsExpression() {}
 
 func (n *Slice) WithPrefix(prefix java.Space) *Slice {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Slice) WithMarkers(markers java.Markers) *Slice {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -283,12 +349,18 @@ func (*ArrayType) IsJ()          {}
 func (*ArrayType) IsExpression() {}
 
 func (n *ArrayType) WithPrefix(prefix java.Space) *ArrayType {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *ArrayType) WithMarkers(markers java.Markers) *ArrayType {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -308,12 +380,18 @@ func (*MapType) IsJ()          {}
 func (*MapType) IsExpression() {}
 
 func (n *MapType) WithPrefix(prefix java.Space) *MapType {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *MapType) WithMarkers(markers java.Markers) *MapType {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -339,12 +417,18 @@ func (*PointerType) IsJ()          {}
 func (*PointerType) IsExpression() {}
 
 func (n *PointerType) WithPrefix(prefix java.Space) *PointerType {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *PointerType) WithMarkers(markers java.Markers) *PointerType {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -363,12 +447,18 @@ func (*Channel) IsJ()          {}
 func (*Channel) IsExpression() {}
 
 func (n *Channel) WithPrefix(prefix java.Space) *Channel {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Channel) WithMarkers(markers java.Markers) *Channel {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -387,12 +477,18 @@ func (*FuncType) IsJ()          {}
 func (*FuncType) IsExpression() {}
 
 func (n *FuncType) WithPrefix(prefix java.Space) *FuncType {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *FuncType) WithMarkers(markers java.Markers) *FuncType {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -410,12 +506,18 @@ func (*StructType) IsJ()          {}
 func (*StructType) IsExpression() {}
 
 func (n *StructType) WithPrefix(prefix java.Space) *StructType {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *StructType) WithMarkers(markers java.Markers) *StructType {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -433,12 +535,18 @@ func (*InterfaceType) IsJ()          {}
 func (*InterfaceType) IsExpression() {}
 
 func (n *InterfaceType) WithPrefix(prefix java.Space) *InterfaceType {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *InterfaceType) WithMarkers(markers java.Markers) *InterfaceType {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -458,12 +566,18 @@ func (*TypeList) IsJ()          {}
 func (*TypeList) IsExpression() {}
 
 func (n *TypeList) WithPrefix(prefix java.Space) *TypeList {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *TypeList) WithMarkers(markers java.Markers) *TypeList {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -488,12 +602,18 @@ func (*Union) IsJ()          {}
 func (*Union) IsExpression() {}
 
 func (n *Union) WithPrefix(prefix java.Space) *Union {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Union) WithMarkers(markers java.Markers) *Union {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -517,12 +637,18 @@ func (*UnderlyingType) IsJ()          {}
 func (*UnderlyingType) IsExpression() {}
 
 func (n *UnderlyingType) WithPrefix(prefix java.Space) *UnderlyingType {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *UnderlyingType) WithMarkers(markers java.Markers) *UnderlyingType {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -547,24 +673,36 @@ func (*TypeDecl) IsJ()         {}
 func (*TypeDecl) IsStatement() {}
 
 func (n *TypeDecl) WithPrefix(prefix java.Space) *TypeDecl {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *TypeDecl) WithMarkers(markers java.Markers) *TypeDecl {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *TypeDecl) WithLeadingAnnotations(anns []*java.Annotation) *TypeDecl {
+	if java.SameSlice(n.LeadingAnnotations, anns) {
+		return n
+	}
 	c := *n
 	c.LeadingAnnotations = anns
 	return &c
 }
 
 func (n *TypeDecl) WithTypeParameters(tps *java.TypeParameters) *TypeDecl {
+	if n.TypeParameters == tps {
+		return n
+	}
 	c := *n
 	c.TypeParameters = tps
 	return &c
@@ -599,18 +737,27 @@ func (*DeclarationBlock) IsJ()         {}
 func (*DeclarationBlock) IsStatement() {}
 
 func (n *DeclarationBlock) WithPrefix(prefix java.Space) *DeclarationBlock {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *DeclarationBlock) WithMarkers(markers java.Markers) *DeclarationBlock {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *DeclarationBlock) WithLeadingAnnotations(anns []*java.Annotation) *DeclarationBlock {
+	if java.SameSlice(n.LeadingAnnotations, anns) {
+		return n
+	}
 	c := *n
 	c.LeadingAnnotations = anns
 	return &c
@@ -669,12 +816,18 @@ func (*MultiAssignment) IsJ()         {}
 func (*MultiAssignment) IsStatement() {}
 
 func (n *MultiAssignment) WithPrefix(prefix java.Space) *MultiAssignment {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *MultiAssignment) WithMarkers(markers java.Markers) *MultiAssignment {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -696,12 +849,18 @@ func (*Return) IsJ()         {}
 func (*Return) IsStatement() {}
 
 func (n *Return) WithPrefix(prefix java.Space) *Return {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Return) WithMarkers(markers java.Markers) *Return {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -727,12 +886,18 @@ func (*MethodDeclaration) IsJ()         {}
 func (*MethodDeclaration) IsStatement() {}
 
 func (n *MethodDeclaration) WithPrefix(prefix java.Space) *MethodDeclaration {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *MethodDeclaration) WithMarkers(markers java.Markers) *MethodDeclaration {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -759,12 +924,18 @@ func (*StatementWithInit) IsJ()         {}
 func (*StatementWithInit) IsStatement() {}
 
 func (n *StatementWithInit) WithPrefix(prefix java.Space) *StatementWithInit {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *StatementWithInit) WithMarkers(markers java.Markers) *StatementWithInit {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -785,12 +956,18 @@ func (*CommClause) IsJ()         {}
 func (*CommClause) IsStatement() {}
 
 func (n *CommClause) WithPrefix(prefix java.Space) *CommClause {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *CommClause) WithMarkers(markers java.Markers) *CommClause {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -810,12 +987,18 @@ func (*StatementExpression) IsJ()          {}
 func (*StatementExpression) IsExpression() {}
 
 func (n *StatementExpression) WithPrefix(prefix java.Space) *StatementExpression {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *StatementExpression) WithMarkers(markers java.Markers) *StatementExpression {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -836,12 +1019,18 @@ func (*IndexList) IsJ()          {}
 func (*IndexList) IsExpression() {}
 
 func (n *IndexList) WithPrefix(prefix java.Space) *IndexList {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *IndexList) WithMarkers(markers java.Markers) *IndexList {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -900,12 +1089,18 @@ func (*Unary) IsExpression() {}
 func (*Unary) IsStatement()  {}
 
 func (n *Unary) WithPrefix(prefix java.Space) *Unary {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Unary) WithMarkers(markers java.Markers) *Unary {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -951,12 +1146,18 @@ func (*Binary) IsJ()          {}
 func (*Binary) IsExpression() {}
 
 func (n *Binary) WithPrefix(prefix java.Space) *Binary {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Binary) WithMarkers(markers java.Markers) *Binary {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -1003,12 +1204,18 @@ func (*AssignmentOperation) IsExpression() {}
 func (*AssignmentOperation) IsStatement()  {}
 
 func (n *AssignmentOperation) WithPrefix(prefix java.Space) *AssignmentOperation {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *AssignmentOperation) WithMarkers(markers java.Markers) *AssignmentOperation {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -1031,12 +1238,18 @@ func (*Variadic) IsJ()          {}
 func (*Variadic) IsExpression() {}
 
 func (n *Variadic) WithPrefix(prefix java.Space) *Variadic {
+	if java.SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Variadic) WithMarkers(markers java.Markers) *Variadic {
+	if java.MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c

--- a/rewrite-go/pkg/tree/java/equality.go
+++ b/rewrite-go/pkg/tree/java/equality.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package java
+
+// These helpers back the OpenRewrite identity invariant: a withX method must
+// return the receiver unchanged when the new value equals the current one, so
+// that visiting a subtree that nothing changed yields the SAME pointer — which
+// is how the engine detects "no change" (and keeps untouched files out of a
+// recipe's results/patch). Go's value types (Space, Markers, slices, the padded
+// wrappers) are not ==-comparable, so withX uses these instead of a bare ==.
+//
+// All of these are O(1) in the unchanged case: the visitor returns the same
+// slice / element pointer when nothing changed, so equality bottoms out in
+// header/pointer comparisons rather than deep traversal.
+
+// SameSlice reports whether a and b are the same slice — same backing array and
+// length. (Go slices aren't ==-comparable.)
+func SameSlice[T any](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	return &a[0] == &b[0]
+}
+
+// SpaceEqual reports whether two Spaces are unchanged: equal whitespace and the
+// same comments slice (the visitor preserves the comments slice when unchanged).
+func SpaceEqual(a, b Space) bool {
+	return a.Whitespace == b.Whitespace && SameSlice(a.Comments, b.Comments)
+}
+
+// MarkersEqual reports whether two Markers are unchanged: same ID and the same
+// entries slice.
+func MarkersEqual(a, b Markers) bool {
+	return a.ID == b.ID && SameSlice(a.Entries, b.Entries)
+}
+
+// LeftPaddedEqual reports whether two LeftPadded values are unchanged.
+func LeftPaddedEqual[T comparable](a, b LeftPadded[T]) bool {
+	return a.Element == b.Element && SpaceEqual(a.Before, b.Before) && MarkersEqual(a.Markers, b.Markers)
+}
+
+// RightPaddedEqual reports whether two RightPadded values are unchanged.
+func RightPaddedEqual[T comparable](a, b RightPadded[T]) bool {
+	return a.Element == b.Element && SpaceEqual(a.After, b.After) && MarkersEqual(a.Markers, b.Markers)
+}
+
+// ContainerEqual reports whether two Containers are unchanged: same before
+// space, markers, and the same elements slice.
+func ContainerEqual[T any](a, b Container[T]) bool {
+	return SpaceEqual(a.Before, b.Before) && MarkersEqual(a.Markers, b.Markers) && SameSlice(a.Elements, b.Elements)
+}

--- a/rewrite-go/pkg/tree/java/j.go
+++ b/rewrite-go/pkg/tree/java/j.go
@@ -33,12 +33,18 @@ func (*Identifier) IsJ()          {}
 func (*Identifier) IsExpression() {}
 
 func (n *Identifier) WithPrefix(prefix Space) *Identifier {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Identifier) WithMarkers(markers Markers) *Identifier {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -54,12 +60,18 @@ func (n *Identifier) WithName(name string) *Identifier {
 }
 
 func (n *Identifier) WithType(t JavaType) *Identifier {
+	if n.Type == t {
+		return n
+	}
 	c := *n
 	c.Type = t
 	return &c
 }
 
 func (n *Identifier) WithFieldType(ft *JavaTypeVariable) *Identifier {
+	if n.FieldType == ft {
+		return n
+	}
 	c := *n
 	c.FieldType = ft
 	return &c
@@ -89,18 +101,27 @@ func (*Literal) IsJ()          {}
 func (*Literal) IsExpression() {}
 
 func (n *Literal) WithPrefix(prefix Space) *Literal {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Literal) WithMarkers(markers Markers) *Literal {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *Literal) WithValue(value any) *Literal {
+	if n.Value == value {
+		return n
+	}
 	c := *n
 	c.Value = value
 	return &c
@@ -244,24 +265,36 @@ func (*Binary) IsJ()          {}
 func (*Binary) IsExpression() {}
 
 func (n *Binary) WithPrefix(prefix Space) *Binary {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Binary) WithMarkers(markers Markers) *Binary {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *Binary) WithLeft(left Expression) *Binary {
+	if n.Left == left {
+		return n
+	}
 	c := *n
 	c.Left = left
 	return &c
 }
 
 func (n *Binary) WithRight(right Expression) *Binary {
+	if n.Right == right {
+		return n
+	}
 	c := *n
 	c.Right = right
 	return &c
@@ -280,24 +313,36 @@ func (*Block) IsJ()         {}
 func (*Block) IsStatement() {}
 
 func (n *Block) WithPrefix(prefix Space) *Block {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Block) WithMarkers(markers Markers) *Block {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *Block) WithStatements(statements []RightPadded[Statement]) *Block {
+	if SameSlice(n.Statements, statements) {
+		return n
+	}
 	c := *n
 	c.Statements = statements
 	return &c
 }
 
 func (n *Block) WithEnd(end Space) *Block {
+	if SpaceEqual(n.End, end) {
+		return n
+	}
 	c := *n
 	c.End = end
 	return &c
@@ -318,12 +363,18 @@ func (*Return) IsJ()         {}
 func (*Return) IsStatement() {}
 
 func (n *Return) WithPrefix(prefix Space) *Return {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Return) WithMarkers(markers Markers) *Return {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -348,30 +399,45 @@ func (*If) IsJ()         {}
 func (*If) IsStatement() {}
 
 func (n *If) WithPrefix(prefix Space) *If {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *If) WithMarkers(markers Markers) *If {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *If) WithCondition(condition *ControlParentheses) *If {
+	if n.Condition == condition {
+		return n
+	}
 	c := *n
 	c.Condition = condition
 	return &c
 }
 
 func (n *If) WithThenPart(thenPart RightPadded[Statement]) *If {
+	if RightPaddedEqual(n.ThenPart, thenPart) {
+		return n
+	}
 	c := *n
 	c.ThenPart = thenPart
 	return &c
 }
 
 func (n *If) WithElsePart(elsePart *Else) *If {
+	if n.ElsePart == elsePart {
+		return n
+	}
 	c := *n
 	c.ElsePart = elsePart
 	return &c
@@ -388,12 +454,18 @@ func (*Else) IsTree() {}
 func (*Else) IsJ()    {}
 
 func (n *Else) WithPrefix(prefix Space) *Else {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Else) WithMarkers(markers Markers) *Else {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -414,18 +486,27 @@ func (*Assignment) IsStatement()  {}
 func (*Assignment) IsExpression() {}
 
 func (n *Assignment) WithPrefix(prefix Space) *Assignment {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Assignment) WithMarkers(markers Markers) *Assignment {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *Assignment) WithVariable(variable Expression) *Assignment {
+	if n.Variable == variable {
+		return n
+	}
 	c := *n
 	c.Variable = variable
 	return &c
@@ -519,18 +600,27 @@ func (*AssignmentOperation) IsStatement()  {}
 func (*AssignmentOperation) IsExpression() {}
 
 func (n *AssignmentOperation) WithPrefix(prefix Space) *AssignmentOperation {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *AssignmentOperation) WithMarkers(markers Markers) *AssignmentOperation {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *AssignmentOperation) WithVariable(variable Expression) *AssignmentOperation {
+	if n.Variable == variable {
+		return n
+	}
 	c := *n
 	c.Variable = variable
 	return &c
@@ -555,36 +645,54 @@ func (*MethodDeclaration) IsStatement()  {}
 func (*MethodDeclaration) IsExpression() {} // for function literals
 
 func (n *MethodDeclaration) WithPrefix(prefix Space) *MethodDeclaration {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *MethodDeclaration) WithMarkers(markers Markers) *MethodDeclaration {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *MethodDeclaration) WithLeadingAnnotations(anns []*Annotation) *MethodDeclaration {
+	if SameSlice(n.LeadingAnnotations, anns) {
+		return n
+	}
 	c := *n
 	c.LeadingAnnotations = anns
 	return &c
 }
 
 func (n *MethodDeclaration) WithName(name *Identifier) *MethodDeclaration {
+	if n.Name == name {
+		return n
+	}
 	c := *n
 	c.Name = name
 	return &c
 }
 
 func (n *MethodDeclaration) WithBody(body *Block) *MethodDeclaration {
+	if n.Body == body {
+		return n
+	}
 	c := *n
 	c.Body = body
 	return &c
 }
 
 func (n *MethodDeclaration) WithTypeParameters(tps *TypeParameters) *MethodDeclaration {
+	if n.TypeParameters == tps {
+		return n
+	}
 	c := *n
 	c.TypeParameters = tps
 	return &c
@@ -608,12 +716,18 @@ func (*TypeParameters) IsTree() {}
 func (*TypeParameters) IsJ()    {}
 
 func (n *TypeParameters) WithPrefix(prefix Space) *TypeParameters {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *TypeParameters) WithMarkers(markers Markers) *TypeParameters {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -637,12 +751,18 @@ func (*TypeParameter) IsTree() {}
 func (*TypeParameter) IsJ()    {}
 
 func (n *TypeParameter) WithPrefix(prefix Space) *TypeParameter {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *TypeParameter) WithMarkers(markers Markers) *TypeParameter {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -663,18 +783,27 @@ func (*ForLoop) IsJ()         {}
 func (*ForLoop) IsStatement() {}
 
 func (n *ForLoop) WithPrefix(prefix Space) *ForLoop {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *ForLoop) WithMarkers(markers Markers) *ForLoop {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *ForLoop) WithBody(body *Block) *ForLoop {
+	if n.Body == body {
+		return n
+	}
 	c := *n
 	c.Body = body
 	return &c
@@ -697,12 +826,18 @@ func (*ForControl) IsTree() {}
 func (*ForControl) IsJ()    {}
 
 func (n *ForControl) WithPrefix(prefix Space) *ForControl {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *ForControl) WithMarkers(markers Markers) *ForControl {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -721,18 +856,27 @@ func (*ForEachLoop) IsJ()         {}
 func (*ForEachLoop) IsStatement() {}
 
 func (n *ForEachLoop) WithPrefix(prefix Space) *ForEachLoop {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *ForEachLoop) WithMarkers(markers Markers) *ForEachLoop {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *ForEachLoop) WithBody(body *Block) *ForEachLoop {
+	if n.Body == body {
+		return n
+	}
 	c := *n
 	c.Body = body
 	return &c
@@ -760,12 +904,18 @@ func (*ForEachControl) IsTree() {}
 func (*ForEachControl) IsJ()    {}
 
 func (n *ForEachControl) WithPrefix(prefix Space) *ForEachControl {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *ForEachControl) WithMarkers(markers Markers) *ForEachControl {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -787,18 +937,27 @@ func (*Switch) IsJ()         {}
 func (*Switch) IsStatement() {}
 
 func (n *Switch) WithPrefix(prefix Space) *Switch {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Switch) WithMarkers(markers Markers) *Switch {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *Switch) WithBody(body *Block) *Switch {
+	if n.Body == body {
+		return n
+	}
 	c := *n
 	c.Body = body
 	return &c
@@ -817,12 +976,18 @@ func (*Case) IsJ()         {}
 func (*Case) IsStatement() {}
 
 func (n *Case) WithPrefix(prefix Space) *Case {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Case) WithMarkers(markers Markers) *Case {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -840,12 +1005,18 @@ func (*Break) IsJ()         {}
 func (*Break) IsStatement() {}
 
 func (n *Break) WithPrefix(prefix Space) *Break {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Break) WithMarkers(markers Markers) *Break {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -863,12 +1034,18 @@ func (*Continue) IsJ()         {}
 func (*Continue) IsStatement() {}
 
 func (n *Continue) WithPrefix(prefix Space) *Continue {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Continue) WithMarkers(markers Markers) *Continue {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -887,12 +1064,18 @@ func (*Label) IsJ()         {}
 func (*Label) IsStatement() {}
 
 func (n *Label) WithPrefix(prefix Space) *Label {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Label) WithMarkers(markers Markers) *Label {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -936,24 +1119,36 @@ func (*Annotation) IsJ()          {}
 func (*Annotation) IsExpression() {}
 
 func (n *Annotation) WithPrefix(prefix Space) *Annotation {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Annotation) WithMarkers(markers Markers) *Annotation {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *Annotation) WithAnnotationType(annotationType Expression) *Annotation {
+	if n.AnnotationType == annotationType {
+		return n
+	}
 	c := *n
 	c.AnnotationType = annotationType
 	return &c
 }
 
 func (n *Annotation) WithArguments(arguments *Container[Expression]) *Annotation {
+	if n.Arguments == arguments {
+		return n
+	}
 	c := *n
 	c.Arguments = arguments
 	return &c
@@ -971,6 +1166,9 @@ func (*Empty) IsStatement()  {}
 func (*Empty) IsExpression() {}
 
 func (n *Empty) WithPrefix(prefix Space) *Empty {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
@@ -1074,18 +1272,27 @@ func (*Unary) IsExpression() {}
 func (*Unary) IsStatement()  {}
 
 func (n *Unary) WithPrefix(prefix Space) *Unary {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Unary) WithMarkers(markers Markers) *Unary {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *Unary) WithOperand(operand Expression) *Unary {
+	if n.Operand == operand {
+		return n
+	}
 	c := *n
 	c.Operand = operand
 	return &c
@@ -1105,18 +1312,27 @@ func (*FieldAccess) IsJ()          {}
 func (*FieldAccess) IsExpression() {}
 
 func (n *FieldAccess) WithPrefix(prefix Space) *FieldAccess {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *FieldAccess) WithMarkers(markers Markers) *FieldAccess {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *FieldAccess) WithTarget(target Expression) *FieldAccess {
+	if n.Target == target {
+		return n
+	}
 	c := *n
 	c.Target = target
 	return &c
@@ -1139,24 +1355,36 @@ func (*MethodInvocation) IsExpression() {}
 func (*MethodInvocation) IsStatement()  {}
 
 func (n *MethodInvocation) WithPrefix(prefix Space) *MethodInvocation {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *MethodInvocation) WithMarkers(markers Markers) *MethodInvocation {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *MethodInvocation) WithName(name *Identifier) *MethodInvocation {
+	if n.Name == name {
+		return n
+	}
 	c := *n
 	c.Name = name
 	return &c
 }
 
 func (n *MethodInvocation) WithTypeParameters(typeParameters *Container[Expression]) *MethodInvocation {
+	if n.TypeParameters == typeParameters {
+		return n
+	}
 	c := *n
 	c.TypeParameters = typeParameters
 	return &c
@@ -1179,18 +1407,27 @@ func (*VariableDeclarations) IsJ()         {}
 func (*VariableDeclarations) IsStatement() {}
 
 func (n *VariableDeclarations) WithPrefix(prefix Space) *VariableDeclarations {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *VariableDeclarations) WithMarkers(markers Markers) *VariableDeclarations {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *VariableDeclarations) WithLeadingAnnotations(anns []*Annotation) *VariableDeclarations {
+	if SameSlice(n.LeadingAnnotations, anns) {
+		return n
+	}
 	c := *n
 	c.LeadingAnnotations = anns
 	return &c
@@ -1208,18 +1445,27 @@ func (*VariableDeclarator) IsTree() {}
 func (*VariableDeclarator) IsJ()    {}
 
 func (n *VariableDeclarator) WithPrefix(prefix Space) *VariableDeclarator {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *VariableDeclarator) WithMarkers(markers Markers) *VariableDeclarator {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
 }
 
 func (n *VariableDeclarator) WithName(name *Identifier) *VariableDeclarator {
+	if n.Name == name {
+		return n
+	}
 	c := *n
 	c.Name = name
 	return &c
@@ -1241,12 +1487,18 @@ func (*ArrayType) IsJ()          {}
 func (*ArrayType) IsExpression() {}
 
 func (n *ArrayType) WithPrefix(prefix Space) *ArrayType {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *ArrayType) WithMarkers(markers Markers) *ArrayType {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -1264,12 +1516,18 @@ func (*Parentheses) IsJ()          {}
 func (*Parentheses) IsExpression() {}
 
 func (n *Parentheses) WithPrefix(prefix Space) *Parentheses {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Parentheses) WithMarkers(markers Markers) *Parentheses {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -1288,12 +1546,18 @@ func (*TypeCast) IsJ()          {}
 func (*TypeCast) IsExpression() {}
 
 func (n *TypeCast) WithPrefix(prefix Space) *TypeCast {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *TypeCast) WithMarkers(markers Markers) *TypeCast {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -1311,12 +1575,18 @@ func (*ControlParentheses) IsJ()          {}
 func (*ControlParentheses) IsExpression() {}
 
 func (n *ControlParentheses) WithPrefix(prefix Space) *ControlParentheses {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *ControlParentheses) WithMarkers(markers Markers) *ControlParentheses {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -1343,12 +1613,18 @@ func (*ArrayAccess) IsJ()          {}
 func (*ArrayAccess) IsExpression() {}
 
 func (n *ArrayAccess) WithPrefix(prefix Space) *ArrayAccess {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *ArrayAccess) WithMarkers(markers Markers) *ArrayAccess {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -1358,12 +1634,18 @@ func (*ArrayDimension) IsTree() {}
 func (*ArrayDimension) IsJ()    {}
 
 func (n *ArrayDimension) WithPrefix(prefix Space) *ArrayDimension {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *ArrayDimension) WithMarkers(markers Markers) *ArrayDimension {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -1383,12 +1665,18 @@ func (*ParameterizedType) IsJ()          {}
 func (*ParameterizedType) IsExpression() {}
 
 func (n *ParameterizedType) WithPrefix(prefix Space) *ParameterizedType {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *ParameterizedType) WithMarkers(markers Markers) *ParameterizedType {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c
@@ -1406,12 +1694,18 @@ func (*Import) IsTree() {}
 func (*Import) IsJ()    {}
 
 func (n *Import) WithPrefix(prefix Space) *Import {
+	if SpaceEqual(n.Prefix, prefix) {
+		return n
+	}
 	c := *n
 	c.Prefix = prefix
 	return &c
 }
 
 func (n *Import) WithMarkers(markers Markers) *Import {
+	if MarkersEqual(n.Markers, markers) {
+		return n
+	}
 	c := *n
 	c.Markers = markers
 	return &c

--- a/rewrite-go/pkg/visitor/go_visitor.go
+++ b/rewrite-go/pkg/visitor/go_visitor.go
@@ -17,6 +17,8 @@
 package visitor
 
 import (
+	"reflect"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
@@ -378,24 +380,47 @@ var _ VisitorI = (*GoVisitor)(nil)
 func (v *GoVisitor) PreVisit(t java.Tree, p any) java.Tree { return t }
 
 func (v *GoVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p any) java.J {
-	cu = cu.WithPrefix(v.self().VisitSpace(cu.Prefix, p))
-	cu = cu.WithMarkers(v.visitMarkers(cu.Markers, p))
-	if cu.PackageDecl != nil {
-		pkg := *cu.PackageDecl
-		pkg.Element = visitAndCast[*java.Identifier](v, pkg.Element, p)
-		pkg.After = v.self().VisitSpace(pkg.After, p)
-		cu = cu.WithPackageDecl(&pkg)
+	prefix := v.self().VisitSpace(cu.Prefix, p)
+	markers := v.visitMarkers(cu.Markers, p)
+	pkg := cu.PackageDecl
+	if pkg != nil {
+		elem := visitAndCast[*java.Identifier](v, pkg.Element, p)
+		after := v.self().VisitSpace(pkg.After, p)
+		if elem != pkg.Element || !java.SpaceEqual(after, pkg.After) {
+			c := *pkg
+			c.Element = elem
+			c.After = after
+			pkg = &c
+		}
 	}
-	if cu.Imports != nil {
-		imports := *cu.Imports
-		imports.Before = v.self().VisitSpace(imports.Before, p)
-		imports.Markers = v.visitMarkers(imports.Markers, p)
-		imports.Elements = visitRightPaddedList(v, imports.Elements, p)
-		cu = cu.WithImports(&imports)
+	imports := cu.Imports
+	if imports != nil {
+		before := v.self().VisitSpace(imports.Before, p)
+		impMarkers := v.visitMarkers(imports.Markers, p)
+		elems := visitRightPaddedList(v, imports.Elements, p)
+		if !java.SpaceEqual(before, imports.Before) || !java.MarkersEqual(impMarkers, imports.Markers) || !java.SameSlice(elems, imports.Elements) {
+			c := *imports
+			c.Before = before
+			c.Markers = impMarkers
+			c.Elements = elems
+			imports = &c
+		}
 	}
-	cu = cu.WithStatements(visitRightPaddedList(v, cu.Statements, p))
-	cu = cu.WithEOF(v.self().VisitSpace(cu.EOF, p))
-	return cu
+	statements := visitRightPaddedList(v, cu.Statements, p)
+	eof := v.self().VisitSpace(cu.EOF, p)
+	if java.SpaceEqual(prefix, cu.Prefix) && java.MarkersEqual(markers, cu.Markers) &&
+		pkg == cu.PackageDecl && imports == cu.Imports &&
+		java.SameSlice(statements, cu.Statements) && java.SpaceEqual(eof, cu.EOF) {
+		return cu
+	}
+	c := *cu
+	c.Prefix = prefix
+	c.Markers = markers
+	c.PackageDecl = pkg
+	c.Imports = imports
+	c.Statements = statements
+	c.EOF = eof
+	return &c
 }
 
 func (v *GoVisitor) VisitGoMod(gm *golang.GoMod, p any) java.Tree {
@@ -409,25 +434,28 @@ func (v *GoVisitor) VisitGoMod(gm *golang.GoMod, p any) java.Tree {
 func (v *GoVisitor) VisitGoModDirective(d *golang.GoModDirective, p any) java.Tree {
 	d = d.WithPrefix(v.self().VisitSpace(d.Prefix, p))
 	d = d.WithMarkers(v.visitMarkers(d.Markers, p))
-	values := make([]*golang.GoModValue, 0, len(d.Values))
-	for _, val := range d.Values {
-		visited := v.self().Visit(val, p)
-		if visited == nil {
-			continue
-		}
-		values = append(values, visited.(*golang.GoModValue))
-	}
-	d = d.WithValues(values)
+	d = d.WithValues(visitGoModValueList(v, d.Values, p))
 	return d
 }
 
 func (v *GoVisitor) VisitGoModBlock(b *golang.GoModBlock, p any) java.Tree {
-	b = b.WithPrefix(v.self().VisitSpace(b.Prefix, p))
-	b = b.WithMarkers(v.visitMarkers(b.Markers, p))
-	b.BeforeLParen = v.self().VisitSpace(b.BeforeLParen, p)
-	b = b.WithEntries(visitGoModStatementList(v, b.Entries, p))
-	b.BeforeRParen = v.self().VisitSpace(b.BeforeRParen, p)
-	return b
+	prefix := v.self().VisitSpace(b.Prefix, p)
+	markers := v.visitMarkers(b.Markers, p)
+	beforeLParen := v.self().VisitSpace(b.BeforeLParen, p)
+	entries := visitGoModStatementList(v, b.Entries, p)
+	beforeRParen := v.self().VisitSpace(b.BeforeRParen, p)
+	if java.SpaceEqual(prefix, b.Prefix) && java.MarkersEqual(markers, b.Markers) &&
+		java.SpaceEqual(beforeLParen, b.BeforeLParen) && java.SameSlice(entries, b.Entries) &&
+		java.SpaceEqual(beforeRParen, b.BeforeRParen) {
+		return b
+	}
+	c := *b
+	c.Prefix = prefix
+	c.Markers = markers
+	c.BeforeLParen = beforeLParen
+	c.Entries = entries
+	c.BeforeRParen = beforeRParen
+	return &c
 }
 
 func (v *GoVisitor) VisitGoModValue(val *golang.GoModValue, p any) java.Tree {
@@ -479,227 +507,388 @@ func (v *GoVisitor) VisitBlock(block *java.Block, p any) java.J {
 }
 
 func (v *GoVisitor) VisitReturn(ret *java.Return, p any) java.J {
-	ret = ret.WithPrefix(v.self().VisitSpace(ret.Prefix, p))
-	ret = ret.WithMarkers(v.visitMarkers(ret.Markers, p))
-	if ret.Expression != nil {
-		ret.Expression = visitAndCast[java.Expression](v, ret.Expression, p)
+	prefix := v.self().VisitSpace(ret.Prefix, p)
+	markers := v.visitMarkers(ret.Markers, p)
+	expr := ret.Expression
+	if expr != nil {
+		expr = visitAndCast[java.Expression](v, expr, p)
 	}
-	return ret
+	if java.SpaceEqual(prefix, ret.Prefix) && java.MarkersEqual(markers, ret.Markers) && expr == ret.Expression {
+		return ret
+	}
+	c := *ret
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Expression = expr
+	return &c
 }
 
 func (v *GoVisitor) VisitGoReturn(ret *golang.Return, p any) java.J {
+	prefix := v.self().VisitSpace(ret.Prefix, p)
+	markers := v.visitMarkers(ret.Markers, p)
+	exprs := visitRightPaddedExpressionList(v, ret.Expressions, p)
+	if java.SpaceEqual(prefix, ret.Prefix) && java.MarkersEqual(markers, ret.Markers) && java.SameSlice(exprs, ret.Expressions) {
+		return ret
+	}
 	c := *ret
-	c.Prefix = v.self().VisitSpace(c.Prefix, p)
-	c.Markers = v.visitMarkers(c.Markers, p)
-	c.Expressions = visitRightPaddedExpressionList(v, c.Expressions, p)
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Expressions = exprs
 	return &c
 }
 
 func (v *GoVisitor) VisitIf(ifStmt *java.If, p any) java.J {
-	ifStmt = ifStmt.WithPrefix(v.self().VisitSpace(ifStmt.Prefix, p))
-	ifStmt = ifStmt.WithMarkers(v.visitMarkers(ifStmt.Markers, p))
-	ifStmt = ifStmt.WithCondition(visitAndCast[*java.ControlParentheses](v, ifStmt.Condition, p))
+	prefix := v.self().VisitSpace(ifStmt.Prefix, p)
+	markers := v.visitMarkers(ifStmt.Markers, p)
+	condition := visitAndCast[*java.ControlParentheses](v, ifStmt.Condition, p)
 	thenPart := ifStmt.ThenPart
-	thenPart.Element = v.self().Visit(thenPart.Element, p).(java.Statement)
-	thenPart.After = v.self().VisitSpace(thenPart.After, p)
-	ifStmt = ifStmt.WithThenPart(thenPart)
-	if ifStmt.ElsePart != nil {
-		ifStmt = ifStmt.WithElsePart(visitAndCast[*java.Else](v, ifStmt.ElsePart, p))
+	thenPart.Element = v.self().Visit(ifStmt.ThenPart.Element, p).(java.Statement)
+	thenPart.After = v.self().VisitSpace(ifStmt.ThenPart.After, p)
+	elsePart := ifStmt.ElsePart
+	if elsePart != nil {
+		elsePart = visitAndCast[*java.Else](v, ifStmt.ElsePart, p)
 	}
-	return ifStmt
+	if java.SpaceEqual(prefix, ifStmt.Prefix) && java.MarkersEqual(markers, ifStmt.Markers) &&
+		condition == ifStmt.Condition && java.RightPaddedEqual(thenPart, ifStmt.ThenPart) && elsePart == ifStmt.ElsePart {
+		return ifStmt
+	}
+	c := *ifStmt
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Condition = condition
+	c.ThenPart = thenPart
+	c.ElsePart = elsePart
+	return &c
 }
 
 func (v *GoVisitor) VisitElse(el *java.Else, p any) java.J {
-	el = el.WithPrefix(v.self().VisitSpace(el.Prefix, p))
-	el = el.WithMarkers(v.visitMarkers(el.Markers, p))
-	body := el.Body
-	body.Element = v.self().Visit(body.Element, p).(java.Statement)
-	body.After = v.self().VisitSpace(body.After, p)
-	el.Body = body
-	return el
+	prefix := v.self().VisitSpace(el.Prefix, p)
+	markers := v.visitMarkers(el.Markers, p)
+	bodyElem := v.self().Visit(el.Body.Element, p).(java.Statement)
+	bodyAfter := v.self().VisitSpace(el.Body.After, p)
+	if java.SpaceEqual(prefix, el.Prefix) && java.MarkersEqual(markers, el.Markers) &&
+		bodyElem == el.Body.Element && java.SpaceEqual(bodyAfter, el.Body.After) {
+		return el
+	}
+	c := *el
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Body.Element = bodyElem
+	c.Body.After = bodyAfter
+	return &c
 }
 
 func (v *GoVisitor) VisitAssignment(assign *java.Assignment, p any) java.J {
-	assign = assign.WithPrefix(v.self().VisitSpace(assign.Prefix, p))
-	assign = assign.WithMarkers(v.visitMarkers(assign.Markers, p))
-	assign = assign.WithVariable(visitExpression(v, assign.Variable, p))
-	assign.Value.Before = v.self().VisitSpace(assign.Value.Before, p)
-	assign.Value.Element = visitExpression(v, assign.Value.Element, p)
-	return assign
+	prefix := v.self().VisitSpace(assign.Prefix, p)
+	markers := v.visitMarkers(assign.Markers, p)
+	variable := visitExpression(v, assign.Variable, p)
+	valueBefore := v.self().VisitSpace(assign.Value.Before, p)
+	valueElem := visitExpression(v, assign.Value.Element, p)
+	if java.SpaceEqual(prefix, assign.Prefix) && java.MarkersEqual(markers, assign.Markers) &&
+		variable == assign.Variable &&
+		java.SpaceEqual(valueBefore, assign.Value.Before) && valueElem == assign.Value.Element {
+		return assign
+	}
+	c := *assign
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Variable = variable
+	c.Value.Before = valueBefore
+	c.Value.Element = valueElem
+	return &c
 }
 
 func (v *GoVisitor) VisitMethodDeclaration(md *java.MethodDeclaration, p any) java.J {
-	md = md.WithPrefix(v.self().VisitSpace(md.Prefix, p))
-	md = md.WithMarkers(v.visitMarkers(md.Markers, p))
-	if len(md.LeadingAnnotations) > 0 {
-		anns := make([]*java.Annotation, 0, len(md.LeadingAnnotations))
-		for _, a := range md.LeadingAnnotations {
-			visited := v.self().Visit(a, p)
-			if visited == nil {
-				continue
-			}
-			anns = append(anns, visited.(*java.Annotation))
-		}
-		md = md.WithLeadingAnnotations(anns)
+	prefix := v.self().VisitSpace(md.Prefix, p)
+	markers := v.visitMarkers(md.Markers, p)
+	anns := visitAnnotationList(v, md.LeadingAnnotations, p)
+	name := visitAndCast[*java.Identifier](v, md.Name, p)
+	tps := md.TypeParameters
+	if tps != nil {
+		tps = visitAndCast[*java.TypeParameters](v, tps, p)
 	}
-	md = md.WithName(visitAndCast[*java.Identifier](v, md.Name, p))
-	if md.TypeParameters != nil {
-		md = md.WithTypeParameters(visitAndCast[*java.TypeParameters](v, md.TypeParameters, p))
+	paramsBefore := v.self().VisitSpace(md.Parameters.Before, p)
+	paramsElems := visitRightPaddedList(v, md.Parameters.Elements, p)
+	returnType := md.ReturnType
+	if returnType != nil {
+		returnType = visitExpression(v, returnType, p)
 	}
-	md.Parameters.Before = v.self().VisitSpace(md.Parameters.Before, p)
-	md.Parameters.Elements = visitRightPaddedList(v, md.Parameters.Elements, p)
-	if md.ReturnType != nil {
-		md.ReturnType = visitExpression(v, md.ReturnType, p)
+	body := md.Body
+	if body != nil {
+		body = visitAndCast[*java.Block](v, body, p)
 	}
-	if md.Body != nil {
-		md = md.WithBody(visitAndCast[*java.Block](v, md.Body, p))
+	if java.SpaceEqual(prefix, md.Prefix) && java.MarkersEqual(markers, md.Markers) &&
+		java.SameSlice(anns, md.LeadingAnnotations) && name == md.Name && tps == md.TypeParameters &&
+		java.SpaceEqual(paramsBefore, md.Parameters.Before) && java.SameSlice(paramsElems, md.Parameters.Elements) &&
+		returnType == md.ReturnType && body == md.Body {
+		return md
 	}
-	return md
+	c := *md
+	c.Prefix = prefix
+	c.Markers = markers
+	c.LeadingAnnotations = anns
+	c.Name = name
+	c.TypeParameters = tps
+	c.Parameters.Before = paramsBefore
+	c.Parameters.Elements = paramsElems
+	c.ReturnType = returnType
+	c.Body = body
+	return &c
 }
 
 func (v *GoVisitor) VisitGoMethodDeclaration(md *golang.MethodDeclaration, p any) java.J {
+	prefix := v.self().VisitSpace(md.Prefix, p)
+	markers := v.visitMarkers(md.Markers, p)
+	recvBefore := v.self().VisitSpace(md.Receiver.Before, p)
+	recvElems := visitRightPaddedList(v, md.Receiver.Elements, p)
+	decl := visitAndCast[*java.MethodDeclaration](v, md.Declaration, p)
+	if java.SpaceEqual(prefix, md.Prefix) && java.MarkersEqual(markers, md.Markers) &&
+		java.SpaceEqual(recvBefore, md.Receiver.Before) && java.SameSlice(recvElems, md.Receiver.Elements) &&
+		decl == md.Declaration {
+		return md
+	}
 	c := *md
-	c.Prefix = v.self().VisitSpace(c.Prefix, p)
-	c.Markers = v.visitMarkers(c.Markers, p)
-	c.Receiver.Before = v.self().VisitSpace(c.Receiver.Before, p)
-	c.Receiver.Elements = visitRightPaddedList(v, c.Receiver.Elements, p)
-	c.Declaration = visitAndCast[*java.MethodDeclaration](v, c.Declaration, p)
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Receiver.Before = recvBefore
+	c.Receiver.Elements = recvElems
+	c.Declaration = decl
 	return &c
 }
 
 func (v *GoVisitor) VisitStatementWithInit(s *golang.StatementWithInit, p any) java.J {
+	prefix := v.self().VisitSpace(s.Prefix, p)
+	markers := v.visitMarkers(s.Markers, p)
+	initElem := v.self().Visit(s.Init.Element, p).(java.Statement)
+	initAfter := v.self().VisitSpace(s.Init.After, p)
+	stmt := v.self().Visit(s.Statement, p).(java.Statement)
+	if java.SpaceEqual(prefix, s.Prefix) && java.MarkersEqual(markers, s.Markers) &&
+		initElem == s.Init.Element && java.SpaceEqual(initAfter, s.Init.After) && stmt == s.Statement {
+		return s
+	}
 	c := *s
-	c.Prefix = v.self().VisitSpace(c.Prefix, p)
-	c.Markers = v.visitMarkers(c.Markers, p)
-	c.Init.Element = v.self().Visit(c.Init.Element, p).(java.Statement)
-	c.Init.After = v.self().VisitSpace(c.Init.After, p)
-	c.Statement = v.self().Visit(c.Statement, p).(java.Statement)
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Init.Element = initElem
+	c.Init.After = initAfter
+	c.Statement = stmt
 	return &c
 }
 
 func (v *GoVisitor) VisitTypeParameters(tps *java.TypeParameters, p any) java.J {
-	tps = tps.WithPrefix(v.self().VisitSpace(tps.Prefix, p))
-	tps = tps.WithMarkers(v.visitMarkers(tps.Markers, p))
-	tps.TypeParameters = visitRightPaddedList(v, tps.TypeParameters, p)
-	return tps
+	prefix := v.self().VisitSpace(tps.Prefix, p)
+	markers := v.visitMarkers(tps.Markers, p)
+	params := visitRightPaddedList(v, tps.TypeParameters, p)
+	if java.SpaceEqual(prefix, tps.Prefix) && java.MarkersEqual(markers, tps.Markers) &&
+		java.SameSlice(params, tps.TypeParameters) {
+		return tps
+	}
+	c := *tps
+	c.Prefix = prefix
+	c.Markers = markers
+	c.TypeParameters = params
+	return &c
 }
 
 func (v *GoVisitor) VisitTypeParameter(tp *java.TypeParameter, p any) java.J {
-	tp = tp.WithPrefix(v.self().VisitSpace(tp.Prefix, p))
-	tp = tp.WithMarkers(v.visitMarkers(tp.Markers, p))
-	if tp.Name != nil {
-		tp.Name = visitExpression(v, tp.Name, p)
+	prefix := v.self().VisitSpace(tp.Prefix, p)
+	markers := v.visitMarkers(tp.Markers, p)
+	name := tp.Name
+	if name != nil {
+		name = visitExpression(v, name, p)
 	}
-	if tp.Bounds != nil {
-		tp.Bounds.Before = v.self().VisitSpace(tp.Bounds.Before, p)
-		tp.Bounds.Elements = visitRightPaddedList(v, tp.Bounds.Elements, p)
+	bounds := tp.Bounds
+	if bounds != nil {
+		before := v.self().VisitSpace(bounds.Before, p)
+		elems := visitRightPaddedList(v, bounds.Elements, p)
+		if !java.SpaceEqual(before, bounds.Before) || !java.SameSlice(elems, bounds.Elements) {
+			c := *bounds
+			c.Before = before
+			c.Elements = elems
+			bounds = &c
+		}
 	}
-	return tp
+	if java.SpaceEqual(prefix, tp.Prefix) && java.MarkersEqual(markers, tp.Markers) &&
+		name == tp.Name && bounds == tp.Bounds {
+		return tp
+	}
+	c := *tp
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Name = name
+	c.Bounds = bounds
+	return &c
 }
 
 func (v *GoVisitor) VisitFieldAccess(fa *java.FieldAccess, p any) java.J {
-	fa = fa.WithPrefix(v.self().VisitSpace(fa.Prefix, p))
-	fa = fa.WithMarkers(v.visitMarkers(fa.Markers, p))
-	fa = fa.WithTarget(visitExpression(v, fa.Target, p))
+	prefix := v.self().VisitSpace(fa.Prefix, p)
+	markers := v.visitMarkers(fa.Markers, p)
+	target := visitExpression(v, fa.Target, p)
 	// Visit the selector identifier so recipes that traverse identifiers
 	// see the right-hand side of `target.Name` (e.g. the `Box` in
 	// `a.Box[int]{...}`). Mirrors JavaIsoVisitor.visitFieldAccess.
-	name := fa.Name
-	name.Before = v.self().VisitSpace(name.Before, p)
-	name.Element = visitAndCast[*java.Identifier](v, name.Element, p)
-	fa.Name = name
-	return fa
+	nameBefore := v.self().VisitSpace(fa.Name.Before, p)
+	nameElem := visitAndCast[*java.Identifier](v, fa.Name.Element, p)
+	if java.SpaceEqual(prefix, fa.Prefix) && java.MarkersEqual(markers, fa.Markers) &&
+		target == fa.Target &&
+		java.SpaceEqual(nameBefore, fa.Name.Before) && nameElem == fa.Name.Element {
+		return fa
+	}
+	c := *fa
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Target = target
+	c.Name.Before = nameBefore
+	c.Name.Element = nameElem
+	return &c
 }
 
 func (v *GoVisitor) VisitMethodInvocation(mi *java.MethodInvocation, p any) java.J {
-	mi = mi.WithPrefix(v.self().VisitSpace(mi.Prefix, p))
-	mi = mi.WithMarkers(v.visitMarkers(mi.Markers, p))
-	if mi.Select != nil {
-		sel := *mi.Select
-		sel.Element = visitExpression(v, sel.Element, p)
-		sel.After = v.self().VisitSpace(sel.After, p)
-		mi.Select = &sel
+	prefix := v.self().VisitSpace(mi.Prefix, p)
+	markers := v.visitMarkers(mi.Markers, p)
+	sel := mi.Select
+	if sel != nil {
+		e := visitExpression(v, sel.Element, p)
+		a := v.self().VisitSpace(sel.After, p)
+		if e != sel.Element || !java.SpaceEqual(a, sel.After) {
+			c := *sel
+			c.Element = e
+			c.After = a
+			sel = &c
+		}
 	}
-	mi = mi.WithName(visitAndCast[*java.Identifier](v, mi.Name, p))
-	if mi.TypeParameters != nil {
-		tp := *mi.TypeParameters
-		tp.Before = v.self().VisitSpace(tp.Before, p)
-		tp.Elements = visitRightPaddedList(v, tp.Elements, p)
-		mi.TypeParameters = &tp
+	name := visitAndCast[*java.Identifier](v, mi.Name, p)
+	tps := mi.TypeParameters
+	if tps != nil {
+		before := v.self().VisitSpace(tps.Before, p)
+		elems := visitRightPaddedList(v, tps.Elements, p)
+		if !java.SpaceEqual(before, tps.Before) || !java.SameSlice(elems, tps.Elements) {
+			c := *tps
+			c.Before = before
+			c.Elements = elems
+			tps = &c
+		}
 	}
-	mi.Arguments.Before = v.self().VisitSpace(mi.Arguments.Before, p)
-	mi.Arguments.Elements = visitRightPaddedList(v, mi.Arguments.Elements, p)
-	return mi
+	argsBefore := v.self().VisitSpace(mi.Arguments.Before, p)
+	argsElems := visitRightPaddedList(v, mi.Arguments.Elements, p)
+	if java.SpaceEqual(prefix, mi.Prefix) && java.MarkersEqual(markers, mi.Markers) &&
+		sel == mi.Select && name == mi.Name && tps == mi.TypeParameters &&
+		java.SpaceEqual(argsBefore, mi.Arguments.Before) && java.SameSlice(argsElems, mi.Arguments.Elements) {
+		return mi
+	}
+	c := *mi
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Select = sel
+	c.Name = name
+	c.TypeParameters = tps
+	c.Arguments.Before = argsBefore
+	c.Arguments.Elements = argsElems
+	return &c
 }
 
 func (v *GoVisitor) VisitVariableDeclarations(vd *java.VariableDeclarations, p any) java.J {
-	vd = vd.WithPrefix(v.self().VisitSpace(vd.Prefix, p))
-	vd = vd.WithMarkers(v.visitMarkers(vd.Markers, p))
-	if len(vd.LeadingAnnotations) > 0 {
-		anns := make([]*java.Annotation, 0, len(vd.LeadingAnnotations))
-		for _, a := range vd.LeadingAnnotations {
-			visited := v.self().Visit(a, p)
-			if visited == nil {
-				continue
-			}
-			anns = append(anns, visited.(*java.Annotation))
-		}
-		vd = vd.WithLeadingAnnotations(anns)
+	prefix := v.self().VisitSpace(vd.Prefix, p)
+	markers := v.visitMarkers(vd.Markers, p)
+	anns := visitAnnotationList(v, vd.LeadingAnnotations, p)
+	typeExpr := vd.TypeExpr
+	if typeExpr != nil {
+		typeExpr = visitExpression(v, typeExpr, p)
 	}
-	if vd.TypeExpr != nil {
-		vd.TypeExpr = visitExpression(v, vd.TypeExpr, p)
+	variables := visitRightPaddedList(v, vd.Variables, p)
+	if java.SpaceEqual(prefix, vd.Prefix) && java.MarkersEqual(markers, vd.Markers) &&
+		java.SameSlice(anns, vd.LeadingAnnotations) && typeExpr == vd.TypeExpr &&
+		java.SameSlice(variables, vd.Variables) {
+		return vd
 	}
-	vd.Variables = visitRightPaddedList(v, vd.Variables, p)
-	return vd
+	c := *vd
+	c.Prefix = prefix
+	c.Markers = markers
+	c.LeadingAnnotations = anns
+	c.TypeExpr = typeExpr
+	c.Variables = variables
+	return &c
 }
 
 func (v *GoVisitor) VisitDeclarationBlock(db *golang.DeclarationBlock, p any) java.J {
-	db = db.WithPrefix(v.self().VisitSpace(db.Prefix, p))
-	db = db.WithMarkers(v.visitMarkers(db.Markers, p))
-	if len(db.LeadingAnnotations) > 0 {
-		anns := make([]*java.Annotation, 0, len(db.LeadingAnnotations))
-		for _, a := range db.LeadingAnnotations {
-			visited := v.self().Visit(a, p)
-			if visited == nil {
-				continue
-			}
-			anns = append(anns, visited.(*java.Annotation))
+	prefix := v.self().VisitSpace(db.Prefix, p)
+	markers := v.visitMarkers(db.Markers, p)
+	anns := visitAnnotationList(v, db.LeadingAnnotations, p)
+	specs := db.Specs
+	if specs != nil {
+		before := v.self().VisitSpace(specs.Before, p)
+		elems := visitRightPaddedList(v, specs.Elements, p)
+		if !java.SpaceEqual(before, specs.Before) || !java.SameSlice(elems, specs.Elements) {
+			c := *specs
+			c.Before = before
+			c.Elements = elems
+			specs = &c
 		}
-		db = db.WithLeadingAnnotations(anns)
 	}
-	if db.Specs != nil {
-		specs := *db.Specs
-		specs.Before = v.self().VisitSpace(specs.Before, p)
-		specs.Elements = visitRightPaddedList(v, specs.Elements, p)
-		db.Specs = &specs
+	if java.SpaceEqual(prefix, db.Prefix) && java.MarkersEqual(markers, db.Markers) &&
+		java.SameSlice(anns, db.LeadingAnnotations) && specs == db.Specs {
+		return db
 	}
-	return db
+	c := *db
+	c.Prefix = prefix
+	c.Markers = markers
+	c.LeadingAnnotations = anns
+	c.Specs = specs
+	return &c
 }
 
 func (v *GoVisitor) VisitVariableDeclarator(vd *java.VariableDeclarator, p any) java.J {
-	vd = vd.WithPrefix(v.self().VisitSpace(vd.Prefix, p))
-	vd = vd.WithMarkers(v.visitMarkers(vd.Markers, p))
-	vd = vd.WithName(visitAndCast[*java.Identifier](v, vd.Name, p))
-	if vd.Initializer != nil {
-		init := *vd.Initializer
-		init.Before = v.self().VisitSpace(init.Before, p)
-		init.Element = visitExpression(v, init.Element, p)
-		vd.Initializer = &init
+	prefix := v.self().VisitSpace(vd.Prefix, p)
+	markers := v.visitMarkers(vd.Markers, p)
+	name := visitAndCast[*java.Identifier](v, vd.Name, p)
+	init := vd.Initializer
+	if init != nil {
+		before := v.self().VisitSpace(init.Before, p)
+		elem := visitExpression(v, init.Element, p)
+		if !java.SpaceEqual(before, init.Before) || elem != init.Element {
+			c := *init
+			c.Before = before
+			c.Element = elem
+			init = &c
+		}
 	}
-	return vd
+	if java.SpaceEqual(prefix, vd.Prefix) && java.MarkersEqual(markers, vd.Markers) &&
+		name == vd.Name && init == vd.Initializer {
+		return vd
+	}
+	c := *vd
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Name = name
+	c.Initializer = init
+	return &c
 }
 
 func (v *GoVisitor) VisitImport(imp *java.Import, p any) java.J {
-	imp = imp.WithPrefix(v.self().VisitSpace(imp.Prefix, p))
-	imp = imp.WithMarkers(v.visitMarkers(imp.Markers, p))
-	if imp.Alias != nil {
-		alias := *imp.Alias
-		alias.Before = v.self().VisitSpace(alias.Before, p)
-		alias.Element = visitAndCast[*java.Identifier](v, alias.Element, p)
-		imp.Alias = &alias
+	prefix := v.self().VisitSpace(imp.Prefix, p)
+	markers := v.visitMarkers(imp.Markers, p)
+	alias := imp.Alias
+	if alias != nil {
+		before := v.self().VisitSpace(alias.Before, p)
+		elem := visitAndCast[*java.Identifier](v, alias.Element, p)
+		if !java.SpaceEqual(before, alias.Before) || elem != alias.Element {
+			c := *alias
+			c.Before = before
+			c.Element = elem
+			alias = &c
+		}
 	}
-	imp.Qualid = visitExpression(v, imp.Qualid, p)
-	return imp
+	qualid := visitExpression(v, imp.Qualid, p)
+	if java.SpaceEqual(prefix, imp.Prefix) && java.MarkersEqual(markers, imp.Markers) &&
+		alias == imp.Alias && qualid == imp.Qualid {
+		return imp
+	}
+	c := *imp
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Alias = alias
+	c.Qualid = qualid
+	return &c
 }
 
 func (v *GoVisitor) VisitUnary(unary *java.Unary, p any) java.J {
@@ -710,11 +899,20 @@ func (v *GoVisitor) VisitUnary(unary *java.Unary, p any) java.J {
 }
 
 func (v *GoVisitor) VisitAssignmentOperation(ao *java.AssignmentOperation, p any) java.J {
-	ao = ao.WithPrefix(v.self().VisitSpace(ao.Prefix, p))
-	ao = ao.WithMarkers(v.visitMarkers(ao.Markers, p))
-	ao = ao.WithVariable(visitExpression(v, ao.Variable, p))
-	ao.Assignment = visitExpression(v, ao.Assignment, p)
-	return ao
+	prefix := v.self().VisitSpace(ao.Prefix, p)
+	markers := v.visitMarkers(ao.Markers, p)
+	variable := visitExpression(v, ao.Variable, p)
+	assignment := visitExpression(v, ao.Assignment, p)
+	if java.SpaceEqual(prefix, ao.Prefix) && java.MarkersEqual(markers, ao.Markers) &&
+		variable == ao.Variable && assignment == ao.Assignment {
+		return ao
+	}
+	c := *ao
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Variable = variable
+	c.Assignment = assignment
+	return &c
 }
 
 func (v *GoVisitor) VisitSwitch(sw *java.Switch, p any) java.J {
@@ -724,45 +922,90 @@ func (v *GoVisitor) VisitSwitch(sw *java.Switch, p any) java.J {
 	return sw
 }
 
-func (v *GoVisitor) VisitCase(c *java.Case, p any) java.J {
-	c = c.WithPrefix(v.self().VisitSpace(c.Prefix, p))
-	c = c.WithMarkers(v.visitMarkers(c.Markers, p))
-	c.Expressions.Before = v.self().VisitSpace(c.Expressions.Before, p)
-	c.Expressions.Elements = visitRightPaddedExpressionList(v, c.Expressions.Elements, p)
-	c.Body = visitRightPaddedList(v, c.Body, p)
-	return c
+func (v *GoVisitor) VisitCase(cse *java.Case, p any) java.J {
+	prefix := v.self().VisitSpace(cse.Prefix, p)
+	markers := v.visitMarkers(cse.Markers, p)
+	exprsBefore := v.self().VisitSpace(cse.Expressions.Before, p)
+	exprsElems := visitRightPaddedExpressionList(v, cse.Expressions.Elements, p)
+	body := visitRightPaddedList(v, cse.Body, p)
+	if java.SpaceEqual(prefix, cse.Prefix) && java.MarkersEqual(markers, cse.Markers) &&
+		java.SpaceEqual(exprsBefore, cse.Expressions.Before) && java.SameSlice(exprsElems, cse.Expressions.Elements) &&
+		java.SameSlice(body, cse.Body) {
+		return cse
+	}
+	c := *cse
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Expressions.Before = exprsBefore
+	c.Expressions.Elements = exprsElems
+	c.Body = body
+	return &c
 }
 
 func (v *GoVisitor) VisitForLoop(forLoop *java.ForLoop, p any) java.J {
-	forLoop = forLoop.WithPrefix(v.self().VisitSpace(forLoop.Prefix, p))
-	forLoop = forLoop.WithMarkers(v.visitMarkers(forLoop.Markers, p))
-	forLoop.Control = *visitAndCast[*java.ForControl](v, &forLoop.Control, p)
-	forLoop = forLoop.WithBody(visitAndCast[*java.Block](v, forLoop.Body, p))
-	return forLoop
+	prefix := v.self().VisitSpace(forLoop.Prefix, p)
+	markers := v.visitMarkers(forLoop.Markers, p)
+	ctrl := visitAndCast[*java.ForControl](v, &forLoop.Control, p)
+	body := visitAndCast[*java.Block](v, forLoop.Body, p)
+	if java.SpaceEqual(prefix, forLoop.Prefix) && java.MarkersEqual(markers, forLoop.Markers) &&
+		ctrl == &forLoop.Control && body == forLoop.Body {
+		return forLoop
+	}
+	c := *forLoop
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Control = *ctrl
+	c.Body = body
+	return &c
 }
 
 func (v *GoVisitor) VisitForControl(control *java.ForControl, p any) java.J {
-	control = control.WithPrefix(v.self().VisitSpace(control.Prefix, p))
-	control = control.WithMarkers(v.visitMarkers(control.Markers, p))
-	if control.Init != nil {
-		init := *control.Init
-		init.Element = visitAndCast[java.Statement](v, init.Element, p)
-		init.After = v.self().VisitSpace(init.After, p)
-		control.Init = &init
+	prefix := v.self().VisitSpace(control.Prefix, p)
+	markers := v.visitMarkers(control.Markers, p)
+	init := control.Init
+	if init != nil {
+		elem := visitAndCast[java.Statement](v, init.Element, p)
+		after := v.self().VisitSpace(init.After, p)
+		if elem != init.Element || !java.SpaceEqual(after, init.After) {
+			c := *init
+			c.Element = elem
+			c.After = after
+			init = &c
+		}
 	}
-	if control.Condition != nil {
-		cond := *control.Condition
-		cond.Element = visitExpression(v, cond.Element, p)
-		cond.After = v.self().VisitSpace(cond.After, p)
-		control.Condition = &cond
+	cond := control.Condition
+	if cond != nil {
+		elem := visitExpression(v, cond.Element, p)
+		after := v.self().VisitSpace(cond.After, p)
+		if elem != cond.Element || !java.SpaceEqual(after, cond.After) {
+			c := *cond
+			c.Element = elem
+			c.After = after
+			cond = &c
+		}
 	}
-	if control.Update != nil {
-		update := *control.Update
-		update.Element = visitAndCast[java.Statement](v, update.Element, p)
-		update.After = v.self().VisitSpace(update.After, p)
-		control.Update = &update
+	update := control.Update
+	if update != nil {
+		elem := visitAndCast[java.Statement](v, update.Element, p)
+		after := v.self().VisitSpace(update.After, p)
+		if elem != update.Element || !java.SpaceEqual(after, update.After) {
+			c := *update
+			c.Element = elem
+			c.After = after
+			update = &c
+		}
 	}
-	return control
+	if java.SpaceEqual(prefix, control.Prefix) && java.MarkersEqual(markers, control.Markers) &&
+		init == control.Init && cond == control.Condition && update == control.Update {
+		return control
+	}
+	c := *control
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Init = init
+	c.Condition = cond
+	c.Update = update
+	return &c
 }
 
 func (v *GoVisitor) VisitForEachLoop(forEach *java.ForEachLoop, p any) java.J {
@@ -773,112 +1016,215 @@ func (v *GoVisitor) VisitForEachLoop(forEach *java.ForEachLoop, p any) java.J {
 }
 
 func (v *GoVisitor) VisitForEachControl(control *java.ForEachControl, p any) java.J {
-	control = control.WithPrefix(v.self().VisitSpace(control.Prefix, p))
-	control = control.WithMarkers(v.visitMarkers(control.Markers, p))
-	control.Variable.Element = visitAndCast[java.Statement](v, control.Variable.Element, p)
-	control.Variable.After = v.self().VisitSpace(control.Variable.After, p)
-	control.Iterable.Element = visitExpression(v, control.Iterable.Element, p)
-	control.Iterable.After = v.self().VisitSpace(control.Iterable.After, p)
-	return control
+	prefix := v.self().VisitSpace(control.Prefix, p)
+	markers := v.visitMarkers(control.Markers, p)
+	varElem := visitAndCast[java.Statement](v, control.Variable.Element, p)
+	varAfter := v.self().VisitSpace(control.Variable.After, p)
+	iterElem := visitExpression(v, control.Iterable.Element, p)
+	iterAfter := v.self().VisitSpace(control.Iterable.After, p)
+	if java.SpaceEqual(prefix, control.Prefix) && java.MarkersEqual(markers, control.Markers) &&
+		varElem == control.Variable.Element && java.SpaceEqual(varAfter, control.Variable.After) &&
+		iterElem == control.Iterable.Element && java.SpaceEqual(iterAfter, control.Iterable.After) {
+		return control
+	}
+	c := *control
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Variable.Element = varElem
+	c.Variable.After = varAfter
+	c.Iterable.Element = iterElem
+	c.Iterable.After = iterAfter
+	return &c
 }
 
 func (v *GoVisitor) VisitBreak(b *java.Break, p any) java.J {
-	b = b.WithPrefix(v.self().VisitSpace(b.Prefix, p))
-	b = b.WithMarkers(v.visitMarkers(b.Markers, p))
-	if b.Label != nil {
-		b.Label = visitAndCast[*java.Identifier](v, b.Label, p)
+	prefix := v.self().VisitSpace(b.Prefix, p)
+	markers := v.visitMarkers(b.Markers, p)
+	label := b.Label
+	if label != nil {
+		label = visitAndCast[*java.Identifier](v, label, p)
 	}
-	return b
+	if java.SpaceEqual(prefix, b.Prefix) && java.MarkersEqual(markers, b.Markers) && label == b.Label {
+		return b
+	}
+	c := *b
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Label = label
+	return &c
 }
 
-func (v *GoVisitor) VisitContinue(c *java.Continue, p any) java.J {
-	c = c.WithPrefix(v.self().VisitSpace(c.Prefix, p))
-	c = c.WithMarkers(v.visitMarkers(c.Markers, p))
-	if c.Label != nil {
-		c.Label = visitAndCast[*java.Identifier](v, c.Label, p)
+func (v *GoVisitor) VisitContinue(cont *java.Continue, p any) java.J {
+	prefix := v.self().VisitSpace(cont.Prefix, p)
+	markers := v.visitMarkers(cont.Markers, p)
+	label := cont.Label
+	if label != nil {
+		label = visitAndCast[*java.Identifier](v, label, p)
 	}
-	return c
+	if java.SpaceEqual(prefix, cont.Prefix) && java.MarkersEqual(markers, cont.Markers) && label == cont.Label {
+		return cont
+	}
+	c := *cont
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Label = label
+	return &c
 }
 
 func (v *GoVisitor) VisitLabel(l *java.Label, p any) java.J {
-	l = l.WithPrefix(v.self().VisitSpace(l.Prefix, p))
-	l = l.WithMarkers(v.visitMarkers(l.Markers, p))
-	l.Name.Element = visitAndCast[*java.Identifier](v, l.Name.Element, p)
-	l.Name.After = v.self().VisitSpace(l.Name.After, p)
-	l.Statement = visitAndCast[java.Statement](v, l.Statement, p)
-	return l
+	prefix := v.self().VisitSpace(l.Prefix, p)
+	markers := v.visitMarkers(l.Markers, p)
+	nameElem := visitAndCast[*java.Identifier](v, l.Name.Element, p)
+	nameAfter := v.self().VisitSpace(l.Name.After, p)
+	stmt := visitAndCast[java.Statement](v, l.Statement, p)
+	if java.SpaceEqual(prefix, l.Prefix) && java.MarkersEqual(markers, l.Markers) &&
+		nameElem == l.Name.Element && java.SpaceEqual(nameAfter, l.Name.After) && stmt == l.Statement {
+		return l
+	}
+	c := *l
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Name.Element = nameElem
+	c.Name.After = nameAfter
+	c.Statement = stmt
+	return &c
 }
 
 func (v *GoVisitor) VisitGoStmt(g *golang.GoStmt, p any) java.J {
-	g = g.WithPrefix(v.self().VisitSpace(g.Prefix, p))
-	g = g.WithMarkers(v.visitMarkers(g.Markers, p))
-	g.Expr = visitExpression(v, g.Expr, p)
-	return g
+	prefix := v.self().VisitSpace(g.Prefix, p)
+	markers := v.visitMarkers(g.Markers, p)
+	expr := visitExpression(v, g.Expr, p)
+	if java.SpaceEqual(prefix, g.Prefix) && java.MarkersEqual(markers, g.Markers) && expr == g.Expr {
+		return g
+	}
+	c := *g
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Expr = expr
+	return &c
 }
 
 func (v *GoVisitor) VisitDefer(d *golang.Defer, p any) java.J {
-	d = d.WithPrefix(v.self().VisitSpace(d.Prefix, p))
-	d = d.WithMarkers(v.visitMarkers(d.Markers, p))
-	d.Expr = visitExpression(v, d.Expr, p)
-	return d
+	prefix := v.self().VisitSpace(d.Prefix, p)
+	markers := v.visitMarkers(d.Markers, p)
+	expr := visitExpression(v, d.Expr, p)
+	if java.SpaceEqual(prefix, d.Prefix) && java.MarkersEqual(markers, d.Markers) && expr == d.Expr {
+		return d
+	}
+	c := *d
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Expr = expr
+	return &c
 }
 
 func (v *GoVisitor) VisitSend(s *golang.Send, p any) java.J {
-	s = s.WithPrefix(v.self().VisitSpace(s.Prefix, p))
-	s = s.WithMarkers(v.visitMarkers(s.Markers, p))
-	s.Channel = visitExpression(v, s.Channel, p)
-	s.Arrow.Before = v.self().VisitSpace(s.Arrow.Before, p)
-	s.Arrow.Element = visitExpression(v, s.Arrow.Element, p)
-	return s
+	prefix := v.self().VisitSpace(s.Prefix, p)
+	markers := v.visitMarkers(s.Markers, p)
+	channel := visitExpression(v, s.Channel, p)
+	arrowBefore := v.self().VisitSpace(s.Arrow.Before, p)
+	arrowElem := visitExpression(v, s.Arrow.Element, p)
+	if java.SpaceEqual(prefix, s.Prefix) && java.MarkersEqual(markers, s.Markers) &&
+		channel == s.Channel &&
+		java.SpaceEqual(arrowBefore, s.Arrow.Before) && arrowElem == s.Arrow.Element {
+		return s
+	}
+	c := *s
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Channel = channel
+	c.Arrow.Before = arrowBefore
+	c.Arrow.Element = arrowElem
+	return &c
 }
 
 func (v *GoVisitor) VisitGoto(g *golang.Goto, p any) java.J {
-	g = g.WithPrefix(v.self().VisitSpace(g.Prefix, p))
-	g = g.WithMarkers(v.visitMarkers(g.Markers, p))
-	if g.Label != nil {
-		g.Label = visitAndCast[*java.Identifier](v, g.Label, p)
+	prefix := v.self().VisitSpace(g.Prefix, p)
+	markers := v.visitMarkers(g.Markers, p)
+	label := g.Label
+	if label != nil {
+		label = visitAndCast[*java.Identifier](v, label, p)
 	}
-	return g
+	if java.SpaceEqual(prefix, g.Prefix) && java.MarkersEqual(markers, g.Markers) && label == g.Label {
+		return g
+	}
+	c := *g
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Label = label
+	return &c
 }
 
 func (v *GoVisitor) VisitGoUnary(u *golang.Unary, p any) java.J {
-	u = u.WithPrefix(v.self().VisitSpace(u.Prefix, p))
-	u = u.WithMarkers(v.visitMarkers(u.Markers, p))
-	op := u.Operator
-	op.Before = v.self().VisitSpace(op.Before, p)
-	u.Operator = op
-	u.Expression = visitAndCast[java.Expression](v, u.Expression, p)
-	return u
+	prefix := v.self().VisitSpace(u.Prefix, p)
+	markers := v.visitMarkers(u.Markers, p)
+	opBefore := v.self().VisitSpace(u.Operator.Before, p)
+	expr := visitAndCast[java.Expression](v, u.Expression, p)
+	if java.SpaceEqual(prefix, u.Prefix) && java.MarkersEqual(markers, u.Markers) &&
+		java.SpaceEqual(opBefore, u.Operator.Before) && expr == u.Expression {
+		return u
+	}
+	c := *u
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Operator.Before = opBefore
+	c.Expression = expr
+	return &c
 }
 
 func (v *GoVisitor) VisitGoBinary(b *golang.Binary, p any) java.J {
-	b = b.WithPrefix(v.self().VisitSpace(b.Prefix, p))
-	b = b.WithMarkers(v.visitMarkers(b.Markers, p))
-	b.Left = visitAndCast[java.Expression](v, b.Left, p)
-	op := b.Operator
-	op.Before = v.self().VisitSpace(op.Before, p)
-	b.Operator = op
-	b.Right = visitAndCast[java.Expression](v, b.Right, p)
-	return b
+	prefix := v.self().VisitSpace(b.Prefix, p)
+	markers := v.visitMarkers(b.Markers, p)
+	left := visitAndCast[java.Expression](v, b.Left, p)
+	opBefore := v.self().VisitSpace(b.Operator.Before, p)
+	right := visitAndCast[java.Expression](v, b.Right, p)
+	if java.SpaceEqual(prefix, b.Prefix) && java.MarkersEqual(markers, b.Markers) &&
+		left == b.Left && java.SpaceEqual(opBefore, b.Operator.Before) && right == b.Right {
+		return b
+	}
+	c := *b
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Left = left
+	c.Operator.Before = opBefore
+	c.Right = right
+	return &c
 }
 
 func (v *GoVisitor) VisitGoAssignmentOperation(a *golang.AssignmentOperation, p any) java.J {
-	a = a.WithPrefix(v.self().VisitSpace(a.Prefix, p))
-	a = a.WithMarkers(v.visitMarkers(a.Markers, p))
-	a.Variable = visitAndCast[java.Expression](v, a.Variable, p)
-	op := a.Operator
-	op.Before = v.self().VisitSpace(op.Before, p)
-	a.Operator = op
-	a.Assignment = visitAndCast[java.Expression](v, a.Assignment, p)
-	return a
+	prefix := v.self().VisitSpace(a.Prefix, p)
+	markers := v.visitMarkers(a.Markers, p)
+	variable := visitAndCast[java.Expression](v, a.Variable, p)
+	opBefore := v.self().VisitSpace(a.Operator.Before, p)
+	assignment := visitAndCast[java.Expression](v, a.Assignment, p)
+	if java.SpaceEqual(prefix, a.Prefix) && java.MarkersEqual(markers, a.Markers) &&
+		variable == a.Variable && java.SpaceEqual(opBefore, a.Operator.Before) && assignment == a.Assignment {
+		return a
+	}
+	c := *a
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Variable = variable
+	c.Operator.Before = opBefore
+	c.Assignment = assignment
+	return &c
 }
 
 func (v *GoVisitor) VisitGoVariadic(vr *golang.Variadic, p any) java.J {
-	vr = vr.WithPrefix(v.self().VisitSpace(vr.Prefix, p))
-	vr = vr.WithMarkers(v.visitMarkers(vr.Markers, p))
-	vr.Element = visitAndCast[java.Expression](v, vr.Element, p)
-	vr.Dots = v.self().VisitSpace(vr.Dots, p)
-	return vr
+	prefix := v.self().VisitSpace(vr.Prefix, p)
+	markers := v.visitMarkers(vr.Markers, p)
+	elem := visitAndCast[java.Expression](v, vr.Element, p)
+	dots := v.self().VisitSpace(vr.Dots, p)
+	if java.SpaceEqual(prefix, vr.Prefix) && java.MarkersEqual(markers, vr.Markers) &&
+		elem == vr.Element && java.SpaceEqual(dots, vr.Dots) {
+		return vr
+	}
+	c := *vr
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Element = elem
+	c.Dots = dots
+	return &c
 }
 
 func (v *GoVisitor) VisitFallthrough(f *golang.Fallthrough, p any) java.J {
@@ -893,283 +1239,562 @@ func (v *GoVisitor) VisitEmpty(empty *java.Empty, p any) java.J {
 }
 
 func (v *GoVisitor) VisitAnnotation(ann *java.Annotation, p any) java.J {
-	ann = ann.WithPrefix(v.self().VisitSpace(ann.Prefix, p))
-	ann = ann.WithMarkers(v.visitMarkers(ann.Markers, p))
-	if ann.AnnotationType != nil {
-		ann = ann.WithAnnotationType(visitExpression(v, ann.AnnotationType, p))
+	prefix := v.self().VisitSpace(ann.Prefix, p)
+	markers := v.visitMarkers(ann.Markers, p)
+	annType := ann.AnnotationType
+	if annType != nil {
+		annType = visitExpression(v, annType, p)
 	}
-	if ann.Arguments != nil {
-		args := *ann.Arguments
-		args.Before = v.self().VisitSpace(args.Before, p)
-		args.Markers = v.visitMarkers(args.Markers, p)
-		args.Elements = visitRightPaddedExpressionList(v, args.Elements, p)
-		ann = ann.WithArguments(&args)
+	args := ann.Arguments
+	if args != nil {
+		before := v.self().VisitSpace(args.Before, p)
+		argMarkers := v.visitMarkers(args.Markers, p)
+		elems := visitRightPaddedExpressionList(v, args.Elements, p)
+		if !java.SpaceEqual(before, args.Before) || !java.MarkersEqual(argMarkers, args.Markers) || !java.SameSlice(elems, args.Elements) {
+			c := *args
+			c.Before = before
+			c.Markers = argMarkers
+			c.Elements = elems
+			args = &c
+		}
 	}
-	return ann
+	if java.SpaceEqual(prefix, ann.Prefix) && java.MarkersEqual(markers, ann.Markers) &&
+		annType == ann.AnnotationType && args == ann.Arguments {
+		return ann
+	}
+	c := *ann
+	c.Prefix = prefix
+	c.Markers = markers
+	c.AnnotationType = annType
+	c.Arguments = args
+	return &c
 }
 
 func (v *GoVisitor) VisitArrayType(at *java.ArrayType, p any) java.J {
-	at = at.WithPrefix(v.self().VisitSpace(at.Prefix, p))
-	at = at.WithMarkers(v.visitMarkers(at.Markers, p))
-	at.Dimension.Before = v.self().VisitSpace(at.Dimension.Before, p)
-	at.Dimension.Element = v.self().VisitSpace(at.Dimension.Element, p)
-	at.ElementType = visitExpression(v, at.ElementType, p)
-	return at
+	prefix := v.self().VisitSpace(at.Prefix, p)
+	markers := v.visitMarkers(at.Markers, p)
+	dimBefore := v.self().VisitSpace(at.Dimension.Before, p)
+	dimElem := v.self().VisitSpace(at.Dimension.Element, p)
+	elemType := visitExpression(v, at.ElementType, p)
+	if java.SpaceEqual(prefix, at.Prefix) && java.MarkersEqual(markers, at.Markers) &&
+		java.SpaceEqual(dimBefore, at.Dimension.Before) && java.SpaceEqual(dimElem, at.Dimension.Element) &&
+		elemType == at.ElementType {
+		return at
+	}
+	c := *at
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Dimension.Before = dimBefore
+	c.Dimension.Element = dimElem
+	c.ElementType = elemType
+	return &c
 }
 
 func (v *GoVisitor) VisitGoArrayType(at *golang.ArrayType, p any) java.J {
-	at = at.WithPrefix(v.self().VisitSpace(at.Prefix, p))
-	at = at.WithMarkers(v.visitMarkers(at.Markers, p))
-	at.Length.Element = visitExpression(v, at.Length.Element, p)
-	at.Length.After = v.self().VisitSpace(at.Length.After, p)
-	at.ElementType = visitExpression(v, at.ElementType, p)
-	return at
+	prefix := v.self().VisitSpace(at.Prefix, p)
+	markers := v.visitMarkers(at.Markers, p)
+	lenElem := visitExpression(v, at.Length.Element, p)
+	lenAfter := v.self().VisitSpace(at.Length.After, p)
+	elemType := visitExpression(v, at.ElementType, p)
+	if java.SpaceEqual(prefix, at.Prefix) && java.MarkersEqual(markers, at.Markers) &&
+		lenElem == at.Length.Element && java.SpaceEqual(lenAfter, at.Length.After) &&
+		elemType == at.ElementType {
+		return at
+	}
+	c := *at
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Length.Element = lenElem
+	c.Length.After = lenAfter
+	c.ElementType = elemType
+	return &c
 }
 
 func (v *GoVisitor) VisitParentheses(paren *java.Parentheses, p any) java.J {
-	paren = paren.WithPrefix(v.self().VisitSpace(paren.Prefix, p))
-	paren = paren.WithMarkers(v.visitMarkers(paren.Markers, p))
-	paren.Tree.Element = visitExpression(v, paren.Tree.Element, p)
-	paren.Tree.After = v.self().VisitSpace(paren.Tree.After, p)
-	return paren
+	prefix := v.self().VisitSpace(paren.Prefix, p)
+	markers := v.visitMarkers(paren.Markers, p)
+	treeElem := visitExpression(v, paren.Tree.Element, p)
+	treeAfter := v.self().VisitSpace(paren.Tree.After, p)
+	if java.SpaceEqual(prefix, paren.Prefix) && java.MarkersEqual(markers, paren.Markers) &&
+		treeElem == paren.Tree.Element && java.SpaceEqual(treeAfter, paren.Tree.After) {
+		return paren
+	}
+	c := *paren
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Tree.Element = treeElem
+	c.Tree.After = treeAfter
+	return &c
 }
 
 func (v *GoVisitor) VisitTypeCast(tc *java.TypeCast, p any) java.J {
-	tc = tc.WithPrefix(v.self().VisitSpace(tc.Prefix, p))
-	tc = tc.WithMarkers(v.visitMarkers(tc.Markers, p))
-	tc.Expr = visitExpression(v, tc.Expr, p)
-	if tc.Clazz != nil {
-		tc.Clazz = visitAndCast[*java.ControlParentheses](v, tc.Clazz, p)
+	prefix := v.self().VisitSpace(tc.Prefix, p)
+	markers := v.visitMarkers(tc.Markers, p)
+	expr := visitExpression(v, tc.Expr, p)
+	clazz := tc.Clazz
+	if clazz != nil {
+		clazz = visitAndCast[*java.ControlParentheses](v, clazz, p)
 	}
-	return tc
+	if java.SpaceEqual(prefix, tc.Prefix) && java.MarkersEqual(markers, tc.Markers) &&
+		expr == tc.Expr && clazz == tc.Clazz {
+		return tc
+	}
+	c := *tc
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Expr = expr
+	c.Clazz = clazz
+	return &c
 }
 
 func (v *GoVisitor) VisitControlParentheses(cp *java.ControlParentheses, p any) java.J {
-	cp = cp.WithPrefix(v.self().VisitSpace(cp.Prefix, p))
-	cp = cp.WithMarkers(v.visitMarkers(cp.Markers, p))
-	cp.Tree.Element = visitExpression(v, cp.Tree.Element, p)
-	cp.Tree.After = v.self().VisitSpace(cp.Tree.After, p)
-	return cp
+	prefix := v.self().VisitSpace(cp.Prefix, p)
+	markers := v.visitMarkers(cp.Markers, p)
+	treeElem := visitExpression(v, cp.Tree.Element, p)
+	treeAfter := v.self().VisitSpace(cp.Tree.After, p)
+	if java.SpaceEqual(prefix, cp.Prefix) && java.MarkersEqual(markers, cp.Markers) &&
+		treeElem == cp.Tree.Element && java.SpaceEqual(treeAfter, cp.Tree.After) {
+		return cp
+	}
+	c := *cp
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Tree.Element = treeElem
+	c.Tree.After = treeAfter
+	return &c
 }
 
 func (v *GoVisitor) VisitArrayAccess(aa *java.ArrayAccess, p any) java.J {
-	aa = aa.WithPrefix(v.self().VisitSpace(aa.Prefix, p))
-	aa = aa.WithMarkers(v.visitMarkers(aa.Markers, p))
-	aa.Indexed = visitExpression(v, aa.Indexed, p)
-	if aa.Dimension != nil {
-		aa.Dimension = visitAndCast[*java.ArrayDimension](v, aa.Dimension, p)
+	prefix := v.self().VisitSpace(aa.Prefix, p)
+	markers := v.visitMarkers(aa.Markers, p)
+	indexed := visitExpression(v, aa.Indexed, p)
+	dim := aa.Dimension
+	if dim != nil {
+		dim = visitAndCast[*java.ArrayDimension](v, dim, p)
 	}
-	return aa
+	if java.SpaceEqual(prefix, aa.Prefix) && java.MarkersEqual(markers, aa.Markers) &&
+		indexed == aa.Indexed && dim == aa.Dimension {
+		return aa
+	}
+	c := *aa
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Indexed = indexed
+	c.Dimension = dim
+	return &c
 }
 
 func (v *GoVisitor) VisitParameterizedType(pt *java.ParameterizedType, p any) java.J {
-	pt = pt.WithPrefix(v.self().VisitSpace(pt.Prefix, p))
-	pt = pt.WithMarkers(v.visitMarkers(pt.Markers, p))
-	if pt.Clazz != nil {
-		pt.Clazz = visitExpression(v, pt.Clazz, p)
+	prefix := v.self().VisitSpace(pt.Prefix, p)
+	markers := v.visitMarkers(pt.Markers, p)
+	clazz := pt.Clazz
+	if clazz != nil {
+		clazz = visitExpression(v, clazz, p)
 	}
-	if pt.TypeParameters != nil {
-		pt.TypeParameters.Before = v.self().VisitSpace(pt.TypeParameters.Before, p)
-		pt.TypeParameters.Elements = visitRightPaddedList(v, pt.TypeParameters.Elements, p)
+	tps := pt.TypeParameters
+	if tps != nil {
+		before := v.self().VisitSpace(tps.Before, p)
+		elems := visitRightPaddedList(v, tps.Elements, p)
+		if !java.SpaceEqual(before, tps.Before) || !java.SameSlice(elems, tps.Elements) {
+			c := *tps
+			c.Before = before
+			c.Elements = elems
+			tps = &c
+		}
 	}
-	return pt
+	if java.SpaceEqual(prefix, pt.Prefix) && java.MarkersEqual(markers, pt.Markers) &&
+		clazz == pt.Clazz && tps == pt.TypeParameters {
+		return pt
+	}
+	c := *pt
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Clazz = clazz
+	c.TypeParameters = tps
+	return &c
 }
 
 func (v *GoVisitor) VisitIndexList(il *golang.IndexList, p any) java.J {
-	il = il.WithPrefix(v.self().VisitSpace(il.Prefix, p))
-	il = il.WithMarkers(v.visitMarkers(il.Markers, p))
-	if il.Target != nil {
-		il.Target = visitExpression(v, il.Target, p)
+	prefix := v.self().VisitSpace(il.Prefix, p)
+	markers := v.visitMarkers(il.Markers, p)
+	target := il.Target
+	if target != nil {
+		target = visitExpression(v, target, p)
 	}
-	il.Indices.Before = v.self().VisitSpace(il.Indices.Before, p)
-	il.Indices.Elements = visitRightPaddedList(v, il.Indices.Elements, p)
-	return il
+	indicesBefore := v.self().VisitSpace(il.Indices.Before, p)
+	indicesElems := visitRightPaddedList(v, il.Indices.Elements, p)
+	if java.SpaceEqual(prefix, il.Prefix) && java.MarkersEqual(markers, il.Markers) &&
+		target == il.Target &&
+		java.SpaceEqual(indicesBefore, il.Indices.Before) && java.SameSlice(indicesElems, il.Indices.Elements) {
+		return il
+	}
+	c := *il
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Target = target
+	c.Indices.Before = indicesBefore
+	c.Indices.Elements = indicesElems
+	return &c
 }
 
 func (v *GoVisitor) VisitArrayDimension(ad *java.ArrayDimension, p any) java.J {
-	ad = ad.WithPrefix(v.self().VisitSpace(ad.Prefix, p))
-	ad = ad.WithMarkers(v.visitMarkers(ad.Markers, p))
-	ad.Index.Element = visitExpression(v, ad.Index.Element, p)
-	ad.Index.After = v.self().VisitSpace(ad.Index.After, p)
-	return ad
+	prefix := v.self().VisitSpace(ad.Prefix, p)
+	markers := v.visitMarkers(ad.Markers, p)
+	idxElem := visitExpression(v, ad.Index.Element, p)
+	idxAfter := v.self().VisitSpace(ad.Index.After, p)
+	if java.SpaceEqual(prefix, ad.Prefix) && java.MarkersEqual(markers, ad.Markers) &&
+		idxElem == ad.Index.Element && java.SpaceEqual(idxAfter, ad.Index.After) {
+		return ad
+	}
+	c := *ad
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Index.Element = idxElem
+	c.Index.After = idxAfter
+	return &c
 }
 
-func (v *GoVisitor) VisitComposite(c *golang.Composite, p any) java.J {
-	c = c.WithPrefix(v.self().VisitSpace(c.Prefix, p))
-	c = c.WithMarkers(v.visitMarkers(c.Markers, p))
-	if c.TypeExpr != nil {
-		c.TypeExpr = visitExpression(v, c.TypeExpr, p)
+func (v *GoVisitor) VisitComposite(comp *golang.Composite, p any) java.J {
+	prefix := v.self().VisitSpace(comp.Prefix, p)
+	markers := v.visitMarkers(comp.Markers, p)
+	typeExpr := comp.TypeExpr
+	if typeExpr != nil {
+		typeExpr = visitExpression(v, typeExpr, p)
 	}
-	c.Elements.Before = v.self().VisitSpace(c.Elements.Before, p)
-	c.Elements.Elements = visitRightPaddedList(v, c.Elements.Elements, p)
-	return c
+	elemsBefore := v.self().VisitSpace(comp.Elements.Before, p)
+	elemsElems := visitRightPaddedList(v, comp.Elements.Elements, p)
+	if java.SpaceEqual(prefix, comp.Prefix) && java.MarkersEqual(markers, comp.Markers) &&
+		typeExpr == comp.TypeExpr &&
+		java.SpaceEqual(elemsBefore, comp.Elements.Before) && java.SameSlice(elemsElems, comp.Elements.Elements) {
+		return comp
+	}
+	c := *comp
+	c.Prefix = prefix
+	c.Markers = markers
+	c.TypeExpr = typeExpr
+	c.Elements.Before = elemsBefore
+	c.Elements.Elements = elemsElems
+	return &c
 }
 
 func (v *GoVisitor) VisitKeyValue(kv *golang.KeyValue, p any) java.J {
-	kv = kv.WithPrefix(v.self().VisitSpace(kv.Prefix, p))
-	kv = kv.WithMarkers(v.visitMarkers(kv.Markers, p))
-	kv.Key = visitExpression(v, kv.Key, p)
-	kv.Value.Before = v.self().VisitSpace(kv.Value.Before, p)
-	kv.Value.Element = visitExpression(v, kv.Value.Element, p)
-	return kv
+	prefix := v.self().VisitSpace(kv.Prefix, p)
+	markers := v.visitMarkers(kv.Markers, p)
+	key := visitExpression(v, kv.Key, p)
+	valueBefore := v.self().VisitSpace(kv.Value.Before, p)
+	valueElem := visitExpression(v, kv.Value.Element, p)
+	if java.SpaceEqual(prefix, kv.Prefix) && java.MarkersEqual(markers, kv.Markers) &&
+		key == kv.Key &&
+		java.SpaceEqual(valueBefore, kv.Value.Before) && valueElem == kv.Value.Element {
+		return kv
+	}
+	c := *kv
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Key = key
+	c.Value.Before = valueBefore
+	c.Value.Element = valueElem
+	return &c
 }
 
 func (v *GoVisitor) VisitSlice(s *golang.Slice, p any) java.J {
-	s = s.WithPrefix(v.self().VisitSpace(s.Prefix, p))
-	s = s.WithMarkers(v.visitMarkers(s.Markers, p))
-	s.Indexed = visitExpression(v, s.Indexed, p)
-	s.OpenBracket = v.self().VisitSpace(s.OpenBracket, p)
-	s.Low.Element = visitExpression(v, s.Low.Element, p)
-	s.Low.After = v.self().VisitSpace(s.Low.After, p)
-	s.High.Element = visitExpression(v, s.High.Element, p)
-	s.High.After = v.self().VisitSpace(s.High.After, p)
-	if s.Max != nil {
-		s.Max = visitExpression(v, s.Max, p)
+	prefix := v.self().VisitSpace(s.Prefix, p)
+	markers := v.visitMarkers(s.Markers, p)
+	indexed := visitExpression(v, s.Indexed, p)
+	openBracket := v.self().VisitSpace(s.OpenBracket, p)
+	lowElem := visitExpression(v, s.Low.Element, p)
+	lowAfter := v.self().VisitSpace(s.Low.After, p)
+	highElem := visitExpression(v, s.High.Element, p)
+	highAfter := v.self().VisitSpace(s.High.After, p)
+	max := s.Max
+	if max != nil {
+		max = visitExpression(v, max, p)
 	}
-	s.CloseBracket = v.self().VisitSpace(s.CloseBracket, p)
-	return s
+	closeBracket := v.self().VisitSpace(s.CloseBracket, p)
+	if java.SpaceEqual(prefix, s.Prefix) && java.MarkersEqual(markers, s.Markers) &&
+		indexed == s.Indexed && java.SpaceEqual(openBracket, s.OpenBracket) &&
+		lowElem == s.Low.Element && java.SpaceEqual(lowAfter, s.Low.After) &&
+		highElem == s.High.Element && java.SpaceEqual(highAfter, s.High.After) &&
+		max == s.Max && java.SpaceEqual(closeBracket, s.CloseBracket) {
+		return s
+	}
+	c := *s
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Indexed = indexed
+	c.OpenBracket = openBracket
+	c.Low.Element = lowElem
+	c.Low.After = lowAfter
+	c.High.Element = highElem
+	c.High.After = highAfter
+	c.Max = max
+	c.CloseBracket = closeBracket
+	return &c
 }
 
 func (v *GoVisitor) VisitMapType(mt *golang.MapType, p any) java.J {
-	mt = mt.WithPrefix(v.self().VisitSpace(mt.Prefix, p))
-	mt = mt.WithMarkers(v.visitMarkers(mt.Markers, p))
-	mt.OpenBracket = v.self().VisitSpace(mt.OpenBracket, p)
-	mt.Key.Element = visitExpression(v, mt.Key.Element, p)
-	mt.Key.After = v.self().VisitSpace(mt.Key.After, p)
-	mt.Value = visitExpression(v, mt.Value, p)
-	return mt
+	prefix := v.self().VisitSpace(mt.Prefix, p)
+	markers := v.visitMarkers(mt.Markers, p)
+	openBracket := v.self().VisitSpace(mt.OpenBracket, p)
+	keyElem := visitExpression(v, mt.Key.Element, p)
+	keyAfter := v.self().VisitSpace(mt.Key.After, p)
+	value := visitExpression(v, mt.Value, p)
+	if java.SpaceEqual(prefix, mt.Prefix) && java.MarkersEqual(markers, mt.Markers) &&
+		java.SpaceEqual(openBracket, mt.OpenBracket) &&
+		keyElem == mt.Key.Element && java.SpaceEqual(keyAfter, mt.Key.After) &&
+		value == mt.Value {
+		return mt
+	}
+	c := *mt
+	c.Prefix = prefix
+	c.Markers = markers
+	c.OpenBracket = openBracket
+	c.Key.Element = keyElem
+	c.Key.After = keyAfter
+	c.Value = value
+	return &c
 }
 
 func (v *GoVisitor) VisitStatementExpression(se *golang.StatementExpression, p any) java.J {
-	se = se.WithPrefix(v.self().VisitSpace(se.Prefix, p))
-	se = se.WithMarkers(v.visitMarkers(se.Markers, p))
-	result := v.self().Visit(se.Statement, p)
-	if stmt, ok := result.(java.Statement); ok {
-		se.Statement = stmt
+	prefix := v.self().VisitSpace(se.Prefix, p)
+	markers := v.visitMarkers(se.Markers, p)
+	stmt := se.Statement
+	if result, ok := v.self().Visit(se.Statement, p).(java.Statement); ok {
+		stmt = result
 	}
-	return se
+	if java.SpaceEqual(prefix, se.Prefix) && java.MarkersEqual(markers, se.Markers) && stmt == se.Statement {
+		return se
+	}
+	c := *se
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Statement = stmt
+	return &c
 }
 
 func (v *GoVisitor) VisitPointerType(pt *golang.PointerType, p any) java.J {
-	pt = pt.WithPrefix(v.self().VisitSpace(pt.Prefix, p))
-	pt = pt.WithMarkers(v.visitMarkers(pt.Markers, p))
-	pt.Elem = visitExpression(v, pt.Elem, p)
-	return pt
+	prefix := v.self().VisitSpace(pt.Prefix, p)
+	markers := v.visitMarkers(pt.Markers, p)
+	elem := visitExpression(v, pt.Elem, p)
+	if java.SpaceEqual(prefix, pt.Prefix) && java.MarkersEqual(markers, pt.Markers) && elem == pt.Elem {
+		return pt
+	}
+	c := *pt
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Elem = elem
+	return &c
 }
 
 func (v *GoVisitor) VisitChannel(ch *golang.Channel, p any) java.J {
-	ch = ch.WithPrefix(v.self().VisitSpace(ch.Prefix, p))
-	ch = ch.WithMarkers(v.visitMarkers(ch.Markers, p))
-	ch.Value = visitExpression(v, ch.Value, p)
-	return ch
+	prefix := v.self().VisitSpace(ch.Prefix, p)
+	markers := v.visitMarkers(ch.Markers, p)
+	value := visitExpression(v, ch.Value, p)
+	if java.SpaceEqual(prefix, ch.Prefix) && java.MarkersEqual(markers, ch.Markers) && value == ch.Value {
+		return ch
+	}
+	c := *ch
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Value = value
+	return &c
 }
 
 func (v *GoVisitor) VisitFuncType(ft *golang.FuncType, p any) java.J {
-	ft = ft.WithPrefix(v.self().VisitSpace(ft.Prefix, p))
-	ft = ft.WithMarkers(v.visitMarkers(ft.Markers, p))
-	ft.Parameters.Before = v.self().VisitSpace(ft.Parameters.Before, p)
-	ft.Parameters.Elements = visitRightPaddedList(v, ft.Parameters.Elements, p)
-	if ft.ReturnType != nil {
-		ft.ReturnType = visitExpression(v, ft.ReturnType, p)
+	prefix := v.self().VisitSpace(ft.Prefix, p)
+	markers := v.visitMarkers(ft.Markers, p)
+	paramsBefore := v.self().VisitSpace(ft.Parameters.Before, p)
+	paramsElems := visitRightPaddedList(v, ft.Parameters.Elements, p)
+	returnType := ft.ReturnType
+	if returnType != nil {
+		returnType = visitExpression(v, returnType, p)
 	}
-	return ft
+	if java.SpaceEqual(prefix, ft.Prefix) && java.MarkersEqual(markers, ft.Markers) &&
+		java.SpaceEqual(paramsBefore, ft.Parameters.Before) && java.SameSlice(paramsElems, ft.Parameters.Elements) &&
+		returnType == ft.ReturnType {
+		return ft
+	}
+	c := *ft
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Parameters.Before = paramsBefore
+	c.Parameters.Elements = paramsElems
+	c.ReturnType = returnType
+	return &c
 }
 
 func (v *GoVisitor) VisitTypeList(tl *golang.TypeList, p any) java.J {
-	tl = tl.WithPrefix(v.self().VisitSpace(tl.Prefix, p))
-	tl = tl.WithMarkers(v.visitMarkers(tl.Markers, p))
-	tl.Types.Before = v.self().VisitSpace(tl.Types.Before, p)
-	tl.Types.Elements = visitRightPaddedList(v, tl.Types.Elements, p)
-	return tl
+	prefix := v.self().VisitSpace(tl.Prefix, p)
+	markers := v.visitMarkers(tl.Markers, p)
+	typesBefore := v.self().VisitSpace(tl.Types.Before, p)
+	typesElems := visitRightPaddedList(v, tl.Types.Elements, p)
+	if java.SpaceEqual(prefix, tl.Prefix) && java.MarkersEqual(markers, tl.Markers) &&
+		java.SpaceEqual(typesBefore, tl.Types.Before) && java.SameSlice(typesElems, tl.Types.Elements) {
+		return tl
+	}
+	c := *tl
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Types.Before = typesBefore
+	c.Types.Elements = typesElems
+	return &c
 }
 
 func (v *GoVisitor) VisitUnion(u *golang.Union, p any) java.J {
-	u = u.WithPrefix(v.self().VisitSpace(u.Prefix, p))
-	u = u.WithMarkers(v.visitMarkers(u.Markers, p))
-	u.Types = visitRightPaddedExpressionList(v, u.Types, p)
-	return u
+	prefix := v.self().VisitSpace(u.Prefix, p)
+	markers := v.visitMarkers(u.Markers, p)
+	types := visitRightPaddedExpressionList(v, u.Types, p)
+	if java.SpaceEqual(prefix, u.Prefix) && java.MarkersEqual(markers, u.Markers) && java.SameSlice(types, u.Types) {
+		return u
+	}
+	c := *u
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Types = types
+	return &c
 }
 
 func (v *GoVisitor) VisitUnderlyingType(ut *golang.UnderlyingType, p any) java.J {
-	ut = ut.WithPrefix(v.self().VisitSpace(ut.Prefix, p))
-	ut = ut.WithMarkers(v.visitMarkers(ut.Markers, p))
-	ut.Element = visitExpression(v, ut.Element, p)
-	return ut
+	prefix := v.self().VisitSpace(ut.Prefix, p)
+	markers := v.visitMarkers(ut.Markers, p)
+	elem := visitExpression(v, ut.Element, p)
+	if java.SpaceEqual(prefix, ut.Prefix) && java.MarkersEqual(markers, ut.Markers) && elem == ut.Element {
+		return ut
+	}
+	c := *ut
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Element = elem
+	return &c
 }
 
 func (v *GoVisitor) VisitTypeDecl(td *golang.TypeDecl, p any) java.J {
-	td = td.WithPrefix(v.self().VisitSpace(td.Prefix, p))
-	td = td.WithMarkers(v.visitMarkers(td.Markers, p))
-	if len(td.LeadingAnnotations) > 0 {
-		anns := make([]*java.Annotation, 0, len(td.LeadingAnnotations))
-		for _, a := range td.LeadingAnnotations {
-			visited := v.self().Visit(a, p)
-			if visited == nil {
-				continue
-			}
-			anns = append(anns, visited.(*java.Annotation))
+	prefix := v.self().VisitSpace(td.Prefix, p)
+	markers := v.visitMarkers(td.Markers, p)
+	anns := visitAnnotationList(v, td.LeadingAnnotations, p)
+	name := td.Name
+	if name != nil {
+		name = visitAndCast[*java.Identifier](v, name, p)
+	}
+	tps := td.TypeParameters
+	if tps != nil {
+		tps = visitAndCast[*java.TypeParameters](v, tps, p)
+	}
+	assign := td.Assign
+	if assign != nil {
+		before := v.self().VisitSpace(assign.Before, p)
+		if !java.SpaceEqual(before, assign.Before) {
+			c := *assign
+			c.Before = before
+			assign = &c
 		}
-		td = td.WithLeadingAnnotations(anns)
 	}
-	if td.Name != nil {
-		td.Name = visitAndCast[*java.Identifier](v, td.Name, p)
+	definition := td.Definition
+	if definition != nil {
+		definition = visitExpression(v, definition, p)
 	}
-	if td.TypeParameters != nil {
-		td = td.WithTypeParameters(visitAndCast[*java.TypeParameters](v, td.TypeParameters, p))
+	specs := td.Specs
+	if specs != nil {
+		before := v.self().VisitSpace(specs.Before, p)
+		elems := visitRightPaddedList(v, specs.Elements, p)
+		if !java.SpaceEqual(before, specs.Before) || !java.SameSlice(elems, specs.Elements) {
+			c := *specs
+			c.Before = before
+			c.Elements = elems
+			specs = &c
+		}
 	}
-	if td.Assign != nil {
-		assign := *td.Assign
-		assign.Before = v.self().VisitSpace(assign.Before, p)
-		td.Assign = &assign
+	if java.SpaceEqual(prefix, td.Prefix) && java.MarkersEqual(markers, td.Markers) &&
+		java.SameSlice(anns, td.LeadingAnnotations) && name == td.Name && tps == td.TypeParameters &&
+		assign == td.Assign && definition == td.Definition && specs == td.Specs {
+		return td
 	}
-	if td.Definition != nil {
-		td.Definition = visitExpression(v, td.Definition, p)
-	}
-	if td.Specs != nil {
-		specs := *td.Specs
-		specs.Before = v.self().VisitSpace(specs.Before, p)
-		specs.Elements = visitRightPaddedList(v, specs.Elements, p)
-		td.Specs = &specs
-	}
-	return td
+	c := *td
+	c.Prefix = prefix
+	c.Markers = markers
+	c.LeadingAnnotations = anns
+	c.Name = name
+	c.TypeParameters = tps
+	c.Assign = assign
+	c.Definition = definition
+	c.Specs = specs
+	return &c
 }
 
 func (v *GoVisitor) VisitStructType(st *golang.StructType, p any) java.J {
-	st = st.WithPrefix(v.self().VisitSpace(st.Prefix, p))
-	st = st.WithMarkers(v.visitMarkers(st.Markers, p))
-	if st.Body != nil {
-		st.Body = visitAndCast[*java.Block](v, st.Body, p)
+	prefix := v.self().VisitSpace(st.Prefix, p)
+	markers := v.visitMarkers(st.Markers, p)
+	body := st.Body
+	if body != nil {
+		body = visitAndCast[*java.Block](v, body, p)
 	}
-	return st
+	if java.SpaceEqual(prefix, st.Prefix) && java.MarkersEqual(markers, st.Markers) && body == st.Body {
+		return st
+	}
+	c := *st
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Body = body
+	return &c
 }
 
 func (v *GoVisitor) VisitInterfaceType(it *golang.InterfaceType, p any) java.J {
-	it = it.WithPrefix(v.self().VisitSpace(it.Prefix, p))
-	it = it.WithMarkers(v.visitMarkers(it.Markers, p))
-	if it.Body != nil {
-		it.Body = visitAndCast[*java.Block](v, it.Body, p)
+	prefix := v.self().VisitSpace(it.Prefix, p)
+	markers := v.visitMarkers(it.Markers, p)
+	body := it.Body
+	if body != nil {
+		body = visitAndCast[*java.Block](v, body, p)
 	}
-	return it
+	if java.SpaceEqual(prefix, it.Prefix) && java.MarkersEqual(markers, it.Markers) && body == it.Body {
+		return it
+	}
+	c := *it
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Body = body
+	return &c
 }
 
 func (v *GoVisitor) VisitMultiAssignment(ma *golang.MultiAssignment, p any) java.J {
-	ma = ma.WithPrefix(v.self().VisitSpace(ma.Prefix, p))
-	ma = ma.WithMarkers(v.visitMarkers(ma.Markers, p))
-	ma.Variables = visitRightPaddedExpressionList(v, ma.Variables, p)
-	ma.Operator.Before = v.self().VisitSpace(ma.Operator.Before, p)
-	ma.Values = visitRightPaddedExpressionList(v, ma.Values, p)
-	return ma
+	prefix := v.self().VisitSpace(ma.Prefix, p)
+	markers := v.visitMarkers(ma.Markers, p)
+	variables := visitRightPaddedExpressionList(v, ma.Variables, p)
+	opBefore := v.self().VisitSpace(ma.Operator.Before, p)
+	values := visitRightPaddedExpressionList(v, ma.Values, p)
+	if java.SpaceEqual(prefix, ma.Prefix) && java.MarkersEqual(markers, ma.Markers) &&
+		java.SameSlice(variables, ma.Variables) && java.SpaceEqual(opBefore, ma.Operator.Before) &&
+		java.SameSlice(values, ma.Values) {
+		return ma
+	}
+	c := *ma
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Variables = variables
+	c.Operator.Before = opBefore
+	c.Values = values
+	return &c
 }
 
 func (v *GoVisitor) VisitCommClause(cc *golang.CommClause, p any) java.J {
-	cc = cc.WithPrefix(v.self().VisitSpace(cc.Prefix, p))
-	cc = cc.WithMarkers(v.visitMarkers(cc.Markers, p))
-	if cc.Comm != nil {
-		cc.Comm = visitAndCast[java.Statement](v, cc.Comm, p)
+	prefix := v.self().VisitSpace(cc.Prefix, p)
+	markers := v.visitMarkers(cc.Markers, p)
+	comm := cc.Comm
+	if comm != nil {
+		comm = visitAndCast[java.Statement](v, comm, p)
 	}
-	cc.Colon = v.self().VisitSpace(cc.Colon, p)
-	cc.Body = visitRightPaddedList(v, cc.Body, p)
-	return cc
+	colon := v.self().VisitSpace(cc.Colon, p)
+	body := visitRightPaddedList(v, cc.Body, p)
+	if java.SpaceEqual(prefix, cc.Prefix) && java.MarkersEqual(markers, cc.Markers) &&
+		comm == cc.Comm && java.SpaceEqual(colon, cc.Colon) && java.SameSlice(body, cc.Body) {
+		return cc
+	}
+	c := *cc
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Comm = comm
+	c.Colon = colon
+	c.Body = body
+	return &c
 }
 
 func (v *GoVisitor) VisitSpace(space java.Space, p any) java.Space {
@@ -1200,11 +1825,39 @@ func (v *GoVisitor) visitMarkers(markers java.Markers, p any) java.Markers {
 	if len(markers.Entries) == 0 {
 		return markers
 	}
-	entries := make([]java.Marker, len(markers.Entries))
+	// Preserve identity: return the same Markers (same entries slice) when no
+	// entry changed, so the enclosing withX guard (java.MarkersEqual) reports
+	// no change. Only allocate once VisitMarker actually rewrites an entry.
+	var entries []java.Marker
 	for i, m := range markers.Entries {
-		entries[i] = v.self().VisitMarker(m, p)
+		visited := v.self().VisitMarker(m, p)
+		if entries == nil && !sameMarker(visited, m) {
+			entries = make([]java.Marker, len(markers.Entries))
+			copy(entries, markers.Entries[:i])
+		}
+		if entries != nil {
+			entries[i] = visited
+		}
+	}
+	if entries == nil {
+		return markers
 	}
 	return java.Markers{ID: markers.ID, Entries: entries}
+}
+
+// sameMarker reports whether VisitMarker left an entry unchanged, without an
+// interface == (which panics on value-typed markers holding slices/maps, e.g.
+// golang.GroupedImport). Pointer markers compare by identity; value markers
+// fall back to a deep compare.
+func sameMarker(a, b java.Marker) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	ra, rb := reflect.ValueOf(a), reflect.ValueOf(b)
+	if ra.Kind() == reflect.Ptr && rb.Kind() == reflect.Ptr {
+		return ra.Pointer() == rb.Pointer()
+	}
+	return reflect.DeepEqual(a, b)
 }
 
 func visitAndCast[T java.Tree](v *GoVisitor, t java.Tree, p any) T {
@@ -1216,19 +1869,107 @@ func visitAndCast[T java.Tree](v *GoVisitor, t java.Tree, p any) T {
 	return result.(T)
 }
 
+// visitAnnotationList visits a slice of annotations, preserving slice identity:
+// it returns the original slice when no annotation changed (and none deleted),
+// allocating only on the first change. Mirrors visitRightPaddedList's idiom.
+func visitAnnotationList(v *GoVisitor, list []*java.Annotation, p any) []*java.Annotation {
+	var result []*java.Annotation
+	materialize := func(i int) {
+		if result == nil {
+			result = make([]*java.Annotation, 0, len(list))
+			result = append(result, list[:i]...)
+		}
+	}
+	for i := range list {
+		a := list[i]
+		visited := v.self().Visit(a, p)
+		if visited == nil {
+			materialize(i)
+			continue
+		}
+		na := visited.(*java.Annotation)
+		if na == a {
+			if result != nil {
+				result = append(result, na)
+			}
+			continue
+		}
+		materialize(i)
+		result = append(result, na)
+	}
+	if result == nil {
+		return list
+	}
+	return result
+}
+
+// visitGoModValueList visits a slice of go.mod values, preserving slice identity:
+// it returns the original slice when nothing changed, allocating only on the
+// first change/deletion.
+func visitGoModValueList(v *GoVisitor, list []*golang.GoModValue, p any) []*golang.GoModValue {
+	var result []*golang.GoModValue
+	materialize := func(i int) {
+		if result == nil {
+			result = make([]*golang.GoModValue, 0, len(list))
+			result = append(result, list[:i]...)
+		}
+	}
+	for i := range list {
+		val := list[i]
+		visited := v.self().Visit(val, p)
+		if visited == nil {
+			materialize(i)
+			continue
+		}
+		nv := visited.(*golang.GoModValue)
+		if nv == val {
+			if result != nil {
+				result = append(result, nv)
+			}
+			continue
+		}
+		materialize(i)
+		result = append(result, nv)
+	}
+	if result == nil {
+		return list
+	}
+	return result
+}
+
 // visitGoModStatementList visits a right-padded list of go.mod statements.
 // GoModStatement is a java.Tree (not java.J), so the J-constrained
 // visitRightPaddedList helper can't be reused here.
 func visitGoModStatementList(v *GoVisitor, list []java.RightPadded[golang.GoModStatement], p any) []java.RightPadded[golang.GoModStatement] {
-	result := make([]java.RightPadded[golang.GoModStatement], 0, len(list))
-	for _, rp := range list {
+	var result []java.RightPadded[golang.GoModStatement]
+	materialize := func(i int) {
+		if result == nil {
+			result = make([]java.RightPadded[golang.GoModStatement], 0, len(list))
+			result = append(result, list[:i]...)
+		}
+	}
+	for i := range list {
+		rp := list[i]
 		visited := v.self().Visit(rp.Element, p)
+		newAfter := v.self().VisitSpace(rp.After, p)
 		if visited == nil {
+			materialize(i)
 			continue
 		}
-		rp.Element = visited.(golang.GoModStatement)
-		rp.After = v.self().VisitSpace(rp.After, p)
+		ne := visited.(golang.GoModStatement)
+		if ne == rp.Element && java.SpaceEqual(newAfter, rp.After) {
+			if result != nil {
+				result = append(result, rp)
+			}
+			continue
+		}
+		materialize(i)
+		rp.Element = ne
+		rp.After = newAfter
 		result = append(result, rp)
+	}
+	if result == nil {
+		return list
 	}
 	return result
 }
@@ -1256,29 +1997,72 @@ func visitExpression(v *GoVisitor, expr java.Expression, p any) java.Expression 
 }
 
 func visitRightPaddedExpressionList(v *GoVisitor, list []java.RightPadded[java.Expression], p any) []java.RightPadded[java.Expression] {
-	result := make([]java.RightPadded[java.Expression], 0, len(list))
-	for _, rp := range list {
+	var result []java.RightPadded[java.Expression]
+	materialize := func(i int) {
+		if result == nil {
+			result = make([]java.RightPadded[java.Expression], 0, len(list))
+			result = append(result, list[:i]...)
+		}
+	}
+	for i := range list {
+		rp := list[i]
 		visited := v.self().Visit(rp.Element, p)
+		newAfter := v.self().VisitSpace(rp.After, p)
 		if visited == nil {
+			materialize(i)
 			continue
 		}
-		rp.Element = visited.(java.Expression)
-		rp.After = v.self().VisitSpace(rp.After, p)
+		ne := visited.(java.Expression)
+		if ne == rp.Element && java.SpaceEqual(newAfter, rp.After) {
+			if result != nil {
+				result = append(result, rp)
+			}
+			continue
+		}
+		materialize(i)
+		rp.Element = ne
+		rp.After = newAfter
 		result = append(result, rp)
+	}
+	if result == nil {
+		return list
 	}
 	return result
 }
 
 func visitRightPaddedList[T java.J](v *GoVisitor, list []java.RightPadded[T], p any) []java.RightPadded[T] {
-	result := make([]java.RightPadded[T], 0, len(list))
-	for _, rp := range list {
+	// Preserve slice identity: return the original `list` when no element
+	// changed, so the enclosing withX guard (java.SameSlice) returns the same
+	// node. Only allocate once the first change (mutation/deletion) is seen.
+	var result []java.RightPadded[T]
+	materialize := func(i int) {
+		if result == nil {
+			result = make([]java.RightPadded[T], 0, len(list))
+			result = append(result, list[:i]...)
+		}
+	}
+	for i := range list {
+		rp := list[i]
 		visited := v.self().Visit(rp.Element, p)
+		newAfter := v.self().VisitSpace(rp.After, p)
 		if visited == nil {
+			materialize(i)
 			continue
 		}
-		rp.Element = visited.(T)
-		rp.After = v.self().VisitSpace(rp.After, p)
+		ne := visited.(T)
+		if any(ne) == any(rp.Element) && java.SpaceEqual(newAfter, rp.After) {
+			if result != nil {
+				result = append(result, rp)
+			}
+			continue
+		}
+		materialize(i)
+		rp.Element = ne
+		rp.After = newAfter
 		result = append(result, rp)
+	}
+	if result == nil {
+		return list
 	}
 	return result
 }

--- a/rewrite-go/test/immutability_test.go
+++ b/rewrite-go/test/immutability_test.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// renamer changes every identifier named "x" to "y" — a minimal change-visit.
+type renamer struct{ visitor.GoVisitor }
+
+func (r *renamer) VisitIdentifier(id *java.Identifier, p any) java.J {
+	if id.Name == "x" {
+		return id.WithName("y")
+	}
+	return r.GoVisitor.VisitIdentifier(id, p)
+}
+
+// immutabilitySamples exercises a broad spread of node types.
+var immutabilitySamples = map[string]string{
+	"assign-if-unary": "package p\n\nfunc f() {\n\tx := 1\n\tif x == 1 {\n\t\tx = 2\n\t}\n\t_ = &x\n}\n",
+	"imports":         "package p\n\nimport \"fmt\"\n\nfunc f() { fmt.Println(\"hi\") }\n",
+	"struct-method":   "package p\n\ntype T struct{ A int }\n\nfunc (t T) M() int { return t.A }\n",
+	"for-range-chan":  "package p\n\nfunc f(ch <-chan int) {\n\tfor i := 0; i < 3; i++ {\n\t\t_ = <-ch\n\t}\n}\n",
+	"composite":       "package p\n\ntype T struct{ A int }\n\nfunc f() { _ = T{A: 1} }\n",
+}
+
+// TestVisitDoesNotMutateOriginal is the immutability invariant: a change-visit
+// must not mutate the shared input tree in place. With identity-preserving
+// withX, any VisitX that assigns to a receiver field directly would corrupt
+// the original — this guards against that.
+func TestVisitDoesNotMutateOriginal(t *testing.T) {
+	for name, src := range immutabilitySamples {
+		cu, err := parser.NewGoParser().Parse("p.go", src)
+		if err != nil {
+			t.Fatalf("%s: parse: %v", name, err)
+		}
+		before := printer.Print(cu)
+		r := &renamer{}
+		visitor.Init(r)
+		r.Visit(cu, nil)
+		if after := printer.Print(cu); after != before {
+			t.Errorf("%s: ORIGINAL tree mutated in place\n--- was ---\n%s\n--- now ---\n%s", name, before, after)
+		}
+	}
+}
+
+// TestNoOpVisitPreservesIdentity is the identity invariant: a visit that
+// changes nothing must return the SAME pointer (so the engine's change
+// detection reports "unchanged"). This is what keeps untouched files out of a
+// recipe's results/patch.
+func TestNoOpVisitPreservesIdentity(t *testing.T) {
+	for name, src := range immutabilitySamples {
+		cu, err := parser.NewGoParser().Parse("p.go", src)
+		if err != nil {
+			t.Fatalf("%s: parse: %v", name, err)
+		}
+		v := &visitor.GoVisitor{}
+		visitor.Init(v)
+		got := v.Visit(cu, nil)
+		if got != java.Tree(cu) {
+			t.Errorf("%s: no-op visit did not preserve identity (returned a new pointer)", name)
+		}
+	}
+}

--- a/rewrite-go/test/whitespace_collapse_repro_test.go
+++ b/rewrite-go/test/whitespace_collapse_repro_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+const collapseReproSrc = `package main
+
+import "fmt"
+
+func Bind(x int) int {
+	value := x
+	if value == 1 {
+		value = 2
+	}
+	fmt.Println(value, x)
+	return value
+}
+`
+
+// ifThenBlockLocator captures the *java.Block that is the then-branch of the
+// untouched `if value == 1 { ... }`, keyed by its stable ID.
+type ifThenBlockLocator struct {
+	visitor.GoVisitor
+	block *java.Block
+	id    uuid.UUID
+}
+
+func (v *ifThenBlockLocator) VisitIf(ifStmt *java.If, p any) java.J {
+	if b, ok := ifStmt.ThenPart.Element.(*java.Block); ok {
+		v.block = b
+		v.id = b.ID
+	}
+	return ifStmt
+}
+
+func locateIfThenBlock(t *testing.T, root java.Tree) *java.Block {
+	t.Helper()
+	loc := visitor.Init(&ifThenBlockLocator{})
+	loc.Visit(root, nil)
+	if loc.block == nil {
+		t.Fatal("could not locate the if-then block in the parsed tree")
+	}
+	return loc.block
+}
+
+// TestNoOpVisitPreservesUntouchedBlockIdentity: the untouched `if` block keeps a
+// stable identity across a no-op visit. This is exactly the subtree that
+// collapses to `if value == 1 {value = 2}` on the wire.
+func TestNoOpVisitPreservesUntouchedBlockIdentity(t *testing.T) {
+	// given
+	p := parser.NewGoParser()
+	cu, err := p.Parse("bind.go", collapseReproSrc)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	before := locateIfThenBlock(t, cu)
+
+	// when
+	result := visitor.Init(&visitor.GoVisitor{}).Visit(cu, nil)
+	after := locateIfThenBlock(t, result)
+
+	// then
+	if before.ID != after.ID {
+		t.Fatalf("block ID changed across visit: %s -> %s", before.ID, after.ID)
+	}
+	if before != after {
+		t.Errorf("no-op visit reallocated the untouched if-then block (id %s); a "+
+			"fresh pointer makes the sender diverge from the receiver baseline, so a "+
+			"NO_CHANGE delta resolves against a diverged node and the block's "+
+			"whitespace is dropped\n  before: %p\n  after:  %p", before.ID, before, after)
+	}
+}


### PR DESCRIPTION
## What's changed?

Fix Go's visitors to maintain immutability.
I.e. when a LST element is not being changed, don't copy it, but return the same.

## What's your motivation?

- Triggered by some whitespace preservation issue in RPC.
- But applying this to satisfy general OpenRewrite expectations.
